### PR TITLE
Mixtral exact row 20260509

### DIFF
--- a/qa/evidence-bundles/mixtral-8x7b-v0.1-q8-larger-support-probe-20260509/manifest.json
+++ b/qa/evidence-bundles/mixtral-8x7b-v0.1-q8-larger-support-probe-20260509/manifest.json
@@ -1,0 +1,127 @@
+{
+  "schema": "camelid.evidence.mixtral_larger_support_probe.v1",
+  "target_row": "Mixtral-8x7B-Instruct-v0.1.Q8_0",
+  "status": "partial_probe_only_do_not_promote_broad_support",
+  "support_boundary": "The top-k router renormalization fix improves Mixtral parity evidence, but larger support is not ready: one 5-token Hello prompt passes and Count-to-three passes at 1 token, while Count-to-three still diverges by token 3 in the 5-token run. Do not claim broad Mixtral, multi-prompt, long-context, frontend, or production support from this bundle.",
+  "code_change": "Renormalize selected Mixtral router top-k weights after truncation, matching the expected top-k expert weighting behavior instead of leaving selected weights scaled by non-selected expert mass.",
+  "cases": [
+    {
+      "id": "hello_5tok",
+      "message": "Hello",
+      "max_tokens": 5,
+      "prompt_tokens_match": true,
+      "generated_tokens_match": true,
+      "generated_text_match": true,
+      "backend_generated_tokens": [
+        22557,
+        28808,
+        1602,
+        541,
+        315
+      ],
+      "llama_generated_tokens": [
+        22557,
+        28808,
+        1602,
+        541,
+        315
+      ],
+      "backend_text": " Hello! How can I",
+      "llama_text": " Hello! How can I"
+    },
+    {
+      "id": "counting_1tok",
+      "message": "Count to three.",
+      "max_tokens": 1,
+      "prompt_tokens_match": true,
+      "generated_tokens_match": true,
+      "generated_text_match": true,
+      "backend_generated_tokens": [
+        28705
+      ],
+      "llama_generated_tokens": [
+        28705
+      ],
+      "backend_text": " ",
+      "llama_text": " "
+    },
+    {
+      "id": "counting_5tok",
+      "message": "Count to three.",
+      "max_tokens": 5,
+      "prompt_tokens_match": true,
+      "generated_tokens_match": false,
+      "generated_text_match": false,
+      "backend_generated_tokens": [
+        28705,
+        28740,
+        28723,
+        12875,
+        28725
+      ],
+      "llama_generated_tokens": [
+        28705,
+        28740,
+        28725,
+        28705,
+        28750
+      ],
+      "backend_text": " 1. Sure,",
+      "llama_text": " 1, 2",
+      "first_generated_token_logit_comparison": {
+        "backend_token_id": 28705,
+        "llama_token_id": 28705,
+        "token_ids_match": true,
+        "backend_margin_llama_minus_backend": 0,
+        "llama_margin_llama_minus_backend": 0,
+        "margin_disagreement": 0,
+        "backend_rows": [
+          {
+            "token_id": 28705,
+            "logit": 33.543617,
+            "probability": 0.7199758,
+            "rank": 1,
+            "selected": true,
+            "text": " "
+          },
+          {
+            "token_id": 28705,
+            "logit": 33.543617,
+            "probability": 0.7199758,
+            "rank": 1,
+            "selected": true,
+            "text": " "
+          }
+        ],
+        "llama_rows": [
+          {
+            "id": 28705,
+            "token": " ",
+            "bytes": [
+              32
+            ],
+            "logprob": -0.39769068360328674
+          },
+          {
+            "id": 28705,
+            "token": " ",
+            "bytes": [
+              32
+            ],
+            "logprob": -0.39769068360328674
+          }
+        ]
+      },
+      "divergence_note": "First generated token matches after top-k renormalization, but the sequence still diverges later; next work should debug multi-token/cache or later-layer accumulation parity rather than promote support."
+    }
+  ],
+  "validation_commands": [
+    "cargo fmt",
+    "cargo test --lib softmax_top_k -- --nocapture",
+    "cargo test --lib mixtral_moe_ffn_routes_top_k_experts -- --nocapture",
+    "cargo check",
+    "scripts/check-public-scrub.sh",
+    "Mixtral llama.cpp parity probes for hello_5tok, counting_1tok, and counting_5tok using the exact Q8_0 row"
+  ],
+  "generated_utc": "2026-05-09T21:48:06Z"
+}

