### PR TITLE
test(q8): guard VNNI rawptr plan isolation

### DIFF
--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -1323,6 +1323,12 @@ mod tests {
         assert_eq!(
             outcome
                 .env_updates
+                .get("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR"),
+            Some(&Some("off"))
+        );
+        assert_eq!(
+            outcome
+                .env_updates
                 .get("CAMELID_X86_Q8_FFN_DOWN_DECODE_OWNER"),
             Some(&Some("off"))
         );

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -4194,6 +4194,47 @@ fn q8_ffn_down_vnni_decode_rawptr_records_selected_route() {
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[test]
+fn q8_ffn_down_vnni_decode_rawptr_env_does_not_bypass_runtime_plan() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    if !x86_q8_vnni_decode_cpu_supported() {
+        std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE");
+        std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR");
+        return;
+    }
+    std::env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR", "on");
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+    let (input, packed_weight, _expected) = runtime_vnni_packed_ffn_down_case();
+    let mut plan = ffn_down_vnni_decode_plan(true);
+    plan.q8.ffn_down_vnni_decode_rawptr = false;
+
+    let _ = try_x86_q8_ffn_down_decode_consumer_path(
+        &input,
+        &packed_weight,
+        "layer_13_ffn_down",
+        "ffn_down",
+        &plan,
+    )
+    .unwrap()
+    .expect("planned VNNI FFN-down decode output");
+
+    let telemetry = snapshot_q8_schedule_telemetry();
+    assert_eq!(telemetry.ffn_down_vnni_decode_taken, 1);
+    assert!(telemetry
+        .output_projection_by_route
+        .contains_key("ffn_down.x86_vnni_decode_consumer"));
+    assert!(!telemetry
+        .output_projection_by_route
+        .contains_key("ffn_down.x86_vnni_decode_rawptr_consumer"));
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
+    std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR");
+    std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE");
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
 fn q8_ffn_down_vnni_decode_rawptr_avx2_matches_rows4_decode_baseline() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();


### PR DESCRIPTION
## Summary
- add Linux x86 regression coverage proving stale `CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR=on` does not bypass a resolved runtime plan with the rawptr sub-gate disabled
- assert the Ubuntu experimental execution profile explicitly forces the rawptr sub-gate off unless opted in

## Validation
Canonical Ubuntu x86_64 host, branch `q8-rawptr-runtime-plan-20260523`, HEAD `f9ffabf6cdeb237f1d9cfafd24d792cc2afe63b1`:
- `uname -sm` -> `Linux x86_64`
- `cargo --version` -> `cargo 1.95.0 (f2d3ce0bd 2026-03-21)`
- `cargo fmt --check` -> passed
- `cargo test q8_ffn_down_vnni_decode_rawptr_env_does_not_bypass_runtime_plan --lib -- --nocapture` -> passed, 1 test
- `cargo test ubuntu_experimental_validated_gates_select_rust_avx2_q8_path --lib -- --nocapture` -> passed, 1 test

No new throughput claim or same-host llama.cpp benchmark is promoted by this QA/control-plane slice.