### PR TITLE
refactor: move q8 file read telemetry helpers

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -47,8 +47,9 @@ use q8_runtime::{
 use q8_telemetry::*;
 pub use q8_telemetry::{
     q8_schedule_telemetry_enabled, reset_q8_schedule_telemetry, snapshot_q8_schedule_telemetry,
-    LlamaQ8OutputProjectionLayerRouteTelemetry, LlamaQ8OutputProjectionRouteTelemetry,
-    LlamaQ8ProjectionRouteDenialTelemetry, LlamaQ8ScheduleRoleTelemetry, LlamaQ8ScheduleTelemetry,
+    LlamaQ8FileReadPhaseTrace, LlamaQ8OutputProjectionLayerRouteTelemetry,
+    LlamaQ8OutputProjectionRouteTelemetry, LlamaQ8ProjectionRouteDenialTelemetry,
+    LlamaQ8ScheduleRoleTelemetry, LlamaQ8ScheduleTelemetry,
 };
 use rope::{
     apply_rope, apply_rope_batch, apply_rope_with_pairing, rope_scaling_from_config,
@@ -937,12 +938,6 @@ pub struct LlamaMemorySample {
     pub kv_cache_allocated_sequence_length: usize,
     pub kv_cache_allocated_elements: usize,
     pub kv_cache_allocated_bytes: u64,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct LlamaQ8FileReadPhaseTrace {
-    pub phase: String,
-    pub q8_file_reads: Q8_0FileReadStats,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -2140,74 +2135,6 @@ impl LlamaForwardMemoryTimings {
             }
         }
     }
-}
-
-fn q8_file_read_stats_has_activity(stats: Q8_0FileReadStats) -> bool {
-    stats.read_calls > 0
-        || stats.read_bytes > 0
-        || stats.cache_hits > 0
-        || stats.cache_hit_bytes > 0
-        || stats.cache_misses > 0
-        || stats.cache_miss_bytes > 0
-        || stats.cache_inserts > 0
-        || stats.cache_insert_bytes > 0
-        || stats.cache_evictions > 0
-        || stats.cache_evicted_bytes > 0
-        || stats.cache_merges > 0
-        || stats.cache_merged_bytes > 0
-        || stats.cache_decoded_scale_hits > 0
-        || stats.cache_decoded_scale_hit_blocks > 0
-}
-
-fn add_q8_file_read_stats_delta(target: &mut Q8_0FileReadStats, delta: Q8_0FileReadStats) {
-    target.read_calls = target.read_calls.saturating_add(delta.read_calls);
-    target.read_bytes = target.read_bytes.saturating_add(delta.read_bytes);
-    target.cache_hits = target.cache_hits.saturating_add(delta.cache_hits);
-    target.cache_hit_bytes = target.cache_hit_bytes.saturating_add(delta.cache_hit_bytes);
-    target.cache_misses = target.cache_misses.saturating_add(delta.cache_misses);
-    target.cache_miss_bytes = target
-        .cache_miss_bytes
-        .saturating_add(delta.cache_miss_bytes);
-    target.cache_inserts = target.cache_inserts.saturating_add(delta.cache_inserts);
-    target.cache_insert_bytes = target
-        .cache_insert_bytes
-        .saturating_add(delta.cache_insert_bytes);
-    target.cache_evictions = target.cache_evictions.saturating_add(delta.cache_evictions);
-    target.cache_evicted_bytes = target
-        .cache_evicted_bytes
-        .saturating_add(delta.cache_evicted_bytes);
-    target.cache_merges = target.cache_merges.saturating_add(delta.cache_merges);
-    target.cache_merged_bytes = target
-        .cache_merged_bytes
-        .saturating_add(delta.cache_merged_bytes);
-    target.cache_decoded_scale_hits = target
-        .cache_decoded_scale_hits
-        .saturating_add(delta.cache_decoded_scale_hits);
-    target.cache_decoded_scale_hit_blocks = target
-        .cache_decoded_scale_hit_blocks
-        .saturating_add(delta.cache_decoded_scale_hit_blocks);
-    // These fields are point-in-time cache state, not additive counters.  A merged timing window
-    // can span a scoped Q8 cache override (for example layer-major prefill) followed by a later
-    // single-token pass after the override has been restored to zero.  Keep the peak observed
-    // state so aggregate diagnostics still show that bounded cache/reuse was active.
-    target.cache_entries = target.cache_entries.max(delta.cache_entries);
-    target.cache_bytes = target.cache_bytes.max(delta.cache_bytes);
-    target.cache_capacity_bytes = target.cache_capacity_bytes.max(delta.cache_capacity_bytes);
-}
-
-fn add_q8_file_read_phase_trace(
-    phases: &mut Vec<LlamaQ8FileReadPhaseTrace>,
-    phase: &str,
-    delta: Q8_0FileReadStats,
-) {
-    if let Some(existing) = phases.iter_mut().find(|entry| entry.phase == phase) {
-        add_q8_file_read_stats_delta(&mut existing.q8_file_reads, delta);
-        return;
-    }
-    phases.push(LlamaQ8FileReadPhaseTrace {
-        phase: phase.to_string(),
-        q8_file_reads: delta,
-    });
 }
 
 impl LlamaLayerMemoryTimings {

--- a/src/inference/q8_telemetry.rs
+++ b/src/inference/q8_telemetry.rs
@@ -10,7 +10,7 @@ use std::{
 
 use serde::Serialize;
 
-use crate::tensor::Q8_0PackedRows4Block;
+use crate::tensor::{Q8_0FileReadStats, Q8_0PackedRows4Block};
 
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
 pub struct LlamaQ8ScheduleTelemetry {
@@ -106,6 +106,12 @@ pub struct LlamaQ8ProjectionRouteDenialTelemetry {
     pub rows: u64,
     pub input_width: u64,
     pub output_width: u64,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct LlamaQ8FileReadPhaseTrace {
+    pub phase: String,
+    pub q8_file_reads: Q8_0FileReadStats,
 }
 
 pub(super) const Q8_SCHEDULE_TELEMETRY_ENV: &str = "CAMELID_Q8_SCHED_TELEMETRY";
@@ -336,6 +342,77 @@ pub fn snapshot_q8_schedule_telemetry() -> LlamaQ8ScheduleTelemetry {
         prefill_single_token_fallbacks: Q8_SCHED_PREFILL_SINGLE_TOKEN_FALLBACKS
             .load(Ordering::Relaxed),
     }
+}
+
+pub(super) fn q8_file_read_stats_has_activity(stats: Q8_0FileReadStats) -> bool {
+    stats.read_calls > 0
+        || stats.read_bytes > 0
+        || stats.cache_hits > 0
+        || stats.cache_hit_bytes > 0
+        || stats.cache_misses > 0
+        || stats.cache_miss_bytes > 0
+        || stats.cache_inserts > 0
+        || stats.cache_insert_bytes > 0
+        || stats.cache_evictions > 0
+        || stats.cache_evicted_bytes > 0
+        || stats.cache_merges > 0
+        || stats.cache_merged_bytes > 0
+        || stats.cache_decoded_scale_hits > 0
+        || stats.cache_decoded_scale_hit_blocks > 0
+}
+
+pub(super) fn add_q8_file_read_stats_delta(
+    target: &mut Q8_0FileReadStats,
+    delta: Q8_0FileReadStats,
+) {
+    target.read_calls = target.read_calls.saturating_add(delta.read_calls);
+    target.read_bytes = target.read_bytes.saturating_add(delta.read_bytes);
+    target.cache_hits = target.cache_hits.saturating_add(delta.cache_hits);
+    target.cache_hit_bytes = target.cache_hit_bytes.saturating_add(delta.cache_hit_bytes);
+    target.cache_misses = target.cache_misses.saturating_add(delta.cache_misses);
+    target.cache_miss_bytes = target
+        .cache_miss_bytes
+        .saturating_add(delta.cache_miss_bytes);
+    target.cache_inserts = target.cache_inserts.saturating_add(delta.cache_inserts);
+    target.cache_insert_bytes = target
+        .cache_insert_bytes
+        .saturating_add(delta.cache_insert_bytes);
+    target.cache_evictions = target.cache_evictions.saturating_add(delta.cache_evictions);
+    target.cache_evicted_bytes = target
+        .cache_evicted_bytes
+        .saturating_add(delta.cache_evicted_bytes);
+    target.cache_merges = target.cache_merges.saturating_add(delta.cache_merges);
+    target.cache_merged_bytes = target
+        .cache_merged_bytes
+        .saturating_add(delta.cache_merged_bytes);
+    target.cache_decoded_scale_hits = target
+        .cache_decoded_scale_hits
+        .saturating_add(delta.cache_decoded_scale_hits);
+    target.cache_decoded_scale_hit_blocks = target
+        .cache_decoded_scale_hit_blocks
+        .saturating_add(delta.cache_decoded_scale_hit_blocks);
+    // These fields are point-in-time cache state, not additive counters.  A merged timing window
+    // can span a scoped Q8 cache override (for example layer-major prefill) followed by a later
+    // single-token pass after the override has been restored to zero.  Keep the peak observed
+    // state so aggregate diagnostics still show that bounded cache/reuse was active.
+    target.cache_entries = target.cache_entries.max(delta.cache_entries);
+    target.cache_bytes = target.cache_bytes.max(delta.cache_bytes);
+    target.cache_capacity_bytes = target.cache_capacity_bytes.max(delta.cache_capacity_bytes);
+}
+
+pub(super) fn add_q8_file_read_phase_trace(
+    phases: &mut Vec<LlamaQ8FileReadPhaseTrace>,
+    phase: &str,
+    delta: Q8_0FileReadStats,
+) {
+    if let Some(existing) = phases.iter_mut().find(|entry| entry.phase == phase) {
+        add_q8_file_read_stats_delta(&mut existing.q8_file_reads, delta);
+        return;
+    }
+    phases.push(LlamaQ8FileReadPhaseTrace {
+        phase: phase.to_string(),
+        q8_file_reads: delta,
+    });
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary
- move Q8 file-read phase trace type into q8_telemetry
- move Q8 file-read activity, stats merge, and phase trace helpers into q8_telemetry
- keep inference behavior unchanged while shrinking src/inference.rs by 73 lines

## Validation
- cargo fmt --all -- --check
- cargo test --lib q8_file_read
- cargo test --lib q8_projection_route_telemetry_records_layer_route_bucket -- --nocapture
- RUST_TEST_THREADS=1 cargo test --lib
- cargo clippy --lib -- -D warnings

Note: plain parallel cargo test --lib hit q8_projection_route_telemetry_records_layer_route_bucket with a global telemetry count mismatch, then passed in isolation and in serial mode.