### PR TITLE
perf(q8): add default-off attention-output gemm4 prefill route

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -9698,6 +9698,14 @@ fn x86_q8_attention_output_gemm4_row_group_min_input_groups() -> usize {
     }
 }
 
+fn x86_q8_attention_output_gemm4_route_name(row_group_schedule: bool) -> &'static str {
+    if row_group_schedule {
+        "x86_gemm4_prefill_row_group"
+    } else {
+        "x86_gemm4_prefill"
+    }
+}
+
 #[cfg(test)]
 fn should_use_x86_q8_attention_output_gemm4_row_group_schedule(
     enabled: bool,
@@ -10823,26 +10831,82 @@ fn try_x86_q8_attention_output_gemm4_prefill_path(
     rectangular_role: &str,
     runtime_plan: &ResolvedRuntimePlan,
 ) -> Result<Option<CpuTensor>> {
-    if !runtime_plan.q8.attention_output_gemm4_prefill
-        || rectangular_role != "linear"
-        || input.rank() != 2
-        || input.dim(0)? < 4
-        || !weight.name.ends_with(".attn_output.weight")
-    {
+    if rectangular_role != "linear" || input.rank() != 2 {
         return Ok(None);
     }
+    let rows = input.dim(0)?;
     let input_width = input.dim(1)?;
+    let route_name =
+        x86_q8_attention_output_gemm4_route_name(runtime_plan.q8.attention_output_gemm4_row_group_schedule);
+    if !runtime_plan.q8.attention_output_gemm4_prefill {
+        record_q8_schedule_projection_route_denial(
+            "attention_output",
+            route_name,
+            "plan_off",
+            rows,
+            input_width,
+            0,
+        );
+        return Ok(None);
+    }
+    if rows < 4 {
+        record_q8_schedule_projection_route_denial(
+            "attention_output",
+            route_name,
+            "rows_lt4",
+            rows,
+            input_width,
+            0,
+        );
+        return Ok(None);
+    }
+    if !weight.name.ends_with(".attn_output.weight") {
+        record_q8_schedule_projection_route_denial(
+            "attention_output",
+            route_name,
+            "weight_name_mismatch",
+            rows,
+            input_width,
+            0,
+        );
+        return Ok(None);
+    }
     if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        record_q8_schedule_projection_route_denial(
+            "attention_output",
+            route_name,
+            "bad_input_width",
+            rows,
+            input_width,
+            0,
+        );
         return Ok(None);
     }
     let Some((packed, output_width)) = q8_0_runtime_packed_projection(weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_output",
+            route_name,
+            "no_runtime_packed",
+            rows,
+            input_width,
+            0,
+        );
         return Ok(None);
     };
     if packed.interleave != Q8_0PackedRows4Interleave::I8 {
+        record_q8_schedule_projection_route_denial(
+            "attention_output",
+            route_name,
+            "non_i8_interleave",
+            rows,
+            input_width,
+            output_width,
+        );
         return Ok(None);
     }
 
-    q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
+    let telemetry_started = q8_schedule_telemetry_enabled().then(Instant::now);
+    let output = q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
         input,
         packed,
         output_width,
@@ -10850,8 +10914,17 @@ fn try_x86_q8_attention_output_gemm4_prefill_path(
         runtime_plan.q8.attention_output_gemm4_row_group_schedule,
         x86_q8_attention_output_gemm4_row_group_min_input_groups(),
         runtime_plan.q8.attention_output_gemm4_avx2,
-    )
-    .map(Some)
+    )?;
+    record_q8_schedule_projection_route_elapsed(
+        "attention_output",
+        route_name,
+        name,
+        rows,
+        input_width,
+        output_width,
+        telemetry_started,
+    );
+    Ok(Some(output))
 }
 
 fn try_x86_q8_attention_projection_decode_consumer_path(

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4535,6 +4535,15 @@ fn linear_for_role_runtime_with_plan(
         )? {
             return Ok(output);
         }
+        if let Some(output) = try_x86_q8_attention_output_gemm4_prefill_path(
+            input,
+            weight,
+            &name,
+            rectangular_role,
+            runtime_plan,
+        )? {
+            return Ok(output);
+        }
         if let Some(output) = try_x86_q8_attention_output_packed_rows4_matmul_path(
             input,
             weight,
@@ -9659,10 +9668,44 @@ fn x86_q8_ffn_down_gemm4_row_group_min_input_groups() -> usize {
     }
 }
 
+#[cfg(test)]
 fn should_use_x86_q8_ffn_down_gemm4_row_group_schedule(enabled: bool, input_groups: usize) -> bool {
     enabled
         && rayon::current_num_threads() > 1
         && input_groups >= x86_q8_ffn_down_gemm4_row_group_min_input_groups()
+}
+
+fn x86_q8_attention_output_gemm4_row_group_min_input_groups() -> usize {
+    #[cfg(test)]
+    {
+        env::var("CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS)
+    }
+    #[cfg(not(test))]
+    {
+        static X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS_ONCE: OnceLock<usize> =
+            OnceLock::new();
+        *X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS_ONCE.get_or_init(|| {
+            env::var("CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS")
+                .ok()
+                .and_then(|value| value.parse::<usize>().ok())
+                .filter(|value| *value > 0)
+                .unwrap_or(X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS)
+        })
+    }
+}
+
+#[cfg(test)]
+fn should_use_x86_q8_attention_output_gemm4_row_group_schedule(
+    enabled: bool,
+    input_groups: usize,
+) -> bool {
+    enabled
+        && rayon::current_num_threads() > 1
+        && input_groups >= x86_q8_attention_output_gemm4_row_group_min_input_groups()
 }
 
 fn x86_q8_packed_rows4_matmul_groups_per_chunk() -> usize {
@@ -10121,6 +10164,7 @@ fn q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
     output_width: usize,
     name: &str,
     row_group_schedule: bool,
+    row_group_min_input_groups: usize,
     use_avx2: bool,
 ) -> Result<CpuTensor> {
     let rows = input.dim(0)?;
@@ -10157,7 +10201,10 @@ fn q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
             &mut packed_inputs,
         );
         let input_groups = packed_rows / 4;
-        if should_use_x86_q8_ffn_down_gemm4_row_group_schedule(row_group_schedule, input_groups) {
+        if row_group_schedule
+            && rayon::current_num_threads() > 1
+            && input_groups >= row_group_min_input_groups
+        {
             run_q8_0_packed_rows4_prefill_gemm4_kernel_row_group_parallel(
                 packed,
                 &packed_inputs,
@@ -10769,6 +10816,44 @@ fn try_x86_q8_attention_output_packed_rows4_matmul_path(
     q8_0_packed_rows4_matmul_projection(input, packed, output_width, name).map(Some)
 }
 
+fn try_x86_q8_attention_output_gemm4_prefill_path(
+    input: &CpuTensor,
+    weight: &CpuTensor,
+    name: &str,
+    rectangular_role: &str,
+    runtime_plan: &ResolvedRuntimePlan,
+) -> Result<Option<CpuTensor>> {
+    if !runtime_plan.q8.attention_output_gemm4_prefill
+        || rectangular_role != "linear"
+        || input.rank() != 2
+        || input.dim(0)? < 4
+        || !weight.name.ends_with(".attn_output.weight")
+    {
+        return Ok(None);
+    }
+    let input_width = input.dim(1)?;
+    if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        return Ok(None);
+    }
+    let Some((packed, output_width)) = q8_0_runtime_packed_projection(weight, input_width)? else {
+        return Ok(None);
+    };
+    if packed.interleave != Q8_0PackedRows4Interleave::I8 {
+        return Ok(None);
+    }
+
+    q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
+        input,
+        packed,
+        output_width,
+        name,
+        runtime_plan.q8.attention_output_gemm4_row_group_schedule,
+        x86_q8_attention_output_gemm4_row_group_min_input_groups(),
+        runtime_plan.q8.attention_output_gemm4_avx2,
+    )
+    .map(Some)
+}
+
 fn try_x86_q8_attention_projection_decode_consumer_path(
     input: &CpuTensor,
     weight: &CpuTensor,
@@ -10893,6 +10978,7 @@ fn try_x86_q8_ffn_down_gemm4_prefill_path(
                 route.output_width,
                 name,
                 runtime_plan.q8.ffn_down_gemm4_row_group_schedule,
+                x86_q8_ffn_down_gemm4_row_group_min_input_groups(),
                 runtime_plan.q8.ffn_down_gemm4_avx2,
             )?;
             let route_name = if runtime_plan.q8.ffn_down_gemm4_row_group_schedule {
@@ -10909,6 +10995,7 @@ fn try_x86_q8_ffn_down_gemm4_prefill_path(
             route.output_width,
             name,
             runtime_plan.q8.ffn_down_gemm4_row_group_schedule,
+            x86_q8_ffn_down_gemm4_row_group_min_input_groups(),
             runtime_plan.q8.ffn_down_gemm4_avx2,
         )?;
         let route_name = if runtime_plan.q8.ffn_down_gemm4_row_group_schedule {

--- a/src/inference/q8_runtime.rs
+++ b/src/inference/q8_runtime.rs
@@ -10,6 +10,9 @@ pub(super) struct Q8RuntimeFlags {
     pub(super) attention_projection_decode_consumer: bool,
     pub(super) attention_output_decode_consumer: bool,
     pub(super) attention_output_packed_rows4_matmul: bool,
+    pub(super) attention_output_gemm4_prefill: bool,
+    pub(super) attention_output_gemm4_row_group_schedule: bool,
+    pub(super) attention_output_gemm4_avx2: bool,
     pub(super) attention_qkv_decode_consumer: bool,
     pub(super) attention_qkv_decode_group_chunking: bool,
     pub(super) attention_qkv_packed_rows4_matmul: bool,
@@ -69,6 +72,15 @@ impl Q8RuntimeFlags {
             ),
             attention_output_packed_rows4_matmul: q8_0_env_flag_enabled_default_off(
                 "CAMELID_X86_Q8_ATTENTION_OUTPUT_PACKED_ROWS4_MATMUL",
+            ),
+            attention_output_gemm4_prefill: q8_0_env_flag_enabled_default_off(
+                "CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_PREFILL",
+            ),
+            attention_output_gemm4_row_group_schedule: q8_0_env_flag_enabled_default_off(
+                "CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_SCHED",
+            ),
+            attention_output_gemm4_avx2: q8_0_env_flag_enabled_default_off(
+                "CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_AVX2",
             ),
             attention_qkv_decode_consumer: q8_0_env_flag_enabled_default_off(
                 "CAMELID_X86_Q8_ATTENTION_QKV_DECODE_CONSUMER",

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -143,6 +143,57 @@ fn x86_q8_ffn_down_gemm4_row_group_schedule_respects_min_input_groups() {
     std::env::remove_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS");
 }
 
+#[test]
+fn x86_q8_attention_output_gemm4_row_group_schedule_respects_min_input_groups() {
+    let _env_guard = env_lock();
+    std::env::remove_var("CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS");
+    assert_eq!(
+        x86_q8_attention_output_gemm4_row_group_min_input_groups(),
+        X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS
+    );
+    assert!(
+        !should_use_x86_q8_attention_output_gemm4_row_group_schedule(
+            false,
+            X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS
+        )
+    );
+    assert!(
+        !should_use_x86_q8_attention_output_gemm4_row_group_schedule(
+            true,
+            X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS - 1
+        )
+    );
+    assert_eq!(
+        should_use_x86_q8_attention_output_gemm4_row_group_schedule(
+            true,
+            X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS
+        ),
+        rayon::current_num_threads() > 1
+    );
+
+    std::env::set_var(
+        "CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
+        "2",
+    );
+    assert_eq!(
+        x86_q8_attention_output_gemm4_row_group_min_input_groups(),
+        2
+    );
+    assert_eq!(
+        should_use_x86_q8_attention_output_gemm4_row_group_schedule(true, 2),
+        rayon::current_num_threads() > 1
+    );
+    std::env::set_var(
+        "CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
+        "0",
+    );
+    assert_eq!(
+        x86_q8_attention_output_gemm4_row_group_min_input_groups(),
+        X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS
+    );
+    std::env::remove_var("CAMELID_X86_Q8_ATTENTION_OUTPUT_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS");
+}
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[test]
 fn x86_q8_avx2_packed_rows4_i8_matches_scalar_dot() {
@@ -1645,6 +1696,9 @@ fn q8_0_hot_path_uses_resolved_plan_not_current_env() {
             attention_projection_decode_consumer: false,
             attention_output_decode_consumer: false,
             attention_output_packed_rows4_matmul: false,
+            attention_output_gemm4_prefill: false,
+            attention_output_gemm4_row_group_schedule: false,
+            attention_output_gemm4_avx2: false,
             attention_qkv_decode_consumer: false,
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
@@ -2522,6 +2576,12 @@ fn attention_output_packed_rows4_matmul_plan(enabled: bool) -> ResolvedRuntimePl
     plan
 }
 
+fn attention_output_gemm4_prefill_plan(enabled: bool) -> ResolvedRuntimePlan {
+    let mut plan = q8_attention_consumer_plan(false, false);
+    plan.q8.attention_output_gemm4_prefill = enabled;
+    plan
+}
+
 fn output_packed_rows4_matmul_plan(enabled: bool) -> ResolvedRuntimePlan {
     let mut plan = q8_attention_consumer_plan(false, false);
     plan.q8.output_packed_rows4_matmul = enabled;
@@ -2540,6 +2600,9 @@ fn q8_attention_consumer_plan(
             attention_projection_decode_consumer,
             attention_output_decode_consumer: false,
             attention_output_packed_rows4_matmul: false,
+            attention_output_gemm4_prefill: false,
+            attention_output_gemm4_row_group_schedule: false,
+            attention_output_gemm4_avx2: false,
             attention_qkv_decode_consumer,
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
@@ -3445,6 +3508,81 @@ fn q8_attention_output_packed_rows4_matmul_is_plan_gated_and_shape_limited() {
     .is_none());
 }
 
+#[test]
+fn q8_attention_output_gemm4_prefill_is_plan_gated_and_matches_rows4_baseline() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    let (_decode_input, packed_weight, _decode_expected) =
+        runtime_packed_attention_projection_case("attention_output", "blk.0.attn_output.weight");
+    let input_width = packed_weight.dim(0).unwrap();
+    let output_width = packed_weight.dim(1).unwrap();
+    let rows = 4;
+    let prefill_input = CpuTensor::from_f32(
+        "prefill_attention_context_gemm4",
+        vec![rows, input_width],
+        (0..rows * input_width)
+            .map(|idx| ((idx % input_width) as f32 - 7.0) * 0.0625 + (idx / input_width) as f32)
+            .collect(),
+    )
+    .unwrap();
+
+    let actual = try_x86_q8_attention_output_gemm4_prefill_path(
+        &prefill_input,
+        &packed_weight,
+        "gemm4_attention_output",
+        "linear",
+        &attention_output_gemm4_prefill_plan(true),
+    )
+    .unwrap()
+    .expect("gemm4 prefill route should activate for 4-row attention output");
+    let expected = q8_0_packed_rows4_matmul_projection(
+        &prefill_input,
+        match packed_weight.q8_0_runtime_storage.as_ref() {
+            Some(Q8_0RuntimeStorage::PackedRows4(packed)) => packed,
+            other => panic!("expected runtime-packed rows4 weight, got {other:?}"),
+        },
+        output_width,
+        "attention_output_rows4_baseline",
+    )
+    .unwrap();
+    assert_eq!(actual.shape.dims, vec![rows, output_width]);
+    assert_slice_close_with_tolerance(&actual.data, &expected.data, 5e-4);
+
+    let short_input = CpuTensor::from_f32(
+        "short_prefill",
+        vec![3, input_width],
+        vec![0.0; 3 * input_width],
+    )
+    .unwrap();
+    assert!(try_x86_q8_attention_output_gemm4_prefill_path(
+        &short_input,
+        &packed_weight,
+        "too_short",
+        "linear",
+        &attention_output_gemm4_prefill_plan(true),
+    )
+    .unwrap()
+    .is_none());
+    assert!(try_x86_q8_attention_output_gemm4_prefill_path(
+        &prefill_input,
+        &packed_weight,
+        "disabled",
+        "linear",
+        &attention_output_gemm4_prefill_plan(false),
+    )
+    .unwrap()
+    .is_none());
+    assert!(try_x86_q8_attention_output_gemm4_prefill_path(
+        &prefill_input,
+        &packed_weight,
+        "wrong_role",
+        "attention_q",
+        &attention_output_gemm4_prefill_plan(true),
+    )
+    .unwrap()
+    .is_none());
+}
+
 fn ffn_down_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
     ResolvedRuntimePlan {
         linear_accumulation_precision: LinearAccumulationPrecision::F32,
@@ -3454,6 +3592,9 @@ fn ffn_down_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             attention_projection_decode_consumer: false,
             attention_output_decode_consumer: false,
             attention_output_packed_rows4_matmul: false,
+            attention_output_gemm4_prefill: false,
+            attention_output_gemm4_row_group_schedule: false,
+            attention_output_gemm4_avx2: false,
             attention_qkv_decode_consumer: false,
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
@@ -3502,6 +3643,9 @@ fn ffn_down_packed_rows4_matmul_plan(enabled: bool) -> ResolvedRuntimePlan {
             attention_projection_decode_consumer: false,
             attention_output_decode_consumer: false,
             attention_output_packed_rows4_matmul: false,
+            attention_output_gemm4_prefill: false,
+            attention_output_gemm4_row_group_schedule: false,
+            attention_output_gemm4_avx2: false,
             attention_qkv_decode_consumer: false,
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
@@ -3554,6 +3698,9 @@ fn ffn_gate_up_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             attention_projection_decode_consumer: false,
             attention_output_decode_consumer: false,
             attention_output_packed_rows4_matmul: false,
+            attention_output_gemm4_prefill: false,
+            attention_output_gemm4_row_group_schedule: false,
+            attention_output_gemm4_avx2: false,
             attention_qkv_decode_consumer: false,
             attention_qkv_decode_group_chunking: false,
             attention_qkv_packed_rows4_matmul: false,
@@ -4771,6 +4918,7 @@ fn q8_ffn_down_gemm4_row_group_threshold_benchmark() {
                     output_width,
                     label,
                     row_group_schedule,
+                    x86_q8_ffn_down_gemm4_row_group_min_input_groups(),
                     false,
                 )
                 .unwrap(),
@@ -4975,6 +5123,7 @@ fn q8_ffn_down_amx_prefill_benchmark() {
             output_width,
             "gemm4",
             false,
+            x86_q8_ffn_down_gemm4_row_group_min_input_groups(),
             true,
         )
         .unwrap()

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -3512,6 +3512,8 @@ fn q8_attention_output_packed_rows4_matmul_is_plan_gated_and_shape_limited() {
 fn q8_attention_output_gemm4_prefill_is_plan_gated_and_matches_rows4_baseline() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
     let (_decode_input, packed_weight, _decode_expected) =
         runtime_packed_attention_projection_case("attention_output", "blk.0.attn_output.weight");
     let input_width = packed_weight.dim(0).unwrap();
@@ -3525,13 +3527,16 @@ fn q8_attention_output_gemm4_prefill_is_plan_gated_and_matches_rows4_baseline() 
             .collect(),
     )
     .unwrap();
+    let mut plan = attention_output_gemm4_prefill_plan(true);
+    plan.q8.attention_output_gemm4_row_group_schedule = true;
+    let route_name = "x86_gemm4_prefill_row_group";
 
     let actual = try_x86_q8_attention_output_gemm4_prefill_path(
         &prefill_input,
         &packed_weight,
-        "gemm4_attention_output",
+        "layer_3_attention_output_gemm4",
         "linear",
-        &attention_output_gemm4_prefill_plan(true),
+        &plan,
     )
     .unwrap()
     .expect("gemm4 prefill route should activate for 4-row attention output");
@@ -3547,6 +3552,21 @@ fn q8_attention_output_gemm4_prefill_is_plan_gated_and_matches_rows4_baseline() 
     .unwrap();
     assert_eq!(actual.shape.dims, vec![rows, output_width]);
     assert_slice_close_with_tolerance(&actual.data, &expected.data, 5e-4);
+    let telemetry = snapshot_q8_schedule_telemetry();
+    let by_route = telemetry
+        .output_projection_by_route
+        .get(&format!("attention_output.{route_name}"))
+        .expect("attention-output gemm4 route telemetry");
+    assert_eq!(by_route.calls, 1);
+    assert_eq!(by_route.rows, rows as u64);
+    assert_eq!(by_route.input_width, input_width as u64);
+    assert_eq!(by_route.output_width, output_width as u64);
+    let layer_route = telemetry
+        .output_projection_by_layer_route
+        .get(&format!("layer_3.attention_output.{route_name}"))
+        .expect("layer-scoped attention-output gemm4 route telemetry");
+    assert_eq!(layer_route.layer_index, 3);
+    assert_eq!(layer_route.calls, 1);
 
     let short_input = CpuTensor::from_f32(
         "short_prefill",
@@ -3581,6 +3601,8 @@ fn q8_attention_output_gemm4_prefill_is_plan_gated_and_matches_rows4_baseline() 
     )
     .unwrap()
     .is_none());
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
 }
 
 fn ffn_down_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {


### PR DESCRIPTION
## Summary
- add a default-off attention-output GEMM4 prefill route for runtime-packed Q8 attention-output weights
- reuse the existing GEMM4 row-group scheduler with a separate attention-output min-input-groups guard
- add targeted inference tests for the new route and the new row-group threshold helper

## Validation
- `cargo fmt --check`
- `cargo test --lib attention_output_gemm4`
- `cargo test --lib ffn_down_gemm4_row_group_schedule_respects_min_input_groups`

Validated on remote Linux x86_64 with formatting and targeted unit tests only. No fresh same-host timing or parity claim is made in this PR.