### PR TITLE
perf(q8): route FFN decode chain through VNNI down

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -8469,15 +8469,98 @@ fn try_x86_q8_ffn_decode_chain_path(
     let down_started = Instant::now();
     let decode_group_chunking = mac_q8_ffn_down_decode_group_chunking_enabled()
         || x86_q8_ffn_down_decode_group_chunking_enabled();
-    let output = q8_0_packed_rows4_single_input_projection_with_decode_chunking(
-        down_route.packed,
-        &quantized_activated.blocks,
-        down_route.output_width,
-        down_name,
-        decode_group_chunking,
-    )?;
+    let mut down_route_name = q8_ffn_down_decode_consumer_route_name(decode_group_chunking);
+    let output = if runtime_plan.q8.ffn_down_vnni_decode {
+        add_q8_schedule_counter(&Q8_SCHED_FFN_DOWN_VNNI_DECODE_CANDIDATES, 1);
+        if !x86_q8_vnni_decode_cpu_supported() {
+            record_q8_ffn_down_vnni_decode_reject(
+                &Q8_SCHED_FFN_DOWN_VNNI_DECODE_REJECT_CPU_FEATURE,
+                "cpu_feature_missing",
+                1,
+                down_route.input_width,
+                down_route.output_width,
+            );
+            q8_0_packed_rows4_single_input_projection_with_decode_chunking(
+                down_route.packed,
+                &quantized_activated.blocks,
+                down_route.output_width,
+                down_name,
+                decode_group_chunking,
+            )?
+        } else if !down_route.input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+            record_q8_ffn_down_vnni_decode_reject(
+                &Q8_SCHED_FFN_DOWN_VNNI_DECODE_REJECT_BAD_INPUT_WIDTH,
+                "bad_input_width",
+                1,
+                down_route.input_width,
+                down_route.output_width,
+            );
+            q8_0_packed_rows4_single_input_projection_with_decode_chunking(
+                down_route.packed,
+                &quantized_activated.blocks,
+                down_route.output_width,
+                down_name,
+                decode_group_chunking,
+            )?
+        } else if !down_route.output_width.is_multiple_of(64) {
+            record_q8_ffn_down_vnni_decode_reject(
+                &Q8_SCHED_FFN_DOWN_VNNI_DECODE_REJECT_BAD_OUTPUT_WIDTH,
+                "bad_output_width",
+                1,
+                down_route.input_width,
+                down_route.output_width,
+            );
+            q8_0_packed_rows4_single_input_projection_with_decode_chunking(
+                down_route.packed,
+                &quantized_activated.blocks,
+                down_route.output_width,
+                down_name,
+                decode_group_chunking,
+            )?
+        } else if let Some(vnni_packed) = down_route.packed.vnni_packed.as_ref() {
+            let vnni_kernel_started = Instant::now();
+            let output = q8_0_vnni_decode_1x64_projection(
+                vnni_packed,
+                &quantized_activated.blocks,
+                down_route.output_width,
+                down_name,
+            )?;
+            add_q8_schedule_counter(
+                &Q8_SCHED_FFN_DOWN_VNNI_DECODE_KERNEL_US,
+                vnni_kernel_started.elapsed().as_micros() as u64,
+            );
+            add_q8_schedule_counter(&Q8_SCHED_FFN_DOWN_VNNI_DECODE_TAKEN, 1);
+            down_route_name = "x86_vnni_decode_consumer";
+            output
+        } else {
+            record_q8_ffn_down_vnni_decode_reject(
+                &Q8_SCHED_FFN_DOWN_VNNI_DECODE_REJECT_NO_VNNI_PACK,
+                "no_vnni_pack",
+                1,
+                down_route.input_width,
+                down_route.output_width,
+            );
+            q8_0_packed_rows4_single_input_projection_with_decode_chunking(
+                down_route.packed,
+                &quantized_activated.blocks,
+                down_route.output_width,
+                down_name,
+                decode_group_chunking,
+            )?
+        }
+    } else {
+        q8_0_packed_rows4_single_input_projection_with_decode_chunking(
+            down_route.packed,
+            &quantized_activated.blocks,
+            down_route.output_width,
+            down_name,
+            decode_group_chunking,
+        )?
+    };
     let down_elapsed = down_started.elapsed().as_micros();
