### PR TITLE
perf(q8): retain AVX2 decode hoist evidence

### DIFF
--- a/docs/performance/ubuntu-x86-q8.md
+++ b/docs/performance/ubuntu-x86-q8.md
@@ -72,6 +72,8 @@ Examples already treated this way include row-dot lookalikes, tile16 hsum/lane/s
 
 The 2026-05-24 current-main AVX2 register-sum recheck also stays rejected for performance retention: exact-row one-token parity still matched llama.cpp, but the cleaned unique-prompt same-host marker run measured Camelid `8837.36 / 8837.65 ms` on `e27a4e1` versus `8823.09 / 8823.37 ms` on `214f733`, so there is no measured Ubuntu x86_64 wall-clock win to retain.
 
+The 2026-05-24 AVX2 decode-accumulator hoist same-host check is retained inside the existing default-off AVX2 lane: exact-row one-token parity matched llama.cpp on both `07c912c` current `main` and candidate `a39a493`, the warmed-cache current-`main` control stayed at `8889.41 / 8889.69 ms`, and the candidate measured `4447.75 / 4448.28 ms` under the same `CAMELID_X86_Q8_REPACK=on CAMELID_X86_Q8_KERNEL=avx2` shape. This retains only the narrow Camelid-on-Camelid Ubuntu x86_64 wall-clock win inside the existing default-off lane; llama.cpp remains much faster overall, so no default-on, portability, or broad throughput claim is made.
+
 ## Clean-host discipline
 
 Ubuntu x86 Q8 benchmarking now requires a clean host before major runs:
@@ -164,6 +166,7 @@ Primary public evidence anchors for this lane:
 - `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260521T2015Z-vnni-rawptr-avx2/README.md` (default-off Rust AVX2 FFN-down VNNI decode raw-pointer implementation slice; local compile check only, with Linux x86_64 AVX2 parity coverage added for canonical host execution and no throughput/support/default-on promotion)
 - `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260522T2320Z-q8-parity/README.md` (Ubuntu Linux x86_64 same-host Llama 3.2 3B Q8_0 Camelid rawptr-VNNI versus llama.cpp timing slice; llama.cpp remained much faster on TTFT/total elapsed and the deterministic marker guard failed, so no throughput/support/default-on promotion)
 - `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-95495a91-20260524T0535Z-avx2-register-sums/README.md` (current-main AVX2 baseline recheck on Ubuntu Linux x86_64: one-token parity stayed exact, but the cleaned unique-prompt marker run was slightly slower than `214f733`, so no measured wall-clock win or promotion is retained)
+- `qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-0719640b-20260524T2358Z-avx2-decode-hoist/README.md` (Ubuntu Linux x86_64 same-host AVX2 decode-accumulator hoist validation: exact-row one-token parity stayed exact, the warmed-cache current-`main` control remained around `8.89 s`, the candidate measured about `4.45 s`, and the result is retained only as a narrow default-off Camelid-on-Camelid wall-clock win)
 - the retained/reject notes for bounded Ubuntu x86 Q8 experiments kept under `qa/evidence-bundles/`
 
 ## Product/runtime note

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-0719640b-20260524T2358Z-avx2-decode-hoist/README.md
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-0719640b-20260524T2358Z-avx2-decode-hoist/README.md
@@ -1,0 +1,52 @@
+# AVX2 decode-accumulator hoist Ubuntu x86 Q8 retain
+
+- Date: 2026-05-24
+- Candidate: `perf(q8): hoist packed rows4 avx2 decode accumulators`
+- Feature commit: `a39a493`
+- Result: retained inside the existing default-off Ubuntu Linux x86_64 AVX2 lane for a narrow Camelid-on-Camelid wall-clock win; no default-on, portability, or broad throughput claim is made
+
+## What ran
+
+- Release builds on current `main` and the candidate head
+- One-token exact-row parity for `hello` on current `main` and the candidate head
+- Same-host benchmark with `warmup=0`, `repeats=2`, `max_tokens=8`, unique prompt, and marker guard enabled
+- Warmed-cache control rerun on current `main` after the candidate benchmark
+
+## Common benchmark env
+
+- `CAMELID_X86_Q8_REPACK=on`
+- `CAMELID_X86_Q8_KERNEL=avx2`
+
+## Measured result
+
+- Current `main` first pass `07c912c`
+  - One-token parity: exact
+  - Camelid TTFT `8618.40 ms`
+  - Camelid total `8618.91 ms`
+  - llama.cpp TTFT `320.06 ms`
+  - llama.cpp total `525.50 ms`
+- Candidate `a39a493`
+  - One-token parity: exact
+  - Camelid TTFT `4447.75 ms`
+  - Camelid total `4448.28 ms`
+  - llama.cpp TTFT `317.16 ms`
+  - llama.cpp total `524.74 ms`
+- Warmed-cache current-`main` control
+  - Camelid TTFT `8889.41 ms`
+  - Camelid total `8889.69 ms`
+  - llama.cpp TTFT `315.95 ms`
+  - llama.cpp total `522.21 ms`
+
+## Guardrails
+
+- Prompt tokens matched the llama.cpp reference on current `main` and the candidate head
+- Generated token ids matched the llama.cpp reference on current `main` and the candidate head
+- Generated text matched the llama.cpp reference on current `main` and the candidate head
+- The unique-prompt marker guard passed for every measured run
+
+## Decision
+
+- The warmed-cache control stayed effectively flat on current `main`, so the candidate win is not explained by simple second-run cache warming
+- Versus the warmed-cache current-`main` control, the candidate reduced Camelid TTFT by about `50.0%` and total elapsed by about `50.0%`
+- llama.cpp remained much faster overall, so this slice retains only the narrow Camelid-on-Camelid improvement inside the existing default-off AVX2 lane
+- Keep the lane default-off and evidence-gated while retaining this accumulator-hoist follow-on as a measured Ubuntu x86_64 win within that lane

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1210Z-ci-guard-ubuntu-rustup/SHA256SUMS
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1210Z-ci-guard-ubuntu-rustup/SHA256SUMS
@@ -1,6 +1,6 @@
 8a3b625146db02c0d51586e50b6b8dda2efcfaa7a91007805974e0435669e53c  ./README.md
 dddf80c457340202488f7b86b119248d9433dd1f2c54b70e52cf78950fbcbacf  ./commands/local-gates.command.txt
