### PR TITLE
perf(q8): materialize tied output decode view

### DIFF
--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/README.md
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/README.md
@@ -1,0 +1,91 @@
+# Ubuntu x86 Q8 tied output logits route
+
+Date: 2026-05-22T02:22Z
+
+Base commit: `b95dd3051397b160f3ad1e0a464e33c14ab3c168`
+
+Ubuntu host: `ubuntu@16.146.143.184`
+
+Shared target dir: `/home/ubuntu/work/shared-targets/tied-output-logits-route`
+
+Disk guard evidence:
+
+- Setup: `2026-05-22T02:22:28Z CHECK avail_kb=158613992 use_pct=22 target_count=4`
+- Tests/build: `2026-05-22T02:22:44Z CHECK avail_kb=158496660 use_pct=22 target_count=4`
+- One-token route run: `2026-05-22T02:25:40Z CHECK avail_kb=157561960 use_pct=23 target_count=4`
+- Benchmark: `2026-05-22T02:26:14Z CHECK avail_kb=157553716 use_pct=23 target_count=4`
+
+Commands:
+
+```sh
+export CARGO_TARGET_DIR=/home/ubuntu/work/shared-targets/tied-output-logits-route
+cargo fmt --all -- --check
+cargo test q8_x86_repack_materializes_tied_embedding_as_output_runtime_storage --lib
+cargo test x86_q8_output_decode_owner_path_uses_runtime_packed_storage --lib
+cargo build --release
+```
+
+One-token route/parity command:
+
+```sh
+env RAYON_NUM_THREADS=16 OMP_NUM_THREADS=16 OMP_PROC_BIND=true OMP_PLACES=cores \
+  CAMELID_PROFILE=experimental \
+  CAMELID_X86_Q8_REPACK=on \
+  CAMELID_X86_Q8_KERNEL=avx2 \
+  CAMELID_X86_Q8_OUTPUT_DECODE_OWNER=on \
+  CAMELID_Q8_SCHED_TELEMETRY=on \
+  CAMELID_STREAM_TIMING_DIAGNOSTICS=on \
+  taskset -c 0-15 node scripts/bench-llama3-same-host.mjs \
+    --model /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf \
+    --backend-bin /home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid \
+    --llama-server /home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server \
+    --threads 16 --warmup 0 --repeats 1 --max-tokens 1 \
+    --out parity-one-token-telemetry.json
+```
+
+One-token result:
+
+- Camelid text: `C`
+- llama.cpp text: `C`
+- Required route: `logits.x86_output_decode_owner`
+- Rejected fallback route: no `logits.q8_0_retained_blocks`
+- Route detail: `calls=1`, `input_width=3072`, `output_width=128256`, `elapsed_us=4958`
+
+Benchmark command:
+
+```sh
+env RAYON_NUM_THREADS=16 OMP_NUM_THREADS=16 OMP_PROC_BIND=true OMP_PLACES=cores \
+  CAMELID_PROFILE=experimental \
+  CAMELID_X86_Q8_REPACK=on \
+  CAMELID_X86_Q8_KERNEL=avx2 \
+  CAMELID_X86_Q8_OUTPUT_DECODE_OWNER=on \
+  CAMELID_Q8_SCHED_TELEMETRY=on \
+  CAMELID_STREAM_TIMING_DIAGNOSTICS=on \
+  taskset -c 0-15 node scripts/bench-llama3-same-host.mjs \
+    --model /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf \
+    --backend-bin /home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid \
+    --llama-server /home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server \
+    --threads 16 --warmup 1 --repeats 3 --max-tokens 16 \
+    --require-marker --expected-marker CMLD-BENCH \
+    --out benchmark-r3.json
+```
+
+Benchmark result:
+
+- Marker guard: pass for all Camelid and llama.cpp measured runs.
+- Camelid TTFT mean: `445.737 ms`
+- llama.cpp TTFT mean: `176.527 ms`
+- Camelid total elapsed mean: `446.04 ms`
+- llama.cpp total elapsed mean: `410.41 ms`
+- Camelid backend first content mean: `117.333 ms`
+- Camelid backend generate mean: `383.333 ms`
+- Top logits route: `logits.x86_output_decode_owner`, `elapsed_mean=24.665 ms`, `calls_mean=5`, `width=3072x128256`
+- No benchmark measured run recorded `logits.q8_0_retained_blocks`.
+
+Artifacts:
+
+- `parity-one-token-telemetry.json`
+- `logs/route-check-one-token-telemetry.json`
+- `benchmark-r3.json`
+- `benchmark-r3.stream-summary.json`
+- `logs/route-check-benchmark-r3.json`

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/README.md
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/README.md
@@ -4,9 +4,9 @@ Date: 2026-05-22T02:22Z
 
 Base commit: `b95dd3051397b160f3ad1e0a464e33c14ab3c168`
 
-Ubuntu host: `ubuntu@16.146.143.184`
+Ubuntu host: `canonical-private-ubuntu-validation-host`
 
-Shared target dir: `/home/ubuntu/work/shared-targets/tied-output-logits-route`
+Shared target dir: `$CAMELID_SHARED_TARGET`
 
 Disk guard evidence:
 
@@ -18,7 +18,7 @@ Disk guard evidence:
 Commands:
 
 ```sh
-export CARGO_TARGET_DIR=/home/ubuntu/work/shared-targets/tied-output-logits-route
+export CARGO_TARGET_DIR=$CAMELID_SHARED_TARGET
 cargo fmt --all -- --check
 cargo test q8_x86_repack_materializes_tied_embedding_as_output_runtime_storage --lib
 cargo test x86_q8_output_decode_owner_path_uses_runtime_packed_storage --lib
@@ -36,9 +36,9 @@ env RAYON_NUM_THREADS=16 OMP_NUM_THREADS=16 OMP_PROC_BIND=true OMP_PLACES=cores 
   CAMELID_Q8_SCHED_TELEMETRY=on \
   CAMELID_STREAM_TIMING_DIAGNOSTICS=on \
   taskset -c 0-15 node scripts/bench-llama3-same-host.mjs \
-    --model /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf \
-    --backend-bin /home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid \
-    --llama-server /home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server \
+    --model $CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf \
+    --backend-bin $CAMELID_SHARED_TARGET/release/camelid \
+    --llama-server $CAMELID_LLAMA_CPP_BIN/llama-server \
     --threads 16 --warmup 0 --repeats 1 --max-tokens 1 \
     --out parity-one-token-telemetry.json
 ```
@@ -62,9 +62,9 @@ env RAYON_NUM_THREADS=16 OMP_NUM_THREADS=16 OMP_PROC_BIND=true OMP_PLACES=cores 
   CAMELID_Q8_SCHED_TELEMETRY=on \
   CAMELID_STREAM_TIMING_DIAGNOSTICS=on \
   taskset -c 0-15 node scripts/bench-llama3-same-host.mjs \
-    --model /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf \
-    --backend-bin /home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid \
-    --llama-server /home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server \
+    --model $CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf \
+    --backend-bin $CAMELID_SHARED_TARGET/release/camelid \
+    --llama-server $CAMELID_LLAMA_CPP_BIN/llama-server \
     --threads 16 --warmup 1 --repeats 3 --max-tokens 16 \
     --require-marker --expected-marker CMLD-BENCH \
     --out benchmark-r3.json

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/SHA256SUMS
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/SHA256SUMS
@@ -1,0 +1,6 @@
+79dc7f66c253605f2d4bc5eda9d438e3a5b288eaf91c3193386a79a226dc0e8e  ./README.md
+ef6a15e42656c6984aead458e6e5a8c1b545accd094e5fd9e5cc21d7c68be462  ./benchmark-r3.json
+ba8c876c560bf5edb1be4e9e61d7cca302374e413ccc43d8308ad89398c12b55  ./benchmark-r3.stream-summary.json
+914a4a786a1c9799d021c103231288ce6020e036f426f4dd627f4425fb45692c  ./logs/route-check-benchmark-r3.json
+de2e0b625ed6f508fec03be49b1a2aa7ea33e375324e950f0ca59ab0d65157b1  ./logs/route-check-one-token-telemetry.json
+f2ab3a911121ff7b66a6c9182171525ad06fef8a986c884aa9f2c1caa9f20a85  ./parity-one-token-telemetry.json

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.json
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.json
@@ -3,7 +3,7 @@
   "generated_utc": "2026-05-22T02:26:30.559Z",
   "model": {
     "row_id": "llama32_3b_instruct_q8_0",
-    "model_path": "/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf",
+    "model_path": "$CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf",
     "model_id": "llama32-3b-q8",
     "render_mode": "compact"
   },
@@ -28,10 +28,10 @@
     "llama_context": 512,
     "threads": 16,
     "commands": {
-      "harness": "node scripts/bench-llama3-same-host.mjs --model /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf --model-id llama32-3b-q8 --row-id llama32_3b_instruct_q8_0 --max-tokens 16 --warmup 1 --repeats 3 --threads 16 --require-marker --expected-marker CMLD-BENCH --out /home/ubuntu/work/camelid-tied-output-logits-route/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.json",
-      "camelid_serve": "/home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid serve --addr 127.0.0.1:8181",
-      "llama_server": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server --host 127.0.0.1 --port 8183 -m /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf -ngl 0 -c 512 --no-warmup -t 16",
-      "camelid_load_request": "POST http://127.0.0.1:8181/api/models/load {\"path\":\"/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf\",\"id\":\"llama32-3b-q8\"}",
+      "harness": "node scripts/bench-llama3-same-host.mjs --model $CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf --model-id llama32-3b-q8 --row-id llama32_3b_instruct_q8_0 --max-tokens 16 --warmup 1 --repeats 3 --threads 16 --require-marker --expected-marker CMLD-BENCH --out $CAMELID_WORKTREE/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.json",
+      "camelid_serve": "$CAMELID_SHARED_TARGET/release/camelid serve --addr 127.0.0.1:8181",
+      "llama_server": "$CAMELID_LLAMA_CPP_BIN/llama-server --host 127.0.0.1 --port 8183 -m $CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf -ngl 0 -c 512 --no-warmup -t 16",
+      "camelid_load_request": "POST http://127.0.0.1:8181/api/models/load {\"path\":\"$CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf\",\"id\":\"llama32-3b-q8\"}",
       "camelid_measure_request": "POST http://127.0.0.1:8181/v1/chat/completions stream=true max_tokens=16 temperature=0",
       "llama_cpp_measure_request": "POST http://127.0.0.1:8183/completion stream=true n_predict=16 temperature=0 cache_prompt=false"
     },
@@ -82,21 +82,19 @@
       "host_class": {
         "os_type": "Linux",
         "platform": "linux",
-        "release": "6.17.0-1013-aws",
         "arch": "x64",
-        "cpu_model": "Intel(R) Xeon(R) Platinum 8488C",
         "cpu_count": 16,
-        "total_memory_gib": 123.79
+        "host_class": "private Ubuntu x86_64 validation host"
       },
       "binaries": {
         "camelid": {
-          "path": "/home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid",
+          "path": "$CAMELID_SHARED_TARGET/release/camelid",
           "exists": true,
           "size_bytes": 9054616,
           "sha256": "dfc59980dd1e93bc2757d3ba61c94f65009a9349bca1b53f085d7be7db497f90"
         },
         "llama_server": {
-          "path": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server",
+          "path": "$CAMELID_LLAMA_CPP_BIN/llama-server",
           "exists": true,
           "size_bytes": 47918720,
           "sha256": "545f8e63151affb94fffd2205c02b0b94a93109cd09cda60631f77b00f598517"
@@ -104,7 +102,7 @@
         "node": "v18.19.1"
       },
       "model_artifact": {
-        "path": "/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf",
+        "path": "$CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf",
         "exists": true,
         "size_bytes": 3421899296,
         "sha256": "b5607b5090a8280063fff2d706bb3408ca6542341b06aab39c3eca0a28575921"
@@ -121,21 +119,13 @@
           1.04
         ],
         "memory": {
-          "total_gib": 123.79,
-          "free_gib": 120.83,
           "process_rss_mib": 89.02
         },
         "linux_meminfo": {
-          "mem_available_gib": 120.83,
-          "swap_total_gib": 0,
-          "swap_free_gib": 0,
           "dirty_mib": 0
         },
         "storage": {
-          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
-          "total_gib": 192.69,
-          "available_gib": 150.25,
-          "used_pct": 22.02
+          "path": "$CAMELID_WORKTREE"
         }
       },
       "before_measured_runs": {
@@ -147,21 +137,13 @@
           1.04
         ],
         "memory": {
-          "total_gib": 123.79,
-          "free_gib": 113.33,
           "process_rss_mib": 130.53
         },
         "linux_meminfo": {
-          "mem_available_gib": 113.33,
-          "swap_total_gib": 0,
-          "swap_free_gib": 0,
           "dirty_mib": 0.01
         },
         "storage": {
-          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
-          "total_gib": 192.69,
-          "available_gib": 150.25,
-          "used_pct": 22.02
+          "path": "$CAMELID_WORKTREE"
         }
       },
       "after_measured_runs": {
@@ -173,21 +155,13 @@
           1.03
         ],
         "memory": {
-          "total_gib": 123.79,
-          "free_gib": 113.21,
           "process_rss_mib": 130.91
         },
         "linux_meminfo": {
-          "mem_available_gib": 113.21,
-          "swap_total_gib": 0,
-          "swap_free_gib": 0,
           "dirty_mib": 3.63
         },
         "storage": {
-          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
-          "total_gib": 192.69,
-          "available_gib": 150.25,
-          "used_pct": 22.02
+          "path": "$CAMELID_WORKTREE"
         }
       }
     },
@@ -2397,7 +2371,7 @@
       "avg_ms_per_token_after_first": 46.78,
       "avg_completion_tokens_estimate": 5
     },
