### PR TITLE
perf(q8): fuse x86 gate-up prefill activation

### DIFF
--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260521T191643Z-x86-gateup-fused-prefill/README.md
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260521T191643Z-x86-gateup-fused-prefill/README.md
@@ -1,0 +1,24 @@
+# cron-95495a91 x86 Q8 gate/up fused prefill
+
+UTC: 2026-05-21T19:16:43Z
+
+Source head: `3776d22` (`origin/main`, includes PR #49)
+
+Branch: `backend-ubuntu-x86-q8-95495a91`
+
+Slice retained:
+
+- `src/inference.rs`: x86 packed rows4 FFN gate/up prefill route now emits the activated output directly from paired Q8 projections. This removes the separate full-width `up` tensor allocation and the follow-on activation pass on that gated route. The existing fallback/reference path remains unchanged.
+- `src/inference/tests.rs`: added parity coverage proving fused gate/up prefill output matches the separate pair-projection plus activation path.
+
+Validation run on the local automation host:
+
+- `cargo check` passed.
+- `cargo test q8_packed_rows4 -- --nocapture` passed: 5 passed.
+- `cargo test q8_ffn_gate_up -- --nocapture` passed: 4 passed.
+
+Timing/parity status:
+
+- Same-host Ubuntu x86 Q8 timing was not feasible in this cron shell: host is `Darwin ... RELEASE_ARM64_T8132 arm64`.
+- `cargo check --target x86_64-unknown-linux-gnu` was attempted, but the Homebrew Rust toolchain has no installed `std/core` for `x86_64-unknown-linux-gnu` and no `rustup` in PATH to add it.
+- Parity was validated by the new focused fused-vs-unfused Q8 rows4 unit test. No Mac, Mixtral, or support-surface promotion is claimed.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -592,6 +592,14 @@ pub fn diagnostic_ffn_gate_up_order() -> Result<FfnGateUpOrder> {
     }
 }
 
