### PR TITLE
AI chat redesign polish

### DIFF
--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -62,9 +62,12 @@ function TopBar({ tab, setTab, selectedConversationTitle, selectedConversationUp
       ? `${currentCompatibilityTarget.id}: ${formatCapabilityStatus(currentCompatibilityTarget.status)}`
       : 'Open the API contract before treating any model family or quant as supported.')
   const runtimeGateDetail = `loaded_now=${runtime?.loaded_now ? 'true' : 'false'} · generation_ready=${runtime?.generation_ready ? 'true' : 'false'} · exact_compatibility_row=${activeChatGate.contractSupported ? 'true' : 'false'}`
-  const chatReadinessTone = selectedModelRunnable ? 'ready' : runtime?.loaded_now ? 'warm' : 'idle'
+  const apiUnavailable = runtime?.status === 'offline'
+  const chatReadinessTone = selectedModelRunnable ? 'ready' : apiUnavailable ? 'offline' : runtime?.loaded_now ? 'warm' : 'idle'
   const chatReadinessLabel = selectedModelRunnable
     ? 'Ready'
+    : apiUnavailable
+      ? 'Offline'
     : runtime?.loaded_now
       ? 'Checking'
       : 'Not ready'

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -2628,6 +2628,9 @@ textarea.composer-input-assistant {
   padding: 0;
   appearance: none;
   -webkit-appearance: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 
@@ -5019,6 +5022,28 @@ textarea.composer-input-assistant {
 }
 
 @media (max-width: 560px) {
+  .topbar-chat-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .topbar-chat .topbar-chat-center {
+    display: none;
+  }
+
+  .topbar-chat .topbar-chat-actions {
+    grid-column: 2;
+    justify-self: end;
+  }
+
+  .topbar-chat-readiness {
+    max-width: 100%;
+  }
+
+  .topbar-chat-readiness .topbar-select-chat {
+    max-width: min(46vw, 150px);
+  }
+
   .topbar-page-row {
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: start;
@@ -6103,6 +6128,11 @@ textarea.composer-input-assistant {
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-warning) 14%, transparent);
 }
 
+.topbar-chat-readiness.offline .topbar-chat-readiness-dot {
+  background: var(--color-error);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-error) 13%, transparent);
+}
+
 .topbar-chat-readiness .topbar-select-chat {
   min-width: 132px;
   max-width: min(28vw, 230px);
@@ -6126,6 +6156,10 @@ textarea.composer-input-assistant {
 
 .topbar-chat-readiness.warm .topbar-chat-readiness-label {
   color: var(--color-warning);
+}
+
+.topbar-chat-readiness.offline .topbar-chat-readiness-label {
+  color: var(--color-error);
 }
 
 /* Calm assistant-first landing. The earlier oversized hero is kept by history, then tightened here. */
@@ -6390,6 +6424,10 @@ textarea.composer-input-assistant {
   background: var(--color-error);
 }
 
+.chat-readiness-pill-row.is-offline .chat-readiness-pill::before {
+  background: var(--color-error);
+}
+
 .chat-readiness-pill-row.is-waiting .chat-readiness-pill::before {
   background: var(--color-warning);
 }
@@ -6617,11 +6655,34 @@ textarea.composer-input-assistant {
     display: none;
   }
 
+  .chat-layout-empty .chat-empty-shell-assistant {
+    min-height: auto;
+    padding: 18px 0 52px;
+  }
+
+  .chat-layout-empty .chat-empty-stage-product {
+    gap: 12px;
+    padding-inline: 16px;
+  }
+
   .chat-layout-empty .chat-empty-hero-clean h2 {
-    font-size: clamp(2.5rem, 15vw, 4rem);
+    max-width: 12ch;
+    font-size: clamp(2.2rem, 11.5vw, 3.25rem);
+  }
+
+  .chat-layout-empty .chat-empty-hero-clean .hero-summary {
+    max-width: 34ch;
+    font-size: 0.92rem;
+    line-height: 1.45;
   }
 
   .chat-layout-empty .composer-assistant-product {
-    padding: 16px;
+    padding: 13px;
+    border-radius: 20px;
+  }
+
+  .chat-layout-empty .composer-assistant-stage-clean .composer-input-assistant-stage {
+    min-height: 66px !important;
+    font-size: 1rem;
   }
 }

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -511,6 +511,7 @@ export default function ChatWorkspace({
   const lastUpdated = selectedConversation?.updated_at ? formatDate(selectedConversation.updated_at) : null
   const modelPickerTitle = selectedModel ? getModelStatusLabel(selectedModel) : 'Choose what Camelid should use for this chat.'
   const selectedChatGate = getChatGateState(capabilities, selectedModel, runtime)
+  const apiUnavailable = runtime?.status === 'offline'
   const selectedRuntimeReady = selectedChatGate.runtimeReady
   const selectedModelCapabilitySupported = selectedChatGate.contractSupported || isCompatibilitySupportedForModel(capabilities, selectedModel)
   const supportBlocked = selectedRuntimeReady && !selectedModelCapabilitySupported
@@ -523,6 +524,8 @@ export default function ChatWorkspace({
     : 'Choose a model before inferring any support boundary. Camelid will not promote filenames or saved paths into compatibility claims.'
   const selectedModelMeta = supportBlocked
     ? 'Load a supported model to chat'
+    : apiUnavailable
+      ? 'API unavailable'
     : !selectedModelRunnable
       ? describeModelState(selectedModel)
       : selectedChatGate.runtimeLoaded
@@ -531,38 +534,49 @@ export default function ChatWorkspace({
   const canSubmit = Boolean(composer.trim()) && selectedModelRunnable && !generationActive
   const capabilityLaneStatus = getChatCapabilityLaneCopy(selectedChatGate, capabilities)
   const selectedModelName = selectedModel?.name || selectedModelId || 'No model selected'
-  const runnableModels = models.filter((model) => getChatGateState(capabilities, model, runtime).chatUnlocked)
-  const runtimeStatusLabel = selectedModelRunnable
+  const runtimeStatusLabel = apiUnavailable
+    ? 'API unavailable'
+    : selectedModelRunnable
     ? 'Local chat ready'
     : selectedRuntimeReady
       ? 'Runtime ready, support gated'
       : runtime?.loaded_now
         ? 'Loaded, not generation-ready'
         : 'No generation-ready model'
-  const runtimeStatusCopy = selectedModelRunnable
+  const runtimeStatusCopy = apiUnavailable
+    ? 'Camelid did not respond. Start the server or check the API base before loading a model.'
+    : selectedModelRunnable
     ? `${selectedModelName} is loaded now and generation_ready=true.`
     : selectedRuntimeReady
       ? 'The runtime is ready; Camelid still needs an exact supported row before chat unlocks.'
       : runtime?.loaded_now
         ? 'Wait for generation_ready=true before sending prompts.'
         : 'Load a local GGUF from Library to start the readiness check.'
-  const supportStatusLabel = selectedModelCapabilitySupported
+  const supportStatusLabel = apiUnavailable
+    ? 'Contract unavailable'
+    : selectedModelCapabilitySupported
     ? selectedCompatibilityLabel
     : selectedModel
       ? selectedCompatibilityLabel
       : 'Choose model first'
-  const supportStatusCopy = selectedModelCapabilitySupported
+  const supportStatusCopy = apiUnavailable
+    ? 'The /api/capabilities contract could not be read while the API is unavailable.'
+    : selectedModelCapabilitySupported
     ? `${selectedCompatibilityLabel}. COMPATIBILITY.md and /api/capabilities agree for this model and quant.`
     : selectedModel
       ? selectedCompatibilityCopy
       : 'Camelid does not infer broad support from filenames, families, or saved paths.'
   const readinessFinePrint = selectedModelRunnable
     ? 'Ready for this loaded exact row. Broader scope details stay in /api/capabilities instead of the chat composer.'
+    : apiUnavailable
+      ? 'Chat unlocks after the Camelid API responds and the selected model passes runtime and support-contract readiness.'
     : 'Chat unlocks only after loaded_now=true, generation_ready=true, and an exact supported compatibility row all match.'
   const emptyHeroEyebrow = 'Camelid'
-  const readinessState = selectedModelRunnable ? 'ready' : supportBlocked ? 'blocked' : selectedModel ? 'waiting' : 'idle'
+  const readinessState = selectedModelRunnable ? 'ready' : apiUnavailable ? 'offline' : supportBlocked ? 'blocked' : selectedModel ? 'waiting' : 'idle'
   const readinessLabel = selectedModelRunnable
     ? 'Ready'
+    : apiUnavailable
+      ? 'API unavailable'
     : supportBlocked
       ? 'Choose a supported model'
       : selectedModel
@@ -570,11 +584,15 @@ export default function ChatWorkspace({
         : 'Choose a model to begin'
   const productHeroTitle = selectedModelRunnable
     ? 'How can I help?'
+    : apiUnavailable
+      ? 'Connect Camelid to begin.'
     : supportBlocked
       ? 'Choose a supported model.'
       : 'Load a model to begin.'
   const productHeroSummary = selectedModelRunnable
     ? 'Ask anything, or start from one of the prompts below. Camelid is running the selected exact row locally.'
+    : apiUnavailable
+      ? 'The frontend is ready, but the Camelid API is not responding. Start the local server and the chat surface will update automatically.'
     : supportBlocked
       ? 'The runtime is available, but chat stays locked until the selected model has an exact supported row.'
       : 'Load a generation-ready GGUF model to unlock local chat. Camelid will keep showing what is missing until then.'
@@ -584,7 +602,7 @@ export default function ChatWorkspace({
   }
 
   const renderReadinessPills = (extraClass = '', ariaLabel = 'Chat readiness and support boundary') => (
-    <div className={`chat-readiness-pill-row chat-readiness-strip-live ${extraClass} is-${readinessState}`} aria-label={ariaLabel}>
+    <div className={`chat-readiness-pill-row chat-readiness-strip-live ${extraClass} is-${readinessState}`} aria-label={ariaLabel} aria-live="polite">
       <div className="chat-readiness-pill" title={runtimeStatusCopy}>
         <span>Runtime</span>
         <strong>{runtimeStatusLabel}</strong>
@@ -609,19 +627,29 @@ export default function ChatWorkspace({
       )
     }
 
+    const modelOptionLabel = (model) => {
+      const gate = getChatGateState(capabilities, model, runtime)
+      if (gate.chatUnlocked) return `${model.name} · Ready`
+      if (apiUnavailable) return `${model.name} · API unavailable`
+      if (gate.runtimeReady) return `${model.name} · Support gated`
+      if (gate.runtimeLoaded) return `${model.name} · Loading`
+      return `${model.name} · Not loaded`
+    }
+
     return (
       <label className="composer-model-picker" title={modelPickerTitle}>
         <span className="composer-tool-label">Model</span>
         <select
           className="composer-model-select"
           aria-label="Choose model for chat"
-          value={selectedModel?.id || selectedModelId}
+          value={selectedModel?.id || selectedModelId || ''}
           onChange={(e) => setSelectedModelId(e.target.value)}
           disabled={generationActive}
         >
-          {runnableModels.map((model) => (
+          {!selectedModel && <option value="">Choose model</option>}
+          {models.map((model) => (
             <option key={model.id} value={model.id}>
-              {model.name}
+              {modelOptionLabel(model)}
             </option>
           ))}
         </select>
@@ -672,7 +700,7 @@ export default function ChatWorkspace({
               )}
 
               <div className="composer composer-assistant composer-assistant-stage composer-assistant-stage-clean composer-assistant-product">
-                <textarea className="composer-input composer-input-assistant composer-input-assistant-stage" value={composer} onChange={(e) => setComposer(e.target.value)} onKeyDown={handleComposerKeyDown} rows={2} placeholder={selectedModelRunnable ? 'Message Camelid…' : 'Load a model first'} disabled={generationActive || !selectedModelRunnable} />
+                <textarea className="composer-input composer-input-assistant composer-input-assistant-stage" value={composer} onChange={(e) => setComposer(e.target.value)} onKeyDown={handleComposerKeyDown} rows={2} placeholder={selectedModelRunnable ? 'Message Camelid…' : apiUnavailable ? 'Camelid API unavailable' : 'Load a model first'} disabled={generationActive || !selectedModelRunnable} />
                 <div className="composer-assistant-footer composer-assistant-footer-stage composer-assistant-footer-stage-clean">
                   <div className="composer-assistant-tools composer-assistant-tools-stage composer-assistant-tools-stage-clean">
                     {renderModelPicker()}
@@ -745,7 +773,7 @@ export default function ChatWorkspace({
 
       {!isFreshThread && (
         <div className="composer composer-assistant composer-assistant-floating">
-          <textarea className="composer-input composer-input-assistant" value={composer} onChange={(e) => setComposer(e.target.value)} onKeyDown={handleComposerKeyDown} rows={3} placeholder={selectedModelRunnable ? 'Ask Camelid' : 'Choose a ready model first'} disabled={generationActive || !selectedModelRunnable} />
+          <textarea className="composer-input composer-input-assistant" value={composer} onChange={(e) => setComposer(e.target.value)} onKeyDown={handleComposerKeyDown} rows={3} placeholder={selectedModelRunnable ? 'Ask Camelid' : apiUnavailable ? 'Camelid API unavailable' : 'Choose a ready model first'} disabled={generationActive || !selectedModelRunnable} />
           <div className="composer-assistant-footer">
             <div className="composer-assistant-tools">
               {renderModelPicker()}


### PR DESCRIPTION
## Summary

Describe the change in 2-4 bullets.

## Why this change exists

Explain the user-visible or engineering reason for the change.

## Validation

- [ ] `git diff --check`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [ ] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [ ] No private hostnames, SSH commands, user home paths, key paths, or local validation details are included
- [ ] `bash scripts/check-public-scrub.sh`
- [ ] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [ ] This PR does not overclaim support
- [ ] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [ ] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

Link logs, screenshots, parity outputs, or notes here.

## Docs impact

List any README / compatibility / status / roadmap updates included in this PR.