--- a/qa/evidence-bundles/mixtral-8x7b-v0.1-q8-moe-runtime-parity-20260509/manifest.json
+++ b/qa/evidence-bundles/mixtral-8x7b-v0.1-q8-moe-runtime-parity-20260509/manifest.json
@@ -1,0 +1,170 @@
+{
+  "schema": "camelid.evidence.mixtral_moe_runtime_parity.v1",
+  "target_row": "Mixtral-8x7B-Instruct-v0.1.Q8_0",
+  "model_file": "mixtral-8x7b-instruct-v0.1-q8_0.gguf",
+  "model_sha256": "c48f9680d5aa60703ed0fd38e29fc6556b3490f8f6c9919a31c9da7996039f81",
+  "branch": "mixtral-exact-row-20260509",
+  "source_head_before_commit": "ce18d7c Add initial Mixtral MoE routing path",
+  "status": "bounded_runtime_and_one_prompt_parity_passed",
+  "support_boundary": "Evidence proves a bounded 1-token runtime smoke and one deterministic Mistral-instruct prompt parity check for the exact Mixtral Q8_0 row only. It does not claim broader Mixtral support, frontend support, long-context support, multi-prompt parity, or production readiness.",
+  "implementation_summary": [
+    "CPU materialization estimator treats lazy/file-backed Q8_0 rank-3 MoE expert tensors like rank-2 lazy Q8 linears so the safety guard reflects actual runtime materialization.",
+    "Loaded-weight validation now requires Mixtral router and rank-3 gate/up/down expert shapes when MoE metadata is present.",
+    "Mixtral router top-k now slices using the produced router logits width, fixing the full-model router panic seen during first smoke."
+  ],
+  "full_model_metadata": {
+    "file_size_bytes": 49626319776,
+    "tensor_count": 323,
+    "general.architecture": "llama",
+    "llama.embedding_length": 4096,
+    "llama.block_count": 32,
+    "llama.feed_forward_length": 14336,
+    "llama.attention.head_count": 32,
+    "llama.attention.head_count_kv": 8,
+    "llama.expert_count": 8,
+    "llama.expert_used_count": 2
+  },
+  "runtime_smoke": {
+    "endpoint": "/v1/completions",
+    "prompt": "Hello",
+    "max_tokens": 1,
+    "temperature": 0,
+    "top_k": 1,
+    "prompt_token_ids": [
+      1,
+      16230
+    ],
+    "generated_token_ids": [
+      28725
+    ],
+    "text": ",",
+    "server_rss_kib_after_smoke": 104764,
+    "timings_ms_summary": {
+      "tokenize": 5,
+      "weight_load": 3,
+      "weight_cache_hit": false,
+      "prompt_cache_hit": false,
+      "generate": 6983,
+      "forward_total": 6981.423,
+      "layers_total": 6946.465,
+      "logits": 34.906,
+      "prompt_token_count": 2,
+      "prefill_token_count": 1,
+      "first_token_evaluated": true
+    }
+  },
+  "one_prompt_parity": {
+    "render_mode": "mistral_instruct",
+    "expected_prompt": "<s>[INST] Hello [/INST]",
+    "reference_prompt_token_count": 9,
+    "reference_context": 512,
+    "prompt_tokens_match": true,
+    "generated_tokens_match": true,
+    "generated_text_match": true,
+    "backend_prompt_tokens": [
+      1,
+      28792,
+      16289,
+      28793,
+      22557,
+      733,
+      28748,
+      16289,
+      28793
+    ],
+    "reference_prompt_tokens": [
+      1,
+      28792,
+      16289,
+      28793,
+      22557,
+      733,
+      28748,
+      16289,
+      28793
+    ],
+    "backend_generated_tokens": [
+      22557
+    ],
+    "llama_generated_tokens": [
+      22557
+    ],
+    "backend_text": " Hello",
+    "llama_text": " Hello",
+    "first_generated_token_logit_comparison": {
+      "backend_token_id": 22557,
+      "llama_token_id": 22557,
+      "token_ids_match": true,
+      "backend_margin_llama_minus_backend": 0,
+      "llama_margin_llama_minus_backend": 0,
+      "margin_disagreement": 0,
+      "backend_rows": [
+        {
+          "token_id": 22557,
+          "logit": 32.353268,
+          "probability": 0.99792683,
+          "rank": 1,
+          "selected": true,
+          "text": " Hello"
+        },
+        {
+          "token_id": 22557,
+          "logit": 32.353268,
+          "probability": 0.99792683,
+          "rank": 1,
+          "selected": true,
+          "text": " Hello"
+        }
+      ],
+      "llama_rows": [
+        {
+          "id": 22557,
+          "token": " Hello",
+          "bytes": [
+            32,
+            72,
+            101,
+            108,
+            108,
+            111
+          ],
+          "logprob": -0.0009977428708225489
+        },
+        {
+          "id": 22557,
+          "token": " Hello",
+          "bytes": [
+            32,
+            72,
+            101,
+            108,
+            108,
+            111
+          ],
+          "logprob": -0.0009977428708225489
+        }
+      ]
+    },
+    "llama_memory_observation": "llama.cpp reference run reported CPU_Mapped model buffer 47193.83 MiB and AMX model buffer 1668.44 MiB in stderr; command time max RSS was 50195188 KiB.",
+    "elapsed_wall_clock": "0:32.13"
+  },
+  "validation_commands": [
+    "cargo fmt",
+    "cargo check",
+    "cargo test --lib mixtral_moe_ffn_routes_top_k_experts -- --nocapture",
+    "cargo test --test model_binding -- --nocapture",
+    "cargo test --test api_vertical_slice capabilities_report_support_contract_and_planned_lanes -- --nocapture",
+    "cargo test --test tokenizer mixtral -- --nocapture",
+    "cargo build --release",
+    "scripts/check-public-scrub.sh",
+    "node scripts/chat-parity-mistral.mjs --backend <camelid-api> --llama-url <llama-server> --model <exact-mixtral-q8-gguf> --model-id mixtral-smoke --llama-server <llama-server-bin> --llama-tokenize <llama-tokenize-bin> --start-llama-server --message Hello --max-tokens 1 --wait-ms 1800000 --require-prompt-match --require-generated-match --diagnostics-out <artifact>"
+  ],
+  "raw_artifacts_not_committed": [
+    "target/mixtral-smoke-20260509/completion-hello-1tok-v4.json",
+    "target/mixtral-parity-20260509/hello-1tok.json",
+    "target/mixtral-parity-20260509/hello-1tok.stdout",
+    "target/mixtral-parity-20260509/hello-1tok.stderr",
+    "target/mixtral-parity-20260509/hello-1tok.time"
+  ],
+  "generated_utc": "2026-05-09T21:10:40Z"
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -32,7 +32,7 @@ use crate::{
         LlamaLayerMemoryTimings, LlamaLayerTimings, LlamaLoadedWeights,
         LlamaOutputProjectionDiagnostic, LlamaSampler, SamplingConfig,
     },
-    model::{DenseLlamaDims, LlamaModelConfig, LlamaTensorBinding},
+    model::{DenseLlamaDims, LlamaFfnTensors, LlamaModelConfig, LlamaTensorBinding},
     tensor::{CpuTensor, Q8_0Block, TensorStore},
     tokenizer::Tokenizer,
     BackendError,
@@ -1773,9 +1773,6 @@ fn estimate_cpu_weight_materialization_bytes(binding: &LlamaTensorBinding) -> cr
             &layer.attention_v,
             &layer.attention_output,
             &layer.ffn_norm,
-            &layer.ffn_gate,
-            &layer.ffn_up,
-            &layer.ffn_down,
         ] {
             total = total
                 .checked_add(tensor_estimate(desc, retain_q8_blocks, lazy_q8_linear)?)
@@ -1784,6 +1781,35 @@ fn estimate_cpu_weight_materialization_bytes(binding: &LlamaTensorBinding) -> cr
                         "CPU materialization byte estimate overflow".to_string(),
                     )
                 })?;
+        }
+        match &layer.ffn {
+            LlamaFfnTensors::Dense { gate, up, down } => {
+                for desc in [gate, up, down] {
+                    total = total
+                        .checked_add(tensor_estimate(desc, retain_q8_blocks, lazy_q8_linear)?)
+                        .ok_or_else(|| {
+                            BackendError::InvalidTensorData(
+                                "CPU materialization byte estimate overflow".to_string(),
+                            )
+                        })?;
+                }
+            }
+            LlamaFfnTensors::MoE {
+                router,
+                gate_experts,
+                up_experts,
+                down_experts,
+            } => {
+                for desc in [router, gate_experts, up_experts, down_experts] {
+                    total = total
+                        .checked_add(tensor_estimate(desc, retain_q8_blocks, lazy_q8_linear)?)
+                        .ok_or_else(|| {
+                            BackendError::InvalidTensorData(
+                                "CPU materialization byte estimate overflow".to_string(),
+                            )
+                        })?;
+                }
+            }
         }
     }
     Ok(total)
@@ -4523,9 +4549,11 @@ mod tests {
                 attention_v: desc("blk.0.attn_v.weight"),
                 attention_output: desc("blk.0.attn_output.weight"),
                 ffn_norm: desc("blk.0.ffn_norm.weight"),
-                ffn_gate: desc("blk.0.ffn_gate.weight"),
-                ffn_up: desc("blk.0.ffn_up.weight"),
-                ffn_down: desc("blk.0.ffn_down.weight"),
+                ffn: LlamaFfnTensors::Dense {
+                    gate: desc("blk.0.ffn_gate.weight"),
+                    up: desc("blk.0.ffn_up.weight"),
+                    down: desc("blk.0.ffn_down.weight"),
+                },
             }],
         }
     }
@@ -4664,6 +4692,7 @@ mod tests {
             rms_norm_epsilon: 1e-6,
             vocab_size: Some(3),
             file_type: Some(0),
+            moe: None,
         }
     }
 
