### PR TITLE
Route packed rows4 matmul chunk schedule through runtime plan

### DIFF
--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -46,6 +46,7 @@ const MANAGED_ENV_KEYS: &[&str] = &[
     "CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUPS_PER_CHUNK",
     "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_GROUPS_PER_CHUNK",
     "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
+    "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK",
 ];
 
 struct ManagedPassthroughEnvKey {
@@ -65,6 +66,10 @@ const MANAGED_PASSTHROUGH_ENV_KEYS: &[ManagedPassthroughEnvKey] = &[
     ManagedPassthroughEnvKey {
         key: "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
         owner_gate: "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED",
+    },
+    ManagedPassthroughEnvKey {
+        key: "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK",
+        owner_gate: "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL",
     },
 ];
 
@@ -972,6 +977,7 @@ mod tests {
             "CAMELID_X86_Q8_FFN_DOWN_VNNI_DECODE_RAWPTR",
             "CAMELID_X86_Q8_FFN_DOWN_DECODE_OWNER",
             "CAMELID_X86_Q8_OUTPUT_DECODE_OWNER",
+            "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK",
         ] {
             env::remove_var(key);
         }
@@ -1561,6 +1567,7 @@ mod tests {
             "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
             "3",
         );
+        env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "9");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_AVX2", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_AMX_PREFILL", "on");
         env::set_var("CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER", "on");
@@ -1595,6 +1602,7 @@ mod tests {
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_PREFILL").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS").is_err());
+        assert!(env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_AVX2").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_AMX_PREFILL").is_err());
         assert!(env::var("CAMELID_X86_Q8_FFN_DOWN_SINGLE_OWNER").is_err());
@@ -1616,6 +1624,7 @@ mod tests {
             "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
             "3",
         );
+        env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "9");
         let planner_env = PlannerEnv::capture();
 
         env::set_var("CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUPS_PER_CHUNK", "99");
@@ -1624,6 +1633,7 @@ mod tests {
             "CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS",
             "99",
         );
+        env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "99");
 
         let updates = BTreeMap::from([
             (
@@ -1635,6 +1645,7 @@ mod tests {
                 Some("on"),
             ),
             ("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_SCHED", Some("on")),
+            ("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL", Some("on")),
         ]);
         planner_env.apply(&updates);
 
@@ -1650,6 +1661,25 @@ mod tests {
             env::var("CAMELID_X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS").ok(),
             Some("3".into())
         );
+        assert_eq!(
+            env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK").ok(),
+            Some("9".into())
+        );
+        clear_profile_env();
+    }
+
+    #[test]
+    fn planner_env_apply_does_not_restore_packed_rows4_matmul_chunk_groups_without_owner_gate() {
+        let _guard = env_lock();
+        clear_profile_env();
+        env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "9");
+        let planner_env = PlannerEnv::capture();
+
+        env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "99");
+
+        planner_env.apply(&BTreeMap::new());
+
+        assert!(env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK").is_err());
         clear_profile_env();
     }
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -42,7 +42,8 @@ pub use kv_cache::{LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, Ll
 pub use q8_block_reader::Q8BlockReader;
 use q8_runtime::{
     q8_0_env_flag_disabled, q8_0_env_flag_enabled_default_off,
-    q8_0_env_flag_enabled_default_on_fail_closed, Q8RuntimeFlags, ResolvedRuntimePlan,
+    q8_0_env_flag_enabled_default_on_fail_closed, Q8PackedRows4MatmulSchedule, Q8RuntimeFlags,
+    ResolvedRuntimePlan,
 };
 use q8_telemetry::*;
 pub use q8_telemetry::{
@@ -6060,6 +6061,7 @@ fn try_x86_q8_ffn_gate_up_packed_rows4_matmul_path(
                     name,
                     order,
                     quantized_inputs,
+                    runtime_plan.q8_packed_rows4_matmul_schedule,
                 )
             },
         )?;
@@ -6229,6 +6231,7 @@ fn try_gated_ffn_activation_batch_packed_prefill_i8mm(
                     "ffn_gate_mac_q8_gate_up_packed_prefill",
                     "ffn_up_mac_q8_gate_up_packed_prefill",
                     quantized_inputs,
+                    Q8PackedRows4MatmulSchedule::default(),
                 )
             },
         )?;
