### PR TITLE
docs: retain support contract host audit

### DIFF
--- a/docs/performance/ubuntu-x86-q8.md
+++ b/docs/performance/ubuntu-x86-q8.md
@@ -149,6 +149,7 @@ Primary public evidence anchors for this lane:
 - `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-5e4b0b83-20260520T1244Z-docs-context-host-reporting-audit/README.md` (docs/context host-reporting retained audit: public docs/context scan passed for stale host-access wording and private host aliases; remote validation was not attempted in this run)
 - `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-5e4b0b83-20260520T1657Z-docs-support-contract-audit/README.md` (docs support-contract/host-reporting audit: narrow stale host-failure scan passed, support-contract wording remains guarded, and remote validation was not attempted in this run)
 - `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-5e4b0b83-20260520T2138Z-docs-support-contract-host-audit/README.md` (docs support-contract/host-reporting audit: narrow stale host-failure scan passed, public docs/context keep canonical host references limited to the reporting rule, and remote validation was not attempted in this run)
+- `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-5e4b0b83-20260520T2332Z-docs-support-contract-host-audit/README.md` (docs support-contract/host-reporting audit: stale host-failure scan passed, support wording remains exact-row scoped, and remote validation was not attempted in this run)
 - the retained/reject notes for bounded Ubuntu x86 Q8 experiments kept under `qa/evidence-bundles/`
 
 ## Product/runtime note

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-5e4b0b83-20260520T2332Z-docs-support-contract-host-audit/README.md
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-5e4b0b83-20260520T2332Z-docs-support-contract-host-audit/README.md
@@ -1,0 +1,39 @@
+# Docs Support Contract / Host Audit
+
+Time: 2026-05-20 23:32 UTC
+
+Scope:
+
+- `CONTEXT.md`
+- `README.md`
+- `COMPATIBILITY.md`
+- `docs/**/*.md`
+- `qa/validation-notes/**/*.md`
+
+Purpose:
+
+- Keep support-contract wording exact-row and evidence-scoped.
+- Confirm public docs do not carry stale negative canonical Ubuntu host-access wording.
+- Preserve the current host-reporting rule: negative canonical Ubuntu host status is current only when the canonical SSH probe was run in the same slice and failure stderr is cited.
+
+Commands:
+
+```bash
+rg -n -S '<stale canonical-host negative-status phrase pattern>' CONTEXT.md README.md COMPATIBILITY.md docs qa/validation-notes -g '*.md' -g '*.txt'
+
+rg -n -S '<support-contract and host-reporting spot-check phrase pattern>' CONTEXT.md README.md COMPATIBILITY.md docs -g '*.md'
+
+git status --short --branch
+```
+
+Results:
+
+- Stale host-failure scan: PASS; no matches in the scoped public docs and validation notes.
+- Support-contract spot check: PASS; supported rows remain exact-row scoped, Mistral remains an active-validation row without a support label, and Mixtral remains partial backend-runtime evidence only.
+- Host-reporting spot check: PASS; canonical host wording is limited to the reporting rule and docs instruct current slices to say when remote validation was not attempted.
+- Remote validation was not attempted in this run.
+
+Retain / reject:
+
+- Retain as a docs-only evidence slice.
+- No support, throughput, Ubuntu timing/profiling, portability, or default-on runtime claim is added by this slice.


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
