### PR TITLE
Frontend 3b webui closure 6e9017a8 20260520 t1848 z

### DIFF
--- a/frontend/scripts/frontend-3b-closure-smoke.mjs
+++ b/frontend/scripts/frontend-3b-closure-smoke.mjs
@@ -188,6 +188,7 @@ const loadedModelDisplaySource = readFileSync(new URL('../src/lib/loadedModelDis
 const chatSource = readFileSync(new URL('../src/views/ChatWorkspace.jsx', import.meta.url), 'utf8')
 const modelsSource = readFileSync(new URL('../src/views/ModelsView.jsx', import.meta.url), 'utf8')
 const apiSource = readFileSync(new URL('../src/views/ApiView.jsx', import.meta.url), 'utf8')
+const systemSource = readFileSync(new URL('../src/views/SystemView.jsx', import.meta.url), 'utf8')
 const topBarSource = readFileSync(new URL('../src/components/TopBar.jsx', import.meta.url), 'utf8')
 
 assert.match(hookSource, /selectedModelChatGate\s*=\s*getChatGateState\(dashboard\?\.capabilities, selectedModel, runtime\)/, 'dashboard selectedModelRunnable must be derived from the shared exact-row chat gate')
@@ -210,6 +211,10 @@ assert.match(modelsSource, /matchedChatGate\s*=\s*matchedModel \? getChatGateSta
 assert.match(apiSource, /Selected exact-row evidence/, 'API view must surface selected 3B exact-row evidence')
 assert.match(apiSource, /selectedExactRowReady/, 'API view endpoint readiness must use selected exact-row readiness, not broad family evidence')
 assert.match(apiSource, /selectedCompatibilityTarget\.frontend_readiness_gate/, 'API view must render the 3B frontend readiness gate from /api/capabilities')
+assert.match(systemSource, /selectedChatGate\s*=\s*getChatGateState\(capabilities, selectedModel, runtime\)/, 'System view must use the shared exact-row chat gate for 3B readiness surfaces')
+assert.match(systemSource, /selectedExactRowReady\s*=\s*selectedChatGate\.chatUnlocked/, 'System view must not promote /v1 chat readiness from generation_ready alone')
+assert.match(systemSource, /Blocked for UX chat until selected exact row evidence and runtime readiness both match/, 'System curl copy must stay blocked until 3B exact-row support and runtime readiness both match')
+assert.match(systemSource, /Endpoint\/chat gate:/, 'System selected 3B evidence must show the retained endpoint/chat readiness gate')
 assert.match(topBarSource, /exactHintDetail\(activeChatGate\.hint\) \|\| exactHintDetail\(selectedChatGate\.hint\)/, 'TopBar support contract detail must prioritize the active/selected exact 3B hint label, including quant-mismatch and quant-missing blockers')
 assert.match(topBarSource, /exactTargetFromHint\(activeChatGate\.hint\)[\s\S]*exactTargetFromHint\(selectedChatGate\.hint\)[\s\S]*getCurrentCompatibilityTarget/, 'TopBar support contract detail must fall back to the first current gate row only after active/selected exact-row hints')
 

--- a/frontend/scripts/frontend-3b-closure-smoke.mjs
+++ b/frontend/scripts/frontend-3b-closure-smoke.mjs
@@ -209,6 +209,8 @@ assert.match(modelsSource, /Fill import form with exact path/, 'ModelsView must 
 assert.match(modelsSource, /Chat unlockable/, 'ModelsView must expose the retained exact-row chat-unlock state')
 assert.match(modelsSource, /matchedChatGate\s*=\s*matchedModel \? getChatGateState\(capabilities, matchedModel, runtime\) : null/, 'ModelsView retained 3B row cards must use the shared chat gate for loaded_now and generation_ready checks')
 assert.match(apiSource, /Selected exact-row evidence/, 'API view must surface selected 3B exact-row evidence')
+assert.match(apiSource, /selectedChatGate\s*=\s*getChatGateState\(capabilities, selectedModel, runtime\)/, 'API view must use the shared exact-row chat gate for 3B endpoint readiness')
+assert.match(apiSource, /selectedExactRowReady\s*=\s*selectedChatGate\.chatUnlocked/, 'API view must not reimplement 3B endpoint readiness separately from Chat/System')
 assert.match(apiSource, /selectedExactRowReady/, 'API view endpoint readiness must use selected exact-row readiness, not broad family evidence')
 assert.match(apiSource, /selectedCompatibilityTarget\.frontend_readiness_gate/, 'API view must render the 3B frontend readiness gate from /api/capabilities')
 assert.match(systemSource, /selectedChatGate\s*=\s*getChatGateState\(capabilities, selectedModel, runtime\)/, 'System view must use the shared exact-row chat gate for 3B readiness surfaces')

--- a/frontend/scripts/frontend-integration-smoke.mjs
+++ b/frontend/scripts/frontend-integration-smoke.mjs
@@ -20,6 +20,7 @@ const server = await createServer({
 try {
   const { default: ChatWorkspace } = await server.ssrLoadModule('/src/views/ChatWorkspace.jsx')
   const { default: ApiView } = await server.ssrLoadModule('/src/views/ApiView.jsx')
+  const { default: SystemView } = await server.ssrLoadModule('/src/views/SystemView.jsx')
   const { default: ModelsView } = await server.ssrLoadModule('/src/views/ModelsView.jsx')
   const { default: TopBar } = await server.ssrLoadModule('/src/components/TopBar.jsx')
   const { getChatGateState } = await server.ssrLoadModule('/src/lib/chatGate.js')
@@ -288,6 +289,19 @@ try {
   assert.doesNotMatch(exactReadyMarkup, /arbitrary-template behavior|arbitrary\/Jinja templates/, 'API support surface should not repeat resolved template/Jinja caveats after row-scoped template evidence is green')
   assert.doesNotMatch(exactReadyMarkup, /normalizing model-native\/larger context; arbitrary\/Jinja template behavior; production throughput/, 'API compatibility list next-step copy should filter resolved template/Jinja caveats while retaining production-throughput blockers')
   assert.match(exactReadyMarkup, /Supported API feature rows/, 'API view should render supported feature rows from /api/capabilities')
+
+  const exactReadySystemMarkup = renderToStaticMarkup(React.createElement(SystemView, {
+    runtime: readyRuntime,
+    selectedModel,
+    capabilities,
+  }))
+
+  assert.match(exactReadySystemMarkup, /Selected exact-row local \/v1 ready/, 'System endpoint status should go green only when the selected 3B exact row and runtime readiness both match')
+  assert.match(exactReadySystemMarkup, /Runs now for this selected GGUF because loaded_now=true, generation_ready=true, active_model_id matches, and the exact \/api\/capabilities row is supported\./, 'System chat-completions copy should name the full 3B exact-row readiness gate')
+  assert.match(exactReadySystemMarkup, /Endpoint\/chat gate:[\s\S]*Ready: runtime readiness and exact-row support both match\./, 'System selected exact-row evidence should expose the retained chat/API gate')
+  assert.match(exactReadySystemMarkup, /Template\/Jinja readiness[\s\S]*Template readiness is green for this supported exact row/, 'System should render 3B template/Jinja lane evidence from /api/capabilities')
+  assert.match(exactReadySystemMarkup, /Throughput readiness[\s\S]*Bounded row-scoped performance\/RSS evidence is present/, 'System should keep bounded 3B performance evidence separate from production-throughput promotion')
+  assert.doesNotMatch(exactReadySystemMarkup, /# Use only after \/v1\/health returns generation_ready=true/, 'System curl should not imply generation_ready alone is sufficient for 3B UX chat')
   assert.match(exactReadyMarkup, /chat completions/, 'API view should display provider-scoped feature ids as neutral capability names')
   assert.match(exactReadyMarkup, /standard-compatible streaming stays enabled\./, 'API view should sanitize provider-specific feature notes before rendering')
 
@@ -643,6 +657,18 @@ try {
   assert.match(backendReadyButUnsupported3BChatMarkup, /Chat unlocks only after loaded_now=true, generation_ready=true, and an exact supported compatibility row all match\./, 'support-gated 3B UX should preserve the exact-row frontend readiness rule')
   assert.match(backendReadyButUnsupported3BChatMarkup, /Load a model first/, 'support-gated 3B composer should stay disabled instead of accepting prompts')
   assert.doesNotMatch(backendReadyButUnsupported3BChatMarkup, /Local chat ready|Message Camelid…|Demo starters/, 'support-gated 3B rows must not render the live-chat ready UX')
+
+  const backendReadyButUnsupported3BSystemMarkup = renderToStaticMarkup(React.createElement(SystemView, {
+    runtime: liveBackendIdRuntime,
+    selectedModel: liveBackendIdModel,
+    capabilities: backendReadyButUnsupported3BCapabilities,
+  }))
+
+  assert.match(backendReadyButUnsupported3BSystemMarkup, /Runtime ready, support gated/, 'System should keep runtime-green 3B rows visible without making unsupported exact rows API/chat-ready')
+  assert.match(backendReadyButUnsupported3BSystemMarkup, /Blocked for UX chat until loaded_now=true, generation_ready=true, active_model_id matches, and this exact row is supported\./, 'System should block chat completions copy when the exact 3B row is downgraded')
+  assert.match(backendReadyButUnsupported3BSystemMarkup, /Endpoint\/chat gate:[\s\S]*llama32_3b_instruct_q8_0: groundwork backend evidence only; loaded_now=true, generation_ready=true, exact row supported=false\./, 'System selected exact-row evidence should show runtime-green/support-red state for downgraded 3B rows')
+  assert.match(backendReadyButUnsupported3BSystemMarkup, /# Blocked for UX chat until selected exact row evidence and runtime readiness both match/, 'System curl should stay blocked for runtime-ready unsupported 3B rows')
+  assert.doesNotMatch(backendReadyButUnsupported3BSystemMarkup, /Selected exact-row local \/v1 ready|Ready: runtime readiness and exact-row support both match/, 'System must not present downgraded 3B rows as exact-row API/chat-ready')
 
   assert.match(exactReadyMarkup, /responses stream/, 'API view should normalize provider-scoped dotted feature ids before rendering')
   assert.match(exactReadyMarkup, /hosted model-style streamed response compatibility stays provider-neutral/, 'API view should neutralize hosted-brand feature notes before rendering')

--- a/frontend/scripts/frontend-integration-smoke.mjs
+++ b/frontend/scripts/frontend-integration-smoke.mjs
@@ -735,6 +735,7 @@ try {
     loaded_now: true,
     generation_ready: true,
     quant: 'Q8_0',
+    model_path: '/models/custom-exact-row-q8-0.gguf',
   }
   const genericExactCapabilities = {
     support_contract: capabilities.support_contract,

--- a/frontend/scripts/ui-regression-smoke.mjs
+++ b/frontend/scripts/ui-regression-smoke.mjs
@@ -131,6 +131,8 @@ assert.match(streamParserSource, /replace\(/, 'stream parser should normalize li
 assert.match(streamParserSource, /split\('\\n\\n'\)/, 'stream parser should split normalized SSE events on blank lines for partial rendering')
 assert.match(dashboardHookSource, /finish_reason:\s*'error',[\s\S]*streaming:\s*false/, 'failed generations should clear streaming state instead of leaving active pellets/status forever')
 assert.match(apiViewSource, /Selected exact-row evidence/, 'API support view should show selected exact-row evidence instead of a broad validated-target claim')
+assert.match(apiViewSource, /selectedChatGate\s*=\s*getChatGateState\(capabilities, selectedModel, runtime\)/, 'API endpoint readiness should use the shared exact-row chat gate')
+assert.match(apiViewSource, /selectedExactRowReady\s*=\s*selectedChatGate\.chatUnlocked/, 'API endpoint readiness should stay aligned with Chat/System exact-row chat unlocks')
 assert.match(apiViewSource, /selectedExactRowReady/, 'API endpoint readiness should only turn green when runtime readiness and the selected exact compatibility row both match')
 assert.match(apiViewSource, /selectedRuntimeMatches/, 'API endpoint readiness should require active_model_id to match the selected model')
 assert.match(apiViewSource, /readinessPillCopy/, 'API endpoint status copy should come from the exact-row readiness gate, not generation_ready alone')

--- a/frontend/src/views/ApiView.jsx
+++ b/frontend/src/views/ApiView.jsx
@@ -1,4 +1,5 @@
 import { capabilityStatusTone, displayCapabilityCopy, displayCapabilityId, exactRowSupportLanes, findCompatibilityHint, formatCapabilityStatus, frontendSupportContractCopy, guardedCapabilityCopy, isExactCompatibilityHint, isGuardedCapabilityStatus, isSupportedCapabilityStatus, rowSupportBoundaryCopy, rowSupportNextStepCopy } from '../lib/capabilities'
+import { getChatGateState } from '../lib/chatGate'
 import { getRuntimeRequestModelId, modelRuntimeIdMatches } from '../lib/modelState'
 
 function guardedApiFeatures(features = []) {
@@ -21,14 +22,15 @@ export default function ApiView({ runtime, selectedModel, capabilities }) {
   const apiFeatures = capabilities?.api_features || []
   const supportedFeatures = apiFeatures.filter((feature) => isSupportedCapabilityStatus(feature.status))
   const guardedFeatures = guardedApiFeatures(apiFeatures)
-  const selectedCompatibilityHint = findCompatibilityHint(capabilities, selectedModel)
+  const selectedChatGate = getChatGateState(capabilities, selectedModel, runtime)
+  const selectedCompatibilityHint = selectedChatGate.hint || findCompatibilityHint(capabilities, selectedModel)
   const selectedCompatibilityTarget = isExactCompatibilityHint(selectedCompatibilityHint) ? selectedCompatibilityHint.target : null
-  const selectedCompatibilitySupported = selectedCompatibilityTarget ? isSupportedCapabilityStatus(selectedCompatibilityTarget.status) : false
+  const selectedCompatibilitySupported = selectedChatGate.contractSupported
   const selectedSupportLanes = exactRowSupportLanes(selectedCompatibilityTarget, apiFeatures)
   const generationReady = Boolean(runtime?.generation_ready)
   const loadedNow = Boolean(runtime?.loaded_now)
   const selectedRuntimeMatches = modelRuntimeIdMatches(selectedModel, runtime)
-  const selectedExactRowReady = Boolean(loadedNow && generationReady && selectedRuntimeMatches && selectedCompatibilitySupported)
+  const selectedExactRowReady = selectedChatGate.chatUnlocked
   const readinessPillCopy = selectedExactRowReady
     ? 'Selected exact row ready'
     : generationReady && selectedModel && !selectedRuntimeMatches

--- a/frontend/src/views/SystemView.jsx
+++ b/frontend/src/views/SystemView.jsx
@@ -1,4 +1,5 @@
-import { capabilityStatusTone, displayCapabilityCopy, displayCapabilityId, findCompatibilityHint, formatCapabilityStatus, frontendSupportContractCopy, guardedCapabilityCopy, isExactCompatibilityHint, isGuardedCapabilityStatus, isSupportedCapabilityStatus } from '../lib/capabilities'
+import { capabilityStatusTone, displayCapabilityCopy, displayCapabilityId, exactRowSupportLanes, findCompatibilityHint, formatCapabilityStatus, frontendSupportContractCopy, guardedCapabilityCopy, isExactCompatibilityHint, isGuardedCapabilityStatus, isSupportedCapabilityStatus } from '../lib/capabilities'
+import { getChatGateState } from '../lib/chatGate'
 import { describeModelState, getRuntimeRequestModelId } from '../lib/modelState'
 
 function runtimeReadinessLabel(runtime) {
@@ -18,8 +19,36 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
   const apiFeatures = capabilities?.api_features || []
   const supportedFeatures = apiFeatures.filter((feature) => isSupportedCapabilityStatus(feature.status))
   const unsupportedFeatures = apiFeatures.filter((feature) => isGuardedCapabilityStatus(feature.status))
+  const selectedChatGate = getChatGateState(capabilities, selectedModel, runtime)
   const selectedCompatibilityHint = findCompatibilityHint(capabilities, selectedModel)
   const selectedCompatibilityTarget = isExactCompatibilityHint(selectedCompatibilityHint) ? selectedCompatibilityHint.target : null
+  const selectedSupportLanes = exactRowSupportLanes(selectedCompatibilityTarget, apiFeatures)
+  const selectedExactRowReady = selectedChatGate.chatUnlocked
+  const endpointReadinessLabel = selectedExactRowReady
+    ? 'Selected exact-row local /v1 ready'
+    : selectedChatGate.runtimeReady
+      ? 'Runtime ready, support gated'
+      : runtime?.generation_ready
+        ? 'Different loaded model or exact row required'
+        : runtime?.loaded_now
+          ? 'Loaded, not generation-ready'
+          : 'Load a supported exact row'
+  const chatCompletionsCopy = selectedExactRowReady
+    ? 'Runs now for this selected GGUF because loaded_now=true, generation_ready=true, active_model_id matches, and the exact /api/capabilities row is supported.'
+    : selectedCompatibilityTarget
+      ? 'Blocked for UX chat until loaded_now=true, generation_ready=true, active_model_id matches, and this exact row is supported.'
+      : 'Blocked for UX chat until a selected model matches an exact supported COMPATIBILITY.md row and runtime readiness is green.'
+  const curlExample = selectedExactRowReady
+    ? `# Selected exact row is runtime-ready now\ncurl ${runtime?.api_base}/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "${modelId}",
+    "messages": [{"role": "user", "content": "Hello from Camelid"}],
+    "temperature": 0
+  }'`
+    : `# Blocked for UX chat until selected exact row evidence and runtime readiness both match
+# loaded_now=${runtime?.loaded_now ? 'true' : 'false'} generation_ready=${runtime?.generation_ready ? 'true' : 'false'} active_model_id=${runtime?.active_model_id || 'none'}
+# selected_exact_row=${selectedCompatibilityTarget?.id || 'none'} support_gate=${selectedChatGate.label}`
   const exactRowQuantEvidence = compatibilityTargets.length
     ? compatibilityTargets.map((target) => `${target.id}: ${target.quantization} (${formatCapabilityStatus(target.status)})`).join(' · ')
     : 'No exact compatibility rows advertised.'
@@ -55,6 +84,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
             <div className="runtime-stat"><span>Local engine</span><strong>{runtime?.engine || 'Unknown'}</strong></div>
             <div className="runtime-stat"><span>Loaded model</span><strong>{runtime?.loaded_now ? runtime?.active_model_id : 'Nothing loaded'}</strong></div>
             <div className="runtime-stat"><span>Generation ready</span><strong>{runtime?.generation_ready ? 'Yes' : 'No'}</strong></div>
+            <div className="runtime-stat"><span>Selected exact-row gate</span><strong>{selectedExactRowReady ? 'Ready for chat/API' : selectedChatGate.runtimeReady ? 'Runtime ready; support gated' : selectedChatGate.label}</strong></div>
             <div className="runtime-stat"><span>Acceleration</span><strong>CPU path today; optimized kernels/GPU are not wired yet</strong></div>
             <div className="runtime-stat"><span>Next chat selection</span><strong>{selectedModelName}</strong></div>
             <div className="runtime-stat"><span>API base</span><strong>{apiBase}</strong></div>
@@ -74,7 +104,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
             <div className="activity-item">Saved memory remains on-device and can be recalled in later chats.</div>
             <div className="activity-item">Camelid is using the local CPU generation path today; GPU acceleration remains future work.</div>
             <div className="activity-item">Current next-chat model state: {describeModelState(selectedModel)}</div>
-            <div className="activity-item">Chat stays blocked until Camelid reports generation_ready for the selected model; once ready, chat runs until EOS, an explicit request limit, or the backend context window.</div>
+            <div className="activity-item">Chat stays blocked until loaded_now=true, generation_ready=true, active_model_id matches the selected local GGUF, and COMPATIBILITY.md plus /api/capabilities expose an exact supported row.</div>
             <div className="activity-item">The standard /v1-compatible local API is exposed at {apiBase}.</div>
           </div>
         </div>
@@ -87,13 +117,13 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
             <h2>Standard /v1-compatible local API</h2>
             <p className="hero-summary">Use the same local runtime through standard endpoints for apps, scripts, and quick terminal checks.</p>
           </div>
-          <div className={`status-pill ${runtime?.generation_ready ? 'ready' : 'warm'}`}>{runtime?.generation_ready ? 'Local /v1 generation ready' : runtime?.loaded_now ? 'Local /v1 loaded, not ready' : 'Load a model to use generation'}</div>
+          <div className={`status-pill ${selectedExactRowReady ? 'ready' : 'warm'}`}>{endpointReadinessLabel}</div>
         </div>
         <div className="api-grid api-grid-polished">
           <div className="api-card">
             <strong>Chat completions</strong>
             <code>{runtime?.api_base ? `${runtime.api_base}/v1/chat/completions` : 'Unavailable until the local API is running'}</code>
-            <p>Runs only after a local GGUF is loaded and Camelid reports generation_ready=true.</p>
+            <p>{chatCompletionsCopy}</p>
           </div>
           <div className="api-card">
             <strong>Models</strong>
@@ -112,13 +142,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
           </div>
           <div className="api-card wide api-card-code">
             <strong>Readiness-gated curl</strong>
-            <pre>{runtime?.api_base ? `# Use only after /v1/health returns generation_ready=true\ncurl ${runtime.api_base}/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "${modelId}",
-    "messages": [{"role": "user", "content": "Hello from Camelid"}],
-    "temperature": 0
-  }'` : 'Start the local runtime to see a ready-to-copy curl example.'}</pre>
+            <pre>{runtime?.api_base ? curlExample : 'Start the local runtime to see an exact-row readiness check.'}</pre>
           </div>
         </div>
       </section>
@@ -154,6 +178,10 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
                 <code>{selectedCompatibilityTarget.id}</code>
                 <p>{formatCapabilityStatus(selectedCompatibilityTarget.status)} · {selectedCompatibilityTarget.family} · {selectedCompatibilityTarget.quantization}</p>
                 <p><b>Readiness gate:</b> {displayCapabilityCopy(selectedCompatibilityTarget.frontend_readiness_gate || 'not advertised')}</p>
+                <p><b>Endpoint/chat gate:</b> {selectedExactRowReady ? 'Ready: runtime readiness and exact-row support both match.' : `${selectedChatGate.label}; loaded_now=${selectedChatGate.runtimeLoaded ? 'true' : 'false'}, generation_ready=${selectedChatGate.runtimeGenerationReady ? 'true' : 'false'}, exact row supported=${selectedChatGate.contractSupported ? 'true' : 'false'}.`}</p>
+                {selectedSupportLanes.map((lane) => (
+                  <p key={lane.key}><b>{lane.key === 'template' ? 'Template/Jinja readiness' : 'Throughput readiness'}:</b> {lane.label}. {displayCapabilityCopy(lane.copy)}</p>
+                ))}
                 <p>{displayCapabilityCopy(selectedCompatibilityTarget.evidence || selectedCompatibilityTarget.next_step || 'No row evidence advertised.')}</p>
               </>
             ) : (


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