@@ -6660,9 +6663,11 @@ fn accumulate_linear_row(
 
 #[allow(dead_code)]
 fn should_use_q8_0_block_dot(weight: &CpuTensor, input_width: usize) -> bool {
+    let q8 = Q8RuntimeFlags::from_env();
     let runtime_plan = ResolvedRuntimePlan::from_env().unwrap_or(ResolvedRuntimePlan {
         linear_accumulation_precision: LinearAccumulationPrecision::F32,
-        q8: Q8RuntimeFlags::from_env(),
+        q8,
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::from_q8_flags(q8),
     });
     should_use_q8_0_block_dot_with_plan(weight, input_width, &runtime_plan)
 }
@@ -6683,9 +6688,11 @@ fn should_use_borrowed_q8_0_block_dot(
     weight: BorrowedLinearWeight<'_>,
     input_width: usize,
 ) -> bool {
+    let q8 = Q8RuntimeFlags::from_env();
     let runtime_plan = ResolvedRuntimePlan::from_env().unwrap_or(ResolvedRuntimePlan {
         linear_accumulation_precision: LinearAccumulationPrecision::F32,
-        q8: Q8RuntimeFlags::from_env(),
+        q8,
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::from_q8_flags(q8),
     });
     should_use_borrowed_q8_0_block_dot_with_plan(weight, input_width, &runtime_plan)
 }
@@ -6878,7 +6885,6 @@ fn lazy_q8_0_linear_enabled() -> bool {
 const Q8_0_BLOCK_VALUES: usize = 32;
 const X86_Q8_PACKED_ROWS4_DECODE_PARALLEL_MIN_OUTPUTS: usize = 1024;
 const X86_Q8_PACKED_ROWS4_MATMUL_PARALLEL_MIN_GROUPS: usize = 64;
-const X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK: usize = 8;
 const X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS: usize = 8;
 
 #[derive(Debug, Clone)]
@@ -6938,7 +6944,14 @@ fn try_x86_q8_output_packed_rows4_matmul_path(
         }
     }
 
-    q8_0_packed_rows4_matmul_projection(input, packed, output_width, name).map(Some)
+    q8_0_packed_rows4_matmul_projection(
+        input,
+        packed,
+        output_width,
+        name,
+        runtime_plan.q8_packed_rows4_matmul_schedule,
+    )
+    .map(Some)
 }
 fn try_x86_q8_output_decode_owner_path(
     input: &CpuTensor,
@@ -7235,6 +7248,7 @@ fn try_x86_q8_attention_qkv_packed_rows4_matmul_path(
                 route.k_width,
                 route.v_width,
                 quantized_inputs,
+                runtime_plan.q8_packed_rows4_matmul_schedule,
             )
         },
     )?;
