### PR TITLE
refactor(q8): resolve FFN decode chain route

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -8350,69 +8350,21 @@ fn try_x86_q8_ffn_decode_chain_path(
     down_name: &str,
     runtime_plan: &ResolvedRuntimePlan,
 ) -> Result<Option<Q8FfnDecodeChainOutput>> {
-    if !runtime_plan.q8.ffn_decode_chain
-        || !runtime_plan.q8.ffn_gate_up_decode_consumer
-        || !runtime_plan.q8.ffn_down_decode_consumer
-        || input.rank() != 2
-        || input.dim(0)? != 1
-    {
-        return Ok(None);
-    }
-
-    let input_width = input.dim(1)?;
-    if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
-        record_q8_schedule_projection_route_denial(
-            "ffn_gate_up_down",
-            "x86_decode_chain",
-            "input_width_not_q8_block_multiple",
-            1,
-            input_width,
-            0,
-        );
-        return Ok(None);
-    }
-    let Some((gate_packed, gate_width)) = q8_0_runtime_packed_projection(gate_weight, input_width)?
+    let Some(route) = resolve_x86_q8_ffn_decode_chain_route(
+        input,
+        gate_weight,
+        up_weight,
+        down_weight,
+        runtime_plan,
+    )?
     else {
-        record_q8_schedule_projection_route_denial(
-            "ffn_gate_up_down",
-            "x86_decode_chain",
-            "missing_gate_runtime_packed_rows4",
-            1,
-            input_width,
-            0,
-        );
         return Ok(None);
     };
-    let Some((up_packed, up_width)) = q8_0_runtime_packed_projection(up_weight, input_width)?
-    else {
-        record_q8_schedule_projection_route_denial(
-            "ffn_gate_up_down",
-            "x86_decode_chain",
-            "missing_up_runtime_packed_rows4",
-            1,
-            input_width,
-            gate_width,
-        );
-        return Ok(None);
-    };
-    if gate_width != up_width
-        || gate_packed.interleave != Q8_0PackedRows4Interleave::I8
-        || up_packed.interleave != Q8_0PackedRows4Interleave::I8
-    {
-        record_q8_schedule_projection_route_denial(
-            "ffn_gate_up_down",
-            "x86_decode_chain",
-            "gate_up_packed_shape_or_interleave_mismatch",
-            1,
-            input_width,
-            gate_width,
-        );
-        return Ok(None);
-    }
+    debug_assert_eq!(route.route_label, "x86_decode_chain");
 
     let total_started = Instant::now();
     let input_quantize_started = Instant::now();
