### PR TITLE
refactor: move q8 telemetry route helpers

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -753,60 +753,6 @@ pub struct LlamaForwardTimings {
     pub memory: Option<LlamaForwardMemoryTimings>,
 }
 
-#[allow(dead_code)]
-fn q8_schedule_output_projection_route_kind(
-    weight: BorrowedLinearWeight<'_>,
-    input_width: usize,
-    output_width: usize,
-) -> &'static str {
-    if weight.source_type == Some(GgufTensorType::Q8_0) {
-        if q8_0_selected_borrowed_packed_rows4(weight)
-            .filter(|(packed, _)| {
-                packed.rows == output_width
-                    && packed.blocks_per_row == input_width / Q8_0_BLOCK_VALUES
-            })
-            .is_some()
-        {
-            "q8_0_borrowed_packed_rows4"
-        } else if weight.q8_0_blocks.is_some() {
-            "q8_0_retained_blocks"
-        } else if weight.q8_0_file_backing.is_some()
-            && weight.cols == input_width
-            && weight.rows == output_width
-            && input_width.is_multiple_of(Q8_0_BLOCK_VALUES)
-        {
-            "q8_0_file_reader"
-        } else {
-            "q8_0_f32_fallback"
-        }
-    } else {
-        "f32"
-    }
-}
-
-#[allow(dead_code)]
-fn q8_schedule_role_for_output_name(name: &str) -> &'static str {
-    if name.contains("attention_q") || name.contains("attn_q") {
-        "attention_q"
-    } else if name.contains("attention_k") || name.contains("attn_k") {
-        "attention_k"
-    } else if name.contains("attention_v") || name.contains("attn_v") {
-        "attention_v"
-    } else if name.contains("attention_output") || name.contains("attn_output") {
-        "attention_output"
-    } else if name.contains("ffn_gate") {
-        "ffn_gate"
-    } else if name.contains("ffn_up") {
-        "ffn_up"
-    } else if name.contains("ffn_down") {
-        "ffn_down"
-    } else if name.contains("logits") {
-        "logits"
-    } else {
-        "unknown"
-    }
-}
-
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct LlamaLayerTimings {
     pub layer_index: usize,

--- a/src/inference/q8_telemetry.rs
+++ b/src/inference/q8_telemetry.rs
@@ -10,7 +10,8 @@ use std::{
 
 use serde::Serialize;
 
-use crate::tensor::Q8_0PackedRows4Block;
+use super::{q8_0_selected_borrowed_packed_rows4, BorrowedLinearWeight, Q8_0_BLOCK_VALUES};
+use crate::{gguf::GgufTensorType, tensor::Q8_0PackedRows4Block};
 
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
 pub struct LlamaQ8ScheduleTelemetry {
@@ -106,6 +107,60 @@ pub struct LlamaQ8ProjectionRouteDenialTelemetry {
     pub rows: u64,
     pub input_width: u64,
     pub output_width: u64,
+}
+
+#[allow(dead_code)]
+pub(super) fn q8_schedule_output_projection_route_kind(
+    weight: BorrowedLinearWeight<'_>,
+    input_width: usize,
+    output_width: usize,
+) -> &'static str {
+    if weight.source_type == Some(GgufTensorType::Q8_0) {
+        if q8_0_selected_borrowed_packed_rows4(weight)
+            .filter(|(packed, _)| {
+                packed.rows == output_width
+                    && packed.blocks_per_row == input_width / Q8_0_BLOCK_VALUES
+            })
+            .is_some()
+        {
+            "q8_0_borrowed_packed_rows4"
+        } else if weight.q8_0_blocks.is_some() {
+            "q8_0_retained_blocks"
+        } else if weight.q8_0_file_backing.is_some()
+            && weight.cols == input_width
+            && weight.rows == output_width
+            && input_width.is_multiple_of(Q8_0_BLOCK_VALUES)
+        {
+            "q8_0_file_reader"
+        } else {
+            "q8_0_f32_fallback"
+        }
+    } else {
+        "f32"
+    }
+}
+
+#[allow(dead_code)]
+pub(super) fn q8_schedule_role_for_output_name(name: &str) -> &'static str {
+    if name.contains("attention_q") || name.contains("attn_q") {
+        "attention_q"
+    } else if name.contains("attention_k") || name.contains("attn_k") {
+        "attention_k"
+    } else if name.contains("attention_v") || name.contains("attn_v") {
+        "attention_v"
+    } else if name.contains("attention_output") || name.contains("attn_output") {
+        "attention_output"
+    } else if name.contains("ffn_gate") {
+        "ffn_gate"
+    } else if name.contains("ffn_up") {
+        "ffn_up"
+    } else if name.contains("ffn_down") {
+        "ffn_down"
+    } else if name.contains("logits") {
+        "logits"
+    } else {
+        "unknown"
+    }
 }
 
 pub(super) const Q8_SCHEDULE_TELEMETRY_ENV: &str = "CAMELID_Q8_SCHED_TELEMETRY";


### PR DESCRIPTION
## Summary
- Move Q8 output projection route classification helpers from `src/inference.rs` into `src/inference/q8_telemetry.rs`.
- Keep helper logic unchanged and local to telemetry routing.
- Reduce `src/inference.rs` by 54 lines without changing runtime behavior.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --lib q8_schedule -- --nocapture`
- `cargo test --lib q8_ -- --nocapture`
- `cargo test --lib`
- `cargo clippy --lib -- -D warnings`