@@ -9206,6 +9220,7 @@ fn q8_0_packed_rows4_matmul_projection(
     packed: &Q8_0PackedRows4,
     output_width: usize,
     name: &str,
+    schedule: Q8PackedRows4MatmulSchedule,
 ) -> Result<CpuTensor> {
     with_q8_0_quantized_matmul_input_rows(input, packed.blocks_per_row, |rows, quantized_inputs| {
         q8_0_packed_rows4_matmul_projection_from_quantized(
@@ -9214,6 +9229,7 @@ fn q8_0_packed_rows4_matmul_projection(
             output_width,
             name,
             quantized_inputs,
+            schedule,
         )
     })
 }
@@ -9261,31 +9277,11 @@ fn should_use_x86_q8_ffn_down_gemm4_row_group_schedule(enabled: bool, input_grou
         && input_groups >= x86_q8_ffn_down_gemm4_row_group_min_input_groups()
 }
 
-fn x86_q8_packed_rows4_matmul_groups_per_chunk() -> usize {
-    #[cfg(test)]
-    {
-        env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK")
-            .ok()
-            .and_then(|value| value.parse::<usize>().ok())
-            .filter(|value| *value > 0)
-            .unwrap_or(X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK)
-    }
-    #[cfg(not(test))]
-    {
-        static X86_Q8_PACKED_ROWS4_MATMUL_CHUNK_GROUPS: OnceLock<usize> = OnceLock::new();
-        *X86_Q8_PACKED_ROWS4_MATMUL_CHUNK_GROUPS.get_or_init(|| {
-            env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK")
-                .ok()
-                .and_then(|value| value.parse::<usize>().ok())
-                .filter(|value| *value > 0)
-                .unwrap_or(X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK)
-        })
-    }
-}
-
-fn q8_packed_rows4_matmul_parallel_chunk_floats(total_output_groups: usize) -> usize {
-    let groups_per_chunk =
-        total_output_groups.clamp(1, x86_q8_packed_rows4_matmul_groups_per_chunk());
+fn q8_packed_rows4_matmul_parallel_chunk_floats(
+    total_output_groups: usize,
+    schedule: Q8PackedRows4MatmulSchedule,
+) -> usize {
+    let groups_per_chunk = total_output_groups.clamp(1, schedule.groups_per_chunk);
     groups_per_chunk * 4
 }
 
@@ -9375,6 +9371,7 @@ fn q8_0_packed_rows4_matmul_projection_from_quantized(
     output_width: usize,
     name: &str,
     quantized_inputs: &[Q8_0Block],
+    schedule: Q8PackedRows4MatmulSchedule,
 ) -> Result<CpuTensor> {
     let blocks_per_row = packed.blocks_per_row;
     let expected_quantized_blocks = rows.checked_mul(blocks_per_row).ok_or_else(|| {
@@ -9401,7 +9398,8 @@ fn q8_0_packed_rows4_matmul_projection_from_quantized(
     let mut output = vec![0.0_f32; rows * output_width];
     let use_hoisted_avx2 = x86_q8_packed_rows4_avx2_dot_hoist_enabled();
     if should_parallelize_q8_packed_rows4_matmul(total_output_groups) {
-        let chunk_floats = q8_packed_rows4_matmul_parallel_chunk_floats(total_output_groups);
+        let chunk_floats =
+            q8_packed_rows4_matmul_parallel_chunk_floats(total_output_groups, schedule);
         output
             .par_chunks_mut(chunk_floats)
             .enumerate()
@@ -9718,6 +9716,7 @@ fn q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
     name: &str,
     row_group_schedule: bool,
     use_avx2: bool,
+    schedule: Q8PackedRows4MatmulSchedule,
 ) -> Result<CpuTensor> {
     let rows = input.dim(0)?;
     let input_width = input.dim(1)?;
@@ -9738,7 +9737,7 @@ fn q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
 
     let packed_rows = rows / 4 * 4;
     if packed_rows == 0 {
-        return q8_0_packed_rows4_matmul_projection(input, packed, output_width, name);
+        return q8_0_packed_rows4_matmul_projection(input, packed, output_width, name, schedule);
     }
 
     let mut output = vec![0.0_f32; rows * output_width];
@@ -9917,6 +9916,7 @@ fn q8_0_packed_rows4_matmul_projection_pair_from_quantized(
     left_name: &str,
     right_name: &str,
     quantized_inputs: &[Q8_0Block],
+    schedule: Q8PackedRows4MatmulSchedule,
 ) -> Result<(CpuTensor, CpuTensor)> {
     let blocks_per_row = left_packed.blocks_per_row;
     if right_packed.blocks_per_row != blocks_per_row {
@@ -9962,7 +9962,8 @@ fn q8_0_packed_rows4_matmul_projection_pair_from_quantized(
     if left_output_width == right_output_width
         && should_parallelize_q8_packed_rows4_matmul(total_left_output_groups)
     {
-        let chunk_floats = q8_packed_rows4_matmul_parallel_chunk_floats(total_left_output_groups);
+        let chunk_floats =
+            q8_packed_rows4_matmul_parallel_chunk_floats(total_left_output_groups, schedule);
         left_output
             .par_chunks_mut(chunk_floats)
             .zip(right_output.par_chunks_mut(chunk_floats))
@@ -10090,6 +10091,7 @@ fn q8_0_packed_rows4_matmul_projection_pair_activated_from_quantized(
     name: &str,
     order: FfnGateUpOrder,
     quantized_inputs: &[Q8_0Block],
+    schedule: Q8PackedRows4MatmulSchedule,
 ) -> Result<CpuTensor> {
     let (blocks_per_row, output_groups_per_row) = validate_q8_0_packed_rows4_pair_matmul_inputs(
         rows,
@@ -10125,7 +10127,8 @@ fn q8_0_packed_rows4_matmul_projection_pair_activated_from_quantized(
     };
 
     if should_parallelize_q8_packed_rows4_matmul(total_output_groups) {
-        let chunk_floats = q8_packed_rows4_matmul_parallel_chunk_floats(total_output_groups);
+        let chunk_floats =
+            q8_packed_rows4_matmul_parallel_chunk_floats(total_output_groups, schedule);
         output
             .par_chunks_mut(chunk_floats)
             .enumerate()
@@ -10155,6 +10158,7 @@ fn q8_0_packed_rows4_matmul_projection_triplet_from_quantized(
     k_width: usize,
     v_width: usize,
     quantized_inputs: &[Q8_0Block],
+    schedule: Q8PackedRows4MatmulSchedule,
 ) -> Result<(CpuTensor, CpuTensor, CpuTensor)> {
     let blocks_per_row = q_packed.blocks_per_row;
     if k_packed.blocks_per_row != blocks_per_row || v_packed.blocks_per_row != blocks_per_row {
@@ -10202,7 +10206,8 @@ fn q8_0_packed_rows4_matmul_projection_triplet_from_quantized(
         && q_width == v_width
         && should_parallelize_q8_packed_rows4_matmul(total_q_output_groups)
     {
-        let chunk_floats = q8_packed_rows4_matmul_parallel_chunk_floats(total_q_output_groups);
+        let chunk_floats =
+            q8_packed_rows4_matmul_parallel_chunk_floats(total_q_output_groups, schedule);
         q_output
             .par_chunks_mut(chunk_floats)
             .zip(k_output.par_chunks_mut(chunk_floats))
@@ -10362,7 +10367,14 @@ fn try_x86_q8_attention_output_packed_rows4_matmul_path(
         return Ok(None);
     }
 
-    q8_0_packed_rows4_matmul_projection(input, packed, output_width, name).map(Some)
+    q8_0_packed_rows4_matmul_projection(
+        input,
+        packed,
+        output_width,
+        name,
+        runtime_plan.q8_packed_rows4_matmul_schedule,
+    )
+    .map(Some)
 }
 
 fn try_x86_q8_attention_projection_decode_consumer_path(
@@ -10438,8 +10450,13 @@ fn try_x86_q8_ffn_down_packed_rows4_matmul_path(
 
     let rows = input.dim(0)?;
     let telemetry_started = q8_schedule_telemetry_enabled().then(Instant::now);
-    let output =
-        q8_0_packed_rows4_matmul_projection(input, route.packed, route.output_width, name)?;
+    let output = q8_0_packed_rows4_matmul_projection(
+        input,
+        route.packed,
+        route.output_width,
+        name,
+        runtime_plan.q8_packed_rows4_matmul_schedule,
+    )?;
     record_q8_schedule_projection_route_elapsed(
         "ffn_down",
         "x86_packed_rows4_matmul",
@@ -10490,6 +10507,7 @@ fn try_x86_q8_ffn_down_gemm4_prefill_path(
                 name,
                 runtime_plan.q8.ffn_down_gemm4_row_group_schedule,
                 runtime_plan.q8.ffn_down_gemm4_avx2,
+                runtime_plan.q8_packed_rows4_matmul_schedule,
             )?;
             let route_name = if runtime_plan.q8.ffn_down_gemm4_row_group_schedule {
                 "x86_gemm4_prefill_row_group"
@@ -10506,6 +10524,7 @@ fn try_x86_q8_ffn_down_gemm4_prefill_path(
             name,
             runtime_plan.q8.ffn_down_gemm4_row_group_schedule,
             runtime_plan.q8.ffn_down_gemm4_avx2,
+            runtime_plan.q8_packed_rows4_matmul_schedule,
         )?;
         let route_name = if runtime_plan.q8.ffn_down_gemm4_row_group_schedule {
             "x86_gemm4_prefill_row_group"
@@ -10555,7 +10574,13 @@ fn try_x86_q8_ffn_down_single_owner_path(
             name,
         )?
     } else {
-        q8_0_packed_rows4_matmul_projection(input, route.packed, route.output_width, name)?
+        q8_0_packed_rows4_matmul_projection(
+            input,
+            route.packed,
+            route.output_width,
+            name,
+            runtime_plan.q8_packed_rows4_matmul_schedule,
+        )?
     };
     let route_name = if rows == 1 {
         "x86_single_owner_decode"
@@ -12308,6 +12333,7 @@ fn accumulate_transposed_linear_row_runtime(
     let runtime_plan = ResolvedRuntimePlan {
         linear_accumulation_precision: precision,
         q8: Q8RuntimeFlags::from_env(),
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::default(),
     };
     accumulate_transposed_linear_row_runtime_with_plan(input_row, weight, output, &runtime_plan)
 }
@@ -12710,6 +12736,7 @@ fn accumulate_transposed_linear_row_with_precision(
     let runtime_plan = ResolvedRuntimePlan {
         linear_accumulation_precision: precision,
         q8: Q8RuntimeFlags::from_env(),
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::default(),
     };
     accumulate_transposed_linear_row_with_precision_with_plan(
         input_row,

--- a/src/inference/q8_runtime.rs
+++ b/src/inference/q8_runtime.rs
@@ -3,6 +3,8 @@ use std::env;
 use super::{diagnostic_linear_accumulation_precision, LinearAccumulationPrecision};
 use crate::Result;
 
+pub(super) const X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK_DEFAULT: usize = 8;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct Q8RuntimeFlags {
     pub(super) block_dot: bool,
@@ -41,16 +43,24 @@ pub(super) struct Q8RuntimeFlags {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Q8PackedRows4MatmulSchedule {
+    pub(super) groups_per_chunk: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ResolvedRuntimePlan {
     pub(super) linear_accumulation_precision: LinearAccumulationPrecision,
     pub(super) q8: Q8RuntimeFlags,
+    pub(super) q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule,
 }
 
 impl ResolvedRuntimePlan {
     pub(super) fn from_env() -> Result<Self> {
+        let q8 = Q8RuntimeFlags::from_env();
         Ok(Self {
             linear_accumulation_precision: diagnostic_linear_accumulation_precision()?,
-            q8: Q8RuntimeFlags::from_env(),
+            q8,
+            q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::from_q8_flags(q8),
         })
     }
 }
@@ -159,6 +169,14 @@ impl Q8RuntimeFlags {
         }
     }
 
+    fn any_packed_rows4_matmul_enabled(self) -> bool {
+        self.attention_output_packed_rows4_matmul
+            || self.attention_qkv_packed_rows4_matmul
+            || self.output_packed_rows4_matmul
+            || self.ffn_gate_up_packed_rows4_matmul
+            || self.ffn_down_packed_rows4_matmul
+    }
+
     pub(super) fn hybrid_gpu_rows_for_output(self, output_rows: usize) -> usize {
         if output_rows < 2 {
             return 0;
@@ -169,6 +187,29 @@ impl Q8RuntimeFlags {
         ((output_rows * self.hybrid_gpu_percent).div_ceil(100))
             .max(1)
             .min(output_rows.saturating_sub(1))
+    }
+}
+
+impl Default for Q8PackedRows4MatmulSchedule {
+    fn default() -> Self {
+        Self {
+            groups_per_chunk: X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK_DEFAULT,
+        }
+    }
+}
+
+impl Q8PackedRows4MatmulSchedule {
+    pub(super) fn from_q8_flags(q8: Q8RuntimeFlags) -> Self {
+        if !q8.any_packed_rows4_matmul_enabled() {
+            return Self::default();
+        }
+        Self {
+            groups_per_chunk: env::var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK")
+                .ok()
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .filter(|value| *value > 0)
+                .unwrap_or(X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK_DEFAULT),
+        }
     }
 }
 

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -84,17 +84,30 @@ fn x86_q8_avx2_kernel_matches_scalar_dot_for_negative_128() {
 fn x86_q8_packed_rows4_matmul_chunk_groups_env_override() {
     let _env_guard = env_lock();
     std::env::remove_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK");
+    std::env::set_var("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL", "on");
+    let mut plan = ResolvedRuntimePlan::from_env().unwrap();
     assert_eq!(
-        x86_q8_packed_rows4_matmul_groups_per_chunk(),
-        X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK
+        plan.q8_packed_rows4_matmul_schedule.groups_per_chunk,
+        q8_runtime::X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK_DEFAULT
     );
     std::env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "32");
-    assert_eq!(x86_q8_packed_rows4_matmul_groups_per_chunk(), 32);
-    assert_eq!(q8_packed_rows4_matmul_parallel_chunk_floats(128), 128);
-    std::env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "0");
+    plan = ResolvedRuntimePlan::from_env().unwrap();
+    assert_eq!(plan.q8_packed_rows4_matmul_schedule.groups_per_chunk, 32);
     assert_eq!(
-        x86_q8_packed_rows4_matmul_groups_per_chunk(),
-        X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK
+        q8_packed_rows4_matmul_parallel_chunk_floats(128, plan.q8_packed_rows4_matmul_schedule),
+        128
+    );
+    std::env::set_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK", "0");
+    plan = ResolvedRuntimePlan::from_env().unwrap();
+    assert_eq!(
+        plan.q8_packed_rows4_matmul_schedule.groups_per_chunk,
+        q8_runtime::X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK_DEFAULT
+    );
+    std::env::remove_var("CAMELID_X86_Q8_OUTPUT_PACKED_ROWS4_MATMUL");
+    plan = ResolvedRuntimePlan::from_env().unwrap();
+    assert_eq!(
+        plan.q8_packed_rows4_matmul_schedule.groups_per_chunk,
+        q8_runtime::X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK_DEFAULT
     );
     std::env::remove_var("CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK");
 }
@@ -1675,6 +1688,7 @@ fn q8_0_hot_path_uses_resolved_plan_not_current_env() {
             hybrid_gpu_rows: None,
             hybrid_gpu_percent: 10,
         },
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::default(),
     };
 
     let actual =
@@ -2582,6 +2596,7 @@ fn q8_attention_consumer_plan(
             hybrid_gpu_rows: None,
             hybrid_gpu_percent: 10,
         },
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::default(),
     }
 }
 
@@ -3162,6 +3177,7 @@ fn q8_attention_qkv_packed_rows4_matmul_matches_runtime_packed_baseline_for_pref
         },
         output_width,
         "expected_q",
+        Q8PackedRows4MatmulSchedule::default(),
     )
     .unwrap();
     let expected_k = q8_0_packed_rows4_matmul_projection(
@@ -3172,6 +3188,7 @@ fn q8_attention_qkv_packed_rows4_matmul_matches_runtime_packed_baseline_for_pref
         },
         output_width,
         "expected_k",
+        Q8PackedRows4MatmulSchedule::default(),
     )
     .unwrap();
     let expected_v = q8_0_packed_rows4_matmul_projection(
@@ -3182,6 +3199,7 @@ fn q8_attention_qkv_packed_rows4_matmul_matches_runtime_packed_baseline_for_pref
         },
         output_width,
         "expected_v",
+        Q8PackedRows4MatmulSchedule::default(),
     )
     .unwrap();
     assert_slice_close_with_tolerance(&q.data, &expected_q.data, 5e-4);
@@ -3497,6 +3515,7 @@ fn ffn_down_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             hybrid_gpu_rows: None,
             hybrid_gpu_percent: 10,
         },
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::default(),
     }
 }
 
@@ -3546,6 +3565,7 @@ fn ffn_down_packed_rows4_matmul_plan(enabled: bool) -> ResolvedRuntimePlan {
             hybrid_gpu_rows: None,
             hybrid_gpu_percent: 10,
         },
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::default(),
     }
 }
 
@@ -3599,6 +3619,7 @@ fn ffn_gate_up_consumer_plan(enabled: bool) -> ResolvedRuntimePlan {
             hybrid_gpu_rows: None,
             hybrid_gpu_percent: 10,
         },
+        q8_packed_rows4_matmul_schedule: Q8PackedRows4MatmulSchedule::default(),
     }
 }
 
@@ -4895,6 +4916,7 @@ fn q8_ffn_down_gemm4_row_group_threshold_benchmark() {
                     label,
                     row_group_schedule,
                     false,
+                    Q8PackedRows4MatmulSchedule::default(),
                 )
                 .unwrap(),
             );
@@ -5089,7 +5111,14 @@ fn q8_ffn_down_amx_prefill_benchmark() {
     };
 
     let (rows4_us, rows4) = bench(Box::new(|| {
-        q8_0_packed_rows4_matmul_projection(&input, packed, output_width, "rows4").unwrap()
+        q8_0_packed_rows4_matmul_projection(
+            &input,
+            packed,
+            output_width,
+            "rows4",
+            Q8PackedRows4MatmulSchedule::default(),
+        )
+        .unwrap()
     }));
     let (gemm4_us, gemm4) = bench(Box::new(|| {
         q8_0_packed_rows4_gemm4_projection_with_row_group_schedule(
@@ -5099,6 +5128,7 @@ fn q8_ffn_down_amx_prefill_benchmark() {
             "gemm4",
             false,
             true,
+            Q8PackedRows4MatmulSchedule::default(),
         )
         .unwrap()
     }));
@@ -5459,11 +5489,22 @@ fn q8_ffn_gate_up_packed_rows4_matmul_matches_runtime_packed_baseline_for_prefil
         Some(Q8_0RuntimeStorage::PackedRows4(packed)) => packed,
         other => panic!("expected runtime-packed up weight, got {other:?}"),
     };
-    let mut gate =
-        q8_0_packed_rows4_matmul_projection(&input, gate_packed, output_width, "expected_gate")
-            .unwrap();
-    let up = q8_0_packed_rows4_matmul_projection(&input, up_packed, output_width, "expected_up")
-        .unwrap();
+    let mut gate = q8_0_packed_rows4_matmul_projection(
+        &input,
+        gate_packed,
+        output_width,
+        "expected_gate",
+        Q8PackedRows4MatmulSchedule::default(),
+    )
+    .unwrap();
+    let up = q8_0_packed_rows4_matmul_projection(
+        &input,
+        up_packed,
+        output_width,
+        "expected_up",
+        Q8PackedRows4MatmulSchedule::default(),
+    )
+    .unwrap();
     for (gate_value, up_value) in gate.data.iter_mut().zip(up.data) {
         *gate_value = (*gate_value / (1.0 + (-*gate_value).exp())) * up_value;
     }
@@ -7839,6 +7880,7 @@ fn q8_packed_rows4_matmul_projection_chunked_prefill_matches_manual_output() {
         output_rows,
         "actual_chunked_prefill",
         &quantized_inputs,
+        Q8PackedRows4MatmulSchedule::default(),
     )
     .unwrap();
 
@@ -7916,6 +7958,7 @@ fn q8_packed_rows4_gate_up_fused_prefill_matches_separate_pair_activation() {
         "gate",
         "up",
         &quantized_inputs,
+        Q8PackedRows4MatmulSchedule::default(),
     )
     .unwrap();
     for (gate_value, up_value) in gate.data.iter_mut().zip(up.data) {
@@ -7930,6 +7973,7 @@ fn q8_packed_rows4_gate_up_fused_prefill_matches_separate_pair_activation() {
         "fused",
         FfnGateUpOrder::GateUp,
         &quantized_inputs,
+        Q8PackedRows4MatmulSchedule::default(),
     )
     .unwrap();
 
@@ -8049,6 +8093,7 @@ fn x86_q8_output_packed_rows4_matmul_matches_runtime_packed_baseline_for_prefill
         &packed,
         vocab_rows,
         "expected_output_prefill_logits",
+        plan.q8_packed_rows4_matmul_schedule,
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
- move packed-rows4 matmul chunk sizing into `ResolvedRuntimePlan` via a private `Q8PackedRows4MatmulSchedule`
- pass the resolved schedule through packed Q8 projection helpers instead of reading the env knob inside inference math helpers
- gate `CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK` cleanup/restoration behind the packed-rows4 owner flag in `PlannerEnv`

## Local checks
- `cargo test --lib planner_env_apply_restores_owned_x86_q8_passthrough_knobs`
- `cargo test --lib planner_env_apply_does_not_restore_packed_rows4_matmul_chunk_groups_without_owner_gate`
- `cargo test --lib capabilities_can_include_selected_execution_plan`
- `cargo test --lib q8_packed_rows4_matmul_projection_chunked_prefill_matches_manual_output`
- `cargo test --lib q8_packed_rows4_gate_up_fused_prefill_matches_separate_pair_activation`
- `cargo test --lib x86_q8_packed_rows4_matmul_chunk_groups_env_override` builds on this host; the x86-only test body does not execute on Darwin arm64

## Scope
Internal route-policy handoff only. No support-contract, frontend readiness, throughput, or Linux x86_64 timing claim.