-    "binary": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server"
+    "binary": "$CAMELID_LLAMA_CPP_BIN/llama-server"
   },
   "comparison": {
     "ttft_delta_pct_vs_llama_cpp": 152.5,

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.json
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.json
@@ -1,0 +1,2451 @@
+{
+  "schema": "camelid.same_host_llama3_benchmark.v1",
+  "generated_utc": "2026-05-22T02:26:30.559Z",
+  "model": {
+    "row_id": "llama32_3b_instruct_q8_0",
+    "model_path": "/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf",
+    "model_id": "llama32-3b-q8",
+    "render_mode": "compact"
+  },
+  "method": {
+    "warmup": 1,
+    "repeats": 3,
+    "max_tokens": 16,
+    "expected_marker": "CMLD-BENCH",
+    "require_marker": true,
+    "unique_prompt": false,
+    "benchmark_messages": [
+      {
+        "role": "system",
+        "content": "You are Camelid benchmark mode. Reply with the exact requested text and nothing else."
+      },
+      {
+        "role": "user",
+        "content": "Reply with exactly this single line and nothing else: CMLD-BENCH"
+      }
+    ],
+    "estimated_prompt_tokens": 75,
+    "llama_context": 512,
+    "threads": 16,
+    "commands": {
+      "harness": "node scripts/bench-llama3-same-host.mjs --model /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf --model-id llama32-3b-q8 --row-id llama32_3b_instruct_q8_0 --max-tokens 16 --warmup 1 --repeats 3 --threads 16 --require-marker --expected-marker CMLD-BENCH --out /home/ubuntu/work/camelid-tied-output-logits-route/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.json",
+      "camelid_serve": "/home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid serve --addr 127.0.0.1:8181",
+      "llama_server": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server --host 127.0.0.1 --port 8183 -m /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf -ngl 0 -c 512 --no-warmup -t 16",
+      "camelid_load_request": "POST http://127.0.0.1:8181/api/models/load {\"path\":\"/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf\",\"id\":\"llama32-3b-q8\"}",
+      "camelid_measure_request": "POST http://127.0.0.1:8181/v1/chat/completions stream=true max_tokens=16 temperature=0",
+      "llama_cpp_measure_request": "POST http://127.0.0.1:8183/completion stream=true n_predict=16 temperature=0 cache_prompt=false"
+    },
+    "outputs": {
+      "stdout": [
+        "camelid_ttft_ms=<mean first non-empty streamed content chunk over measured runs>",
+        "camelid_decode_tok_s=<mean estimated streamed chunks per second after first content>",
+        "camelid_ms_tok=<mean estimated milliseconds per streamed content chunk after first content>",
+        "llama_cpp_ttft_ms=<same metric for llama.cpp>",
+        "llama_cpp_decode_tok_s=<same metric for llama.cpp>",
+        "llama_cpp_ms_tok=<same metric for llama.cpp>",
+        "camelid_backend_generate_ms=<mean Camelid backend generate timing when CAMELID_STREAM_TIMING_DIAGNOSTICS=on>",
+        "camelid_backend_first_content_ms=<mean Camelid backend first-content timing when CAMELID_STREAM_TIMING_DIAGNOSTICS=on>",
+        "json_out=<absolute path when --out is set>"
+      ],
+      "json": "Full machine-readable report at --out, schema camelid.same_host_llama3_benchmark.v1.",
+      "guardrail": "marker_presence=CMLD-BENCH; pass/fail is recorded under guardrails and can be enforced with --require-marker",
+      "lifecycle": "Report records server startup timing, model-load timing, warmups, and whether servers were started by the harness or reused preloaded."
+    },
+    "bounded_metrics": [
+      "first_byte_ms: first network byte from each streaming response",
+      "first_event_ms: first parsed SSE event",
+      "first_content_ms / TTFT: first non-empty streamed content chunk",
+      "total_elapsed_ms: full streaming response wall time",
+      "completion_tokens_estimate: count of non-empty streamed content chunks, not tokenizer-ground-truth tokens",
+      "decode_tok_per_s and ms_per_token_after_first: derived from completion_tokens_estimate after first content",
+      "marker_presence: exact expected marker observed in measured output text, optionally enforced with --require-marker",
+      "camelid_backend_generate_ms and camelid_backend_first_content_ms: opt-in backend timings when CAMELID_STREAM_TIMING_DIAGNOSTICS=on",
+      "camelid_backend_q8_calls and q8 timing counters: opt-in Q8 scheduler diagnostics when Camelid Q8 scheduler telemetry is also enabled; call count includes single-projection, fused gate/up, FFN-down decode, and route-table counters",
+      "resource_snapshots: host memory/load/storage snapshots before start, before measured runs, and after measured runs",
+      "server_lifecycle: Camelid/llama-server startup timing, model-load timing, reuse/preloaded status, and warmup behavior"
+    ],
+    "server_lifecycle": {
+      "camelid_started_by_harness": true,
+      "llama_started_by_harness": true,
+      "camelid_startup_ms": 55.12,
+      "llama_startup_ms": 1108.31,
+      "camelid_model_load_ms": 625.87,
+      "camelid_model_preloaded": false,
+      "llama_model_preloaded": false
+    },
+    "evidence_context": {
+      "repository": {
+        "head": "b95dd3051397b160f3ad1e0a464e33c14ab3c168",
+        "branch": "HEAD",
+        "status_short": "M src/inference.rs\n M src/tensor/mod.rs\n?? qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/"
+      },
+      "host_class": {
+        "os_type": "Linux",
+        "platform": "linux",
+        "release": "6.17.0-1013-aws",
+        "arch": "x64",
+        "cpu_model": "Intel(R) Xeon(R) Platinum 8488C",
+        "cpu_count": 16,
+        "total_memory_gib": 123.79
+      },
+      "binaries": {
+        "camelid": {
+          "path": "/home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid",
+          "exists": true,
+          "size_bytes": 9054616,
+          "sha256": "dfc59980dd1e93bc2757d3ba61c94f65009a9349bca1b53f085d7be7db497f90"
+        },
+        "llama_server": {
+          "path": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server",
+          "exists": true,
+          "size_bytes": 47918720,
+          "sha256": "545f8e63151affb94fffd2205c02b0b94a93109cd09cda60631f77b00f598517"
+        },
+        "node": "v18.19.1"
+      },
+      "model_artifact": {
+        "path": "/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf",
+        "exists": true,
+        "size_bytes": 3421899296,
+        "sha256": "b5607b5090a8280063fff2d706bb3408ca6542341b06aab39c3eca0a28575921"
+      },
+      "privacy_note": "Host name, user name, and home-relative local paths are intentionally not recorded; scrub full artifacts before publication if absolute paths appear in commands."
+    },
+    "resource_snapshots": {
+      "pre_start": {
+        "label": "pre_start",
+        "captured_utc": "2026-05-22T02:26:19.886Z",
+        "loadavg_1m_5m_15m": [
+          1.04,
+          1,
+          1.04
+        ],
+        "memory": {
+          "total_gib": 123.79,
+          "free_gib": 120.83,
+          "process_rss_mib": 89.02
+        },
+        "linux_meminfo": {
+          "mem_available_gib": 120.83,
+          "swap_total_gib": 0,
+          "swap_free_gib": 0,
+          "dirty_mib": 0
+        },
+        "storage": {
+          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
+          "total_gib": 192.69,
+          "available_gib": 150.25,
+          "used_pct": 22.02
+        }
+      },
+      "before_measured_runs": {
+        "label": "before_measured_runs",
+        "captured_utc": "2026-05-22T02:26:27.985Z",
+        "loadavg_1m_5m_15m": [
+          1.04,
+          1,
+          1.04
+        ],
+        "memory": {
+          "total_gib": 123.79,
+          "free_gib": 113.33,
+          "process_rss_mib": 130.53
+        },
+        "linux_meminfo": {
+          "mem_available_gib": 113.33,
+          "swap_total_gib": 0,
+          "swap_free_gib": 0,
+          "dirty_mib": 0.01
+        },
+        "storage": {
+          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
+          "total_gib": 192.69,
+          "available_gib": 150.25,
+          "used_pct": 22.02
+        }
+      },
+      "after_measured_runs": {
+        "label": "after_measured_runs",
+        "captured_utc": "2026-05-22T02:26:30.558Z",
+        "loadavg_1m_5m_15m": [
+          1.03,
+          1,
+          1.03
+        ],
+        "memory": {
+          "total_gib": 123.79,
+          "free_gib": 113.21,
+          "process_rss_mib": 130.91
+        },
+        "linux_meminfo": {
+          "mem_available_gib": 113.21,
+          "swap_total_gib": 0,
+          "swap_free_gib": 0,
+          "dirty_mib": 3.63
+        },
+        "storage": {
+          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
+          "total_gib": 192.69,
+          "available_gib": 150.25,
+          "used_pct": 22.02
+        }
+      }
+    },
+    "measured_order": [
+      {
+        "engine": "camelid",
+        "label": "camelid-measure-1"
+      },
+      {
+        "engine": "llama_cpp",
+        "label": "llama-measure-1"
+      },
+      {
+        "engine": "camelid",
+        "label": "camelid-measure-2"
+      },
+      {
+        "engine": "llama_cpp",
+        "label": "llama-measure-2"
+      },
+      {
+        "engine": "camelid",
+        "label": "camelid-measure-3"
+      },
+      {
+        "engine": "llama_cpp",
+        "label": "llama-measure-3"
+      }
+    ],
+    "note": "Same-host comparison using alternating streaming requests to Camelid /v1/chat/completions and llama.cpp /completion. TTFT is first non-empty streamed content chunk; token throughput is estimated from streamed content chunks, not tokenizer-ground-truth completion tokens."
+  },
+  "camelid": {
+    "base_url": "http://127.0.0.1:8181",
+    "warmups": [
+      {
+        "label": "camelid-warmup-1",
+        "text": "CMLD-BENCH",
+        "first_byte_ms": 5976.59,
+        "first_event_ms": 5976.69,
+        "first_content_ms": 5976.77,
+        "total_elapsed_ms": 5977.24,
+        "completion_tokens_estimate": 5,
+        "chunk_count": 5,
+        "backend_timing": {
+          "q8_schedule": {
+            "activation_pack_bytes_requested": 0,
+            "activation_pack_calls": 0,
+            "activation_pack_rows": 0,
+            "activation_quantize_pack_us": 0,
+            "conservative_tail_rows": 0,
+            "ffn_down_decode_consumer_taken": 168,
+            "ffn_down_gemm4_prefill_candidates": 196,
+            "ffn_down_gemm4_prefill_reject_bad_input_width": 0,
+            "ffn_down_gemm4_prefill_reject_no_runtime_packed": 0,
+            "ffn_down_gemm4_prefill_reject_non_i8_interleave": 0,
+            "ffn_down_gemm4_prefill_reject_plan_off": 196,
+            "ffn_down_gemm4_prefill_reject_rows_lt4": 0,
+            "ffn_down_vnni_decode_candidates": 532,
+            "ffn_down_vnni_decode_kernel_us": 0,
+            "ffn_down_vnni_decode_quantize_us": 0,
+            "ffn_down_vnni_decode_reject_bad_input_width": 0,
+            "ffn_down_vnni_decode_reject_bad_output_width": 0,
+            "ffn_down_vnni_decode_reject_cpu_feature": 0,
+            "ffn_down_vnni_decode_reject_gate_off": 532,
+            "ffn_down_vnni_decode_reject_no_vnni_pack": 0,
+            "ffn_down_vnni_decode_reject_shape_or_role": 0,
+            "ffn_down_vnni_decode_taken": 0,
+            "ffn_gate_up_decode_consumer_activation_us": 0,
+            "ffn_gate_up_decode_consumer_tensor_us": 0,
+            "i8mm_fused_gate_up_calls": 0,
+            "i8mm_single_projection_by_role": {},
+            "i8mm_single_projection_calls": 0,
+            "output_projection_by_layer_route": {
+              "layer_0.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 3526,
+                "input_width": 8192,
+                "layer_index": 0,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_1.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 3427,
+                "input_width": 8192,
+                "layer_index": 1,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_10.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2650,
+                "input_width": 8192,
+                "layer_index": 10,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_11.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2922,
+                "input_width": 8192,
+                "layer_index": 11,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_12.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2709,
+                "input_width": 8192,
+                "layer_index": 12,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_13.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2584,
+                "input_width": 8192,
+                "layer_index": 13,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_14.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2599,
+                "input_width": 8192,
+                "layer_index": 14,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_15.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2801,
+                "input_width": 8192,
+                "layer_index": 15,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_16.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2717,
+                "input_width": 8192,
+                "layer_index": 16,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_17.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2807,
+                "input_width": 8192,
+                "layer_index": 17,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_18.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2923,
+                "input_width": 8192,
+                "layer_index": 18,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_19.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2748,
+                "input_width": 8192,
+                "layer_index": 19,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_2.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 3042,
+                "input_width": 8192,
+                "layer_index": 2,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_20.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 3032,
+                "input_width": 8192,
+                "layer_index": 20,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_21.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2853,
+                "input_width": 8192,
+                "layer_index": 21,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_22.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2863,
+                "input_width": 8192,
+                "layer_index": 22,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_23.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2624,
+                "input_width": 8192,
+                "layer_index": 23,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_24.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2729,
+                "input_width": 8192,
+                "layer_index": 24,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_25.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2965,
+                "input_width": 8192,
+                "layer_index": 25,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_26.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2730,
+                "input_width": 8192,
+                "layer_index": 26,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_27.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2901,
+                "input_width": 8192,
+                "layer_index": 27,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_3.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2933,
+                "input_width": 8192,
+                "layer_index": 3,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_4.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2809,
+                "input_width": 8192,
+                "layer_index": 4,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_5.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2708,
+                "input_width": 8192,
+                "layer_index": 5,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_6.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2694,
+                "input_width": 8192,
+                "layer_index": 6,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_7.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2584,
+                "input_width": 8192,
+                "layer_index": 7,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_8.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2955,
+                "input_width": 8192,
+                "layer_index": 8,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              },
+              "layer_9.ffn_down.x86_decode_consumer": {
+                "calls": 6,
+                "elapsed_us": 2912,
+                "input_width": 8192,
+                "layer_index": 9,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 6
+              }
+            },
+            "output_projection_by_route": {
+              "ffn_down.x86_decode_consumer": {
+                "calls": 168,
+                "elapsed_us": 79747,
+                "input_width": 8192,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 168
+              },
+              "logits.x86_output_decode_owner": {
+                "calls": 6,
+                "elapsed_us": 30039,
+                "input_width": 3072,
+                "output_width": 128256,
+                "role": "logits",
+                "route": "x86_output_decode_owner",
+                "rows": 6
+              }
+            },
+            "output_projection_calls": 174,
+            "prefill_single_token_fallbacks": 0,
+            "projection_route_denials": {
+              "ffn_down.x86_gemm4_prefill.plan_off": {
+                "denials": 196,
+                "input_width": 8192,
+                "output_width": 0,
+                "reason": "plan_off",
+                "role": "ffn_down",
+                "route": "x86_gemm4_prefill",
+                "rows": 1456
+              },
+              "ffn_down.x86_vnni_decode_consumer.gate_off": {
+                "denials": 532,
+                "input_width": 8192,
+                "output_width": 3072,
+                "reason": "gate_off",
+                "role": "ffn_down",
+                "route": "x86_vnni_decode_consumer",
+                "rows": 9352
+              },
+              "ffn_gate_up.packed_rows4_matmul_prefill.plan_off": {
+                "denials": 28,
+                "input_width": 3072,
+                "output_width": 0,
+                "reason": "plan_off",
+                "role": "ffn_gate_up",
+                "route": "packed_rows4_matmul_prefill",
+                "rows": 1288
+              }
+            },
+            "q8_gemm_compute_us": 0,
+            "rayon_fanout_boundaries": 0,
+            "scratch_allocation_count": 0,
+            "scratch_bytes_allocated": 0,
+            "scratch_bytes_reused": 0,
+            "scratch_peak_capacity_bytes": 0
+          },
+          "timings_ms": {
+            "first_content": 1866,
+            "first_content_accounting": {
+              "first_content_minus_prompt_eval_forward": 30.202999999999975,
+              "first_content_minus_prompt_eval_forward_plus_sample": 30.013999999999896,
+              "prompt_eval_forward_plus_sample": 1835.986,
+              "prompt_eval_forward_total": 1835.797,
+              "prompt_eval_logits": 5.24,
+              "prompt_eval_sample": 0.189
+            },
+            "first_token_forward_total": 68.13,
+            "first_token_role_timings": {
+              "attention_context": 2.999000000000001,
+              "attention_output": 8.554999999999998,
+              "ffn_down": 13.544999999999998,
+              "ffn_gate": 10.549999999999999,
+              "ffn_up": 10.565,
+              "logits": 5.24
+            },
+            "generate": 2205,
+            "generation_forward_total": 2173.448,
+            "generation_role_timings": {
+              "attention_context": 45.228,
+              "attention_output": 185.24599999999995,
+              "ffn_down": 503.3119999999999,
+              "ffn_gate": 435.69000000000005,
+              "ffn_up": 448.20000000000005,
+              "logits": 30.074
+            },
+            "layer_role_hotspots": {
+              "first_token": [
+                {
+                  "elapsed_ms": 0.652,
+                  "layer_index": 3,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.635,
+                  "layer_index": 25,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.629,
+                  "layer_index": 26,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.61,
+                  "layer_index": 18,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.6,
+                  "layer_index": 2,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.585,
+                  "layer_index": 25,
+                  "role": "attention_output"
+                },
+                {
+                  "elapsed_ms": 0.562,
+                  "layer_index": 21,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.559,
+                  "layer_index": 9,
+                  "role": "attention_output"
+                },
+                {
+                  "elapsed_ms": 0.549,
+                  "layer_index": 17,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.513,
+                  "layer_index": 15,
+                  "role": "ffn_down"
+                }
+              ],
+              "generation": [
+                {
+                  "elapsed_ms": 23.25,
+                  "layer_index": 0,
+                  "role": "ffn_gate"
+                },
+                {
+                  "elapsed_ms": 22.522,
+                  "layer_index": 0,
+                  "role": "ffn_up"
+                },
+                {
+                  "elapsed_ms": 20.663,
+                  "layer_index": 0,
+                  "role": "kv_cache_write"
+                },
+                {
+                  "elapsed_ms": 18.469,
+                  "layer_index": 22,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 18.445,
+                  "layer_index": 26,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 18.386,
+                  "layer_index": 17,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 18.36,
+                  "layer_index": 20,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 18.342,
+                  "layer_index": 18,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 18.332,
+                  "layer_index": 1,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 18.285,
+                  "layer_index": 0,
+                  "role": "ffn_down"
+                }
+              ],
+              "prefill": [
+                {
+                  "elapsed_ms": 20.596,
+                  "layer_index": 0,
+                  "role": "ffn_gate"
+                },
+                {
+                  "elapsed_ms": 20.579,
+                  "layer_index": 0,
+                  "role": "kv_cache_write"
+                },
+                {
+                  "elapsed_ms": 19.867,
+                  "layer_index": 0,
+                  "role": "ffn_up"
+                },
+                {
+                  "elapsed_ms": 15.657,
+                  "layer_index": 26,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.568,
+                  "layer_index": 22,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.536,
+                  "layer_index": 17,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.456,
+                  "layer_index": 16,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.434,
+                  "layer_index": 19,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.379,
+                  "layer_index": 18,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.356,
+                  "layer_index": 23,
+                  "role": "ffn_down"
+                }
+              ]
+            },
+            "prefill_forward_total": 1767.667,
+            "prefill_role_timings": {
+              "attention_context": 25.907999999999998,
+              "attention_output": 136.727,
+              "ffn_down": 422.3159999999999,
+              "ffn_gate": 371.631,
+              "ffn_up": 384.0549999999999,
+              "logits": 0
+            },
+            "prompt_cache_hit": false,
+            "session_create": 0,
+            "stream_event_accounting": {
+              "final_yield": 2205,
+              "final_yield_minus_first_content_yield": 339,
+              "first_content_yield": 1866,
+              "first_content_yield_minus_role_yield": 1866,
+              "generate_start": 0,
+              "generate_start_minus_role_yield": 0,
+              "poll_yield_enabled": false,
+              "role_yield": 0
+            },
+            "tokenize": 29,
+            "weight_cache_hit": false,
+            "weight_load": 3707
+          }
+        },
+        "backend_generate_ms": 2205,
+        "backend_first_content_ms": 1866,
+        "backend_q8_gemm_compute_us": 0,
+        "backend_q8_pack_us": 0,
+        "backend_q8_calls": 174,
+        "decode_tok_per_s": 10795.41,
+        "ms_per_token_after_first": 0.09
+      }
+    ],
+    "runs": [
+      {
+        "label": "camelid-measure-1",
+        "text": "CMLD-BENCH",
+        "first_byte_ms": 452.29,
+        "first_event_ms": 452.36,
+        "first_content_ms": 452.4,
+        "total_elapsed_ms": 452.61,
+        "completion_tokens_estimate": 4,
+        "chunk_count": 4,
+        "backend_timing": {
+          "q8_schedule": {
+            "activation_pack_bytes_requested": 0,
+            "activation_pack_calls": 0,
+            "activation_pack_rows": 0,
+            "activation_quantize_pack_us": 0,
+            "conservative_tail_rows": 0,
+            "ffn_down_decode_consumer_taken": 140,
+            "ffn_down_gemm4_prefill_candidates": 140,
+            "ffn_down_gemm4_prefill_reject_bad_input_width": 0,
+            "ffn_down_gemm4_prefill_reject_no_runtime_packed": 0,
+            "ffn_down_gemm4_prefill_reject_non_i8_interleave": 0,
+            "ffn_down_gemm4_prefill_reject_plan_off": 140,
+            "ffn_down_gemm4_prefill_reject_rows_lt4": 0,
+            "ffn_down_vnni_decode_candidates": 280,
+            "ffn_down_vnni_decode_kernel_us": 0,
+            "ffn_down_vnni_decode_quantize_us": 0,
+            "ffn_down_vnni_decode_reject_bad_input_width": 0,
+            "ffn_down_vnni_decode_reject_bad_output_width": 0,
+            "ffn_down_vnni_decode_reject_cpu_feature": 0,
+            "ffn_down_vnni_decode_reject_gate_off": 280,
+            "ffn_down_vnni_decode_reject_no_vnni_pack": 0,
+            "ffn_down_vnni_decode_reject_shape_or_role": 0,
+            "ffn_down_vnni_decode_taken": 0,
+            "ffn_gate_up_decode_consumer_activation_us": 0,
+            "ffn_gate_up_decode_consumer_tensor_us": 0,
+            "i8mm_fused_gate_up_calls": 0,
+            "i8mm_single_projection_by_role": {},
+            "i8mm_single_projection_calls": 0,
+            "output_projection_by_layer_route": {
+              "layer_0.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2670,
+                "input_width": 8192,
+                "layer_index": 0,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_1.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2510,
+                "input_width": 8192,
+                "layer_index": 1,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_10.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2147,
+                "input_width": 8192,
+                "layer_index": 10,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_11.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2339,
+                "input_width": 8192,
+                "layer_index": 11,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_12.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2178,
+                "input_width": 8192,
+                "layer_index": 12,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_13.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2566,
+                "input_width": 8192,
+                "layer_index": 13,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_14.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2274,
+                "input_width": 8192,
+                "layer_index": 14,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_15.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2365,
+                "input_width": 8192,
+                "layer_index": 15,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_16.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2347,
+                "input_width": 8192,
+                "layer_index": 16,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_17.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2578,
+                "input_width": 8192,
+                "layer_index": 17,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_18.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2425,
+                "input_width": 8192,
+                "layer_index": 18,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_19.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2435,
+                "input_width": 8192,
+                "layer_index": 19,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_2.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2367,
+                "input_width": 8192,
+                "layer_index": 2,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_20.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2633,
+                "input_width": 8192,
+                "layer_index": 20,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_21.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2107,
+                "input_width": 8192,
+                "layer_index": 21,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_22.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2179,
+                "input_width": 8192,
+                "layer_index": 22,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_23.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2136,
+                "input_width": 8192,
+                "layer_index": 23,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_24.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2147,
+                "input_width": 8192,
+                "layer_index": 24,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_25.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2157,
+                "input_width": 8192,
+                "layer_index": 25,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_26.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2186,
+                "input_width": 8192,
+                "layer_index": 26,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_27.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2258,
+                "input_width": 8192,
+                "layer_index": 27,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_3.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2086,
+                "input_width": 8192,
+                "layer_index": 3,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_4.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2321,
+                "input_width": 8192,
+                "layer_index": 4,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_5.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2195,
+                "input_width": 8192,
+                "layer_index": 5,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_6.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2177,
+                "input_width": 8192,
+                "layer_index": 6,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_7.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2376,
+                "input_width": 8192,
+                "layer_index": 7,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_8.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2094,
+                "input_width": 8192,
+                "layer_index": 8,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_9.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2406,
+                "input_width": 8192,
+                "layer_index": 9,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              }
+            },
+            "output_projection_by_route": {
+              "ffn_down.x86_decode_consumer": {
+                "calls": 140,
+                "elapsed_us": 64659,
+                "input_width": 8192,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 140
+              },
+              "logits.x86_output_decode_owner": {
+                "calls": 5,
+                "elapsed_us": 24839,
+                "input_width": 3072,
+                "output_width": 128256,
+                "role": "logits",
+                "route": "x86_output_decode_owner",
+                "rows": 5
+              }
+            },
+            "output_projection_calls": 145,
+            "prefill_single_token_fallbacks": 0,
+            "projection_route_denials": {
+              "ffn_down.x86_gemm4_prefill.plan_off": {
+                "denials": 140,
+                "input_width": 8192,
+                "output_width": 0,
+                "reason": "plan_off",
+                "role": "ffn_down",
+                "route": "x86_gemm4_prefill",
+                "rows": 140
+              },
+              "ffn_down.x86_vnni_decode_consumer.gate_off": {
+                "denials": 280,
+                "input_width": 8192,
+                "output_width": 3072,
+                "reason": "gate_off",
+                "role": "ffn_down",
+                "route": "x86_vnni_decode_consumer",
+                "rows": 280
+              }
+            },
+            "q8_gemm_compute_us": 0,
+            "rayon_fanout_boundaries": 0,
+            "scratch_allocation_count": 0,
+            "scratch_bytes_allocated": 0,
+            "scratch_bytes_reused": 0,
+            "scratch_peak_capacity_bytes": 0
+          },
+          "timings_ms": {
+            "first_content": 123,
+            "first_content_accounting": {
+              "first_content_minus_prompt_eval_forward": 123,
+              "first_content_minus_prompt_eval_forward_plus_sample": 123,
+              "prompt_eval_forward_plus_sample": 0,
+              "prompt_eval_forward_total": 0,
+              "prompt_eval_logits": 0,
+              "prompt_eval_sample": 0
+            },
+            "first_token_forward_total": 0,
+            "first_token_role_timings": {
+              "attention_context": 0,
+              "attention_output": 0,
+              "ffn_down": 0,
+              "ffn_gate": 0,
+              "ffn_up": 0,
+              "logits": 0
+            },
+            "generate": 386,
+            "generation_forward_total": 328.734,
+            "generation_role_timings": {
+              "attention_context": 16.270999999999997,
+              "attention_output": 37.639,
+              "ffn_down": 65.702,
+              "ffn_gate": 52.496000000000016,
+              "ffn_up": 52.579,
+              "logits": 24.865
+            },
+            "layer_role_hotspots": {
+              "first_token": [],
+              "generation": [
+                {
+                  "elapsed_ms": 2.714,
+                  "layer_index": 0,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.675,
+                  "layer_index": 20,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.619,
+                  "layer_index": 17,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.6,
+                  "layer_index": 13,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.554,
+                  "layer_index": 1,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.476,
+                  "layer_index": 19,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.465,
+                  "layer_index": 18,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.442,
+                  "layer_index": 9,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.41,
+                  "layer_index": 7,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.402,
+                  "layer_index": 2,
+                  "role": "ffn_down"
+                }
+              ],
+              "prefill": []
+            },
+            "prefill_forward_total": 0,
+            "prefill_role_timings": {
+              "attention_context": 0,
+              "attention_output": 0,
+              "ffn_down": 0,
+              "ffn_gate": 0,
+              "ffn_up": 0,
+              "logits": 0
+            },
+            "prompt_cache_hit": true,
+            "session_create": 0,
+            "stream_event_accounting": {
+              "final_yield": 386,
+              "final_yield_minus_first_content_yield": 263,
+              "first_content_yield": 123,
+              "first_content_yield_minus_role_yield": 123,
+              "generate_start": 0,
+              "generate_start_minus_role_yield": 0,
+              "poll_yield_enabled": false,
+              "role_yield": 0
+            },
+            "tokenize": 29,
+            "weight_cache_hit": true,
+            "weight_load": 0
+          }
+        },
+        "backend_generate_ms": 386,
+        "backend_first_content_ms": 123,
+        "backend_q8_gemm_compute_us": 0,
+        "backend_q8_pack_us": 0,
+        "backend_q8_calls": 145,
+        "decode_tok_per_s": 19658.34,
+        "ms_per_token_after_first": 0.05
+      },
+      {
+        "label": "camelid-measure-2",
+        "text": "CMLD-BENCH",
+        "first_byte_ms": 451.28,
+        "first_event_ms": 451.32,
+        "first_content_ms": 451.36,
+        "total_elapsed_ms": 451.88,
+        "completion_tokens_estimate": 4,
+        "chunk_count": 4,
+        "backend_timing": {
+          "q8_schedule": {
+            "activation_pack_bytes_requested": 0,
+            "activation_pack_calls": 0,
+            "activation_pack_rows": 0,
+            "activation_quantize_pack_us": 0,
+            "conservative_tail_rows": 0,
+            "ffn_down_decode_consumer_taken": 140,
+            "ffn_down_gemm4_prefill_candidates": 140,
+            "ffn_down_gemm4_prefill_reject_bad_input_width": 0,
+            "ffn_down_gemm4_prefill_reject_no_runtime_packed": 0,
+            "ffn_down_gemm4_prefill_reject_non_i8_interleave": 0,
+            "ffn_down_gemm4_prefill_reject_plan_off": 140,
+            "ffn_down_gemm4_prefill_reject_rows_lt4": 0,
+            "ffn_down_vnni_decode_candidates": 280,
+            "ffn_down_vnni_decode_kernel_us": 0,
+            "ffn_down_vnni_decode_quantize_us": 0,
+            "ffn_down_vnni_decode_reject_bad_input_width": 0,
+            "ffn_down_vnni_decode_reject_bad_output_width": 0,
+            "ffn_down_vnni_decode_reject_cpu_feature": 0,
+            "ffn_down_vnni_decode_reject_gate_off": 280,
+            "ffn_down_vnni_decode_reject_no_vnni_pack": 0,
+            "ffn_down_vnni_decode_reject_shape_or_role": 0,
+            "ffn_down_vnni_decode_taken": 0,
+            "ffn_gate_up_decode_consumer_activation_us": 0,
+            "ffn_gate_up_decode_consumer_tensor_us": 0,
+            "i8mm_fused_gate_up_calls": 0,
+            "i8mm_single_projection_by_role": {},
+            "i8mm_single_projection_calls": 0,
+            "output_projection_by_layer_route": {
+              "layer_0.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2543,
+                "input_width": 8192,
+                "layer_index": 0,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_1.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2796,
+                "input_width": 8192,
+                "layer_index": 1,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_10.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2212,
+                "input_width": 8192,
+                "layer_index": 10,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_11.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2269,
+                "input_width": 8192,
+                "layer_index": 11,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_12.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2304,
+                "input_width": 8192,
+                "layer_index": 12,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_13.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2644,
+                "input_width": 8192,
+                "layer_index": 13,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_14.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2607,
+                "input_width": 8192,
+                "layer_index": 14,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_15.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2401,
+                "input_width": 8192,
+                "layer_index": 15,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_16.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2272,
+                "input_width": 8192,
+                "layer_index": 16,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_17.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2157,
+                "input_width": 8192,
+                "layer_index": 17,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_18.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2465,
+                "input_width": 8192,
+                "layer_index": 18,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_19.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2289,
+                "input_width": 8192,
+                "layer_index": 19,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_2.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2907,
+                "input_width": 8192,
+                "layer_index": 2,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_20.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2227,
+                "input_width": 8192,
+                "layer_index": 20,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_21.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2690,
+                "input_width": 8192,
+                "layer_index": 21,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_22.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2451,
+                "input_width": 8192,
+                "layer_index": 22,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_23.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2268,
+                "input_width": 8192,
+                "layer_index": 23,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_24.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2506,
+                "input_width": 8192,
+                "layer_index": 24,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_25.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2395,
+                "input_width": 8192,
+                "layer_index": 25,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_26.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2495,
+                "input_width": 8192,
+                "layer_index": 26,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_27.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2422,
+                "input_width": 8192,
+                "layer_index": 27,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_3.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2436,
+                "input_width": 8192,
+                "layer_index": 3,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_4.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2357,
+                "input_width": 8192,
+                "layer_index": 4,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_5.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2222,
+                "input_width": 8192,
+                "layer_index": 5,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_6.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2208,
+                "input_width": 8192,
+                "layer_index": 6,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_7.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2287,
+                "input_width": 8192,
+                "layer_index": 7,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_8.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2271,
+                "input_width": 8192,
+                "layer_index": 8,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_9.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2291,
+                "input_width": 8192,
+                "layer_index": 9,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              }
+            },
+            "output_projection_by_route": {
+              "ffn_down.x86_decode_consumer": {
+                "calls": 140,
+                "elapsed_us": 67392,
+                "input_width": 8192,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 140
+              },
+              "logits.x86_output_decode_owner": {
+                "calls": 5,
+                "elapsed_us": 24658,
+                "input_width": 3072,
+                "output_width": 128256,
+                "role": "logits",
+                "route": "x86_output_decode_owner",
+                "rows": 5
+              }
+            },
+            "output_projection_calls": 145,
+            "prefill_single_token_fallbacks": 0,
+            "projection_route_denials": {
+              "ffn_down.x86_gemm4_prefill.plan_off": {
+                "denials": 140,
+                "input_width": 8192,
+                "output_width": 0,
+                "reason": "plan_off",
+                "role": "ffn_down",
+                "route": "x86_gemm4_prefill",
+                "rows": 140
+              },
+              "ffn_down.x86_vnni_decode_consumer.gate_off": {
+                "denials": 280,
+                "input_width": 8192,
+                "output_width": 3072,
+                "reason": "gate_off",
+                "role": "ffn_down",
+                "route": "x86_vnni_decode_consumer",
+                "rows": 280
+              }
+            },
+            "q8_gemm_compute_us": 0,
+            "rayon_fanout_boundaries": 0,
+            "scratch_allocation_count": 0,
+            "scratch_bytes_allocated": 0,
+            "scratch_bytes_reused": 0,
+            "scratch_peak_capacity_bytes": 0
+          },
+          "timings_ms": {
+            "first_content": 116,
+            "first_content_accounting": {
+              "first_content_minus_prompt_eval_forward": 116,
+              "first_content_minus_prompt_eval_forward_plus_sample": 116,
+              "prompt_eval_forward_plus_sample": 0,
+              "prompt_eval_forward_total": 0,
+              "prompt_eval_logits": 0,
+              "prompt_eval_sample": 0
+            },
+            "first_token_forward_total": 0,
+            "first_token_role_timings": {
+              "attention_context": 0,
+              "attention_output": 0,
+              "ffn_down": 0,
+              "ffn_gate": 0,
+              "ffn_up": 0,
+              "logits": 0
+            },
+            "generate": 389,
+            "generation_forward_total": 340.485,
+            "generation_role_timings": {
+              "attention_context": 17.182,
+              "attention_output": 39.683,
+              "ffn_down": 68.52499999999999,
+              "ffn_gate": 52.961999999999996,
+              "ffn_up": 53.036,
+              "logits": 24.686
+            },
+            "layer_role_hotspots": {
+              "first_token": [],
+              "generation": [
+                {
+                  "elapsed_ms": 2.954,
+                  "layer_index": 2,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.845,
+                  "layer_index": 1,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.729,
+                  "layer_index": 21,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.68,
+                  "layer_index": 13,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.642,
+                  "layer_index": 14,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.594,
+                  "layer_index": 0,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.546,
+                  "layer_index": 24,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.533,
+                  "layer_index": 26,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.506,
+                  "layer_index": 18,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.5,
+                  "layer_index": 3,
+                  "role": "ffn_down"
+                }
+              ],
+              "prefill": []
+            },
+            "prefill_forward_total": 0,
+            "prefill_role_timings": {
+              "attention_context": 0,
+              "attention_output": 0,
+              "ffn_down": 0,
+              "ffn_gate": 0,
+              "ffn_up": 0,
+              "logits": 0
+            },
+            "prompt_cache_hit": true,
+            "session_create": 0,
+            "stream_event_accounting": {
+              "final_yield": 389,
+              "final_yield_minus_first_content_yield": 273,
+              "first_content_yield": 116,
+              "first_content_yield_minus_role_yield": 116,
+              "generate_start": 0,
+              "generate_start_minus_role_yield": 0,
+              "poll_yield_enabled": false,
+              "role_yield": 0
+            },
+            "tokenize": 32,
+            "weight_cache_hit": true,
+            "weight_load": 0
+          }
+        },
+        "backend_generate_ms": 389,
+        "backend_first_content_ms": 116,
+        "backend_q8_gemm_compute_us": 0,
+        "backend_q8_pack_us": 0,
+        "backend_q8_calls": 145,
+        "decode_tok_per_s": 7650.66,
+        "ms_per_token_after_first": 0.13
+      },
+      {
+        "label": "camelid-measure-3",
+        "text": "CMLD-BENCH",
+        "first_byte_ms": 433.38,
+        "first_event_ms": 433.42,
+        "first_content_ms": 433.45,
+        "total_elapsed_ms": 433.62,
+        "completion_tokens_estimate": 4,
+        "chunk_count": 4,
+        "backend_timing": {
+          "q8_schedule": {
+            "activation_pack_bytes_requested": 0,
+            "activation_pack_calls": 0,
+            "activation_pack_rows": 0,
+            "activation_quantize_pack_us": 0,
+            "conservative_tail_rows": 0,
+            "ffn_down_decode_consumer_taken": 140,
+            "ffn_down_gemm4_prefill_candidates": 140,
+            "ffn_down_gemm4_prefill_reject_bad_input_width": 0,
+            "ffn_down_gemm4_prefill_reject_no_runtime_packed": 0,
+            "ffn_down_gemm4_prefill_reject_non_i8_interleave": 0,
+            "ffn_down_gemm4_prefill_reject_plan_off": 140,
+            "ffn_down_gemm4_prefill_reject_rows_lt4": 0,
+            "ffn_down_vnni_decode_candidates": 280,
+            "ffn_down_vnni_decode_kernel_us": 0,
+            "ffn_down_vnni_decode_quantize_us": 0,
+            "ffn_down_vnni_decode_reject_bad_input_width": 0,
+            "ffn_down_vnni_decode_reject_bad_output_width": 0,
+            "ffn_down_vnni_decode_reject_cpu_feature": 0,
+            "ffn_down_vnni_decode_reject_gate_off": 280,
+            "ffn_down_vnni_decode_reject_no_vnni_pack": 0,
+            "ffn_down_vnni_decode_reject_shape_or_role": 0,
+            "ffn_down_vnni_decode_taken": 0,
+            "ffn_gate_up_decode_consumer_activation_us": 0,
+            "ffn_gate_up_decode_consumer_tensor_us": 0,
+            "i8mm_fused_gate_up_calls": 0,
+            "i8mm_single_projection_by_role": {},
+            "i8mm_single_projection_calls": 0,
+            "output_projection_by_layer_route": {
+              "layer_0.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2351,
+                "input_width": 8192,
+                "layer_index": 0,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_1.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2437,
+                "input_width": 8192,
+                "layer_index": 1,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_10.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2042,
+                "input_width": 8192,
+                "layer_index": 10,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_11.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2241,
+                "input_width": 8192,
+                "layer_index": 11,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_12.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2553,
+                "input_width": 8192,
+                "layer_index": 12,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_13.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2184,
+                "input_width": 8192,
+                "layer_index": 13,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_14.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2257,
+                "input_width": 8192,
+                "layer_index": 14,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_15.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2319,
+                "input_width": 8192,
+                "layer_index": 15,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_16.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2125,
+                "input_width": 8192,
+                "layer_index": 16,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_17.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2230,
+                "input_width": 8192,
+                "layer_index": 17,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_18.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2191,
+                "input_width": 8192,
+                "layer_index": 18,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_19.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2383,
+                "input_width": 8192,
+                "layer_index": 19,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_2.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2210,
+                "input_width": 8192,
+                "layer_index": 2,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_20.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2357,
+                "input_width": 8192,
+                "layer_index": 20,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_21.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2334,
+                "input_width": 8192,
+                "layer_index": 21,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_22.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2526,
+                "input_width": 8192,
+                "layer_index": 22,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_23.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2259,
+                "input_width": 8192,
+                "layer_index": 23,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_24.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2285,
+                "input_width": 8192,
+                "layer_index": 24,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_25.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2305,
+                "input_width": 8192,
+                "layer_index": 25,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_26.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2076,
+                "input_width": 8192,
+                "layer_index": 26,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_27.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2079,
+                "input_width": 8192,
+                "layer_index": 27,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_3.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2315,
+                "input_width": 8192,
+                "layer_index": 3,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_4.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2117,
+                "input_width": 8192,
+                "layer_index": 4,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_5.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2337,
+                "input_width": 8192,
+                "layer_index": 5,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_6.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2103,
+                "input_width": 8192,
+                "layer_index": 6,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_7.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2376,
+                "input_width": 8192,
+                "layer_index": 7,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_8.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2175,
+                "input_width": 8192,
+                "layer_index": 8,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              },
+              "layer_9.ffn_down.x86_decode_consumer": {
+                "calls": 5,
+                "elapsed_us": 2043,
+                "input_width": 8192,
+                "layer_index": 9,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 5
+              }
+            },
+            "output_projection_by_route": {
+              "ffn_down.x86_decode_consumer": {
+                "calls": 140,
+                "elapsed_us": 63210,
+                "input_width": 8192,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 140
+              },
+              "logits.x86_output_decode_owner": {
+                "calls": 5,
+                "elapsed_us": 24498,
+                "input_width": 3072,
+                "output_width": 128256,
+                "role": "logits",
+                "route": "x86_output_decode_owner",
+                "rows": 5
+              }
+            },
+            "output_projection_calls": 145,
+            "prefill_single_token_fallbacks": 0,
+            "projection_route_denials": {
+              "ffn_down.x86_gemm4_prefill.plan_off": {
+                "denials": 140,
+                "input_width": 8192,
+                "output_width": 0,
+                "reason": "plan_off",
+                "role": "ffn_down",
+                "route": "x86_gemm4_prefill",
+                "rows": 140
+              },
+              "ffn_down.x86_vnni_decode_consumer.gate_off": {
+                "denials": 280,
+                "input_width": 8192,
+                "output_width": 3072,
+                "reason": "gate_off",
+                "role": "ffn_down",
+                "route": "x86_vnni_decode_consumer",
+                "rows": 280
+              }
+            },
+            "q8_gemm_compute_us": 0,
+            "rayon_fanout_boundaries": 0,
+            "scratch_allocation_count": 0,
+            "scratch_bytes_allocated": 0,
+            "scratch_bytes_reused": 0,
+            "scratch_peak_capacity_bytes": 0
+          },
+          "timings_ms": {
+            "first_content": 113,
+            "first_content_accounting": {
+              "first_content_minus_prompt_eval_forward": 113,
+              "first_content_minus_prompt_eval_forward_plus_sample": 113,
+              "prompt_eval_forward_plus_sample": 0,
+              "prompt_eval_forward_total": 0,
+              "prompt_eval_logits": 0,
+              "prompt_eval_sample": 0
+            },
+            "first_token_forward_total": 0,
+            "first_token_role_timings": {
+              "attention_context": 0,
+              "attention_output": 0,
+              "ffn_down": 0,
+              "ffn_gate": 0,
+              "ffn_up": 0,
+              "logits": 0
+            },
+            "generate": 375,
+            "generation_forward_total": 327.442,
+            "generation_role_timings": {
+              "attention_context": 16.258,
+              "attention_output": 36.657,
+              "ffn_down": 64.24699999999999,
+              "ffn_gate": 53.362,
+              "ffn_up": 53.436,
+              "logits": 24.523
+            },
+            "layer_role_hotspots": {
+              "first_token": [],
+              "generation": [
+                {
+                  "elapsed_ms": 2.586,
+                  "layer_index": 12,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.568,
+                  "layer_index": 22,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.481,
+                  "layer_index": 1,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.421,
+                  "layer_index": 19,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.412,
+                  "layer_index": 7,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.395,
+                  "layer_index": 20,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.393,
+                  "layer_index": 0,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.375,
+                  "layer_index": 5,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.371,
+                  "layer_index": 21,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 2.352,
+                  "layer_index": 15,
+                  "role": "ffn_down"
+                }
+              ],
+              "prefill": []
+            },
+            "prefill_forward_total": 0,
+            "prefill_role_timings": {
+              "attention_context": 0,
+              "attention_output": 0,
+              "ffn_down": 0,
+              "ffn_gate": 0,
+              "ffn_up": 0,
+              "logits": 0
+            },
+            "prompt_cache_hit": true,
+            "session_create": 0,
+            "stream_event_accounting": {
+              "final_yield": 375,
+              "final_yield_minus_first_content_yield": 262,
+              "first_content_yield": 113,
+              "first_content_yield_minus_role_yield": 113,
+              "generate_start": 0,
+              "generate_start_minus_role_yield": 0,
+              "poll_yield_enabled": false,
+              "role_yield": 0
+            },
+            "tokenize": 29,
+            "weight_cache_hit": true,
+            "weight_load": 0
+          }
+        },
+        "backend_generate_ms": 375,
+        "backend_first_content_ms": 113,
+        "backend_q8_gemm_compute_us": 0,
+        "backend_q8_pack_us": 0,
+        "backend_q8_calls": 145,
+        "decode_tok_per_s": 23040.28,
+        "ms_per_token_after_first": 0.04
+      }
+    ],
+    "summary": {
+      "count": 3,
+      "avg_first_byte_ms": 445.65,
+      "avg_first_event_ms": 445.7,
+      "avg_ttft_ms": 445.74,
+      "avg_total_elapsed_ms": 446.04,
+      "avg_backend_generate_ms": 383.33,
+      "avg_backend_first_content_ms": 117.33,
+      "avg_backend_q8_calls": 145,
+      "avg_backend_q8_gemm_compute_us": 0,
+      "avg_backend_q8_pack_us": 0,
+      "avg_decode_tok_per_s": 16783.09,
+      "avg_ms_per_token_after_first": 0.07,
+      "avg_completion_tokens_estimate": 4
+    }
+  },
+  "llama_cpp": {
+    "base_url": "http://127.0.0.1:8183",
+    "warmups": [
+      {
+        "label": "llama-warmup-1",
+        "text": "CMLD-BENCH",
+        "first_byte_ms": 171.94,
+        "first_event_ms": 172.16,
+        "first_content_ms": 172.23,
+        "total_elapsed_ms": 378.15,
+        "completion_tokens_estimate": 5,
+        "chunk_count": 5,
+        "backend_timing": null,
+        "backend_generate_ms": null,
+        "backend_first_content_ms": null,
+        "backend_q8_gemm_compute_us": null,
+        "backend_q8_pack_us": null,
+        "backend_q8_calls": null,
+        "decode_tok_per_s": 24.28,
+        "ms_per_token_after_first": 41.18
+      }
+    ],
+    "runs": [
+      {
+        "label": "llama-measure-1",
+        "text": "CMLD-BENCH",
+        "first_byte_ms": 171.18,
+        "first_event_ms": 171.21,
+        "first_content_ms": 171.24,
+        "total_elapsed_ms": 380.48,
+        "completion_tokens_estimate": 5,
+        "chunk_count": 5,
+        "backend_timing": null,
+        "backend_generate_ms": null,
+        "backend_first_content_ms": null,
+        "backend_q8_gemm_compute_us": null,
+        "backend_q8_pack_us": null,
+        "backend_q8_calls": null,
+        "decode_tok_per_s": 23.9,
+        "ms_per_token_after_first": 41.85
+      },
+      {
+        "label": "llama-measure-2",
+        "text": "CMLD-BENCH",
+        "first_byte_ms": 186.44,
+        "first_event_ms": 186.47,
+        "first_content_ms": 186.5,
+        "total_elapsed_ms": 473.59,
+        "completion_tokens_estimate": 5,
+        "chunk_count": 5,
+        "backend_timing": null,
+        "backend_generate_ms": null,
+        "backend_first_content_ms": null,
+        "backend_q8_gemm_compute_us": null,
+        "backend_q8_pack_us": null,
+        "backend_q8_calls": null,
+        "decode_tok_per_s": 17.42,
+        "ms_per_token_after_first": 57.42
+      },
+      {
+        "label": "llama-measure-3",
+        "text": "CMLD-BENCH",
+        "first_byte_ms": 171.77,
+        "first_event_ms": 171.81,
+        "first_content_ms": 171.84,
+        "total_elapsed_ms": 377.17,
+        "completion_tokens_estimate": 5,
+        "chunk_count": 5,
+        "backend_timing": null,
+        "backend_generate_ms": null,
+        "backend_first_content_ms": null,
+        "backend_q8_gemm_compute_us": null,
+        "backend_q8_pack_us": null,
+        "backend_q8_calls": null,
+        "decode_tok_per_s": 24.35,
+        "ms_per_token_after_first": 41.07
+      }
+    ],
+    "summary": {
+      "count": 3,
+      "avg_first_byte_ms": 176.46,
+      "avg_first_event_ms": 176.5,
+      "avg_ttft_ms": 176.53,
+      "avg_total_elapsed_ms": 410.41,
+      "avg_backend_generate_ms": null,
+      "avg_backend_first_content_ms": null,
+      "avg_backend_q8_calls": null,
+      "avg_backend_q8_gemm_compute_us": null,
+      "avg_backend_q8_pack_us": null,
+      "avg_decode_tok_per_s": 21.89,
+      "avg_ms_per_token_after_first": 46.78,
+      "avg_completion_tokens_estimate": 5
+    },
+    "binary": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server"
+  },
+  "comparison": {
+    "ttft_delta_pct_vs_llama_cpp": 152.5,
+    "total_elapsed_delta_pct_vs_llama_cpp": 8.68,
+    "decode_tok_per_s_delta_pct_vs_llama_cpp": 76570.12,
+    "ms_per_token_after_first_delta_pct_vs_llama_cpp": -99.85
+  },
+  "guardrails": {
+    "expected_marker": "CMLD-BENCH",
+    "require_marker": true,
+    "marker_presence": {
+      "camelid": [
+        {
+          "label": "camelid-measure-1",
+          "contains_expected_marker": true,
+          "nonempty_streamed_output": true
+        },
+        {
+          "label": "camelid-measure-2",
+          "contains_expected_marker": true,
+          "nonempty_streamed_output": true
+        },
+        {
+          "label": "camelid-measure-3",
+          "contains_expected_marker": true,
+          "nonempty_streamed_output": true
+        }
+      ],
+      "llama_cpp": [
+        {
+          "label": "llama-measure-1",
+          "contains_expected_marker": true,
+          "nonempty_streamed_output": true
+        },
+        {
+          "label": "llama-measure-2",
+          "contains_expected_marker": true,
+          "nonempty_streamed_output": true
+        },
+        {
+          "label": "llama-measure-3",
+          "contains_expected_marker": true,
+          "nonempty_streamed_output": true
+        }
+      ]
+    },
+    "passed": true,
+    "note": "The harness exits non-zero if any measured run omits the expected marker; empty measured output is always treated as a failed guardrail."
+  },
+  "claim_boundary": "Same-host benchmark snapshot only for exact row llama32_3b_instruct_q8_0 with the provided GGUF, prompt, max-token budget, host, binaries, and thread settings. It is bounded timing evidence only: it does not widen support, portability, production-throughput, model-native/larger-context, neighboring-row, broad Llama-family, 1B, or Mixtral claims unless a separate row-specific evidence bundle records those exact conditions."
+}

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.stream-summary.json
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/benchmark-r3.stream-summary.json
@@ -1,0 +1,6726 @@
+{
+  "schema": "camelid.same_host_stream_timing_summary.v1",
+  "input": "benchmark-r3.json",
+  "generated_utc": "2026-05-22T02:26:30.995Z",
+  "method": {
+    "row_id": "llama32_3b_instruct_q8_0",
+    "model_id": "llama32-3b-q8",
+    "warmup": 1,
+    "repeats": 3,
+    "max_tokens": 16,
+    "unique_prompt": false,
+    "require_marker": true
+  },
+  "aggregate": {
+    "camelid_client_first_byte_ms": {
+      "count": 3,
+      "min": 433.38,
+      "p50": 451.28,
+      "mean": 445.65,
+      "p95": 452.189,
+      "max": 452.29
+    },
+    "camelid_client_ttft_ms": {
+      "count": 3,
+      "min": 433.45,
+      "p50": 451.36,
+      "mean": 445.737,
+      "p95": 452.296,
+      "max": 452.4
+    },
+    "camelid_backend_first_content_ms": {
+      "count": 3,
+      "min": 113,
+      "p50": 116,
+      "mean": 117.333,
+      "p95": 122.3,
+      "max": 123
+    },
+    "camelid_backend_generate_ms": {
+      "count": 3,
+      "min": 375,
+      "p50": 386,
+      "mean": 383.333,
+      "p95": 388.7,
+      "max": 389
+    },
+    "camelid_client_total_ms": {
+      "count": 3,
+      "min": 433.62,
+      "p50": 451.88,
+      "mean": 446.037,
+      "p95": 452.537,
+      "max": 452.61
+    },
+    "llama_cpp_ttft_ms": {
+      "count": 3,
+      "min": 171.24,
+      "p50": 171.84,
+      "mean": 176.527,
+      "p95": 185.034,
+      "max": 186.5
+    },
+    "first_content_minus_first_byte_ms": {
+      "count": 3,
+      "min": 0.07,
+      "p50": 0.08,
+      "mean": 0.087,
+      "p95": 0.107,
+      "max": 0.11
+    },
+    "backend_generate_minus_first_byte_ms": {
+      "count": 3,
+      "min": -66.29,
+      "p50": -62.28,
+      "mean": -62.317,
+      "p95": -58.77,
+      "max": -58.38
+    },
+    "backend_generate_minus_first_content_ms": {
+      "count": 3,
+      "min": 262,
+      "p50": 263,
+      "mean": 266,
+      "p95": 272,
+      "max": 273
+    },
+    "first_content_minus_prompt_eval_forward_ms": {
+      "count": 3,
+      "min": 113,
+      "p50": 116,
+      "mean": 117.333,
+      "p95": 122.3,
+      "max": 123
+    },
+    "first_content_minus_prompt_eval_forward_plus_sample_ms": {
+      "count": 3,
+      "min": 113,
+      "p50": 116,
+      "mean": 117.333,
+      "p95": 122.3,
+      "max": 123
+    },
+    "prompt_eval_forward_ms": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "prompt_eval_logits_ms": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "prompt_eval_sample_ms": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "role_yield_ms": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "generate_start_yield_ms": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "first_content_yield_ms": {
+      "count": 3,
+      "min": 113,
+      "p50": 116,
+      "mean": 117.333,
+      "p95": 122.3,
+      "max": 123
+    },
+    "final_yield_ms": {
+      "count": 3,
+      "min": 375,
+      "p50": 386,
+      "mean": 383.333,
+      "p95": 388.7,
+      "max": 389
+    },
+    "client_first_byte_minus_role_yield_ms": {
+      "count": 3,
+      "min": 433.38,
+      "p50": 451.28,
+      "mean": 445.65,
+      "p95": 452.189,
+      "max": 452.29
+    },
+    "client_first_content_minus_content_yield_ms": {
+      "count": 3,
+      "min": 320.45,
+      "p50": 329.4,
+      "mean": 328.403,
+      "p95": 334.764,
+      "max": 335.36
+    },
+    "client_done_minus_final_yield_ms": {
+      "count": 3,
+      "min": 58.62,
+      "p50": 62.88,
+      "mean": 62.703,
+      "p95": 66.237,
+      "max": 66.61
+    },
+    "client_minus_backend_first_content_ms": {
+      "count": 3,
+      "min": 320.45,
+      "p50": 329.4,
+      "mean": 328.403,
+      "p95": 334.764,
+      "max": 335.36
+    },
+    "backend_first_content_delta_vs_llama_cpp_ttft_ms": {
+      "count": 3,
+      "min": -70.5,
+      "p50": -58.84,
+      "mean": -59.193,
+      "p95": -49.3,
+      "max": -48.24
+    },
+    "q8_calls": {
+      "count": 3,
+      "min": 145,
+      "p50": 145,
+      "mean": 145,
+      "p95": 145,
+      "max": 145
+    },
+    "q8_total_gemm_us": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "q8_total_pack_us": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "q8_fused_gate_up_calls": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "q8_gate_up_decode_consumer_activation_us": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "q8_gate_up_decode_consumer_tensor_us": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "projection_route_calls": {
+      "count": 3,
+      "min": 145,
+      "p50": 145,
+      "mean": 145,
+      "p95": 145,
+      "max": 145
+    },
+    "output_projection_calls": {
+      "count": 3,
+      "min": 145,
+      "p50": 145,
+      "mean": 145,
+      "p95": 145,
+      "max": 145
+    },
+    "prompt_cache_hits": 3,
+    "weight_cache_hits": 3
+  },
+  "stages": {
+    "prefill": {
+      "attention_context": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "attention_output": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "ffn_gate": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "ffn_up": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "ffn_down": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "logits": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      }
+    },
+    "first_token": {
+      "attention_context": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "attention_output": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "ffn_gate": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "ffn_up": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "ffn_down": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "logits": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      }
+    },
+    "generation": {
+      "attention_context": {
+        "count": 3,
+        "min": 16.258,
+        "p50": 16.271,
+        "mean": 16.57,
+        "p95": 17.091,
+        "max": 17.182
+      },
+      "attention_output": {
+        "count": 3,
+        "min": 36.657,
+        "p50": 37.639,
+        "mean": 37.993,
+        "p95": 39.479,
+        "max": 39.683
+      },
+      "ffn_gate": {
+        "count": 3,
+        "min": 52.496,
+        "p50": 52.962,
+        "mean": 52.94,
+        "p95": 53.322,
+        "max": 53.362
+      },
+      "ffn_up": {
+        "count": 3,
+        "min": 52.579,
+        "p50": 53.036,
+        "mean": 53.017,
+        "p95": 53.396,
+        "max": 53.436
+      },
+      "ffn_down": {
+        "count": 3,
+        "min": 64.247,
+        "p50": 65.702,
+        "mean": 66.158,
+        "p95": 68.243,
+        "max": 68.525
+      },
+      "logits": {
+        "count": 3,
+        "min": 24.523,
+        "p50": 24.686,
+        "mean": 24.691,
+        "p95": 24.847,
+        "max": 24.865
+      }
+    }
+  },
+  "ranked_roles": [
+    {
+      "stage": "generation",
+      "role": "ffn_down",
+      "mean_ms": 66.158,
+      "p95_ms": 68.243,
+      "max_ms": 68.525
+    },
+    {
+      "stage": "generation",
+      "role": "ffn_up",
+      "mean_ms": 53.017,
+      "p95_ms": 53.396,
+      "max_ms": 53.436
+    },
+    {
+      "stage": "generation",
+      "role": "ffn_gate",
+      "mean_ms": 52.94,
+      "p95_ms": 53.322,
+      "max_ms": 53.362
+    },
+    {
+      "stage": "generation",
+      "role": "attention_output",
+      "mean_ms": 37.993,
+      "p95_ms": 39.479,
+      "max_ms": 39.683
+    },
+    {
+      "stage": "generation",
+      "role": "logits",
+      "mean_ms": 24.691,
+      "p95_ms": 24.847,
+      "max_ms": 24.865
+    },
+    {
+      "stage": "generation",
+      "role": "attention_context",
+      "mean_ms": 16.57,
+      "p95_ms": 17.091,
+      "max_ms": 17.182
+    },
+    {
+      "stage": "prefill",
+      "role": "attention_context",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "prefill",
+      "role": "attention_output",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "prefill",
+      "role": "ffn_gate",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "prefill",
+      "role": "ffn_up",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "prefill",
+      "role": "ffn_down",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "prefill",
+      "role": "logits",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "first_token",
+      "role": "attention_context",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "first_token",
+      "role": "attention_output",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "first_token",
+      "role": "ffn_gate",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "first_token",
+      "role": "ffn_up",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "first_token",
+      "role": "ffn_down",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    },
+    {
+      "stage": "first_token",
+      "role": "logits",
+      "mean_ms": 0,
+      "p95_ms": 0,
+      "max_ms": 0
+    }
+  ],
+  "q8_role_work": [],
+  "q8_gate_up_decode_consumer_overhead": {
+    "activation_us": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "tensor_us": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "total_us": {
+      "count": 3,
+      "min": 0,
+      "p50": 0,
+      "mean": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "activation_ms_mean": 0,
+    "tensor_ms_mean": 0,
+    "total_ms_mean": 0
+  },
+  "projection_routes": [
+    {
+      "key": "ffn_down.x86_decode_consumer",
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 140,
+        "p50": 140,
+        "mean": 140,
+        "p95": 140,
+        "max": 140
+      },
+      "rows": {
+        "count": 3,
+        "min": 140,
+        "p50": 140,
+        "mean": 140,
+        "p95": 140,
+        "max": 140
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 63210,
+        "p50": 64659,
+        "mean": 65087,
+        "p95": 67118.7,
+        "max": 67392
+      },
+      "elapsed_ms_mean": 65.087
+    },
+    {
+      "key": "logits.x86_output_decode_owner",
+      "role": "logits",
+      "route": "x86_output_decode_owner",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "output_width": {
+        "count": 3,
+        "min": 128256,
+        "p50": 128256,
+        "mean": 128256,
+        "p95": 128256,
+        "max": 128256
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 24498,
+        "p50": 24658,
+        "mean": 24665,
+        "p95": 24820.9,
+        "max": 24839
+      },
+      "elapsed_ms_mean": 24.665
+    }
+  ],
+  "projection_layer_routes": [
+    {
+      "key": "layer_1.ffn_down.x86_decode_consumer",
+      "layer_index": 1,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2437,
+        "p50": 2510,
+        "mean": 2581,
+        "p95": 2767.4,
+        "max": 2796
+      },
+      "elapsed_ms_mean": 2.581
+    },
+    {
+      "key": "layer_0.ffn_down.x86_decode_consumer",
+      "layer_index": 0,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2351,
+        "p50": 2543,
+        "mean": 2521.333,
+        "p95": 2657.3,
+        "max": 2670
+      },
+      "elapsed_ms_mean": 2.521
+    },
+    {
+      "key": "layer_2.ffn_down.x86_decode_consumer",
+      "layer_index": 2,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2210,
+        "p50": 2367,
+        "mean": 2494.667,
+        "p95": 2853,
+        "max": 2907
+      },
+      "elapsed_ms_mean": 2.495
+    },
+    {
+      "key": "layer_13.ffn_down.x86_decode_consumer",
+      "layer_index": 13,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2184,
+        "p50": 2566,
+        "mean": 2464.667,
+        "p95": 2636.2,
+        "max": 2644
+      },
+      "elapsed_ms_mean": 2.465
+    },
+    {
+      "key": "layer_20.ffn_down.x86_decode_consumer",
+      "layer_index": 20,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2227,
+        "p50": 2357,
+        "mean": 2405.667,
+        "p95": 2605.4,
+        "max": 2633
+      },
+      "elapsed_ms_mean": 2.406
+    },
+    {
+      "key": "layer_22.ffn_down.x86_decode_consumer",
+      "layer_index": 22,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2179,
+        "p50": 2451,
+        "mean": 2385.333,
+        "p95": 2518.5,
+        "max": 2526
+      },
+      "elapsed_ms_mean": 2.385
+    },
+    {
+      "key": "layer_14.ffn_down.x86_decode_consumer",
+      "layer_index": 14,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2257,
+        "p50": 2274,
+        "mean": 2379.333,
+        "p95": 2573.7,
+        "max": 2607
+      },
+      "elapsed_ms_mean": 2.379
+    },
+    {
+      "key": "layer_21.ffn_down.x86_decode_consumer",
+      "layer_index": 21,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2107,
+        "p50": 2334,
+        "mean": 2377,
+        "p95": 2654.4,
+        "max": 2690
+      },
+      "elapsed_ms_mean": 2.377
+    },
+    {
+      "key": "layer_19.ffn_down.x86_decode_consumer",
+      "layer_index": 19,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2289,
+        "p50": 2383,
+        "mean": 2369,
+        "p95": 2429.8,
+        "max": 2435
+      },
+      "elapsed_ms_mean": 2.369
+    },
+    {
+      "key": "layer_15.ffn_down.x86_decode_consumer",
+      "layer_index": 15,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2319,
+        "p50": 2365,
+        "mean": 2361.667,
+        "p95": 2397.4,
+        "max": 2401
+      },
+      "elapsed_ms_mean": 2.362
+    },
+    {
+      "key": "layer_18.ffn_down.x86_decode_consumer",
+      "layer_index": 18,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2191,
+        "p50": 2425,
+        "mean": 2360.333,
+        "p95": 2461,
+        "max": 2465
+      },
+      "elapsed_ms_mean": 2.36
+    },
+    {
+      "key": "layer_7.ffn_down.x86_decode_consumer",
+      "layer_index": 7,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2287,
+        "p50": 2376,
+        "mean": 2346.333,
+        "p95": 2376,
+        "max": 2376
+      },
+      "elapsed_ms_mean": 2.346
+    },
+    {
+      "key": "layer_12.ffn_down.x86_decode_consumer",
+      "layer_index": 12,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2178,
+        "p50": 2304,
+        "mean": 2345,
+        "p95": 2528.1,
+        "max": 2553
+      },
+      "elapsed_ms_mean": 2.345
+    },
+    {
+      "key": "layer_17.ffn_down.x86_decode_consumer",
+      "layer_index": 17,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2157,
+        "p50": 2230,
+        "mean": 2321.667,
+        "p95": 2543.2,
+        "max": 2578
+      },
+      "elapsed_ms_mean": 2.322
+    },
+    {
+      "key": "layer_24.ffn_down.x86_decode_consumer",
+      "layer_index": 24,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2147,
+        "p50": 2285,
+        "mean": 2312.667,
+        "p95": 2483.9,
+        "max": 2506
+      },
+      "elapsed_ms_mean": 2.313
+    },
+    {
+      "key": "layer_25.ffn_down.x86_decode_consumer",
+      "layer_index": 25,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2157,
+        "p50": 2305,
+        "mean": 2285.667,
+        "p95": 2386,
+        "max": 2395
+      },
+      "elapsed_ms_mean": 2.286
+    },
+    {
+      "key": "layer_11.ffn_down.x86_decode_consumer",
+      "layer_index": 11,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2241,
+        "p50": 2269,
+        "mean": 2283,
+        "p95": 2332,
+        "max": 2339
+      },
+      "elapsed_ms_mean": 2.283
+    },
+    {
+      "key": "layer_3.ffn_down.x86_decode_consumer",
+      "layer_index": 3,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2086,
+        "p50": 2315,
+        "mean": 2279,
+        "p95": 2423.9,
+        "max": 2436
+      },
+      "elapsed_ms_mean": 2.279
+    },
+    {
+      "key": "layer_4.ffn_down.x86_decode_consumer",
+      "layer_index": 4,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2117,
+        "p50": 2321,
+        "mean": 2265,
+        "p95": 2353.4,
+        "max": 2357
+      },
+      "elapsed_ms_mean": 2.265
+    },
+    {
+      "key": "layer_27.ffn_down.x86_decode_consumer",
+      "layer_index": 27,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2079,
+        "p50": 2258,
+        "mean": 2253,
+        "p95": 2405.6,
+        "max": 2422
+      },
+      "elapsed_ms_mean": 2.253
+    },
+    {
+      "key": "layer_26.ffn_down.x86_decode_consumer",
+      "layer_index": 26,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2076,
+        "p50": 2186,
+        "mean": 2252.333,
+        "p95": 2464.1,
+        "max": 2495
+      },
+      "elapsed_ms_mean": 2.252
+    },
+    {
+      "key": "layer_5.ffn_down.x86_decode_consumer",
+      "layer_index": 5,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2195,
+        "p50": 2222,
+        "mean": 2251.333,
+        "p95": 2325.5,
+        "max": 2337
+      },
+      "elapsed_ms_mean": 2.251
+    },
+    {
+      "key": "layer_16.ffn_down.x86_decode_consumer",
+      "layer_index": 16,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2125,
+        "p50": 2272,
+        "mean": 2248,
+        "p95": 2339.5,
+        "max": 2347
+      },
+      "elapsed_ms_mean": 2.248
+    },
+    {
+      "key": "layer_9.ffn_down.x86_decode_consumer",
+      "layer_index": 9,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2043,
+        "p50": 2291,
+        "mean": 2246.667,
+        "p95": 2394.5,
+        "max": 2406
+      },
+      "elapsed_ms_mean": 2.247
+    },
+    {
+      "key": "layer_23.ffn_down.x86_decode_consumer",
+      "layer_index": 23,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2136,
+        "p50": 2259,
+        "mean": 2221,
+        "p95": 2267.1,
+        "max": 2268
+      },
+      "elapsed_ms_mean": 2.221
+    },
+    {
+      "key": "layer_8.ffn_down.x86_decode_consumer",
+      "layer_index": 8,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2094,
+        "p50": 2175,
+        "mean": 2180,
+        "p95": 2261.4,
+        "max": 2271
+      },
+      "elapsed_ms_mean": 2.18
+    },
+    {
+      "key": "layer_6.ffn_down.x86_decode_consumer",
+      "layer_index": 6,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2103,
+        "p50": 2177,
+        "mean": 2162.667,
+        "p95": 2204.9,
+        "max": 2208
+      },
+      "elapsed_ms_mean": 2.163
+    },
+    {
+      "key": "layer_10.ffn_down.x86_decode_consumer",
+      "layer_index": 10,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2042,
+        "p50": 2147,
+        "mean": 2133.667,
+        "p95": 2205.5,
+        "max": 2212
+      },
+      "elapsed_ms_mean": 2.134
+    }
+  ],
+  "output_projection_routes": [
+    {
+      "key": "ffn_down.x86_decode_consumer",
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 140,
+        "p50": 140,
+        "mean": 140,
+        "p95": 140,
+        "max": 140
+      },
+      "rows": {
+        "count": 3,
+        "min": 140,
+        "p50": 140,
+        "mean": 140,
+        "p95": 140,
+        "max": 140
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 63210,
+        "p50": 64659,
+        "mean": 65087,
+        "p95": 67118.7,
+        "max": 67392
+      },
+      "elapsed_ms_mean": 65.087
+    },
+    {
+      "key": "logits.x86_output_decode_owner",
+      "role": "logits",
+      "route": "x86_output_decode_owner",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "output_width": {
+        "count": 3,
+        "min": 128256,
+        "p50": 128256,
+        "mean": 128256,
+        "p95": 128256,
+        "max": 128256
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 24498,
+        "p50": 24658,
+        "mean": 24665,
+        "p95": 24820.9,
+        "max": 24839
+      },
+      "elapsed_ms_mean": 24.665
+    }
+  ],
+  "output_projection_layer_routes": [
+    {
+      "key": "layer_1.ffn_down.x86_decode_consumer",
+      "layer_index": 1,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2437,
+        "p50": 2510,
+        "mean": 2581,
+        "p95": 2767.4,
+        "max": 2796
+      },
+      "elapsed_ms_mean": 2.581
+    },
+    {
+      "key": "layer_0.ffn_down.x86_decode_consumer",
+      "layer_index": 0,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2351,
+        "p50": 2543,
+        "mean": 2521.333,
+        "p95": 2657.3,
+        "max": 2670
+      },
+      "elapsed_ms_mean": 2.521
+    },
+    {
+      "key": "layer_2.ffn_down.x86_decode_consumer",
+      "layer_index": 2,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2210,
+        "p50": 2367,
+        "mean": 2494.667,
+        "p95": 2853,
+        "max": 2907
+      },
+      "elapsed_ms_mean": 2.495
+    },
+    {
+      "key": "layer_13.ffn_down.x86_decode_consumer",
+      "layer_index": 13,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2184,
+        "p50": 2566,
+        "mean": 2464.667,
+        "p95": 2636.2,
+        "max": 2644
+      },
+      "elapsed_ms_mean": 2.465
+    },
+    {
+      "key": "layer_20.ffn_down.x86_decode_consumer",
+      "layer_index": 20,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2227,
+        "p50": 2357,
+        "mean": 2405.667,
+        "p95": 2605.4,
+        "max": 2633
+      },
+      "elapsed_ms_mean": 2.406
+    },
+    {
+      "key": "layer_22.ffn_down.x86_decode_consumer",
+      "layer_index": 22,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2179,
+        "p50": 2451,
+        "mean": 2385.333,
+        "p95": 2518.5,
+        "max": 2526
+      },
+      "elapsed_ms_mean": 2.385
+    },
+    {
+      "key": "layer_14.ffn_down.x86_decode_consumer",
+      "layer_index": 14,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2257,
+        "p50": 2274,
+        "mean": 2379.333,
+        "p95": 2573.7,
+        "max": 2607
+      },
+      "elapsed_ms_mean": 2.379
+    },
+    {
+      "key": "layer_21.ffn_down.x86_decode_consumer",
+      "layer_index": 21,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2107,
+        "p50": 2334,
+        "mean": 2377,
+        "p95": 2654.4,
+        "max": 2690
+      },
+      "elapsed_ms_mean": 2.377
+    },
+    {
+      "key": "layer_19.ffn_down.x86_decode_consumer",
+      "layer_index": 19,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2289,
+        "p50": 2383,
+        "mean": 2369,
+        "p95": 2429.8,
+        "max": 2435
+      },
+      "elapsed_ms_mean": 2.369
+    },
+    {
+      "key": "layer_15.ffn_down.x86_decode_consumer",
+      "layer_index": 15,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2319,
+        "p50": 2365,
+        "mean": 2361.667,
+        "p95": 2397.4,
+        "max": 2401
+      },
+      "elapsed_ms_mean": 2.362
+    },
+    {
+      "key": "layer_18.ffn_down.x86_decode_consumer",
+      "layer_index": 18,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2191,
+        "p50": 2425,
+        "mean": 2360.333,
+        "p95": 2461,
+        "max": 2465
+      },
+      "elapsed_ms_mean": 2.36
+    },
+    {
+      "key": "layer_7.ffn_down.x86_decode_consumer",
+      "layer_index": 7,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2287,
+        "p50": 2376,
+        "mean": 2346.333,
+        "p95": 2376,
+        "max": 2376
+      },
+      "elapsed_ms_mean": 2.346
+    },
+    {
+      "key": "layer_12.ffn_down.x86_decode_consumer",
+      "layer_index": 12,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2178,
+        "p50": 2304,
+        "mean": 2345,
+        "p95": 2528.1,
+        "max": 2553
+      },
+      "elapsed_ms_mean": 2.345
+    },
+    {
+      "key": "layer_17.ffn_down.x86_decode_consumer",
+      "layer_index": 17,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2157,
+        "p50": 2230,
+        "mean": 2321.667,
+        "p95": 2543.2,
+        "max": 2578
+      },
+      "elapsed_ms_mean": 2.322
+    },
+    {
+      "key": "layer_24.ffn_down.x86_decode_consumer",
+      "layer_index": 24,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2147,
+        "p50": 2285,
+        "mean": 2312.667,
+        "p95": 2483.9,
+        "max": 2506
+      },
+      "elapsed_ms_mean": 2.313
+    },
+    {
+      "key": "layer_25.ffn_down.x86_decode_consumer",
+      "layer_index": 25,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2157,
+        "p50": 2305,
+        "mean": 2285.667,
+        "p95": 2386,
+        "max": 2395
+      },
+      "elapsed_ms_mean": 2.286
+    },
+    {
+      "key": "layer_11.ffn_down.x86_decode_consumer",
+      "layer_index": 11,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2241,
+        "p50": 2269,
+        "mean": 2283,
+        "p95": 2332,
+        "max": 2339
+      },
+      "elapsed_ms_mean": 2.283
+    },
+    {
+      "key": "layer_3.ffn_down.x86_decode_consumer",
+      "layer_index": 3,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2086,
+        "p50": 2315,
+        "mean": 2279,
+        "p95": 2423.9,
+        "max": 2436
+      },
+      "elapsed_ms_mean": 2.279
+    },
+    {
+      "key": "layer_4.ffn_down.x86_decode_consumer",
+      "layer_index": 4,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2117,
+        "p50": 2321,
+        "mean": 2265,
+        "p95": 2353.4,
+        "max": 2357
+      },
+      "elapsed_ms_mean": 2.265
+    },
+    {
+      "key": "layer_27.ffn_down.x86_decode_consumer",
+      "layer_index": 27,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2079,
+        "p50": 2258,
+        "mean": 2253,
+        "p95": 2405.6,
+        "max": 2422
+      },
+      "elapsed_ms_mean": 2.253
+    },
+    {
+      "key": "layer_26.ffn_down.x86_decode_consumer",
+      "layer_index": 26,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2076,
+        "p50": 2186,
+        "mean": 2252.333,
+        "p95": 2464.1,
+        "max": 2495
+      },
+      "elapsed_ms_mean": 2.252
+    },
+    {
+      "key": "layer_5.ffn_down.x86_decode_consumer",
+      "layer_index": 5,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2195,
+        "p50": 2222,
+        "mean": 2251.333,
+        "p95": 2325.5,
+        "max": 2337
+      },
+      "elapsed_ms_mean": 2.251
+    },
+    {
+      "key": "layer_16.ffn_down.x86_decode_consumer",
+      "layer_index": 16,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2125,
+        "p50": 2272,
+        "mean": 2248,
+        "p95": 2339.5,
+        "max": 2347
+      },
+      "elapsed_ms_mean": 2.248
+    },
+    {
+      "key": "layer_9.ffn_down.x86_decode_consumer",
+      "layer_index": 9,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2043,
+        "p50": 2291,
+        "mean": 2246.667,
+        "p95": 2394.5,
+        "max": 2406
+      },
+      "elapsed_ms_mean": 2.247
+    },
+    {
+      "key": "layer_23.ffn_down.x86_decode_consumer",
+      "layer_index": 23,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2136,
+        "p50": 2259,
+        "mean": 2221,
+        "p95": 2267.1,
+        "max": 2268
+      },
+      "elapsed_ms_mean": 2.221
+    },
+    {
+      "key": "layer_8.ffn_down.x86_decode_consumer",
+      "layer_index": 8,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2094,
+        "p50": 2175,
+        "mean": 2180,
+        "p95": 2261.4,
+        "max": 2271
+      },
+      "elapsed_ms_mean": 2.18
+    },
+    {
+      "key": "layer_6.ffn_down.x86_decode_consumer",
+      "layer_index": 6,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2103,
+        "p50": 2177,
+        "mean": 2162.667,
+        "p95": 2204.9,
+        "max": 2208
+      },
+      "elapsed_ms_mean": 2.163
+    },
+    {
+      "key": "layer_10.ffn_down.x86_decode_consumer",
+      "layer_index": 10,
+      "role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "calls": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "rows": {
+        "count": 3,
+        "min": 5,
+        "p50": 5,
+        "mean": 5,
+        "p95": 5,
+        "max": 5
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      },
+      "elapsed_us": {
+        "count": 3,
+        "min": 2042,
+        "p50": 2147,
+        "mean": 2133.667,
+        "p95": 2205.5,
+        "max": 2212
+      },
+      "elapsed_ms_mean": 2.134
+    }
+  ],
+  "projection_route_denials": [
+    {
+      "key": "ffn_down.x86_vnni_decode_consumer.gate_off",
+      "role": "ffn_down",
+      "route": "x86_vnni_decode_consumer",
+      "reason": "gate_off",
+      "denials": {
+        "count": 3,
+        "min": 280,
+        "p50": 280,
+        "mean": 280,
+        "p95": 280,
+        "max": 280
+      },
+      "rows": {
+        "count": 3,
+        "min": 280,
+        "p50": 280,
+        "mean": 280,
+        "p95": 280,
+        "max": 280
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 3072,
+        "p50": 3072,
+        "mean": 3072,
+        "p95": 3072,
+        "max": 3072
+      }
+    },
+    {
+      "key": "ffn_down.x86_gemm4_prefill.plan_off",
+      "role": "ffn_down",
+      "route": "x86_gemm4_prefill",
+      "reason": "plan_off",
+      "denials": {
+        "count": 3,
+        "min": 140,
+        "p50": 140,
+        "mean": 140,
+        "p95": 140,
+        "max": 140
+      },
+      "rows": {
+        "count": 3,
+        "min": 140,
+        "p50": 140,
+        "mean": 140,
+        "p95": 140,
+        "max": 140
+      },
+      "input_width": {
+        "count": 3,
+        "min": 8192,
+        "p50": 8192,
+        "mean": 8192,
+        "p95": 8192,
+        "max": 8192
+      },
+      "output_width": {
+        "count": 3,
+        "min": 0,
+        "p50": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      }
+    }
+  ],
+  "layer_role_hotspots": [
+    {
+      "stage": "generation",
+      "layer_index": 2,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 2,
+        "min": 2.402,
+        "p50": 2.678,
+        "mean": 2.678,
+        "p95": 2.926,
+        "max": 2.954
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 14,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.642,
+        "p50": 2.642,
+        "mean": 2.642,
+        "p95": 2.642,
+        "max": 2.642
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 13,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 2,
+        "min": 2.6,
+        "p50": 2.64,
+        "mean": 2.64,
+        "p95": 2.676,
+        "max": 2.68
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 1,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 3,
+        "min": 2.481,
+        "p50": 2.554,
+        "mean": 2.627,
+        "p95": 2.816,
+        "max": 2.845
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 17,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.619,
+        "p50": 2.619,
+        "mean": 2.619,
+        "p95": 2.619,
+        "max": 2.619
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 12,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.586,
+        "p50": 2.586,
+        "mean": 2.586,
+        "p95": 2.586,
+        "max": 2.586
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 22,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.568,
+        "p50": 2.568,
+        "mean": 2.568,
+        "p95": 2.568,
+        "max": 2.568
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 0,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 3,
+        "min": 2.393,
+        "p50": 2.594,
+        "mean": 2.567,
+        "p95": 2.702,
+        "max": 2.714
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 21,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 2,
+        "min": 2.371,
+        "p50": 2.55,
+        "mean": 2.55,
+        "p95": 2.711,
+        "max": 2.729
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 24,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.546,
+        "p50": 2.546,
+        "mean": 2.546,
+        "p95": 2.546,
+        "max": 2.546
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 20,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 2,
+        "min": 2.395,
+        "p50": 2.535,
+        "mean": 2.535,
+        "p95": 2.661,
+        "max": 2.675
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 26,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.533,
+        "p50": 2.533,
+        "mean": 2.533,
+        "p95": 2.533,
+        "max": 2.533
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 3,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.5,
+        "p50": 2.5,
+        "mean": 2.5,
+        "p95": 2.5,
+        "max": 2.5
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 18,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 2,
+        "min": 2.465,
+        "p50": 2.486,
+        "mean": 2.486,
+        "p95": 2.504,
+        "max": 2.506
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 19,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 2,
+        "min": 2.421,
+        "p50": 2.449,
+        "mean": 2.449,
+        "p95": 2.473,
+        "max": 2.476
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 9,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.442,
+        "p50": 2.442,
+        "mean": 2.442,
+        "p95": 2.442,
+        "max": 2.442
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 7,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 2,
+        "min": 2.41,
+        "p50": 2.411,
+        "mean": 2.411,
+        "p95": 2.412,
+        "max": 2.412
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 5,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.375,
+        "p50": 2.375,
+        "mean": 2.375,
+        "p95": 2.375,
+        "max": 2.375
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 15,
+      "role": "ffn_down",
+      "elapsed_ms": {
+        "count": 1,
+        "min": 2.352,
+        "p50": 2.352,
+        "mean": 2.352,
+        "p95": 2.352,
+        "max": 2.352
+      }
+    }
+  ],
+  "layer_route_role_gaps": [
+    {
+      "stage": "generation",
+      "layer_index": 3,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_3.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.5,
+        "p50": 2.5,
+        "mean": 2.5,
+        "p95": 2.5,
+        "max": 2.5
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.436,
+        "p50": 2.436,
+        "mean": 2.436,
+        "p95": 2.436,
+        "max": 2.436
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.064,
+        "p50": 0.064,
+        "mean": 0.064,
+        "p95": 0.064,
+        "max": 0.064
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.064,
+        "p50": 0.064,
+        "mean": 0.064,
+        "p95": 0.064,
+        "max": 0.064
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 0,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_0.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 3,
+        "min": 2.393,
+        "p50": 2.594,
+        "mean": 2.567,
+        "p95": 2.702,
+        "max": 2.714
+      },
+      "route_elapsed_ms": {
+        "count": 3,
+        "min": 2.351,
+        "p50": 2.543,
+        "mean": 2.521,
+        "p95": 2.657,
+        "max": 2.67
+      },
+      "role_minus_route_ms": {
+        "count": 3,
+        "min": 0.042,
+        "p50": 0.044,
+        "mean": 0.046,
+        "p95": 0.05,
+        "max": 0.051
+      },
+      "abs_gap_ms": {
+        "count": 3,
+        "min": 0.042,
+        "p50": 0.044,
+        "mean": 0.046,
+        "p95": 0.05,
+        "max": 0.051
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 1,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_1.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 3,
+        "min": 2.481,
+        "p50": 2.554,
+        "mean": 2.627,
+        "p95": 2.816,
+        "max": 2.845
+      },
+      "route_elapsed_ms": {
+        "count": 3,
+        "min": 2.437,
+        "p50": 2.51,
+        "mean": 2.581,
+        "p95": 2.767,
+        "max": 2.796
+      },
+      "role_minus_route_ms": {
+        "count": 3,
+        "min": 0.044,
+        "p50": 0.044,
+        "mean": 0.046,
+        "p95": 0.049,
+        "max": 0.049
+      },
+      "abs_gap_ms": {
+        "count": 3,
+        "min": 0.044,
+        "p50": 0.044,
+        "mean": 0.046,
+        "p95": 0.049,
+        "max": 0.049
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 22,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_22.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.568,
+        "p50": 2.568,
+        "mean": 2.568,
+        "p95": 2.568,
+        "max": 2.568
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.526,
+        "p50": 2.526,
+        "mean": 2.526,
+        "p95": 2.526,
+        "max": 2.526
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.042,
+        "p50": 0.042,
+        "mean": 0.042,
+        "p95": 0.042,
+        "max": 0.042
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.042,
+        "p50": 0.042,
+        "mean": 0.042,
+        "p95": 0.042,
+        "max": 0.042
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 2,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_2.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 2,
+        "min": 2.402,
+        "p50": 2.678,
+        "mean": 2.678,
+        "p95": 2.926,
+        "max": 2.954
+      },
+      "route_elapsed_ms": {
+        "count": 2,
+        "min": 2.367,
+        "p50": 2.637,
+        "mean": 2.637,
+        "p95": 2.88,
+        "max": 2.907
+      },
+      "role_minus_route_ms": {
+        "count": 2,
+        "min": 0.035,
+        "p50": 0.041,
+        "mean": 0.041,
+        "p95": 0.046,
+        "max": 0.047
+      },
+      "abs_gap_ms": {
+        "count": 2,
+        "min": 0.035,
+        "p50": 0.041,
+        "mean": 0.041,
+        "p95": 0.046,
+        "max": 0.047
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 17,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_17.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.619,
+        "p50": 2.619,
+        "mean": 2.619,
+        "p95": 2.619,
+        "max": 2.619
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.578,
+        "p50": 2.578,
+        "mean": 2.578,
+        "p95": 2.578,
+        "max": 2.578
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.041,
+        "p50": 0.041,
+        "mean": 0.041,
+        "p95": 0.041,
+        "max": 0.041
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.041,
+        "p50": 0.041,
+        "mean": 0.041,
+        "p95": 0.041,
+        "max": 0.041
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 18,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_18.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 2,
+        "min": 2.465,
+        "p50": 2.486,
+        "mean": 2.486,
+        "p95": 2.504,
+        "max": 2.506
+      },
+      "route_elapsed_ms": {
+        "count": 2,
+        "min": 2.425,
+        "p50": 2.445,
+        "mean": 2.445,
+        "p95": 2.463,
+        "max": 2.465
+      },
+      "role_minus_route_ms": {
+        "count": 2,
+        "min": 0.04,
+        "p50": 0.041,
+        "mean": 0.041,
+        "p95": 0.041,
+        "max": 0.041
+      },
+      "abs_gap_ms": {
+        "count": 2,
+        "min": 0.04,
+        "p50": 0.041,
+        "mean": 0.041,
+        "p95": 0.041,
+        "max": 0.041
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 19,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_19.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 2,
+        "min": 2.421,
+        "p50": 2.449,
+        "mean": 2.449,
+        "p95": 2.473,
+        "max": 2.476
+      },
+      "route_elapsed_ms": {
+        "count": 2,
+        "min": 2.383,
+        "p50": 2.409,
+        "mean": 2.409,
+        "p95": 2.432,
+        "max": 2.435
+      },
+      "role_minus_route_ms": {
+        "count": 2,
+        "min": 0.038,
+        "p50": 0.04,
+        "mean": 0.04,
+        "p95": 0.041,
+        "max": 0.041
+      },
+      "abs_gap_ms": {
+        "count": 2,
+        "min": 0.038,
+        "p50": 0.04,
+        "mean": 0.04,
+        "p95": 0.041,
+        "max": 0.041
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 20,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_20.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 2,
+        "min": 2.395,
+        "p50": 2.535,
+        "mean": 2.535,
+        "p95": 2.661,
+        "max": 2.675
+      },
+      "route_elapsed_ms": {
+        "count": 2,
+        "min": 2.357,
+        "p50": 2.495,
+        "mean": 2.495,
+        "p95": 2.619,
+        "max": 2.633
+      },
+      "role_minus_route_ms": {
+        "count": 2,
+        "min": 0.038,
+        "p50": 0.04,
+        "mean": 0.04,
+        "p95": 0.042,
+        "max": 0.042
+      },
+      "abs_gap_ms": {
+        "count": 2,
+        "min": 0.038,
+        "p50": 0.04,
+        "mean": 0.04,
+        "p95": 0.042,
+        "max": 0.042
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 24,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_24.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.546,
+        "p50": 2.546,
+        "mean": 2.546,
+        "p95": 2.546,
+        "max": 2.546
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.506,
+        "p50": 2.506,
+        "mean": 2.506,
+        "p95": 2.506,
+        "max": 2.506
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.04,
+        "p50": 0.04,
+        "mean": 0.04,
+        "p95": 0.04,
+        "max": 0.04
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.04,
+        "p50": 0.04,
+        "mean": 0.04,
+        "p95": 0.04,
+        "max": 0.04
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 5,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_5.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.375,
+        "p50": 2.375,
+        "mean": 2.375,
+        "p95": 2.375,
+        "max": 2.375
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.337,
+        "p50": 2.337,
+        "mean": 2.337,
+        "p95": 2.337,
+        "max": 2.337
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.038,
+        "p50": 0.038,
+        "mean": 0.038,
+        "p95": 0.038,
+        "max": 0.038
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.038,
+        "p50": 0.038,
+        "mean": 0.038,
+        "p95": 0.038,
+        "max": 0.038
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 21,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_21.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 2,
+        "min": 2.371,
+        "p50": 2.55,
+        "mean": 2.55,
+        "p95": 2.711,
+        "max": 2.729
+      },
+      "route_elapsed_ms": {
+        "count": 2,
+        "min": 2.334,
+        "p50": 2.512,
+        "mean": 2.512,
+        "p95": 2.672,
+        "max": 2.69
+      },
+      "role_minus_route_ms": {
+        "count": 2,
+        "min": 0.037,
+        "p50": 0.038,
+        "mean": 0.038,
+        "p95": 0.039,
+        "max": 0.039
+      },
+      "abs_gap_ms": {
+        "count": 2,
+        "min": 0.037,
+        "p50": 0.038,
+        "mean": 0.038,
+        "p95": 0.039,
+        "max": 0.039
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 26,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_26.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.533,
+        "p50": 2.533,
+        "mean": 2.533,
+        "p95": 2.533,
+        "max": 2.533
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.495,
+        "p50": 2.495,
+        "mean": 2.495,
+        "p95": 2.495,
+        "max": 2.495
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.038,
+        "p50": 0.038,
+        "mean": 0.038,
+        "p95": 0.038,
+        "max": 0.038
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.038,
+        "p50": 0.038,
+        "mean": 0.038,
+        "p95": 0.038,
+        "max": 0.038
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 9,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_9.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.442,
+        "p50": 2.442,
+        "mean": 2.442,
+        "p95": 2.442,
+        "max": 2.442
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.406,
+        "p50": 2.406,
+        "mean": 2.406,
+        "p95": 2.406,
+        "max": 2.406
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.036,
+        "p50": 0.036,
+        "mean": 0.036,
+        "p95": 0.036,
+        "max": 0.036
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.036,
+        "p50": 0.036,
+        "mean": 0.036,
+        "p95": 0.036,
+        "max": 0.036
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 7,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_7.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 2,
+        "min": 2.41,
+        "p50": 2.411,
+        "mean": 2.411,
+        "p95": 2.412,
+        "max": 2.412
+      },
+      "route_elapsed_ms": {
+        "count": 2,
+        "min": 2.376,
+        "p50": 2.376,
+        "mean": 2.376,
+        "p95": 2.376,
+        "max": 2.376
+      },
+      "role_minus_route_ms": {
+        "count": 2,
+        "min": 0.034,
+        "p50": 0.035,
+        "mean": 0.035,
+        "p95": 0.036,
+        "max": 0.036
+      },
+      "abs_gap_ms": {
+        "count": 2,
+        "min": 0.034,
+        "p50": 0.035,
+        "mean": 0.035,
+        "p95": 0.036,
+        "max": 0.036
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 13,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_13.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 2,
+        "min": 2.6,
+        "p50": 2.64,
+        "mean": 2.64,
+        "p95": 2.676,
+        "max": 2.68
+      },
+      "route_elapsed_ms": {
+        "count": 2,
+        "min": 2.566,
+        "p50": 2.605,
+        "mean": 2.605,
+        "p95": 2.64,
+        "max": 2.644
+      },
+      "role_minus_route_ms": {
+        "count": 2,
+        "min": 0.034,
+        "p50": 0.035,
+        "mean": 0.035,
+        "p95": 0.036,
+        "max": 0.036
+      },
+      "abs_gap_ms": {
+        "count": 2,
+        "min": 0.034,
+        "p50": 0.035,
+        "mean": 0.035,
+        "p95": 0.036,
+        "max": 0.036
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 14,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_14.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.642,
+        "p50": 2.642,
+        "mean": 2.642,
+        "p95": 2.642,
+        "max": 2.642
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.607,
+        "p50": 2.607,
+        "mean": 2.607,
+        "p95": 2.607,
+        "max": 2.607
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.035,
+        "p50": 0.035,
+        "mean": 0.035,
+        "p95": 0.035,
+        "max": 0.035
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.035,
+        "p50": 0.035,
+        "mean": 0.035,
+        "p95": 0.035,
+        "max": 0.035
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 12,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_12.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.586,
+        "p50": 2.586,
+        "mean": 2.586,
+        "p95": 2.586,
+        "max": 2.586
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.553,
+        "p50": 2.553,
+        "mean": 2.553,
+        "p95": 2.553,
+        "max": 2.553
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.033,
+        "p50": 0.033,
+        "mean": 0.033,
+        "p95": 0.033,
+        "max": 0.033
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.033,
+        "p50": 0.033,
+        "mean": 0.033,
+        "p95": 0.033,
+        "max": 0.033
+      }
+    },
+    {
+      "stage": "generation",
+      "layer_index": 15,
+      "projection_role": "ffn_down",
+      "route": "x86_decode_consumer",
+      "route_key": "layer_15.ffn_down.x86_decode_consumer",
+      "matched_roles": [
+        "ffn_down"
+      ],
+      "role_elapsed_ms": {
+        "count": 1,
+        "min": 2.352,
+        "p50": 2.352,
+        "mean": 2.352,
+        "p95": 2.352,
+        "max": 2.352
+      },
+      "route_elapsed_ms": {
+        "count": 1,
+        "min": 2.319,
+        "p50": 2.319,
+        "mean": 2.319,
+        "p95": 2.319,
+        "max": 2.319
+      },
+      "role_minus_route_ms": {
+        "count": 1,
+        "min": 0.033,
+        "p50": 0.033,
+        "mean": 0.033,
+        "p95": 0.033,
+        "max": 0.033
+      },
+      "abs_gap_ms": {
+        "count": 1,
+        "min": 0.033,
+        "p50": 0.033,
+        "mean": 0.033,
+        "p95": 0.033,
+        "max": 0.033
+      }
+    }
+  ],
+  "role_focus": [
+    {
+      "role": "attention_output",
+      "total_mean_ms": 37.993,
+      "stages": {
+        "prefill": {
+          "count": 3,
+          "min": 0,
+          "p50": 0,
+          "mean": 0,
+          "p95": 0,
+          "max": 0
+        },
+        "first_token": {
+          "count": 3,
+          "min": 0,
+          "p50": 0,
+          "mean": 0,
+          "p95": 0,
+          "max": 0
+        },
+        "generation": {
+          "count": 3,
+          "min": 36.657,
+          "p50": 37.639,
+          "mean": 37.993,
+          "p95": 39.479,
+          "max": 39.683
+        }
+      }
+    },
+    {
+      "role": "logits",
+      "total_mean_ms": 24.691,
+      "stages": {
+        "prefill": {
+          "count": 3,
+          "min": 0,
+          "p50": 0,
+          "mean": 0,
+          "p95": 0,
+          "max": 0
+        },
+        "first_token": {
+          "count": 3,
+          "min": 0,
+          "p50": 0,
+          "mean": 0,
+          "p95": 0,
+          "max": 0
+        },
+        "generation": {
+          "count": 3,
+          "min": 24.523,
+          "p50": 24.686,
+          "mean": 24.691,
+          "p95": 24.847,
+          "max": 24.865
+        }
+      }
+    },
+    {
+      "role": "attention_context",
+      "total_mean_ms": 16.57,
+      "stages": {
+        "prefill": {
+          "count": 3,
+          "min": 0,
+          "p50": 0,
+          "mean": 0,
+          "p95": 0,
+          "max": 0
+        },
+        "first_token": {
+          "count": 3,
+          "min": 0,
+          "p50": 0,
+          "mean": 0,
+          "p95": 0,
+          "max": 0
+        },
+        "generation": {
+          "count": 3,
+          "min": 16.258,
+          "p50": 16.271,
+          "mean": 16.57,
+          "p95": 17.091,
+          "max": 17.182
+        }
+      }
+    }
+  ],
+  "outliers": [
+    {
+      "label": "camelid-measure-1",
+      "backend_first_content_ms": 123,
+      "client_ttft_ms": 452.4,
+      "over_mean_ms": 5.667,
+      "q8_calls": 145,
+      "q8_total_gemm_us": 0,
+      "q8_total_pack_us": 0,
+      "top_role_deltas": [
+        {
+          "stage": "generation",
+          "role": "logits",
+          "value_ms": 24.865,
+          "over_role_mean_ms": 0.174
+        },
+        {
+          "stage": "prefill",
+          "role": "attention_context",
+          "value_ms": 0,
+          "over_role_mean_ms": 0
+        },
+        {
+          "stage": "prefill",
+          "role": "attention_output",
+          "value_ms": 0,
+          "over_role_mean_ms": 0
+        },
+        {
+          "stage": "prefill",
+          "role": "ffn_down",
+          "value_ms": 0,
+          "over_role_mean_ms": 0
+        },
+        {
+          "stage": "prefill",
+          "role": "ffn_gate",
+          "value_ms": 0,
+          "over_role_mean_ms": 0
+        }
+      ],
+      "prompt_cache_hit": true
+    },
+    {
+      "label": "camelid-measure-2",
+      "backend_first_content_ms": 116,
+      "client_ttft_ms": 451.36,
+      "over_mean_ms": -1.333,
+      "q8_calls": 145,
+      "q8_total_gemm_us": 0,
+      "q8_total_pack_us": 0,
+      "top_role_deltas": [
+        {
+          "stage": "generation",
+          "role": "ffn_down",
+          "value_ms": 68.52499999999999,
+          "over_role_mean_ms": 2.367
+        },
+        {
+          "stage": "generation",
+          "role": "attention_output",
+          "value_ms": 39.683,
+          "over_role_mean_ms": 1.69
+        },
+        {
+          "stage": "generation",
+          "role": "attention_context",
+          "value_ms": 17.182,
+          "over_role_mean_ms": 0.612
+        },
+        {
+          "stage": "generation",
+          "role": "ffn_gate",
+          "value_ms": 52.961999999999996,
+          "over_role_mean_ms": 0.022
+        },
+        {
+          "stage": "generation",
+          "role": "ffn_up",
+          "value_ms": 53.036,
+          "over_role_mean_ms": 0.019
+        }
+      ],
+      "prompt_cache_hit": true
+    },
+    {
+      "label": "camelid-measure-3",
+      "backend_first_content_ms": 113,
+      "client_ttft_ms": 433.45,
+      "over_mean_ms": -4.333,
+      "q8_calls": 145,
+      "q8_total_gemm_us": 0,
+      "q8_total_pack_us": 0,
+      "top_role_deltas": [
+        {
+          "stage": "generation",
+          "role": "ffn_gate",
+          "value_ms": 53.362,
+          "over_role_mean_ms": 0.422
+        },
+        {
+          "stage": "generation",
+          "role": "ffn_up",
+          "value_ms": 53.436,
+          "over_role_mean_ms": 0.419
+        },
+        {
+          "stage": "prefill",
+          "role": "attention_context",
+          "value_ms": 0,
+          "over_role_mean_ms": 0
+        },
+        {
+          "stage": "prefill",
+          "role": "attention_output",
+          "value_ms": 0,
+          "over_role_mean_ms": 0
+        },
+        {
+          "stage": "prefill",
+          "role": "ffn_down",
+          "value_ms": 0,
+          "over_role_mean_ms": 0
+        }
+      ],
+      "prompt_cache_hit": true
+    }
+  ],
+  "runs": [
+    {
+      "label": "camelid-measure-1",
+      "client_first_byte_ms": 452.29,
+      "client_ttft_ms": 452.4,
+      "backend_first_content_ms": 123,
+      "backend_generate_ms": 386,
+      "first_content_minus_first_byte_ms": 0.11,
+      "backend_generate_minus_first_byte_ms": -66.29,
+      "backend_generate_minus_first_content_ms": 263,
+      "client_minus_backend_first_content_ms": 329.4,
+      "first_content_minus_prompt_eval_forward_ms": 123,
+      "first_content_minus_prompt_eval_forward_plus_sample_ms": 123,
+      "prompt_eval_forward_ms": 0,
+      "prompt_eval_logits_ms": 0,
+      "prompt_eval_sample_ms": 0,
+      "role_yield_ms": 0,
+      "generate_start_yield_ms": 0,
+      "first_content_yield_ms": 123,
+      "final_yield_ms": 386,
+      "client_first_byte_minus_role_yield_ms": 452.29,
+      "client_first_content_minus_content_yield_ms": 329.4,
+      "client_done_minus_final_yield_ms": 66.61,
+      "llama_cpp_ttft_ms": 171.24,
+      "backend_first_content_delta_vs_llama_cpp_ms": -48.24,
+      "q8_calls": 145,
+      "q8_total_gemm_us": 0,
+      "q8_total_pack_us": 0,
+      "q8_fused_gate_up_calls": 0,
+      "q8_gate_up_decode_consumer_activation_us": 0,
+      "q8_gate_up_decode_consumer_tensor_us": 0,
+      "projection_route_calls": 145,
+      "projection_routes": {
+        "ffn_down.x86_decode_consumer": {
+          "calls": 140,
+          "elapsed_us": 64659,
+          "input_width": 8192,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 140
+        },
+        "logits.x86_output_decode_owner": {
+          "calls": 5,
+          "elapsed_us": 24839,
+          "input_width": 3072,
+          "output_width": 128256,
+          "role": "logits",
+          "route": "x86_output_decode_owner",
+          "rows": 5
+        }
+      },
+      "projection_layer_routes": {
+        "layer_0.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2670,
+          "input_width": 8192,
+          "layer_index": 0,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_1.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2510,
+          "input_width": 8192,
+          "layer_index": 1,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_10.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2147,
+          "input_width": 8192,
+          "layer_index": 10,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_11.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2339,
+          "input_width": 8192,
+          "layer_index": 11,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_12.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2178,
+          "input_width": 8192,
+          "layer_index": 12,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_13.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2566,
+          "input_width": 8192,
+          "layer_index": 13,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_14.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2274,
+          "input_width": 8192,
+          "layer_index": 14,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_15.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2365,
+          "input_width": 8192,
+          "layer_index": 15,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_16.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2347,
+          "input_width": 8192,
+          "layer_index": 16,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_17.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2578,
+          "input_width": 8192,
+          "layer_index": 17,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_18.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2425,
+          "input_width": 8192,
+          "layer_index": 18,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_19.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2435,
+          "input_width": 8192,
+          "layer_index": 19,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_2.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2367,
+          "input_width": 8192,
+          "layer_index": 2,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_20.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2633,
+          "input_width": 8192,
+          "layer_index": 20,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_21.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2107,
+          "input_width": 8192,
+          "layer_index": 21,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_22.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2179,
+          "input_width": 8192,
+          "layer_index": 22,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_23.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2136,
+          "input_width": 8192,
+          "layer_index": 23,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_24.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2147,
+          "input_width": 8192,
+          "layer_index": 24,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_25.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2157,
+          "input_width": 8192,
+          "layer_index": 25,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_26.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2186,
+          "input_width": 8192,
+          "layer_index": 26,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_27.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2258,
+          "input_width": 8192,
+          "layer_index": 27,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_3.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2086,
+          "input_width": 8192,
+          "layer_index": 3,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_4.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2321,
+          "input_width": 8192,
+          "layer_index": 4,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_5.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2195,
+          "input_width": 8192,
+          "layer_index": 5,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_6.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2177,
+          "input_width": 8192,
+          "layer_index": 6,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_7.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2376,
+          "input_width": 8192,
+          "layer_index": 7,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_8.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2094,
+          "input_width": 8192,
+          "layer_index": 8,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_9.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2406,
+          "input_width": 8192,
+          "layer_index": 9,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        }
+      },
+      "output_projection_calls": 145,
+      "output_projection_routes": {
+        "ffn_down.x86_decode_consumer": {
+          "calls": 140,
+          "elapsed_us": 64659,
+          "input_width": 8192,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 140
+        },
+        "logits.x86_output_decode_owner": {
+          "calls": 5,
+          "elapsed_us": 24839,
+          "input_width": 3072,
+          "output_width": 128256,
+          "role": "logits",
+          "route": "x86_output_decode_owner",
+          "rows": 5
+        }
+      },
+      "output_projection_layer_routes": {
+        "layer_0.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2670,
+          "input_width": 8192,
+          "layer_index": 0,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_1.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2510,
+          "input_width": 8192,
+          "layer_index": 1,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_10.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2147,
+          "input_width": 8192,
+          "layer_index": 10,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_11.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2339,
+          "input_width": 8192,
+          "layer_index": 11,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_12.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2178,
+          "input_width": 8192,
+          "layer_index": 12,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_13.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2566,
+          "input_width": 8192,
+          "layer_index": 13,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_14.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2274,
+          "input_width": 8192,
+          "layer_index": 14,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_15.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2365,
+          "input_width": 8192,
+          "layer_index": 15,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_16.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2347,
+          "input_width": 8192,
+          "layer_index": 16,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_17.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2578,
+          "input_width": 8192,
+          "layer_index": 17,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_18.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2425,
+          "input_width": 8192,
+          "layer_index": 18,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_19.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2435,
+          "input_width": 8192,
+          "layer_index": 19,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_2.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2367,
+          "input_width": 8192,
+          "layer_index": 2,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_20.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2633,
+          "input_width": 8192,
+          "layer_index": 20,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_21.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2107,
+          "input_width": 8192,
+          "layer_index": 21,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_22.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2179,
+          "input_width": 8192,
+          "layer_index": 22,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_23.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2136,
+          "input_width": 8192,
+          "layer_index": 23,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_24.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2147,
+          "input_width": 8192,
+          "layer_index": 24,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_25.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2157,
+          "input_width": 8192,
+          "layer_index": 25,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_26.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2186,
+          "input_width": 8192,
+          "layer_index": 26,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_27.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2258,
+          "input_width": 8192,
+          "layer_index": 27,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_3.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2086,
+          "input_width": 8192,
+          "layer_index": 3,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_4.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2321,
+          "input_width": 8192,
+          "layer_index": 4,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_5.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2195,
+          "input_width": 8192,
+          "layer_index": 5,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_6.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2177,
+          "input_width": 8192,
+          "layer_index": 6,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_7.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2376,
+          "input_width": 8192,
+          "layer_index": 7,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_8.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2094,
+          "input_width": 8192,
+          "layer_index": 8,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_9.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2406,
+          "input_width": 8192,
+          "layer_index": 9,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        }
+      },
+      "projection_route_denials": {
+        "ffn_down.x86_gemm4_prefill.plan_off": {
+          "denials": 140,
+          "input_width": 8192,
+          "output_width": 0,
+          "reason": "plan_off",
+          "role": "ffn_down",
+          "route": "x86_gemm4_prefill",
+          "rows": 140
+        },
+        "ffn_down.x86_vnni_decode_consumer.gate_off": {
+          "denials": 280,
+          "input_width": 8192,
+          "output_width": 3072,
+          "reason": "gate_off",
+          "role": "ffn_down",
+          "route": "x86_vnni_decode_consumer",
+          "rows": 280
+        }
+      },
+      "prompt_cache_hit": true,
+      "weight_cache_hit": true
+    },
+    {
+      "label": "camelid-measure-2",
+      "client_first_byte_ms": 451.28,
+      "client_ttft_ms": 451.36,
+      "backend_first_content_ms": 116,
+      "backend_generate_ms": 389,
+      "first_content_minus_first_byte_ms": 0.08,
+      "backend_generate_minus_first_byte_ms": -62.28,
+      "backend_generate_minus_first_content_ms": 273,
+      "client_minus_backend_first_content_ms": 335.36,
+      "first_content_minus_prompt_eval_forward_ms": 116,
+      "first_content_minus_prompt_eval_forward_plus_sample_ms": 116,
+      "prompt_eval_forward_ms": 0,
+      "prompt_eval_logits_ms": 0,
+      "prompt_eval_sample_ms": 0,
+      "role_yield_ms": 0,
+      "generate_start_yield_ms": 0,
+      "first_content_yield_ms": 116,
+      "final_yield_ms": 389,
+      "client_first_byte_minus_role_yield_ms": 451.28,
+      "client_first_content_minus_content_yield_ms": 335.36,
+      "client_done_minus_final_yield_ms": 62.88,
+      "llama_cpp_ttft_ms": 186.5,
+      "backend_first_content_delta_vs_llama_cpp_ms": -70.5,
+      "q8_calls": 145,
+      "q8_total_gemm_us": 0,
+      "q8_total_pack_us": 0,
+      "q8_fused_gate_up_calls": 0,
+      "q8_gate_up_decode_consumer_activation_us": 0,
+      "q8_gate_up_decode_consumer_tensor_us": 0,
+      "projection_route_calls": 145,
+      "projection_routes": {
+        "ffn_down.x86_decode_consumer": {
+          "calls": 140,
+          "elapsed_us": 67392,
+          "input_width": 8192,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 140
+        },
+        "logits.x86_output_decode_owner": {
+          "calls": 5,
+          "elapsed_us": 24658,
+          "input_width": 3072,
+          "output_width": 128256,
+          "role": "logits",
+          "route": "x86_output_decode_owner",
+          "rows": 5
+        }
+      },
+      "projection_layer_routes": {
+        "layer_0.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2543,
+          "input_width": 8192,
+          "layer_index": 0,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_1.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2796,
+          "input_width": 8192,
+          "layer_index": 1,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_10.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2212,
+          "input_width": 8192,
+          "layer_index": 10,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_11.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2269,
+          "input_width": 8192,
+          "layer_index": 11,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_12.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2304,
+          "input_width": 8192,
+          "layer_index": 12,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_13.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2644,
+          "input_width": 8192,
+          "layer_index": 13,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_14.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2607,
+          "input_width": 8192,
+          "layer_index": 14,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_15.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2401,
+          "input_width": 8192,
+          "layer_index": 15,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_16.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2272,
+          "input_width": 8192,
+          "layer_index": 16,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_17.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2157,
+          "input_width": 8192,
+          "layer_index": 17,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_18.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2465,
+          "input_width": 8192,
+          "layer_index": 18,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_19.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2289,
+          "input_width": 8192,
+          "layer_index": 19,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_2.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2907,
+          "input_width": 8192,
+          "layer_index": 2,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_20.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2227,
+          "input_width": 8192,
+          "layer_index": 20,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_21.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2690,
+          "input_width": 8192,
+          "layer_index": 21,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_22.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2451,
+          "input_width": 8192,
+          "layer_index": 22,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_23.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2268,
+          "input_width": 8192,
+          "layer_index": 23,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_24.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2506,
+          "input_width": 8192,
+          "layer_index": 24,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_25.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2395,
+          "input_width": 8192,
+          "layer_index": 25,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_26.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2495,
+          "input_width": 8192,
+          "layer_index": 26,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_27.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2422,
+          "input_width": 8192,
+          "layer_index": 27,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_3.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2436,
+          "input_width": 8192,
+          "layer_index": 3,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_4.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2357,
+          "input_width": 8192,
+          "layer_index": 4,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_5.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2222,
+          "input_width": 8192,
+          "layer_index": 5,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_6.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2208,
+          "input_width": 8192,
+          "layer_index": 6,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_7.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2287,
+          "input_width": 8192,
+          "layer_index": 7,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_8.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2271,
+          "input_width": 8192,
+          "layer_index": 8,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_9.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2291,
+          "input_width": 8192,
+          "layer_index": 9,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        }
+      },
+      "output_projection_calls": 145,
+      "output_projection_routes": {
+        "ffn_down.x86_decode_consumer": {
+          "calls": 140,
+          "elapsed_us": 67392,
+          "input_width": 8192,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 140
+        },
+        "logits.x86_output_decode_owner": {
+          "calls": 5,
+          "elapsed_us": 24658,
+          "input_width": 3072,
+          "output_width": 128256,
+          "role": "logits",
+          "route": "x86_output_decode_owner",
+          "rows": 5
+        }
+      },
+      "output_projection_layer_routes": {
+        "layer_0.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2543,
+          "input_width": 8192,
+          "layer_index": 0,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_1.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2796,
+          "input_width": 8192,
+          "layer_index": 1,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_10.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2212,
+          "input_width": 8192,
+          "layer_index": 10,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_11.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2269,
+          "input_width": 8192,
+          "layer_index": 11,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_12.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2304,
+          "input_width": 8192,
+          "layer_index": 12,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_13.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2644,
+          "input_width": 8192,
+          "layer_index": 13,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_14.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2607,
+          "input_width": 8192,
+          "layer_index": 14,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_15.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2401,
+          "input_width": 8192,
+          "layer_index": 15,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_16.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2272,
+          "input_width": 8192,
+          "layer_index": 16,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_17.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2157,
+          "input_width": 8192,
+          "layer_index": 17,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_18.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2465,
+          "input_width": 8192,
+          "layer_index": 18,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_19.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2289,
+          "input_width": 8192,
+          "layer_index": 19,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_2.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2907,
+          "input_width": 8192,
+          "layer_index": 2,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_20.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2227,
+          "input_width": 8192,
+          "layer_index": 20,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_21.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2690,
+          "input_width": 8192,
+          "layer_index": 21,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_22.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2451,
+          "input_width": 8192,
+          "layer_index": 22,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_23.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2268,
+          "input_width": 8192,
+          "layer_index": 23,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_24.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2506,
+          "input_width": 8192,
+          "layer_index": 24,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_25.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2395,
+          "input_width": 8192,
+          "layer_index": 25,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_26.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2495,
+          "input_width": 8192,
+          "layer_index": 26,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_27.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2422,
+          "input_width": 8192,
+          "layer_index": 27,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_3.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2436,
+          "input_width": 8192,
+          "layer_index": 3,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_4.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2357,
+          "input_width": 8192,
+          "layer_index": 4,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_5.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2222,
+          "input_width": 8192,
+          "layer_index": 5,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_6.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2208,
+          "input_width": 8192,
+          "layer_index": 6,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_7.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2287,
+          "input_width": 8192,
+          "layer_index": 7,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_8.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2271,
+          "input_width": 8192,
+          "layer_index": 8,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_9.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2291,
+          "input_width": 8192,
+          "layer_index": 9,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        }
+      },
+      "projection_route_denials": {
+        "ffn_down.x86_gemm4_prefill.plan_off": {
+          "denials": 140,
+          "input_width": 8192,
+          "output_width": 0,
+          "reason": "plan_off",
+          "role": "ffn_down",
+          "route": "x86_gemm4_prefill",
+          "rows": 140
+        },
+        "ffn_down.x86_vnni_decode_consumer.gate_off": {
+          "denials": 280,
+          "input_width": 8192,
+          "output_width": 3072,
+          "reason": "gate_off",
+          "role": "ffn_down",
+          "route": "x86_vnni_decode_consumer",
+          "rows": 280
+        }
+      },
+      "prompt_cache_hit": true,
+      "weight_cache_hit": true
+    },
+    {
+      "label": "camelid-measure-3",
+      "client_first_byte_ms": 433.38,
+      "client_ttft_ms": 433.45,
+      "backend_first_content_ms": 113,
+      "backend_generate_ms": 375,
+      "first_content_minus_first_byte_ms": 0.07,
+      "backend_generate_minus_first_byte_ms": -58.38,
+      "backend_generate_minus_first_content_ms": 262,
+      "client_minus_backend_first_content_ms": 320.45,
+      "first_content_minus_prompt_eval_forward_ms": 113,
+      "first_content_minus_prompt_eval_forward_plus_sample_ms": 113,
+      "prompt_eval_forward_ms": 0,
+      "prompt_eval_logits_ms": 0,
+      "prompt_eval_sample_ms": 0,
+      "role_yield_ms": 0,
+      "generate_start_yield_ms": 0,
+      "first_content_yield_ms": 113,
+      "final_yield_ms": 375,
+      "client_first_byte_minus_role_yield_ms": 433.38,
+      "client_first_content_minus_content_yield_ms": 320.45,
+      "client_done_minus_final_yield_ms": 58.62,
+      "llama_cpp_ttft_ms": 171.84,
+      "backend_first_content_delta_vs_llama_cpp_ms": -58.84,
+      "q8_calls": 145,
+      "q8_total_gemm_us": 0,
+      "q8_total_pack_us": 0,
+      "q8_fused_gate_up_calls": 0,
+      "q8_gate_up_decode_consumer_activation_us": 0,
+      "q8_gate_up_decode_consumer_tensor_us": 0,
+      "projection_route_calls": 145,
+      "projection_routes": {
+        "ffn_down.x86_decode_consumer": {
+          "calls": 140,
+          "elapsed_us": 63210,
+          "input_width": 8192,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 140
+        },
+        "logits.x86_output_decode_owner": {
+          "calls": 5,
+          "elapsed_us": 24498,
+          "input_width": 3072,
+          "output_width": 128256,
+          "role": "logits",
+          "route": "x86_output_decode_owner",
+          "rows": 5
+        }
+      },
+      "projection_layer_routes": {
+        "layer_0.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2351,
+          "input_width": 8192,
+          "layer_index": 0,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_1.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2437,
+          "input_width": 8192,
+          "layer_index": 1,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_10.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2042,
+          "input_width": 8192,
+          "layer_index": 10,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_11.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2241,
+          "input_width": 8192,
+          "layer_index": 11,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_12.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2553,
+          "input_width": 8192,
+          "layer_index": 12,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_13.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2184,
+          "input_width": 8192,
+          "layer_index": 13,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_14.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2257,
+          "input_width": 8192,
+          "layer_index": 14,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_15.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2319,
+          "input_width": 8192,
+          "layer_index": 15,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_16.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2125,
+          "input_width": 8192,
+          "layer_index": 16,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_17.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2230,
+          "input_width": 8192,
+          "layer_index": 17,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_18.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2191,
+          "input_width": 8192,
+          "layer_index": 18,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_19.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2383,
+          "input_width": 8192,
+          "layer_index": 19,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_2.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2210,
+          "input_width": 8192,
+          "layer_index": 2,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_20.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2357,
+          "input_width": 8192,
+          "layer_index": 20,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_21.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2334,
+          "input_width": 8192,
+          "layer_index": 21,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_22.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2526,
+          "input_width": 8192,
+          "layer_index": 22,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_23.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2259,
+          "input_width": 8192,
+          "layer_index": 23,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_24.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2285,
+          "input_width": 8192,
+          "layer_index": 24,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_25.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2305,
+          "input_width": 8192,
+          "layer_index": 25,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_26.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2076,
+          "input_width": 8192,
+          "layer_index": 26,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_27.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2079,
+          "input_width": 8192,
+          "layer_index": 27,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_3.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2315,
+          "input_width": 8192,
+          "layer_index": 3,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_4.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2117,
+          "input_width": 8192,
+          "layer_index": 4,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_5.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2337,
+          "input_width": 8192,
+          "layer_index": 5,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_6.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2103,
+          "input_width": 8192,
+          "layer_index": 6,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_7.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2376,
+          "input_width": 8192,
+          "layer_index": 7,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_8.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2175,
+          "input_width": 8192,
+          "layer_index": 8,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_9.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2043,
+          "input_width": 8192,
+          "layer_index": 9,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        }
+      },
+      "output_projection_calls": 145,
+      "output_projection_routes": {
+        "ffn_down.x86_decode_consumer": {
+          "calls": 140,
+          "elapsed_us": 63210,
+          "input_width": 8192,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 140
+        },
+        "logits.x86_output_decode_owner": {
+          "calls": 5,
+          "elapsed_us": 24498,
+          "input_width": 3072,
+          "output_width": 128256,
+          "role": "logits",
+          "route": "x86_output_decode_owner",
+          "rows": 5
+        }
+      },
+      "output_projection_layer_routes": {
+        "layer_0.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2351,
+          "input_width": 8192,
+          "layer_index": 0,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_1.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2437,
+          "input_width": 8192,
+          "layer_index": 1,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_10.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2042,
+          "input_width": 8192,
+          "layer_index": 10,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_11.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2241,
+          "input_width": 8192,
+          "layer_index": 11,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_12.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2553,
+          "input_width": 8192,
+          "layer_index": 12,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_13.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2184,
+          "input_width": 8192,
+          "layer_index": 13,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_14.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2257,
+          "input_width": 8192,
+          "layer_index": 14,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_15.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2319,
+          "input_width": 8192,
+          "layer_index": 15,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_16.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2125,
+          "input_width": 8192,
+          "layer_index": 16,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_17.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2230,
+          "input_width": 8192,
+          "layer_index": 17,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_18.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2191,
+          "input_width": 8192,
+          "layer_index": 18,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_19.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2383,
+          "input_width": 8192,
+          "layer_index": 19,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_2.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2210,
+          "input_width": 8192,
+          "layer_index": 2,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_20.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2357,
+          "input_width": 8192,
+          "layer_index": 20,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_21.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2334,
+          "input_width": 8192,
+          "layer_index": 21,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_22.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2526,
+          "input_width": 8192,
+          "layer_index": 22,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_23.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2259,
+          "input_width": 8192,
+          "layer_index": 23,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_24.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2285,
+          "input_width": 8192,
+          "layer_index": 24,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_25.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2305,
+          "input_width": 8192,
+          "layer_index": 25,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_26.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2076,
+          "input_width": 8192,
+          "layer_index": 26,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_27.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2079,
+          "input_width": 8192,
+          "layer_index": 27,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_3.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2315,
+          "input_width": 8192,
+          "layer_index": 3,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_4.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2117,
+          "input_width": 8192,
+          "layer_index": 4,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_5.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2337,
+          "input_width": 8192,
+          "layer_index": 5,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_6.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2103,
+          "input_width": 8192,
+          "layer_index": 6,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_7.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2376,
+          "input_width": 8192,
+          "layer_index": 7,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_8.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2175,
+          "input_width": 8192,
+          "layer_index": 8,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        },
+        "layer_9.ffn_down.x86_decode_consumer": {
+          "calls": 5,
+          "elapsed_us": 2043,
+          "input_width": 8192,
+          "layer_index": 9,
+          "output_width": 3072,
+          "role": "ffn_down",
+          "route": "x86_decode_consumer",
+          "rows": 5
+        }
+      },
+      "projection_route_denials": {
+        "ffn_down.x86_gemm4_prefill.plan_off": {
+          "denials": 140,
+          "input_width": 8192,
+          "output_width": 0,
+          "reason": "plan_off",
+          "role": "ffn_down",
+          "route": "x86_gemm4_prefill",
+          "rows": 140
+        },
+        "ffn_down.x86_vnni_decode_consumer.gate_off": {
+          "denials": 280,
+          "input_width": 8192,
+          "output_width": 3072,
+          "reason": "gate_off",
+          "role": "ffn_down",
+          "route": "x86_vnni_decode_consumer",
+          "rows": 280
+        }
+      },
+      "prompt_cache_hit": true,
+      "weight_cache_hit": true
+    }
+  ]
+}

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/logs/route-check-benchmark-r3.json
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/logs/route-check-benchmark-r3.json
@@ -1,0 +1,18 @@
+{
+  "routes": [
+    "ffn_down.x86_decode_consumer",
+    "logits.x86_output_decode_owner",
+    "ffn_down.x86_decode_consumer",
+    "logits.x86_output_decode_owner",
+    "ffn_down.x86_decode_consumer",
+    "logits.x86_output_decode_owner"
+  ],
+  "denials": [
+    "ffn_down.x86_gemm4_prefill.plan_off",
+    "ffn_down.x86_vnni_decode_consumer.gate_off",
+    "ffn_down.x86_gemm4_prefill.plan_off",
+    "ffn_down.x86_vnni_decode_consumer.gate_off",
+    "ffn_down.x86_gemm4_prefill.plan_off",
+    "ffn_down.x86_vnni_decode_consumer.gate_off"
+  ]
+}

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/logs/route-check-one-token-telemetry.json
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/logs/route-check-one-token-telemetry.json
@@ -1,0 +1,17 @@
+{
+  "camelid_text": [
+    "C"
+  ],
+  "llama_text": [
+    "C"
+  ],
+  "routes": [
+    "ffn_down.x86_decode_consumer",
+    "logits.x86_output_decode_owner"
+  ],
+  "denials": [
+    "ffn_down.x86_gemm4_prefill.plan_off",
+    "ffn_down.x86_vnni_decode_consumer.gate_off",
+    "ffn_gate_up.packed_rows4_matmul_prefill.plan_off"
+  ]
+}

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/parity-one-token-telemetry.json
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/parity-one-token-telemetry.json
@@ -3,7 +3,7 @@
   "generated_utc": "2026-05-22T02:25:53.280Z",
   "model": {
     "row_id": "llama32_3b_instruct_q8_0",
-    "model_path": "/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf",
+    "model_path": "$CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf",
     "model_id": "llama32-3b-q8",
     "render_mode": "compact"
   },