+#[inline(always)]
+fn apply_ffn_gate_up_order(gate_value: f32, up_value: f32, order: FfnGateUpOrder) -> f32 {
+    match order {
+        FfnGateUpOrder::GateUp => (gate_value / (1.0 + (-gate_value).exp())) * up_value,
+        FfnGateUpOrder::UpGate => (up_value / (1.0 + (-up_value).exp())) * gate_value,
+    }
+}
+
 fn attention_score_scale_value(head_dim: usize, mode: AttentionScoreScale) -> f32 {
     match mode {
         AttentionScoreScale::HeadDim => 1.0 / (head_dim as f32).sqrt(),
@@ -7047,10 +7055,7 @@ fn gated_ffn_activation_batch(
     let order = diagnostic_ffn_gate_up_order()?;
     let started = Instant::now();
     for (gate_value, up_value) in gate.data.iter_mut().zip(up.data) {
-        *gate_value = match order {
-            FfnGateUpOrder::GateUp => (*gate_value / (1.0 + (-*gate_value).exp())) * up_value,
-            FfnGateUpOrder::UpGate => (up_value / (1.0 + (-up_value).exp())) * *gate_value,
-        };
+        *gate_value = apply_ffn_gate_up_order(*gate_value, up_value, order);
     }
     gate.name = name;
     let activation_elapsed = started.elapsed().as_micros();
@@ -7126,10 +7131,7 @@ fn try_x86_q8_ffn_gate_up_single_owner_path(
     let order = diagnostic_ffn_gate_up_order()?;
     let activation_started = Instant::now();
     for (gate_value, up_value) in gate.iter_mut().zip(up) {
-        *gate_value = match order {
-            FfnGateUpOrder::GateUp => (*gate_value / (1.0 + (-*gate_value).exp())) * up_value,
-            FfnGateUpOrder::UpGate => (up_value / (1.0 + (-up_value).exp())) * *gate_value,
-        };
+        *gate_value = apply_ffn_gate_up_order(*gate_value, up_value, order);
     }
 
     Ok(Some(GatedFfnActivation {
@@ -7171,19 +7173,19 @@ fn try_x86_q8_ffn_gate_up_packed_rows4_matmul_path(
             return Ok(None);
         };
 
+        let order = diagnostic_ffn_gate_up_order()?;
         let projection_started = Instant::now();
-        let (mut gate, up) = with_q8_0_quantized_matmul_input_rows(
+        let gate = with_q8_0_quantized_matmul_input_rows(
             input,
             route.gate_packed.blocks_per_row,
             |rows, quantized_inputs| {
-                q8_0_packed_rows4_matmul_projection_pair_from_quantized(
+                q8_0_packed_rows4_matmul_projection_pair_activated_from_quantized(
                     rows,
                     route.gate_packed,
                     route.up_packed,
                     route.output_width,
-                    route.output_width,
-                    "ffn_gate_x86_q8_gate_up_packed_rows4_matmul",
-                    "ffn_up_x86_q8_gate_up_packed_rows4_matmul",
+                    name,
+                    order,
                     quantized_inputs,
                 )
             },
@@ -7201,21 +7203,11 @@ fn try_x86_q8_ffn_gate_up_packed_rows4_matmul_path(
         let gate_elapsed = projection_elapsed / 2;
         let up_elapsed = projection_elapsed - gate_elapsed;
 
-        let order = diagnostic_ffn_gate_up_order()?;
-        let activation_started = Instant::now();
-        for (gate_value, up_value) in gate.data.iter_mut().zip(up.data) {
-            *gate_value = match order {
-                FfnGateUpOrder::GateUp => (*gate_value / (1.0 + (-*gate_value).exp())) * up_value,
-                FfnGateUpOrder::UpGate => (up_value / (1.0 + (-up_value).exp())) * *gate_value,
-            };
-        }
-        gate.name = name.to_string();
-
         Ok(Some(GatedFfnActivation {
             tensor: gate,
             gate: gate_elapsed,
             up: up_elapsed,
-            activation: activation_started.elapsed().as_micros(),
+            activation: 0,
             gate_stats: None,
             up_stats: None,
             gate_diagnostic: None,
@@ -10296,6 +10288,115 @@ fn q8_0_packed_rows4_matmul_projection_pair_from_quantized(
         CpuTensor::from_f32(left_name, vec![rows, left_output_width], left_output)?,
         CpuTensor::from_f32(right_name, vec![rows, right_output_width], right_output)?,
     ))
+}
+
+#[cfg(any(test, target_arch = "x86", target_arch = "x86_64"))]
+fn validate_q8_0_packed_rows4_pair_matmul_inputs(
+    rows: usize,
+    left_packed: &Q8_0PackedRows4,
+    right_packed: &Q8_0PackedRows4,
+    output_width: usize,
+    quantized_inputs: &[Q8_0Block],
+    context: &str,
+) -> Result<(usize, usize)> {
+    let blocks_per_row = left_packed.blocks_per_row;
+    if right_packed.blocks_per_row != blocks_per_row {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Q8_0 packed rows4 {context} blocks_per_row mismatch: left={}, right={}",
+            left_packed.blocks_per_row, right_packed.blocks_per_row
+        )));
+    }
+    if left_packed.interleave != Q8_0PackedRows4Interleave::I8
+        || right_packed.interleave != Q8_0PackedRows4Interleave::I8
+    {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Q8_0 packed rows4 {context} requires I8 interleave"
+        )));
+    }
+    let expected_quantized_blocks = rows.checked_mul(blocks_per_row).ok_or_else(|| {
+        BackendError::RuntimeShapeMismatch(format!(
+            "Q8_0 packed rows4 {context} input block count overflow"
+        ))
+    })?;
+    if quantized_inputs.len() != expected_quantized_blocks {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Q8_0 packed rows4 {context} expected {expected_quantized_blocks} quantized input blocks, got {}",
+            quantized_inputs.len()
+        )));
+    }
+    if left_packed.rows != output_width || right_packed.rows != output_width {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Q8_0 packed rows4 {context} output width mismatch: left packed rows={}, requested={}, right packed rows={}",
+            left_packed.rows, output_width, right_packed.rows
+        )));
+    }
+    let output_groups_per_row =
+        q8_0_packed_rows4_output_groups(output_width, "pair matmul fused projection")?;
+    Ok((blocks_per_row, output_groups_per_row))
+}
+
+#[cfg(any(test, target_arch = "x86", target_arch = "x86_64"))]
+fn q8_0_packed_rows4_matmul_projection_pair_activated_from_quantized(
+    rows: usize,
+    gate_packed: &Q8_0PackedRows4,
+    up_packed: &Q8_0PackedRows4,
+    output_width: usize,
+    name: &str,
+    order: FfnGateUpOrder,
+    quantized_inputs: &[Q8_0Block],
+) -> Result<CpuTensor> {
+    let (blocks_per_row, output_groups_per_row) = validate_q8_0_packed_rows4_pair_matmul_inputs(
+        rows,
+        gate_packed,
+        up_packed,
+        output_width,
+        quantized_inputs,
+        "fused gate/up matmul activation",
+    )?;
+
+    let mut output = vec![0.0_f32; rows * output_width];
+    let use_hoisted_avx2 = x86_q8_packed_rows4_avx2_dot_hoist_enabled();
+    let total_output_groups = rows * output_groups_per_row;
+    let compute_group = |flat_group_idx: usize, output_group: &mut [f32]| {
+        let row_idx = flat_group_idx / output_groups_per_row;
+        let group_idx = flat_group_idx % output_groups_per_row;
+        let input_start = row_idx * blocks_per_row;
+        let group_start = group_idx * blocks_per_row;
+        let quantized_row = &quantized_inputs[input_start..input_start + blocks_per_row];
+        let gate_sums = q8_0_packed_rows4_dot_i8_matmul(
+            &gate_packed.blocks[group_start..group_start + blocks_per_row],
+            quantized_row,
+            use_hoisted_avx2,
+        );
+        let up_sums = q8_0_packed_rows4_dot_i8_matmul(
+            &up_packed.blocks[group_start..group_start + blocks_per_row],
+            quantized_row,
+            use_hoisted_avx2,
+        );
+        for lane in 0..4 {
+            output_group[lane] = apply_ffn_gate_up_order(gate_sums[lane], up_sums[lane], order);
+        }
+    };
+
+    if should_parallelize_q8_packed_rows4_matmul(total_output_groups) {
+        let chunk_floats = q8_packed_rows4_matmul_parallel_chunk_floats(total_output_groups);
+        output
+            .par_chunks_mut(chunk_floats)
+            .enumerate()
+            .for_each(|(chunk_idx, output_chunk)| {
+                let first_group_idx = chunk_idx * (chunk_floats / 4);
+                for (local_group_idx, output_group) in output_chunk.chunks_exact_mut(4).enumerate()
+                {
+                    compute_group(first_group_idx + local_group_idx, output_group);
+                }
+            });
+    } else {
+        for (flat_group_idx, output_group) in output.chunks_exact_mut(4).enumerate() {
+            compute_group(flat_group_idx, output_group);
+        }
+    }
+
+    CpuTensor::from_f32(name, vec![rows, output_width], output)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -10161,7 +10161,7 @@ unsafe fn q8_0_packed_rows4_gemm4_accumulate_block_avx2(
     unsafe { _mm_storeu_ps(sums.add(12), _mm_add_ps(sum3, scaled3)) };
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(dead_code, clippy::too_many_arguments)]
 fn q8_0_packed_rows4_matmul_projection_pair_from_quantized(
     rows: usize,
     left_packed: &Q8_0PackedRows4,

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -6920,6 +6920,84 @@ fn q8_packed_rows4_matmul_projection_chunked_prefill_matches_manual_output() {
 }
 
 #[test]
+fn q8_packed_rows4_gate_up_fused_prefill_matches_separate_pair_activation() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+
+    let rows = 6;
+    let output_rows = 128;
+    let blocks_per_row = 3;
+    let input_width = blocks_per_row * Q8_0_BLOCK_VALUES;
+    let gate_blocks: Vec<Q8_0Block> = (0..output_rows * blocks_per_row)
+        .map(|block_idx| Q8_0Block {
+            scale: 0.0234375 + (block_idx % 19) as f32 * 0.001953125,
+            quants: std::array::from_fn(|idx| {
+                ((block_idx as i32 * 5 + idx as i32 * 7) % 83 - 41) as i8
+            }),
+        })
+        .collect();
+    let up_blocks: Vec<Q8_0Block> = (0..output_rows * blocks_per_row)
+        .map(|block_idx| Q8_0Block {
+            scale: 0.03125 + (block_idx % 17) as f32 * 0.001953125,
+            quants: std::array::from_fn(|idx| {
+                ((block_idx as i32 * 11 + idx as i32 * 3) % 79 - 39) as i8
+            }),
+        })
+        .collect();
+    let gate_packed = Q8_0PackedRows4::from_rows(
+        output_rows,
+        blocks_per_row,
+        Q8_0PackedRows4Interleave::I8,
+        &gate_blocks,
+    )
+    .unwrap();
+    let up_packed = Q8_0PackedRows4::from_rows(
+        output_rows,
+        blocks_per_row,
+        Q8_0PackedRows4Interleave::I8,
+        &up_blocks,
+    )
+    .unwrap();
+    let input = CpuTensor::from_f32(
+        "gate_up_fused_prefill_input",
+        vec![rows, input_width],
+        (0..rows * input_width)
+            .map(|idx| ((idx % 43) as f32 - 21.0) * 0.0390625)
+            .collect(),
+    )
+    .unwrap();
+    let quantized_inputs = q8_0_quantized_matmul_input_rows(&input, blocks_per_row).unwrap();
+    let (mut gate, up) = q8_0_packed_rows4_matmul_projection_pair_from_quantized(
+        rows,
+        &gate_packed,
+        &up_packed,
+        output_rows,
+        output_rows,
+        "gate",
+        "up",
+        &quantized_inputs,
+    )
+    .unwrap();
+    for (gate_value, up_value) in gate.data.iter_mut().zip(up.data) {
+        *gate_value = apply_ffn_gate_up_order(*gate_value, up_value, FfnGateUpOrder::GateUp);
+    }
+
+    let fused = q8_0_packed_rows4_matmul_projection_pair_activated_from_quantized(
+        rows,
+        &gate_packed,
+        &up_packed,
+        output_rows,
+        "fused",
+        FfnGateUpOrder::GateUp,
+        &quantized_inputs,
+    )
+    .unwrap();
+
+    assert_eq!(fused.shape.dims, vec![rows, output_rows]);
+    assert_eq!(fused.data, gate.data);
+}
+
+#[test]
 fn q8_packed_rows4_parallel_input_quantize_matches_serial() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();


### PR DESCRIPTION
## Summary
- fuse the x86 packed-rows4 FFN gate/up prefill route so it writes activated output directly
- remove the separate `up` tensor allocation and follow-on activation pass on that routed path
- add focused fused-vs-unfused Q8 rows4 parity coverage and an evidence note

## Validation
- `cargo check`
- `cargo test q8_packed_rows4 -- --nocapture`
- `cargo test q8_ffn_gate_up -- --nocapture`

## Timing / host note
- Same-host Ubuntu x86 Q8 timing was not feasible in this cron shell: local host is Darwin arm64.
- `cargo check --target x86_64-unknown-linux-gnu` was attempted but the Homebrew Rust toolchain has no installed `std/core` for that target and no `rustup` in PATH.
- Evidence: `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260521T191643Z-x86-gateup-fused-prefill/README.md`