### PR TITLE
Ubuntu x86 q8 planner attn consumer

### DIFF
--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -282,7 +282,7 @@ fn select_macos_q8_plan(
 
 fn select_linux_x86_q8_plan(
     profile: &ExecutionProfile,
-    _platform: &PlanPlatform,
+    platform: &PlanPlatform,
     env_updates: &mut BTreeMap<&'static str, Option<&'static str>>,
     reasons: &mut Vec<String>,
 ) -> (
@@ -293,8 +293,11 @@ fn select_linux_x86_q8_plan(
     &'static str,
     &'static str,
 ) {
-    if matches!(profile, ExecutionProfile::Safe) {
-        reasons.push("safe profile selected; optimized x86 Q8 paths disabled".into());
+    if !matches!(profile, ExecutionProfile::Experimental) {
+        reasons.push(
+            "Ubuntu/Linux x86_64 optimized Q8 path requires profile=experimental; failing closed to safe path"
+                .into(),
+        );
         return safe_q8_plan();
     }
     if env_flag_disabled("CAMELID_X86_Q8_REPACK") || env_flag_disabled("CAMELID_X86_Q8_KERNEL") {
@@ -316,11 +319,40 @@ fn select_linux_x86_q8_plan(
         env_updates.insert("CAMELID_X86_Q8_KERNEL", Some("off"));
         return safe_q8_plan();
     }
+    if !env_flag_enabled("CAMELID_X86_Q8_REPACK") || !x86_kernel_avx2_explicitly_requested() {
+        reasons.push(
+            "Ubuntu/Linux x86_64 optimized Q8 path requires explicit CAMELID_X86_Q8_REPACK=on and CAMELID_X86_Q8_KERNEL=avx2 gates; failing closed to safe path"
+                .into(),
+        );
+        return safe_q8_plan();
+    }
+    if !has_feature(&platform.cpu_features, "avx2") {
+        reasons.push(
+            "AVX2 feature not detected for x86 Q8 kernel; failing closed to safe path".into(),
+        );
+        return safe_q8_plan();
+    }
+
+    env_updates.insert("CAMELID_PARALLEL_LINEAR", Some("on"));
+    env_updates.insert("CAMELID_X86_Q8_REPACK", Some("on"));
+    env_updates.insert("CAMELID_X86_Q8_KERNEL", Some("avx2"));
+    env_updates.insert("CAMELID_X86_Q8_FFN_DOWN_DECODE_OWNER", Some("off"));
+    env_updates.insert("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER", Some("off"));
+    reasons.push("validated Ubuntu/Linux x86_64 Rust Q8 runtime repack enabled".into());
+    reasons.push("validated Rust AVX2 Q8 packed rows4 kernel selected".into());
     reasons.push(
-        "Ubuntu/Linux x86_64 Q8 experiment flags are default-off and not selected by the appliance planner yet; use manual developer overrides only with fresh evidence"
-            .into(),
+        "FFN-down and attention-output owner experiments remain disabled by execution plan".into(),
     );
-    safe_q8_plan()
+    reasons.push("experimental profile active; support claims remain unchanged".into());
+
+    (
+        "cpu_q8_runtime_repack",
+        "x86_experimental_q8_0_avx2_rust",
+        "q8_0_runtime_packed_rows4_prefill_avx2_available",
+        "enabled_when_q8_runtime_storage_active",
+        "q8_0_decode_packed_rows4_avx2",
+        "retained_q8_reference_path",
+    )
 }
 
 fn safe_q8_plan() -> (
@@ -576,6 +608,24 @@ fn env_flag_disabled(key: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn env_flag_enabled(key: &str) -> bool {
+    env::var(key)
+        .map(|value| {
+            let value = value.trim();
+            value.eq_ignore_ascii_case("1")
+                || value.eq_ignore_ascii_case("on")
+                || value.eq_ignore_ascii_case("true")
+                || value.eq_ignore_ascii_case("enabled")
+        })
+        .unwrap_or(false)
+}
+
+fn x86_kernel_avx2_explicitly_requested() -> bool {
+    env::var("CAMELID_X86_Q8_KERNEL")
+        .map(|value| value.trim().eq_ignore_ascii_case("avx2"))
+        .unwrap_or(false)
+}
+
 fn invalid_x86_kernel_override() -> Option<String> {
     let value = env::var("CAMELID_X86_Q8_KERNEL").ok()?;
     let trimmed = value.trim();
@@ -817,7 +867,93 @@ mod tests {
             .plan
             .reasons
             .iter()
-            .any(|reason| reason.contains("default-off")));
+            .any(|reason| reason.contains("requires profile=experimental")));
+        clear_profile_env();
+    }
+
+    #[test]
+    fn ubuntu_experimental_validated_gates_select_rust_avx2_q8_path() {
+        let _guard = env_lock();
+        clear_profile_env();
+        env::set_var("CAMELID_PROFILE", "experimental");
+        env::set_var("CAMELID_X86_Q8_REPACK", "on");
+        env::set_var("CAMELID_X86_Q8_KERNEL", "avx2");
+        let outcome = plan_for_model_with_platform(
+            &PathBuf::from("/tmp/Llama-3.2-3B-Instruct-Q8_0.gguf"),
+            &fixture("Llama 3.2 3B Instruct"),
+            Some(16),
+            platform("linux", "x86_64", &["avx2", "avx512f"]),
+        );
+        assert_eq!(outcome.plan.profile, ExecutionProfile::Experimental);
+        assert_eq!(outcome.plan.selected_backend, "cpu_q8_runtime_repack");
+        assert_eq!(
+            outcome.plan.selected_q8_path,
+            "x86_experimental_q8_0_avx2_rust"
+        );
+        assert_eq!(
+            outcome.plan.prefill_runtime_policy,
+            "enabled_when_q8_runtime_storage_active"
+        );
+        assert_eq!(
+            outcome.env_updates.get("CAMELID_PARALLEL_LINEAR"),
+            Some(&Some("on"))
+        );
+        assert_eq!(
+            outcome.env_updates.get("CAMELID_X86_Q8_REPACK"),
+            Some(&Some("on"))
+        );
+        assert_eq!(
+            outcome.env_updates.get("CAMELID_X86_Q8_KERNEL"),
+            Some(&Some("avx2"))
+        );
+        assert_eq!(
+            outcome
+                .env_updates
+                .get("CAMELID_X86_Q8_FFN_DOWN_DECODE_OWNER"),
+            Some(&Some("off"))
+        );
+        assert_eq!(
+            outcome
+                .env_updates
+                .get("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER"),
+            Some(&Some("off"))
+        );
+        clear_profile_env();
+    }
+
+    #[test]
+    fn ubuntu_experimental_missing_x86_gate_fails_closed() {
+        let _guard = env_lock();
+        clear_profile_env();
+        env::set_var("CAMELID_PROFILE", "experimental");
+        env::set_var("CAMELID_X86_Q8_KERNEL", "avx2");
+        let outcome = plan_for_model_with_platform(
+            &PathBuf::from("/tmp/Llama-3.2-3B-Instruct-Q8_0.gguf"),
+            &fixture("Llama 3.2 3B Instruct"),
+            Some(16),
+            platform("linux", "x86_64", &["avx2"]),
+        );
+        assert_eq!(outcome.plan.selected_backend, "cpu_reference");
+        assert_eq!(outcome.plan.selected_q8_path, "safe_q8_0_block_dot");
+        assert!(!outcome.env_updates.contains_key("CAMELID_X86_Q8_REPACK"));
+        clear_profile_env();
+    }
+
+    #[test]
+    fn ubuntu_experimental_without_avx2_feature_fails_closed() {
+        let _guard = env_lock();
+        clear_profile_env();
+        env::set_var("CAMELID_PROFILE", "experimental");
+        env::set_var("CAMELID_X86_Q8_REPACK", "on");
+        env::set_var("CAMELID_X86_Q8_KERNEL", "avx2");
+        let outcome = plan_for_model_with_platform(
+            &PathBuf::from("/tmp/Llama-3.2-3B-Instruct-Q8_0.gguf"),
+            &fixture("Llama 3.2 3B Instruct"),
+            Some(16),
+            platform("linux", "x86_64", &["sse4_2"]),
+        );
+        assert_eq!(outcome.plan.selected_backend, "cpu_reference");
+        assert_eq!(outcome.plan.selected_q8_path, "safe_q8_0_block_dot");
         clear_profile_env();
     }
 
@@ -866,6 +1002,7 @@ mod tests {
     fn invalid_x86_kernel_override_fails_closed() {
         let _guard = env_lock();
         clear_profile_env();
+        env::set_var("CAMELID_PROFILE", "experimental");
         env::set_var("CAMELID_X86_Q8_KERNEL", "amx_now_please");
         let outcome = plan_for_model_with_platform(
             &PathBuf::from("/tmp/Llama-3.2-3B-Instruct-Q8_0.gguf"),

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -668,6 +668,7 @@ fn diagnostic_rectangular_linear_layout_env(key: &str) -> Result<RectangularLine
 struct Q8RuntimeFlags {
     block_dot: bool,
     file_reader_block_dot: bool,
+    attention_projection_decode_consumer: bool,
     metal: bool,
     metal_retained: bool,
     hybrid_retained: bool,
@@ -696,6 +697,9 @@ impl Q8RuntimeFlags {
             block_dot: q8_0_env_flag_enabled_default_on_fail_closed("CAMELID_Q8_0_BLOCK_DOT"),
             file_reader_block_dot: q8_0_env_flag_enabled_default_on_fail_closed(
                 "CAMELID_Q8_0_FILE_READER_BLOCK_DOT",
+            ),
+            attention_projection_decode_consumer: q8_0_env_flag_enabled_default_off(
+                "CAMELID_X86_Q8_ATTENTION_PROJECTION_DECODE_CONSUMER",
             ),
             metal: q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8"),
             metal_retained: q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8_RETAINED"),
@@ -4667,6 +4671,15 @@ fn linear_for_role_runtime_with_plan(
         linear_for_role(input, weight, name, rectangular_role)
     } else {
         let name = name.into();
+        if let Some(output) = try_x86_q8_attention_projection_decode_consumer_path(
+            input,
+            weight,
+            &name,
+            rectangular_role,
+            runtime_plan,
+        )? {
+            return Ok(output);
+        }
         if let Some(output) =
             try_x86_q8_ffn_down_decode_owner_path(input, weight, &name, rectangular_role)?
         {
@@ -7203,6 +7216,76 @@ fn try_x86_q8_output_decode_owner_path(
     Ok(Some(CpuTensor::from_f32(
         name,
         vec![1, borrowed.rows],
+        output,
+    )?))
+}
+
+fn try_x86_q8_attention_projection_decode_consumer_path(
+    input: &CpuTensor,
+    weight: &CpuTensor,
+    name: &str,
+    rectangular_role: &str,
+    runtime_plan: &ResolvedRuntimePlan,
+) -> Result<Option<CpuTensor>> {
+    if !runtime_plan.q8.attention_projection_decode_consumer
+        || !matches!(
+            rectangular_role,
+            "attention_q"
+                | "attention_k"
+                | "attention_v"
+                | "attention q"
+                | "attention k"
+                | "attention v"
+        )
+        || input.rank() != 2
+        || input.dim(0)? != 1
+        || weight.source_type != Some(GgufTensorType::Q8_0)
+    {
+        return Ok(None);
+    }
+
+    let input_width = input.dim(1)?;
+    if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        return Ok(None);
+    }
+    let weight_rows = weight.dim(0)?;
+    let weight_cols = weight.dim(1)?;
+    let output_width = if weight_rows == input_width && weight_cols == input_width {
+        weight_cols
+    } else if weight_rows == input_width {
+        weight_cols
+    } else if weight_cols == input_width {
+        weight_rows
+    } else {
+        return Ok(None);
+    };
+    let Some(Q8_0RuntimeStorage::PackedRows4(packed)) = weight.q8_0_runtime_storage.as_ref() else {
+        return Ok(None);
+    };
+    if packed.interleave != Q8_0PackedRows4Interleave::I8
+        || packed.rows != output_width
+        || packed.blocks_per_row != input_width / Q8_0_BLOCK_VALUES
+        || !output_width.is_multiple_of(4)
+    {
+        return Ok(None);
+    }
+
+    let quantized_input = quantize_q8_0_row(&input.data[..input_width]);
+    let mut output = vec![0.0_f32; output_width];
+    let blocks_per_row = packed.blocks_per_row;
+    for (group_idx, output_chunk) in output.chunks_exact_mut(4).enumerate() {
+        let group_blocks =
+            &packed.blocks[group_idx * blocks_per_row..(group_idx + 1) * blocks_per_row];
+        let sums = q8_0_packed_rows4_dot(
+            group_blocks,
+            &quantized_input.blocks,
+            Q8_0PackedRows4Interleave::I8,
+        );
+        output_chunk.copy_from_slice(&sums);
+    }
+    Ok(Some(CpuTensor::from_f32(
+        name,
+        vec![1, output_width],
         output,
     )?))
 }
@@ -12507,6 +12590,7 @@ mod tests {
             "CAMELID_ROPE_POSITION_MODE",
             "CAMELID_RUNTIME_PROFILE",
             "CAMELID_SQUARE_LINEAR_LAYOUT",
+            "CAMELID_X86_Q8_ATTENTION_PROJECTION_DECODE_CONSUMER",
             "CAMELID_X86_Q8_OUTPUT_DECODE_OWNER",
         ] {
             std::env::remove_var(key);
@@ -12818,6 +12902,7 @@ mod tests {
             q8: Q8RuntimeFlags {
                 block_dot: true,
                 file_reader_block_dot: false,
+                attention_projection_decode_consumer: false,
                 metal: false,
                 metal_retained: false,
                 hybrid_retained: false,
@@ -12909,6 +12994,7 @@ mod tests {
         clear_dense_diagnostic_env();
         std::env::set_var("CAMELID_Q8_0_BLOCK_DOT", "on");
         std::env::set_var("CAMELID_Q8_0_FILE_READER_BLOCK_DOT", "1");
+        std::env::set_var("CAMELID_X86_Q8_ATTENTION_PROJECTION_DECODE_CONSUMER", "on");
         std::env::set_var("CAMELID_HYBRID_Q8_GPU_ROWS", "7");
         std::env::set_var("CAMELID_HYBRID_Q8_GPU_PERCENT", "25");
 
@@ -12920,6 +13006,12 @@ mod tests {
         );
         assert!(plan.q8.block_dot);
         assert!(plan.q8.file_reader_block_dot);
+        assert!(plan.q8.attention_projection_decode_consumer);
+        std::env::remove_var("CAMELID_X86_Q8_ATTENTION_PROJECTION_DECODE_CONSUMER");
+        assert!(
+            plan.q8.attention_projection_decode_consumer,
+            "resolved plan should cache the attention projection consumer gate"
+        );
         assert_eq!(plan.q8.hybrid_gpu_rows, Some(7));
         assert_eq!(plan.q8.hybrid_gpu_percent, 25);
         assert_eq!(plan.q8.hybrid_gpu_rows_for_output(100), 7);
@@ -12939,6 +13031,10 @@ mod tests {
             assert!(
                 plan.q8.file_reader_block_dot,
                 "{profile} should preserve Q8 file-reader block-dot default-on behavior"
+            );
+            assert!(
+                !plan.q8.attention_projection_decode_consumer,
+                "{profile} should not enable attention projection consumer by default"
             );
             assert!(
                 !plan.q8.metal,
@@ -13443,6 +13539,140 @@ mod tests {
             (0..input_width)
                 .map(|idx| (idx as f32 - 16.0) * 0.1875)
                 .collect(),
+        );
+    }
+
+    fn attention_projection_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
+        ResolvedRuntimePlan {
+            linear_accumulation_precision: LinearAccumulationPrecision::F32,
+            q8: Q8RuntimeFlags {
+                block_dot: false,
+                file_reader_block_dot: false,
+                attention_projection_decode_consumer: enabled,
+                metal: false,
+                metal_retained: false,
+                hybrid_retained: false,
+                hybrid_gpu_rows: None,
+                hybrid_gpu_percent: 10,
+            },
+        }
+    }
+
+    fn runtime_packed_attention_projection_case(
+        role_name: &str,
+        tensor_name: &str,
+    ) -> (CpuTensor, CpuTensor, CpuTensor) {
+        let rows = 12;
+        let input_width = Q8_0_BLOCK_VALUES * 2;
+        let blocks_per_row = input_width / Q8_0_BLOCK_VALUES;
+        let row_blocks: Vec<Q8_0Block> = (0..rows * blocks_per_row)
+            .map(|row| Q8_0Block {
+                scale: 0.125 + row as f32 * 0.004,
+                quants: std::array::from_fn(|idx| {
+                    (idx as i8).wrapping_mul(5).wrapping_sub(row as i8)
+                }),
+            })
+            .collect();
+        let input = CpuTensor::from_f32(
+            "input",
+            vec![1, input_width],
+            (0..input_width)
+                .map(|idx| (idx as f32 - 20.0) * 0.15625)
+                .collect(),
+        )
+        .unwrap();
+        let retained_weight = CpuTensor::from_f32_with_q8_0_blocks(
+            format!("retained_{role_name}"),
+            vec![rows, input_width],
+            dequantized_q8_0_rows(&row_blocks),
+            row_blocks.clone(),
+        )
+        .unwrap();
+        let expected =
+            matmul_rhs_transposed_with_precision(&input, &retained_weight, "expected").unwrap();
+        let packed_weight = CpuTensor::q8_0_runtime_packed_rows4_linear(
+            tensor_name,
+            TensorShape {
+                dims: vec![input_width, rows],
+            },
+            Q8_0PackedRows4::from_rows(
+                rows,
+                blocks_per_row,
+                Q8_0PackedRows4Interleave::I8,
+                &row_blocks,
+            )
+            .unwrap(),
+        );
+        assert!(packed_weight.data.is_empty());
+        assert!(packed_weight.q8_0_blocks.is_none());
+        assert!(packed_weight.q8_0_file_backing.is_none());
+        assert!(matches!(
+            packed_weight.q8_0_runtime_storage.as_ref(),
+            Some(Q8_0RuntimeStorage::PackedRows4(_))
+        ));
+        (input, packed_weight, expected)
+    }
+
+    #[test]
+    fn q8_attention_projection_consumer_matches_runtime_packed_baseline_for_qkv() {
+        let _env_guard = env_lock();
+        clear_dense_diagnostic_env();
+        let plan = attention_projection_consumer_plan(true);
+
+        for (role, tensor_name) in [
+            ("attention_q", "blk.0.attn_q.weight"),
+            ("attention_k", "blk.0.attn_k.weight"),
+            ("attention_v", "blk.0.attn_v.weight"),
+        ] {
+            let (input, packed_weight, expected) =
+                runtime_packed_attention_projection_case(role, tensor_name);
+            let actual = linear_for_role_runtime_with_plan(
+                &input,
+                &packed_weight,
+                format!("actual_{role}"),
+                role,
+                &plan,
+                false,
+            )
+            .unwrap();
+            assert_eq!(actual.shape.dims, expected.shape.dims, "{role}");
+            assert_slice_close_with_tolerance(&actual.data, &expected.data, 5e-4);
+        }
+    }
+
+    #[test]
+    fn q8_attention_projection_consumer_is_plan_gated_and_role_limited() {
+        let _env_guard = env_lock();
+        clear_dense_diagnostic_env();
+        let (input, packed_weight, _expected) =
+            runtime_packed_attention_projection_case("attention_k", "blk.0.attn_k.weight");
+
+        let disabled = attention_projection_consumer_plan(false);
+        assert!(
+            try_x86_q8_attention_projection_decode_consumer_path(
+                &input,
+                &packed_weight,
+                "disabled",
+                "attention_k",
+                &disabled,
+            )
+            .unwrap()
+            .is_none(),
+            "default-off plan should not enter the Q/K/V consumer"
+        );
+
+        let enabled = attention_projection_consumer_plan(true);
+        assert!(
+            try_x86_q8_attention_projection_decode_consumer_path(
+                &input,
+                &packed_weight,
+                "wrong_role",
+                "attention_output",
+                &enabled,
+            )
+            .unwrap()
+            .is_none(),
+            "attention_output must not use the Q/K/V consumer slice"
         );
     }
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -334,12 +334,15 @@ fn q8_repack_linear_shape(name: &str, shape: &TensorShape) -> Option<(usize, usi
     } else if name.ends_with(".ffn_gate.weight")
         || name.ends_with(".ffn_up.weight")
         || name.ends_with(".ffn_down.weight")
+        || name.ends_with(".attn_q.weight")
+        || name.ends_with(".attn_k.weight")
+        || name.ends_with(".attn_v.weight")
     {
-        // Llama FFN descriptors are stored as [input, output], while the runtime
-        // linear path consumes transposed rows [output, input]. Pack the
-        // backend-owned storage in the same output-row order used by the existing
-        // file-backed Q8 reader instead of packing descriptor rows that the hot
-        // matmul path cannot consume directly.
+        // Llama FFN and attention Q/K/V descriptors are stored as [input, output],
+        // while Camelid's hot linear path consumes rows as [output, input]. Pack
+        // backend-owned runtime storage in output-row order so optimized consumers
+        // do not have to fall back to row-major f32 data that runtime-packed tensors
+        // intentionally do not retain.
         Some((cols, rows))
     } else {
         Some((rows, cols))

--- a/tests/tensor_store.rs
+++ b/tests/tensor_store.rs
@@ -351,6 +351,55 @@ fn x86_q8_repack_loads_dense_attention_family_as_packed_runtime() {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[test]
+fn x86_q8_repack_loads_attention_qkv_as_output_row_packed_runtime() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::set_var("CAMELID_X86_Q8_REPACK", "on");
+    std::env::remove_var("CAMELID_MAC_Q8_REPACK");
+    std::env::remove_var("CAMELID_Q8_0_BLOCK_DOT");
+    std::env::remove_var("CAMELID_Q8_0_PACKED_4X8_DOT");
+
+    for (tensor_name, dims, expected_rows, expected_blocks_per_row) in [
+        ("blk.0.attn_q.weight", [32_i64, 32_i64], 32_usize, 1_usize),
+        ("blk.0.attn_k.weight", [64_i64, 32_i64], 32_usize, 2_usize),
+        ("blk.0.attn_v.weight", [64_i64, 32_i64], 32_usize, 2_usize),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tensor.gguf");
+        let block_count = (dims[0] as usize * dims[1] as usize) / 32;
+        let mut payload = Vec::new();
+        for block_idx in 0..block_count {
+            payload.extend_from_slice(&0x3c00u16.to_le_bytes());
+            payload.extend((0..32).map(|v| (v as i8).wrapping_add(block_idx as i8) as u8));
+        }
+        write_named_tensor_gguf_with_dims(&path, tensor_name, 8, &dims, &payload);
+
+        let gguf = read_metadata(&path).unwrap();
+        let store = TensorStore::open(&path, &gguf);
+        let tensor = store.load_q8_0_file_backed_linear(tensor_name).unwrap();
+
+        assert_eq!(tensor.shape.dims, vec![dims[0] as usize, dims[1] as usize]);
+        assert!(
+            tensor.data.is_empty(),
+            "{tensor_name} materialized f32 data"
+        );
+        assert!(tensor.q8_0_blocks.is_none(), "{tensor_name} kept q8 blocks");
+        assert!(
+            tensor.q8_0_file_backing.is_none(),
+            "{tensor_name} kept file backing"
+        );
+        let Q8_0RuntimeStorage::PackedRows4(packed) = tensor.q8_0_runtime_storage.unwrap();
+        assert_eq!(packed.rows, expected_rows, "{tensor_name} packed row count");
+        assert_eq!(
+            packed.blocks_per_row, expected_blocks_per_row,
+            "{tensor_name} packed blocks per output row"
+        );
+    }
+
+    std::env::remove_var("CAMELID_X86_Q8_REPACK");
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
 fn x86_q8_repack_loads_dense_ffn_family_as_transposed_packed_runtime() {
     let _guard = ENV_LOCK.lock().unwrap();
     std::env::set_var("CAMELID_X86_Q8_REPACK", "on");


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
