### PR TITLE
Work/ubuntu x86 q8 ffndown owner experimental

### DIFF
--- a/frontend/scripts/frontend-integration-smoke.mjs
+++ b/frontend/scripts/frontend-integration-smoke.mjs
@@ -53,6 +53,21 @@ try {
     supported_quantization: [{ id: 'broad_quant_trap', status: 'supported' }],
     model_compatibility: [
       {
+        id: 'tinyllama_1_1b_chat_q8_0',
+        status: 'supported_current_gate',
+        family: 'llama_spm_decoder',
+        quantization: 'Q8_0',
+        support_scope: 'exact row only',
+        frontend_readiness_gate: 'loaded_now + generation_ready + active_model_id + exact row',
+        full_support_status: 'guarded_by_exact_row',
+        full_support_blockers: 'arbitrary/Jinja templates, production throughput, portability',
+        evidence: 'TinyLlama fixture row; must not be inherited by misleading 3B backend ids.',
+        chat_template_renderer: 'tinyllama-marker',
+        chat_template_shape_pack: 'validated_bounded_pack',
+        performance_measured: 'measured',
+        next_step: 'preserve exact-row scoping before widening support claims',
+      },
+      {
         id: 'llama32_3b_instruct_q8_0',
         status: 'supported_current_gate',
         family: 'llama_bpe_decoder',
@@ -373,6 +388,42 @@ try {
   const liveBackendIdChatGate = getChatGateState(capabilities, liveBackendIdModel, liveBackendIdRuntime)
   assert.equal(liveBackendIdChatGate.chatUnlocked, true, '3B rows loaded under a backend-generated runtime id should still unlock from GGUF path + Q8_0 exact-row evidence')
   assert.equal(liveBackendIdChatGate.hint.target.id, 'llama32_3b_instruct_q8_0', 'backend-generated 3B runtime ids must resolve to the canonical exact row, not a broad family claim')
+
+  const misleadingTinyRuntimeModel = {
+    ...selectedModel,
+    id: 'tinyllama-q8',
+    name: resolveLoadedModelDisplayName({ fallbackName: 'tinyllama-q8', modelPath: selectedModel.model_path, quantLabel: selectedModel.quant }),
+    runtime_model_name: 'tinyllama-q8',
+  }
+  const misleadingTinyRuntime = { ...readyRuntime, active_model_id: misleadingTinyRuntimeModel.id }
+  const misleadingTinyChatGate = getChatGateState(capabilities, misleadingTinyRuntimeModel, misleadingTinyRuntime)
+  assert.equal(misleadingTinyChatGate.chatUnlocked, true, 'live 3B runs with a stale tinyllama-q8 runtime id should still unlock only from exact loaded GGUF path + Q8_0 support evidence')
+  assert.equal(misleadingTinyChatGate.hint.target.id, 'llama32_3b_instruct_q8_0', 'stale tinyllama-q8 runtime ids must not steal the TinyLlama row when the loaded file is Llama 3.2 3B Instruct Q8_0')
+
+  const misleadingTinyModelsMarkup = renderToStaticMarkup(React.createElement(ModelsView, {
+    runtime: misleadingTinyRuntime,
+    capabilities,
+    refreshDashboard: noop,
+    registerForm: { id: '', name: '', model_path: '', runtime_model_name: '' },
+    setRegisterForm: noop,
+    externalForm: { id: '', name: '', source: '', api_base: '', api_key: '', model_name: '' },
+    setExternalForm: noop,
+    registerModel: noop,
+    connectExternalModel: noop,
+    models: [misleadingTinyRuntimeModel],
+    selectedModelId: misleadingTinyRuntimeModel.id,
+    setSelectedModelId: noop,
+    loadingModelId: '',
+    activateModel: noop,
+    unloadCurrentModel: noop,
+    installModel: noop,
+    installCatalogModel: noop,
+    cancelModelDownload: noop,
+  }))
+
+  assert.match(misleadingTinyModelsMarkup, /llama32_3b_instruct_q8_0: supported current gate/, 'Models view should present the stale-id live run as the exact 3B row, not TinyLlama')
+  assert.match(misleadingTinyModelsMarkup, /Loaded exact-row match/, 'Models tracked 3B card should mark stale-id live runs as loaded exact-row matches')
+  assert.doesNotMatch(misleadingTinyModelsMarkup, /tinyllama_1_1b_chat_q8_0: supported current gate/, 'stale tinyllama-q8 runtime ids must not make the selected live 3B model inherit TinyLlama support copy')
 
   const liveBackendIdChatMarkup = renderToStaticMarkup(React.createElement(ChatWorkspace, {
     selectedConversation: null,

--- a/frontend/scripts/model-state-smoke.mjs
+++ b/frontend/scripts/model-state-smoke.mjs
@@ -419,6 +419,15 @@ const liveNamedThreeBModel = {
 const liveNamedThreeBGate = getChatGateState(capabilityFixture, liveNamedThreeBModel, { active_model_id: 'Llama 3.2 3B Instruct', loaded_now: true, generation_ready: true })
 assert.equal(liveNamedThreeBGate.hint.target.id, 'llama32_3b_instruct_q8_0', 'canonical Ubuntu 3B active_model_id copy without Q8_0 in the runtime name should still resolve through the exact loaded GGUF path plus Q8_0 metadata')
 assert.equal(liveNamedThreeBGate.chatUnlocked, true, 'canonical Ubuntu 3B human-readable active_model_id should unlock WebUI chat only when the exact loaded path, Q8_0 metadata, and runtime readiness are all green')
+const liveMisleadingTinyThreeBModel = {
+  ...liveScalarThreeBModel,
+  id: 'tinyllama-q8',
+  name: 'Llama 3.2 3B Instruct Q8_0',
+  runtime_model_name: 'tinyllama-q8',
+}
+const liveMisleadingTinyThreeBGate = getChatGateState(capabilityFixture, liveMisleadingTinyThreeBModel, { active_model_id: 'tinyllama-q8', loaded_now: true, generation_ready: true })
+assert.equal(liveMisleadingTinyThreeBGate.hint.target.id, 'llama32_3b_instruct_q8_0', 'canonical Ubuntu 3B runtime labels that still say tinyllama-q8 must resolve through the exact 3B GGUF path/name + Q8_0 metadata, not the TinyLlama row')
+assert.equal(liveMisleadingTinyThreeBGate.chatUnlocked, true, 'misleading backend runtime ids should not block or mislabel exact 3B WebUI support when the loaded GGUF path, quant, and runtime readiness are green')
 assert.equal(
   getChatGateState(capabilityFixture, { ...liveScalarThreeBModel, quant: 'Q4_K_M' }, { active_model_id: 'scalar_default_rerun', loaded_now: true, generation_ready: true }).chatUnlocked,
   false,

--- a/frontend/src/lib/capabilities.js
+++ b/frontend/src/lib/capabilities.js
@@ -505,6 +505,12 @@ export function findCompatibilityHint(capabilities, model, catalogItem) {
   const exactIdentityTarget = findExactCompatibilityRowByIdentity(rows, model, catalogItem)
   if (exactIdentityTarget) return quantAwareCompatibilityHint(exactIdentityTarget, quantKey, 'exact /api/capabilities row id match', { exact: true })
 
+  const llamaBpeIdentity = detectLlamaBpeTarget(subject)
+  if (llamaBpeIdentity) {
+    const hint = findLlamaBpeCompatibilityHint(rows, plannedFamilies, quantKey, llamaBpeIdentity)
+    if (hint) return hint.kind === 'quant_mismatch' ? { ...hint, observedQuant: model?.quant || catalogItem?.quant || quantKey } : hint
+  }
+
   if (subject.includes('tinyllama')) {
     const target = findRow((row) => row.id.includes('tinyllama'))
     if (target && quantKey && targetMatchesQuant(target, quantKey)) return { kind: 'compatibility', target, confidence: 'exact TinyLlama row + quant match', exact: true }
@@ -512,12 +518,6 @@ export function findCompatibilityHint(capabilities, model, catalogItem) {
     const quantSpecificTarget = findCompatibilityRowForQuant(rows, 'llama_spm_decoder', quantKey)
     if (quantSpecificTarget) return { kind: 'family', target: quantSpecificTarget, observedQuant: model?.quant || catalogItem?.quant || quantKey, confidence: 'family + quant match without exact TinyLlama row' }
     if (target) return { kind: 'quant_mismatch', target, observedQuant: model?.quant || catalogItem?.quant || quantKey, confidence: 'name/path match with different quant', exact: true }
-  }
-
-  const llamaBpeIdentity = detectLlamaBpeTarget(subject)
-  if (llamaBpeIdentity) {
-    const hint = findLlamaBpeCompatibilityHint(rows, plannedFamilies, quantKey, llamaBpeIdentity)
-    if (hint) return hint.kind === 'quant_mismatch' ? { ...hint, observedQuant: model?.quant || catalogItem?.quant || quantKey } : hint
   }
 
   if (subject.includes('mistral')) {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -3654,6 +3654,7 @@ fn forward_layer_timed(
         ffn_activation_stats,
         ffn_down_diagnostic,
         ffn_output_stats,
+        ffn_out_already_residual,
     ) = if let (Some(moe), Some(router)) = (&params.config.moe, &layer.moe_router) {
         if collect_diagnostics {
             return Err(BackendError::UnsupportedModelArchitecture(
@@ -3673,7 +3674,9 @@ fn forward_layer_timed(
         timings.ffn_up = up;
         timings.ffn_activation = activation;
         timings.ffn_down = down;
-        (ffn_out, None, None, None, None, None, None, None, None)
+        (
+            ffn_out, None, None, None, None, None, None, None, None, false,
+        )
     } else {
         let activated = gated_ffn_activation(
             &ffn_norm,
@@ -3699,13 +3702,39 @@ fn forward_layer_timed(
         }
         trace_forward_layer_memory(layer_idx, "ffn_gate_up_activation_done");
         let started = Instant::now();
-        let ffn_out = linear_for_role_runtime(
-            &activated,
-            &layer.ffn_down,
-            format!("layer_{layer_idx}_ffn_down"),
-            "ffn_down",
-            collect_diagnostics,
-        )?;
+        let (ffn_out, ffn_out_already_residual) = if !collect_diagnostics {
+            if let Some(output) = try_x86_q8_ffn_down_decode_owner_residual_path(
+                &activated,
+                &layer.ffn_down,
+                &residual,
+                format!("layer_{layer_idx}_ffn_residual"),
+                "ffn_down",
+            )? {
+                (output, true)
+            } else {
+                (
+                    linear_for_role_runtime(
+                        &activated,
+                        &layer.ffn_down,
+                        format!("layer_{layer_idx}_ffn_down"),
+                        "ffn_down",
+                        collect_diagnostics,
+                    )?,
+                    false,
+                )
+            }
+        } else {
+            (
+                linear_for_role_runtime(
+                    &activated,
+                    &layer.ffn_down,
+                    format!("layer_{layer_idx}_ffn_down"),
+                    "ffn_down",
+                    collect_diagnostics,
+                )?,
+                false,
+            )
+        };
         let ffn_output_stats = collect_diagnostics
             .then(|| LlamaTensorStats::from_tensor(&ffn_out))
             .transpose()?;
@@ -3725,6 +3754,7 @@ fn forward_layer_timed(
             ffn_activation_stats,
             ffn_down_diagnostic,
             ffn_output_stats,
+            ffn_out_already_residual,
         )
     };
     if collect_diagnostics && diagnostic_zero_delta(DeltaZeroTarget::Ffn, layer_idx)? {
@@ -3736,7 +3766,11 @@ fn forward_layer_timed(
     trace_forward_layer_memory(layer_idx, "ffn_down_done");
 
     let started = Instant::now();
-    let output = residual.add(&ffn_out, format!("layer_{layer_idx}_ffn_residual"))?;
+    let output = if ffn_out_already_residual {
+        ffn_out.clone()
+    } else {
+        residual.add(&ffn_out, format!("layer_{layer_idx}_ffn_residual"))?
+    };
     let ffn_residual_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&output))
         .transpose()?;
@@ -6891,6 +6925,78 @@ fn try_x86_q8_ffn_down_decode_owner_path(
             &packed.blocks[group_idx * blocks_per_row..(group_idx + 1) * blocks_per_row];
         let sums = q8_0_packed_rows4_dot(group_blocks, &quantized_input.blocks, interleave);
         output_chunk.copy_from_slice(&sums);
+    }
+    Ok(Some(CpuTensor::from_f32(
+        name,
+        vec![1, output_width],
+        output,
+    )?))
+}
+
+fn try_x86_q8_ffn_down_decode_owner_residual_path(
+    input: &CpuTensor,
+    weight: &CpuTensor,
+    residual: &CpuTensor,
+    name: impl Into<String>,
+    rectangular_role: &str,
+) -> Result<Option<CpuTensor>> {
+    if !x86_q8_ffn_down_decode_owner_enabled()
+        || rectangular_role != "ffn_down"
+        || input.rank() != 2
+        || input.dim(0)? != 1
+        || residual.rank() != 2
+        || residual.dim(0)? != 1
+        || weight.source_type != Some(GgufTensorType::Q8_0)
+    {
+        return Ok(None);
+    }
+    let input_width = input.dim(1)?;
+    let output_width = linear_output_width(input, weight, rectangular_role)?;
+    if residual.dim(1)? != output_width || residual.data.len() != output_width {
+        return Ok(None);
+    }
+    let borrowed = if weight.dim(1)? == input_width {
+        BorrowedLinearWeight::from_tensor(weight)?
+    } else if weight.dim(0)? == input_width {
+        BorrowedLinearWeight::from_tensor(weight)?.with_swapped_matrix_shape()
+    } else {
+        return Ok(None);
+    };
+    let Some((packed, interleave)) = q8_0_selected_borrowed_packed_rows4(borrowed) else {
+        return Ok(None);
+    };
+    if interleave != Q8_0PackedRows4Interleave::I8
+        || packed.rows != output_width
+        || packed.blocks_per_row != input_width / Q8_0_BLOCK_VALUES
+        || !input_width.is_multiple_of(Q8_0_BLOCK_VALUES)
+        || !output_width.is_multiple_of(4)
+    {
+        return Ok(None);
+    }
+    let quantized_input = quantize_q8_0_row(&input.data[..input_width]);
+    let mut output = residual.data.clone();
+    let blocks_per_row = packed.blocks_per_row;
+    if should_parallelize_linear_output(output.len()) {
+        output
+            .par_chunks_mut(4)
+            .enumerate()
+            .for_each(|(group_idx, output_chunk)| {
+                let group_blocks =
+                    &packed.blocks[group_idx * blocks_per_row..(group_idx + 1) * blocks_per_row];
+                let sums = q8_0_packed_rows4_dot(group_blocks, &quantized_input.blocks, interleave);
+                for lane in 0..4 {
+                    output_chunk[lane] += sums[lane];
+                }
+            });
+    } else {
+        for (group_idx, output_chunk) in output.chunks_mut(4).enumerate() {
+            let group_blocks =
+                &packed.blocks[group_idx * blocks_per_row..(group_idx + 1) * blocks_per_row];
+            let sums = q8_0_packed_rows4_dot(group_blocks, &quantized_input.blocks, interleave);
+            for lane in 0..4 {
+                output_chunk[lane] += sums[lane];
+            }
+        }
     }
     Ok(Some(CpuTensor::from_f32(
         name,


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
