### PR TITLE
Guard x86 Q8 gate-up owner env

### DIFF
--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/README.md
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/README.md
@@ -1,0 +1,23 @@
+# cron-95495a91 backend tracer: ffn gate-up single-owner env guard
+
+## Target
+Sharpen the Ubuntu/Linux x86_64 Q8 execution-plan feedback loop for active Q8 performance/parity lanes by preventing stale FFN gate-up single-owner env state from leaking into a retained/rejected run.
+
+## Hypotheses
+1. `CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER` is consumed by the Rust runtime but was not managed by the execution planner, so a stale shell env could accidentally activate it outside the current retained baseline envelope.
+2. Adding it to managed planner keys and explicitly setting it `off` in the x86 experimental baseline keeps the slice default-off without widening support claims.
+3. The existing execution-plan tests plus the gate-up owner default-off test are enough feedback loop for this control-plane guard; no throughput retain claim is made.
+
+## Change
+- `src/execution_plan.rs`
+  - Added `CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER` to `MANAGED_ENV_KEYS`.
+  - The x86 experimental AVX2 plan now explicitly writes it as `off` with the other default-off Q8 consumer experiments.
+  - Tests now assert the env is cleared/applied and reset between cases; also filled missing GEMM4 env cleanup in the fixture helper.
+
+## Gates
+- Local: `cargo fmt --check && cargo test execution_plan --lib` — pass.
+- Local: `cargo test q8_ffn_gate_up_single_owner_is_default_off_and_requires_runtime_storage --lib` — pass.
+- Ubuntu access: SSH worked with the requested exact shape. Host Rust toolchain is `rustc 1.75.0` / `cargo 1.75.0`, below repo `rust-version = 1.87`, so Rust gates were not run on Ubuntu without changing the host toolchain.
+
+## Retain/reject
+Retain as a default-off backend control-plane guard. This is parity/performance-lane hygiene only: it prevents accidental gate leakage and does not claim throughput, parity-envelope expansion, frontend/API support, or public support widening.

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/SHA256SUMS
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/SHA256SUMS
@@ -1,0 +1,5 @@
+9faaeb98f6a4db611a4f6c5d9b4251e9f44358b9a144096106b5dfa6e3080d59  qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/README.md
+7bc6d1bc76286d788a2d822f1f3aef5bbbc4e1c26f4143d59c945c12d560b4ec  qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/logs/dirty-diff.log
+32d66b6abb45b49dc4fcdd15935e9229ef611577196f829a64a594885646440b  qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/logs/local-execution-plan-gate.log
+47769c4d571101df81ff1a5a9e4158e77dad9e841f944c2d41f63abb2619def3  qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/logs/local-ffn-gate-up-default-off-gate.log
+0ccc17b391a68509e9522e763da3c261f8bbcd0524280105dbfe7dfa28a02e36  qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260518T1616Z-ffn-gate-up-single-owner-env-guard/logs/ubuntu-rust-version.log

--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -20,6 +20,7 @@ const MANAGED_ENV_KEYS: &[&str] = &[
     "CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL",
     "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER",
     "CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL",
+    "CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER",
     "CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER",
     "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL",
     "CAMELID_X86_Q8_FFN_DOWN_GEMM4_PREFILL",
@@ -380,6 +381,7 @@ fn select_linux_x86_q8_plan(
         "CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL",
         Some("off"),
     );
+    env_updates.insert("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER", Some("off"));
     env_updates.insert("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER", Some("off"));
     env_updates.insert("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL", Some("off"));
     env_updates.insert("CAMELID_X86_Q8_FFN_DOWN_GEMM4_PREFILL", Some("off"));
@@ -760,8 +762,12 @@ mod tests {
             "CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL",
             "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER",
             "CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL",
+            "CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER",
             "CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER",
             "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL",
+            "CAMELID_X86_Q8_FFN_DOWN_GEMM4_PREFILL",
+            "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED",
+            "CAMELID_X86_Q8_FFN_DOWN_GEMM4_AVX2",
             "CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER",
             "CAMELID_X86_Q8_FFN_DOWN_DECODE_OWNER",
             "CAMELID_X86_Q8_OUTPUT_DECODE_OWNER",
@@ -1020,6 +1026,12 @@ mod tests {
         assert_eq!(
             outcome
                 .env_updates
+                .get("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER"),
+            Some(&Some("off"))
+        );
+        assert_eq!(
+            outcome
+                .env_updates
                 .get("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER"),
             Some(&Some("off"))
         );
@@ -1039,6 +1051,12 @@ mod tests {
             outcome
                 .env_updates
                 .get("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED"),
+            Some(&Some("off"))
+        );
+        assert_eq!(
+            outcome
+                .env_updates
+                .get("CAMELID_X86_Q8_FFN_DOWN_GEMM4_AVX2"),
             Some(&Some("off"))
         );
         assert_eq!(
@@ -1074,10 +1092,12 @@ mod tests {
         env::set_var("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL", "on");
         env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER", "on");
         env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL", "on");
+        env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER", "on");
         env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_PREFILL", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED", "on");
+        env::set_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_AVX2", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER", "on");
 
         PlannerEnv::capture().apply(&BTreeMap::new());
@@ -1090,10 +1110,12 @@ mod tests {
         assert!(env::var("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL").is_err());
+        assert!(env::var("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER").is_err());
         assert!(env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_PREFILL").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED").is_err());
+        assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_AVX2").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER").is_err());
         clear_profile_env();
     }


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
