### PR TITLE
Fix Linux rust CI clippy gates

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -43,6 +43,7 @@ use crate::{
 use crate::tensor::Q8_0AmxPackedBlock;
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[allow(dead_code)]
 unsafe extern "C" {
     fn camelid_x86_q8_amx_supported() -> std::os::raw::c_int;
     fn camelid_q8_0_amx_compute_tile16(
@@ -8653,6 +8654,10 @@ fn mac_q8_ffn_down_decode_consumer_enabled() -> bool {
     }
 }
 
+#[cfg_attr(
+    not(all(target_os = "macos", target_arch = "aarch64")),
+    allow(dead_code)
+)]
 fn mac_q8_ffn_down_single_projection_scheduler_counters_enabled() -> bool {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
@@ -8805,6 +8810,7 @@ fn q8_0_vnni_tile16_dot_scalar(tile: &Q8_0VnniTile16, input_block: &Q8_0Block) -
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[allow(clippy::incompatible_msrv)]
 #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
 unsafe fn q8_0_vnni_tile16_dot_avx512(tile: &Q8_0VnniTile16, input_block: &Q8_0Block) -> [i32; 16] {
     #[cfg(target_arch = "x86")]
@@ -17927,6 +17933,7 @@ mod tests {
         std::env::remove_var("CAMELID_MAC_Q8_FFN_DOWN_DECODE_CONSUMER");
     }
 
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     #[test]
     fn mac_q8_ffn_down_single_projection_scheduler_counters_are_default_off_and_opt_in() {
         let _env_guard = env_lock();
@@ -17936,6 +17943,16 @@ mod tests {
 
         std::env::set_var("CAMELID_MAC_Q8_FFN_DOWN_SINGLE_PROJECTION_COUNTERS", "on");
         assert!(mac_q8_ffn_down_single_projection_scheduler_counters_enabled());
+        std::env::remove_var("CAMELID_MAC_Q8_FFN_DOWN_SINGLE_PROJECTION_COUNTERS");
+    }
+
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[test]
+    fn mac_q8_ffn_down_single_projection_scheduler_counters_fail_closed_off_mac() {
+        let _env_guard = env_lock();
+        clear_dense_diagnostic_env();
+        std::env::set_var("CAMELID_MAC_Q8_FFN_DOWN_SINGLE_PROJECTION_COUNTERS", "on");
+        assert!(!mac_q8_ffn_down_single_projection_scheduler_counters_enabled());
         std::env::remove_var("CAMELID_MAC_Q8_FFN_DOWN_SINGLE_PROJECTION_COUNTERS");
     }
 


### PR DESCRIPTION
Fixes the current main CI rust job failure on Linux by:

- allowing unused Linux AMX extern declarations while the AMX route remains staged but not wired
- allowing the AVX512 VNNI intrinsic MSRV lint on the gated x86 fast path
- splitting the mac-only scheduler counter test so non-mac targets assert fail-closed behavior

Verified:
- same-host Ubuntu x86_64 reproduced main failure with `cargo clippy --all-targets --all-features -- -D warnings`
- same-host Ubuntu x86_64 passed `cargo fmt --all -- --check`
- same-host Ubuntu x86_64 passed `cargo clippy --all-targets --all-features -- -D warnings`
- same-host Ubuntu x86_64 passed `cargo test --all-targets --all-features`
- same-host Ubuntu x86_64 passed `cargo doc --no-deps --all-features`
- local macOS passed the same four Rust gates