### PR TITLE
fix(q8): wire FFN decode-chain planner and packed-output diagnostics

### DIFF
--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -517,17 +517,28 @@ fn select_linux_x86_q8_plan(
         "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_PAIRED_DOT",
         optional_x86_q8_gate("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_PAIRED_DOT"),
     );
+    let ffn_decode_chain_enabled = env_flag_enabled("CAMELID_X86_Q8_FFN_DECODE_CHAIN");
     env_updates.insert(
         "CAMELID_X86_Q8_FFN_DECODE_CHAIN",
-        optional_x86_q8_gate("CAMELID_X86_Q8_FFN_DECODE_CHAIN"),
+        if ffn_decode_chain_enabled {
+            Some("on")
+        } else {
+            Some("off")
+        },
     );
     env_updates.insert(
         "CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL",
         optional_x86_q8_gate("CAMELID_X86_Q8_FFN_GATE_UP_PACKED_ROWS4_MATMUL"),
     );
+    let ffn_down_decode_consumer_enabled =
+        ffn_decode_chain_enabled || env_flag_enabled("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER");
     env_updates.insert(
         "CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER",
-        optional_x86_q8_gate("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER"),
+        if ffn_down_decode_consumer_enabled {
+            Some("on")
+        } else {
+            Some("off")
+        },
     );
     env_updates.insert(
         "CAMELID_X86_Q8_FFN_DOWN_PACKED_ROWS4_MATMUL",
@@ -574,6 +585,13 @@ fn select_linux_x86_q8_plan(
         "CAMELID_X86_Q8_OUTPUT_DECODE_OWNER",
         optional_x86_q8_gate("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER"),
     );
+
+    if ffn_decode_chain_enabled && !env_flag_enabled("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER") {
+        reasons.push(
+            "FFN decode-chain opt-in also enables the required FFN-down decode consumer gate"
+                .into(),
+        );
+    }
     reasons.push("validated Ubuntu/Linux x86_64 Rust Q8 runtime repack enabled".into());
     reasons.push("validated Rust AVX2 Q8 packed rows4 kernel selected".into());
     reasons.push(
@@ -1528,6 +1546,36 @@ mod tests {
                 .get("CAMELID_X86_Q8_ATTENTION_QKV_PACKED_ROWS4_MATMUL"),
             Some(&Some("off"))
         );
+        clear_profile_env();
+    }
+
+    #[test]
+    fn ubuntu_experimental_ffn_decode_chain_enables_required_down_leg() {
+        let _guard = env_lock();
+        clear_profile_env();
+        env::set_var("CAMELID_PROFILE", "experimental");
+        env::set_var("CAMELID_X86_Q8_REPACK", "on");
+        env::set_var("CAMELID_X86_Q8_KERNEL", "avx2");
+        env::set_var("CAMELID_X86_Q8_FFN_DECODE_CHAIN", "on");
+        let outcome = plan_for_model_with_platform(
+            &PathBuf::from("/tmp/Llama-3.2-3B-Instruct-Q8_0.gguf"),
+            &fixture("Llama 3.2 3B Instruct"),
+            Some(16),
+            platform("linux", "x86_64", &["avx2", "avx512f"]),
+        );
+        assert_eq!(
+            outcome.env_updates.get("CAMELID_X86_Q8_FFN_DECODE_CHAIN"),
+            Some(&Some("on"))
+        );
+        assert_eq!(
+            outcome
+                .env_updates
+                .get("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER"),
+            Some(&Some("on"))
+        );
+        assert!(outcome.plan.reasons.iter().any(|reason| reason.contains(
+            "FFN decode-chain opt-in also enables the required FFN-down decode consumer gate"
+        )));
         clear_profile_env();
     }
 

--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -501,9 +501,16 @@ fn select_linux_x86_q8_plan(
         "CAMELID_X86_Q8_PARALLEL_INPUT_QUANTIZE",
         optional_x86_q8_gate("CAMELID_X86_Q8_PARALLEL_INPUT_QUANTIZE"),
     );
+    let ffn_decode_chain_enabled = env_flag_enabled("CAMELID_X86_Q8_FFN_DECODE_CHAIN");
+    let ffn_gate_up_decode_consumer_enabled =
+        ffn_decode_chain_enabled || env_flag_enabled("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER");
     env_updates.insert(
         "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER",
-        optional_x86_q8_gate("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER"),
+        if ffn_gate_up_decode_consumer_enabled {
+            Some("on")
+        } else {
+            Some("off")
+        },
     );
     env_updates.insert(
         "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_GROUP_CHUNKING",
@@ -517,7 +524,6 @@ fn select_linux_x86_q8_plan(
         "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_PAIRED_DOT",
         optional_x86_q8_gate("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_PAIRED_DOT"),
     );
-    let ffn_decode_chain_enabled = env_flag_enabled("CAMELID_X86_Q8_FFN_DECODE_CHAIN");
     env_updates.insert(
         "CAMELID_X86_Q8_FFN_DECODE_CHAIN",
         if ffn_decode_chain_enabled {
@@ -586,6 +592,12 @@ fn select_linux_x86_q8_plan(
         optional_x86_q8_gate("CAMELID_X86_Q8_OUTPUT_DECODE_OWNER"),
     );
 
+    if ffn_decode_chain_enabled && !env_flag_enabled("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER") {
+        reasons.push(
+            "FFN decode-chain opt-in also enables the required FFN gate/up decode consumer gate"
+                .into(),
+        );
+    }
     if ffn_decode_chain_enabled && !env_flag_enabled("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER") {
         reasons.push(
             "FFN decode-chain opt-in also enables the required FFN-down decode consumer gate"
@@ -1550,7 +1562,7 @@ mod tests {
     }
 
     #[test]
-    fn ubuntu_experimental_ffn_decode_chain_enables_required_down_leg() {
+    fn ubuntu_experimental_ffn_decode_chain_enables_required_gate_up_and_down_legs() {
         let _guard = env_lock();
         clear_profile_env();
         env::set_var("CAMELID_PROFILE", "experimental");
@@ -1570,9 +1582,18 @@ mod tests {
         assert_eq!(
             outcome
                 .env_updates
+                .get("CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER"),
+            Some(&Some("on"))
+        );
+        assert_eq!(
+            outcome
+                .env_updates
                 .get("CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER"),
             Some(&Some("on"))
         );
+        assert!(outcome.plan.reasons.iter().any(|reason| reason.contains(
+            "FFN decode-chain opt-in also enables the required FFN gate/up decode consumer gate"
+        )));
         assert!(outcome.plan.reasons.iter().any(|reason| reason.contains(
             "FFN decode-chain opt-in also enables the required FFN-down decode consumer gate"
         )));

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -7559,6 +7559,7 @@ fn try_x86_q8_ffn_gate_up_decode_consumer_path(
         up,
         runtime_plan.q8.ffn_gate_up_decode_group_chunking,
     )?;
+    add_q8_schedule_counter(&Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TAKEN, 1);
     let total_elapsed = started.elapsed().as_micros();
     record_q8_schedule_output_projection_route_call(
         "ffn_gate_up",
@@ -7661,6 +7662,7 @@ fn try_x86_q8_ffn_decode_chain_path(
         &quantized_input.blocks,
         runtime_plan.q8.ffn_gate_up_decode_paired_dot,
     )?;
+    add_q8_schedule_counter(&Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TAKEN, 1);
     let gate_up_elapsed = gate_up_started.elapsed().as_micros();
     record_q8_schedule_output_projection_route_call(
         "ffn_gate_up",

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4977,7 +4977,8 @@ fn validate_output_projection_row_layout(
             } else if rows == hidden_width
                 && cols == vocab_size
                 && (output_weight.data.len() == hidden_width * vocab_size
-                    || output_weight.q8_0_file_backing.is_some())
+                    || output_weight.q8_0_file_backing.is_some()
+                    || output_weight.q8_0_runtime_storage.is_some())
             {
                 Ok(EffectiveOutputProjectionRowLayout::TokenMajorReinterpret)
             } else {
@@ -5013,6 +5014,49 @@ struct OutputProjectionTokenRow {
     q8_0_row_bytes: Option<Vec<u8>>,
 }
 
+fn output_projection_runtime_packed_row(
+    packed: &Q8_0PackedRows4,
+    hidden_width: usize,
+    token_index: usize,
+) -> Result<Vec<f32>> {
+    if token_index >= packed.rows {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "output projection runtime-packed row {token_index} exceeds packed row count {}",
+            packed.rows
+        )));
+    }
+    if !hidden_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "output projection runtime-packed hidden width {hidden_width} is not block aligned"
+        )));
+    }
+    let blocks_per_row = hidden_width / Q8_0_BLOCK_VALUES;
+    if packed.blocks_per_row != blocks_per_row {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "output projection runtime-packed rows expected {blocks_per_row} blocks per row, got {}",
+            packed.blocks_per_row
+        )));
+    }
+    let row_group = token_index / 4;
+    let lane = token_index % 4;
+    let block_len = packed.interleave.block_len();
+    let chunks_per_block = Q8_0_BLOCK_VALUES / block_len;
+    let mut values = Vec::with_capacity(hidden_width);
+    for block_idx in 0..blocks_per_row {
+        let packed_block = &packed.blocks[row_group * blocks_per_row + block_idx];
+        let scale = packed_block.scales[lane];
+        for chunk in 0..chunks_per_block {
+            let start = chunk * 4 * block_len + lane * block_len;
+            values.extend(
+                packed_block.quants[start..start + block_len]
+                    .iter()
+                    .map(|value| scale * f32::from(*value)),
+            );
+        }
+    }
+    Ok(values)
+}
+
 fn output_projection_token_row(
     output_weight: &CpuTensor,
     hidden_width: usize,
@@ -5041,6 +5085,30 @@ fn output_projection_token_row(
         };
         return Ok(OutputProjectionTokenRow {
             values,
+            q8_0_row_bytes: None,
+        });
+    }
+
+    if let Some(Q8_0RuntimeStorage::PackedRows4(packed)) =
+        output_weight.q8_0_runtime_storage.as_ref()
+    {
+        if output_weight.source_type != Some(GgufTensorType::Q8_0) {
+            return Err(BackendError::RuntimeShapeMismatch(format!(
+                "output projection diagnostics only support runtime-packed q8_0 rows, got {:?}",
+                output_weight.source_type
+            )));
+        }
+        if layout != EffectiveOutputProjectionRowLayout::TokenMajorReinterpret
+            && layout != EffectiveOutputProjectionRowLayout::DescriptorOutputInput
+        {
+            return Err(BackendError::RuntimeShapeMismatch(format!(
+                "output projection diagnostics cannot decode runtime-packed {} layout for tensor {}",
+                layout.label(),
+                output_weight.name
+            )));
+        }
+        return Ok(OutputProjectionTokenRow {
+            values: output_projection_runtime_packed_row(packed, hidden_width, token_index)?,
             q8_0_row_bytes: None,
         });
     }

--- a/src/inference/q8_telemetry.rs
+++ b/src/inference/q8_telemetry.rs
@@ -23,6 +23,7 @@ pub struct LlamaQ8ScheduleTelemetry {
     pub output_projection_by_layer_route:
         HashMap<String, LlamaQ8OutputProjectionLayerRouteTelemetry>,
     pub projection_route_denials: HashMap<String, LlamaQ8ProjectionRouteDenialTelemetry>,
+    pub ffn_gate_up_decode_consumer_taken: u64,
     pub ffn_gate_up_decode_consumer_activation_us: u64,
     pub ffn_gate_up_decode_consumer_tensor_us: u64,
     pub ffn_decode_chain_taken: u64,
@@ -114,6 +115,7 @@ pub(super) static Q8_SCHED_RAYON_FANOUT_BOUNDARIES: AtomicU64 = AtomicU64::new(0
 pub(super) static Q8_SCHED_I8MM_SINGLE_PROJECTION_CALLS: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_I8MM_FUSED_GATE_UP_CALLS: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_OUTPUT_PROJECTION_CALLS: AtomicU64 = AtomicU64::new(0);
+pub(super) static Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TAKEN: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_ACTIVATION_US: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TENSOR_US: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_TAKEN: AtomicU64 = AtomicU64::new(0);
@@ -183,6 +185,7 @@ pub fn reset_q8_schedule_telemetry() {
     Q8_SCHED_I8MM_SINGLE_PROJECTION_CALLS.store(0, Ordering::Relaxed);
     Q8_SCHED_I8MM_FUSED_GATE_UP_CALLS.store(0, Ordering::Relaxed);
     Q8_SCHED_OUTPUT_PROJECTION_CALLS.store(0, Ordering::Relaxed);
+    Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TAKEN.store(0, Ordering::Relaxed);
     Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_ACTIVATION_US.store(0, Ordering::Relaxed);
     Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TENSOR_US.store(0, Ordering::Relaxed);
     Q8_SCHED_FFN_DECODE_CHAIN_TAKEN.store(0, Ordering::Relaxed);
@@ -278,6 +281,8 @@ pub fn snapshot_q8_schedule_telemetry() -> LlamaQ8ScheduleTelemetry {
                     .clone()
             })
             .unwrap_or_default(),
+        ffn_gate_up_decode_consumer_taken: Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TAKEN
+            .load(Ordering::Relaxed),
         ffn_gate_up_decode_consumer_activation_us:
             Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_ACTIVATION_US.load(Ordering::Relaxed),
         ffn_gate_up_decode_consumer_tensor_us: Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TENSOR_US

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -3910,6 +3910,7 @@ fn q8_projection_route_telemetry_records_layer_route_bucket() {
 
     let telemetry = snapshot_q8_schedule_telemetry();
     assert_eq!(telemetry.output_projection_calls, 2);
+    assert_eq!(telemetry.ffn_gate_up_decode_consumer_taken, 0);
     assert_eq!(telemetry.ffn_gate_up_decode_consumer_activation_us, 0);
     assert_eq!(telemetry.ffn_gate_up_decode_consumer_tensor_us, 0);
     assert!(telemetry
@@ -4040,7 +4041,9 @@ fn x86_q8_ffn_decode_chain_is_default_off_and_matches_split_consumers() {
     assert_eq!(actual.tensor.shape.dims, expected.shape.dims);
     assert_slice_close_with_tolerance(&actual.tensor.data, &expected.data, 5e-4);
     let telemetry = snapshot_q8_schedule_telemetry();
+    assert_eq!(telemetry.ffn_gate_up_decode_consumer_taken, 1);
     assert_eq!(telemetry.ffn_decode_chain_taken, 1);
+    assert_eq!(telemetry.ffn_down_decode_consumer_taken, 1);
     assert!(telemetry.ffn_decode_chain_total_us > 0);
     assert!(telemetry.ffn_decode_chain_input_quantize_us > 0);
     assert!(telemetry.ffn_decode_chain_activation_quantize_us > 0);
@@ -5339,6 +5342,8 @@ fn q8_ffn_down_single_owner_is_plan_gated_and_role_limited() {
 fn q8_ffn_gate_up_consumer_matches_runtime_packed_baseline() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
     let (input, packed_gate, packed_up, expected) = runtime_packed_ffn_gate_up_case();
 
     let actual = gated_ffn_activation_with_plan(
@@ -5362,6 +5367,10 @@ fn q8_ffn_gate_up_consumer_matches_runtime_packed_baseline() {
         packed_up.q8_0_runtime_storage.as_ref(),
         Some(Q8_0RuntimeStorage::PackedRows4(_))
     ));
+    let telemetry = snapshot_q8_schedule_telemetry();
+    assert_eq!(telemetry.ffn_gate_up_decode_consumer_taken, 1);
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
 }
 
 #[test]

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -7635,6 +7635,80 @@ fn output_projection_diagnostics_support_q8_0_file_backed_token_major_rows() {
 }
 
 #[test]
+fn output_projection_diagnostics_support_runtime_packed_tied_output_rows() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+
+    let output_norm_values = (0..32)
+        .map(|idx| idx as f32 * 0.125 - 1.5)
+        .collect::<Vec<_>>();
+    let output_norm =
+        CpuTensor::from_f32("output_norm", vec![1, 32], output_norm_values.clone()).unwrap();
+    let row_blocks = vec![
+        Q8_0Block {
+            scale: 0.125,
+            quants: std::array::from_fn(|idx| idx as i8 - 8),
+        },
+        Q8_0Block {
+            scale: 0.0625,
+            quants: std::array::from_fn(|idx| if idx.is_multiple_of(2) { 6 } else { -5 }),
+        },
+        Q8_0Block {
+            scale: 0.09375,
+            quants: std::array::from_fn(|idx| (idx as i8 % 9) - 4),
+        },
+        Q8_0Block {
+            scale: 0.15625,
+            quants: std::array::from_fn(|idx| if idx.is_multiple_of(3) { 7 } else { -3 }),
+        },
+    ];
+    let packed =
+        Q8_0PackedRows4::from_rows(4, 1, Q8_0PackedRows4Interleave::I8, &row_blocks).unwrap();
+    let output_weight = CpuTensor::q8_0_runtime_packed_rows4_linear(
+        "output.weight",
+        TensorShape { dims: vec![32, 4] },
+        packed,
+    );
+
+    let logits = row_blocks
+        .iter()
+        .map(|block| {
+            output_norm_values
+                .iter()
+                .zip(block.quants.iter())
+                .map(|(input, quant)| *input * block.scale * f32::from(*quant))
+                .sum::<f32>()
+        })
+        .collect::<Vec<_>>();
+    let logits = CpuTensor::from_f32("logits", vec![1, 4], logits).unwrap();
+
+    let diagnostics = output_projection_diagnostics(
+        &output_norm,
+        &output_weight,
+        &logits,
+        &[0, 1],
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(diagnostics.len(), 2);
+    for (idx, diagnostic) in diagnostics.iter().enumerate() {
+        assert_eq!(diagnostic.token_id as usize, idx);
+        assert_eq!(diagnostic.layout, "token_major");
+        assert_close(diagnostic.reconstructed_logit, diagnostic.reported_logit);
+        assert_close(
+            diagnostic.decoded_component_reconstructed_logit,
+            diagnostic.reported_logit,
+        );
+        assert_eq!(diagnostic.q8_direct_reconstructed_logit, None);
+        assert_eq!(diagnostic.q8_direct_absolute_delta, None);
+        assert_eq!(diagnostic.q8_direct_decoded_component_delta, None);
+    }
+}
+
+#[test]
 fn output_projection_diagnostics_reject_q8_0_file_backed_unaligned_rows_before_read() {
     let _env_guard = env_lock();
     let _q8_guard = crate::test_support::q8_file_state_lock();

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -4025,6 +4025,7 @@ fn x86_q8_ffn_decode_chain_is_default_off_and_matches_split_consumers() {
         false,
     )
     .unwrap();
+    reset_q8_schedule_telemetry();
 
     let actual = try_x86_q8_ffn_decode_chain_path(
         &input,


### PR DESCRIPTION
## Summary

- enable `CAMELID_X86_Q8_FFN_GATE_UP_DECODE_CONSUMER` and `CAMELID_X86_Q8_FFN_DOWN_DECODE_CONSUMER` automatically when `CAMELID_X86_Q8_FFN_DECODE_CHAIN=on` is selected by the Linux x86 experimental planner
- let output-projection diagnostics decode runtime-packed tied-output Q8 rows so the experimental packed-output routes can still be inspected precisely
- count `ffn_gate_up_decode_consumer_taken` so decode-chain and split gate/up consumer runs leave explicit schedule telemetry

## Why this change exists

The FFN decode-chain fast path already hard-requires both `runtime_plan.q8.ffn_gate_up_decode_consumer` and `runtime_plan.q8.ffn_down_decode_consumer`, but the Linux x86 experimental planner previously treated the decode-chain flag and those required decode-consumer legs as unrelated knobs. That made the decode-chain opt-in silently miss the intended route unless callers also knew to set the extra dependent gates.

The runtime-packed output diagnostics slice closes a separate observability gap on the same lane: once tied output is materialized as runtime-packed Q8 storage, output-projection diagnostics need to be able to reconstruct token rows from that packed representation instead of requiring dense values or file backing.

The follow-up telemetry slice closes a smaller proof gap on top of that work: once the planner implies the gate/up leg and the decode chain executes, schedule telemetry should record that the gate/up decode consumer actually fired instead of leaving only the decode-chain aggregate counter.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --lib ubuntu_experimental_ffn_decode_chain_enables_required_gate_up_and_down_legs`
- `cargo test --lib x86_q8_ffn_decode_chain_is_default_off_and_matches_split_consumers`
- `cargo test --lib q8_ffn_gate_up_consumer_matches_runtime_packed_baseline`
- `cargo test --lib output_projection_diagnostics_support_runtime_packed_tied_output_rows`
- Existing Ubuntu Linux x86_64 same-host Llama 3.2 3B Q8_0 branch evidence remains bounded route/timing evidence:
  - Camelid TTFT `3137.54 ms`, total `3138.06 ms`
  - llama.cpp TTFT `316.21 ms`, total `504.97 ms`
  - marker guard passed
  - route proof: `ffn_decode_chain_taken=168`, `ffn_down_decode_consumer_taken=168`, `logits.x86_output_decode_owner.calls=6`

## Public-repo privacy check

- No private hostnames, SSH commands, user home paths, key paths, or local validation details included

## Support-contract check

- This change does not widen support claims
- Evidence remains bounded to the exact Ubuntu Linux x86_64 Llama 3.2 3B Q8_0 same-host lane

## Evidence / artifacts

- Focused planner and diagnostics tests for the decode-chain planner wiring, runtime-packed tied-output inspection, and gate/up decode-consumer telemetry
- Existing Ubuntu same-host timing artifact for the decode-chain-only opt-in case

## Docs impact

- None