### PR TITLE
perf(q8): gate output AMX prefill route

### DIFF
--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -21,6 +21,7 @@ const MANAGED_ENV_KEYS: &[&str] = &[
     "CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUP_CHUNKING",
     "CAMELID_X86_Q8_ATTENTION_QKV_PACKED_ROWS4_MATMUL",
     "CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL",
+    "CAMELID_X86_Q8_OUTPUT_AMX_PREFILL",
     "CAMELID_X86_Q8_PACKED_ROWS4_SERIAL_DECODE",
     "CAMELID_X86_Q8_PARALLEL_INPUT_QUANTIZE",
     "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER",
@@ -421,6 +422,10 @@ fn select_linux_x86_q8_plan(
     env_updates.insert(
         "CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL",
         optional_x86_q8_gate("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL"),
+    );
+    env_updates.insert(
+        "CAMELID_X86_Q8_OUTPUT_AMX_PREFILL",
+        optional_x86_q8_gate("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL"),
     );
     env_updates.insert(
         "CAMELID_X86_Q8_PACKED_ROWS4_SERIAL_DECODE",
@@ -876,6 +881,7 @@ mod tests {
             "CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUP_CHUNKING",
             "CAMELID_X86_Q8_ATTENTION_QKV_PACKED_ROWS4_MATMUL",
             "CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL",
+            "CAMELID_X86_Q8_OUTPUT_AMX_PREFILL",
             "CAMELID_X86_Q8_PACKED_ROWS4_SERIAL_DECODE",
             "CAMELID_X86_Q8_PARALLEL_INPUT_QUANTIZE",
             "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER",
@@ -1215,6 +1221,10 @@ mod tests {
             Some(&Some("off"))
         );
         assert_eq!(
+            outcome.env_updates.get("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL"),
+            Some(&Some("off"))
+        );
+        assert_eq!(
             outcome
                 .env_updates
                 .get("CAMELID_X86_Q8_PACKED_ROWS4_SERIAL_DECODE"),
@@ -1350,6 +1360,7 @@ mod tests {
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_AMX_PREFILL", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR", "on");
+        env::set_var("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL", "on");
         env::set_var("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER", "on");
         env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_PAIRED_DOT", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DECODE_CHAIN", "on");
@@ -1410,6 +1421,10 @@ mod tests {
             Some(&Some("on"))
         );
         assert_eq!(
+            outcome.env_updates.get("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL"),
+            Some(&Some("on"))
+        );
+        assert_eq!(
             outcome
                 .env_updates
                 .get("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER"),
@@ -1457,6 +1472,7 @@ mod tests {
         env::set_var("CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUP_CHUNKING", "on");
         env::set_var("CAMELID_X86_Q8_ATTENTION_QKV_PACKED_ROWS4_MATMUL", "on");
         env::set_var("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL", "on");
+        env::set_var("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL", "on");
         env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER", "on");
         env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_GROUP_CHUNKING", "on");
         env::set_var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_FUSED_ACTIVATION", "on");
@@ -1487,6 +1503,7 @@ mod tests {
         assert!(env::var("CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUP_CHUNKING").is_err());
         assert!(env::var("CAMELID_X86_Q8_ATTENTION_QKV_PACKED_ROWS4_MATMUL").is_err());
         assert!(env::var("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL").is_err());
+        assert!(env::var("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_GROUP_CHUNKING").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_FUSED_ACTIVATION").is_err());

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -7434,7 +7434,19 @@ fn try_x86_q8_output_packed_rows4_matmul_path(
         return Ok(None);
     }
 
+    if x86_q8_output_amx_prefill_enabled() {
+        if let Some(output) =
+            try_q8_0_packed_rows4_amx_prefill_projection(input, packed, output_width, name)?
+        {
+            return Ok(Some(output));
+        }
+    }
+
     q8_0_packed_rows4_matmul_projection(input, packed, output_width, name).map(Some)
+}
+
+fn x86_q8_output_amx_prefill_enabled() -> bool {
+    q8_0_env_flag_enabled_default_off("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL")
 }
 
 fn try_x86_q8_output_decode_owner_path(

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -1334,6 +1334,8 @@ fn clear_dense_diagnostic_env() {
         "CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER",
         "CAMELID_X86_Q8_FFN_DOWN_PACKED_ROWS4_MATMUL",
         "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL",
+        "CAMELID_X86_Q8_AMX_REPACK",
+        "CAMELID_X86_Q8_OUTPUT_AMX_PREFILL",
         "CAMELID_X86_Q8_OUTPUT_DECODE_OWNER",
     ] {
         std::env::remove_var(key);
@@ -7947,6 +7949,79 @@ fn x86_q8_output_packed_rows4_matmul_matches_runtime_packed_baseline_for_prefill
 
     assert_eq!(actual.shape.dims, vec![rows, vocab_rows]);
     assert_eq!(actual.data, expected.data);
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn x86_q8_output_amx_prefill_matches_rows4_matmul_when_supported() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    if unsafe { camelid_x86_q8_amx_supported() } == 0 {
+        return;
+    }
+
+    std::env::set_var("CAMELID_X86_Q8_AMX_REPACK", "on");
+    std::env::set_var("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL", "on");
+    let rows = 20;
+    let vocab_rows = 16;
+    let blocks_per_row = 2;
+    let input_width = blocks_per_row * Q8_0_BLOCK_VALUES;
+    let row_blocks: Vec<Q8_0Block> = (0..vocab_rows * blocks_per_row)
+        .map(|block_idx| Q8_0Block {
+            scale: 0.0625 + (block_idx % 13) as f32 * 0.00390625,
+            quants: std::array::from_fn(|idx| {
+                ((block_idx as i32 * 11 + idx as i32 * 5) % 67 - 33) as i8
+            }),
+        })
+        .collect();
+    let packed = Q8_0PackedRows4::from_rows(
+        vocab_rows,
+        blocks_per_row,
+        Q8_0PackedRows4Interleave::I8,
+        &row_blocks,
+    )
+    .unwrap();
+    assert!(
+        packed.amx_blocks.is_some(),
+        "explicit AMX repack gate should create AMX tile sidecar"
+    );
+    let output_weight = CpuTensor::q8_0_runtime_packed_rows4_linear(
+        "output.weight",
+        TensorShape {
+            dims: vec![input_width, vocab_rows],
+        },
+        packed.clone(),
+    );
+    let input = CpuTensor::from_f32(
+        "output_amx_prefill_hidden",
+        vec![rows, input_width],
+        (0..rows * input_width)
+            .map(|idx| ((idx % 23) as f32 - 11.0) * 0.109375)
+            .collect(),
+    )
+    .unwrap();
+    let plan = output_packed_rows4_matmul_plan(true);
+
+    let actual = output_projection_runtime_with_plan(
+        &input,
+        &output_weight,
+        "output_amx_prefill_logits",
+        &plan,
+        false,
+    )
+    .unwrap();
+    let expected = q8_0_packed_rows4_matmul_projection(
+        &input,
+        &packed,
+        vocab_rows,
+        "expected_output_prefill_logits",
+    )
+    .unwrap();
+
+    assert_eq!(actual.shape.dims, vec![rows, vocab_rows]);
+    assert_slice_close_with_tolerance(&actual.data, &expected.data, 5e-4);
+    std::env::remove_var("CAMELID_X86_Q8_OUTPUT_AMX_PREFILL");
+    std::env::remove_var("CAMELID_X86_Q8_AMX_REPACK");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Route `output.weight` packed rows4 prefill through the existing AMX prefill helper behind `CAMELID_X86_Q8_OUTPUT_AMX_PREFILL=on`.
- Add the new output AMX gate to managed execution-plan env handling.
- Add parity/cleanup coverage for the gated output prefill route while preserving the existing rows4 fallback.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib ubuntu_experimental_validated_gates_select_rust_avx2_q8_path -- --nocapture`
- `cargo test --lib planner_env_apply_clears_stale_x86_q8_decode_consumer_flags -- --nocapture`
- `cargo test --lib x86_q8_output_packed_rows4_matmul_matches_runtime_packed_baseline_for_prefill -- --nocapture`
- `cargo test --lib x86_q8_output_amx_prefill_matches_rows4_matmul_when_supported -- --nocapture` (cfg-gated on non-Linux hosts)
- `cargo clippy --lib -- -D warnings`

Stacked on #111.