### PR TITLE
perf(q8): trace shared-input qkv routes

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -7103,6 +7103,15 @@ enum X86Q8AttentionQkvRouteKind {
     PackedRows4Matmul,
 }
 
+impl X86Q8AttentionQkvRouteKind {
+    fn telemetry_name(self) -> &'static str {
+        match self {
+            Self::Decode => "shared_input_decode_consumer",
+            Self::PackedRows4Matmul => "shared_input_packed_rows4_matmul_prefill",
+        }
+    }
+}
+
 struct X86Q8AttentionQkvRoute<'a> {
     q_packed: &'a Q8_0PackedRows4,
     k_packed: &'a Q8_0PackedRows4,
@@ -7127,34 +7136,107 @@ fn resolve_x86_q8_attention_qkv_route<'a>(
             runtime_plan.q8.attention_qkv_packed_rows4_matmul
         }
     };
+    let route_name = route.telemetry_name();
     if !route_enabled || input.rank() != 2 {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            if !route_enabled {
+                "plan_off"
+            } else {
+                "rank_mismatch"
+            },
+            input.dim(0).unwrap_or(0),
+            input.dim(1).unwrap_or(0),
+            0,
+        );
         return Ok(None);
     }
 
     let rows = input.dim(0)?;
     match route {
-        X86Q8AttentionQkvRouteKind::Decode if rows != 1 => return Ok(None),
-        X86Q8AttentionQkvRouteKind::PackedRows4Matmul if rows <= 1 => return Ok(None),
+        X86Q8AttentionQkvRouteKind::Decode if rows != 1 => {
+            record_q8_schedule_projection_route_denial(
+                "attention_qkv",
+                route_name,
+                "decode_requires_single_row",
+                rows,
+                input.dim(1).unwrap_or(0),
+                0,
+            );
+            return Ok(None);
+        }
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul if rows <= 1 => {
+            record_q8_schedule_projection_route_denial(
+                "attention_qkv",
+                route_name,
+                "prefill_requires_multi_row",
+                rows,
+                input.dim(1).unwrap_or(0),
+                0,
+            );
+            return Ok(None);
+        }
         _ => {}
     }
 
     let input_width = input.dim(1)?;
     if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "bad_input_width",
+            rows,
+            input_width,
+            0,
+        );
         return Ok(None);
     }
 
     let Some((q_packed, q_width)) = q8_0_runtime_packed_projection(q_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "no_runtime_packed_q",
+            rows,
+            input_width,
+            0,
+        );
         return Ok(None);
     };
     let Some((k_packed, k_width)) = q8_0_runtime_packed_projection(k_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "no_runtime_packed_k",
+            rows,
+            input_width,
+            q_width,
+        );
         return Ok(None);
     };
     let Some((v_packed, v_width)) = q8_0_runtime_packed_projection(v_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "no_runtime_packed_v",
+            rows,
+            input_width,
+            q_width,
+        );
         return Ok(None);
     };
     if q_packed.blocks_per_row != k_packed.blocks_per_row
         || q_packed.blocks_per_row != v_packed.blocks_per_row
     {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "packed_block_stride_mismatch",
+            rows,
+            input_width,
+            q_width,
+        );
         return Ok(None);
     }
 
@@ -7188,6 +7270,7 @@ fn try_x86_q8_attention_qkv_decode_consumer_path(
         return Ok(None);
     };
 
+    let telemetry_started = q8_schedule_telemetry_enabled().then(Instant::now);
     let quantized_input = quantize_q8_0_row(&input.data[..route.input_width]);
     let (q, k, v) = q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
         route.q_packed,
@@ -7200,6 +7283,34 @@ fn try_x86_q8_attention_qkv_decode_consumer_path(
         runtime_plan.q8.attention_qkv_decode_group_chunking
             && x86_q8_attention_qkv_decode_group_chunking_enabled(),
     )?;
+    let route_name = X86Q8AttentionQkvRouteKind::Decode.telemetry_name();
+    record_q8_schedule_projection_route_elapsed(
+        "attention_q",
+        route_name,
+        &q_weight.name,
+        1,
+        route.input_width,
+        route.q_width,
+        telemetry_started,
+    );
+    record_q8_schedule_projection_route_elapsed(
+        "attention_k",
+        route_name,
+        &k_weight.name,
+        1,
+        route.input_width,
+        route.k_width,
+        telemetry_started,
+    );
+    record_q8_schedule_projection_route_elapsed(
+        "attention_v",
+        route_name,
+        &v_weight.name,
+        1,
+        route.input_width,
+        route.v_width,
+        telemetry_started,
+    );
     Ok(Some((q, k, v)))
 }
 