@@ -4698,6 +4727,7 @@ mod tests {
                 ffn_gate: select_rows("blk.0.ffn_gate.weight", ffn, hidden, &[0, 1, 2, 3, 0, 1]),
                 ffn_up: select_rows("blk.0.ffn_up.weight", ffn, hidden, &[0, 1, 2, 3, 0, 1]),
                 ffn_down: select_rows("blk.0.ffn_down.weight", hidden, ffn, &[0, 1, 2, 3]),
+                moe_router: None,
             }],
         }
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1686,7 +1686,7 @@ fn estimate_cpu_weight_materialization_bytes(binding: &LlamaTensorBinding) -> cr
         })?;
         let file_backed_q8_linear = lazy_q8_linear
             && desc.tensor_type == GgufTensorType::Q8_0
-            && desc.dimensions.len() == 2;
+            && matches!(desc.dimensions.len(), 2 | 3);
         let f32_bytes = if file_backed_q8_linear {
             0
         } else {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -5601,6 +5601,12 @@ fn softmax_top_k(logits: &[f32], k: usize) -> Vec<(usize, f32)> {
             .unwrap_or(std::cmp::Ordering::Equal)
     });
     scored.truncate(k);
+    let selected_sum = scored.iter().map(|(_, value)| *value).sum::<f32>();
+    if selected_sum > 0.0 {
+        for (_, value) in &mut scored {
+            *value /= selected_sum;
+        }
+    }
     scored
 }
 
@@ -13805,6 +13811,17 @@ mod tests {
             sampled_attention_trace_heads(32, 8, 4, GqaHeadMapping::Modulo),
             vec![0, 1, 2, 3, 28, 29, 30, 31]
         );
