### PR TITLE
Gate 3B frontend display alias in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,9 @@ jobs:
 
       - name: Frontend support-contract smoke
         run: npm run smoke:model-state
+
+      - name: Frontend 3B exact-row closure smoke
+        run: npm run smoke:3b-closure
+
+      - name: Frontend integration smoke
+        run: npm run smoke:integration

--- a/frontend/scripts/frontend-3b-closure-smoke.mjs
+++ b/frontend/scripts/frontend-3b-closure-smoke.mjs
@@ -19,6 +19,7 @@ import {
   rowSupportNextStepCopy,
 } from '../src/lib/capabilities.js'
 import { getChatGateState } from '../src/lib/chatGate.js'
+import { resolveLoadedModelDisplayName } from '../src/lib/loadedModelDisplay.js'
 import {
   getRuntimeRequestModelId,
   isRunnableInCurrentRuntime,
@@ -103,6 +104,26 @@ assert.equal(compatibilityHintMatchesExactTarget(capabilities, exactThreeBModel,
 assert.equal(modelRuntimeIdMatches(exactThreeBModel, runtime), true, '3B backend active_model_id must match the selected runtime row')
 assert.equal(isRunnableInCurrentRuntime(exactThreeBModel, runtime), true, '3B runtime readiness must require the active backend row and generation_ready=true')
 assert.equal(getRuntimeRequestModelId(exactThreeBModel, runtime, 'fallback'), 'scalar_default_rerun', 'API/chat requests should use the loaded backend model id for alias-safe 3B sends')
+assert.equal(
+  resolveLoadedModelDisplayName({ fallbackName: 'scalar_default_rerun', modelPath: exactThreeBModel.model_path, quantLabel: 'Q8_0' }),
+  LLAMA32_3B_ACCEPTANCE_TARGET.name,
+  'loaded backend aliases should render as the canonical 3B row only when the exact GGUF filename and decoded Q8_0 file_type evidence match',
+)
+assert.equal(
+  resolveLoadedModelDisplayName({ fallbackName: 'scalar_default_rerun', modelPath: exactThreeBModel.model_path, quantLabel: 'file_type 7' }),
+  LLAMA32_3B_ACCEPTANCE_TARGET.name,
+  'loaded backend aliases should also accept direct GGUF file_type 7 quant evidence for the exact 3B Q8_0 row',
+)
+assert.equal(
+  resolveLoadedModelDisplayName({ fallbackName: 'scalar_default_rerun', modelPath: exactThreeBModel.model_path, quantLabel: 'Q4_K_M' }),
+  'scalar_default_rerun',
+  'loaded backend aliases must not render as the 3B supported row when quant evidence is not Q8_0',
+)
+assert.equal(
+  resolveLoadedModelDisplayName({ fallbackName: 'scalar_default_rerun', modelPath: '/models/llama32-3b-instruct-q8-neighbor.gguf', quantLabel: 'Q8_0' }),
+  'scalar_default_rerun',
+  'loaded backend aliases must not render as the 3B supported row from a loose neighboring filename plus Q8_0 label',
+)
 
 const exactGate = getChatGateState(capabilities, exactThreeBModel, runtime)
 assert.deepEqual(
@@ -110,6 +131,12 @@ assert.deepEqual(
   [true, true, true, true, true],
   '3B WebUI chat unlock is retained only when loaded_now, generation_ready, active_model_id, and exact supported row all pass',
 )
+
+const missingCapabilitiesGate = getChatGateState(null, exactThreeBModel, runtime)
+assert.equal(missingCapabilitiesGate.runtimeReady, true, '3B runtime readiness must remain visible when /api/capabilities is unavailable')
+assert.equal(missingCapabilitiesGate.contractSupported, false, '3B support must fail closed when /api/capabilities is unavailable')
+assert.equal(missingCapabilitiesGate.chatUnlocked, false, '3B WebUI chat must not unlock from runtime health alone without the exact capabilities row')
+assert.equal(missingCapabilitiesGate.label, 'No matching COMPATIBILITY.md row', '3B support-gated copy should name the missing exact row when capabilities are absent')
 
 for (const [label, model, runtimeOverride] of [
   ['loaded_now=false', exactThreeBModel, { ...runtime, loaded_now: false }],
@@ -157,6 +184,7 @@ assert.match(LLAMA32_3B_ACCEPTANCE_GATING_NOTE, /loaded_now=true and generation_
 assert.match(LLAMA32_3B_ACCEPTANCE_GATING_NOTE, /exact supported Llama 3\.2 3B Q8_0 compatibility row/)
 
 const hookSource = readFileSync(new URL('../src/hooks/useDashboardData.js', import.meta.url), 'utf8')
+const loadedModelDisplaySource = readFileSync(new URL('../src/lib/loadedModelDisplay.js', import.meta.url), 'utf8')
 const chatSource = readFileSync(new URL('../src/views/ChatWorkspace.jsx', import.meta.url), 'utf8')
 const modelsSource = readFileSync(new URL('../src/views/ModelsView.jsx', import.meta.url), 'utf8')
 const apiSource = readFileSync(new URL('../src/views/ApiView.jsx', import.meta.url), 'utf8')
@@ -164,7 +192,8 @@ const topBarSource = readFileSync(new URL('../src/components/TopBar.jsx', import
 
 assert.match(hookSource, /selectedModelChatGate\s*=\s*getChatGateState\(dashboard\?\.capabilities, selectedModel, runtime\)/, 'dashboard selectedModelRunnable must be derived from the shared exact-row chat gate')
 assert.match(hookSource, /selectedModelRunnable\s*=\s*selectedModelChatGate\.chatUnlocked/, 'dashboard must pass chatUnlocked, not runtime readiness alone, into the composer')
-assert.match(hookSource, /LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'backend 3B display aliasing must stay exact-filename plus Q8_0 gated')
+assert.match(loadedModelDisplaySource, /quantLabelFromGgufFileType[\s\S]*file\[_\\s-\]\*type[\s\S]*LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'backend 3B display aliasing must stay exact-filename plus decoded Q8_0/file_type 7 gated')
+assert.match(hookSource, /resolveLoadedModelDisplayName/, 'dashboard model merge must use the shared exact-filename plus Q8_0 loaded-model display gate')
 assert.match(chatSource, /runnableModels\s*=\s*models\.filter\(\(model\) => getChatGateState\(capabilities, model, runtime\)\.chatUnlocked\)/, 'chat model picker must list only exact-row unlocked models')
 assert.match(chatSource, /canSubmit\s*=\s*Boolean\(composer\.trim\(\)\) && selectedModelRunnable && !generationActive/, 'composer send button must be blocked unless the exact-row chat gate unlocked')
 assert.match(chatSource, /runtimeStatusCopy[\s\S]*loaded now and generation_ready=true/, 'chat readiness copy must name the runtime readiness requirement')

--- a/frontend/scripts/ui-regression-smoke.mjs
+++ b/frontend/scripts/ui-regression-smoke.mjs
@@ -37,6 +37,7 @@ assert.match(readmeSource, /product-forward while still reflecting the local-fir
 
 const chatWorkspaceSource = readFileSync(new URL('../src/views/ChatWorkspace.jsx', import.meta.url), 'utf8')
 const dashboardHookSource = readFileSync(new URL('../src/hooks/useDashboardData.js', import.meta.url), 'utf8')
+const loadedModelDisplaySource = readFileSync(new URL('../src/lib/loadedModelDisplay.js', import.meta.url), 'utf8')
 const apiViewSource = readFileSync(new URL('../src/views/ApiView.jsx', import.meta.url), 'utf8')
 const systemViewSource = readFileSync(new URL('../src/views/SystemView.jsx', import.meta.url), 'utf8')
 const modelsViewSource = readFileSync(new URL('../src/views/ModelsView.jsx', import.meta.url), 'utf8')
@@ -102,7 +103,7 @@ assert.match(dashboardHookSource, /selectedConversationIdRef\.current = next[\s\
 assert.match(dashboardHookSource, /activeModelRunnable && current !== activeModel\.id/, 'browser-selected model should snap back to the backend active model when the runtime changes')
 assert.match(dashboardHookSource, /modelRuntimeIdMatches/, 'dashboard model merge should treat runtime_model_name as an active_model_id alias instead of losing readiness for imported exact rows')
 assert.match(dashboardHookSource, /resolveLoadedModelDisplayName/, 'dashboard model merge should rewrite backend-generated active ids to the exact 3B display row only from exact GGUF filename plus Q8_0 metadata')
-assert.match(dashboardHookSource, /LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'the 3B display alias must stay exact-row and quant-gated rather than broad-family')
+assert.match(loadedModelDisplaySource, /quantLabelFromGgufFileType[\s\S]*file\[_\\s-\]\*type[\s\S]*LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'the 3B display alias must stay exact-row and decoded Q8_0/file_type 7 gated rather than broad-family')
 assert.match(dashboardHookSource, /localRecordMatchesBackendId/, 'dashboard model merge should de-duplicate backend model rows against saved browser records by id or runtime_model_name')
 assert.match(dashboardHookSource, /const id = localRecord\?\.id \|\| item\.id/, 'backend model merges should preserve the browser row id while keeping the backend runtime id as runtime_model_name')
 assert.match(dashboardHookSource, /const conversation = await ensureConversation\(\)[\s\S]*?setSelectedConversationId\(conversation\.id\)[\s\S]*?fetch\(`\$\{normalizedApiBase\}\/v1\/chat\/completions`/, 'fresh-chat sends must select the real conversation before streaming starts so the main pane updates with sidebar previews')

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { LLAMA32_3B_ACCEPTANCE_TARGET } from '../lib/acceptanceTargets'
 import { compatibilityHintCopy, compatibilityHintLabel, findCompatibilityHint, isCompatibilitySupportedForModel, quantLabelFromGgufFileType } from '../lib/capabilities'
 import { getChatGateState } from '../lib/chatGate'
+import { resolveLoadedModelDisplayName } from '../lib/loadedModelDisplay'
 import { readStreamingChatCompletion } from '../lib/chatCompletionStream'
 import { NEW_CHAT_SENTINEL, resolveSelectedConversation, shouldCreateConversationForSend } from '../lib/chatState'
 import { normalizeStoredConversations } from '../lib/conversationStorage.js'
@@ -76,25 +76,7 @@ function getModelPath(model) {
   return typeof model?.path === 'string' ? model.path : ''
 }
 
-function pathBasename(value) {
-  return String(value || '').split(/[\\/]/).filter(Boolean).pop() || ''
-}
-
-function normalizeQuantLabel(value) {
-  return String(value || '').trim().toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '')
-}
-
-const LLAMA32_3B_ACCEPTANCE_FILENAME = pathBasename(LLAMA32_3B_ACCEPTANCE_TARGET.source)
-
-function isExactLlama32ThreeBLoadedGguf(modelPath, quantLabel) {
-  return pathBasename(modelPath).toLowerCase() === LLAMA32_3B_ACCEPTANCE_FILENAME.toLowerCase()
-    && normalizeQuantLabel(quantLabel) === 'Q8_0'
-}
-
-export function resolveLoadedModelDisplayName({ fallbackName, modelPath, quantLabel }) {
-  if (isExactLlama32ThreeBLoadedGguf(modelPath, quantLabel)) return LLAMA32_3B_ACCEPTANCE_TARGET.name
-  return fallbackName
-}
+export { resolveLoadedModelDisplayName }
 
 function getLoadedModelFileType(model) {
   const metadata = model?.gguf?.metadata || {}

--- a/frontend/src/lib/loadedModelDisplay.js
+++ b/frontend/src/lib/loadedModelDisplay.js
@@ -1,0 +1,24 @@
+import { LLAMA32_3B_ACCEPTANCE_TARGET } from './acceptanceTargets.js'
+import { quantLabelFromGgufFileType } from './capabilities.js'
+
+function pathBasename(value) {
+  return String(value || '').split(/[\\/]/).filter(Boolean).pop() || ''
+}
+
+function normalizeQuantLabel(value) {
+  const text = String(value || '').trim()
+  const fileType = text.match(/\bfile[_\s-]*type\s*(\d+)\b/i)?.[1]
+  return String(fileType ? quantLabelFromGgufFileType(fileType) : text).trim().toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+}
+
+const LLAMA32_3B_ACCEPTANCE_FILENAME = pathBasename(LLAMA32_3B_ACCEPTANCE_TARGET.source)
+
+function isExactLlama32ThreeBLoadedGguf(modelPath, quantLabel) {
+  return pathBasename(modelPath).toLowerCase() === LLAMA32_3B_ACCEPTANCE_FILENAME.toLowerCase()
+    && normalizeQuantLabel(quantLabel) === 'Q8_0'
+}
+
+export function resolveLoadedModelDisplayName({ fallbackName, modelPath, quantLabel }) {
+  if (isExactLlama32ThreeBLoadedGguf(modelPath, quantLabel)) return LLAMA32_3B_ACCEPTANCE_TARGET.name
+  return fallbackName
+}

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/README.md
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/README.md
@@ -1,0 +1,10 @@
+# Frontend 3B display + CI gate slice — 2026-05-20T1243Z
+
+Scope: Llama 3.2 3B Instruct Q8_0 frontend/WebUI closure only.
+
+Retained slice:
+- Extracted the loaded-model display alias into a shared frontend helper so backend runtime aliases render as the canonical 3B row only from the exact GGUF filename plus Q8_0 evidence.
+- Hardened regression coverage for direct GGUF `file_type 7` evidence, Q4/neighbor-row fail-closed paths, and missing `/api/capabilities` fail-closed chat gating while preserving visible runtime readiness.
+- Added the 3B exact-row closure smoke and frontend integration smoke to the GitHub frontend CI job after build and model-state smoke.
+
+Live backend note: the canonical validation host API port was not listening during this local frontend slice, so no fresh live API/WebUI promotion evidence is claimed here. The retained evidence is the exact local CI-equivalent frontend/support-contract/script gate set recorded in logs.

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/SHA256SUMS
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/SHA256SUMS
@@ -1,0 +1,9 @@
+8670d5732ed42643f28b3cdcae31529db151218f83933e578bedf50e8345abdb  ./README.md
+53f13cdd3d3fdaade17e43be946b16092e3524037ee93c5795b2b9b8cf2a2780  ./commands.txt
+ae06540d335c65882b4e3a31cc7a4bfd3d6822d2150795fde5c7d817c26a86ef  ./dirty-diff-stat.txt
+0ee319fac2e40c2564ae3c3b32e9f73133db5a06fffefef9caa390d2b60487bf  ./git-state.txt
+f27eca4c57c786592a888dd19f736100edfdd17c09640c59f3edfcddbe3174ea  ./logs/frontend-gates.log
+430825b9d29958b05e966303bee6186c93a013694c9e2fee4c696bec42f05ebb  ./logs/public-scrub-privacy.log
+efd93fad08f52747865dd30092b924938b820cea6eb6197f7c932e1e675fc84e  ./logs/script-gates.log
+d2bbfc2db5c44986a2cd608369941330224d2e9ff77eae012e3b03be90ee60e8  ./retained-slice.diff
+f200df9427cda7034bb8d1538b671d5354b32bf76a81401dd967540d237bc746  ./summary.json

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/commands.txt
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/commands.txt
@@ -1,0 +1,14 @@
+git diff --check
+bash scripts/check-public-scrub.sh
+node scripts/audit-evidence-bundle-privacy.mjs --strict
+bash scripts/check-evidence-bundle-checksums.sh
+node scripts/check-public-evidence-claims.mjs
+node scripts/test-readme-screenshot.mjs
+cd frontend && npm ci
+cd frontend && npm run build
+cd frontend && npm run smoke:model-state
+cd frontend && npm run smoke:3b-closure
+cd frontend && npm run smoke:ui
+cd frontend && npm run smoke:streaming
+cd frontend && npm run smoke:integration
+for test_script in scripts/test-*.mjs; do node "$test_script"; done

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/dirty-diff-stat.txt
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/dirty-diff-stat.txt
@@ -1,0 +1,5 @@
+ .github/workflows/ci.yml                       |  6 +++++
+ frontend/scripts/frontend-3b-closure-smoke.mjs | 31 +++++++++++++++++++++++++-
+ frontend/scripts/ui-regression-smoke.mjs       |  3 ++-
+ frontend/src/hooks/useDashboardData.js         | 22 ++----------------
+ 4 files changed, 40 insertions(+), 22 deletions(-)

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/git-state.txt
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/git-state.txt
@@ -1,0 +1,10 @@
+branch=frontend-3b-webui-closure-6e9017a8-20260520T1235Z
+base_head=0c26b9e15ebf775069fbdc8072498d3a2ddb89c1
+origin_main=0c26b9e15ebf775069fbdc8072498d3a2ddb89c1
+status_short:
+ M .github/workflows/ci.yml
+ M frontend/scripts/frontend-3b-closure-smoke.mjs
+ M frontend/scripts/ui-regression-smoke.mjs
+ M frontend/src/hooks/useDashboardData.js
+?? frontend/src/lib/loadedModelDisplay.js
+?? qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/logs/frontend-gates.log
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/logs/frontend-gates.log
@@ -1,0 +1,53 @@
+$ git diff --check
+$ cd frontend && npm ci
+
+added 21 packages, and audited 22 packages in 691ms
+
+8 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+$ cd frontend && npm run build
+
+> camelid-frontend@0.1.0 build
+> vite build
+
+vite v8.0.10 building client environment for production...
+[2Ktransforming...✓ 39 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/index.html                   0.39 kB │ gzip:   0.26 kB
+dist/assets/index-BEi57WzR.css  124.03 kB │ gzip:  21.41 kB
+dist/assets/index-hKhjzgaP.js   375.56 kB │ gzip: 105.73 kB
+
+✓ built in 267ms
+$ cd frontend && npm run smoke:model-state
+
+> camelid-frontend@0.1.0 smoke:model-state
+> node scripts/model-state-smoke.mjs
+
+✓ model-state smoke passed
+$ cd frontend && npm run smoke:3b-closure
+
+> camelid-frontend@0.1.0 smoke:3b-closure
+> node scripts/frontend-3b-closure-smoke.mjs
+
+✓ frontend 3B closure smoke passed
+$ cd frontend && npm run smoke:ui
+
+> camelid-frontend@0.1.0 smoke:ui
+> node scripts/ui-regression-smoke.mjs
+
+UI regression smoke passed
+$ cd frontend && npm run smoke:streaming
+
+> camelid-frontend@0.1.0 smoke:streaming
+> node scripts/streaming-parser-smoke.mjs
+
+Streaming parser smoke passed
+$ cd frontend && npm run smoke:integration
+
+> camelid-frontend@0.1.0 smoke:integration
+> node scripts/frontend-integration-smoke.mjs
+
+Frontend integration smoke passed

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/logs/public-scrub-privacy.log
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/logs/public-scrub-privacy.log
@@ -1,0 +1,15 @@
+$ bash scripts/check-public-scrub.sh
+$ node scripts/audit-evidence-bundle-privacy.mjs --strict
+{
+  "schema": "camelid.evidence_bundle_privacy_audit.v1",
+  "generated_at": "2026-05-20T12:41:40.509Z",
+  "root": "qa/evidence-bundles",
+  "strict": true,
+  "finding_count": 0,
+  "bundle_count_with_findings": 0,
+  "bundles": []
+}
+$ node scripts/check-public-evidence-claims.mjs
+public evidence claim check passed: 96 manifest(s), 49 summary file(s)
+$ node scripts/test-readme-screenshot.mjs
+README screenshot guard passed

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/logs/script-gates.log
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/logs/script-gates.log
@@ -1,0 +1,36 @@
+$ for test_script in scripts/test-*.mjs; do node "$test_script"; done
+== scripts/test-audit-evidence-bundle-privacy.mjs
+== scripts/test-bench-llama3-same-host.mjs
+== scripts/test-chat-parity-harness.mjs
+chat-parity-harness self-test passed
+== scripts/test-check-attention-checkpoints.mjs
+check-attention-checkpoints self-test passed
+== scripts/test-check-forward-trace-invariants.mjs
+check-forward-trace-invariants self-test passed
+== scripts/test-check-output-projection-layout.mjs
+check-output-projection-layout self-test passed
+== scripts/test-check-public-evidence-claims.mjs
+== scripts/test-compare-attention-checkpoints.mjs
+compare-attention-checkpoints self-test passed
+== scripts/test-compare-dense-stage-flow.mjs
+compare-dense-stage-flow self-test passed
+== scripts/test-compare-forward-traces.mjs
+compare-forward-traces self-test passed
+== scripts/test-compare-tensor-dumps.mjs
+compare-tensor-dumps self-test passed
+== scripts/test-edge-prompt-gate-report.mjs
+edge-prompt-gate-report self-test passed
+== scripts/test-extract-forward-trace.mjs
+extract-forward-trace self-test passed
+== scripts/test-prepare-full-support-bundle.mjs
+== scripts/test-readme-screenshot.mjs
+README screenshot guard passed
+== scripts/test-run-llama3-prompt-pack.mjs
+run-llama3-prompt-pack self-test passed
+== scripts/test-summarize-attention-layer-diagnostics.mjs
+== scripts/test-summarize-dense-capture.mjs
+summarize-dense-capture self-test passed
+== scripts/test-summarize-generation-timings.mjs
+summarize-generation-timings self-test passed
+== scripts/test-summarize-same-host-stream-timing.mjs
+summarize-same-host-stream-timing self-test passed

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/retained-slice.diff
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/retained-slice.diff
@@ -1,0 +1,145 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 4a108a5..3d434c7 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -105,3 +105,9 @@ jobs:
+
+       - name: Frontend support-contract smoke
+         run: npm run smoke:model-state
++
++      - name: Frontend 3B exact-row closure smoke
++        run: npm run smoke:3b-closure
++
++      - name: Frontend integration smoke
++        run: npm run smoke:integration
+diff --git a/frontend/scripts/frontend-3b-closure-smoke.mjs b/frontend/scripts/frontend-3b-closure-smoke.mjs
+index 13bbcfd..a5e0b4b 100644
+--- a/frontend/scripts/frontend-3b-closure-smoke.mjs
++++ b/frontend/scripts/frontend-3b-closure-smoke.mjs
+@@ -19,6 +19,7 @@ import {
+   rowSupportNextStepCopy,
+ } from '../src/lib/capabilities.js'
+ import { getChatGateState } from '../src/lib/chatGate.js'
++import { resolveLoadedModelDisplayName } from '../src/lib/loadedModelDisplay.js'
+ import {
+   getRuntimeRequestModelId,
+   isRunnableInCurrentRuntime,
+@@ -103,6 +104,26 @@ assert.equal(compatibilityHintMatchesExactTarget(capabilities, exactThreeBModel,
+ assert.equal(modelRuntimeIdMatches(exactThreeBModel, runtime), true, '3B backend active_model_id must match the selected runtime row')
+ assert.equal(isRunnableInCurrentRuntime(exactThreeBModel, runtime), true, '3B runtime readiness must require the active backend row and generation_ready=true')
+ assert.equal(getRuntimeRequestModelId(exactThreeBModel, runtime, 'fallback'), 'scalar_default_rerun', 'API/chat requests should use the loaded backend model id for alias-safe 3B sends')
++assert.equal(
++  resolveLoadedModelDisplayName({ fallbackName: 'scalar_default_rerun', modelPath: exactThreeBModel.model_path, quantLabel: 'Q8_0' }),
++  LLAMA32_3B_ACCEPTANCE_TARGET.name,
++  'loaded backend aliases should render as the canonical 3B row only when the exact GGUF filename and decoded Q8_0 file_type evidence match',
++)
++assert.equal(
++  resolveLoadedModelDisplayName({ fallbackName: 'scalar_default_rerun', modelPath: exactThreeBModel.model_path, quantLabel: 'file_type 7' }),
++  LLAMA32_3B_ACCEPTANCE_TARGET.name,
++  'loaded backend aliases should also accept direct GGUF file_type 7 quant evidence for the exact 3B Q8_0 row',
++)
++assert.equal(
++  resolveLoadedModelDisplayName({ fallbackName: 'scalar_default_rerun', modelPath: exactThreeBModel.model_path, quantLabel: 'Q4_K_M' }),
++  'scalar_default_rerun',
++  'loaded backend aliases must not render as the 3B supported row when quant evidence is not Q8_0',
++)
++assert.equal(
++  resolveLoadedModelDisplayName({ fallbackName: 'scalar_default_rerun', modelPath: '/models/llama32-3b-instruct-q8-neighbor.gguf', quantLabel: 'Q8_0' }),
++  'scalar_default_rerun',
++  'loaded backend aliases must not render as the 3B supported row from a loose neighboring filename plus Q8_0 label',
++)
+
+ const exactGate = getChatGateState(capabilities, exactThreeBModel, runtime)
+ assert.deepEqual(
+@@ -111,6 +132,12 @@ assert.deepEqual(
+   '3B WebUI chat unlock is retained only when loaded_now, generation_ready, active_model_id, and exact supported row all pass',
+ )
+
++const missingCapabilitiesGate = getChatGateState(null, exactThreeBModel, runtime)
++assert.equal(missingCapabilitiesGate.runtimeReady, true, '3B runtime readiness must remain visible when /api/capabilities is unavailable')
++assert.equal(missingCapabilitiesGate.contractSupported, false, '3B support must fail closed when /api/capabilities is unavailable')
++assert.equal(missingCapabilitiesGate.chatUnlocked, false, '3B WebUI chat must not unlock from runtime health alone without the exact capabilities row')
++assert.equal(missingCapabilitiesGate.label, 'No matching COMPATIBILITY.md row', '3B support-gated copy should name the missing exact row when capabilities are absent')
++
+ for (const [label, model, runtimeOverride] of [
+   ['loaded_now=false', exactThreeBModel, { ...runtime, loaded_now: false }],
+   ['generation_ready=false', exactThreeBModel, { ...runtime, generation_ready: false }],
+@@ -157,6 +184,7 @@ assert.match(LLAMA32_3B_ACCEPTANCE_GATING_NOTE, /loaded_now=true and generation_
+ assert.match(LLAMA32_3B_ACCEPTANCE_GATING_NOTE, /exact supported Llama 3\.2 3B Q8_0 compatibility row/)
+
+ const hookSource = readFileSync(new URL('../src/hooks/useDashboardData.js', import.meta.url), 'utf8')
++const loadedModelDisplaySource = readFileSync(new URL('../src/lib/loadedModelDisplay.js', import.meta.url), 'utf8')
+ const chatSource = readFileSync(new URL('../src/views/ChatWorkspace.jsx', import.meta.url), 'utf8')
+ const modelsSource = readFileSync(new URL('../src/views/ModelsView.jsx', import.meta.url), 'utf8')
+ const apiSource = readFileSync(new URL('../src/views/ApiView.jsx', import.meta.url), 'utf8')
+@@ -164,7 +192,8 @@ const topBarSource = readFileSync(new URL('../src/components/TopBar.jsx', import
+
+ assert.match(hookSource, /selectedModelChatGate\s*=\s*getChatGateState\(dashboard\?\.capabilities, selectedModel, runtime\)/, 'dashboard selectedModelRunnable must be derived from the shared exact-row chat gate')
+ assert.match(hookSource, /selectedModelRunnable\s*=\s*selectedModelChatGate\.chatUnlocked/, 'dashboard must pass chatUnlocked, not runtime readiness alone, into the composer')
+-assert.match(hookSource, /LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'backend 3B display aliasing must stay exact-filename plus Q8_0 gated')
++assert.match(loadedModelDisplaySource, /quantLabelFromGgufFileType[\s\S]*file\[_\\s-\]\*type[\s\S]*LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'backend 3B display aliasing must stay exact-filename plus decoded Q8_0/file_type 7 gated')
++assert.match(hookSource, /resolveLoadedModelDisplayName/, 'dashboard model merge must use the shared exact-filename plus Q8_0 loaded-model display gate')
+ assert.match(chatSource, /runnableModels\s*=\s*models\.filter\(\(model\) => getChatGateState\(capabilities, model, runtime\)\.chatUnlocked\)/, 'chat model picker must list only exact-row unlocked models')
+ assert.match(chatSource, /canSubmit\s*=\s*Boolean\(composer\.trim\(\)\) && selectedModelRunnable && !generationActive/, 'composer send button must be blocked unless the exact-row chat gate unlocked')
+ assert.match(chatSource, /runtimeStatusCopy[\s\S]*loaded now and generation_ready=true/, 'chat readiness copy must name the runtime readiness requirement')
+diff --git a/frontend/scripts/ui-regression-smoke.mjs b/frontend/scripts/ui-regression-smoke.mjs
+index 8fe71c8..12eafae 100644
+--- a/frontend/scripts/ui-regression-smoke.mjs
++++ b/frontend/scripts/ui-regression-smoke.mjs
+@@ -37,6 +37,7 @@ assert.match(readmeSource, /product-forward while still reflecting the local-fir
+
+ const chatWorkspaceSource = readFileSync(new URL('../src/views/ChatWorkspace.jsx', import.meta.url), 'utf8')
+ const dashboardHookSource = readFileSync(new URL('../src/hooks/useDashboardData.js', import.meta.url), 'utf8')
++const loadedModelDisplaySource = readFileSync(new URL('../src/lib/loadedModelDisplay.js', import.meta.url), 'utf8')
+ const apiViewSource = readFileSync(new URL('../src/views/ApiView.jsx', import.meta.url), 'utf8')
+ const systemViewSource = readFileSync(new URL('../src/views/SystemView.jsx', import.meta.url), 'utf8')
+ const modelsViewSource = readFileSync(new URL('../src/views/ModelsView.jsx', import.meta.url), 'utf8')
+@@ -102,7 +103,7 @@ assert.match(dashboardHookSource, /selectedConversationIdRef\.current = next[\s\
+ assert.match(dashboardHookSource, /activeModelRunnable && current !== activeModel\.id/, 'browser-selected model should snap back to the backend active model when the runtime changes')
+ assert.match(dashboardHookSource, /modelRuntimeIdMatches/, 'dashboard model merge should treat runtime_model_name as an active_model_id alias instead of losing readiness for imported exact rows')
+ assert.match(dashboardHookSource, /resolveLoadedModelDisplayName/, 'dashboard model merge should rewrite backend-generated active ids to the exact 3B display row only from exact GGUF filename plus Q8_0 metadata')
+-assert.match(dashboardHookSource, /LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'the 3B display alias must stay exact-row and quant-gated rather than broad-family')
++assert.match(loadedModelDisplaySource, /quantLabelFromGgufFileType[\s\S]*file\[_\\s-\]\*type[\s\S]*LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'the 3B display alias must stay exact-row and decoded Q8_0/file_type 7 gated rather than broad-family')
+ assert.match(dashboardHookSource, /localRecordMatchesBackendId/, 'dashboard model merge should de-duplicate backend model rows against saved browser records by id or runtime_model_name')
+ assert.match(dashboardHookSource, /const id = localRecord\?\.id \|\| item\.id/, 'backend model merges should preserve the browser row id while keeping the backend runtime id as runtime_model_name')
+ assert.match(dashboardHookSource, /const conversation = await ensureConversation\(\)[\s\S]*?setSelectedConversationId\(conversation\.id\)[\s\S]*?fetch\(`\$\{normalizedApiBase\}\/v1\/chat\/completions`/, 'fresh-chat sends must select the real conversation before streaming starts so the main pane updates with sidebar previews')
+diff --git a/frontend/src/hooks/useDashboardData.js b/frontend/src/hooks/useDashboardData.js
+index a999280..50b97c6 100644
+--- a/frontend/src/hooks/useDashboardData.js
++++ b/frontend/src/hooks/useDashboardData.js
+@@ -1,7 +1,7 @@
+ import { useEffect, useMemo, useRef, useState } from 'react'
+-import { LLAMA32_3B_ACCEPTANCE_TARGET } from '../lib/acceptanceTargets'
+ import { compatibilityHintCopy, compatibilityHintLabel, findCompatibilityHint, isCompatibilitySupportedForModel, quantLabelFromGgufFileType } from '../lib/capabilities'
+ import { getChatGateState } from '../lib/chatGate'
++import { resolveLoadedModelDisplayName } from '../lib/loadedModelDisplay'
+ import { readStreamingChatCompletion } from '../lib/chatCompletionStream'
+ import { NEW_CHAT_SENTINEL, resolveSelectedConversation, shouldCreateConversationForSend } from '../lib/chatState'
+ import { normalizeStoredConversations } from '../lib/conversationStorage.js'
+@@ -76,25 +76,7 @@ function getModelPath(model) {
+   return typeof model?.path === 'string' ? model.path : ''
+ }
+
+-function pathBasename(value) {
+-  return String(value || '').split(/[\\/]/).filter(Boolean).pop() || ''
+-}
+-
+-function normalizeQuantLabel(value) {
+-  return String(value || '').trim().toUpperCase().replace(/[^A-Z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+-}
+-
+-const LLAMA32_3B_ACCEPTANCE_FILENAME = pathBasename(LLAMA32_3B_ACCEPTANCE_TARGET.source)
+-
+-function isExactLlama32ThreeBLoadedGguf(modelPath, quantLabel) {
+-  return pathBasename(modelPath).toLowerCase() === LLAMA32_3B_ACCEPTANCE_FILENAME.toLowerCase()
+-    && normalizeQuantLabel(quantLabel) === 'Q8_0'
+-}
+-
+-export function resolveLoadedModelDisplayName({ fallbackName, modelPath, quantLabel }) {
+-  if (isExactLlama32ThreeBLoadedGguf(modelPath, quantLabel)) return LLAMA32_3B_ACCEPTANCE_TARGET.name
+-  return fallbackName
+-}
++export { resolveLoadedModelDisplayName }
+
+ function getLoadedModelFileType(model) {
+   const metadata = model?.gguf?.metadata || {}

--- a/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/summary.json
+++ b/qa/evidence-bundles/frontend-3b-display-ci-gate-20260520T1243Z-head-0c26b9e/summary.json
@@ -1,0 +1,9 @@
+{
+  "schema": "camelid.frontend_3b_slice.v1",
+  "generated_at": "2026-05-20T12:43:00Z",
+  "target": "llama32_3b_instruct_q8_0",
+  "quantization": "Q8_0",
+  "retain": true,
+  "claim": "Frontend display alias and CI regression gates preserve exact-row 3B support-contract behavior; no broader/full-support or live backend promotion claim is made.",
+  "live_backend": "blocked: canonical validation host API port refused connections during this slice"
+}


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
