### PR TITLE
Enable x86 Q8 ffn_down decode under avx2 kernel

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -9155,7 +9155,7 @@ fn try_x86_q8_ffn_down_decode_consumer_path(
     rectangular_role: &str,
     runtime_plan: &ResolvedRuntimePlan,
 ) -> Result<Option<CpuTensor>> {
-    if !runtime_plan.q8.ffn_down_decode_consumer
+    if !(runtime_plan.q8.ffn_down_decode_consumer || x86_q8_kernel_avx2_enabled())
         || rectangular_role != "ffn_down"
         || input.rank() != 2
         || input.dim(0)? != 1
@@ -13738,6 +13738,67 @@ mod tests {
             .unwrap();
         assert_eq!(actual, expected);
         std::env::remove_var("CAMELID_X86_Q8_PACKED_ROWS4_AVX2_DOT_DECODE_HOIST");
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[test]
+    fn x86_q8_ffn_down_decode_uses_avx2_reference_gate() {
+        let _env_guard = env_lock();
+        std::env::set_var("CAMELID_X86_Q8_KERNEL", "avx2");
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            std::env::remove_var("CAMELID_X86_Q8_KERNEL");
+            return;
+        }
+
+        let input = CpuTensor::from_f32(
+            "hidden",
+            vec![1, Q8_0_BLOCK_VALUES],
+            (0..Q8_0_BLOCK_VALUES)
+                .map(|idx| (idx as f32 - 15.0) / 8.0)
+                .collect(),
+        )
+        .unwrap();
+        let row_major_blocks: Vec<Q8_0Block> = (0..4)
+            .map(|row| Q8_0Block {
+                scale: 0.25 + row as f32 * 0.125,
+                quants: std::array::from_fn(|idx| {
+                    (idx as i8).wrapping_mul(3).wrapping_add(row as i8 * 11)
+                }),
+            })
+            .collect();
+        let packed =
+            Q8_0PackedRows4::from_rows(4, 1, Q8_0PackedRows4Interleave::I8, &row_major_blocks)
+                .unwrap();
+        let weight = CpuTensor::q8_0_runtime_packed_rows4_linear(
+            "blk.0.ffn_down.weight",
+            TensorShape {
+                dims: vec![4, Q8_0_BLOCK_VALUES],
+            },
+            packed.clone(),
+        );
+        let runtime_plan = ResolvedRuntimePlan::from_env().unwrap();
+        assert!(!runtime_plan.q8.ffn_down_decode_consumer);
+
+        let actual = try_x86_q8_ffn_down_decode_consumer_path(
+            &input,
+            &weight,
+            "ffn_down",
+            "ffn_down",
+            &runtime_plan,
+        )
+        .unwrap()
+        .unwrap();
+        let quantized_input = quantize_q8_0_row(&input.data);
+        let expected = q8_0_packed_rows4_single_input_projection(
+            &packed,
+            &quantized_input.blocks,
+            4,
+            "expected",
+        )
+        .unwrap();
+        assert_eq!(actual.shape.dims, vec![1, 4]);
+        assert_eq!(actual.data, expected.data);
+        std::env::remove_var("CAMELID_X86_Q8_KERNEL");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
