### PR TITLE
perf(q8): trace attention qkv packed route

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -7103,6 +7103,15 @@ enum X86Q8AttentionQkvRouteKind {
     PackedRows4Matmul,
 }
 
+impl X86Q8AttentionQkvRouteKind {
+    fn telemetry_name(self) -> &'static str {
+        match self {
+            Self::Decode => "decode_consumer",
+            Self::PackedRows4Matmul => "packed_rows4_matmul_prefill",
+        }
+    }
+}
+
 struct X86Q8AttentionQkvRoute<'a> {
     q_packed: &'a Q8_0PackedRows4,
     k_packed: &'a Q8_0PackedRows4,
@@ -7121,6 +7130,7 @@ fn resolve_x86_q8_attention_qkv_route<'a>(
     runtime_plan: &ResolvedRuntimePlan,
     route: X86Q8AttentionQkvRouteKind,
 ) -> Result<Option<X86Q8AttentionQkvRoute<'a>>> {
+    let route_name = route.telemetry_name();
     let route_enabled = match route {
         X86Q8AttentionQkvRouteKind::Decode => runtime_plan.q8.attention_qkv_decode_consumer,
         X86Q8AttentionQkvRouteKind::PackedRows4Matmul => {
@@ -7128,33 +7138,105 @@ fn resolve_x86_q8_attention_qkv_route<'a>(
         }
     };
     if !route_enabled || input.rank() != 2 {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            if !route_enabled {
+                "plan_off"
+            } else {
+                "rank_mismatch"
+            },
+            input.dim(0).unwrap_or(0),
+            input.dim(1).unwrap_or(0),
+            0,
+        );
         return Ok(None);
     }
 
     let rows = input.dim(0)?;
     match route {
-        X86Q8AttentionQkvRouteKind::Decode if rows != 1 => return Ok(None),
-        X86Q8AttentionQkvRouteKind::PackedRows4Matmul if rows <= 1 => return Ok(None),
+        X86Q8AttentionQkvRouteKind::Decode if rows != 1 => {
+            record_q8_schedule_projection_route_denial(
+                "attention_qkv",
+                route_name,
+                "prefill_or_empty_input",
+                rows,
+                input.dim(1).unwrap_or(0),
+                0,
+            );
+            return Ok(None);
+        }
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul if rows <= 1 => {
+            record_q8_schedule_projection_route_denial(
+                "attention_qkv",
+                route_name,
+                "decode_or_empty_input",
+                rows,
+                input.dim(1).unwrap_or(0),
+                0,
+            );
+            return Ok(None);
+        }
         _ => {}
     }
 
     let input_width = input.dim(1)?;
     if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "bad_input_width",
+            rows,
+            input_width,
+            0,
+        );
         return Ok(None);
     }
 
     let Some((q_packed, q_width)) = q8_0_runtime_packed_projection(q_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "missing_q_runtime_packed_rows4",
+            rows,
+            input_width,
+            0,
+        );
         return Ok(None);
     };
     let Some((k_packed, k_width)) = q8_0_runtime_packed_projection(k_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "missing_k_runtime_packed_rows4",
+            rows,
+            input_width,
+            q_width,
+        );
         return Ok(None);
     };
     let Some((v_packed, v_width)) = q8_0_runtime_packed_projection(v_weight, input_width)? else {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "missing_v_runtime_packed_rows4",
+            rows,
+            input_width,
+            k_width,
+        );
         return Ok(None);
     };
     if q_packed.blocks_per_row != k_packed.blocks_per_row
         || q_packed.blocks_per_row != v_packed.blocks_per_row
     {
+        record_q8_schedule_projection_route_denial(
+            "attention_qkv",
+            route_name,
+            "packed_block_stride_mismatch",
+            rows,
+            input_width,
+            q_width,
+        );
         return Ok(None);
     }
 
