### PR TITLE
perf(q8): route VNNI rawptr gate through runtime plan

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -8548,10 +8548,10 @@ fn record_q8_ffn_down_vnni_decode_reject(
     );
 }
 
-fn q8_ffn_down_vnni_decode_route_name() -> &'static str {
+fn q8_ffn_down_vnni_decode_route_name(use_rawptr: bool) -> &'static str {
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
-        if x86_q8_vnni_decode_rawptr_enabled() {
+        if use_rawptr {
             return "x86_vnni_decode_rawptr_consumer";
         }
     }
@@ -8580,6 +8580,7 @@ fn q8_0_vnni_decode_1x64_projection(
     quantized_input: &[Q8_0Block],
     output_width: usize,
     name: &str,
+    use_rawptr: bool,
 ) -> Result<CpuTensor> {
     if packed.rows != output_width
         || packed.blocks_per_row != quantized_input.len()
@@ -8595,7 +8596,7 @@ fn q8_0_vnni_decode_1x64_projection(
     }
 
     let mut output = vec![0.0_f32; output_width];
-    q8_0_vnni_decode_1x64_projection_into(packed, quantized_input, &mut output)?;
+    q8_0_vnni_decode_1x64_projection_into(packed, quantized_input, &mut output, use_rawptr)?;
     CpuTensor::from_f32(name, vec![1, output_width], output)
 }
 