+    }
+
+    #[test]
+    fn softmax_top_k_renormalizes_selected_experts() {
+        let top = softmax_top_k(&[0.0, 1.0, 2.0], 2);
+        assert_eq!(top[0].0, 2);
+        assert_eq!(top[1].0, 1);
+        let selected_sum = top.iter().map(|(_, weight)| *weight).sum::<f32>();
+        assert!((selected_sum - 1.0).abs() < 1.0e-6, "{top:?}");
+        let expected_first = 2.0_f32.exp() / (2.0_f32.exp() + 1.0_f32.exp());
+        assert!((top[0].1 - expected_first).abs() < 1.0e-6, "{top:?}");
     }
 
     #[test]

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 
 use crate::{
     gguf::GgufTensorType,
-    model::{DenseLlamaDims, LlamaModelConfig, LlamaTensorBinding},
+    model::{DenseLlamaDims, LlamaFfnTensors, LlamaModelConfig, LlamaTensorBinding},
     tensor::{
         dot_product, parse_byte_count_env, q8_0_file_read_stats, record_q8_0_file_read,
         should_parallelize_linear_output, with_q8_file_cache_capacity_override, CpuTensor,
@@ -198,6 +198,7 @@ pub struct LlamaLayerWeights {
     pub ffn_gate: CpuTensor,
     pub ffn_up: CpuTensor,
     pub ffn_down: CpuTensor,
+    pub moe_router: Option<CpuTensor>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -670,6 +671,10 @@ impl LlamaLoadedWeights {
                     || tensor_has_q8_0_file_backing(&layer.ffn_gate)
                     || tensor_has_q8_0_file_backing(&layer.ffn_up)
                     || tensor_has_q8_0_file_backing(&layer.ffn_down)
+                    || layer
+                        .moe_router
+                        .as_ref()
+                        .is_some_and(tensor_has_q8_0_file_backing)
             })
     }
 
@@ -685,6 +690,7 @@ impl LlamaLoadedWeights {
                     &layer.ffn_gate,
                     &layer.ffn_up,
                     &layer.ffn_down,
+                    layer.moe_router.as_ref().unwrap_or(&layer.ffn_norm),
                 ]
                 .into_iter()
                 .map(tensor_q8_0_file_backed_storage_bytes)
@@ -722,6 +728,25 @@ impl LlamaLoadedWeights {
             .transpose()?;
         let mut layers = Vec::with_capacity(binding.layers.len());
         for layer in &binding.layers {
+            let (ffn_gate, ffn_up, ffn_down, moe_router) = match &layer.ffn {
+                LlamaFfnTensors::Dense { gate, up, down } => (
+                    load_linear(&gate.name)?,
+                    load_linear(&up.name)?,
+                    load_linear(&down.name)?,
+                    None,
+                ),
+                LlamaFfnTensors::MoE {
+                    router,
+                    gate_experts,
+                    up_experts,
+                    down_experts,
+                } => (
+                    store.load_q8_0_file_backed_tensor(&gate_experts.name)?,
+                    store.load_q8_0_file_backed_tensor(&up_experts.name)?,
+                    store.load_q8_0_file_backed_tensor(&down_experts.name)?,
+                    Some(store.load_cpu_f32(&router.name)?),
+                ),
+            };
             layers.push(LlamaLayerWeights {
                 attention_norm: store.load_cpu_f32(&layer.attention_norm.name)?,
                 attention_q: load_linear(&layer.attention_q.name)?,
@@ -729,9 +754,10 @@ impl LlamaLoadedWeights {
                 attention_v: load_linear(&layer.attention_v.name)?,
                 attention_output: load_linear(&layer.attention_output.name)?,
                 ffn_norm: store.load_cpu_f32(&layer.ffn_norm.name)?,
-                ffn_gate: load_linear(&layer.ffn_gate.name)?,
-                ffn_up: load_linear(&layer.ffn_up.name)?,
-                ffn_down: load_linear(&layer.ffn_down.name)?,
+                ffn_gate,
+                ffn_up,
+                ffn_down,
+                moe_router,
             });
         }
         Ok(Self {
@@ -3367,48 +3393,92 @@ fn forward_layer_timed(
     }
     trace_forward_layer_memory(layer_idx, "ffn_norm_done");
 
-    let activated = gated_ffn_activation(
-        &ffn_norm,
-        &layer.ffn_gate,
-        &layer.ffn_up,
-        format!("layer_{layer_idx}_ffn_activated"),
-        collect_diagnostics,
-    )?;
-    timings.ffn_gate = activated.gate;
-    timings.ffn_up = activated.up;
-    timings.ffn_activation = activated.activation;
-    let ffn_gate_stats = activated.gate_stats;
-    let ffn_up_stats = activated.up_stats;
-    let ffn_gate_diagnostic = activated.gate_diagnostic;
-    let ffn_up_diagnostic = activated.up_diagnostic;
-    let ffn_activation_diagnostic = activated.activation_diagnostic;
-    let activated = activated.tensor;
-    let ffn_activation_stats = collect_diagnostics
-        .then(|| LlamaTensorStats::from_tensor(&activated))
-        .transpose()?;
-    if let Some(memory) = &mut memory {
-        memory.record_after_ffn_activation(capture_memory_sample(kv_cache));
-    }
-    trace_forward_layer_memory(layer_idx, "ffn_gate_up_activation_done");
-
-    let started = Instant::now();
-    let mut ffn_out = linear_for_role_runtime(
-        &activated,
-        &layer.ffn_down,
-        format!("layer_{layer_idx}_ffn_down"),
-        "ffn_down",
-        collect_diagnostics,
-    )?;
+    let (
+        mut ffn_out,
+        ffn_gate_stats,
+        ffn_up_stats,
+        ffn_gate_diagnostic,
+        ffn_up_diagnostic,
+        ffn_activation_diagnostic,
+        ffn_activation_stats,
+        ffn_down_diagnostic,
+        ffn_output_stats,
+    ) = if let (Some(moe), Some(router)) = (&params.config.moe, &layer.moe_router) {
+        if collect_diagnostics {
+            return Err(BackendError::UnsupportedModelArchitecture(
+                    "Mixtral MoE diagnostics are not implemented yet; generation remains runtime-only until parity evidence is collected".to_string(),
+                ));
+        }
+        let (ffn_out, gate, up, activation, down) = mixtral_moe_ffn(
+            &ffn_norm,
+            router,
+            &layer.ffn_gate,
+            &layer.ffn_up,
+            &layer.ffn_down,
+            moe.expert_used_count as usize,
+            format!("layer_{layer_idx}_mixtral_moe_ffn"),
+        )?;
+        timings.ffn_gate = gate;
+        timings.ffn_up = up;
+        timings.ffn_activation = activation;
+        timings.ffn_down = down;
+        (ffn_out, None, None, None, None, None, None, None, None)
+    } else {
+        let activated = gated_ffn_activation(
+            &ffn_norm,
+            &layer.ffn_gate,
+            &layer.ffn_up,
+            format!("layer_{layer_idx}_ffn_activated"),
+            collect_diagnostics,
+        )?;
+        timings.ffn_gate = activated.gate;
+        timings.ffn_up = activated.up;
+        timings.ffn_activation = activated.activation;
+        let ffn_gate_stats = activated.gate_stats;
+        let ffn_up_stats = activated.up_stats;
+        let ffn_gate_diagnostic = activated.gate_diagnostic;
+        let ffn_up_diagnostic = activated.up_diagnostic;
+        let ffn_activation_diagnostic = activated.activation_diagnostic;
+        let activated = activated.tensor;
+        let ffn_activation_stats = collect_diagnostics
+            .then(|| LlamaTensorStats::from_tensor(&activated))
+            .transpose()?;
+        if let Some(memory) = &mut memory {
+            memory.record_after_ffn_activation(capture_memory_sample(kv_cache));
+        }
+        trace_forward_layer_memory(layer_idx, "ffn_gate_up_activation_done");
+        let started = Instant::now();
+        let ffn_out = linear_for_role_runtime(
+            &activated,
+            &layer.ffn_down,
+            format!("layer_{layer_idx}_ffn_down"),
+            "ffn_down",
+            collect_diagnostics,
+        )?;
+        let ffn_output_stats = collect_diagnostics
+            .then(|| LlamaTensorStats::from_tensor(&ffn_out))
+            .transpose()?;
+        let ffn_down_diagnostic = collect_diagnostics
+            .then(|| {
+                linear_projection_diagnostics(&activated, &layer.ffn_down, &ffn_out, "ffn_down")
+            })
+            .transpose()?;
+        timings.ffn_down = started.elapsed().as_micros();
+        (
+            ffn_out,
+            ffn_gate_stats,
+            ffn_up_stats,
+            ffn_gate_diagnostic,
+            ffn_up_diagnostic,
+            ffn_activation_diagnostic,
+            ffn_activation_stats,
+            ffn_down_diagnostic,
+            ffn_output_stats,
+        )
+    };
     if collect_diagnostics && diagnostic_zero_delta(DeltaZeroTarget::Ffn, layer_idx)? {
         ffn_out = zero_like(&ffn_out, format!("layer_{layer_idx}_ffn_down_zeroed"))?;
     }
-    let ffn_output_stats = collect_diagnostics
-        .then(|| LlamaTensorStats::from_tensor(&ffn_out))
-        .transpose()?;
-    let ffn_down_diagnostic = collect_diagnostics
-        .then(|| linear_projection_diagnostics(&activated, &layer.ffn_down, &ffn_out, "ffn_down"))
-        .transpose()?;
-    timings.ffn_down = started.elapsed().as_micros();
     if let Some(memory) = &mut memory {
         memory.record_after_ffn_down(capture_memory_sample(kv_cache));
     }
@@ -3679,30 +3749,47 @@ fn forward_prefill_layer_chunk_timed(
     }
     trace_chunk_memory("ffn_norm_done");
 
-    let activated = gated_ffn_activation_batch(
-        &ffn_norm,
-        &layer.ffn_gate,
-        &layer.ffn_up,
-        format!("layer_{layer_idx}_prefill_ffn_activated"),
-    )?;
-    timings.ffn_gate = activated.gate;
-    timings.ffn_up = activated.up;
-    timings.ffn_activation = activated.activation;
-    let activated = activated.tensor;
-    if let Some(memory) = &mut memory {
-        memory.record_after_ffn_activation(capture_memory_sample(kv_cache));
-    }
-    trace_chunk_memory("ffn_gate_up_activation_done");
-
-    let started = Instant::now();
-    let ffn_out = linear_for_role_runtime(
-        &activated,
-        &layer.ffn_down,
-        format!("layer_{layer_idx}_prefill_ffn_down"),
-        "ffn_down",
-        false,
-    )?;
-    timings.ffn_down = started.elapsed().as_micros();
+    let ffn_out = if let (Some(moe), Some(router)) = (&params.config.moe, &layer.moe_router) {
+        let (ffn_out, gate, up, activation, down) = mixtral_moe_ffn(
+            &ffn_norm,
+            router,
+            &layer.ffn_gate,
+            &layer.ffn_up,
+            &layer.ffn_down,
+            moe.expert_used_count as usize,
+            format!("layer_{layer_idx}_prefill_mixtral_moe_ffn"),
+        )?;
+        timings.ffn_gate = gate;
+        timings.ffn_up = up;
+        timings.ffn_activation = activation;
+        timings.ffn_down = down;
+        ffn_out
+    } else {
+        let activated = gated_ffn_activation_batch(
+            &ffn_norm,
+            &layer.ffn_gate,
+            &layer.ffn_up,
+            format!("layer_{layer_idx}_prefill_ffn_activated"),
+        )?;
+        timings.ffn_gate = activated.gate;
+        timings.ffn_up = activated.up;
+        timings.ffn_activation = activated.activation;
+        let activated = activated.tensor;
+        if let Some(memory) = &mut memory {
+            memory.record_after_ffn_activation(capture_memory_sample(kv_cache));
+        }
+        trace_chunk_memory("ffn_gate_up_activation_done");
+        let started = Instant::now();
+        let ffn_out = linear_for_role_runtime(
+            &activated,
+            &layer.ffn_down,
+            format!("layer_{layer_idx}_prefill_ffn_down"),
+            "ffn_down",
+            false,
+        )?;
+        timings.ffn_down = started.elapsed().as_micros();
+        ffn_out
+    };
     if let Some(memory) = &mut memory {
         memory.record_after_ffn_down(capture_memory_sample(kv_cache));
     }
@@ -5455,6 +5542,165 @@ fn gated_ffn_activation_batch(
     })
 }
 
+fn softmax_top_k(logits: &[f32], k: usize) -> Vec<(usize, f32)> {
+    let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let mut scored = logits
+        .iter()
+        .enumerate()
+        .map(|(idx, value)| (idx, (*value - max).exp()))
+        .collect::<Vec<_>>();
+    let sum = scored.iter().map(|(_, value)| *value).sum::<f32>();
+    for (_, value) in &mut scored {
+        *value /= sum;
+    }
+    scored.sort_by(|left, right| {
+        right
+            .1
+            .partial_cmp(&left.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    scored.truncate(k);
+    scored
+}
+
+fn expert_matrix_view(
+    weight: &CpuTensor,
+    expert_idx: usize,
+    input_width: usize,
+    output_width: usize,
+    name: impl Into<String>,
+) -> Result<CpuTensor> {
+    if weight.rank() != 3 {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "MoE expert tensor {} expected rank 3, got {:?}",
+            weight.name, weight.shape.dims
+        )));
+    }
+    let experts = weight.dim(2)?;
+    if expert_idx >= experts {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "MoE expert index {expert_idx} out of bounds for {} experts",
+            experts
+        )));
+    }
+    let expert_elements = input_width.checked_mul(output_width).ok_or_else(|| {
+        BackendError::RuntimeShapeMismatch("MoE expert element count overflow".to_string())
+    })?;
+    if weight.dim(0)? != input_width || weight.dim(1)? != output_width {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "MoE expert tensor {} expected per-expert dims [{input_width}, {output_width}], got {:?}",
+            weight.name, weight.shape.dims
+        )));
+    }
+    let block_offset = expert_elements.checked_mul(expert_idx).ok_or_else(|| {
+        BackendError::RuntimeShapeMismatch("MoE expert offset overflow".to_string())
+    })? / Q8_0_BLOCK_VALUES;
+    let block_count = expert_elements / Q8_0_BLOCK_VALUES;
+    let mut tensor = if let Some(backing) = &weight.q8_0_file_backing {
+        CpuTensor::q8_0_file_backed_linear(
+            name,
+            TensorShape {
+                dims: vec![output_width, input_width],
+            },
+            Q8_0FileBacking::new(
+                backing.path.clone(),
+                backing.absolute_offset + (block_offset * Q8BlockReader::BLOCK_SIZE_BYTES) as u64,
+                block_count,
+            ),
+        )
+    } else {
+        let start = expert_elements * expert_idx;
+        let end = start + expert_elements;
+        let data = weight
+            .data
+            .get(start..end)
+            .ok_or_else(|| {
+                BackendError::RuntimeShapeMismatch(format!(
+                    "MoE expert slice {start}..{end} missing from {}",
+                    weight.name
+                ))
+            })?
+            .to_vec();
+        CpuTensor::from_f32(name, vec![output_width, input_width], data)?
+    };
+    tensor.source_type = weight.source_type;
+    if let Some(blocks) = &weight.q8_0_blocks {
+        tensor.q8_0_blocks = Some(blocks[block_offset..block_offset + block_count].to_vec());
+    }
+    Ok(tensor)
+}
+
+fn mixtral_moe_ffn(
+    input: &CpuTensor,
+    router: &CpuTensor,
+    gate_experts: &CpuTensor,
+    up_experts: &CpuTensor,
+    down_experts: &CpuTensor,
+    expert_used_count: usize,
+    name: impl Into<String>,
+) -> Result<(CpuTensor, u128, u128, u128, u128)> {
+    if input.rank() != 2 {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Mixtral MoE FFN expects rank-2 input, got {:?}",
+            input.shape.dims
+        )));
+    }
+    let rows = input.dim(0)?;
+    let hidden = input.dim(1)?;
+    let ff = gate_experts.dim(1)?;
+    let expert_count = router.dim(0)?.max(router.dim(1)?);
+    let router_started = Instant::now();
+    let logits = linear_for_role_runtime(input, router, "mixtral_router", "linear", false)?;
+    let router_elapsed = router_started.elapsed().as_micros();
+    let mut output = vec![0.0_f32; rows * hidden];
+    let mut gate_elapsed = 0;
+    let mut up_elapsed = 0;
+    let mut activation_elapsed = 0;
+    let mut down_elapsed = 0;
+    for row in 0..rows {
+        let row_input = CpuTensor::from_f32(
+            "mixtral_moe_row",
+            vec![1, hidden],
+            input.data[row * hidden..(row + 1) * hidden].to_vec(),
+        )?;
+        let top = softmax_top_k(
+            &logits.data[row * expert_count..(row + 1) * expert_count],
+            expert_used_count,
+        );
+        for (expert_idx, weight) in top {
+            let gate =
+                expert_matrix_view(gate_experts, expert_idx, hidden, ff, "mixtral_gate_expert")?;
+            let up = expert_matrix_view(up_experts, expert_idx, hidden, ff, "mixtral_up_expert")?;
+            let down =
+                expert_matrix_view(down_experts, expert_idx, ff, hidden, "mixtral_down_expert")?;
+            let activated =
+                gated_ffn_activation(&row_input, &gate, &up, "mixtral_expert_activated", false)?;
+            gate_elapsed += activated.gate;
+            up_elapsed += activated.up;
+            activation_elapsed += activated.activation;
+            let started = Instant::now();
+            let expert_out = linear_for_role_runtime(
+                &activated.tensor,
+                &down,
+                "mixtral_expert_down",
+                "ffn_down",
+                false,
+            )?;
+            down_elapsed += started.elapsed().as_micros();
+            for col in 0..hidden {
+                output[row * hidden + col] += expert_out.data[col] * weight;
+            }
+        }
+    }
+    Ok((
+        CpuTensor::from_f32(name, vec![rows, hidden], output)?,
+        gate_elapsed + router_elapsed,
+        up_elapsed,
+        activation_elapsed,
+        down_elapsed,
+    ))
+}
+
 fn ffn_activation_diagnostics(
     gate: &CpuTensor,
     up: &CpuTensor,
@@ -5730,12 +5976,30 @@ fn auto_retain_q8_0_blocks_for_fast_local_chat(binding: &LlamaTensorBinding) -> 
             &layer.attention_k,
             &layer.attention_v,
             &layer.attention_output,
-            &layer.ffn_gate,
-            &layer.ffn_up,
-            &layer.ffn_down,
         ] {
             if add_linear(desc).is_none() {
                 return false;
+            }
+        }
+        match &layer.ffn {
+            LlamaFfnTensors::Dense { gate, up, down } => {
+                for desc in [gate, up, down] {
+                    if add_linear(desc).is_none() {
+                        return false;
+                    }
+                }
+            }
+            LlamaFfnTensors::MoE {
+                router,
+                gate_experts,
+                up_experts,
+                down_experts,
+            } => {
+                for desc in [router, gate_experts, up_experts, down_experts] {
+                    if add_linear(desc).is_none() {
+                        return false;
+                    }
+                }
             }
         }
     }