@@ -7222,6 +7333,8 @@ fn try_x86_q8_attention_qkv_packed_rows4_matmul_path(
         return Ok(None);
     };
 
+    let rows = input.dim(0)?;
+    let telemetry_started = q8_schedule_telemetry_enabled().then(Instant::now);
     let (q, k, v) = with_q8_0_quantized_matmul_input_rows(
         input,
         route.q_packed.blocks_per_row,
@@ -7238,6 +7351,34 @@ fn try_x86_q8_attention_qkv_packed_rows4_matmul_path(
             )
         },
     )?;
+    let route_name = X86Q8AttentionQkvRouteKind::PackedRows4Matmul.telemetry_name();
+    record_q8_schedule_projection_route_elapsed(
+        "attention_q",
+        route_name,
+        &q_weight.name,
+        rows,
+        route.input_width,
+        route.q_width,
+        telemetry_started,
+    );
+    record_q8_schedule_projection_route_elapsed(
+        "attention_k",
+        route_name,
+        &k_weight.name,
+        rows,
+        route.input_width,
+        route.k_width,
+        telemetry_started,
+    );
+    record_q8_schedule_projection_route_elapsed(
+        "attention_v",
+        route_name,
+        &v_weight.name,
+        rows,
+        route.input_width,
+        route.v_width,
+        telemetry_started,
+    );
     Ok(Some((q, k, v)))
 }
 

--- a/src/inference/q8_telemetry.rs
+++ b/src/inference/q8_telemetry.rs
@@ -531,12 +531,22 @@ pub(super) fn record_q8_schedule_output_projection_route_call(
 }
 
 pub(super) fn q8_schedule_layer_index_for_projection_name(name: &str) -> Option<usize> {
-    let rest = name.strip_prefix("layer_")?;
-    let (digits, _) = rest.split_once('_')?;
-    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
-        return None;
+    fn parse_ascii_digits(digits: &str) -> Option<usize> {
+        if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+            return None;
+        }
+        digits.parse().ok()
     }
