### PR TITLE
perf(q8): cache FFN-down decode chunking gate

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -8128,8 +8128,7 @@ fn try_x86_q8_ffn_decode_chain_path(
     );
 
     let down_started = Instant::now();
-    let decode_group_chunking = mac_q8_ffn_down_decode_group_chunking_enabled()
-        || x86_q8_ffn_down_decode_group_chunking_enabled();
+    let decode_group_chunking = runtime_plan.q8.ffn_down_decode_group_chunking;
     let output = q8_0_packed_rows4_single_input_projection_with_decode_chunking(
         down_route.packed,
         &quantized_activated.blocks,
@@ -8436,6 +8435,7 @@ fn x86_q8_packed_rows4_serial_decode_enabled() -> bool {
     q8_0_env_flag_enabled_default_off("CAMELID_X86_Q8_PACKED_ROWS4_SERIAL_DECODE")
 }
 
+#[allow(dead_code)]
 fn mac_q8_ffn_down_decode_group_chunking_enabled() -> bool {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     {
@@ -8499,6 +8499,7 @@ fn q8_ffn_down_decode_consumer_route_name(decode_group_chunking: bool) -> &'stat
     }
 }
 
+#[allow(dead_code)]
 fn x86_q8_ffn_down_decode_group_chunking_enabled() -> bool {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -11098,8 +11099,7 @@ fn try_x86_q8_ffn_down_decode_consumer_path(
     let telemetry_started = q8_schedule_telemetry_enabled().then(Instant::now);
     add_q8_schedule_counter(&Q8_SCHED_FFN_DOWN_DECODE_CONSUMER_TAKEN, 1);
     let quantized_input = quantize_q8_0_row(&input.data[..route.input_width]);
-    let decode_group_chunking = mac_q8_ffn_down_decode_group_chunking_enabled()
-        || x86_q8_ffn_down_decode_group_chunking_enabled();
+    let decode_group_chunking = runtime_plan.q8.ffn_down_decode_group_chunking;
     let output = q8_0_packed_rows4_single_input_projection_with_decode_chunking(
         route.packed,
         &quantized_input.blocks,

--- a/src/inference/q8_runtime.rs
+++ b/src/inference/q8_runtime.rs
@@ -23,6 +23,7 @@ pub(super) struct Q8RuntimeFlags {
     pub(super) ffn_gate_up_packed_rows4_matmul: bool,
     pub(super) ffn_gate_up_single_owner: bool,
     pub(super) ffn_down_decode_consumer: bool,
+    pub(super) ffn_down_decode_group_chunking: bool,
     pub(super) ffn_down_packed_rows4_matmul: bool,
     pub(super) ffn_down_gemm4_prefill: bool,
     pub(super) ffn_down_gemm4_row_group_schedule: bool,
@@ -110,6 +111,11 @@ impl Q8RuntimeFlags {
                 "CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER",
             ) || q8_0_env_flag_enabled_default_off(
                 "CAMELID_MAC_Q8_FFN_DOWN_DECODE_CONSUMER",
+            ),
+            ffn_down_decode_group_chunking: q8_0_env_flag_enabled_default_off(
+                "CAMELID_X86_Q8_FFN_DOWN_DECODE_GROUP_CHUNKING",
+            ) || q8_0_env_flag_enabled_default_off(
+                "CAMELID_MAC_Q8_FFN_DOWN_DECODE_GROUP_CHUNKING",
             ),
             ffn_down_packed_rows4_matmul: x86_q8_ffn_down_packed_rows4_matmul_enabled(),
             ffn_down_gemm4_prefill: q8_0_env_flag_enabled_default_off(

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -1658,6 +1658,7 @@ fn q8_0_hot_path_uses_resolved_plan_not_current_env() {
             ffn_gate_up_packed_rows4_matmul: false,
             ffn_gate_up_single_owner: false,
             ffn_down_decode_consumer: false,
+            ffn_down_decode_group_chunking: false,
             ffn_down_packed_rows4_matmul: false,
             ffn_down_gemm4_prefill: false,
             ffn_down_gemm4_row_group_schedule: false,
@@ -1768,6 +1769,7 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     std::env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL", "on");
     std::env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER", "on");
     std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER", "on");
+    std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_GROUP_CHUNKING", "on");
     std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_PACKED_ROWS4_MATMUL", "on");
     std::env::set_var("CAMELID_HYBRID_Q8_GPU_ROWS", "7");
     std::env::set_var("CAMELID_HYBRID_Q8_GPU_PERCENT", "25");
@@ -1795,6 +1797,7 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     assert!(plan.q8.ffn_gate_up_packed_rows4_matmul);
     assert!(plan.q8.ffn_gate_up_single_owner);
     assert!(plan.q8.ffn_down_decode_consumer);
+    assert!(plan.q8.ffn_down_decode_group_chunking);
     assert!(plan.q8.ffn_down_packed_rows4_matmul);
     std::env::remove_var("CAMELID_X86_Q8_ATTENTION_PROJECTION_DECODE_CONSUMER");
     std::env::remove_var("CAMELID_X86_Q8_ATTENTION_OUTPUT_DECODE_CONSUMER");
@@ -1812,6 +1815,7 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     std::env::remove_var("CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL");
     std::env::remove_var("CAMELID_X86_Q8_FFN_GATE_UP_SINGLE_OWNER");
     std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER");
+    std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_GROUP_CHUNKING");
     std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_PACKED_ROWS4_MATMUL");
     assert!(
         plan.q8.attention_projection_decode_consumer,
@@ -1872,6 +1876,10 @@ fn resolved_runtime_plan_captures_q8_env_once() {
     assert!(
         plan.q8.ffn_down_decode_consumer,
         "resolved plan should cache the FFN-down consumer gate"
+    );
+    assert!(
+        plan.q8.ffn_down_decode_group_chunking,
+        "resolved plan should cache the FFN-down decode group-chunking gate"
     );
     assert!(
         plan.q8.ffn_down_packed_rows4_matmul,
@@ -2522,6 +2530,7 @@ fn q8_attention_consumer_plan(
             ffn_gate_up_packed_rows4_matmul: false,
             ffn_gate_up_single_owner: false,
             ffn_down_decode_consumer: false,
+            ffn_down_decode_group_chunking: false,
             ffn_down_packed_rows4_matmul: false,
             ffn_down_gemm4_prefill: false,
             ffn_down_gemm4_row_group_schedule: false,
@@ -3434,6 +3443,7 @@ fn ffn_down_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             ffn_gate_up_packed_rows4_matmul: false,
             ffn_gate_up_single_owner: false,
             ffn_down_decode_consumer: enabled,
+            ffn_down_decode_group_chunking: false,
             ffn_down_packed_rows4_matmul: false,
             ffn_down_gemm4_prefill: false,
             ffn_down_gemm4_row_group_schedule: false,
@@ -3478,6 +3488,7 @@ fn ffn_down_packed_rows4_matmul_plan(enabled: bool) -> ResolvedRuntimePlan {
             ffn_gate_up_packed_rows4_matmul: false,
             ffn_gate_up_single_owner: false,
             ffn_down_decode_consumer: false,
+            ffn_down_decode_group_chunking: false,
             ffn_down_packed_rows4_matmul: enabled,
             ffn_down_gemm4_prefill: false,
             ffn_down_gemm4_row_group_schedule: false,
@@ -3528,6 +3539,7 @@ fn ffn_gate_up_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             ffn_gate_up_packed_rows4_matmul: false,
             ffn_gate_up_single_owner: false,
             ffn_down_decode_consumer: false,
+            ffn_down_decode_group_chunking: false,
             ffn_down_packed_rows4_matmul: false,
             ffn_down_gemm4_prefill: false,
             ffn_down_gemm4_row_group_schedule: false,
@@ -4371,13 +4383,17 @@ fn mac_q8_ffn_down_decode_group_chunking_is_default_off_and_matches_consumer() {
     std::env::set_var("CAMELID_MAC_Q8_FFN_DOWN_DECODE_GROUPS_PER_CHUNK", "2");
     assert!(mac_q8_ffn_down_decode_group_chunking_enabled());
     assert_eq!(mac_q8_ffn_down_decode_groups_per_chunk(), 2);
+    let mut chunked_plan = plan;
+    chunked_plan.q8.ffn_down_decode_group_chunking =
+        Q8RuntimeFlags::from_env().ffn_down_decode_group_chunking;
+    assert!(chunked_plan.q8.ffn_down_decode_group_chunking);
 
     let chunked = try_x86_q8_ffn_down_decode_consumer_path(
         &input,
         &packed_weight,
         "chunked",
         "ffn_down",
-        &plan,
+        &chunked_plan,
     )
     .unwrap()
     .expect("chunked ffn_down consumer");
@@ -4412,18 +4428,22 @@ fn x86_q8_ffn_down_decode_group_chunking_is_default_off_and_matches_consumer() {
     std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_GROUP_CHUNKING", "on");
     std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_DECODE_GROUPS_PER_CHUNK", "2");
     assert!(x86_q8_ffn_down_decode_group_chunking_enabled());
+    assert!(Q8RuntimeFlags::from_env().ffn_down_decode_group_chunking);
     assert_eq!(q8_ffn_down_decode_groups_per_chunk(), 2);
     assert_eq!(
         q8_ffn_down_decode_consumer_route_name(true),
         "x86_decode_consumer_group_chunking"
     );
 
+    let mut chunked_plan = plan;
+    chunked_plan.q8.ffn_down_decode_group_chunking =
+        Q8RuntimeFlags::from_env().ffn_down_decode_group_chunking;
     let chunked = try_x86_q8_ffn_down_decode_consumer_path(
         &input,
         &packed_weight,
         "chunked",
         "ffn_down",
-        &plan,
+        &chunked_plan,
     )
     .unwrap()
     .expect("chunked ffn_down consumer");


### PR DESCRIPTION
## Summary
- Add `ffn_down_decode_group_chunking` to the resolved Q8 runtime plan.
- Route FFN-down decode consumer and FFN decode-chain down projection through the resolved plan instead of re-reading chunking env gates.
- Extend runtime-plan and FFN-down chunking tests so the gate stays default-off and cached once.

## Validation
- CI run #678 passed.
- Focused Rust checks covered resolved runtime plan capture, FFN-down chunking default-off behavior, formatting, and clippy.

No same-host llama.cpp timing comparison was run for this slice; this is default-off control-plane/code hygiene, not a retained speed claim.