### PR TITLE
Port llama.cpp AVX2 Q8 block dot shape

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -12344,28 +12344,45 @@ fn x86_q8_packed_rows4_avx2_dot_decode_hoist_enabled() -> bool {
 unsafe fn q8_0_i8_block_avx2(weight: *const i8, input: *const i8) -> i32 {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::{
-        _mm256_add_epi32, _mm256_cvtepi8_epi16, _mm256_madd_epi16, _mm256_mullo_epi16,
-        _mm256_set1_epi16, _mm256_setzero_si256, _mm256_storeu_si256, _mm_loadu_si128,
+        _mm256_add_epi32, _mm256_cmpeq_epi8, _mm256_cvtepi8_epi16, _mm256_loadu_si256,
+        _mm256_madd_epi16, _mm256_maddubs_epi16, _mm256_movemask_epi8, _mm256_mullo_epi16,
+        _mm256_set1_epi16, _mm256_set1_epi8, _mm256_setzero_si256, _mm256_sign_epi8,
+        _mm256_storeu_si256, _mm_loadu_si128,
     };
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::{
-        _mm256_add_epi32, _mm256_cvtepi8_epi16, _mm256_madd_epi16, _mm256_mullo_epi16,
-        _mm256_set1_epi16, _mm256_setzero_si256, _mm256_storeu_si256, _mm_loadu_si128,
+        _mm256_add_epi32, _mm256_cmpeq_epi8, _mm256_cvtepi8_epi16, _mm256_loadu_si256,
+        _mm256_madd_epi16, _mm256_maddubs_epi16, _mm256_movemask_epi8, _mm256_mullo_epi16,
+        _mm256_set1_epi16, _mm256_set1_epi8, _mm256_setzero_si256, _mm256_sign_epi8,
+        _mm256_storeu_si256, _mm_loadu_si128,
     };
 
     let ones = _mm256_set1_epi16(1);
-    let mut acc = _mm256_setzero_si256();
-    for offset in [0usize, 16] {
-        // SAFETY: callers provide two complete 32-byte Q8_0 quant arrays; each iteration
-        // loads one unaligned 16-byte half from both arrays.
-        let weight_i8 = unsafe { _mm_loadu_si128(weight.add(offset).cast()) };
-        let input_i8 = unsafe { _mm_loadu_si128(input.add(offset).cast()) };
-        let weight_i16 = _mm256_cvtepi8_epi16(weight_i8);
-        let input_i16 = _mm256_cvtepi8_epi16(input_i8);
-        let products_i16 = _mm256_mullo_epi16(weight_i16, input_i16);
-        let pair_sums_i32 = _mm256_madd_epi16(products_i16, ones);
-        acc = _mm256_add_epi32(acc, pair_sums_i32);
-    }
+    let weight_i8 = unsafe { _mm256_loadu_si256(weight.cast()) };
+    let input_i8 = unsafe { _mm256_loadu_si256(input.cast()) };
+    let min_i8 = _mm256_set1_epi8(i8::MIN);
+    let has_min_i8 = (_mm256_movemask_epi8(_mm256_cmpeq_epi8(weight_i8, min_i8))
+        | _mm256_movemask_epi8(_mm256_cmpeq_epi8(input_i8, min_i8)))
+        != 0;
+    let acc = if has_min_i8 {
+        let mut acc = _mm256_setzero_si256();
+        for offset in [0usize, 16] {
+            let weight_half = unsafe { _mm_loadu_si128(weight.add(offset).cast()) };
+            let input_half = unsafe { _mm_loadu_si128(input.add(offset).cast()) };
+            let products = _mm256_mullo_epi16(
+                _mm256_cvtepi8_epi16(weight_half),
+                _mm256_cvtepi8_epi16(input_half),
+            );
+            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(products, ones));
+        }
+        acc
+    } else {
+        // Mirrors llama.cpp's x86 q8_0 dot for well-formed Q8_0 blocks, whose
+        // quantized values are in [-127, 127].
+        let abs_weight = _mm256_sign_epi8(weight_i8, weight_i8);
+        let signed_input = _mm256_sign_epi8(input_i8, weight_i8);
+        _mm256_madd_epi16(_mm256_maddubs_epi16(abs_weight, signed_input), ones)
+    };
 
     let mut lanes = [0_i32; 8];
     // SAFETY: lanes has exactly 32 bytes of storage for one __m256i value.

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -59,6 +59,28 @@ fn x86_q8_avx2_kernel_matches_scalar_dot() {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[test]
+fn x86_q8_avx2_kernel_matches_scalar_dot_for_negative_128() {
+    let _env_guard = env_lock();
+    std::env::set_var("CAMELID_X86_Q8_KERNEL", "avx2");
+    let weight = std::array::from_fn(|idx| match idx % 4 {
+        0 => -128,
+        1 => 127,
+        2 => -7,
+        _ => idx as i8,
+    });
+    let input = std::array::from_fn(|idx| match idx % 5 {
+        0 => -128,
+        1 => 127,
+        2 => 5,
+        _ => (idx as i8).wrapping_mul(-3),
+    });
+    let expected = q8_0_block_int_dot_horizontal_sum_scalar(&weight, &input);
+    assert_eq!(q8_0_block_int_dot_horizontal_sum(&weight, &input), expected);
+    std::env::remove_var("CAMELID_X86_Q8_KERNEL");
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
 fn x86_q8_packed_rows4_matmul_chunk_groups_env_override() {
     let _env_guard = env_lock();
     std::env::remove_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK");


### PR DESCRIPTION
## Summary
- map llama.cpp's x86 Q8_0 CPU dot path to Camelid's default-off AVX2 block-dot kernel
- use the sign+maddubs shape for valid Q8_0 blocks and keep a widening fallback for any i8::MIN byte
- add targeted AVX2 parity coverage including the i8::MIN edge case

## Ubuntu x86 proof
- `uname -sm` -> `Linux x86_64`; `cargo --version` -> `cargo 1.95.0`
- `cargo test x86_q8_avx2_kernel_matches_scalar_dot -- --nocapture` passed
- `cargo test q8_0_block_dot -- --nocapture` passed
- `cargo test --release x86_q8_avx2_kernel_matches_scalar_dot -- --nocapture` passed
- `cargo test --lib` passed: 307 passed, 0 failed, 2 ignored
- temporary Ubuntu AVX2 microbench, 50M valid-Q8 block dots: old widen 87.7/87.6 ms, new maddubs 71.7/72.1 ms, ~1.22x
- Llama 3.2 3B Q8_0 one-token smoke on `CAMELID_PROFILE=experimental CAMELID_X86_Q8_REPACK=on CAMELID_X86_Q8_KERNEL=avx2`: selected `x86_experimental_q8_0_avx2_rust`, generated token `539` (`" not"`), `timings_ms.generate=711`

## llama.cpp source map
- `ggml/src/ggml-cpu/ggml-cpu.c`: `GGML_TYPE_Q8_0` maps to `quantize_row_q8_0`, `ggml_vec_dot_q8_0_q8_0`, `vec_dot_type=GGML_TYPE_Q8_0`, x86 `nrows=1`
- `ggml/src/ggml-cpu/ggml-cpu.c`: `ggml_compute_forward_mul_mat` quantizes F32 src1 to vec-dot type in `params->wdata`, chunks work by result rows/cols, then calls `ggml_compute_forward_mul_mat_one_chunk`
- `ggml/src/ggml-cpu/arch/x86/quants.c`: `ggml_vec_dot_q8_0_q8_0` AVX2 uses `mul_sum_i8_pairs_float`, implemented with `_mm256_sign_epi8` + `_mm256_maddubs_epi16` + pair reduction
- `ggml/src/ggml-quants.c`: Q8_0 quantization uses block max / 127 and stores fp16 scale plus 32 i8 quants; dequant is `scale * quant`