### PR TITLE
ci: harden evidence bundle privacy audit

### DIFF
--- a/scripts/audit-evidence-bundle-privacy.mjs
+++ b/scripts/audit-evidence-bundle-privacy.mjs
@@ -37,6 +37,26 @@ const patterns = [
     description: 'Literal EC2 private hostname leaked into durable bundle content',
     regex: /\bip-(?:\d+-){3}\d+\b/g,
   },
+  {
+    id: 'raw_ssh_command',
+    description: 'Raw SSH command leaked into durable bundle content',
+    regex: /(^|[\s"'])ssh\s+(?=[^\n]*(?:-i\b|StrictHostKeyChecking|BatchMode|IdentitiesOnly))[^\n"']*/g,
+  },
+  {
+    id: 'raw_ssh_timeout',
+    description: 'Raw SSH timeout stderr leaked into durable bundle content',
+    regex: /Operation\s+timed\s+out/g,
+  },
+  {
+    id: 'raw_ssh_rc_255',
+    description: 'Raw SSH connection status leaked into durable bundle content',
+    regex: /\brc=25[5]\b/g,
+  },
+  {
+    id: 'ssh_key_path',
+    description: 'SSH private-key path leaked into durable bundle content',
+    regex: /[^\s"']*[.]pem\b/g,
+  },
 ]
 
 await walk(rootDir)

--- a/scripts/test-audit-evidence-bundle-privacy.mjs
+++ b/scripts/test-audit-evidence-bundle-privacy.mjs
@@ -19,6 +19,8 @@ await writeFile(
       model_path: '$CAMELID_MODEL_DIR/Llama-3.2-3B-Instruct-Q8_0.gguf',
       health_endpoint: '127.0.0.1',
       elapsed_seconds: '0.03.255.467',
+      validation_status:
+        'Remote Linux x86_64 validation was unavailable during this cycle; no fresh same-host timing/parity claim is made.',
     },
     null,
     2,
@@ -33,6 +35,9 @@ await writeFile(
       schema: 'camelid.local_smoke.v1',
       host: 'local-only mac smoke',
       model_path: '/Volumes/SSK Drive/Camelid/models/llama-3.2-3b-instruct/Llama-3.2-3B-Instruct-Q8_0.gguf',
+      remote_attempt: 'ssh -i /tmp/operator.pem -o BatchMode=yes ubuntu@203.0.113.7 uname -sm',
+      remote_stderr: 'ssh: connect to host validation.example port 22: Operation timed out',
+      remote_rc: 'rc=255',
     },
     null,
     2,
@@ -55,12 +60,18 @@ assert.equal(safeReport.finding_count, 0)
 const leaked = spawnAudit(leakRoot)
 assert.notEqual(leaked.status, 0, 'mounted-volume paths in evidence bundles must fail strict privacy audit')
 const leakedReport = JSON.parse(leaked.stdout)
-assert.equal(leakedReport.finding_count, 3)
+assert.ok(leakedReport.finding_count >= 7)
 const leakedPatterns = leakedReport.bundles[0].findings.map((finding) => finding.pattern).sort()
-assert.deepEqual(leakedPatterns, ['linux_home_path', 'mac_home_path', 'mac_mounted_volume_path'])
 assert.ok(leakedReport.bundles[0].findings.some((finding) => finding.file.endsWith('/SHA256SUMS')))
 assert.ok(leakedReport.bundles[0].findings.some((finding) => /file:\/\/\/home\/tim\/\.cache\/camelid\/model\.gguf/.test(finding.sample)))
 assert.ok(leakedReport.bundles[0].findings.some((finding) => /Llama-3\.2-3B-Instruct-Q8_0\.gguf/.test(finding.sample)))
+assert.ok(leakedPatterns.includes('mac_mounted_volume_path'))
+assert.ok(leakedPatterns.includes('mac_home_path'))
+assert.ok(leakedPatterns.includes('linux_home_path'))
+assert.ok(leakedPatterns.includes('ipv4_literal'))
+assert.ok(leakedReport.bundles[0].findings.some((finding) => finding.pattern === 'raw_ssh_command'))
+assert.ok(leakedReport.bundles[0].findings.some((finding) => finding.pattern === 'raw_ssh_timeout'))
+assert.ok(leakedReport.bundles[0].findings.some((finding) => finding.pattern === 'raw_ssh_rc_255'))
 
 function spawnAudit(root) {
   return spawnSync(process.execPath, ['scripts/audit-evidence-bundle-privacy.mjs', '--root', root, '--strict'], {


### PR DESCRIPTION
Summary:
- Extend the evidence-bundle privacy auditor to reject raw remote-access command lines, timeout stderr, connection-status markers, and private key-file references in strict mode.
- Extend the auditor self-test so sanitized unavailable-validation wording remains allowed while leaked remote-access evidence is rejected.

Validation:
- `node scripts/test-audit-evidence-bundle-privacy.mjs`
- `bash scripts/check-public-scrub.sh`
- `git diff --check`

Remote Linux x86_64 validation was unavailable during this cycle; no fresh same-host timing/parity claim is made.