-    digits.parse().ok()
+
+    if let Some(rest) = name.strip_prefix("layer_") {
+        let (digits, _) = rest.split_once('_')?;
+        return parse_ascii_digits(digits);
+    }
+    if let Some(rest) = name.strip_prefix("blk.") {
+        let (digits, _) = rest.split_once('.')?;
+        return parse_ascii_digits(digits);
+    }
+    None
 }
 
 pub(super) fn record_q8_schedule_projection_route_elapsed(

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -3105,6 +3105,183 @@ fn q8_attention_qkv_route_resolver_preserves_decode_and_prefill_guards() {
 }
 
 #[test]
+fn q8_attention_qkv_decode_route_records_route_and_denials() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+
+    let (decode_input, q_weight, q_expected) =
+        runtime_packed_attention_projection_case("attention_q", "blk.0.attn_q.weight");
+    let (_, k_weight, k_expected) =
+        runtime_packed_attention_projection_case("attention_k", "blk.0.attn_k.weight");
+    let (_, v_weight, v_expected) =
+        runtime_packed_attention_projection_case("attention_v", "blk.0.attn_v.weight");
+    let prefill_input = CpuTensor::from_f32(
+        "prefill_qkv_input",
+        vec![2, decode_input.dim(1).unwrap()],
+        vec![0.0; 2 * decode_input.dim(1).unwrap()],
+    )
+    .unwrap();
+    let route_name = X86Q8AttentionQkvRouteKind::Decode.telemetry_name();
+
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &prefill_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_consumer_plan(true),
+        X86Q8AttentionQkvRouteKind::Decode,
+    )
+    .unwrap()
+    .is_none());
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &decode_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_consumer_plan(false),
+        X86Q8AttentionQkvRouteKind::Decode,
+    )
+    .unwrap()
+    .is_none());
+
+    let (q, k, v) = try_x86_q8_attention_qkv_decode_consumer_path(
+        &decode_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_consumer_plan(true),
+    )
+    .unwrap()
+    .expect("decode route should run once telemetry is enabled");
+
+    assert_slice_close_with_tolerance(&q.data, &q_expected.data, 5e-4);
+    assert_slice_close_with_tolerance(&k.data, &k_expected.data, 5e-4);
+    assert_slice_close_with_tolerance(&v.data, &v_expected.data, 5e-4);
+
+    let telemetry = snapshot_q8_schedule_telemetry();
+    for role in ["attention_q", "attention_k", "attention_v"] {
+        let by_route = telemetry
+            .output_projection_by_route
+            .get(&format!("{role}.{route_name}"))
+            .expect("QKV decode route telemetry");
+        assert_eq!(by_route.calls, 1, "{role}");
+        assert_eq!(by_route.rows, 1, "{role}");
+        assert_eq!(
+            by_route.input_width,
+            decode_input.dim(1).unwrap() as u64,
+            "{role}"
+        );
+        let layer_route = telemetry
+            .output_projection_by_layer_route
+            .get(&format!("layer_0.{role}.{route_name}"))
+            .expect("layer-scoped QKV decode route telemetry");
+        assert_eq!(layer_route.layer_index, 0, "{role}");
+        assert_eq!(layer_route.calls, 1, "{role}");
+    }
+    assert!(telemetry.projection_route_denials.contains_key(&format!(
+        "attention_qkv.{route_name}.decode_requires_single_row"
+    )));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key(&format!("attention_qkv.{route_name}.plan_off")));
+
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
+}
+
+#[test]
+fn q8_attention_qkv_prefill_route_records_route_and_denials() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+
+    let (decode_input, q_weight, _q_expected) =
+        runtime_packed_attention_projection_case("attention_q", "blk.0.attn_q.weight");
+    let (_, k_weight, _k_expected) =
+        runtime_packed_attention_projection_case("attention_k", "blk.0.attn_k.weight");
+    let (_, v_weight, _v_expected) =
+        runtime_packed_attention_projection_case("attention_v", "blk.0.attn_v.weight");
+    let rows = 3;
+    let input_width = decode_input.dim(1).unwrap();
+    let prefill_input = CpuTensor::from_f32(
+        "prefill_qkv_input",
+        vec![rows, input_width],
+        (0..rows * input_width)
+            .map(|idx| {
+                ((idx % input_width) as f32 - 13.0) * 0.078125
+                    + (idx / input_width) as f32 * 0.046875
+            })
+            .collect(),
+    )
+    .unwrap();
+    let route_name = X86Q8AttentionQkvRouteKind::PackedRows4Matmul.telemetry_name();
+
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &decode_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_packed_rows4_matmul_plan(true),
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &prefill_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_packed_rows4_matmul_plan(false),
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+
+    let (q, k, v) = try_x86_q8_attention_qkv_packed_rows4_matmul_path(
+        &prefill_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_packed_rows4_matmul_plan(true),
+    )
+    .unwrap()
+    .expect("prefill route should run once telemetry is enabled");
+
+    assert_eq!(q.shape.dims, vec![rows, q_weight.dim(1).unwrap()]);
+    assert_eq!(k.shape.dims, q.shape.dims);
+    assert_eq!(v.shape.dims, q.shape.dims);
+
+    let telemetry = snapshot_q8_schedule_telemetry();
+    for role in ["attention_q", "attention_k", "attention_v"] {
+        let by_route = telemetry
+            .output_projection_by_route
+            .get(&format!("{role}.{route_name}"))
+            .expect("QKV prefill route telemetry");
+        assert_eq!(by_route.calls, 1, "{role}");
+        assert_eq!(by_route.rows, rows as u64, "{role}");
+        assert_eq!(by_route.input_width, input_width as u64, "{role}");
+        let layer_route = telemetry
+            .output_projection_by_layer_route
+            .get(&format!("layer_0.{role}.{route_name}"))
+            .expect("layer-scoped QKV prefill route telemetry");
+        assert_eq!(layer_route.layer_index, 0, "{role}");
+        assert_eq!(layer_route.calls, 1, "{role}");
+    }
+    assert!(telemetry.projection_route_denials.contains_key(&format!(
+        "attention_qkv.{route_name}.prefill_requires_multi_row"
+    )));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key(&format!("attention_qkv.{route_name}.plan_off")));
+
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
+}
+
+#[test]
 fn q8_attention_qkv_prefill_consumer_gate_is_default_off() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();
@@ -3885,6 +4062,10 @@ fn q8_projection_route_telemetry_records_layer_route_bucket() {
 
     assert_eq!(
         q8_schedule_layer_index_for_projection_name("layer_21_ffn_down"),
+        Some(21)
+    );
+    assert_eq!(
+        q8_schedule_layer_index_for_projection_name("blk.21.attn_q.weight"),
         Some(21)
     );
     assert_eq!(q8_schedule_layer_index_for_projection_name("logits"), None);


### PR DESCRIPTION
## Summary
- add route names and denial telemetry for the shared-input x86 Q8 attention Q/K/V decode and prefill paths
- record per-role route hits for Q/K/V using packed-runtime projection names so layer buckets populate from `blk.N.*` tensors
- extend tests to cover the new route telemetry and denial breadcrumbs

## Validation
- `cargo fmt --all -- --check`
- `cargo test q8_projection_route_telemetry_records_layer_route_bucket -- --nocapture`
- `cargo test q8_attention_qkv_decode_route_records_route_and_denials -- --nocapture`
- `cargo test q8_attention_qkv_prefill_route_records_route_and_denials -- --nocapture`