### PR TITLE
Gate x86 Q8 output decode-owner route

### DIFF
--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -469,11 +469,14 @@ fn select_linux_x86_q8_plan(
         optional_x86_q8_gate("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER"),
     );
     env_updates.insert("CAMELID_X86_Q8_FFN_DOWN_DECODE_OWNER", Some("off"));
-    env_updates.insert("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER", Some("off"));
+    env_updates.insert(
+        "CAMELID_X86_Q8_OUTPUT_DECODE_OWNER",
+        optional_x86_q8_gate("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER"),
+    );
     reasons.push("validated Ubuntu/Linux x86_64 Rust Q8 runtime repack enabled".into());
     reasons.push("validated Rust AVX2 Q8 packed rows4 kernel selected".into());
     reasons.push(
-        "attention, FFN, and output decode-consumer experiments remain disabled by execution plan"
+        "attention, FFN, and output decode-consumer experiments remain default-off unless explicitly opted in"
             .into(),
     );
     reasons.push("experimental profile active; support claims remain unchanged".into());
@@ -1276,6 +1279,7 @@ mod tests {
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_AMX_PREFILL", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR", "on");
+        env::set_var("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER", "on");
         let outcome = plan_for_model_with_platform(
             &PathBuf::from("/tmp/Llama-3.2-3B-Instruct-Q8_0.gguf"),
             &fixture("Llama 3.2 3B Instruct"),
@@ -1327,6 +1331,12 @@ mod tests {
         assert_eq!(
             outcome
                 .env_updates
+                .get("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER"),
+            Some(&Some("on"))
+        );
+        assert_eq!(
+            outcome
+                .env_updates
                 .get("CAMELID_X86_Q8_ATTENTION_QKV_PACKED_ROWS4_MATMUL"),
             Some(&Some("off"))
         );
@@ -1357,6 +1367,7 @@ mod tests {
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR", "on");
+        env::set_var("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER", "on");
 
         PlannerEnv::capture().apply(&BTreeMap::new());
 
@@ -1380,6 +1391,7 @@ mod tests {
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR").is_err());
+        assert!(env::var("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER").is_err());
         clear_profile_env();
     }
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -505,6 +505,7 @@ struct Q8RuntimeFlags {
     attention_qkv_decode_group_chunking: bool,
     attention_qkv_packed_rows4_matmul: bool,
     output_packed_rows4_matmul: bool,
+    output_decode_owner: bool,
     ffn_gate_up_decode_consumer: bool,
     ffn_gate_up_decode_group_chunking: bool,
     ffn_gate_up_packed_rows4_matmul: bool,
@@ -566,6 +567,9 @@ impl Q8RuntimeFlags {
             ),
             output_packed_rows4_matmul: q8_0_env_flag_enabled_default_off(
                 "CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL",
+            ),
+            output_decode_owner: q8_0_env_flag_enabled_default_off(
+                "CAMELID_X86_Q8_OUTPUT_DECODE_OWNER",
             ),
             ffn_gate_up_decode_consumer: q8_0_env_flag_enabled_default_off(
                 "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER",
@@ -5678,7 +5682,9 @@ fn output_projection_with_layout_with_plan(
             {
                 return Ok(output);
             }
-            if let Some(output) = try_x86_q8_output_decode_owner_path(input, weight, &name)? {
+            if let Some(output) =
+                try_x86_q8_output_decode_owner_path(input, weight, &name, runtime_plan)?
+            {
                 return Ok(output);
             }
             let token_major = borrowed_linear_weight_as_transposed(weight, input_width)?;
@@ -7875,17 +7881,6 @@ impl BorrowedQuantizedQ8_0Rows<'_> {
     }
 }
 
-fn x86_q8_output_decode_owner_enabled() -> bool {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        env_flag_enabled("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER")
-    }
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-    {
-        false
-    }
-}
-
 fn try_x86_q8_output_packed_rows4_matmul_path(
     input: &CpuTensor,
     weight: &CpuTensor,
@@ -7919,31 +7914,116 @@ fn try_x86_q8_output_decode_owner_path(
     input: &CpuTensor,
     weight: &CpuTensor,
     name: &str,
+    runtime_plan: &ResolvedRuntimePlan,
 ) -> Result<Option<CpuTensor>> {
-    if !x86_q8_output_decode_owner_enabled()
-        || input.rank() != 2
-        || input.dim(0)? != 1
-        || weight.name != "output.weight"
-        || weight.source_type != Some(GgufTensorType::Q8_0)
-    {
+    if !runtime_plan.q8.output_decode_owner {
+        return Ok(None);
+    }
+    let rows_for_telemetry = input.dim(0).unwrap_or(0);
+    let input_width_for_telemetry = input.dim(1).unwrap_or(0);
+    let output_width_for_telemetry = if weight.rank() == 2 {
+        let weight_rows = weight.dim(0).unwrap_or(0);
+        let weight_cols = weight.dim(1).unwrap_or(0);
+        if weight_rows == input_width_for_telemetry {
+            weight_cols
+        } else if weight_cols == input_width_for_telemetry {
+            weight_rows
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+    if input.rank() != 2 || rows_for_telemetry != 1 {
+        record_q8_schedule_projection_route_denial(
+            "logits",
+            "x86_output_decode_owner",
+            "shape_or_role_mismatch",
+            rows_for_telemetry,
+            input_width_for_telemetry,
+            output_width_for_telemetry,
+        );
+        return Ok(None);
+    }
+    if weight.name != "output.weight" {
+        record_q8_schedule_projection_route_denial(
+            "logits",
+            "x86_output_decode_owner",
+            "output_weight_not_materialized",
+            rows_for_telemetry,
+            input_width_for_telemetry,
+            output_width_for_telemetry,
+        );
+        return Ok(None);
+    }
+    if weight.source_type != Some(GgufTensorType::Q8_0) {
+        record_q8_schedule_projection_route_denial(
+            "logits",
+            "x86_output_decode_owner",
+            "source_not_q8_0",
+            rows_for_telemetry,
+            input_width_for_telemetry,
+            output_width_for_telemetry,
+        );
         return Ok(None);
     }
     let input_width = input.dim(1)?;
+    if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        record_q8_schedule_projection_route_denial(
+            "logits",
+            "x86_output_decode_owner",
+            "input_width_not_q8_block_multiple",
+            1,
+            input_width,
+            output_width_for_telemetry,
+        );
+        return Ok(None);
+    }
     let borrowed = borrowed_linear_weight_as_transposed(weight, input_width)?;
     let Some((packed, interleave)) = q8_0_selected_borrowed_packed_rows4(borrowed) else {
+        record_q8_schedule_projection_route_denial(
+            "logits",
+            "x86_output_decode_owner",
+            "missing_runtime_packed_rows4",
+            1,
+            input_width,
+            borrowed.rows,
+        );
         return Ok(None);
     };
     if interleave != Q8_0PackedRows4Interleave::I8
         || packed.rows != borrowed.rows
         || packed.blocks_per_row != input_width / Q8_0_BLOCK_VALUES
-        || !input_width.is_multiple_of(Q8_0_BLOCK_VALUES)
         || !borrowed.rows.is_multiple_of(4)
     {
+        record_q8_schedule_projection_route_denial(
+            "logits",
+            "x86_output_decode_owner",
+            "packed_projection_shape_or_interleave_mismatch",
+            1,
+            input_width,
+            borrowed.rows,
+        );
         return Ok(None);
     }
+    let telemetry_started = q8_schedule_telemetry_enabled().then(Instant::now);
     let quantized_input = quantize_q8_0_row(&input.data[..input_width]);
-    q8_0_packed_rows4_single_input_projection(packed, &quantized_input.blocks, borrowed.rows, name)
-        .map(Some)
+    let output = q8_0_packed_rows4_single_input_projection(
+        packed,
+        &quantized_input.blocks,
+        borrowed.rows,
+        name,
+    )?;
+    record_q8_schedule_projection_route_elapsed(
+        "logits",
+        "x86_output_decode_owner",
+        name,
+        1,
+        input_width,
+        borrowed.rows,
+        telemetry_started,
+    );
+    Ok(Some(output))
 }
 
 fn x86_q8_attention_qkv_prefill_consumer_enabled() -> bool {

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -1580,6 +1580,7 @@ fn q8_0_hot_path_uses_resolved_plan_not_current_env() {
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
             output_packed_rows4_matmul: false,
+            output_decode_owner: false,
             ffn_gate_up_decode_consumer: false,
             ffn_gate_up_decode_group_chunking: false,
             ffn_gate_up_packed_rows4_matmul: false,
@@ -1685,6 +1686,7 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     std::env::set_var("CAMELID_X86_Q8_ATTENTION_QKV_DECODE_CONSUMER", "yes");
     std::env::set_var("CAMELID_X86_Q8_ATTENTION_QKV_PACKED_ROWS4_MATMUL", "on");
     std::env::set_var("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL", "on");
+    std::env::set_var("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER", "on");
     std::env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER", "true");
     std::env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_GROUP_CHUNKING", "on");
     std::env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL", "on");
@@ -1708,6 +1710,7 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     assert!(plan.q8.attention_qkv_decode_consumer);
     assert!(plan.q8.attention_qkv_packed_rows4_matmul);
     assert!(plan.q8.output_packed_rows4_matmul);
+    assert!(plan.q8.output_decode_owner);
     assert!(plan.q8.ffn_gate_up_decode_consumer);
     assert!(plan.q8.ffn_gate_up_decode_group_chunking);
     assert!(plan.q8.ffn_gate_up_packed_rows4_matmul);
@@ -1720,6 +1723,7 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     std::env::remove_var("CAMELID_X86_Q8_ATTENTION_QKV_DECODE_CONSUMER");
     std::env::remove_var("CAMELID_X86_Q8_ATTENTION_QKV_PACKED_ROWS4_MATMUL");
     std::env::remove_var("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL");
+    std::env::remove_var("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER");
     std::env::remove_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER");
     std::env::remove_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_GROUP_CHUNKING");
     std::env::remove_var("CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL");
@@ -1749,6 +1753,10 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     assert!(
         plan.q8.output_packed_rows4_matmul,
         "resolved plan should cache the output packed-rows4 matmul gate"
+    );
+    assert!(
+        plan.q8.output_decode_owner,
+        "resolved plan should cache the output decode-owner gate"
     );
     assert!(
         plan.q8.ffn_gate_up_decode_consumer,
@@ -1817,6 +1825,10 @@ fn runtime_profile_defaults_keep_experimental_q8_gates_closed() {
         assert!(
             !plan.q8.output_packed_rows4_matmul,
             "{profile} should not enable output packed-rows4 matmul by default"
+        );
+        assert!(
+            !plan.q8.output_decode_owner,
+            "{profile} should not enable output decode owner by default"
         );
         assert!(
             !plan.q8.ffn_gate_up_decode_consumer,
@@ -2381,6 +2393,7 @@ fn q8_attention_consumer_plan(
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
             output_packed_rows4_matmul: false,
+            output_decode_owner: false,
             ffn_gate_up_decode_consumer: false,
             ffn_gate_up_decode_group_chunking: false,
             ffn_gate_up_packed_rows4_matmul: false,
@@ -3155,6 +3168,7 @@ fn ffn_down_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
             output_packed_rows4_matmul: false,
+            output_decode_owner: false,
             ffn_gate_up_decode_consumer: false,
             ffn_gate_up_decode_group_chunking: false,
             ffn_gate_up_packed_rows4_matmul: false,
@@ -3195,6 +3209,7 @@ fn ffn_down_packed_rows4_matmul_plan(enabled: bool) -> ResolvedRuntimePlan {
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
             output_packed_rows4_matmul: false,
+            output_decode_owner: false,
             ffn_gate_up_decode_consumer: false,
             ffn_gate_up_decode_group_chunking: false,
             ffn_gate_up_packed_rows4_matmul: false,
@@ -3241,6 +3256,7 @@ fn ffn_gate_up_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
             output_packed_rows4_matmul: false,
+            output_decode_owner: false,
             ffn_gate_up_decode_consumer: enabled,
             ffn_gate_up_decode_group_chunking: false,
             ffn_gate_up_packed_rows4_matmul: false,
@@ -7461,6 +7477,8 @@ fn x86_q8_output_decode_owner_path_uses_runtime_packed_storage() {
     clear_dense_diagnostic_env();
     std::env::set_var("CAMELID_X86_Q8_REPACK", "on");
     std::env::set_var("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER", "on");
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
 
     let vocab_rows = 8;
     let input_width = Q8_0_BLOCK_VALUES * 2;
@@ -7506,7 +7524,18 @@ fn x86_q8_output_decode_owner_path_uses_runtime_packed_storage() {
         ));
     }
     assert_eq!(logits.data, expected);
+    let telemetry = snapshot_q8_schedule_telemetry();
+    let route = telemetry
+        .output_projection_by_route
+        .get("logits.x86_output_decode_owner")
+        .expect("output decode-owner route telemetry");
+    assert_eq!(route.calls, 1);
+    assert_eq!(route.rows, 1);
+    assert_eq!(route.input_width, input_width as u64);
+    assert_eq!(route.output_width, vocab_rows as u64);
 
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
     std::env::remove_var("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER");
     std::env::remove_var("CAMELID_X86_Q8_REPACK");
 }


### PR DESCRIPTION
## Summary
- Built on merged PR #74 AVX2 Q8 block-dot work.
- Added `CAMELID_X86_Q8_OUTPUT_DECODE_OWNER` to the resolved x86 Q8 runtime plan as a default-off explicit opt-in instead of having the execution planner force it off.
- Routed output decode-owner through resolved plan state and added Q8 schedule route/denial telemetry for logits.
- Added Linux x86_64 unit coverage for the runtime-packed logits route and planner opt-in preservation.

## Linux x86_64 proof
- Focused output decode-owner route tests passed.
- Runtime-plan opt-in preservation tests passed.
- Release build passed.
- Llama 3.2 3B Q8_0 one-token parity against llama.cpp passed for the checked prompt: prompt tokens matched, generated token `[34]` matched, and text `"C"` matched.
- Same-host benchmark smoke remained a bounded diagnostic, not a support or throughput promotion.

## Evidence
- Retained evidence artifacts were captured in the PR branch before merge.
- Public summary intentionally omits hostnames, local paths, key paths, and operator commands.

The 3B tied-output run recorded one output-weight materialization miss while logits fell back to the retained Q8 block path; this pins the next backend slice to materializing or repacking the tied output embedding for the logits route.