### PR TITLE
refactor: extract Q8 file-reader scratch helpers

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -21,6 +21,7 @@ mod diagnostic_config;
 mod kv_cache;
 mod q8_block_reader;
 mod q8_runtime;
+mod q8_scratch;
 mod q8_telemetry;
 mod rope;
 
@@ -43,6 +44,13 @@ pub use q8_block_reader::Q8BlockReader;
 use q8_runtime::{
     q8_0_env_flag_disabled, q8_0_env_flag_enabled_default_off,
     q8_0_env_flag_enabled_default_on_fail_closed, Q8RuntimeFlags, ResolvedRuntimePlan,
+};
+#[cfg(test)]
+use q8_scratch::q8_0_file_reader_scratch_capacities;
+use q8_scratch::{
+    cap_q8_0_file_reader_scratch, with_q8_0_file_reader_chunk_scales,
+    with_q8_0_file_reader_output_chunk, with_q8_0_file_reader_quantized_inputs,
+    with_q8_0_file_reader_row_chunk,
 };
 use q8_telemetry::*;
 pub use q8_telemetry::{
@@ -12493,100 +12501,9 @@ fn accumulate_transposed_linear_row_q8_0_file_reader_with_flags(
 }
 
 thread_local! {
-    static Q8_0_FILE_READER_ROW_CHUNK: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
-    static Q8_0_FILE_READER_CHUNK_SCALES: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
-    static Q8_0_FILE_READER_QUANTIZED_INPUTS: RefCell<Vec<Q8_0Block>> = const { RefCell::new(Vec::new()) };
-    static Q8_0_FILE_READER_OUTPUT_CHUNK: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
     static Q8_0_PREFILL_PACKED_INPUTS: RefCell<Vec<Q8_0PackedRows4Block>> = const { RefCell::new(Vec::new()) };
     static Q8_0_RETAINED_INPUT_SCALES: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
     static Q8_0_RETAINED_INPUT_QUANTS: RefCell<Vec<i8>> = const { RefCell::new(Vec::new()) };
-}
-
-fn q8_0_file_reader_retained_scratch_bytes() -> usize {
-    const DEFAULT_Q8_0_FILE_READER_RETAINED_SCRATCH_BYTES: usize = 64 * 1024 * 1024;
-    parse_byte_count_env("CAMELID_Q8_0_FILE_READER_RETAINED_SCRATCH_BYTES")
-        .unwrap_or(DEFAULT_Q8_0_FILE_READER_RETAINED_SCRATCH_BYTES)
-}
-
-fn q8_0_file_reader_retained_scratch_entries<T>() -> usize {
-    q8_0_file_reader_retained_scratch_bytes() / mem::size_of::<T>().max(1)
-}
-
-fn cap_q8_0_file_reader_scratch<T>(scratch: &mut Vec<T>, retained_len: usize) {
-    let retained_entries = q8_0_file_reader_retained_scratch_entries::<T>();
-    if scratch.capacity() > retained_entries {
-        *scratch = Vec::with_capacity(retained_len.min(retained_entries));
-    } else if scratch.len() > retained_len {
-        scratch.truncate(retained_len);
-    }
-}
-
-fn with_q8_0_file_reader_row_chunk<T>(
-    len: usize,
-    f: impl FnOnce(&mut [u8]) -> Result<T>,
-) -> Result<T> {
-    Q8_0_FILE_READER_ROW_CHUNK.with(|cell| {
-        let mut row_chunk = cell.borrow_mut();
-        if row_chunk.len() < len {
-            row_chunk.resize(len, 0);
-        }
-        let result = f(&mut row_chunk[..len]);
-        cap_q8_0_file_reader_scratch(&mut row_chunk, len);
-        result
-    })
-}
-
-fn with_q8_0_file_reader_chunk_scales<T>(
-    len: usize,
-    f: impl FnOnce(&mut [f32]) -> Result<T>,
-) -> Result<T> {
-    Q8_0_FILE_READER_CHUNK_SCALES.with(|cell| {
-        let mut scales = cell.borrow_mut();
-        if scales.len() < len {
-            scales.resize(len, 0.0);
-        }
-        let result = f(&mut scales[..len]);
-        cap_q8_0_file_reader_scratch(&mut scales, len);
-        result
-    })
-}
-
-fn with_q8_0_file_reader_quantized_inputs<T>(
-    f: impl FnOnce(&mut Vec<Q8_0Block>) -> Result<T>,
-) -> Result<T> {
-    Q8_0_FILE_READER_QUANTIZED_INPUTS.with(|cell| {
-        let mut quantized_inputs = cell.borrow_mut();
-        let result = f(&mut quantized_inputs);
-        // Keep the allocation as reusable scratch capacity, but do not leave the
-        // previous activation blocks logically live between file-backed Q8 calls.
-        quantized_inputs.clear();
-        cap_q8_0_file_reader_scratch(&mut quantized_inputs, 0);
-        result
-    })
-}
-
-fn with_q8_0_file_reader_output_chunk<T>(
-    len: usize,
-    f: impl FnOnce(&mut [f32]) -> Result<T>,
-) -> Result<T> {
-    Q8_0_FILE_READER_OUTPUT_CHUNK.with(|cell| {
-        let mut output_chunk = cell.borrow_mut();
-        if output_chunk.len() < len {
-            output_chunk.resize(len, 0.0);
-        }
-        let result = f(&mut output_chunk[..len]);
-        cap_q8_0_file_reader_scratch(&mut output_chunk, len);
-        result
-    })
-}
-
-#[cfg(test)]
-fn q8_0_file_reader_scratch_capacities() -> (usize, usize, usize, usize) {
-    let row_chunk = Q8_0_FILE_READER_ROW_CHUNK.with(|cell| cell.borrow().capacity());
-    let chunk_scales = Q8_0_FILE_READER_CHUNK_SCALES.with(|cell| cell.borrow().capacity());
-    let quantized_inputs = Q8_0_FILE_READER_QUANTIZED_INPUTS.with(|cell| cell.borrow().capacity());
-    let output_chunk = Q8_0_FILE_READER_OUTPUT_CHUNK.with(|cell| cell.borrow().capacity());
-    (row_chunk, chunk_scales, quantized_inputs, output_chunk)
 }
 
 fn should_parallelize_q8_0_file_reader_output(output_width: usize) -> bool {

--- a/src/inference/q8_scratch.rs
+++ b/src/inference/q8_scratch.rs
@@ -1,0 +1,100 @@
+use std::{cell::RefCell, mem};
+
+use crate::{
+    tensor::{parse_byte_count_env, Q8_0Block},
+    Result,
+};
+
+thread_local! {
+    static Q8_0_FILE_READER_ROW_CHUNK: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
+    static Q8_0_FILE_READER_CHUNK_SCALES: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
+    static Q8_0_FILE_READER_QUANTIZED_INPUTS: RefCell<Vec<Q8_0Block>> = const { RefCell::new(Vec::new()) };
+    static Q8_0_FILE_READER_OUTPUT_CHUNK: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
+}
+
+fn q8_0_file_reader_retained_scratch_bytes() -> usize {
+    const DEFAULT_Q8_0_FILE_READER_RETAINED_SCRATCH_BYTES: usize = 64 * 1024 * 1024;
+    parse_byte_count_env("CAMELID_Q8_0_FILE_READER_RETAINED_SCRATCH_BYTES")
+        .unwrap_or(DEFAULT_Q8_0_FILE_READER_RETAINED_SCRATCH_BYTES)
+}
+
+fn q8_0_file_reader_retained_scratch_entries<T>() -> usize {
+    q8_0_file_reader_retained_scratch_bytes() / mem::size_of::<T>().max(1)
+}
+
+pub(super) fn cap_q8_0_file_reader_scratch<T>(scratch: &mut Vec<T>, retained_len: usize) {
+    let retained_entries = q8_0_file_reader_retained_scratch_entries::<T>();
+    if scratch.capacity() > retained_entries {
+        *scratch = Vec::with_capacity(retained_len.min(retained_entries));
+    } else if scratch.len() > retained_len {
+        scratch.truncate(retained_len);
+    }
+}
+
+pub(super) fn with_q8_0_file_reader_row_chunk<T>(
+    len: usize,
+    f: impl FnOnce(&mut [u8]) -> Result<T>,
+) -> Result<T> {
+    Q8_0_FILE_READER_ROW_CHUNK.with(|cell| {
+        let mut row_chunk = cell.borrow_mut();
+        if row_chunk.len() < len {
+            row_chunk.resize(len, 0);
+        }
+        let result = f(&mut row_chunk[..len]);
+        cap_q8_0_file_reader_scratch(&mut row_chunk, len);
+        result
+    })
+}
+
+pub(super) fn with_q8_0_file_reader_chunk_scales<T>(
+    len: usize,
+    f: impl FnOnce(&mut [f32]) -> Result<T>,
+) -> Result<T> {
+    Q8_0_FILE_READER_CHUNK_SCALES.with(|cell| {
+        let mut scales = cell.borrow_mut();
+        if scales.len() < len {
+            scales.resize(len, 0.0);
+        }
+        let result = f(&mut scales[..len]);
+        cap_q8_0_file_reader_scratch(&mut scales, len);
+        result
+    })
+}
+
+pub(super) fn with_q8_0_file_reader_quantized_inputs<T>(
+    f: impl FnOnce(&mut Vec<Q8_0Block>) -> Result<T>,
+) -> Result<T> {
+    Q8_0_FILE_READER_QUANTIZED_INPUTS.with(|cell| {
+        let mut quantized_inputs = cell.borrow_mut();
+        let result = f(&mut quantized_inputs);
+        // Keep the allocation as reusable scratch capacity, but do not leave the
+        // previous activation blocks logically live between file-backed Q8 calls.
+        quantized_inputs.clear();
+        cap_q8_0_file_reader_scratch(&mut quantized_inputs, 0);
+        result
+    })
+}
+
+pub(super) fn with_q8_0_file_reader_output_chunk<T>(
+    len: usize,
+    f: impl FnOnce(&mut [f32]) -> Result<T>,
+) -> Result<T> {
+    Q8_0_FILE_READER_OUTPUT_CHUNK.with(|cell| {
+        let mut output_chunk = cell.borrow_mut();
+        if output_chunk.len() < len {
+            output_chunk.resize(len, 0.0);
+        }
+        let result = f(&mut output_chunk[..len]);
+        cap_q8_0_file_reader_scratch(&mut output_chunk, len);
+        result
+    })
+}
+
+#[cfg(test)]
+pub(super) fn q8_0_file_reader_scratch_capacities() -> (usize, usize, usize, usize) {
+    let row_chunk = Q8_0_FILE_READER_ROW_CHUNK.with(|cell| cell.borrow().capacity());
+    let chunk_scales = Q8_0_FILE_READER_CHUNK_SCALES.with(|cell| cell.borrow().capacity());
+    let quantized_inputs = Q8_0_FILE_READER_QUANTIZED_INPUTS.with(|cell| cell.borrow().capacity());
+    let output_chunk = Q8_0_FILE_READER_OUTPUT_CHUNK.with(|cell| cell.borrow().capacity());
+    (row_chunk, chunk_scales, quantized_inputs, output_chunk)
+}


### PR DESCRIPTION
## Summary
- Move Q8 file-reader scratch buffers and retention helpers into `src/inference/q8_scratch.rs`
- Keep existing inference call sites wired through module-private helpers
- Leave Q8 kernel semantics and performance behavior unchanged

## Validation
- `cargo fmt --all -- --check`
- `cargo test --lib q8_0_file_reader`
- `cargo test --lib`
- `cargo clippy --lib -- -D warnings`