@@ -7188,6 +7270,7 @@ fn try_x86_q8_attention_qkv_decode_consumer_path(
         return Ok(None);
     };
 
+    let telemetry_started = q8_schedule_telemetry_enabled().then(Instant::now);
     let quantized_input = quantize_q8_0_row(&input.data[..route.input_width]);
     let (q, k, v) = q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
         route.q_packed,
@@ -7200,6 +7283,15 @@ fn try_x86_q8_attention_qkv_decode_consumer_path(
         runtime_plan.q8.attention_qkv_decode_group_chunking
             && x86_q8_attention_qkv_decode_group_chunking_enabled(),
     )?;
+    record_q8_schedule_projection_route_elapsed(
+        "attention_qkv",
+        X86Q8AttentionQkvRouteKind::Decode.telemetry_name(),
+        &q.name,
+        1,
+        route.input_width,
+        route.q_width,
+        telemetry_started,
+    );
     Ok(Some((q, k, v)))
 }
 
@@ -7222,6 +7314,8 @@ fn try_x86_q8_attention_qkv_packed_rows4_matmul_path(
         return Ok(None);
     };
 
+    let rows = input.dim(0)?;
+    let telemetry_started = q8_schedule_telemetry_enabled().then(Instant::now);
     let (q, k, v) = with_q8_0_quantized_matmul_input_rows(
         input,
         route.q_packed.blocks_per_row,
@@ -7238,6 +7332,15 @@ fn try_x86_q8_attention_qkv_packed_rows4_matmul_path(
             )
         },
     )?;
+    record_q8_schedule_projection_route_elapsed(
+        "attention_qkv",
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul.telemetry_name(),
+        &q.name,
+        rows,
+        route.input_width,
+        route.q_width,
+        telemetry_started,
+    );
     Ok(Some((q, k, v)))
 }
 

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -3105,6 +3105,101 @@ fn q8_attention_qkv_route_resolver_preserves_decode_and_prefill_guards() {
 }
 
 #[test]
