### PR TITLE
perf(q8): gate ffn-down row-group scheduler

### DIFF
--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-0719640b-20260518T1515Z-ffndown-rowgroup-threshold/README.md
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-0719640b-20260518T1515Z-ffndown-rowgroup-threshold/README.md
@@ -1,0 +1,38 @@
+# Ubuntu x86 Q8 FFN-down GEMM4 row-group scheduler threshold
+
+Target: `CAMELID_X86_Q8_REPACK=on` + `CAMELID_X86_Q8_FFN_DOWN_GEMM4_PREFILL=on` + `CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED=on`, first FFN-down.
+
+Feedback loop / hypotheses:
+1. Existing row-group scheduler parallelizes by input row-group. For shallow prefills (few input groups), it under-feeds Rayon versus the output-group scheduler and increases context-switch/scheduler overhead.
+2. A default-off row-group scheduler should fail closed to the existing output-group GEMM4 path below a minimum input-group threshold without changing Q8 parity.
+3. The threshold must remain tunable for future same-host model probes.
+
+Slice:
+- Added `CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS` (default 8) behind the already default-off row-group scheduler gate.
+- Below threshold, row-group scheduler requests use the existing GEMM4 output-group kernel; at/above threshold, behavior is unchanged.
+- Added a unit guard for the min-input-groups gate and an ignored manual x86 benchmark that compares baseline output-group, forced old row-group (`min=1`), and thresholded row-group (`min=8`).
+
+Gates:
+- Local macOS: `cargo test -q q8_ffn_down_gemm4` -> PASS (5 passed, 1 ignored).
+- Local macOS: `cargo fmt --check` -> PASS.
+- Canonical host `16.146.143.184` (with `source ~/.cargo/env` because login PATH has Cargo 1.75 but rustup Cargo is 1.95):
+  - `cargo test -q x86_q8_ffn_down_gemm4_row_group_schedule_respects_min_input_groups` -> PASS.
+  - `CAMELID_X86_Q8_SCHED_BENCH_ITERS=30 cargo test -q q8_ffn_down_gemm4_row_group_threshold_benchmark -- --ignored --nocapture` -> PASS.
+
+Canonical host benchmark output:
+
+```text
+rows=16 input_groups=4 input_width=256 output_width=1024 iterations=30 baseline_us=251236 forced_row_group_us=560972 thresholded_us=256118
+```
+
+Interpretation:
+- Forced old row-group scheduler was ~2.23x slower than output-group baseline for the shallow-prefill synthetic FFN-down surface (560,972µs vs 251,236µs over 30 iterations).
+- Thresholded row-group preserves parity and stays near the existing output-group baseline (256,118µs, +1.9% vs baseline) instead of taking the slow row-group path.
+- This is not a broad throughput/support claim and does not compare against llama.cpp; it is a scheduler/context-switch tracer bullet inside the existing default-off Q8 GEMM4 path.
+
+Retain/reject:
+- Retain as a safe default-off scheduler guard for FFN-down GEMM4 row-group scheduling.
+- Not promoted to default-on; no support-contract/docs widening.
+
+Next tracer bullet:
+- Run the same threshold gate against model-backed same-host FFN-down timing with `CAMELID_X86_Q8_REPACK=on`, then test whether attention output/QKV need the same input-group threshold seam.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -7492,6 +7492,7 @@ const Q8_0_BLOCK_VALUES: usize = 32;
 const X86_Q8_PACKED_ROWS4_DECODE_PARALLEL_MIN_OUTPUTS: usize = 1024;
 const X86_Q8_PACKED_ROWS4_MATMUL_PARALLEL_MIN_GROUPS: usize = 64;
 const X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK: usize = 8;
+const X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS: usize = 8;
 
 #[derive(Debug, Clone)]
 struct QuantizedQ8_0Row {
@@ -8082,6 +8083,35 @@ fn should_parallelize_q8_packed_rows4_matmul(total_output_groups: usize) -> bool
         && rayon::current_num_threads() > 1
 }
 