-    let quantized_input = quantize_q8_0_row(&input.data[..input_width]);
+    let quantized_input = quantize_q8_0_row(&input.data[..route.input_width]);
     add_q8_schedule_counter(
         &Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_US,
         input_quantize_started.elapsed().as_micros() as u64,
@@ -8421,9 +8373,9 @@ fn try_x86_q8_ffn_decode_chain_path(
     let order = diagnostic_ffn_gate_up_order()?;
     let gate_up_started = Instant::now();
     let activated = q8_0_packed_rows4_single_input_projection_pair_activated_from_quantized(
-        gate_packed,
-        up_packed,
-        gate_width,
+        route.gate,
+        route.up,
+        route.activation_width,
         activated_name,
         order,
         &quantized_input.blocks,
@@ -8435,32 +8387,13 @@ fn try_x86_q8_ffn_decode_chain_path(
         "decode_fused_activation",
         Some(activated_name),
         1,
-        input_width,
-        gate_width,
+        route.input_width,
+        route.activation_width,
         gate_up_elapsed,
     );
 
-    let Some(down_route) = resolve_x86_q8_ffn_down_route(
-        &activated,
-        down_weight,
-        "ffn_down",
-        runtime_plan,
-        X86Q8FfnDownRouteKind::Decode,
-    )?
-    else {
-        record_q8_schedule_projection_route_denial(
-            "ffn_gate_up_down",
-            "x86_decode_chain",
-            "missing_down_runtime_packed_rows4",
-            1,
-            gate_width,
-            0,
-        );
-        return Ok(None);
-    };
-
     let activation_quantize_started = Instant::now();
-    let quantized_activated = quantize_q8_0_row(&activated.data[..down_route.input_width]);
+    let quantized_activated = quantize_q8_0_row(&activated.data[..route.activation_width]);
     add_q8_schedule_counter(
         &Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_US,
         activation_quantize_started.elapsed().as_micros() as u64,
@@ -8470,9 +8403,9 @@ fn try_x86_q8_ffn_decode_chain_path(
     let decode_group_chunking = mac_q8_ffn_down_decode_group_chunking_enabled()
         || x86_q8_ffn_down_decode_group_chunking_enabled();
     let output = q8_0_packed_rows4_single_input_projection_with_decode_chunking(
-        down_route.packed,
+        route.down,
         &quantized_activated.blocks,
-        down_route.output_width,
+        route.output_width,
         down_name,
         decode_group_chunking,
     )?;
@@ -8489,8 +8422,8 @@ fn try_x86_q8_ffn_decode_chain_path(
         q8_ffn_down_decode_consumer_route_name(decode_group_chunking),
         Some(down_name),
         1,
-        down_route.input_width,
-        down_route.output_width,
+        route.activation_width,
+        route.output_width,
         down_elapsed,
     );
 
@@ -8501,6 +8434,119 @@ fn try_x86_q8_ffn_decode_chain_path(
         up: gate_up_elapsed - gate_elapsed,
         activation: 0,
         down: down_elapsed,
+    }))
+}
+
+struct Q8FfnDecodeChainRoute<'a> {
+    gate: &'a Q8_0PackedRows4,
+    up: &'a Q8_0PackedRows4,
+    down: &'a Q8_0PackedRows4,
+    input_width: usize,
+    activation_width: usize,
+    output_width: usize,
+    route_label: &'static str,
+}
+
+fn resolve_x86_q8_ffn_decode_chain_route<'a>(
+    input: &CpuTensor,
+    gate_weight: &'a CpuTensor,
+    up_weight: &'a CpuTensor,
+    down_weight: &'a CpuTensor,
+    runtime_plan: &ResolvedRuntimePlan,
+) -> Result<Option<Q8FfnDecodeChainRoute<'a>>> {
+    const ROUTE_LABEL: &str = "x86_decode_chain";
+    if !runtime_plan.q8.ffn_decode_chain
+        || !runtime_plan.q8.ffn_gate_up_decode_consumer
+        || !runtime_plan.q8.ffn_down_decode_consumer
+        || input.rank() != 2
+        || input.dim(0)? != 1
+    {
+        return Ok(None);
+    }
+
+    let input_width = input.dim(1)?;
+    if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up_down",
+            ROUTE_LABEL,
+            "input_width_not_q8_block_multiple",
+            1,
+            input_width,
+            0,
+        );
+        return Ok(None);
+    }
+    let Some((gate_packed, gate_width)) = q8_0_runtime_packed_projection(gate_weight, input_width)?
+    else {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up_down",
+            ROUTE_LABEL,
+            "missing_gate_runtime_packed_rows4",
+            1,
+            input_width,
+            0,
+        );
+        return Ok(None);
+    };
+    let Some((up_packed, up_width)) = q8_0_runtime_packed_projection(up_weight, input_width)?
+    else {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up_down",
+            ROUTE_LABEL,
+            "missing_up_runtime_packed_rows4",
+            1,
+            input_width,
+            gate_width,
+        );
+        return Ok(None);
+    };
+    if gate_width != up_width
+        || gate_packed.interleave != Q8_0PackedRows4Interleave::I8
+        || up_packed.interleave != Q8_0PackedRows4Interleave::I8
+    {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up_down",
+            ROUTE_LABEL,
+            "gate_up_packed_shape_or_interleave_mismatch",
+            1,
+            input_width,
+            gate_width,
+        );
+        return Ok(None);
+    }
+
+    let Some((down_packed, down_width)) = q8_0_runtime_packed_projection(down_weight, gate_width)?
+    else {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up_down",
+            ROUTE_LABEL,
+            "missing_down_runtime_packed_rows4",
+            1,
+            gate_width,
+            0,
+        );
+        return Ok(None);
+    };
+    if down_packed.interleave != Q8_0PackedRows4Interleave::I8 {
+        record_q8_schedule_projection_route_denial(
+            "ffn_gate_up_down",
+            ROUTE_LABEL,
+            "down_packed_shape_or_interleave_mismatch",
+            1,
+            gate_width,
+            down_width,
+        );
+        return Ok(None);
+    }
+
+    Ok(Some(Q8FfnDecodeChainRoute {
+        gate: gate_packed,
+        up: up_packed,
+        down: down_packed,
+        input_width,
+        activation_width: gate_width,
+        output_width: down_width,
+        route_label: ROUTE_LABEL,
     }))
 }
 

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -3991,6 +3991,79 @@ fn x86_q8_ffn_decode_chain_is_default_off_and_matches_split_consumers() {
     std::env::remove_var("CAMELID_X86_Q8_FFN_DECODE_CHAIN");
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
+fn x86_q8_ffn_decode_chain_route_resolver_fails_closed_on_incomplete_inputs() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+
+    let (input, packed_gate, packed_up, _expected_gate_up) = runtime_packed_ffn_gate_up_case();
+    let (_down_input, packed_down, _expected_down) = runtime_packed_ffn_down_case();
+    let plan = ffn_decode_chain_plan();
+
+    let route = resolve_x86_q8_ffn_decode_chain_route(
+        &input,
+        &packed_gate,
+        &packed_up,
+        &packed_down,
+        &plan,
+    )
+    .unwrap()
+    .expect("complete runtime-packed chain route");
+    assert_eq!(route.route_label, "x86_decode_chain");
+    assert_eq!(route.input_width, input.dim(1).unwrap());
+    assert_eq!(route.activation_width, packed_gate.dim(1).unwrap());
+    assert_eq!(route.output_width, packed_down.dim(1).unwrap());
+
+    let mut gate_up_disabled = plan;
+    gate_up_disabled.q8.ffn_gate_up_decode_consumer = false;
+    assert!(resolve_x86_q8_ffn_decode_chain_route(
+        &input,
+        &packed_gate,
+        &packed_up,
+        &packed_down,
+        &gate_up_disabled,
+    )
+    .unwrap()
+    .is_none());
+
+    let mut down_disabled = plan;
+    down_disabled.q8.ffn_down_decode_consumer = false;
+    assert!(resolve_x86_q8_ffn_decode_chain_route(
+        &input,
+        &packed_gate,
+        &packed_up,
+        &packed_down,
+        &down_disabled,
+    )
+    .unwrap()
+    .is_none());
+
+    let mut missing_gate_storage = packed_gate.clone();
+    missing_gate_storage.q8_0_runtime_storage = None;
+    assert!(resolve_x86_q8_ffn_decode_chain_route(
+        &input,
+        &missing_gate_storage,
+        &packed_up,
+        &packed_down,
+        &plan,
+    )
+    .unwrap()
+    .is_none());
+
+    let mut mismatched_down_shape = packed_down.clone();
+    mismatched_down_shape.shape.dims = vec![Q8_0_BLOCK_VALUES, packed_down.dim(1).unwrap()];
+    assert!(resolve_x86_q8_ffn_decode_chain_route(
+        &input,
+        &packed_gate,
+        &packed_up,
+        &mismatched_down_shape,
+        &plan,
+    )
+    .unwrap()
+    .is_none());
+}
+
 #[test]
 fn q8_ffn_down_consumer_matches_runtime_packed_baseline() {
     let _env_guard = env_lock();


### PR DESCRIPTION
## Summary
- Extract the x86 Q8 FFN decode-chain gate/up/down packed-storage decision into a private route resolver.
- Keep the route default-off and fail-closed with no capability/frontend/support-surface changes.
- Add resolver fallback coverage for disabled gates, missing runtime-packed storage, and shape mismatch.

## Validation
Canonical Ubuntu x86_64 host, fresh clone under `/home/ubuntu/work/camelid-pr84-ffn-chain-route-resolver-20260522T0710Z`, head `865990dcdccccee74679c0414084c645597c0981`:
- `uname -sm` -> `Linux x86_64`
- `cargo --version` -> `cargo 1.95.0 (f2d3ce0bd 2026-03-21)`
- `cargo fmt --check` -> pass
- `cargo test q8_ffn_decode_chain --lib` -> pass, 2 passed
- `cargo test execution_plan --lib` -> pass, 16 passed

No throughput or llama.cpp parity claim is made for this architecture cleanup slice.