-64837a1e4d43c1c093f46bf100e9415ba4adc7e9505f15a6638952e45ef4fbbc  ./commands/ubuntu-gates.command.txt
+2f714cb9c0664fc88f77b63b12afb454f045627d043f71c58effcbc2ffb290b6  ./commands/ubuntu-gates.command.txt
 cc07b55ce99cdbf933fdb6c51ef0ff7feb95ab45287f0bbe3797f7dfe2f654ab  ./logs/local-gates.log
 014c27612511bd3e6187e0c2ccc59d17633666a1821e4a1cd29cd894cfcd8861  ./logs/local-repo-state.log
 63ffa457f6296e07d4307d7c407d3ed3ea6ef3ca9a596ae01ea4edab9aa22644  ./logs/ubuntu-discovery.log

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1422Z-ci-qa-guard/SHA256SUMS
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1422Z-ci-qa-guard/SHA256SUMS
@@ -1,6 +1,6 @@
 aa18e9eceaba2ea33f17153acf99fc444f86e96e2f5508ef3f778949d7be328c  ./README.md
 60945c0bfab2b9bc9ec509b83ea7449e3278c17e3c27b0243de78a2c9b86eab4  ./commands/local-gates.command.txt
-213fd409cede01c9e535b777198bea3df15fc9fd5f09c7564791c1de2b833901  ./commands/ubuntu-gates.command.txt
+2dd0558a2cdc4a681023d6dcb53f2f9708acc64871fe1cf3d3216ddc69f14daa  ./commands/ubuntu-gates.command.txt
 453320da6ae5f150d2fba081eb7b3b93b34d5261b940d0edefe1185a74ff4a47  ./logs/local-gates.log
 2abaa1acc0a6cddab77de665a1badad3815bf30f5ad22cbdee5b920e238c1bb7  ./logs/local-repo-state.log
 7489ef0ac711903e0b5bb6d9bfbb8d075d6169b046e9dec8170beef2fc3181c9  ./logs/ubuntu-gates.log

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -13,6 +13,11 @@ use std::sync::OnceLock;
 use rayon::prelude::*;
 use serde::Serialize;
 
+#[cfg(target_arch = "x86")]
+use std::arch::x86::{__m128i, __m256i};
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::{__m128i, __m256i};
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::execution_plan::MAC_Q8_PREFILL_I8MM_MIN_ROWS;
 use crate::metal;