@@ -8840,6 +9104,7 @@ mod tests {
                     .unwrap(),
                 ffn_down: CpuTensor::from_f32("blk.0.ffn_down.weight", vec![2, 2], vec![1.0; 4])
                     .unwrap(),
+                moe_router: None,
             }],
         }
     }
@@ -9112,6 +9377,7 @@ mod tests {
             rms_norm_epsilon: 1.0e-5,
             vocab_size: Some(2),
             file_type: None,
+            moe: None,
         };
         let dense_vector = |name: &str| CpuTensor::from_f32(name, vec![32], vec![1.0; 32]).unwrap();
         let dense_matrix =
@@ -9141,6 +9407,7 @@ mod tests {
                 ffn_gate: dense_matrix("blk.0.ffn_gate.weight"),
                 ffn_up: dense_matrix("blk.0.ffn_up.weight"),
                 ffn_down: dense_matrix("blk.0.ffn_down.weight"),
+                moe_router: None,
             }],
         };
         let mut session = LlamaInferenceSession::new(config, weights).unwrap();
@@ -10934,6 +11201,7 @@ mod tests {
             rms_norm_epsilon: 1e-6,
             vocab_size: None,
             file_type: None,
+            moe: None,
         };
         let tensor = CpuTensor::from_f32("query", vec![1, 4], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
 
@@ -10969,6 +11237,7 @@ mod tests {
             rms_norm_epsilon: 1e-5,
             vocab_size: None,
             file_type: None,
+            moe: None,
         };
         let tensor = CpuTensor::from_f32("query", vec![1, 4], vec![0.0, 0.0, 1.0, 0.0]).unwrap();
 
@@ -11014,6 +11283,7 @@ mod tests {
             rms_norm_epsilon: 1e-5,
             vocab_size: None,
             file_type: None,
+            moe: None,
         };
         let tensor = CpuTensor::from_f32("query", vec![1, 4], vec![0.0, 0.0, 1.0, 0.0]).unwrap();
 
@@ -11063,6 +11333,7 @@ mod tests {
             rms_norm_epsilon: 1e-5,
             vocab_size: None,
             file_type: None,
+            moe: None,
         };
         let tensor = CpuTensor::from_f32("query", vec![1, 4], vec![0.0, 0.0, 1.0, 0.0]).unwrap();
         let rope_freqs = CpuTensor::from_f32("rope_freqs.weight", vec![2], vec![1.0, 4.0]).unwrap();
@@ -11119,6 +11390,7 @@ mod tests {
             rms_norm_epsilon: 1e-6,
             vocab_size: None,
             file_type: None,
+            moe: None,
         };
         let tensor = CpuTensor::from_f32("query", vec![1, 4], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
         let reported = apply_rope(&tensor, 1, 2, &config, None, "query_rope").unwrap();
@@ -11180,6 +11452,7 @@ mod tests {
             rms_norm_epsilon: 1e-6,
             vocab_size: None,
             file_type: None,
+            moe: None,
         };
         let tensor = CpuTensor::from_f32("query", vec![1, 4], vec![1.0, 0.0, 0.0, 0.0]).unwrap();
         let head_dim = 4;
@@ -11253,6 +11526,7 @@ mod tests {
             rms_norm_epsilon: 1e-6,
             vocab_size: None,
             file_type: None,
+            moe: None,
         };
         let tensor = CpuTensor::from_f32("query", vec![1, 2], vec![1.0, 0.0]).unwrap();
         let head_dim = 2;
@@ -11325,6 +11599,7 @@ mod tests {
             rms_norm_epsilon: 1e-6,
             vocab_size: None,
             file_type: None,
+            moe: None,
         };
         let tensor = CpuTensor::from_f32("query", vec![1, 2], vec![1.0, 0.0]).unwrap();
 
@@ -12221,6 +12496,7 @@ mod tests {
             rms_norm_epsilon: 0.0,
             vocab_size: Some(3),
             file_type: None,
+            moe: None,
         };
         let weights = Arc::new(LlamaLoadedWeights {
             token_embedding: CpuTensor::from_f32(
@@ -12298,6 +12574,7 @@ mod tests {
                     vec![1.0, 0.0, 0.0, 1.0],
                 )
                 .unwrap(),
+                moe_router: None,
             }],
         });
         let mut session = LlamaInferenceSession::new(config, weights).unwrap();
@@ -12461,6 +12738,7 @@ mod tests {
             rms_norm_epsilon: 1.0e-5,
             vocab_size: Some(4),
             file_type: None,
+            moe: None,
         };
         let weights = Arc::new(LlamaLoadedWeights {
             token_embedding: CpuTensor::from_f32(
@@ -12531,6 +12809,7 @@ mod tests {
                     vec![0.7, -0.2, 0.4, 0.3],
                 )
                 .unwrap(),
+                moe_router: None,
             }],
         });
 