@@ -28,10 +28,10 @@
     "llama_context": 512,
     "threads": 16,
     "commands": {
-      "harness": "node scripts/bench-llama3-same-host.mjs --model /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf --model-id llama32-3b-q8 --row-id llama32_3b_instruct_q8_0 --max-tokens 1 --warmup 0 --repeats 1 --threads 16 --out /home/ubuntu/work/camelid-tied-output-logits-route/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/parity-one-token-telemetry.json",
-      "camelid_serve": "/home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid serve --addr 127.0.0.1:8181",
-      "llama_server": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server --host 127.0.0.1 --port 8183 -m /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf -ngl 0 -c 512 --no-warmup -t 16",
-      "camelid_load_request": "POST http://127.0.0.1:8181/api/models/load {\"path\":\"/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf\",\"id\":\"llama32-3b-q8\"}",
+      "harness": "node scripts/bench-llama3-same-host.mjs --model $CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf --model-id llama32-3b-q8 --row-id llama32_3b_instruct_q8_0 --max-tokens 1 --warmup 0 --repeats 1 --threads 16 --out $CAMELID_WORKTREE/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/parity-one-token-telemetry.json",
+      "camelid_serve": "$CAMELID_SHARED_TARGET/release/camelid serve --addr 127.0.0.1:8181",
+      "llama_server": "$CAMELID_LLAMA_CPP_BIN/llama-server --host 127.0.0.1 --port 8183 -m $CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf -ngl 0 -c 512 --no-warmup -t 16",
+      "camelid_load_request": "POST http://127.0.0.1:8181/api/models/load {\"path\":\"$CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf\",\"id\":\"llama32-3b-q8\"}",
       "camelid_measure_request": "POST http://127.0.0.1:8181/v1/chat/completions stream=true max_tokens=1 temperature=0",
       "llama_cpp_measure_request": "POST http://127.0.0.1:8183/completion stream=true n_predict=1 temperature=0 cache_prompt=false"
     },