@@ -8603,6 +8604,7 @@ fn q8_0_vnni_decode_1x64_projection_into(
     packed: &Q8_0VnniPacked,
     quantized_input: &[Q8_0Block],
     output: &mut [f32],
+    use_rawptr: bool,
 ) -> Result<()> {
     let output_width = output.len();
     if packed.rows != output_width
@@ -8620,9 +8622,9 @@ fn q8_0_vnni_decode_1x64_projection_into(
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
-        if x86_q8_vnni_decode_rawptr_enabled() {
-            // SAFETY: runtime feature detection in `x86_q8_vnni_decode_rawptr_enabled`
-            // confirms the selected x86 SIMD support, and the shape guard above proves that
+        if use_rawptr && x86_q8_vnni_decode_rawptr_supported() {
+            // SAFETY: runtime feature detection confirms the selected x86 SIMD support,
+            // and the shape guard above proves that
             // `packed.tiles`, `quantized_input`, and `output` cover every 64-row group.
             unsafe {
                 if x86_q8_vnni_decode_avx512_supported() {
@@ -8664,9 +8666,8 @@ fn q8_0_vnni_decode_1x64_projection_into(
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-fn x86_q8_vnni_decode_rawptr_enabled() -> bool {
-    q8_0_env_flag_enabled_default_off("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR")
-        && (x86_q8_vnni_decode_avx512_supported() || std::arch::is_x86_feature_detected!("avx2"))
+fn x86_q8_vnni_decode_rawptr_supported() -> bool {
+    x86_q8_vnni_decode_avx512_supported() || std::arch::is_x86_feature_detected!("avx2")
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -11061,11 +11062,13 @@ fn try_x86_q8_ffn_down_decode_consumer_path(
                 );
             }
             let kernel_started = q8_schedule_telemetry_enabled().then(Instant::now);
+            let use_rawptr = runtime_plan.q8.ffn_down_vnni_decode_rawptr;
             let output = q8_0_vnni_decode_1x64_projection(
                 vnni_packed,
                 &quantized_input.blocks,
                 route.output_width,
                 name,
+                use_rawptr,
             )?;
             if let Some(started) = kernel_started {
                 add_q8_schedule_counter(
@@ -11076,7 +11079,7 @@ fn try_x86_q8_ffn_down_decode_consumer_path(
             add_q8_schedule_counter(&Q8_SCHED_FFN_DOWN_VNNI_DECODE_TAKEN, 1);
             record_q8_schedule_projection_route_elapsed(
                 "ffn_down",
-                q8_ffn_down_vnni_decode_route_name(),
+                q8_ffn_down_vnni_decode_route_name(use_rawptr),
                 name,
                 1,
                 route.input_width,

--- a/src/inference/q8_runtime.rs
+++ b/src/inference/q8_runtime.rs
@@ -30,6 +30,7 @@ pub(super) struct Q8RuntimeFlags {
     pub(super) ffn_down_amx_prefill: bool,
     pub(super) ffn_down_single_owner: bool,
     pub(super) ffn_down_vnni_decode: bool,
+    pub(super) ffn_down_vnni_decode_rawptr: bool,
     pub(super) metal: bool,
     pub(super) metal_retained: bool,
     pub(super) hybrid_retained: bool,
@@ -129,6 +130,9 @@ impl Q8RuntimeFlags {
             ),
             ffn_down_vnni_decode: q8_0_env_flag_enabled_default_off(
                 "CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE",
+            ),
+            ffn_down_vnni_decode_rawptr: q8_0_env_flag_enabled_default_off(
+                "CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR",
             ),
             metal: q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8"),
             metal_retained: q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8_RETAINED"),

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -1665,6 +1665,7 @@ fn q8_0_hot_path_uses_resolved_plan_not_current_env() {
             ffn_down_amx_prefill: false,
             ffn_down_single_owner: false,
             ffn_down_vnni_decode: false,
+            ffn_down_vnni_decode_rawptr: false,
             metal: false,
             metal_retained: false,
             hybrid_retained: false,
@@ -1769,6 +1770,8 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     std::env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER", "on");
     std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER", "on");
     std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_PACKED_ROWS4_MATMUL", "on");
+    std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE", "on");
+    std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR", "on");
     std::env::set_var("CAMELID_HYBRID_Q8_GPU_ROWS", "7");
     std::env::set_var("CAMELID_HYBRID_Q8_GPU_PERCENT", "25");
 
@@ -1796,6 +1799,8 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     assert!(plan.q8.ffn_gate_up_single_owner);
     assert!(plan.q8.ffn_down_decode_consumer);
     assert!(plan.q8.ffn_down_packed_rows4_matmul);
+    assert!(plan.q8.ffn_down_vnni_decode);
+    assert!(plan.q8.ffn_down_vnni_decode_rawptr);
     std::env::remove_var("CAMELID_X86_Q8_ATTENTION_PROJECTION_DECODE_CONSUMER");
     std::env::remove_var("CAMELID_X86_Q8_ATTENTION_OUTPUT_DECODE_CONSUMER");
     std::env::remove_var("CAMELID_X86_Q8_ATTENTION_OUTPUT_PACKED_ROWS4_MATMUL");
@@ -1813,6 +1818,8 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     std::env::remove_var("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER");
     std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER");
     std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_PACKED_ROWS4_MATMUL");
+    std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE");
+    std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR");
     assert!(
         plan.q8.attention_projection_decode_consumer,
         "resolved plan should cache the attention projection consumer gate"
@@ -1876,6 +1883,14 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     assert!(
         plan.q8.ffn_down_packed_rows4_matmul,
         "resolved plan should cache the packed-rows4 matmul gate"
+    );
+    assert!(
+        plan.q8.ffn_down_vnni_decode,
+        "resolved plan should cache the FFN-down VNNI decode gate"
+    );
+    assert!(
+        plan.q8.ffn_down_vnni_decode_rawptr,
+        "resolved plan should cache the FFN-down VNNI rawptr decode gate"
     );
     assert_eq!(plan.q8.hybrid_gpu_rows, Some(7));
     assert_eq!(plan.q8.hybrid_gpu_percent, 25);
@@ -1973,6 +1988,14 @@ fn runtime_profile_defaults_keep_experimental_q8_gates_closed() {
         assert!(
             !plan.q8.ffn_down_packed_rows4_matmul,
             "{profile} should not enable packed-rows4 matmul by default"
+        );
+        assert!(
+            !plan.q8.ffn_down_vnni_decode,
+            "{profile} should not enable FFN-down VNNI decode by default"
+        );
+        assert!(
+            !plan.q8.ffn_down_vnni_decode_rawptr,
+            "{profile} should not enable FFN-down VNNI rawptr decode by default"
         );
         assert!(
             !plan.q8.metal,
@@ -2529,6 +2552,7 @@ fn q8_attention_consumer_plan(
             ffn_down_amx_prefill: false,
             ffn_down_single_owner: false,
             ffn_down_vnni_decode: false,
+            ffn_down_vnni_decode_rawptr: false,
             metal: false,
             metal_retained: false,
             hybrid_retained: false,
@@ -3441,6 +3465,7 @@ fn ffn_down_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             ffn_down_amx_prefill: false,
             ffn_down_single_owner: false,
             ffn_down_vnni_decode: false,
+            ffn_down_vnni_decode_rawptr: false,
             metal: false,
             metal_retained: false,
             hybrid_retained: false,
@@ -3453,6 +3478,8 @@ fn ffn_down_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
 fn ffn_down_vnni_decode_plan(enabled: bool) -> ResolvedRuntimePlan {
     let mut plan = ffn_down_consumer_plan(false);
     plan.q8.ffn_down_vnni_decode = enabled;
+    plan.q8.ffn_down_vnni_decode_rawptr =
+        q8_0_env_flag_enabled_default_off("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR");
     plan
 }
 
@@ -3485,6 +3512,7 @@ fn ffn_down_packed_rows4_matmul_plan(enabled: bool) -> ResolvedRuntimePlan {
             ffn_down_amx_prefill: false,
             ffn_down_single_owner: false,
             ffn_down_vnni_decode: false,
+            ffn_down_vnni_decode_rawptr: false,
             metal: false,
             metal_retained: false,
             hybrid_retained: false,
@@ -3535,6 +3563,7 @@ fn ffn_gate_up_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             ffn_down_amx_prefill: false,
             ffn_down_single_owner: false,
             ffn_down_vnni_decode: false,
+            ffn_down_vnni_decode_rawptr: false,
             metal: false,
             metal_retained: false,
             hybrid_retained: false,


### PR DESCRIPTION
## Summary
- Cache `CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR` in `Q8RuntimeFlags`.
- Pass the rawptr decision through the FFN-down VNNI decode route instead of re-reading the environment in the hot path.
- Extend runtime-plan tests so the rawptr gate is captured once and remains default-off.

## Validation
- CI run #676 passed.
- Focused Rust tests covered resolved runtime plan capture, default-off experimental gates, hot-path plan usage, and FFN-down VNNI decode behavior.

No same-host llama.cpp timing comparison was run for this slice; this is default-off control-plane/code hygiene, not a retained speed claim.