### PR TITLE
perf(q8): label VNNI rawptr telemetry route

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -8887,6 +8887,16 @@ fn record_q8_ffn_down_vnni_decode_reject(
     );
 }
 
+fn q8_ffn_down_vnni_decode_route_name() -> &'static str {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        if x86_q8_vnni_decode_rawptr_enabled() {
+            return "x86_vnni_decode_rawptr_consumer";
+        }
+    }
+    "x86_vnni_decode_consumer"
+}
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn x86_q8_vnni_decode_cpu_supported() -> bool {
     x86_q8_vnni_decode_avx512_supported() || std::arch::is_x86_feature_detected!("avx2")
@@ -11405,7 +11415,7 @@ fn try_x86_q8_ffn_down_decode_consumer_path(
             add_q8_schedule_counter(&Q8_SCHED_FFN_DOWN_VNNI_DECODE_TAKEN, 1);
             record_q8_schedule_projection_route_elapsed(
                 "ffn_down",
-                "x86_vnni_decode_consumer",
+                q8_ffn_down_vnni_decode_route_name(),
                 name,
                 1,
                 route.input_width,

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -4107,6 +4107,45 @@ fn q8_ffn_down_vnni_decode_rawptr_matches_rows4_decode_baseline() {
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
+fn q8_ffn_down_vnni_decode_rawptr_records_selected_route() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    if !x86_q8_vnni_decode_cpu_supported() {
+        std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE");
+        std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR");
+        return;
+    }
+    std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR", "on");
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+    let (input, packed_weight, _expected) = runtime_vnni_packed_ffn_down_case();
+
+    let _ = try_x86_q8_ffn_down_decode_consumer_path(
+        &input,
+        &packed_weight,
+        "layer_11_ffn_down",
+        "ffn_down",
+        &ffn_down_vnni_decode_plan(true),
+    )
+    .unwrap()
+    .expect("rawptr VNNI FFN-down decode output");
+
+    let telemetry = snapshot_q8_schedule_telemetry();
+    assert_eq!(telemetry.ffn_down_vnni_decode_taken, 1);
+    assert!(telemetry
+        .output_projection_by_route
+        .contains_key("ffn_down.x86_vnni_decode_rawptr_consumer"));
+    assert!(telemetry
+        .output_projection_by_layer_route
+        .contains_key("layer_11.ffn_down.x86_vnni_decode_rawptr_consumer"));
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
+    std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR");
+    std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE");
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
 fn q8_ffn_down_vnni_decode_rawptr_avx2_matches_rows4_decode_baseline() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();


### PR DESCRIPTION
## Summary
- Record a distinct Q8 schedule route name when the default-off FFN-down VNNI raw-pointer kernel is selected.
- Keep the existing non-rawptr VNNI route name for scalar/non-rawptr runs.
- Add Linux x86_64 test coverage so telemetry proves rawptr route selection.

## Validation
- Linux x86_64 focused route-selection tests passed on the PR branch before closure.
- Same-host bounded parity/timing guardrails passed and proved the rawptr route telemetry key was emitted.
- The measured same-host result rejected any throughput, default-on, or support-promotion claim; this remains default-off route/parity evidence only.

## Closure
The same change was ported onto current `main` after #95-#98 landed and pushed directly as `f1433ed` (`perf(q8): label VNNI rawptr route`). This stale pre-refactor PR branch is closed unmerged.