@@ -12669,6 +12948,7 @@ mod tests {
             rms_norm_epsilon: 1.0e-5,
             vocab_size: Some(4),
             file_type: None,
+            moe: None,
         };
         let layer = LlamaLayerWeights {
             attention_norm: CpuTensor::from_f32("blk.0.attn_norm.weight", vec![2], vec![1.0, 1.0])
@@ -12717,6 +12997,7 @@ mod tests {
                 vec![1.0, 0.0, 0.0, 1.0],
             )
             .unwrap(),
+            moe_router: None,
         };
         let hidden = CpuTensor::from_f32("hidden", vec![2, 2], vec![0.1, 0.2, 0.3, 0.4]).unwrap();
         let plan = LlamaKvCachePlan::from_config(&config).unwrap();
@@ -12766,6 +13047,7 @@ mod tests {
             rms_norm_epsilon: 1.0e-5,
             vocab_size: Some(4),
             file_type: None,
+            moe: None,
         };
         let kv_cache = LlamaKvCache::new(LlamaKvCachePlan::from_config(&config).unwrap()).unwrap();
         let query = CpuTensor::from_f32("query", vec![1, 2], vec![0.1, 0.2]).unwrap();
@@ -12905,6 +13187,7 @@ mod tests {
             rms_norm_epsilon: 1.0e-5,
             vocab_size: Some(4),
             file_type: None,
+            moe: None,
         };
         let weights = Arc::new(LlamaLoadedWeights {
             token_embedding: CpuTensor::from_f32(
@@ -12975,6 +13258,7 @@ mod tests {
                     vec![0.7, -0.2, 0.4, 0.3],
                 )
                 .unwrap(),
+                moe_router: None,
             }],
         });
 
@@ -13480,5 +13764,44 @@ mod tests {
             sampled_attention_trace_heads(32, 8, 4, GqaHeadMapping::Modulo),
             vec![0, 1, 2, 3, 28, 29, 30, 31]
         );
+    }
+
+    #[test]
+    fn mixtral_moe_ffn_routes_top_k_experts() {
+        let input = CpuTensor::from_f32("input", vec![1, 2], vec![1.0, 1.0]).unwrap();
+        let router = CpuTensor::from_f32("router", vec![2, 2], vec![10.0, 0.0, 0.0, 0.0]).unwrap();
+        let gate_experts = CpuTensor::from_f32(
+            "gate_experts",
+            vec![2, 2, 2],
+            vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        )
+        .unwrap();
+        let up_experts = CpuTensor::from_f32(
+            "up_experts",
+            vec![2, 2, 2],
+            vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        )
+        .unwrap();
+        let down_experts = CpuTensor::from_f32(
+            "down_experts",
+            vec![2, 2, 2],
+            vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        )
+        .unwrap();
+
+        let (out, ..) = mixtral_moe_ffn(
+            &input,
+            &router,
+            &gate_experts,
+            &up_experts,
+            &down_experts,
+            2,
+            "out",
+        )
+        .unwrap();
+
+        let expected = 1.0 / (1.0 + (-1.0_f32).exp());
+        assert!((out.data[0] - expected).abs() < 1.0e-3, "{:?}", out.data);
+        assert!((out.data[1] - expected).abs() < 1.0e-3, "{:?}", out.data);
     }
 }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -831,24 +831,65 @@ impl LlamaLoadedWeights {
                 &[dims.embedding_length],
                 &format!("layer {idx} ffn norm"),
             )?;
