### PR TITLE
Fix x86 rust CI clippy gate

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -44,7 +44,9 @@ use crate::tensor::Q8_0AmxPackedBlock;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 unsafe extern "C" {
+    #[allow(dead_code)]
     fn camelid_x86_q8_amx_supported() -> std::os::raw::c_int;
+    #[allow(dead_code)]
     fn camelid_q8_0_amx_compute_tile16(
         input_groups: *const Q8_0PackedRows4Block,
         blocks_per_row: usize,
@@ -8653,6 +8655,10 @@ fn mac_q8_ffn_down_decode_consumer_enabled() -> bool {
     }
 }
 
+#[cfg_attr(
+    not(all(target_os = "macos", target_arch = "aarch64")),
+    allow(dead_code)
+)]
 fn mac_q8_ffn_down_single_projection_scheduler_counters_enabled() -> bool {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
@@ -8805,6 +8811,7 @@ fn q8_0_vnni_tile16_dot_scalar(tile: &Q8_0VnniTile16, input_block: &Q8_0Block) -
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[allow(clippy::incompatible_msrv)]
 #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
 unsafe fn q8_0_vnni_tile16_dot_avx512(tile: &Q8_0VnniTile16, input_block: &Q8_0Block) -> [i32; 16] {
     #[cfg(target_arch = "x86")]
@@ -17927,6 +17934,7 @@ mod tests {
         std::env::remove_var("CAMELID_MAC_Q8_FFN_DOWN_DECODE_CONSUMER");
     }
 
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     #[test]
     fn mac_q8_ffn_down_single_projection_scheduler_counters_are_default_off_and_opt_in() {
         let _env_guard = env_lock();


### PR DESCRIPTION
## Summary
- suppress Linux-only dead-code lints for currently unused AMX FFI declarations
- scope the mac-only scheduler counter test to macOS/aarch64
- allow the AVX512-VNNI helper's Rust 1.89 intrinsic MSRV lint while the crate MSRV remains 1.87

## Verification
- Ubuntu x86_64: `cargo fmt --all -- --check`
- Ubuntu x86_64: `cargo clippy --all-targets --all-features -- -D warnings`
- Ubuntu x86_64: `cargo test --all-targets --all-features`
- Ubuntu x86_64: `cargo doc --no-deps --all-features`