### PR TITLE
fix(ci): unblock x86 clippy gate

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -43,6 +43,7 @@ use crate::{
 use crate::tensor::Q8_0AmxPackedBlock;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[allow(dead_code)]
 unsafe extern "C" {
     fn camelid_x86_q8_amx_supported() -> std::os::raw::c_int;
     fn camelid_q8_0_amx_compute_tile16(
@@ -8653,6 +8654,7 @@ fn mac_q8_ffn_down_decode_consumer_enabled() -> bool {
     }
 }
 
+#[allow(dead_code)]
 fn mac_q8_ffn_down_single_projection_scheduler_counters_enabled() -> bool {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
@@ -8805,6 +8807,7 @@ fn q8_0_vnni_tile16_dot_scalar(tile: &Q8_0VnniTile16, input_block: &Q8_0Block) -
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[allow(clippy::incompatible_msrv)]
 #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
 unsafe fn q8_0_vnni_tile16_dot_avx512(tile: &Q8_0VnniTile16, input_block: &Q8_0Block) -> [i32; 16] {
     #[cfg(target_arch = "x86")]
@@ -17928,6 +17931,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     fn mac_q8_ffn_down_single_projection_scheduler_counters_are_default_off_and_opt_in() {
         let _env_guard = env_lock();
         clear_dense_diagnostic_env();


### PR DESCRIPTION
## Summary
- allow unused x86 AMX FFI declarations while the retained route is not wired
- allow Clippy MSRV lint on the AVX512-VNNI helper that is runtime feature-gated and built with the repo toolchain
- scope the mac-only scheduler counter env test to macOS aarch64

## Verified
- Ubuntu x86 same-host: `cargo fmt --all -- --check`
- Ubuntu x86 same-host: `cargo clippy --all-targets --all-features -- -D warnings`
- Ubuntu x86 same-host: `cargo test --all-targets --all-features`
- Ubuntu x86 same-host: `cargo doc --no-deps --all-features`