@@ -82,21 +82,19 @@
       "host_class": {
         "os_type": "Linux",
         "platform": "linux",
-        "release": "6.17.0-1013-aws",
         "arch": "x64",
-        "cpu_model": "Intel(R) Xeon(R) Platinum 8488C",
         "cpu_count": 16,
-        "total_memory_gib": 123.79
+        "host_class": "private Ubuntu x86_64 validation host"
       },
       "binaries": {
         "camelid": {
-          "path": "/home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid",
+          "path": "$CAMELID_SHARED_TARGET/release/camelid",
           "exists": true,
           "size_bytes": 9054616,
           "sha256": "dfc59980dd1e93bc2757d3ba61c94f65009a9349bca1b53f085d7be7db497f90"
         },
         "llama_server": {
-          "path": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server",
+          "path": "$CAMELID_LLAMA_CPP_BIN/llama-server",
           "exists": true,
           "size_bytes": 47918720,
           "sha256": "545f8e63151affb94fffd2205c02b0b94a93109cd09cda60631f77b00f598517"
@@ -104,7 +102,7 @@
         "node": "v18.19.1"
       },
       "model_artifact": {
-        "path": "/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf",
+        "path": "$CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf",
         "exists": true,
         "size_bytes": 3421899296,
         "sha256": "b5607b5090a8280063fff2d706bb3408ca6542341b06aab39c3eca0a28575921"
@@ -121,21 +119,13 @@
           1.06
         ],
         "memory": {
-          "total_gib": 123.79,
-          "free_gib": 121.09,
           "process_rss_mib": 88.93
         },
         "linux_meminfo": {
-          "mem_available_gib": 121.09,
-          "swap_total_gib": 0,
-          "swap_free_gib": 0,
           "dirty_mib": 0
         },
         "storage": {
-          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
-          "total_gib": 192.69,
-          "available_gib": 150.26,
-          "used_pct": 22.02
+          "path": "$CAMELID_WORKTREE"
         }
       },
       "before_measured_runs": {
@@ -147,21 +137,13 @@
           1.06
         ],
         "memory": {
-          "total_gib": 123.79,
-          "free_gib": 117.47,
           "process_rss_mib": 137.68
         },
         "linux_meminfo": {
-          "mem_available_gib": 117.47,
-          "swap_total_gib": 0,
-          "swap_free_gib": 0,
           "dirty_mib": 0.01
         },
         "storage": {
-          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
-          "total_gib": 192.69,
-          "available_gib": 150.26,
-          "used_pct": 22.02
+          "path": "$CAMELID_WORKTREE"
         }
       },
       "after_measured_runs": {
@@ -173,21 +155,13 @@
           1.06
         ],
         "memory": {
-          "total_gib": 123.79,
-          "free_gib": 113.46,
           "process_rss_mib": 129.5
         },
         "linux_meminfo": {
-          "mem_available_gib": 113.46,
-          "swap_total_gib": 0,
-          "swap_free_gib": 0,
           "dirty_mib": 0.01
         },
         "storage": {
-          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
-          "total_gib": 192.69,
-          "available_gib": 150.26,
-          "used_pct": 22.02
+          "path": "$CAMELID_WORKTREE"
         }
       }
     },
