### PR TITLE
perf(q8): trace x86 gate/up prefill route

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -7160,53 +7160,28 @@ fn try_x86_q8_ffn_gate_up_packed_rows4_matmul_path(
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        let rows = input.dim(0)?;
-        if !runtime_plan.q8.ffn_gate_up_packed_rows4_matmul || input.rank() != 2 || rows <= 1 {
-            return Ok(None);
-        }
-        let input_width = input.dim(1)?;
-        if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
-            return Ok(None);
-        }
-
-        let gate_width = linear_output_width(input, gate_weight, "ffn gate")?;
-        let up_width = linear_output_width(input, up_weight, "ffn up")?;
-        if gate_width != up_width {
-            return Err(BackendError::RuntimeShapeMismatch(format!(
-                "gated FFN gate/up width mismatch: gate output {gate_width}, up output {up_width}"
-            )));
-        }
-
-        let Some((gate_packed, packed_gate_width)) =
-            q8_0_runtime_packed_projection(gate_weight, input_width)?
+        let Some(route) = resolve_x86_q8_ffn_gate_up_route(
+            input,
+            gate_weight,
+            up_weight,
+            runtime_plan,
+            X86Q8FfnGateUpRouteKind::PackedRows4Matmul,
+        )?
         else {
             return Ok(None);
         };
