### PR TITLE
Refine README benchmark highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ Camelid does not treat “probably works” as “supported.” Support moves on
 
 ## Benchmark highlights
 
-Camelid is working toward 1:1 behavioral parity with llama.cpp while keeping the implementation Rust-native. The goal is simple: match the trusted local-inference baseline, show exactly where Camelid already agrees with it, and keep closing the remaining performance gap with measured Rust runtime work.
+Camelid is working toward 1:1 behavioral parity with llama.cpp while keeping the implementation Rust-native. The first goal is verification, not speed theater: match the trusted local-inference baseline for exact rows, prove bit-perfect generated-token agreement where Camelid already agrees with it, and only then promote faster paths.
 
-Current retained highlights:
+Current retained highlights, ordered by product importance:
 
-| What we measured | llama.cpp | Camelid | Takeaway |
-| --- | ---: | ---: | --- |
-| Exact-row generation parity | Reference output | **Matched token IDs and text** across the promoted Q8_0 rows | Correctness is already green for TinyLlama 1.1B, Llama 3.2 1B, Llama 3.2 3B, and Llama 3 8B checked envelopes. |
-| Llama 3.2 3B Q8_0 guarded stream run | 5.60s total | **3.01s total** | Best retained experimental stream result: Camelid was **46.4% faster** with marker guards passing for both runtimes. |
-| Llama 3.2 3B Q8_0 x86 route-map run | 374.88ms total | **413.42ms total** | Closest retained same-host x86 result: Camelid landed **within 10.3%** while the Q8 route work remains experimental. |
-| Llama 3.2 3B Q8_0 opt-in parallel Q8 probe | Camelid baseline: 13.96s | **12.20s** | Rust-side Q8 work cut first-token generate time by **12.6%** in the retained direction probe. |
+| Priority | Workload / envelope | Path | Reference | Camelid | Status |
+| --- | --- | --- | ---: | ---: | --- |
+| Verification first | Exact-row generation parity for Llama 3.2 1B, Llama 3.2 3B, and Llama 3 8B Q8_0 checked envelopes | Default supported path | llama.cpp token IDs and text | **Bit-perfect generated token IDs and text** | Promoted only where exact-row parity, API, WebUI, and evidence agree. |
+| Headline win | Llama 3.2 3B Q8_0 guarded stream run | Confirmed experimental highlight | 5.60s total | **3.01s total** | **46.4% faster** with marker guards passing for both runtimes. |
+| Current target | Llama 3.2 3B Q8_0 x86 route-map run | Default-off Rust Q8 optimization lane | **374.88ms total** | 413.42ms total | Camelid trails by **10.3%**; this is the current measured optimization target. |
+| Direction probe | Llama 3.2 3B Q8_0 parallel Q8 first-token probe | Default-off parallel Q8 probe | Camelid baseline: 13.96s TTFT | **12.20s TTFT** | Rust-side Q8 work cut TTFT by **12.6%** in the retained direction probe. |
 
-> **Benchmark boundary:** these are retained highlights, not a broad production-throughput claim. Optimized paths stay evidence-gated and default-off until parity, repeatability, portability, and support-contract checks all agree.
+> **Benchmark boundary:** these are retained highlights, not a broad production-throughput claim. Optimized paths are evidence-gated and default-off. Camelid promotes code to the default path only after exact-row parity, repeatability, portability, and support-contract checks all agree.
 
 Public evidence anchors include [`STATUS.md`](STATUS.md) and the [`Llama 3.2 3B parallel Q8 first-token manifest`](qa/evidence-bundles/llama32-3b-parallel-q8-first-token-20260505T140400Z-head-ffc22b85214f/manifest.json). Same-host raw benchmark artifacts are retained in validation evidence and must be scrubbed before publication.
 


### PR DESCRIPTION
## Summary
- Reorders the top README benchmark table around verification first.
- Labels exact-row generated-token parity as the primary metric for the 1B, 3B, and 8B checked envelopes.
- Promotes the 46.4% guarded-stream result as the confirmed experimental headline.
- Reframes the 10.3% x86 trailing result as the current measured optimization target.
- Labels optimized paths as default-off and evidence-gated, and uses TTFT for the parallel Q8 probe.

## Local validation
- `git diff --check`
- `bash scripts/check-public-scrub.sh`
- `node scripts/check-public-evidence-claims.mjs`