### PR TITLE
refactor: extract Q8 route helpers

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -20,6 +20,7 @@ use crate::metal;
 mod diagnostic_config;
 mod kv_cache;
 mod q8_block_reader;
+mod q8_routes;
 mod q8_runtime;
 mod q8_telemetry;
 mod rope;
@@ -40,6 +41,7 @@ pub use diagnostic_config::{
 };
 pub use kv_cache::{LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, LlamaKvCacheTrace};
 pub use q8_block_reader::Q8BlockReader;
+use q8_routes::{q8_schedule_output_projection_route_kind, q8_schedule_role_for_output_name};
 use q8_runtime::{
     q8_0_env_flag_disabled, q8_0_env_flag_enabled_default_off,
     q8_0_env_flag_enabled_default_on_fail_closed, Q8RuntimeFlags, ResolvedRuntimePlan,
@@ -751,60 +753,6 @@ pub struct LlamaForwardTimings {
     pub logits: u128,
     pub layers: Vec<LlamaLayerTimings>,
     pub memory: Option<LlamaForwardMemoryTimings>,
-}
-
-#[allow(dead_code)]
-fn q8_schedule_output_projection_route_kind(
-    weight: BorrowedLinearWeight<'_>,
-    input_width: usize,
-    output_width: usize,
-) -> &'static str {
-    if weight.source_type == Some(GgufTensorType::Q8_0) {
-        if q8_0_selected_borrowed_packed_rows4(weight)
-            .filter(|(packed, _)| {
-                packed.rows == output_width
-                    && packed.blocks_per_row == input_width / Q8_0_BLOCK_VALUES
-            })
-            .is_some()
-        {
-            "q8_0_borrowed_packed_rows4"
-        } else if weight.q8_0_blocks.is_some() {
-            "q8_0_retained_blocks"
-        } else if weight.q8_0_file_backing.is_some()
-            && weight.cols == input_width
-            && weight.rows == output_width
-            && input_width.is_multiple_of(Q8_0_BLOCK_VALUES)
-        {
-            "q8_0_file_reader"
-        } else {
-            "q8_0_f32_fallback"
-        }
-    } else {
-        "f32"
-    }
-}
-
-#[allow(dead_code)]
-fn q8_schedule_role_for_output_name(name: &str) -> &'static str {
-    if name.contains("attention_q") || name.contains("attn_q") {
-        "attention_q"
-    } else if name.contains("attention_k") || name.contains("attn_k") {
-        "attention_k"
-    } else if name.contains("attention_v") || name.contains("attn_v") {
-        "attention_v"
-    } else if name.contains("attention_output") || name.contains("attn_output") {
-        "attention_output"
-    } else if name.contains("ffn_gate") {
-        "ffn_gate"
-    } else if name.contains("ffn_up") {
-        "ffn_up"
-    } else if name.contains("ffn_down") {
-        "ffn_down"
-    } else if name.contains("logits") {
-        "logits"
-    } else {
-        "unknown"
-    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]

--- a/src/inference/q8_routes.rs
+++ b/src/inference/q8_routes.rs
@@ -1,0 +1,57 @@
+use super::{
+    q8_0_selected_borrowed_packed_rows4, BorrowedLinearWeight, GgufTensorType, Q8_0_BLOCK_VALUES,
+};
+
+#[allow(dead_code)]
+pub(super) fn q8_schedule_output_projection_route_kind(
+    weight: BorrowedLinearWeight<'_>,
+    input_width: usize,
+    output_width: usize,
+) -> &'static str {
+    if weight.source_type == Some(GgufTensorType::Q8_0) {
+        if q8_0_selected_borrowed_packed_rows4(weight)
+            .filter(|(packed, _)| {
+                packed.rows == output_width
+                    && packed.blocks_per_row == input_width / Q8_0_BLOCK_VALUES
+            })
+            .is_some()
+        {
+            "q8_0_borrowed_packed_rows4"
+        } else if weight.q8_0_blocks.is_some() {
+            "q8_0_retained_blocks"
+        } else if weight.q8_0_file_backing.is_some()
+            && weight.cols == input_width
+            && weight.rows == output_width
+            && input_width.is_multiple_of(Q8_0_BLOCK_VALUES)
+        {
+            "q8_0_file_reader"
+        } else {
+            "q8_0_f32_fallback"
+        }
+    } else {
+        "f32"
+    }
+}
+
+#[allow(dead_code)]
+pub(super) fn q8_schedule_role_for_output_name(name: &str) -> &'static str {
+    if name.contains("attention_q") || name.contains("attn_q") {
+        "attention_q"
+    } else if name.contains("attention_k") || name.contains("attn_k") {
+        "attention_k"
+    } else if name.contains("attention_v") || name.contains("attn_v") {
+        "attention_v"
+    } else if name.contains("attention_output") || name.contains("attn_output") {
+        "attention_output"
+    } else if name.contains("ffn_gate") {
+        "ffn_gate"
+    } else if name.contains("ffn_up") {
+        "ffn_up"
+    } else if name.contains("ffn_down") {
+        "ffn_down"
+    } else if name.contains("logits") {
+        "logits"
+    } else {
+        "unknown"
+    }
+}


### PR DESCRIPTION
## Summary
- move output-projection Q8 route classification helpers into `src/inference/q8_routes.rs`
- leave route strings, shape checks, and telemetry decisions unchanged
- reduce `src/inference.rs` by 52 net lines

## Validation
- `cargo fmt --all -- --check`
- `cargo test --lib output_projection`
- `cargo test --lib`
- `cargo clippy --lib -- -D warnings`

Note: Cargo emitted its existing hard-link cache warning for the external target directory during test/clippy builds.