-            require_matrix_shape(
-                &layer.ffn_gate,
-                dims.embedding_length,
-                dims.feed_forward_length,
-                &format!("layer {idx} ffn gate"),
-            )?;
-            require_matrix_shape(
-                &layer.ffn_up,
-                dims.embedding_length,
-                dims.feed_forward_length,
-                &format!("layer {idx} ffn up"),
-            )?;
-            require_matrix_shape(
-                &layer.ffn_down,
-                dims.feed_forward_length,
-                dims.embedding_length,
-                &format!("layer {idx} ffn down"),
-            )?;
+            if let Some(moe) = &config.moe {
+                let router = layer.moe_router.as_ref().ok_or_else(|| {
+                    BackendError::RuntimeShapeMismatch(format!(
+                        "layer {idx} Mixtral MoE router tensor is missing"
+                    ))
+                })?;
+                require_matrix_shape(
+                    router,
+                    dims.embedding_length,
+                    moe.expert_count as usize,
+                    &format!("layer {idx} ffn router"),
+                )?;
+                require_tensor_shape(
+                    &layer.ffn_gate,
+                    &[
+                        dims.embedding_length,
+                        dims.feed_forward_length,
+                        moe.expert_count as usize,
+                    ],
+                    &format!("layer {idx} ffn gate experts"),
+                )?;
+                require_tensor_shape(
+                    &layer.ffn_up,
+                    &[
+                        dims.embedding_length,
+                        dims.feed_forward_length,
+                        moe.expert_count as usize,
+                    ],
+                    &format!("layer {idx} ffn up experts"),
+                )?;
+                require_tensor_shape(
+                    &layer.ffn_down,
+                    &[
+                        dims.feed_forward_length,
+                        dims.embedding_length,
+                        moe.expert_count as usize,
+                    ],
+                    &format!("layer {idx} ffn down experts"),
+                )?;
+            } else {
+                require_matrix_shape(
+                    &layer.ffn_gate,
+                    dims.embedding_length,
+                    dims.feed_forward_length,
+                    &format!("layer {idx} ffn gate"),
+                )?;
+                require_matrix_shape(
+                    &layer.ffn_up,
+                    dims.embedding_length,
+                    dims.feed_forward_length,
+                    &format!("layer {idx} ffn up"),
+                )?;
+                require_matrix_shape(
+                    &layer.ffn_down,
+                    dims.feed_forward_length,
+                    dims.embedding_length,
+                    &format!("layer {idx} ffn down"),
+                )?;
+            }
         }
 
         Ok(())
@@ -5648,10 +5689,10 @@ fn mixtral_moe_ffn(
     let rows = input.dim(0)?;
     let hidden = input.dim(1)?;
     let ff = gate_experts.dim(1)?;
-    let expert_count = router.dim(0)?.max(router.dim(1)?);
     let router_started = Instant::now();
     let logits = linear_for_role_runtime(input, router, "mixtral_router", "linear", false)?;
     let router_elapsed = router_started.elapsed().as_micros();
+    let expert_count = logits.dim(1)?;
     let mut output = vec![0.0_f32; rows * hidden];
     let mut gate_elapsed = 0;
     let mut up_elapsed = 0;

--- a/src/model.rs
+++ b/src/model.rs
@@ -23,6 +23,7 @@ pub struct LlamaModelConfig {
     pub rms_norm_epsilon: f32,
     pub vocab_size: Option<u32>,
     pub file_type: Option<u32>,
+    pub moe: Option<MixtralMoeMetadata>,
 }
 
 impl LlamaModelConfig {
@@ -37,12 +38,7 @@ impl LlamaModelConfig {
             }
         };
 
-        if let Some(moe) = MixtralMoeMetadata::from_gguf(gguf, architecture) {
-            return Err(BackendError::UnsupportedModelArchitecture(format!(
-                "{} MoE runtime is not implemented: expert_count={}, expert_used_count={}, router tensor pattern blk.N.ffn_gate_inp.weight plus expert tensors blk.N.ffn_{{gate,up,down}}_exps.weight require top-k expert routing; dense LLaMA/Mistral generation is disabled for this exact GGUF until that path has parity evidence",
-                moe.family_label, moe.expert_count, moe.expert_used_count
-            )));
-        }
+        let moe = MixtralMoeMetadata::from_gguf(gguf, architecture);
 
         let attention_head_count = required_u32(
             gguf,
@@ -100,6 +96,7 @@ impl LlamaModelConfig {
                     )
                 }),
             file_type: gguf.metadata_u32("general.file_type"),
+            moe,
         })
     }
 }
@@ -156,9 +153,22 @@ pub struct LlamaLayerTensors {
     pub attention_v: GgufTensorDescriptor,
     pub attention_output: GgufTensorDescriptor,
     pub ffn_norm: GgufTensorDescriptor,
-    pub ffn_gate: GgufTensorDescriptor,
-    pub ffn_up: GgufTensorDescriptor,
-    pub ffn_down: GgufTensorDescriptor,
+    pub ffn: LlamaFfnTensors,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub enum LlamaFfnTensors {
+    Dense {
+        gate: GgufTensorDescriptor,
+        up: GgufTensorDescriptor,
+        down: GgufTensorDescriptor,
+    },
+    MoE {
+        router: GgufTensorDescriptor,
+        gate_experts: GgufTensorDescriptor,
+        up_experts: GgufTensorDescriptor,
+        down_experts: GgufTensorDescriptor,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -196,9 +206,32 @@ impl LlamaTensorBinding {
                     &format!("blk.{layer_idx}.attn_output.weight"),
                 )?,
                 ffn_norm: required_tensor(gguf, &format!("blk.{layer_idx}.ffn_norm.weight"))?,
-                ffn_gate: required_tensor(gguf, &format!("blk.{layer_idx}.ffn_gate.weight"))?,
-                ffn_up: required_tensor(gguf, &format!("blk.{layer_idx}.ffn_up.weight"))?,
-                ffn_down: required_tensor(gguf, &format!("blk.{layer_idx}.ffn_down.weight"))?,
+                ffn: if config.moe.is_some() {
+                    LlamaFfnTensors::MoE {
+                        router: required_tensor(
+                            gguf,
+                            &format!("blk.{layer_idx}.ffn_gate_inp.weight"),
+                        )?,
+                        gate_experts: required_tensor(
+                            gguf,
+                            &format!("blk.{layer_idx}.ffn_gate_exps.weight"),
+                        )?,
+                        up_experts: required_tensor(
+                            gguf,
+                            &format!("blk.{layer_idx}.ffn_up_exps.weight"),
+                        )?,
+                        down_experts: required_tensor(
+                            gguf,
+                            &format!("blk.{layer_idx}.ffn_down_exps.weight"),
+                        )?,
+                    }
+                } else {
+                    LlamaFfnTensors::Dense {
+                        gate: required_tensor(gguf, &format!("blk.{layer_idx}.ffn_gate.weight"))?,
+                        up: required_tensor(gguf, &format!("blk.{layer_idx}.ffn_up.weight"))?,
+                        down: required_tensor(gguf, &format!("blk.{layer_idx}.ffn_down.weight"))?,
+                    }
+                },
             });
         }
 