+fn q8_attention_qkv_route_policy_records_denials() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+
+    let (decode_input, q_weight, _) =
+        runtime_packed_attention_projection_case("attention_q", "blk.0.attn_q.weight");
+    let (_, k_weight, _) =
+        runtime_packed_attention_projection_case("attention_k", "blk.0.attn_k.weight");
+    let (_, v_weight, _) =
+        runtime_packed_attention_projection_case("attention_v", "blk.0.attn_v.weight");
+    let prefill_input = CpuTensor::from_f32(
+        "prefill_input",
+        vec![2, decode_input.dim(1).unwrap()],
+        vec![0.0; 2 * decode_input.dim(1).unwrap()],
+    )
+    .unwrap();
+
+    assert_eq!(
+        X86Q8AttentionQkvRouteKind::Decode.telemetry_name(),
+        "decode_consumer"
+    );
+    assert_eq!(
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul.telemetry_name(),
+        "packed_rows4_matmul_prefill"
+    );
+
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &prefill_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_consumer_plan(true),
+        X86Q8AttentionQkvRouteKind::Decode,
+    )
+    .unwrap()
+    .is_none());
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &decode_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_packed_rows4_matmul_plan(true),
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &prefill_input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_packed_rows4_matmul_plan(false),
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+
+    let dense_v = CpuTensor::from_f32(
+        "dense_v",
+        vec![12, Q8_0_BLOCK_VALUES * 2],
+        vec![0.0; 12 * Q8_0_BLOCK_VALUES * 2],
+    )
+    .unwrap();
+    assert!(resolve_x86_q8_attention_qkv_route(
+        &prefill_input,
+        &q_weight,
+        &k_weight,
+        &dense_v,
+        &attention_qkv_packed_rows4_matmul_plan(true),
+        X86Q8AttentionQkvRouteKind::PackedRows4Matmul,
+    )
+    .unwrap()
+    .is_none());
+
+    let telemetry = snapshot_q8_schedule_telemetry();
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key("attention_qkv.decode_consumer.prefill_or_empty_input"));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key("attention_qkv.packed_rows4_matmul_prefill.decode_or_empty_input"));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key("attention_qkv.packed_rows4_matmul_prefill.plan_off"));
+    assert!(telemetry
+        .projection_route_denials
+        .contains_key("attention_qkv.packed_rows4_matmul_prefill.missing_v_runtime_packed_rows4"));
+
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
+}
+
+#[test]
 fn q8_attention_qkv_prefill_consumer_gate_is_default_off() {
     let _env_guard = env_lock();
     clear_dense_diagnostic_env();
@@ -3187,6 +3282,58 @@ fn q8_attention_qkv_packed_rows4_matmul_matches_runtime_packed_baseline_for_pref
     assert_slice_close_with_tolerance(&q.data, &expected_q.data, 5e-4);
     assert_slice_close_with_tolerance(&k.data, &expected_k.data, 5e-4);
     assert_slice_close_with_tolerance(&v.data, &expected_v.data, 5e-4);
+}
+
+#[test]
+fn q8_attention_qkv_packed_rows4_matmul_records_route_telemetry() {
+    let _env_guard = env_lock();
+    clear_dense_diagnostic_env();
+    std::env::set_var(Q8_SCHEDULE_TELEMETRY_ENV, "on");
+    reset_q8_schedule_telemetry();
+
+    let (_decode_input, q_weight, _) =
+        runtime_packed_attention_projection_case("attention_q", "blk.0.attn_q.weight");
+    let (_, k_weight, _) =
+        runtime_packed_attention_projection_case("attention_k", "blk.0.attn_k.weight");
+    let (_, v_weight, _) =
+        runtime_packed_attention_projection_case("attention_v", "blk.0.attn_v.weight");
+    let input_width = q_weight.dim(0).unwrap();
+    let output_width = q_weight.dim(1).unwrap();
+    let rows = 3;
+    let input = CpuTensor::from_f32(
+        "prefill_qkv_context",
+        vec![rows, input_width],
+        (0..rows * input_width)
+            .map(|idx| {
+                ((idx % input_width) as f32 - 13.0) * 0.078125
+                    + (idx / input_width) as f32 * 0.046875
+            })
+            .collect(),
+    )
+    .unwrap();
+
+    let _ = try_x86_q8_attention_qkv_packed_rows4_matmul_path(
+        &input,
+        &q_weight,
+        &k_weight,
+        &v_weight,
+        &attention_qkv_packed_rows4_matmul_plan(true),
+    )
+    .unwrap()
+    .expect("QKV packed-rows4 matmul should accept multi-row runtime-packed Q/K/V weights");
+
+    let telemetry = snapshot_q8_schedule_telemetry();
+    let route = telemetry
+        .output_projection_by_route
+        .get("attention_qkv.packed_rows4_matmul_prefill")
+        .expect("QKV prefill route telemetry");
+    assert_eq!(route.calls, 1);
+    assert_eq!(route.rows, rows as u64);
+    assert_eq!(route.input_width, input_width as u64);
+    assert_eq!(route.output_width, output_width as u64);
+
+    reset_q8_schedule_telemetry();
+    std::env::remove_var(Q8_SCHEDULE_TELEMETRY_ENV);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add QKV route telemetry names for the x86 decode-consumer and packed-rows4 prefill paths
- record denial reasons when the shared QKV route fails closed before a same-host run
- record successful packed-route telemetry so the Ubuntu same-host lane can prove the specialized prefill route executed

## Validation
- `cargo fmt --all -- --check`
- `cargo test q8_attention_qkv_route_policy_records_denials --lib -- --nocapture`
- `cargo test q8_attention_qkv_packed_rows4_matmul_records_route_telemetry --lib -- --nocapture`
- `cargo test q8_attention_qkv_ --lib`