### PR TITLE
perf(q8): manage packed-rows4 planner chunk knob

### DIFF
--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1210Z-ci-guard-ubuntu-rustup/SHA256SUMS
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1210Z-ci-guard-ubuntu-rustup/SHA256SUMS
@@ -1,6 +1,6 @@
 8a3b625146db02c0d51586e50b6b8dda2efcfaa7a91007805974e0435669e53c  ./README.md
 dddf80c457340202488f7b86b119248d9433dd1f2c54b70e52cf78950fbcbacf  ./commands/local-gates.command.txt
-64837a1e4d43c1c093f46bf100e9415ba4adc7e9505f15a6638952e45ef4fbbc  ./commands/ubuntu-gates.command.txt
+2f714cb9c0664fc88f77b63b12afb454f045627d043f71c58effcbc2ffb290b6  ./commands/ubuntu-gates.command.txt
 cc07b55ce99cdbf933fdb6c51ef0ff7feb95ab45287f0bbe3797f7dfe2f654ab  ./logs/local-gates.log
 014c27612511bd3e6187e0c2ccc59d17633666a1821e4a1cd29cd894cfcd8861  ./logs/local-repo-state.log
 63ffa457f6296e07d4307d7c407d3ed3ea6ef3ca9a596ae01ea4edab9aa22644  ./logs/ubuntu-discovery.log

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1422Z-ci-qa-guard/SHA256SUMS
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1422Z-ci-qa-guard/SHA256SUMS
@@ -1,6 +1,6 @@
 aa18e9eceaba2ea33f17153acf99fc444f86e96e2f5508ef3f778949d7be328c  ./README.md
 60945c0bfab2b9bc9ec509b83ea7449e3278c17e3c27b0243de78a2c9b86eab4  ./commands/local-gates.command.txt
-213fd409cede01c9e535b777198bea3df15fc9fd5f09c7564791c1de2b833901  ./commands/ubuntu-gates.command.txt
+2dd0558a2cdc4a681023d6dcb53f2f9708acc64871fe1cf3d3216ddc69f14daa  ./commands/ubuntu-gates.command.txt
 453320da6ae5f150d2fba081eb7b3b93b34d5261b940d0edefe1185a74ff4a47  ./logs/local-gates.log
 2abaa1acc0a6cddab77de665a1badad3815bf30f5ad22cbdee5b920e238c1bb7  ./logs/local-repo-state.log
 7489ef0ac711903e0b5bb6d9bfbb8d075d6169b046e9dec8170beef2fc3181c9  ./logs/ubuntu-gates.log

--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -46,6 +46,7 @@ const MANAGED_ENV_KEYS: &[&str] = &[
     "CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUPS_PER_CHUNK",
     "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_GROUPS_PER_CHUNK",
     "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
+    "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK",
 ];
 
 struct ManagedPassthroughEnvKey {
@@ -65,6 +66,10 @@ const MANAGED_PASSTHROUGH_ENV_KEYS: &[ManagedPassthroughEnvKey] = &[
     ManagedPassthroughEnvKey {
         key: "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
         owner_gate: "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED",
+    },
+    ManagedPassthroughEnvKey {
+        key: "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK",
+        owner_gate: "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL",
     },
 ];
 
@@ -972,6 +977,7 @@ mod tests {
             "CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR",
             "CAMELID_X86_Q8_FFN_DOWN_DECODE_OWNER",
             "CAMELID_X86_Q8_OUTPUT_DECODE_OWNER",
+            "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK",
         ] {
             env::remove_var(key);
         }
@@ -1561,6 +1567,7 @@ mod tests {
             "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
             "3",
         );
+        env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "9");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_AVX2", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_AMX_PREFILL", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER", "on");
@@ -1595,6 +1602,7 @@ mod tests {
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_PREFILL").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS").is_err());
+        assert!(env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_AVX2").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_AMX_PREFILL").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER").is_err());
@@ -1616,6 +1624,7 @@ mod tests {
             "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
             "3",
         );
+        env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "9");
         let planner_env = PlannerEnv::capture();
 
         env::set_var("CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUPS_PER_CHUNK", "99");
@@ -1624,6 +1633,7 @@ mod tests {
             "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
             "99",
         );
+        env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "99");
 
         let updates = BTreeMap::from([
             (
@@ -1635,6 +1645,7 @@ mod tests {
                 Some("on"),
             ),
             ("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED", Some("on")),
+            ("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL", Some("on")),
         ]);
         planner_env.apply(&updates);
 
@@ -1649,6 +1660,10 @@ mod tests {
         assert_eq!(
             env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS").ok(),
             Some("3".into())
+        );
+        assert_eq!(
+            env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK").ok(),
+            Some("9".into())
         );
         clear_profile_env();
     }


### PR DESCRIPTION
## Summary
- add execution-plan ownership for `CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK`
- clear the packed-rows4 chunk-size override unless `CAMELID_X86_Q8_PACKED_ROWS4_MATMUL` is explicitly enabled
- restore the startup-supplied positive chunk-size override only when that planner gate is selected, with focused execution-plan coverage

## Validation
- Ubuntu Linux x86_64: `cargo fmt --all --check`
- Ubuntu Linux x86_64: `cargo test --locked --lib planner_env_apply_clears_stale_x86_q8_decode_consumer_flags`
- Ubuntu Linux x86_64: `cargo test --locked --lib planner_env_apply_restores_owned_x86_q8_passthrough_knobs`
- Ubuntu Linux x86_64: `cargo test --locked --lib ubuntu_experimental_validated_gates_select_rust_avx2_q8_path`
- Ubuntu Linux x86_64: one-token parity with packed-rows4 enabled and `CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK=9`
- Ubuntu Linux x86_64: same-host benchmark with `warmup=1`, `repeats=3`, `max_tokens=16`, unique prompt, and marker guard enabled
- `bash scripts/check-public-scrub.sh`
- `node scripts/check-public-evidence-claims.mjs`

## Same-host evidence
- rebased head `cbcadd4` versus current `main` `07c912cf3041` preserved exact one-token parity (`Hello` vs `Hello`)
- Camelid TTFT: `3113.01 ms -> 3101.40 ms` (`-11.61 ms`, `-0.37%`)
- Camelid total elapsed: `3113.58 ms -> 3101.97 ms` (`-11.61 ms`, `-0.37%`)
- Camelid backend first-content: `2610.00 ms -> 2601.33 ms`
- Camelid backend Q8 calls stayed flat at `202`
- llama.cpp TTFT on the same run stayed in the same range (`379.63 ms` base, `377.10 ms` candidate)
- marker guard passed for both base and candidate

## Notes
- rebased onto current `main` so this PR isolates only the packed-rows4 planner chunk-knob delta on the current backend lane
- keep this PR framed as a planner-hygiene slice, not a retained performance improvement claim