### PR TITLE
Frontend: polish Camelid chat readiness UI

### DIFF
--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -2594,10 +2594,36 @@ textarea.composer-input-assistant {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 30px 7px 10px;
+  padding: 7px 30px 7px 12px;
   border: 1px solid color-mix(in srgb, var(--color-border-soft) 62%, transparent);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.04);
+}
+
+.composer-model-picker::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--color-text-muted);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-text-muted) 9%, transparent);
+}
+
+.composer-model-picker.is-ready::before {
+  background: var(--color-ready);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-ready) 13%, transparent);
+}
+
+.composer-model-picker.is-blocked::before,
+.composer-model-picker.is-offline::before {
+  background: var(--color-error);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-error) 12%, transparent);
+}
+
+.composer-model-picker.is-waiting::before {
+  background: var(--color-warning);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-warning) 12%, transparent);
 }
 
 .composer-model-picker::after {
@@ -5584,6 +5610,17 @@ textarea.composer-input-assistant {
 
 .composer-assistant-readiness-note.is-waiting {
   color: color-mix(in srgb, var(--color-warning) 60%, var(--color-text-muted) 40%);
+}
+
+.composer-assistant-readiness-note.is-offline {
+  color: color-mix(in srgb, var(--color-error) 60%, var(--color-text-muted) 40%);
+}
+
+.composer-assistant-readiness-note-floating {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid color-mix(in srgb, var(--color-border-soft) 44%, transparent);
+  font-size: 0.76rem;
 }
 
 .chat-layout-empty .composer-assistant-disclaimer-product {

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -433,6 +433,7 @@ export default function ChatWorkspace({
   const [generationElapsedSeconds, setGenerationElapsedSeconds] = useState(0)
   const chatBottomRef = useRef(null)
   const autoFollowGenerationRef = useRef(true)
+  const composerReadinessId = 'camelid-chat-readiness-note'
   const rawVisibleMessages = useMemo(
     () => (selectedConversation?.messages || []).filter((message) => !isBootstrapMessage(message)),
     [selectedConversation?.messages],
@@ -627,8 +628,6 @@ export default function ChatWorkspace({
       )
     }
 
-    const runnableModels = models.filter((model) => getChatGateState(capabilities, model, runtime).chatUnlocked)
-
     const modelOptionLabel = (model) => {
       const gate = getChatGateState(capabilities, model, runtime)
       if (gate.chatUnlocked) return `${model.name} · Ready`
@@ -638,17 +637,21 @@ export default function ChatWorkspace({
       return `${model.name} · Not loaded`
     }
 
+    const runnableModels = models.filter((model) => getChatGateState(capabilities, model, runtime).chatUnlocked)
+    const waitingModels = models.filter((model) => !getChatGateState(capabilities, model, runtime).chatUnlocked)
+    const selectedRunnableModelId = runnableModels.some((model) => model.id === selectedModel?.id) ? selectedModel.id : ''
+
     return (
-      <label className="composer-model-picker" title={modelPickerTitle}>
+      <label className={`composer-model-picker is-${readinessState}`} title={modelPickerTitle}>
         <span className="composer-tool-label">Model</span>
         <select
           className="composer-model-select"
           aria-label="Choose model for chat"
-          value={selectedModel?.id || selectedModelId || ''}
+          value={selectedRunnableModelId}
           onChange={(e) => setSelectedModelId(e.target.value)}
           disabled={generationActive}
         >
-          {!selectedModel && <option value="">Choose model</option>}
+          {(!selectedModel || !runnableModels.length) && <option value="">{waitingModels.length ? 'No ready models' : 'Choose model'}</option>}
           {runnableModels.map((model) => (
             <option key={model.id} value={model.id}>
               {modelOptionLabel(model)}
@@ -702,7 +705,7 @@ export default function ChatWorkspace({
               )}
 
               <div className="composer composer-assistant composer-assistant-stage composer-assistant-stage-clean composer-assistant-product">
-                <textarea className="composer-input composer-input-assistant composer-input-assistant-stage" value={composer} onChange={(e) => setComposer(e.target.value)} onKeyDown={handleComposerKeyDown} rows={2} placeholder={selectedModelRunnable ? 'Message Camelid…' : apiUnavailable ? 'Camelid API unavailable' : 'Load a model first'} disabled={generationActive || !selectedModelRunnable} />
+                <textarea className="composer-input composer-input-assistant composer-input-assistant-stage" aria-label="Message Camelid" aria-describedby={composerReadinessId} value={composer} onChange={(e) => setComposer(e.target.value)} onKeyDown={handleComposerKeyDown} rows={2} placeholder={selectedModelRunnable ? 'Message Camelid…' : apiUnavailable ? 'Camelid API unavailable' : 'Load a model first'} disabled={generationActive || !selectedModelRunnable} />
                 <div className="composer-assistant-footer composer-assistant-footer-stage composer-assistant-footer-stage-clean">
                   <div className="composer-assistant-tools composer-assistant-tools-stage composer-assistant-tools-stage-clean">
                     {renderModelPicker()}
@@ -712,7 +715,7 @@ export default function ChatWorkspace({
                     <button className="primary-button composer-send-button" onClick={sendMessage} disabled={!canSubmit}>{generationActive ? `Generating ${generationElapsedSeconds}s…` : 'Send'}</button>
                   </div>
                 </div>
-                <p className={`composer-assistant-readiness-note is-${readinessState}`}>{readinessFinePrint}</p>
+                <p id={composerReadinessId} className={`composer-assistant-readiness-note is-${readinessState}`}>{readinessFinePrint}</p>
               </div>
             </div>
           </div>
@@ -775,7 +778,7 @@ export default function ChatWorkspace({
 
       {!isFreshThread && (
         <div className="composer composer-assistant composer-assistant-floating">
-          <textarea className="composer-input composer-input-assistant" value={composer} onChange={(e) => setComposer(e.target.value)} onKeyDown={handleComposerKeyDown} rows={3} placeholder={selectedModelRunnable ? 'Ask Camelid' : apiUnavailable ? 'Camelid API unavailable' : 'Choose a ready model first'} disabled={generationActive || !selectedModelRunnable} />
+          <textarea className="composer-input composer-input-assistant" aria-label="Message Camelid" aria-describedby={composerReadinessId} value={composer} onChange={(e) => setComposer(e.target.value)} onKeyDown={handleComposerKeyDown} rows={3} placeholder={selectedModelRunnable ? 'Ask Camelid' : apiUnavailable ? 'Camelid API unavailable' : 'Choose a ready model first'} disabled={generationActive || !selectedModelRunnable} />
           <div className="composer-assistant-footer">
             <div className="composer-assistant-tools">
               {renderModelPicker()}
@@ -787,6 +790,7 @@ export default function ChatWorkspace({
               <button className="primary-button composer-send-button" onClick={sendMessage} disabled={!canSubmit}>{generationActive ? `Generating ${generationElapsedSeconds}s…` : 'Send'}</button>
             </div>
           </div>
+          <p id={composerReadinessId} className={`composer-assistant-readiness-note composer-assistant-readiness-note-floating is-${readinessState}`}>{readinessFinePrint}</p>
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary
- Refines the Camelid chat composer readiness affordance for ready, waiting, blocked, and offline states.
- Keeps the chat model selector exact-row gated while showing clearer no-ready-model and disabled composer copy.
- Adds accessible composer readiness descriptions for empty and active chat states.

## Validation
- CI run #684 passed.
- Frontend smoke, integration, 3B closure, model-state, streaming, and production build checks passed.