@@ -8734,7 +8739,7 @@ fn q8_0_packed_rows4_single_input_projection_into_with_decode_chunking(
     let compute_group = |group_idx: usize, output_chunk: &mut [f32]| {
         let group_start = group_idx * blocks_per_row;
         let group_blocks = &packed.blocks[group_start..group_start + blocks_per_row];
-        let sums = q8_0_packed_rows4_dot_i8_matmul(group_blocks, quantized_input, use_hoisted_avx2);
+        let sums = q8_0_packed_rows4_dot_i8_decode(group_blocks, quantized_input, use_hoisted_avx2);
         output_chunk.copy_from_slice(&sums);
     };
 
@@ -8905,9 +8910,9 @@ fn q8_0_packed_rows4_single_input_projection_pair_into_with_decode_chunking(
         let left_blocks = &left_packed.blocks[group_start..group_start + blocks_per_row];
         let right_blocks = &right_packed.blocks[group_start..group_start + blocks_per_row];
         let left_sums =
-            q8_0_packed_rows4_dot_i8_matmul(left_blocks, quantized_input, use_hoisted_avx2);
+            q8_0_packed_rows4_dot_i8_decode(left_blocks, quantized_input, use_hoisted_avx2);
         let right_sums =
-            q8_0_packed_rows4_dot_i8_matmul(right_blocks, quantized_input, use_hoisted_avx2);
+            q8_0_packed_rows4_dot_i8_decode(right_blocks, quantized_input, use_hoisted_avx2);
         left_chunk.copy_from_slice(&left_sums);
         right_chunk.copy_from_slice(&right_sums);
     };
@@ -9089,17 +9094,17 @@ fn q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
                         .enumerate()
                     {
                         let group_start = (first_group_idx + local_group_idx) * blocks_per_row;
-                        q_group.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+                        q_group.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                             &q_packed.blocks[group_start..group_start + blocks_per_row],
                             quantized_input,
                             use_hoisted_avx2,
                         ));
-                        k_group.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+                        k_group.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                             &k_packed.blocks[group_start..group_start + blocks_per_row],
                             quantized_input,
                             use_hoisted_avx2,
                         ));
-                        v_group.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+                        v_group.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                             &v_packed.blocks[group_start..group_start + blocks_per_row],
                             quantized_input,
                             use_hoisted_avx2,
@@ -9114,17 +9119,17 @@ fn q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
                 .enumerate()
                 .for_each(|(group_idx, ((q_chunk, k_chunk), v_chunk))| {
                     let group_start = group_idx * blocks_per_row;
-                    q_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+                    q_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                         &q_packed.blocks[group_start..group_start + blocks_per_row],
                         quantized_input,
                         use_hoisted_avx2,
                     ));
-                    k_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+                    k_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                         &k_packed.blocks[group_start..group_start + blocks_per_row],
                         quantized_input,
                         use_hoisted_avx2,
                     ));
-                    v_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+                    v_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                         &v_packed.blocks[group_start..group_start + blocks_per_row],
                         quantized_input,
                         use_hoisted_avx2,
@@ -9139,17 +9144,17 @@ fn q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
             .enumerate()
         {
             let group_start = group_idx * blocks_per_row;
-            q_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+            q_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                 &q_packed.blocks[group_start..group_start + blocks_per_row],
                 quantized_input,
                 use_hoisted_avx2,
             ));
-            k_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+            k_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                 &k_packed.blocks[group_start..group_start + blocks_per_row],
                 quantized_input,
                 use_hoisted_avx2,
             ));
-            v_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+            v_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                 &v_packed.blocks[group_start..group_start + blocks_per_row],
                 quantized_input,
                 use_hoisted_avx2,
