### PR TITLE
buildqa: refresh scrubbed evidence checksums

### DIFF
--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1210Z-ci-guard-ubuntu-rustup/SHA256SUMS
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1210Z-ci-guard-ubuntu-rustup/SHA256SUMS
@@ -1,6 +1,6 @@
 8a3b625146db02c0d51586e50b6b8dda2efcfaa7a91007805974e0435669e53c  ./README.md
 dddf80c457340202488f7b86b119248d9433dd1f2c54b70e52cf78950fbcbacf  ./commands/local-gates.command.txt
-64837a1e4d43c1c093f46bf100e9415ba4adc7e9505f15a6638952e45ef4fbbc  ./commands/ubuntu-gates.command.txt
+2f714cb9c0664fc88f77b63b12afb454f045627d043f71c58effcbc2ffb290b6  ./commands/ubuntu-gates.command.txt
 cc07b55ce99cdbf933fdb6c51ef0ff7feb95ab45287f0bbe3797f7dfe2f654ab  ./logs/local-gates.log
 014c27612511bd3e6187e0c2ccc59d17633666a1821e4a1cd29cd894cfcd8861  ./logs/local-repo-state.log
 63ffa457f6296e07d4307d7c407d3ed3ea6ef3ca9a596ae01ea4edab9aa22644  ./logs/ubuntu-discovery.log

--- a/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1422Z-ci-qa-guard/SHA256SUMS
+++ b/qa/evidence-bundles/llamacpp-q8-cpu-re-20260514T1200Z/artifacts/cron-58d09b5e-20260519T1422Z-ci-qa-guard/SHA256SUMS
@@ -1,6 +1,6 @@
 aa18e9eceaba2ea33f17153acf99fc444f86e96e2f5508ef3f778949d7be328c  ./README.md
 60945c0bfab2b9bc9ec509b83ea7449e3278c17e3c27b0243de78a2c9b86eab4  ./commands/local-gates.command.txt
-213fd409cede01c9e535b777198bea3df15fc9fd5f09c7564791c1de2b833901  ./commands/ubuntu-gates.command.txt
+2dd0558a2cdc4a681023d6dcb53f2f9708acc64871fe1cf3d3216ddc69f14daa  ./commands/ubuntu-gates.command.txt
 453320da6ae5f150d2fba081eb7b3b93b34d5261b940d0edefe1185a74ff4a47  ./logs/local-gates.log
 2abaa1acc0a6cddab77de665a1badad3815bf30f5ad22cbdee5b920e238c1bb7  ./logs/local-repo-state.log
 7489ef0ac711903e0b5bb6d9bfbb8d075d6169b046e9dec8170beef2fc3181c9  ./logs/ubuntu-gates.log


### PR DESCRIPTION
## Summary
- refresh the recorded SHA256 for the scrubbed `ubuntu-gates.command.txt` artifact in the Ubuntu rustup CI-guard bundle
- refresh the matching SHA256 for the scrubbed `ubuntu-gates.command.txt` artifact in the Ubuntu QA-guard bundle
- keep the evidence contents unchanged; this only realigns integrity metadata after the public scrub edits

## Validation
- `bash scripts/check-evidence-bundle-checksums.sh`
- `bash scripts/check-public-scrub.sh`

## Scope
- shared CI metadata repair only
- no support-claim, performance, or validation-lane change