### PR TITLE
refactor: split Q8 file-read helpers from inference

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -20,6 +20,7 @@ use crate::metal;
 mod diagnostic_config;
 mod kv_cache;
 mod q8_block_reader;
+mod q8_file_reads;
 mod q8_runtime;
 mod q8_telemetry;
 mod rope;
@@ -40,6 +41,10 @@ pub use diagnostic_config::{
 };
 pub use kv_cache::{LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, LlamaKvCacheTrace};
 pub use q8_block_reader::Q8BlockReader;
+pub use q8_file_reads::LlamaQ8FileReadPhaseTrace;
+use q8_file_reads::{
+    add_q8_file_read_phase_trace, add_q8_file_read_stats_delta, q8_file_read_stats_has_activity,
+};
 use q8_runtime::{
     q8_0_env_flag_disabled, q8_0_env_flag_enabled_default_off,
     q8_0_env_flag_enabled_default_on_fail_closed, Q8RuntimeFlags, ResolvedRuntimePlan,
@@ -937,12 +942,6 @@ pub struct LlamaMemorySample {
     pub kv_cache_allocated_sequence_length: usize,
     pub kv_cache_allocated_elements: usize,
     pub kv_cache_allocated_bytes: u64,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct LlamaQ8FileReadPhaseTrace {
-    pub phase: String,
-    pub q8_file_reads: Q8_0FileReadStats,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -2140,74 +2139,6 @@ impl LlamaForwardMemoryTimings {
             }
         }
     }
-}
-
-fn q8_file_read_stats_has_activity(stats: Q8_0FileReadStats) -> bool {
-    stats.read_calls > 0
-        || stats.read_bytes > 0
-        || stats.cache_hits > 0
-        || stats.cache_hit_bytes > 0
-        || stats.cache_misses > 0
-        || stats.cache_miss_bytes > 0
-        || stats.cache_inserts > 0
-        || stats.cache_insert_bytes > 0
-        || stats.cache_evictions > 0
-        || stats.cache_evicted_bytes > 0
-        || stats.cache_merges > 0
-        || stats.cache_merged_bytes > 0
-        || stats.cache_decoded_scale_hits > 0
-        || stats.cache_decoded_scale_hit_blocks > 0
-}
-
-fn add_q8_file_read_stats_delta(target: &mut Q8_0FileReadStats, delta: Q8_0FileReadStats) {
-    target.read_calls = target.read_calls.saturating_add(delta.read_calls);
-    target.read_bytes = target.read_bytes.saturating_add(delta.read_bytes);
-    target.cache_hits = target.cache_hits.saturating_add(delta.cache_hits);
-    target.cache_hit_bytes = target.cache_hit_bytes.saturating_add(delta.cache_hit_bytes);
-    target.cache_misses = target.cache_misses.saturating_add(delta.cache_misses);
-    target.cache_miss_bytes = target
-        .cache_miss_bytes
-        .saturating_add(delta.cache_miss_bytes);
-    target.cache_inserts = target.cache_inserts.saturating_add(delta.cache_inserts);
-    target.cache_insert_bytes = target
-        .cache_insert_bytes
-        .saturating_add(delta.cache_insert_bytes);
-    target.cache_evictions = target.cache_evictions.saturating_add(delta.cache_evictions);
-    target.cache_evicted_bytes = target
-        .cache_evicted_bytes
-        .saturating_add(delta.cache_evicted_bytes);
-    target.cache_merges = target.cache_merges.saturating_add(delta.cache_merges);
-    target.cache_merged_bytes = target
-        .cache_merged_bytes
-        .saturating_add(delta.cache_merged_bytes);
-    target.cache_decoded_scale_hits = target
-        .cache_decoded_scale_hits
-        .saturating_add(delta.cache_decoded_scale_hits);
-    target.cache_decoded_scale_hit_blocks = target
-        .cache_decoded_scale_hit_blocks
-        .saturating_add(delta.cache_decoded_scale_hit_blocks);
-    // These fields are point-in-time cache state, not additive counters.  A merged timing window
-    // can span a scoped Q8 cache override (for example layer-major prefill) followed by a later
-    // single-token pass after the override has been restored to zero.  Keep the peak observed
-    // state so aggregate diagnostics still show that bounded cache/reuse was active.
-    target.cache_entries = target.cache_entries.max(delta.cache_entries);
-    target.cache_bytes = target.cache_bytes.max(delta.cache_bytes);
-    target.cache_capacity_bytes = target.cache_capacity_bytes.max(delta.cache_capacity_bytes);
-}
-
-fn add_q8_file_read_phase_trace(
-    phases: &mut Vec<LlamaQ8FileReadPhaseTrace>,
-    phase: &str,
-    delta: Q8_0FileReadStats,
-) {
-    if let Some(existing) = phases.iter_mut().find(|entry| entry.phase == phase) {
-        add_q8_file_read_stats_delta(&mut existing.q8_file_reads, delta);
-        return;
-    }
-    phases.push(LlamaQ8FileReadPhaseTrace {
-        phase: phase.to_string(),
-        q8_file_reads: delta,
-    });
 }
 
 impl LlamaLayerMemoryTimings {

--- a/src/inference/q8_file_reads.rs
+++ b/src/inference/q8_file_reads.rs
@@ -1,0 +1,78 @@
+use serde::Serialize;
+
+use crate::tensor::Q8_0FileReadStats;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct LlamaQ8FileReadPhaseTrace {
+    pub phase: String,
+    pub q8_file_reads: Q8_0FileReadStats,
+}
+
+pub(super) fn q8_file_read_stats_has_activity(stats: Q8_0FileReadStats) -> bool {
+    stats.read_calls > 0
+        || stats.read_bytes > 0
+        || stats.cache_hits > 0
+        || stats.cache_hit_bytes > 0
+        || stats.cache_misses > 0
+        || stats.cache_miss_bytes > 0
+        || stats.cache_inserts > 0
+        || stats.cache_insert_bytes > 0
+        || stats.cache_evictions > 0
+        || stats.cache_evicted_bytes > 0
+        || stats.cache_merges > 0
+        || stats.cache_merged_bytes > 0
+        || stats.cache_decoded_scale_hits > 0
+        || stats.cache_decoded_scale_hit_blocks > 0
+}
+
+pub(super) fn add_q8_file_read_stats_delta(
+    target: &mut Q8_0FileReadStats,
+    delta: Q8_0FileReadStats,
+) {
+    target.read_calls = target.read_calls.saturating_add(delta.read_calls);
+    target.read_bytes = target.read_bytes.saturating_add(delta.read_bytes);
+    target.cache_hits = target.cache_hits.saturating_add(delta.cache_hits);
+    target.cache_hit_bytes = target.cache_hit_bytes.saturating_add(delta.cache_hit_bytes);
+    target.cache_misses = target.cache_misses.saturating_add(delta.cache_misses);
+    target.cache_miss_bytes = target
+        .cache_miss_bytes
+        .saturating_add(delta.cache_miss_bytes);
+    target.cache_inserts = target.cache_inserts.saturating_add(delta.cache_inserts);
+    target.cache_insert_bytes = target
+        .cache_insert_bytes
+        .saturating_add(delta.cache_insert_bytes);
+    target.cache_evictions = target.cache_evictions.saturating_add(delta.cache_evictions);
+    target.cache_evicted_bytes = target
+        .cache_evicted_bytes
+        .saturating_add(delta.cache_evicted_bytes);
+    target.cache_merges = target.cache_merges.saturating_add(delta.cache_merges);
+    target.cache_merged_bytes = target
+        .cache_merged_bytes
+        .saturating_add(delta.cache_merged_bytes);
+    target.cache_decoded_scale_hits = target
+        .cache_decoded_scale_hits
+        .saturating_add(delta.cache_decoded_scale_hits);
+    target.cache_decoded_scale_hit_blocks = target
+        .cache_decoded_scale_hit_blocks
+        .saturating_add(delta.cache_decoded_scale_hit_blocks);
+    // These fields are point-in-time cache state, not additive counters. A merged timing window
+    // can span a scoped Q8 cache override and later single-token pass; keep the peak state.
+    target.cache_entries = target.cache_entries.max(delta.cache_entries);
+    target.cache_bytes = target.cache_bytes.max(delta.cache_bytes);
+    target.cache_capacity_bytes = target.cache_capacity_bytes.max(delta.cache_capacity_bytes);
+}
+
+pub(super) fn add_q8_file_read_phase_trace(
+    phases: &mut Vec<LlamaQ8FileReadPhaseTrace>,
+    phase: &str,
+    delta: Q8_0FileReadStats,
+) {
+    if let Some(existing) = phases.iter_mut().find(|entry| entry.phase == phase) {
+        add_q8_file_read_stats_delta(&mut existing.q8_file_reads, delta);
+        return;
+    }
+    phases.push(LlamaQ8FileReadPhaseTrace {
+        phase: phase.to_string(),
+        q8_file_reads: delta,
+    });
+}


### PR DESCRIPTION
## Summary
- move Q8 file-read phase trace type and aggregation helpers into `src/inference/q8_file_reads.rs`
- keep `LlamaQ8FileReadPhaseTrace` re-exported from `inference` to preserve callers
- reduce `src/inference.rs` by 69 lines without behavior changes

## Validation
- `cargo fmt --all -- --check`
- `cargo test --lib q8_file_read`
- `cargo test --lib`
- `cargo clippy --lib -- -D warnings`