-        let Some((up_packed, packed_up_width)) =
-            q8_0_runtime_packed_projection(up_weight, input_width)?
-        else {
-            return Ok(None);
-        };
-        if packed_gate_width != gate_width
-            || packed_up_width != up_width
-            || gate_packed.interleave != Q8_0PackedRows4Interleave::I8
-            || up_packed.interleave != Q8_0PackedRows4Interleave::I8
-            || gate_packed.blocks_per_row != up_packed.blocks_per_row
-        {
-            return Ok(None);
-        }
 
         let projection_started = Instant::now();
         let (mut gate, up) = with_q8_0_quantized_matmul_input_rows(
             input,
-            gate_packed.blocks_per_row,
+            route.gate_packed.blocks_per_row,
             |rows, quantized_inputs| {
                 q8_0_packed_rows4_matmul_projection_pair_from_quantized(
                     rows,
-                    gate_packed,
-                    up_packed,
-                    gate_width,
-                    up_width,
+                    route.gate_packed,
+                    route.up_packed,
+                    route.output_width,
+                    route.output_width,
                     "ffn_gate_x86_q8_gate_up_packed_rows4_matmul",
                     "ffn_up_x86_q8_gate_up_packed_rows4_matmul",
                     quantized_inputs,
@@ -7214,6 +7189,15 @@ fn try_x86_q8_ffn_gate_up_packed_rows4_matmul_path(
             },
         )?;
         let projection_elapsed = projection_started.elapsed().as_micros();
+        record_q8_schedule_output_projection_route_call(
+            "ffn_gate_up",
+            X86Q8FfnGateUpRouteKind::PackedRows4Matmul.telemetry_name(),
+            Some(name),
+            route.rows,
+            route.input_width,
+            route.output_width,
+            projection_elapsed,
+        );
         let gate_elapsed = projection_elapsed / 2;
         let up_elapsed = projection_elapsed - gate_elapsed;
 
@@ -8313,6 +8297,174 @@ fn try_x86_q8_attention_qkv_packed_rows4_matmul_path(
         },
     )?;
     Ok(Some((q, k, v)))
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum X86Q8FfnGateUpRouteKind {
+    PackedRows4Matmul,
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl X86Q8FfnGateUpRouteKind {
+    fn telemetry_name(self) -> &'static str {
+        match self {
+            Self::PackedRows4Matmul => "packed_rows4_matmul_prefill",
+        }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+struct X86Q8FfnGateUpRoute<'a> {
+    gate_packed: &'a Q8_0PackedRows4,
+    up_packed: &'a Q8_0PackedRows4,
+    rows: usize,
+    input_width: usize,
+    output_width: usize,
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn resolve_x86_q8_ffn_gate_up_route<'a>(
+    input: &CpuTensor,
+    gate_weight: &'a CpuTensor,
+    up_weight: &'a CpuTensor,
+    runtime_plan: &ResolvedRuntimePlan,
+    route: X86Q8FfnGateUpRouteKind,
+) -> Result<Option<X86Q8FfnGateUpRoute<'a>>> {
+    let route_enabled = match route {
+        X86Q8FfnGateUpRouteKind::PackedRows4Matmul => {
+            runtime_plan.q8.ffn_gate_up_packed_rows4_matmul
+        }
+    };
+    let route_name = route.telemetry_name();
+    if !route_enabled || input.rank() != 2 {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up",
+            route_name,
+            if !route_enabled {
+                "plan_off"
+            } else {
+                "rank_mismatch"
+            },
+            input.dim(0).unwrap_or(0),
+            input.dim(1).unwrap_or(0),
+            0,
+        );
+        return Ok(None);
+    }
+
+    let rows = input.dim(0)?;
+    match route {
+        X86Q8FfnGateUpRouteKind::PackedRows4Matmul if rows <= 1 => {
+            record_q8_schedule_projection_route_denial(
+                "ffn_gate_up",
+                route_name,
+                "decode_or_empty_input",
+                rows,
+                input.dim(1).unwrap_or(0),
+                0,
+            );
+            return Ok(None);
+        }
+        _ => {}
+    }
+
+    let input_width = input.dim(1)?;
+    if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up",
+            route_name,
+            "bad_input_width",
+            rows,
+            input_width,
+            0,
+        );
+        return Ok(None);
+    }
+
+    let gate_width = linear_output_width(input, gate_weight, "ffn gate")?;
+    let up_width = linear_output_width(input, up_weight, "ffn up")?;
+    if gate_width != up_width {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "gated FFN gate/up width mismatch: gate output {gate_width}, up output {up_width}"
+        )));
+    }
+
+    let Some((gate_packed, packed_gate_width)) =
+        q8_0_runtime_packed_projection(gate_weight, input_width)?
+    else {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up",
+            route_name,
+            "no_runtime_packed_gate",
+            rows,
+            input_width,
+            gate_width,
+        );
+        return Ok(None);
+    };
+    let Some((up_packed, packed_up_width)) =
+        q8_0_runtime_packed_projection(up_weight, input_width)?
+    else {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up",
+            route_name,
+            "no_runtime_packed_up",
+            rows,
+            input_width,
+            up_width,
+        );
+        return Ok(None);
+    };
+    if packed_gate_width != gate_width
+        || packed_up_width != up_width
+        || gate_packed.rows != gate_width
+        || up_packed.rows != up_width
+        || gate_packed.blocks_per_row != input_width / Q8_0_BLOCK_VALUES
+        || up_packed.blocks_per_row != input_width / Q8_0_BLOCK_VALUES
+    {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up",
+            route_name,
+            "packed_shape_mismatch",
+            rows,
+            input_width,
+            gate_width,
+        );
+        return Ok(None);
+    }
+    if gate_packed.interleave != Q8_0PackedRows4Interleave::I8
+        || up_packed.interleave != Q8_0PackedRows4Interleave::I8
+    {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up",
+            route_name,
+            "non_i8_interleave",
+            rows,
+            input_width,
+            gate_width,
+        );
+        return Ok(None);
+    }
+    if gate_packed.blocks_per_row != up_packed.blocks_per_row {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up",
+            route_name,
+            "gate_up_block_stride_mismatch",
+            rows,
+            input_width,
+            gate_width,
+        );
+        return Ok(None);
+    }
+
+    Ok(Some(X86Q8FfnGateUpRoute {
+        gate_packed,
+        up_packed,
+        rows,
+        input_width,
+        output_width: gate_width,
+    }))
 }
 
 fn try_x86_q8_ffn_gate_up_decode_consumer_path(

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -4586,6 +4586,99 @@ fn q8_ffn_gate_up_packed_rows4_matmul_is_plan_gated_and_prefill_limited() {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[test]
+fn q8_ffn_gate_up_prefill_route_resolver_records_route_and_denials() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+    let (decode_input, packed_gate, packed_up, _expected) = runtime_packed_ffn_gate_up_case();
+    let input_width = packed_gate.dim(0).unwrap();
+    let output_width = packed_gate.dim(1).unwrap();
+    let rows = 3;
+    let prefill_input = CpuTensor::from_f32(
+        "prefill_gate_up_input",
+        vec![rows, input_width],
+        (0..rows * input_width)
+            .map(|idx| {
+                ((idx % input_width) as f32 - 7.0) * 0.109375
+                    + (idx / input_width) as f32 * 0.046875
+            })
+            .collect(),
+    )
+    .unwrap();
+    let route_name = X86Q8FfnGateUpRouteKind::PackedRows4Matmul.telemetry_name();
+
+    let route = resolve_x86_q8_ffn_gate_up_route(
+        &prefill_input,
+        &packed_gate,
+        &packed_up,
+        &ffn_gate_up_packed_rows4_matmul_plan(true),
+        X86Q8FfnGateUpRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .expect("prefill route should accept multi-row runtime-packed FFN gate/up weights");
+    assert_eq!(route.rows, rows);
+    assert_eq!(route.input_width, input_width);
+    assert_eq!(route.output_width, output_width);
+
+    assert!(resolve_x86_q8_ffn_gate_up_route(
+        &decode_input,
+        &packed_gate,
+        &packed_up,
+        &ffn_gate_up_packed_rows4_matmul_plan(true),
+        X86Q8FfnGateUpRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+    assert!(resolve_x86_q8_ffn_gate_up_route(
+        &prefill_input,
+        &packed_gate,
+        &packed_up,
+        &ffn_gate_up_packed_rows4_matmul_plan(false),
+        X86Q8FfnGateUpRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+
+    let actual = try_x86_q8_ffn_gate_up_packed_rows4_matmul_path(
+        &prefill_input,
+        &packed_gate,
+        &packed_up,
+        "layer_3_ffn_activated",
+        &ffn_gate_up_packed_rows4_matmul_plan(true),
+    )
+    .unwrap()
+    .expect("prefill route should produce the fused gate/up activation");
+    assert_eq!(actual.tensor.shape.dims, vec![rows, output_width]);
+
+    let telemetry = snapshot_q8_schedule_telemetry();
+    let by_route = telemetry
+        .output_projection_by_route
+        .get(&format!("ffn_gate_up.{route_name}"))
+        .expect("FFN gate/up prefill route telemetry");
+    assert_eq!(by_route.calls, 1);
+    assert_eq!(by_route.rows, rows as u64);
+    assert_eq!(by_route.input_width, input_width as u64);
+    assert_eq!(by_route.output_width, output_width as u64);
+    let layer_route = telemetry
+        .output_projection_by_layer_route
+        .get(&format!("layer_3.ffn_gate_up.{route_name}"))
+        .expect("layer-scoped FFN gate/up prefill route telemetry");
+    assert_eq!(layer_route.layer_index, 3);
+    assert_eq!(layer_route.calls, 1);
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key(&format!("ffn_gate_up.{route_name}.decode_or_empty_input")));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key(&format!("ffn_gate_up.{route_name}.plan_off")));
+
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
 fn q8_ffn_gate_up_single_owner_matches_decode_and_prefill_owners() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();


### PR DESCRIPTION
## Summary
- add a resolver for the default-off x86 FFN gate/up packed-rows4 prefill route
- record route telemetry for `ffn_gate_up.packed_rows4_matmul_prefill`, including layer-scoped buckets and route-denial reasons
- keep the path behind existing `CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL` / x86 experimental gates with reference fallback unchanged

## Validation
- Ubuntu x86_64 branch checkout `/home/ubuntu/work/camelid-codex-gateup-telemetry-20260521T1905Z` at `b70749406c50f08fc18ef239eec84e55a76cf122`
- `cargo test q8_ffn_gate_up --lib` PASS: 8 passed
- `cargo fmt --all -- --check` PASS
- `cargo clippy --lib -- -D warnings` PASS
- same-host 3B Q8 run PASS marker/non-empty guard for Camelid and llama.cpp; artifact: `/home/ubuntu/work/camelid-codex-gateup-telemetry-20260521T1905Z/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/codex-5bc6409e-20260521T1905Z-gateup-prefill-route-telemetry/same-host-gateup-prefill-telemetry-b707494.json`

## Same-host result
- flags: `CAMELID_PROFILE=experimental CAMELID_X86_Q8_REPACK=on CAMELID_X86_Q8_KERNEL=avx2 CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL=on CAMELID_Q8_SCHED_TELEMETRY=on CAMELID_STREAM_TIMING_DIAGNOSTICS=on`
- Camelid TTFT: 5216.26 ms; backend first content: 1619 ms; backend generate: 1938 ms
- llama.cpp TTFT: 351.31 ms; total elapsed: 711.77 ms
- retained decision: retain as route telemetry/control-plane slice only, not a performance promotion
- recorded route: `ffn_gate_up.packed_rows4_matmul_prefill`, 28 calls, 1288 rows, 396.608 ms total route elapsed, shape 3072x8192

No Mac, Mixtral, public support, default-on, or throughput promotion claim is made.