-    add_q8_schedule_counter(&Q8_SCHED_FFN_DOWN_DECODE_CONSUMER_TAKEN, 1);
+    if down_route_name != "x86_vnni_decode_consumer" {
+        add_q8_schedule_counter(&Q8_SCHED_FFN_DOWN_DECODE_CONSUMER_TAKEN, 1);
+    }
     add_q8_schedule_counter(&Q8_SCHED_FFN_DECODE_CHAIN_TAKEN, 1);
     add_q8_schedule_counter(
         &Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_US,
@@ -8486,7 +8569,7 @@ fn try_x86_q8_ffn_decode_chain_path(
     add_q8_schedule_counter(&Q8_SCHED_FFN_DECODE_CHAIN_DOWN_US, down_elapsed as u64);
     record_q8_schedule_output_projection_route_call(
         "ffn_down",
-        q8_ffn_down_decode_consumer_route_name(decode_group_chunking),
+        down_route_name,
         Some(down_name),
         1,
         down_route.input_width,

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -3991,6 +3991,69 @@ fn x86_q8_ffn_decode_chain_is_default_off_and_matches_split_consumers() {
     std::env::remove_var("CAMELID_X86_Q8_FFN_DECODE_CHAIN");
 }
 
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn x86_q8_ffn_decode_chain_can_use_vnni_down_consumer() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    if !x86_q8_vnni_decode_cpu_supported() {
+        std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE");
+        return;
+    }
+
+    let (input, packed_gate, packed_up, _expected_gate_up) = runtime_packed_ffn_gate_up_case();
+    let (_down_input, packed_down, _expected_down) = runtime_vnni_packed_ffn_down_case();
+    let activated = gated_ffn_activation_with_plan(
+        &input,
+        &packed_gate,
+        &packed_up,
+        "expected_activated",
+        &ffn_gate_up_consumer_plan(true),
+        false,
+    )
+    .unwrap()
+    .tensor;
+    let expected = try_x86_q8_ffn_down_decode_consumer_path(
+        &activated,
+        &packed_down,
+        "expected_down",
+        "ffn_down",
+        &ffn_down_vnni_decode_plan(true),
+    )
+    .unwrap()
+    .expect("split VNNI FFN-down decode output");
+
+    let mut vnni_plan = ffn_decode_chain_plan();
+    vnni_plan.q8.ffn_down_vnni_decode = true;
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+
+    let actual = try_x86_q8_ffn_decode_chain_path(
+        &input,
+        &packed_gate,
+        &packed_up,
+        &packed_down,
+        "layer_0_ffn_activated",
+        "layer_0_ffn_down",
+        &vnni_plan,
+    )
+    .unwrap()
+    .expect("VNNI FFN decode chain output");
+
+    assert_eq!(actual.tensor.shape.dims, expected.shape.dims);
+    assert_slice_close_with_tolerance(&actual.tensor.data, &expected.data, 5e-4);
+    let telemetry = snapshot_q8_schedule_telemetry();
+    assert_eq!(telemetry.ffn_decode_chain_taken, 1);
+    assert_eq!(telemetry.ffn_down_vnni_decode_taken, 1);
+    assert!(telemetry.ffn_down_vnni_decode_kernel_us > 0);
+    assert!(telemetry
+        .output_projection_by_route
+        .contains_key("ffn_down.x86_vnni_decode_consumer"));
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
+    std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE");
+}
+
 #[test]
 fn q8_ffn_down_consumer_matches_runtime_packed_baseline() {
     let _env_guard = env_lock();


### PR DESCRIPTION
## Summary
- Lets the default-off x86 FFN decode-chain path use the existing FFN-down VNNI decode consumer when that VNNI gate is also enabled.
- Preserves fallback to the packed-rows4 decode consumer for missing CPU support, bad widths, or missing VNNI sidecar storage.
- Adds a Linux x86_64 unit test proving the chain records and uses the VNNI down route, while existing VNNI parity tests keep covering rows4 equivalence.

## Ubuntu x86_64 validation
Canonical host fresh clone under `/home/ubuntu/work/camelid-cron-0719640b-ffn-chain-vnni-down`, head `a53fb525bf6564ddae82bace47586c972a09639c`:

```text
Linux x86_64
cargo 1.95.0 (f2d3ce0bd 2026-03-21)
cargo fmt --check
cargo test q8_ffn_down_vnni --lib -- --nocapture
  6 passed; 0 failed
cargo test x86_q8_ffn_decode_chain_can_use_vnni_down_consumer --lib -- --nocapture
  1 passed; 0 failed
rc=0
```

No same-host llama.cpp timing comparison was run for this PR; this is a default-off code and parity/control-plane slice, not a throughput promotion.