@@ -861,7 +835,7 @@
       "avg_ms_per_token_after_first": 0.3,
       "avg_completion_tokens_estimate": 1
     },
-    "binary": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server"
+    "binary": "$CAMELID_LLAMA_CPP_BIN/llama-server"
   },
   "comparison": {
     "ttft_delta_pct_vs_llama_cpp": 3211.07,

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/parity-one-token-telemetry.json
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/parity-one-token-telemetry.json
@@ -1,0 +1,895 @@
+{
+  "schema": "camelid.same_host_llama3_benchmark.v1",
+  "generated_utc": "2026-05-22T02:25:53.280Z",
+  "model": {
+    "row_id": "llama32_3b_instruct_q8_0",
+    "model_path": "/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf",
+    "model_id": "llama32-3b-q8",
+    "render_mode": "compact"
+  },
+  "method": {
+    "warmup": 0,
+    "repeats": 1,
+    "max_tokens": 1,
+    "expected_marker": "CMLD-BENCH",
+    "require_marker": false,
+    "unique_prompt": false,
+    "benchmark_messages": [
+      {
+        "role": "system",
+        "content": "You are Camelid benchmark mode. Reply with the exact requested text and nothing else."
+      },
+      {
+        "role": "user",
+        "content": "Reply with exactly this single line and nothing else: CMLD-BENCH"
+      }
+    ],
+    "estimated_prompt_tokens": 75,
+    "llama_context": 512,
+    "threads": 16,
+    "commands": {
+      "harness": "node scripts/bench-llama3-same-host.mjs --model /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf --model-id llama32-3b-q8 --row-id llama32_3b_instruct_q8_0 --max-tokens 1 --warmup 0 --repeats 1 --threads 16 --out /home/ubuntu/work/camelid-tied-output-logits-route/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/parity-one-token-telemetry.json",
+      "camelid_serve": "/home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid serve --addr 127.0.0.1:8181",
+      "llama_server": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server --host 127.0.0.1 --port 8183 -m /home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf -ngl 0 -c 512 --no-warmup -t 16",
+      "camelid_load_request": "POST http://127.0.0.1:8181/api/models/load {\"path\":\"/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf\",\"id\":\"llama32-3b-q8\"}",
+      "camelid_measure_request": "POST http://127.0.0.1:8181/v1/chat/completions stream=true max_tokens=1 temperature=0",
+      "llama_cpp_measure_request": "POST http://127.0.0.1:8183/completion stream=true n_predict=1 temperature=0 cache_prompt=false"
+    },
+    "outputs": {
+      "stdout": [
+        "camelid_ttft_ms=<mean first non-empty streamed content chunk over measured runs>",
+        "camelid_decode_tok_s=<mean estimated streamed chunks per second after first content>",
+        "camelid_ms_tok=<mean estimated milliseconds per streamed content chunk after first content>",
+        "llama_cpp_ttft_ms=<same metric for llama.cpp>",
+        "llama_cpp_decode_tok_s=<same metric for llama.cpp>",
+        "llama_cpp_ms_tok=<same metric for llama.cpp>",
+        "camelid_backend_generate_ms=<mean Camelid backend generate timing when CAMELID_STREAM_TIMING_DIAGNOSTICS=on>",
+        "camelid_backend_first_content_ms=<mean Camelid backend first-content timing when CAMELID_STREAM_TIMING_DIAGNOSTICS=on>",
+        "json_out=<absolute path when --out is set>"
+      ],
+      "json": "Full machine-readable report at --out, schema camelid.same_host_llama3_benchmark.v1.",
+      "guardrail": "marker_presence=CMLD-BENCH; pass/fail is recorded under guardrails and can be enforced with --require-marker",
+      "lifecycle": "Report records server startup timing, model-load timing, warmups, and whether servers were started by the harness or reused preloaded."
+    },
+    "bounded_metrics": [
+      "first_byte_ms: first network byte from each streaming response",
+      "first_event_ms: first parsed SSE event",
+      "first_content_ms / TTFT: first non-empty streamed content chunk",
+      "total_elapsed_ms: full streaming response wall time",
+      "completion_tokens_estimate: count of non-empty streamed content chunks, not tokenizer-ground-truth tokens",
+      "decode_tok_per_s and ms_per_token_after_first: derived from completion_tokens_estimate after first content",
+      "marker_presence: exact expected marker observed in measured output text, optionally enforced with --require-marker",
+      "camelid_backend_generate_ms and camelid_backend_first_content_ms: opt-in backend timings when CAMELID_STREAM_TIMING_DIAGNOSTICS=on",
+      "camelid_backend_q8_calls and q8 timing counters: opt-in Q8 scheduler diagnostics when Camelid Q8 scheduler telemetry is also enabled; call count includes single-projection, fused gate/up, FFN-down decode, and route-table counters",
+      "resource_snapshots: host memory/load/storage snapshots before start, before measured runs, and after measured runs",
+      "server_lifecycle: Camelid/llama-server startup timing, model-load timing, reuse/preloaded status, and warmup behavior"
+    ],
+    "server_lifecycle": {
+      "camelid_started_by_harness": true,
+      "llama_started_by_harness": true,
+      "camelid_startup_ms": 55.39,
+      "llama_startup_ms": 1119.11,
+      "camelid_model_load_ms": 631.68,
+      "camelid_model_preloaded": false,
+      "llama_model_preloaded": false
+    },
+    "evidence_context": {
+      "repository": {
+        "head": "b95dd3051397b160f3ad1e0a464e33c14ab3c168",
+        "branch": "HEAD",
+        "status_short": "M src/inference.rs\n M src/tensor/mod.rs\n?? qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/"
+      },
+      "host_class": {
+        "os_type": "Linux",
+        "platform": "linux",
+        "release": "6.17.0-1013-aws",
+        "arch": "x64",
+        "cpu_model": "Intel(R) Xeon(R) Platinum 8488C",
+        "cpu_count": 16,
+        "total_memory_gib": 123.79
+      },
+      "binaries": {
+        "camelid": {
+          "path": "/home/ubuntu/work/shared-targets/tied-output-logits-route/release/camelid",
+          "exists": true,
+          "size_bytes": 9054616,
+          "sha256": "dfc59980dd1e93bc2757d3ba61c94f65009a9349bca1b53f085d7be7db497f90"
+        },
+        "llama_server": {
+          "path": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server",
+          "exists": true,
+          "size_bytes": 47918720,
+          "sha256": "545f8e63151affb94fffd2205c02b0b94a93109cd09cda60631f77b00f598517"
+        },
+        "node": "v18.19.1"
+      },
+      "model_artifact": {
+        "path": "/home/ubuntu/models/Llama-3.2-3B-Instruct-Q8_0.gguf",
+        "exists": true,
+        "size_bytes": 3421899296,
+        "sha256": "b5607b5090a8280063fff2d706bb3408ca6542341b06aab39c3eca0a28575921"
+      },
+      "privacy_note": "Host name, user name, and home-relative local paths are intentionally not recorded; scrub full artifacts before publication if absolute paths appear in commands."
+    },
+    "resource_snapshots": {
+      "pre_start": {
+        "label": "pre_start",
+        "captured_utc": "2026-05-22T02:25:45.622Z",
+        "loadavg_1m_5m_15m": [
+          1.51,
+          1.07,
+          1.06
+        ],
+        "memory": {
+          "total_gib": 123.79,
+          "free_gib": 121.09,
+          "process_rss_mib": 88.93
+        },
+        "linux_meminfo": {
+          "mem_available_gib": 121.09,
+          "swap_total_gib": 0,
+          "swap_free_gib": 0,
+          "dirty_mib": 0
+        },
+        "storage": {
+          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
+          "total_gib": 192.69,
+          "available_gib": 150.26,
+          "used_pct": 22.02
+        }
+      },
+      "before_measured_runs": {
+        "label": "before_measured_runs",
+        "captured_utc": "2026-05-22T02:25:47.384Z",
+        "loadavg_1m_5m_15m": [
+          1.51,
+          1.07,
+          1.06
+        ],
+        "memory": {
+          "total_gib": 123.79,
+          "free_gib": 117.47,
+          "process_rss_mib": 137.68
+        },
+        "linux_meminfo": {
+          "mem_available_gib": 117.47,
+          "swap_total_gib": 0,
+          "swap_free_gib": 0,
+          "dirty_mib": 0.01
+        },
+        "storage": {
+          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
+          "total_gib": 192.69,
+          "available_gib": 150.26,
+          "used_pct": 22.02
+        }
+      },
+      "after_measured_runs": {
+        "label": "after_measured_runs",
+        "captured_utc": "2026-05-22T02:25:53.280Z",
+        "loadavg_1m_5m_15m": [
+          1.47,
+          1.07,
+          1.06
+        ],
+        "memory": {
+          "total_gib": 123.79,
+          "free_gib": 113.46,
+          "process_rss_mib": 129.5
+        },
+        "linux_meminfo": {
+          "mem_available_gib": 113.46,
+          "swap_total_gib": 0,
+          "swap_free_gib": 0,
+          "dirty_mib": 0.01
+        },
+        "storage": {
+          "path": "/home/ubuntu/work/camelid-tied-output-logits-route",
+          "total_gib": 192.69,
+          "available_gib": 150.26,
+          "used_pct": 22.02
+        }
+      }
+    },
+    "measured_order": [
+      {
+        "engine": "camelid",
+        "label": "camelid-measure-1"
+      },
+      {
+        "engine": "llama_cpp",
+        "label": "llama-measure-1"
+      }
+    ],
+    "note": "Same-host comparison using alternating streaming requests to Camelid /v1/chat/completions and llama.cpp /completion. TTFT is first non-empty streamed content chunk; token throughput is estimated from streamed content chunks, not tokenizer-ground-truth completion tokens."
+  },
+  "camelid": {
+    "base_url": "http://127.0.0.1:8181",
+    "warmups": [],
+    "runs": [
+      {
+        "label": "camelid-measure-1",
+        "text": "C",
+        "first_byte_ms": 5719.38,
+        "first_event_ms": 5719.49,
+        "first_content_ms": 5719.54,
+        "total_elapsed_ms": 5720.03,
+        "completion_tokens_estimate": 1,
+        "chunk_count": 1,
+        "backend_timing": {
+          "q8_schedule": {
+            "activation_pack_bytes_requested": 0,
+            "activation_pack_calls": 0,
+            "activation_pack_rows": 0,
+            "activation_quantize_pack_us": 0,
+            "conservative_tail_rows": 0,
+            "ffn_down_decode_consumer_taken": 28,
+            "ffn_down_gemm4_prefill_candidates": 56,
+            "ffn_down_gemm4_prefill_reject_bad_input_width": 0,
+            "ffn_down_gemm4_prefill_reject_no_runtime_packed": 0,
+            "ffn_down_gemm4_prefill_reject_non_i8_interleave": 0,
+            "ffn_down_gemm4_prefill_reject_plan_off": 56,
+            "ffn_down_gemm4_prefill_reject_rows_lt4": 0,
+            "ffn_down_vnni_decode_candidates": 252,
+            "ffn_down_vnni_decode_kernel_us": 0,
+            "ffn_down_vnni_decode_quantize_us": 0,
+            "ffn_down_vnni_decode_reject_bad_input_width": 0,
+            "ffn_down_vnni_decode_reject_bad_output_width": 0,
+            "ffn_down_vnni_decode_reject_cpu_feature": 0,
+            "ffn_down_vnni_decode_reject_gate_off": 252,
+            "ffn_down_vnni_decode_reject_no_vnni_pack": 0,
+            "ffn_down_vnni_decode_reject_shape_or_role": 0,
+            "ffn_down_vnni_decode_taken": 0,
+            "ffn_gate_up_decode_consumer_activation_us": 0,
+            "ffn_gate_up_decode_consumer_tensor_us": 0,
+            "i8mm_fused_gate_up_calls": 0,
+            "i8mm_single_projection_by_role": {},
+            "i8mm_single_projection_calls": 0,
+            "output_projection_by_layer_route": {
+              "layer_0.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 544,
+                "input_width": 8192,
+                "layer_index": 0,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_1.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 544,
+                "input_width": 8192,
+                "layer_index": 1,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_10.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 523,
+                "input_width": 8192,
+                "layer_index": 10,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_11.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 615,
+                "input_width": 8192,
+                "layer_index": 11,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_12.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 497,
+                "input_width": 8192,
+                "layer_index": 12,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_13.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 537,
+                "input_width": 8192,
+                "layer_index": 13,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_14.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 567,
+                "input_width": 8192,
+                "layer_index": 14,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_15.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 475,
+                "input_width": 8192,
+                "layer_index": 15,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_16.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 440,
+                "input_width": 8192,
+                "layer_index": 16,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_17.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 442,
+                "input_width": 8192,
+                "layer_index": 17,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_18.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 428,
+                "input_width": 8192,
+                "layer_index": 18,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_19.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 486,
+                "input_width": 8192,
+                "layer_index": 19,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_2.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 453,
+                "input_width": 8192,
+                "layer_index": 2,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_20.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 444,
+                "input_width": 8192,
+                "layer_index": 20,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_21.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 448,
+                "input_width": 8192,
+                "layer_index": 21,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_22.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 402,
+                "input_width": 8192,
+                "layer_index": 22,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_23.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 725,
+                "input_width": 8192,
+                "layer_index": 23,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_24.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 609,
+                "input_width": 8192,
+                "layer_index": 24,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_25.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 547,
+                "input_width": 8192,
+                "layer_index": 25,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_26.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 469,
+                "input_width": 8192,
+                "layer_index": 26,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_27.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 421,
+                "input_width": 8192,
+                "layer_index": 27,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_3.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 601,
+                "input_width": 8192,
+                "layer_index": 3,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_4.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 574,
+                "input_width": 8192,
+                "layer_index": 4,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_5.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 600,
+                "input_width": 8192,
+                "layer_index": 5,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_6.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 524,
+                "input_width": 8192,
+                "layer_index": 6,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_7.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 477,
+                "input_width": 8192,
+                "layer_index": 7,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_8.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 510,
+                "input_width": 8192,
+                "layer_index": 8,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              },
+              "layer_9.ffn_down.x86_decode_consumer": {
+                "calls": 1,
+                "elapsed_us": 456,
+                "input_width": 8192,
+                "layer_index": 9,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 1
+              }
+            },
+            "output_projection_by_route": {
+              "ffn_down.x86_decode_consumer": {
+                "calls": 28,
+                "elapsed_us": 14358,
+                "input_width": 8192,
+                "output_width": 3072,
+                "role": "ffn_down",
+                "route": "x86_decode_consumer",
+                "rows": 28
+              },
+              "logits.x86_output_decode_owner": {
+                "calls": 1,
+                "elapsed_us": 4958,
+                "input_width": 3072,
+                "output_width": 128256,
+                "role": "logits",
+                "route": "x86_output_decode_owner",
+                "rows": 1
+              }
+            },
+            "output_projection_calls": 29,
+            "prefill_single_token_fallbacks": 0,
+            "projection_route_denials": {
+              "ffn_down.x86_gemm4_prefill.plan_off": {
+                "denials": 56,
+                "input_width": 8192,
+                "output_width": 0,
+                "reason": "plan_off",
+                "role": "ffn_down",
+                "route": "x86_gemm4_prefill",
+                "rows": 1316
+              },
+              "ffn_down.x86_vnni_decode_consumer.gate_off": {
+                "denials": 252,
+                "input_width": 8192,
+                "output_width": 3072,
+                "reason": "gate_off",
+                "role": "ffn_down",
+                "route": "x86_vnni_decode_consumer",
+                "rows": 9072
+              },
+              "ffn_gate_up.packed_rows4_matmul_prefill.plan_off": {
+                "denials": 28,
+                "input_width": 3072,
+                "output_width": 0,
+                "reason": "plan_off",
+                "role": "ffn_gate_up",
+                "route": "packed_rows4_matmul_prefill",
+                "rows": 1288
+              }
+            },
+            "q8_gemm_compute_us": 0,
+            "rayon_fanout_boundaries": 0,
+            "scratch_allocation_count": 0,
+            "scratch_bytes_allocated": 0,
+            "scratch_bytes_reused": 0,
+            "scratch_peak_capacity_bytes": 0
+          },
+          "timings_ms": {
+            "first_content": 1894,
+            "first_content_accounting": {
+              "first_content_minus_prompt_eval_forward": 30.686999999999898,
+              "first_content_minus_prompt_eval_forward_plus_sample": 30.449999999999818,
+              "prompt_eval_forward_plus_sample": 1863.5500000000002,
+              "prompt_eval_forward_total": 1863.313,
+              "prompt_eval_logits": 4.964,
+              "prompt_eval_sample": 0.237
+            },
+            "first_token_forward_total": 71.9,
+            "first_token_role_timings": {
+              "attention_context": 3.3990000000000005,
+              "attention_output": 9.405,
+              "ffn_down": 14.613000000000001,
+              "ffn_gate": 10.993,
+              "ffn_up": 11.009000000000002,
+              "logits": 4.964
+            },
+            "generate": 1894,
+            "generation_forward_total": 1863.313,
+            "generation_role_timings": {
+              "attention_context": 31.520999999999997,
+              "attention_output": 146.802,
+              "ffn_down": 439.084,
+              "ffn_gate": 390.154,
+              "ffn_up": 402.276,
+              "logits": 4.964
+            },
+            "layer_role_hotspots": {
+              "first_token": [
+                {
+                  "elapsed_ms": 0.734,
+                  "layer_index": 23,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.645,
+                  "layer_index": 14,
+                  "role": "attention_output"
+                },
+                {
+                  "elapsed_ms": 0.623,
+                  "layer_index": 11,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.621,
+                  "layer_index": 24,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.614,
+                  "layer_index": 3,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.611,
+                  "layer_index": 5,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.583,
+                  "layer_index": 4,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.582,
+                  "layer_index": 14,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 0.558,
+                  "layer_index": 8,
+                  "role": "attention_output"
+                },
+                {
+                  "elapsed_ms": 0.556,
+                  "layer_index": 0,
+                  "role": "ffn_down"
+                }
+              ],
+              "generation": [
+                {
+                  "elapsed_ms": 21.317,
+                  "layer_index": 0,
+                  "role": "ffn_gate"
+                },
+                {
+                  "elapsed_ms": 20.822,
+                  "layer_index": 0,
+                  "role": "kv_cache_write"
+                },
+                {
+                  "elapsed_ms": 20.531,
+                  "layer_index": 0,
+                  "role": "ffn_up"
+                },
+                {
+                  "elapsed_ms": 16.848,
+                  "layer_index": 23,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 16.14,
+                  "layer_index": 22,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 16.125,
+                  "layer_index": 4,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 16.04,
+                  "layer_index": 9,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.862,
+                  "layer_index": 8,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.836,
+                  "layer_index": 20,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.809,
+                  "layer_index": 7,
+                  "role": "ffn_down"
+                }
+              ],
+              "prefill": [
+                {
+                  "elapsed_ms": 20.946,
+                  "layer_index": 0,
+                  "role": "ffn_gate"
+                },
+                {
+                  "elapsed_ms": 20.81,
+                  "layer_index": 0,
+                  "role": "kv_cache_write"
+                },
+                {
+                  "elapsed_ms": 20.16,
+                  "layer_index": 0,
+                  "role": "ffn_up"
+                },
+                {
+                  "elapsed_ms": 16.114,
+                  "layer_index": 23,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.731,
+                  "layer_index": 22,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.575,
+                  "layer_index": 9,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.542,
+                  "layer_index": 4,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.385,
+                  "layer_index": 20,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.342,
+                  "layer_index": 8,
+                  "role": "ffn_down"
+                },
+                {
+                  "elapsed_ms": 15.323,
+                  "layer_index": 7,
+                  "role": "ffn_down"
+                }
+              ]
+            },
+            "prefill_forward_total": 1791.413,
+            "prefill_role_timings": {
+              "attention_context": 28.122000000000003,
+              "attention_output": 137.397,
+              "ffn_down": 424.47099999999995,
+              "ffn_gate": 379.16099999999994,
+              "ffn_up": 391.267,
+              "logits": 0
+            },
+            "prompt_cache_hit": false,
+            "session_create": 0,
+            "stream_event_accounting": {
+              "final_yield": 1894,
+              "final_yield_minus_first_content_yield": 0,
+              "first_content_yield": 1894,
+              "first_content_yield_minus_role_yield": 1894,
+              "generate_start": 0,
+              "generate_start_minus_role_yield": 0,
+              "poll_yield_enabled": false,
+              "role_yield": 0
+            },
+            "tokenize": 32,
+            "weight_cache_hit": false,
+            "weight_load": 3761
+          }
+        },
+        "backend_generate_ms": 1894,
+        "backend_first_content_ms": 1894,
+        "backend_q8_gemm_compute_us": 0,
+        "backend_q8_pack_us": 0,
+        "backend_q8_calls": 29,
+        "decode_tok_per_s": 2030.39,
+        "ms_per_token_after_first": 0.49
+      }
+    ],
+    "summary": {
+      "count": 1,
+      "avg_first_byte_ms": 5719.38,
+      "avg_first_event_ms": 5719.49,
+      "avg_ttft_ms": 5719.54,
+      "avg_total_elapsed_ms": 5720.03,
+      "avg_backend_generate_ms": 1894,
+      "avg_backend_first_content_ms": 1894,
+      "avg_backend_q8_calls": 29,
+      "avg_backend_q8_gemm_compute_us": 0,
+      "avg_backend_q8_pack_us": 0,
+      "avg_decode_tok_per_s": 2030.39,
+      "avg_ms_per_token_after_first": 0.49,
+      "avg_completion_tokens_estimate": 1
+    }
+  },
+  "llama_cpp": {
+    "base_url": "http://127.0.0.1:8183",
+    "warmups": [],
+    "runs": [
+      {
+        "label": "llama-measure-1",
+        "text": "C",
+        "first_byte_ms": 172.46,
+        "first_event_ms": 172.69,
+        "first_content_ms": 172.74,
+        "total_elapsed_ms": 173.04,
+        "completion_tokens_estimate": 1,
+        "chunk_count": 1,
+        "backend_timing": null,
+        "backend_generate_ms": null,
+        "backend_first_content_ms": null,
+        "backend_q8_gemm_compute_us": null,
+        "backend_q8_pack_us": null,
+        "backend_q8_calls": null,
+        "decode_tok_per_s": 3323.82,
+        "ms_per_token_after_first": 0.3
+      }
+    ],
+    "summary": {
+      "count": 1,
+      "avg_first_byte_ms": 172.46,
+      "avg_first_event_ms": 172.69,
+      "avg_ttft_ms": 172.74,
+      "avg_total_elapsed_ms": 173.04,
+      "avg_backend_generate_ms": null,
+      "avg_backend_first_content_ms": null,
+      "avg_backend_q8_calls": null,
+      "avg_backend_q8_gemm_compute_us": null,
+      "avg_backend_q8_pack_us": null,
+      "avg_decode_tok_per_s": 3323.82,
+      "avg_ms_per_token_after_first": 0.3,
+      "avg_completion_tokens_estimate": 1
+    },
+    "binary": "/home/ubuntu/work/llama.cpp-fc0b298f-20260520T0325Z/build/bin/llama-server"
+  },
+  "comparison": {
+    "ttft_delta_pct_vs_llama_cpp": 3211.07,
+    "total_elapsed_delta_pct_vs_llama_cpp": 3205.61,
+    "decode_tok_per_s_delta_pct_vs_llama_cpp": -38.91,
+    "ms_per_token_after_first_delta_pct_vs_llama_cpp": 63.33
+  },
+  "guardrails": {
+    "expected_marker": "CMLD-BENCH",
+    "require_marker": false,
+    "marker_presence": {
+      "camelid": [
+        {
+          "label": "camelid-measure-1",
+          "contains_expected_marker": false,
+          "nonempty_streamed_output": true
+        }
+      ],
+      "llama_cpp": [
+        {
+          "label": "llama-measure-1",
+          "contains_expected_marker": false,
+          "nonempty_streamed_output": true
+        }
+      ]
+    },
+    "passed": false,
+    "note": "Marker presence and non-empty streamed output are recorded for deterministic-output hygiene; empty measured output always fails the recorded guardrail even when marker enforcement is not requested."
+  },
+  "claim_boundary": "Same-host benchmark snapshot only for exact row llama32_3b_instruct_q8_0 with the provided GGUF, prompt, max-token budget, host, binaries, and thread settings. It is bounded timing evidence only: it does not widen support, portability, production-throughput, model-native/larger-context, neighboring-row, broad Llama-family, 1B, or Mixtral claims unless a separate row-specific evidence bundle records those exact conditions."
+}

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -745,7 +745,19 @@ impl LlamaLoadedWeights {
         )?;
         let output_norm = store.load_cpu_f32(&binding.output_norm.name)?;
         let output = if binding.output_is_tied_embedding {
-            None
+            if auto_retain_q8_0_blocks {
+                Some(store.load_q8_0_block_backed_linear_as(
+                    &binding.token_embedding.name,
+                    "output.weight",
+                )?)
+            } else if lazy_q8_0_linear_enabled() {
+                Some(store.load_q8_0_file_backed_tensor_as(
+                    &binding.token_embedding.name,
+                    "output.weight",
+                )?)
+            } else {
+                None
+            }
         } else {
             Some(load_linear(&binding.output.name)?)
         };

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -2647,25 +2647,39 @@ impl TensorStore {
     }
 
     pub fn load_q8_0_block_backed_linear(&self, name: &str) -> Result<CpuTensor> {
-        let desc = self.descriptor(name)?.clone();
+        self.load_q8_0_block_backed_linear_as(name, name)
+    }
+
+    pub fn load_q8_0_block_backed_linear_as(
+        &self,
+        source_name: &str,
+        tensor_name: &str,
+    ) -> Result<CpuTensor> {
+        let desc = self.descriptor(source_name)?.clone();
         if desc.tensor_type != GgufTensorType::Q8_0 {
-            return self.load_cpu_f32(name);
+            let mut tensor = self.load_cpu_f32(source_name)?;
+            tensor.name = tensor_name.to_string();
+            return Ok(tensor);
         }
         let shape = TensorShape::from_gguf_dims(&desc.dimensions)?;
         if shape.dims.len() != 2 {
-            return self.load_cpu_f32(name);
+            let mut tensor = self.load_cpu_f32(source_name)?;
+            tensor.name = tensor_name.to_string();
+            return Ok(tensor);
         }
         let expected_elements = shape.element_count()?;
-        let bytes = self.tensor_bytes(name)?;
+        let bytes = self.tensor_bytes(source_name)?;
         if let Some(Q8_0RuntimeStorage::PackedRows4(packed)) =
-            q8_0_runtime_packed_rows4_for_tensor(name, &shape, &bytes)?
+            q8_0_runtime_packed_rows4_for_tensor(tensor_name, &shape, &bytes)?
         {
             return Ok(CpuTensor::q8_0_runtime_packed_rows4_linear(
-                name, shape, packed,
+                tensor_name,
+                shape,
+                packed,
             ));
         }
-        let blocks = decode_q8_0_blocks(name, &bytes, expected_elements)?;
-        CpuTensor::from_q8_0_blocks(name, shape, blocks)
+        let blocks = decode_q8_0_blocks(source_name, &bytes, expected_elements)?;
+        CpuTensor::from_q8_0_blocks(tensor_name, shape, blocks)
     }
 
     pub fn load_q8_0_split_file_backed_tensor(
@@ -2722,29 +2736,41 @@ impl TensorStore {
     }
 
     pub fn load_q8_0_file_backed_tensor(&self, name: &str) -> Result<CpuTensor> {
-        let desc = self.descriptor(name)?.clone();
+        self.load_q8_0_file_backed_tensor_as(name, name)
+    }
+
+    pub fn load_q8_0_file_backed_tensor_as(
+        &self,
+        source_name: &str,
+        tensor_name: &str,
+    ) -> Result<CpuTensor> {
+        let desc = self.descriptor(source_name)?.clone();
         if desc.tensor_type != GgufTensorType::Q8_0 {
-            return self.load_cpu_f32(name);
+            let mut tensor = self.load_cpu_f32(source_name)?;
+            tensor.name = tensor_name.to_string();
+            return Ok(tensor);
         }
         let shape = TensorShape::from_gguf_dims(&desc.dimensions)?;
         let expected_elements = shape.element_count()?;
         if expected_elements % 32 != 0 {
             return Err(BackendError::InvalidTensorData(format!(
-                "tensor {name} Q8_0 element count {expected_elements} is not block aligned"
+                "tensor {source_name} Q8_0 element count {expected_elements} is not block aligned"
             )));
         }
-        if q8_repack_tensor_enabled(name) {
-            let bytes = self.tensor_bytes(name)?;
+        if q8_repack_tensor_enabled(tensor_name) {
+            let bytes = self.tensor_bytes(source_name)?;
             if let Some(Q8_0RuntimeStorage::PackedRows4(packed)) =
-                q8_0_runtime_packed_rows4_for_tensor(name, &shape, &bytes)?
+                q8_0_runtime_packed_rows4_for_tensor(tensor_name, &shape, &bytes)?
             {
                 return Ok(CpuTensor::q8_0_runtime_packed_rows4_linear(
-                    name, shape, packed,
+                    tensor_name,
+                    shape,
+                    packed,
                 ));
             }
         }
         let mut tensor = CpuTensor::q8_0_file_backed_linear(
-            name,
+            tensor_name,
             shape.clone(),
             Q8_0FileBacking::new(
                 self.path.clone(),
@@ -2752,19 +2778,19 @@ impl TensorStore {
                 expected_elements / 32,
             ),
         );
-        if q8_0_packed_rows4_enabled_for_tensor(name, Q8_0PackedRows4Interleave::I4)
-            || q8_0_packed_rows4_enabled_for_tensor(name, Q8_0PackedRows4Interleave::I8)
+        if q8_0_packed_rows4_enabled_for_tensor(tensor_name, Q8_0PackedRows4Interleave::I4)
+            || q8_0_packed_rows4_enabled_for_tensor(tensor_name, Q8_0PackedRows4Interleave::I8)
         {
-            let bytes = self.tensor_bytes(name)?;
-            let blocks = decode_q8_0_blocks(name, &bytes, expected_elements)?;
+            let bytes = self.tensor_bytes(source_name)?;
+            let blocks = decode_q8_0_blocks(source_name, &bytes, expected_elements)?;
             tensor.q8_0_packed_rows4_4x4 = q8_0_packed_rows4_for_shape(
-                name,
+                tensor_name,
                 &shape,
                 Some(&blocks),
                 Q8_0PackedRows4Interleave::I4,
             )?;
             tensor.q8_0_packed_rows4_4x8 = q8_0_packed_rows4_for_shape(
-                name,
+                tensor_name,
                 &shape,
                 Some(&blocks),
                 Q8_0PackedRows4Interleave::I8,
@@ -3363,6 +3389,76 @@ mod tests {
             super::Q8_0PackedRows4Interleave::I8
         );
 
+        std::env::remove_var("CAMELID_X86_Q8_REPACK");
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[test]
+    fn q8_x86_repack_materializes_tied_embedding_as_output_runtime_storage() {
+        let _env_guard = env_lock();
+        std::env::remove_var("CAMELID_Q8_0_BLOCK_DOT");
+        std::env::set_var("CAMELID_X86_Q8_REPACK", "on");
+
+        let source_shape = TensorShape { dims: vec![32, 64] };
+        let rows = 64;
+        let blocks_per_row = 1;
+        let mut bytes = Vec::with_capacity(rows * blocks_per_row * Q8_0_BLOCK_BYTES);
+        for row in 0..rows {
+            bytes.extend_from_slice(&(0x3000_u16 + row as u16).to_le_bytes());
+            bytes.extend((0..32).map(|idx| (idx as i8).wrapping_sub(row as i8) as u8));
+        }
+
+        let path = std::env::temp_dir().join(format!(
+            "camelid-tied-output-q8-{}-{}.bin",
+            std::process::id(),
+            rows
+        ));
+        {
+            use std::io::Write;
+            let mut file = std::fs::File::create(&path).unwrap();
+            file.write_all(&bytes).unwrap();
+        }
+        let gguf = crate::gguf::GgufFile {
+            path: path.clone(),
+            version: 3,
+            tensor_count: 1,
+            metadata_count: 0,
+            alignment: 32,
+            data_start_offset: 0,
+            metadata: std::collections::BTreeMap::new(),
+            tensors: vec![crate::gguf::GgufTensorDescriptor {
+                name: "token_embd.weight".to_string(),
+                dimensions: source_shape.dims.iter().map(|dim| *dim as u64).collect(),
+                tensor_type: crate::gguf::GgufTensorType::Q8_0,
+                relative_offset: 0,
+                absolute_offset: 0,
+                n_bytes: bytes.len() as u64,
+            }],
+        };
+        let store = super::TensorStore::open(&path, &gguf);
+
+        let embedding = store
+            .load_q8_0_file_backed_tensor("token_embd.weight")
+            .unwrap();
+        assert_eq!(embedding.name, "token_embd.weight");
+        assert!(embedding.q8_0_runtime_storage.is_none());
+        assert!(embedding.q8_0_file_backing.is_some());
+
+        let output = store
+            .load_q8_0_file_backed_tensor_as("token_embd.weight", "output.weight")
+            .unwrap();
+        assert_eq!(output.name, "output.weight");
+        assert_eq!(output.shape, source_shape);
+        assert!(output.q8_0_file_backing.is_none());
+        let Some(super::Q8_0RuntimeStorage::PackedRows4(packed)) = output.q8_0_runtime_storage
+        else {
+            panic!("expected tied output alias to materialize output-compatible rows4 storage");
+        };
+        assert_eq!(packed.rows, rows);
+        assert_eq!(packed.blocks_per_row, blocks_per_row);
+        assert_eq!(packed.interleave, Q8_0PackedRows4Interleave::I8);
+
+        std::fs::remove_file(path).unwrap();
         std::env::remove_var("CAMELID_X86_Q8_REPACK");
     }
 


### PR DESCRIPTION
## Summary
- Add TensorStore alias loaders so tied `token_embd.weight` can be loaded under runtime name `output.weight` without widening embedding repack behavior.
- Use that alias for tied output weights when Q8 block/file-backed loading is active, giving the default-off x86 output decode-owner path an output-compatible runtime-packed rows4 view.
- Add x86 unit coverage and a public-scrubbed Ubuntu x86 evidence bundle for the Llama 3.2 3B Q8_0 route.

## Validation
- Private Ubuntu x86_64 validation host with disk guard active; disk guard samples stayed around 22-23% used with `target_count=4`.
- Shared Cargo target dir used for the lane; no per-worktree Cargo target growth left behind.
- `cargo fmt --all -- --check`
- `cargo test q8_x86_repack_materializes_tied_embedding_as_output_runtime_storage --lib`
- `cargo test x86_q8_output_decode_owner_path_uses_runtime_packed_storage --lib`
- `cargo build --release`
- One-token same-host Llama 3.2 3B Q8_0 with `CAMELID_PROFILE=experimental CAMELID_X86_Q8_REPACK=on CAMELID_X86_Q8_KERNEL=avx2 CAMELID_X86_Q8_OUTPUT_DECODE_OWNER=on CAMELID_Q8_SCHED_TELEMETRY=on CAMELID_STREAM_TIMING_DIAGNOSTICS=on`: Camelid text `C`, llama.cpp text `C`; route `logits.x86_output_decode_owner`; no `logits.q8_0_retained_blocks`.
- Bounded benchmark r3: marker guard passed; Camelid TTFT mean `445.737 ms`; llama.cpp TTFT mean `176.527 ms`; Camelid total elapsed mean `446.04 ms`; llama.cpp total elapsed mean `410.41 ms`; logits route `logits.x86_output_decode_owner` elapsed mean `24.665 ms`.
- Local public-scrub checks after cleanup: `scripts/check-public-scrub.sh`, `scripts/audit-evidence-bundle-privacy.mjs --root qa/evidence-bundles --strict`, `scripts/check-public-evidence-claims.mjs --root qa/evidence-bundles`, and bundle checksum validation.

Artifacts: `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/subagent-tied-output-logits-route-20260522T0224Z/README.md`