### PR TITLE
frontend: keep 3b throughput row-owned

### DIFF
--- a/frontend/scripts/frontend-3b-closure-smoke.mjs
+++ b/frontend/scripts/frontend-3b-closure-smoke.mjs
@@ -170,6 +170,20 @@ assert.equal(getChatGateState(noThreeBRowCapabilities, exactThreeBModel, runtime
 
 const lanes = exactRowSupportLanes(llama32ThreeBTarget, capabilities.api_features)
 assert.deepEqual(lanes.map((lane) => [lane.key, lane.ready]), [['template', true], ['throughput', false]], '3B template/Jinja readiness is row-green while production throughput remains unpromoted')
+const genericThroughputCapabilities = {
+  ...capabilities,
+  api_features: [
+    {
+      id: 'production_throughput_api',
+      status: 'supported_current_gate',
+      notes: 'generic API throughput reporting exists',
+    },
+  ],
+}
+const lanesWithGenericThroughput = exactRowSupportLanes(llama32ThreeBTarget, genericThroughputCapabilities.api_features)
+const throughputLaneWithGenericFeature = lanesWithGenericThroughput.find((lane) => lane.key === 'throughput')
+assert.equal(throughputLaneWithGenericFeature.ready, false, '3B production-throughput readiness must stay row-owned and not inherit a generic API feature')
+assert.match(throughputLaneWithGenericFeature.copy, /generic API feature supported current gate does not widen row support/, '3B throughput copy must explain why generic API features do not promote exact-row throughput')
 assert.doesNotMatch(rowSupportBoundaryCopy(llama32ThreeBTarget, capabilities.api_features), /arbitrary|Jinja/i, '3B boundary copy should not repeat resolved row-scoped metadata-Jinja caveats')
 assert.match(rowSupportBoundaryCopy(llama32ThreeBTarget, capabilities.api_features), /production|throughput/i, '3B boundary copy must keep production-throughput caveats visible')
 assert.doesNotMatch(rowSupportNextStepCopy(llama32ThreeBTarget, capabilities.api_features), /arbitrary|Jinja/i, '3B next-step copy should not repeat resolved template/Jinja caveats')

--- a/frontend/scripts/frontend-integration-smoke.mjs
+++ b/frontend/scripts/frontend-integration-smoke.mjs
@@ -466,7 +466,7 @@ try {
     selectedModel: aliasSelectedModel,
     capabilities: green3BCapabilities,
   }))
-  assert.match(green3BApiMarkup, /Throughput readiness[\s\S]*Production-throughput support is advertised by \/api\/capabilities as supported exact row evidence/, 'API view should render green 3B production-throughput evidence only when /api/capabilities advertises it')
+  assert.match(green3BApiMarkup, /Throughput readiness[\s\S]*Production-throughput readiness is green for this supported exact row from production throughput validated evidence/, 'API view should render green 3B production-throughput evidence only when /api/capabilities advertises row-owned evidence')
   assert.doesNotMatch(green3BApiMarkup, /Remaining support boundary:<\/b>[\s\S]{0,220}(?:arbitrary|Jinja|production|throughput)/i, 'API view 3B boundary should not repeat resolved template/Jinja or production-throughput blockers after green evidence')
 
   const green3BModelsMarkup = renderToStaticMarkup(React.createElement(ModelsView, {
@@ -489,9 +489,11 @@ try {
     installCatalogModel: noop,
     cancelModelDownload: noop,
   }))
+  const green3BTrackedCard = green3BModelsMarkup.match(/<article class="model-card models-model-card">(?:(?!<\/article>)[\s\S])*<strong>llama32_3b_instruct_q8_0<\/strong>(?:(?!<\/article>)[\s\S])*<\/article>/)?.[0] || ''
+  assert.ok(green3BTrackedCard, 'Models view should render the tracked 3B row card')
   assert.match(green3BModelsMarkup, /Chat unlockable/, 'Models tracked 3B card should remain chat-unlockable when exact row, runtime readiness, and green evidence all align')
   assert.match(green3BModelsMarkup, /Throughput: Production throughput ready for this exact row/, 'Models tracked 3B card should show production-throughput green only from row/API evidence')
-  assert.doesNotMatch(green3BModelsMarkup, /Remaining support boundary:<\/b>[\s\S]{0,220}(?:arbitrary|Jinja|production|throughput)/i, 'Models tracked 3B card should not keep resolved 3B support blockers visible when evidence is green')
+  assert.doesNotMatch(green3BTrackedCard, /Remaining support boundary:<\/b>[\s\S]{0,220}(?:arbitrary|Jinja|production|throughput)/i, 'Models tracked 3B card should not keep resolved 3B support blockers visible when evidence is green')
 
   assert.equal(
     resolveLoadedModelDisplayName({

--- a/frontend/src/lib/capabilities.js
+++ b/frontend/src/lib/capabilities.js
@@ -248,22 +248,20 @@ export function describeThroughputReadiness(target, apiFeatures = []) {
   const performance = target.performance_measured || ''
   const rowThroughputReady = hasExactRowProductionThroughputReadiness(target)
   const boundedPerformanceReady = hasExactRowBoundedPerformanceEvidence(target)
-  const ready = Boolean(feature || rowThroughputReady)
+  const ready = rowThroughputReady
   const label = ready ? 'Production throughput ready for this exact row' : 'Production throughput not promoted'
 
   return {
     key: 'throughput',
     label,
-    status: feature?.status || performance || 'not advertised',
+    status: performance || feature?.status || 'not advertised',
     tone: ready ? 'ready' : boundedPerformanceReady ? 'warm' : 'warm',
     ready,
-    copy: feature
-      ? `Production-throughput support is advertised by /api/capabilities as ${formatCapabilityStatus(feature.status)}: ${displayCapabilityCopy(feature.notes || 'No notes advertised.')}`
-      : rowThroughputReady
+    copy: rowThroughputReady
         ? `Production-throughput readiness is green for this supported exact row from ${formatCapabilityStatus(performance)} evidence reported by /api/capabilities.`
         : boundedPerformanceReady
-          ? `Bounded row-scoped performance/RSS evidence is present as ${formatCapabilityStatus(performance)}, but production throughput is still not promoted for this exact row.`
-          : 'Production throughput evidence is not promoted for this row; keep readiness guarded until /api/capabilities reports explicit production-throughput support.',
+          ? `Bounded row-scoped performance/RSS evidence is present as ${formatCapabilityStatus(performance)}, but production throughput is still not promoted for this exact row${feature ? `; generic API feature ${formatCapabilityStatus(feature.status)} does not widen row support.` : '.'}`
+          : `Production throughput evidence is not promoted for this row; keep readiness guarded until /api/capabilities reports explicit production-throughput support on the exact row${feature ? `, not just generic API feature ${formatCapabilityStatus(feature.status)}.` : '.'}`,
   }
 }
 


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