+fn x86_q8_ffn_down_gemm4_row_group_min_input_groups() -> usize {
+    #[cfg(test)]
+    {
+        env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS)
+    }
+    #[cfg(not(test))]
+    {
+        static X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS_ONCE: OnceLock<usize> =
+            OnceLock::new();
+        *X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS_ONCE.get_or_init(|| {
+            env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS")
+                .ok()
+                .and_then(|value| value.parse::<usize>().ok())
+                .filter(|value| *value > 0)
+                .unwrap_or(X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS)
+        })
+    }
+}
+
+fn should_use_x86_q8_ffn_down_gemm4_row_group_schedule(enabled: bool, input_groups: usize) -> bool {
+    enabled
+        && rayon::current_num_threads() > 1
+        && input_groups >= x86_q8_ffn_down_gemm4_row_group_min_input_groups()
+}
+
 fn x86_q8_packed_rows4_matmul_groups_per_chunk() -> usize {
     #[cfg(test)]
     {
@@ -8440,11 +8470,12 @@ fn q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
             blocks_per_row,
             &mut packed_inputs,
         );
-        if row_group_schedule {
+        let input_groups = packed_rows / 4;
+        if should_use_x86_q8_ffn_down_gemm4_row_group_schedule(row_group_schedule, input_groups) {
             run_q8_0_packed_rows4_prefill_gemm4_kernel_row_group_parallel(
                 packed,
                 &packed_inputs,
-                packed_rows / 4,
+                input_groups,
                 &mut output,
                 use_avx2,
             );
@@ -8452,7 +8483,7 @@ fn q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
             run_q8_0_packed_rows4_prefill_gemm4_kernel(
                 packed,
                 &packed_inputs,
-                packed_rows / 4,
+                input_groups,
                 &mut output,
                 use_avx2,
             );
@@ -13480,6 +13511,50 @@ mod tests {
         std::env::remove_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK");
     }
 
+    #[test]
+    fn x86_q8_ffn_down_gemm4_row_group_schedule_respects_min_input_groups() {
+        let _env_guard = env_lock();
+        std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS");
+        assert_eq!(
+            x86_q8_ffn_down_gemm4_row_group_min_input_groups(),
+            X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS
+        );
+        assert!(!should_use_x86_q8_ffn_down_gemm4_row_group_schedule(
+            false,
+            X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS
+        ));
+        assert!(!should_use_x86_q8_ffn_down_gemm4_row_group_schedule(
+            true,
+            X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS - 1
+        ));
+        assert_eq!(
+            should_use_x86_q8_ffn_down_gemm4_row_group_schedule(
+                true,
+                X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS
+            ),
+            rayon::current_num_threads() > 1
+        );
+
+        std::env::set_var(
+            "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
+            "2",
+        );
+        assert_eq!(x86_q8_ffn_down_gemm4_row_group_min_input_groups(), 2);
+        assert_eq!(
+            should_use_x86_q8_ffn_down_gemm4_row_group_schedule(true, 2),
+            rayon::current_num_threads() > 1
+        );
+        std::env::set_var(
+            "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
+            "0",
+        );
+        assert_eq!(
+            x86_q8_ffn_down_gemm4_row_group_min_input_groups(),
+            X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS
+        );
+        std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS");
+    }
+
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[test]
     fn x86_q8_avx2_packed_rows4_i8_matches_scalar_dot() {
@@ -16564,6 +16639,94 @@ mod tests {
         )
         .unwrap()
         .is_none());
+    }
+
+    #[test]
+    #[ignore = "manual x86 Q8 scheduler tracer bullet benchmark"]
+    fn q8_ffn_down_gemm4_row_group_threshold_benchmark() {
+        let _env_guard = env_lock();
+        clear_dense_diagnostic_env();
+        let input_width = Q8_0_BLOCK_VALUES * 8;
+        let output_width = 1024;
+        let blocks_per_row = input_width / Q8_0_BLOCK_VALUES;
+        let row_blocks: Vec<Q8_0Block> = (0..output_width * blocks_per_row)
+            .map(|row| Q8_0Block {
+                scale: 0.03125 + row as f32 * 0.000001,
+                quants: std::array::from_fn(|idx| {
+                    (idx as i8).wrapping_mul(9).wrapping_sub(row as i8)
+                }),
+            })
+            .collect();
+        let packed_weight = CpuTensor::q8_0_runtime_packed_rows4_linear(
+            "blk.0.ffn_down.weight",
+            TensorShape {
+                dims: vec![input_width, output_width],
+            },
+            Q8_0PackedRows4::from_rows(
+                output_width,
+                blocks_per_row,
+                Q8_0PackedRows4Interleave::I8,
+                &row_blocks,
+            )
+            .unwrap(),
+        );
+        let rows = 16;
+        let input = CpuTensor::from_f32(
+            "ffn_down_gemm4_threshold_bench_input",
+            vec![rows, input_width],
+            (0..rows * input_width)
+                .map(|idx| {
+                    ((idx % input_width) as f32 - 9.0) * 0.125 + (idx / input_width) as f32 * 0.0625
+                })
+                .collect(),
+        )
+        .unwrap();
+        let Some((packed, packed_output_width)) =
+            q8_0_runtime_packed_projection(&packed_weight, input_width).unwrap()
+        else {
+            panic!("expected runtime packed FFN-down weight")
+        };
+        assert_eq!(packed_output_width, output_width);
+
+        let iterations = std::env::var("CAMELID_X86_Q8_SCHED_BENCH_ITERS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(50);
+        let run = |label: &str, min_groups: &str, row_group_schedule: bool| {
+            std::env::set_var(
+                "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
+                min_groups,
+            );
+            let started = Instant::now();
+            let mut last = None;
+            for _ in 0..iterations {
+                last = Some(
+                    q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
+                        &input,
+                        packed,
+                        output_width,
+                        label,
+                        row_group_schedule,
+                        false,
+                    )
+                    .unwrap(),
+                );
+            }
+            let elapsed = started.elapsed().as_micros();
+            (elapsed, last.unwrap())
+        };
+
+        let (baseline_us, baseline) = run("baseline_output_group", "8", false);
+        let (old_row_group_us, old_row_group) = run("forced_row_group", "1", true);
+        let (thresholded_us, thresholded) = run("thresholded_row_group", "8", true);
+        assert_slice_close_with_tolerance(&old_row_group.data, &baseline.data, 5e-4);
+        assert_slice_close_with_tolerance(&thresholded.data, &baseline.data, 5e-4);
+        println!(
+            "rows={rows} input_groups={} input_width={input_width} output_width={output_width} iterations={iterations} baseline_us={baseline_us} forced_row_group_us={old_row_group_us} thresholded_us={thresholded_us}",
+            rows / 4
+        );
+        std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