@@ -9158,7 +9163,7 @@ fn q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
     } else {
         for (group_idx, q_chunk) in q_output.chunks_exact_mut(4).enumerate().take(q_groups) {
             let group_start = group_idx * blocks_per_row;
-            q_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+            q_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                 &q_packed.blocks[group_start..group_start + blocks_per_row],
                 quantized_input,
                 use_hoisted_avx2,
@@ -9166,7 +9171,7 @@ fn q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
         }
         for (group_idx, k_chunk) in k_output.chunks_exact_mut(4).enumerate().take(k_groups) {
             let group_start = group_idx * blocks_per_row;
-            k_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+            k_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                 &k_packed.blocks[group_start..group_start + blocks_per_row],
                 quantized_input,
                 use_hoisted_avx2,
@@ -9174,7 +9179,7 @@ fn q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
         }
         for (group_idx, v_chunk) in v_output.chunks_exact_mut(4).enumerate().take(v_groups) {
             let group_start = group_idx * blocks_per_row;
-            v_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
+            v_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_decode(
                 &v_packed.blocks[group_start..group_start + blocks_per_row],
                 quantized_input,
                 use_hoisted_avx2,
@@ -13431,6 +13436,69 @@ fn q8_0_packed_rows4_dot_i8_matmul(
     q8_0_packed_rows4_dot(packed_blocks, input, Q8_0PackedRows4Interleave::I8)
 }
 
+fn q8_0_packed_rows4_dot_i8_decode(
+    packed_blocks: &[Q8_0PackedRows4Block],
+    input: &[Q8_0Block],
+    use_hoisted_avx2: bool,
+) -> [f32; 4] {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if use_hoisted_avx2 {
+            // SAFETY: `use_hoisted_avx2` is only true after runtime AVX2 detection.
+            return unsafe { q8_0_packed_rows4_dot_i8_decode_avx2(packed_blocks, input) };
+        }
+    }
+    let _ = use_hoisted_avx2;
+    q8_0_packed_rows4_dot(packed_blocks, input, Q8_0PackedRows4Interleave::I8)
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn q8_0_packed_rows4_dot_i8_decode_avx2(
+    packed_blocks: &[Q8_0PackedRows4Block],
+    input: &[Q8_0Block],
+) -> [f32; 4] {
+    unsafe { q8_0_packed_rows4_dot_i8_hoisted_avx2(packed_blocks, input) }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn q8_0_packed_rows4_dot_i8_hoisted_avx2(
+    packed_blocks: &[Q8_0PackedRows4Block],
+    input: &[Q8_0Block],
+) -> [f32; 4] {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::{
+        _mm_add_ps, _mm_cvtepi32_ps, _mm_loadu_ps, _mm_mul_ps, _mm_set1_ps, _mm_setzero_ps,
+        _mm_storeu_ps,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::{
+        _mm_add_ps, _mm_cvtepi32_ps, _mm_loadu_ps, _mm_mul_ps, _mm_set1_ps, _mm_setzero_ps,
+        _mm_storeu_ps,
+    };
+
+    debug_assert_eq!(packed_blocks.len(), input.len());
+    let mut sums = _mm_setzero_ps();
+    for (packed_block, input_block) in packed_blocks.iter().zip(input) {
+        let acc = unsafe {
+            q8_0_packed_4x8_block_avx2_accumulator(
+                packed_block.quants.as_ptr(),
+                input_block.quants.as_ptr(),
+            )
+        };
+        let row_sums = unsafe { q8_0_packed_4x8_block_avx2_row_sums(acc) };
+        let scales = unsafe { _mm_loadu_ps(packed_block.scales.as_ptr()) };
+        let input_scale = _mm_set1_ps(input_block.scale);
+        let scaled = _mm_mul_ps(_mm_mul_ps(_mm_cvtepi32_ps(row_sums), scales), input_scale);
+        sums = _mm_add_ps(sums, scaled);
+    }
+
+    let mut output = [0.0_f32; 4];
+    unsafe { _mm_storeu_ps(output.as_mut_ptr(), sums) };
+    output
+}
+
 fn q8_0_packed_rows4_dot_i8_matmul_pair(
     left_packed_blocks: &[Q8_0PackedRows4Block],
     right_packed_blocks: &[Q8_0PackedRows4Block],
@@ -13587,18 +13655,7 @@ unsafe fn q8_0_packed_rows4_dot_i8_avx2(
     packed_blocks: &[Q8_0PackedRows4Block],
     input: &[Q8_0Block],
 ) -> [f32; 4] {
-    debug_assert_eq!(packed_blocks.len(), input.len());
-    let mut sums = [0.0_f32; 4];
-    for (packed_block, input_block) in packed_blocks.iter().zip(input) {
-        let int_sums = unsafe {
-            q8_0_packed_4x8_block_avx2(packed_block.quants.as_ptr(), input_block.quants.as_ptr())
-        };
-        let input_scale = input_block.scale;
-        for lane in 0..4 {
-            sums[lane] += int_sums[lane] as f32 * packed_block.scales[lane] * input_scale;
-        }
-    }
-    sums
+    unsafe { q8_0_packed_rows4_dot_i8_hoisted_avx2(packed_blocks, input) }
 }
 
 fn q8_0_packed_rows4_dot(
@@ -13808,18 +13865,18 @@ unsafe fn q8_0_packed_4x8_block_avx512vnni_dpwssd(packed: *const i8, input: *con
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
-unsafe fn q8_0_packed_4x8_block_avx2(packed: *const i8, input: *const i8) -> [i32; 4] {
+unsafe fn q8_0_packed_4x8_block_avx2_accumulator(packed: *const i8, input: *const i8) -> __m256i {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::{
         _mm256_add_epi32, _mm256_broadcastsi128_si256, _mm256_loadu_si256, _mm256_madd_epi16,
         _mm256_maddubs_epi16, _mm256_set1_epi16, _mm256_setzero_si256, _mm256_sign_epi8,
-        _mm256_storeu_si256, _mm_loadl_epi64, _mm_unpacklo_epi64,
+        _mm_loadl_epi64, _mm_unpacklo_epi64,
     };
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::{
         _mm256_add_epi32, _mm256_broadcastsi128_si256, _mm256_loadu_si256, _mm256_madd_epi16,
         _mm256_maddubs_epi16, _mm256_set1_epi16, _mm256_setzero_si256, _mm256_sign_epi8,
-        _mm256_storeu_si256, _mm_loadl_epi64, _mm_unpacklo_epi64,
+        _mm_loadl_epi64, _mm_unpacklo_epi64,
     };
 
     let ones = _mm256_set1_epi16(1);
@@ -13840,16 +13897,44 @@ unsafe fn q8_0_packed_4x8_block_avx2(packed: *const i8, input: *const i8) -> [i3
         );
     }
 
-    let mut lanes = [0_i32; 8];
-    unsafe {
-        _mm256_storeu_si256(lanes.as_mut_ptr().cast(), acc);
-    }
-    [
-        lanes[0] + lanes[1],
-        lanes[2] + lanes[3],
-        lanes[4] + lanes[5],
-        lanes[6] + lanes[7],
-    ]
+    acc
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn q8_0_packed_4x8_block_avx2_row_sums(acc: __m256i) -> __m128i {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::{
+        _mm256_castsi256_si128, _mm256_extracti128_si256, _mm_hadd_epi32, _mm_setzero_si128,
+        _mm_unpacklo_epi64,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::{
+        _mm256_castsi256_si128, _mm256_extracti128_si256, _mm_hadd_epi32, _mm_setzero_si128,
+        _mm_unpacklo_epi64,
+    };
+
+    let zero = _mm_setzero_si128();
+    let lo = _mm256_castsi256_si128(acc);
+    let hi = _mm256_extracti128_si256::<1>(acc);
+    let lo = _mm_hadd_epi32(lo, zero);
+    let hi = _mm_hadd_epi32(hi, zero);
+    _mm_unpacklo_epi64(lo, hi)
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn q8_0_packed_4x8_block_avx2(packed: *const i8, input: *const i8) -> [i32; 4] {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::_mm_storeu_si128;
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::_mm_storeu_si128;
+
+    let acc = unsafe { q8_0_packed_4x8_block_avx2_accumulator(packed, input) };
+    let rows = unsafe { q8_0_packed_4x8_block_avx2_row_sums(acc) };
+    let mut sums = [0_i32; 4];
+    unsafe { _mm_storeu_si128(sums.as_mut_ptr().cast(), rows) };
+    sums
 }
 
 fn accumulate_q8_0_block_dot_quantized_cpu(


### PR DESCRIPTION
## Summary
- cherry-pick the AVX2 packed-rows4 decode-accumulator hoist onto a clean branch from `main`
- add a scrubbed Ubuntu x86_64 same-host evidence note for the candidate
- update Q8 performance docs to retain the narrow default-off AVX2 wall-clock win

## Validation
- Ubuntu Linux x86_64 release builds on current `main` and candidate `a39a493`
- one-token exact-row parity passed on current `main` and candidate
- same-host unique-prompt marker benchmark (`warmup=0`, `repeats=2`, `max_tokens=8`, `CAMELID_X86_Q8_REPACK=on`, `CAMELID_X86_Q8_KERNEL=avx2`)
- warmed-cache current-`main` control rerun
- `bash scripts/check-public-scrub.sh`
- `git diff --check`

## Measured result
- current `main` first pass: Camelid `8618.40 / 8618.91 ms`, llama.cpp `320.06 / 525.50 ms`
- candidate `a39a493`: Camelid `4447.75 / 4448.28 ms`, llama.cpp `317.16 / 524.74 ms`
- warmed-cache current `main` control: Camelid `8889.41 / 8889.69 ms`, llama.cpp `315.95 / 522.21 ms`

This retains only the narrow Camelid-on-Camelid win inside the existing default-off AVX2 lane. llama.cpp remains materially faster overall, so this PR does not make a default-on, portability, or broad throughput claim.