@@ -288,24 +321,73 @@ impl LlamaTensorBinding {
                 &[dims.embedding_length],
                 &format!("layer {idx} ffn norm"),
             )?;
-            require_descriptor_matrix_shape(
-                &layer.ffn_gate,
-                dims.embedding_length,
-                dims.feed_forward_length,
-                &format!("layer {idx} ffn gate"),
-            )?;
-            require_descriptor_matrix_shape(
-                &layer.ffn_up,
-                dims.embedding_length,
-                dims.feed_forward_length,
-                &format!("layer {idx} ffn up"),
-            )?;
-            require_descriptor_matrix_shape(
-                &layer.ffn_down,
-                dims.feed_forward_length,
-                dims.embedding_length,
-                &format!("layer {idx} ffn down"),
-            )?;
+            match &layer.ffn {
+                LlamaFfnTensors::Dense { gate, up, down } => {
+                    require_descriptor_matrix_shape(
+                        gate,
+                        dims.embedding_length,
+                        dims.feed_forward_length,
+                        &format!("layer {idx} ffn gate"),
+                    )?;
+                    require_descriptor_matrix_shape(
+                        up,
+                        dims.embedding_length,
+                        dims.feed_forward_length,
+                        &format!("layer {idx} ffn up"),
+                    )?;
+                    require_descriptor_matrix_shape(
+                        down,
+                        dims.feed_forward_length,
+                        dims.embedding_length,
+                        &format!("layer {idx} ffn down"),
+                    )?;
+                }
+                LlamaFfnTensors::MoE {
+                    router,
+                    gate_experts,
+                    up_experts,
+                    down_experts,
+                } => {
+                    let moe = config.moe.as_ref().ok_or_else(|| {
+                        BackendError::InvalidModelMetadata(
+                            "MoE tensors were bound for a dense config".to_string(),
+                        )
+                    })?;
+                    require_descriptor_matrix_shape(
+                        router,
+                        dims.embedding_length,
+                        moe.expert_count as usize,
+                        &format!("layer {idx} ffn router"),
+                    )?;
+                    require_descriptor_shape(
+                        gate_experts,
+                        &[
+                            dims.embedding_length,
+                            dims.feed_forward_length,
+                            moe.expert_count as usize,
+                        ],
+                        &format!("layer {idx} ffn gate experts"),
+                    )?;
+                    require_descriptor_shape(
+                        up_experts,
+                        &[
+                            dims.embedding_length,
+                            dims.feed_forward_length,
+                            moe.expert_count as usize,
+                        ],
+                        &format!("layer {idx} ffn up experts"),
+                    )?;
+                    require_descriptor_shape(
+                        down_experts,
+                        &[
+                            dims.feed_forward_length,
+                            dims.embedding_length,
+                            moe.expert_count as usize,
+                        ],
+                        &format!("layer {idx} ffn down experts"),
+                    )?;
+                }
+            }
         }
 
         Ok(())

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1935,6 +1935,15 @@ impl TensorStore {
         if shape.dims.len() != 2 {
             return self.load_cpu_f32(name);
         }
+        self.load_q8_0_file_backed_tensor(name)
+    }
+
+    pub fn load_q8_0_file_backed_tensor(&self, name: &str) -> Result<CpuTensor> {
+        let desc = self.descriptor(name)?.clone();
+        if desc.tensor_type != GgufTensorType::Q8_0 {
+            return self.load_cpu_f32(name);
+        }
+        let shape = TensorShape::from_gguf_dims(&desc.dimensions)?;
         let expected_elements = shape.element_count()?;
         if expected_elements % 32 != 0 {
             return Err(BackendError::InvalidTensorData(format!(

--- a/tests/model_binding.rs
+++ b/tests/model_binding.rs
@@ -3,7 +3,7 @@ use std::{fs, path::Path};
 use camelid::{
     gguf::read_metadata,
     inference::LlamaKvCachePlan,
-    model::{LlamaModelConfig, LlamaTensorBinding},
+    model::{LlamaFfnTensors, LlamaModelConfig, LlamaTensorBinding},
 };
 
 #[test]
@@ -76,18 +76,33 @@ fn accepts_mistral_metadata_on_llama_dense_runtime() {
 }
 
 #[test]
-fn rejects_mixtral_moe_metadata_before_dense_tensor_binding() {
+fn binds_mixtral_moe_metadata_and_expert_tensors() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("mixtral-moe.gguf");
     write_mixtral_moe_gguf(&path);
 
     let gguf = read_metadata(&path).unwrap();
-    let err = LlamaModelConfig::from_gguf(&gguf).unwrap_err().to_string();
+    let config = LlamaModelConfig::from_gguf(&gguf).unwrap();
+    let binding = LlamaTensorBinding::bind(&gguf, &config).unwrap();
+    let moe = config.moe.as_ref().unwrap();
 
-    assert!(err.contains("Mixtral MoE runtime is not implemented"));
-    assert!(err.contains("expert_count=8"));
-    assert!(err.contains("expert_used_count=2"));
-    assert!(err.contains("ffn_gate_inp.weight"));
+    assert_eq!(moe.family_label, "Mixtral");
+    assert_eq!(moe.expert_count, 8);
+    assert_eq!(moe.expert_used_count, 2);
+    match &binding.layers[0].ffn {
+        LlamaFfnTensors::MoE {
+            router,
+            gate_experts,
+            up_experts,
+            down_experts,
+        } => {
+            assert_eq!(router.name, "blk.0.ffn_gate_inp.weight");
+            assert_eq!(gate_experts.name, "blk.0.ffn_gate_exps.weight");
+            assert_eq!(up_experts.name, "blk.0.ffn_up_exps.weight");
+            assert_eq!(down_experts.name, "blk.0.ffn_down_exps.weight");
+        }
+        LlamaFfnTensors::Dense { .. } => panic!("expected Mixtral MoE FFN tensors"),
+    }
 }
 
 #[test]
@@ -155,7 +170,10 @@ fn binds_required_llama_tensors() {
     assert!(!binding.output_is_tied_embedding);
     assert_eq!(binding.layers.len(), 1);
     assert_eq!(binding.layers[0].attention_q.name, "blk.0.attn_q.weight");
-    assert_eq!(binding.layers[0].ffn_down.name, "blk.0.ffn_down.weight");
+    match &binding.layers[0].ffn {
+        LlamaFfnTensors::Dense { down, .. } => assert_eq!(down.name, "blk.0.ffn_down.weight"),
+        LlamaFfnTensors::MoE { .. } => panic!("expected dense FFN tensors"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
