### PR TITLE
telemetry(q8): name attention QKV route denials

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -7103,6 +7103,15 @@ enum X86Q8AttentionQkvRouteKind {
     PackedRows4Matmul,
 }
 
+impl X86Q8AttentionQkvRouteKind {
+    fn telemetry_name(self) -> &'static str {
+        match self {
+            Self::Decode => "x86_decode_consumer",
+            Self::PackedRows4Matmul => "x86_packed_rows4_matmul",
+        }
+    }
+}
+
 struct X86Q8AttentionQkvRoute<'a> {
     q_packed: &'a Q8_0PackedRows4,
     k_packed: &'a Q8_0PackedRows4,
@@ -7127,34 +7136,107 @@ fn resolve_x86_q8_attention_qkv_route<'a>(
             runtime_plan.q8.attention_qkv_packed_rows4_matmul
         }
     };
+    let route_name = route.telemetry_name();
     if !route_enabled || input.rank() != 2 {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            if !route_enabled {
+                "plan_off"
+            } else {
+                "rank_mismatch"
+            },
+            input.dim(0).unwrap_or(0),
+            input.dim(1).unwrap_or(0),
+            0,
+        );
         return Ok(None);
     }
 
     let rows = input.dim(0)?;
     match route {
-        X86Q8AttentionQkvRouteKind::Decode if rows != 1 => return Ok(None),
-        X86Q8AttentionQkvRouteKind::PackedRows4Matmul if rows <= 1 => return Ok(None),
+        X86Q8AttentionQkvRouteKind::Decode if rows != 1 => {
+            record_q8_schedule_projection_route_denial(
+                "attention_qkv",
+                route_name,
+                "prefill_or_empty_input",
+                rows,
+                input.dim(1).unwrap_or(0),
+                0,
+            );
+            return Ok(None);
+        }
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul if rows <= 1 => {
+            record_q8_schedule_projection_route_denial(
+                "attention_qkv",
+                route_name,
+                "decode_or_empty_input",
+                rows,
+                input.dim(1).unwrap_or(0),
+                0,
+            );
+            return Ok(None);
+        }
         _ => {}
     }
 
     let input_width = input.dim(1)?;
     if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "bad_input_width",
+            rows,
+            input_width,
+            0,
+        );
         return Ok(None);
     }
 
     let Some((q_packed, q_width)) = q8_0_runtime_packed_projection(q_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "missing_q_runtime_packed_rows4",
+            rows,
+            input_width,
+            0,
+        );
         return Ok(None);
     };
     let Some((k_packed, k_width)) = q8_0_runtime_packed_projection(k_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "missing_k_runtime_packed_rows4",
+            rows,
+            input_width,
+            q_width,
+        );
         return Ok(None);
     };
     let Some((v_packed, v_width)) = q8_0_runtime_packed_projection(v_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "missing_v_runtime_packed_rows4",
+            rows,
+            input_width,
+            q_width.max(k_width),
+        );
         return Ok(None);
     };
     if q_packed.blocks_per_row != k_packed.blocks_per_row
         || q_packed.blocks_per_row != v_packed.blocks_per_row
     {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "qkv_block_stride_mismatch",
+            rows,
+            input_width,
+            q_width.max(k_width).max(v_width),
+        );
         return Ok(None);
     }
 

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -3105,6 +3105,91 @@ fn q8_attention_qkv_route_resolver_preserves_decode_and_prefill_guards() {
 }
 
 #[test]
+fn q8_attention_qkv_route_resolver_records_denials() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+
+    let (decode_input, q_weight, _) =
+        runtime_packed_attention_projection_case("attention_q", "blk.0.attn_q.weight");
+    let (_, k_weight, _) =
+        runtime_packed_attention_projection_case("attention_k", "blk.0.attn_k.weight");
+    let (_, v_weight, _) =
+        runtime_packed_attention_projection_case("attention_v", "blk.0.attn_v.weight");
+    let prefill_input = CpuTensor::from_f32(
+        "prefill_input",
+        vec![2, decode_input.dim(1).unwrap()],
+        vec![0.0; 2 * decode_input.dim(1).unwrap()],
+    )
+    .unwrap();
+    let dense_v = CpuTensor::from_f32(
+        "dense_v",
+        vec![12, Q8_0_BLOCK_VALUES * 2],
+        vec![0.0; 12 * Q8_0_BLOCK_VALUES * 2],
+    )
+    .unwrap();
+
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &prefill_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_consumer_plan(true),
+        X86Q8AttentionQkvRouteKind::Decode,
+    )
+    .unwrap()
+    .is_none());
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &decode_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_packed_rows4_matmul_plan(true),
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &prefill_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_packed_rows4_matmul_plan(false),
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &decode_input,
+        &q_weight,
+        &k_weight,
+        &dense_v,
+        &attention_qkv_consumer_plan(true),
+        X86Q8AttentionQkvRouteKind::Decode,
+    )
+    .unwrap()
+    .is_none());
+
+    let telemetry = snapshot_q8_schedule_telemetry();
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key("attention_qkv.x86_decode_consumer.prefill_or_empty_input"));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key("attention_qkv.x86_packed_rows4_matmul.decode_or_empty_input"));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key("attention_qkv.x86_packed_rows4_matmul.plan_off"));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key("attention_qkv.x86_decode_consumer.missing_v_runtime_packed_rows4"));
+
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
+}
+
+#[test]
 fn q8_attention_qkv_prefill_consumer_gate_is_default_off() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();


### PR DESCRIPTION
## Summary
- add named telemetry-denial reasons to the x86 Q8 attention Q/K/V route resolver instead of silently returning `None`
- distinguish plan-off, rank mismatch, row-policy mismatch, bad input width, missing runtime-packed Q/K/V storage, and Q/K/V block-stride mismatch
- add a focused regression test that asserts denial keys are recorded for representative decode and prefill guard failures

## Validation
- `cargo test q8_attention_qkv_route_resolver -- --nocapture`
- same-host Linux x86_64 validation passed on a clean checkout of this branch