### PR TITLE
style: run rustfmt on merged main

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,25 +107,25 @@ npm run dev
 
 ---
 
-## 🤝 High-Speed Cluster Commands
+## High-Speed Cluster Commands
 
-To scale across two Mac minis using direct IP-over-Thunderbolt bridges:
+To scale across two local machines using a private link or trusted LAN:
 
-#### 1. On Worker Mini (`192.168.0.2`):
+#### 1. On the worker:
 ```bash
 ./target/release/camelid serve-distributed \
     --role worker \
-    --addr 192.168.0.2:8089 \
+    --addr <worker-host>:8089 \
     --layer-range 16..32 \
     --model /path/to/model.gguf
 ```
 
-#### 2. On Coordinator Mini (`192.168.0.1`):
+#### 2. On the coordinator:
 ```bash
 ./target/release/camelid serve-distributed \
     --role coordinator \
-    --addr 192.168.0.1:8181 \
-    --worker-addr 192.168.0.2:8089 \
+    --addr <coordinator-host>:8181 \
+    --worker-addr <worker-host>:8089 \
     --layer-range 0..16 \
     --model /path/to/model.gguf
 ```

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -787,7 +787,10 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     let loaded_now = !loaded_models.is_empty();
     let generation_ready = model.is_some_and(|m| loaded_model_generation_ready(m));
     let execution_plans = state.execution_plans.read().await;
-    let execution_plan = active_id_lock.as_ref().and_then(|id| execution_plans.get(id)).cloned();
+    let execution_plan = active_id_lock
+        .as_ref()
+        .and_then(|id| execution_plans.get(id))
+        .cloned();
     Json(HealthResponse {
         ok: true,
         engine: "camelid",
@@ -811,14 +814,20 @@ fn loaded_model_generation_ready(model: &LoadedModel) -> bool {
 async fn capabilities(State(state): State<AppState>) -> Json<CapabilitiesResponse> {
     let active_id_lock = state.active_model_id.read().await;
     let execution_plans = state.execution_plans.read().await;
-    let execution_plan = active_id_lock.as_ref().and_then(|id| execution_plans.get(id)).cloned();
+    let execution_plan = active_id_lock
+        .as_ref()
+        .and_then(|id| execution_plans.get(id))
+        .cloned();
     Json(capabilities_response_with_plan(execution_plan))
 }
 
 async fn execution_plan(State(state): State<AppState>) -> Json<Option<ExecutionPlan>> {
     let active_id_lock = state.active_model_id.read().await;
     let execution_plans = state.execution_plans.read().await;
-    let execution_plan = active_id_lock.as_ref().and_then(|id| execution_plans.get(id)).cloned();
+    let execution_plan = active_id_lock
+        .as_ref()
+        .and_then(|id| execution_plans.get(id))
+        .cloned();
     Json(execution_plan)
 }
 
@@ -1415,12 +1424,24 @@ async fn load_model_from_path(
         tokenizer,
         tokenizer_runtime,
     };
-    
-    state.loaded_models.write().await.insert(id.clone(), loaded.clone());
-    state.execution_plans.write().await.insert(id.clone(), outcome.plan);
-    state.model_last_used.write().await.insert(id.clone(), std::time::Instant::now());
+
+    state
+        .loaded_models
+        .write()
+        .await
+        .insert(id.clone(), loaded.clone());
+    state
+        .execution_plans
+        .write()
+        .await
+        .insert(id.clone(), outcome.plan);
+    state
+        .model_last_used
+        .write()
+        .await
+        .insert(id.clone(), std::time::Instant::now());
     *state.active_model_id.write().await = Some(id.clone());
-    
+
     clear_prompt_prefix_cache(state);
     Ok(loaded)
 }
@@ -1451,7 +1472,10 @@ pub struct UnloadModelRequest {
     pub id: Option<String>,
 }
 
-async fn unload_model(State(state): State<AppState>, payload: Option<Json<UnloadModelRequest>>) -> Response {
+async fn unload_model(
+    State(state): State<AppState>,
+    payload: Option<Json<UnloadModelRequest>>,
+) -> Response {
     let model_id = if let Some(Json(req)) = payload {
         req.id
     } else {
@@ -1469,7 +1493,7 @@ async fn unload_model(State(state): State<AppState>, payload: Option<Json<Unload
         state.execution_plans.write().await.remove(&id);
         state.cached_weights.write().await.remove(&id);
         state.model_last_used.write().await.remove(&id);
-        
+
         let mut active = state.active_model_id.write().await;
         if active.as_ref() == Some(&id) {
             *active = state.loaded_models.read().await.keys().next().cloned();
@@ -1481,7 +1505,7 @@ async fn unload_model(State(state): State<AppState>, payload: Option<Json<Unload
         state.model_last_used.write().await.clear();
         *state.active_model_id.write().await = None;
     }
-    
+
     clear_prompt_prefix_cache(&state);
     StatusCode::NO_CONTENT.into_response()
 }
@@ -1543,9 +1567,12 @@ async fn model_tokenizer(State(state): State<AppState>) -> Response {
     )
 }
 
-async fn get_or_load_model(state: &AppState, model_id: Option<&str>) -> Result<LoadedModel, Response> {
+async fn get_or_load_model(
+    state: &AppState,
+    model_id: Option<&str>,
+) -> Result<LoadedModel, Response> {
     let loaded_models = state.loaded_models.read().await;
-    
+
     let target_id = if let Some(id) = model_id {
         id.to_string()
     } else {
@@ -1564,14 +1591,28 @@ async fn get_or_load_model(state: &AppState, model_id: Option<&str>) -> Result<L
     };
 
     if let Some(loaded) = loaded_models.get(&target_id) {
-        state.model_last_used.write().await.insert(target_id.clone(), std::time::Instant::now());
+        state
+            .model_last_used
+            .write()
+            .await
+            .insert(target_id.clone(), std::time::Instant::now());
         *state.active_model_id.write().await = Some(target_id.clone());
         return Ok(loaded.clone());
     }
 
     for (id, loaded) in loaded_models.iter() {
-        if id == &target_id || loaded.id == target_id || loaded.path.file_name().is_some_and(|f| f.to_string_lossy() == target_id) {
-            state.model_last_used.write().await.insert(id.clone(), std::time::Instant::now());
+        if id == &target_id
+            || loaded.id == target_id
+            || loaded
+                .path
+                .file_name()
+                .is_some_and(|f| f.to_string_lossy() == target_id)
+        {
+            state
+                .model_last_used
+                .write()
+                .await
+                .insert(id.clone(), std::time::Instant::now());
             *state.active_model_id.write().await = Some(id.clone());
             return Ok(loaded.clone());
         }
@@ -1584,12 +1625,14 @@ async fn get_or_load_model(state: &AppState, model_id: Option<&str>) -> Result<L
             drop(loaded_models);
             match load_model_from_path(state, path, Some(target_id.clone())).await {
                 Ok(loaded) => return Ok(loaded),
-                Err(err) => return Err(api_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "model_load_failed",
-                    format!("Failed to load model {target_id} on-demand: {err}"),
-                    None,
-                )),
+                Err(err) => {
+                    return Err(api_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "model_load_failed",
+                        format!("Failed to load model {target_id} on-demand: {err}"),
+                        None,
+                    ))
+                }
             }
         }
     }
@@ -1651,11 +1694,19 @@ fn resolve_model_path(model_id: &str) -> Option<PathBuf> {
     None
 }
 
-async fn load_weights_lru(state: &AppState, model: &LoadedModel, binding: &LlamaTensorBinding) -> Result<Arc<LlamaLoadedWeights>, Response> {
+async fn load_weights_lru(
+    state: &AppState,
+    model: &LoadedModel,
+    binding: &LlamaTensorBinding,
+) -> Result<Arc<LlamaLoadedWeights>, Response> {
     {
         let cached = state.cached_weights.read().await;
         if let Some(weights) = cached.get(&model.id) {
-            state.model_last_used.write().await.insert(model.id.clone(), std::time::Instant::now());
+            state
+                .model_last_used
+                .write()
+                .await
+                .insert(model.id.clone(), std::time::Instant::now());
             return Ok(weights.clone());
         }
     }
@@ -1674,7 +1725,7 @@ async fn load_weights_lru(state: &AppState, model: &LoadedModel, binding: &Llama
     loop {
         let loaded = state.loaded_models.read().await;
         let cached = state.cached_weights.read().await;
-        
+
         let mut current_sum = 0u64;
         for (id, _) in cached.iter() {
             if id != &model.id {
@@ -1698,7 +1749,10 @@ async fn load_weights_lru(state: &AppState, model: &LoadedModel, binding: &Llama
 
         for (id, _) in cached.iter() {
             if id != &model.id {
-                let time = last_used.get(id).cloned().unwrap_or_else(std::time::Instant::now);
+                let time = last_used
+                    .get(id)
+                    .cloned()
+                    .unwrap_or_else(std::time::Instant::now);
                 if time < oldest_time {
                     oldest_time = time;
                     lru_id = Some(id.clone());
@@ -1720,23 +1774,38 @@ async fn load_weights_lru(state: &AppState, model: &LoadedModel, binding: &Llama
     }
 
     let store = TensorStore::open(&model.path, &model.gguf);
-    let range = if let Some(&(layer_start, layer_end)) = crate::distributed::DISTRIBUTED_RANGE.get() {
-        tracing::info!("API loader running in distributed coordinator mode; loading layers {}..{}", layer_start, layer_end);
+    let range = if let Some(&(layer_start, layer_end)) = crate::distributed::DISTRIBUTED_RANGE.get()
+    {
+        tracing::info!(
+            "API loader running in distributed coordinator mode; loading layers {}..{}",
+            layer_start,
+            layer_end
+        );
         Some(layer_start..layer_end)
     } else {
         None
     };
-    let weights = Arc::new(LlamaLoadedWeights::load(&store, binding, range).map_err(|err| {
-        api_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "loaded_cpu_weights_unavailable",
-            err.to_string(),
-            Some("model"),
-        )
-    })?);
+    let weights = Arc::new(
+        LlamaLoadedWeights::load(&store, binding, range).map_err(|err| {
+            api_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "loaded_cpu_weights_unavailable",
+                err.to_string(),
+                Some("model"),
+            )
+        })?,
+    );
 
-    state.cached_weights.write().await.insert(model.id.clone(), weights.clone());
-    state.model_last_used.write().await.insert(model.id.clone(), std::time::Instant::now());
+    state
+        .cached_weights
+        .write()
+        .await
+        .insert(model.id.clone(), weights.clone());
+    state
+        .model_last_used
+        .write()
+        .await
+        .insert(model.id.clone(), std::time::Instant::now());
 
     Ok(weights)
 }
@@ -4453,14 +4522,17 @@ fn render_role_colon_prompt(messages: &[ChatMessage]) -> String {
 async fn loaded_tokenizer(state: &AppState) -> std::result::Result<Tokenizer, Response> {
     let active_id = state.active_model_id.read().await;
     let loaded_models = state.loaded_models.read().await;
-    let model = active_id.as_ref().and_then(|id| loaded_models.get(id)).ok_or_else(|| {
-        api_error(
-            StatusCode::NOT_FOUND,
-            "model_not_loaded",
-            BackendError::ModelNotLoaded.to_string(),
-            None,
-        )
-    })?;
+    let model = active_id
+        .as_ref()
+        .and_then(|id| loaded_models.get(id))
+        .ok_or_else(|| {
+            api_error(
+                StatusCode::NOT_FOUND,
+                "model_not_loaded",
+                BackendError::ModelNotLoaded.to_string(),
+                None,
+            )
+        })?;
     Tokenizer::from_gguf(&model.gguf).map_err(|err| {
         api_error(
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -5052,11 +5124,11 @@ mod tests {
             .expect("Mistral exact-row bring-up lane should stay advertised");
         assert_eq!(mistral.status, "supported_exact_row_smoke");
         assert_eq!(mistral.support_scope, "exact_row_smoke_only");
-        assert_eq!(mistral.full_support_status, "blocked_pending_normalized_full_support");
         assert_eq!(
-            mistral.frontend_load_path_verified,
-            "validated"
+            mistral.full_support_status,
+            "blocked_pending_normalized_full_support"
         );
+        assert_eq!(mistral.frontend_load_path_verified, "validated");
         assert_eq!(
             mistral.performance_measured,
             "bounded_unique_chat_perf_rss_validated"
@@ -5065,16 +5137,12 @@ mod tests {
             mistral.latest_checked_bucket,
             "current_head_api_webui_rss_fail_closed"
         );
-        assert_eq!(
-            mistral.latest_checked_result,
-            "pass"
-        );
+        assert_eq!(mistral.latest_checked_result, "pass");
         assert_eq!(mistral.latest_checked_output, "CMLD-M7B");
-        assert!(mistral.frontend_readiness_gate.contains("green only when this exact GGUF row"));
-        assert_eq!(
-            mistral.bounded_context_8192_pack,
-            "validated_fifth_pack"
-        );
+        assert!(mistral
+            .frontend_readiness_gate
+            .contains("green only when this exact GGUF row"));
+        assert_eq!(mistral.bounded_context_8192_pack, "validated_fifth_pack");
         assert_eq!(
             mistral.bounded_context_8192_pack_id,
             "mistral-context-8192-max-ladder-v1"
@@ -5111,7 +5179,11 @@ mod tests {
             .collect::<BTreeSet<_>>();
         assert_eq!(
             supported_family_ids,
-            BTreeSet::from(["llama_bpe_decoder_exact_1b_3b_8b_q8_0", "llama_spm_decoder", "mistral",])
+            BTreeSet::from([
+                "llama_bpe_decoder_exact_1b_3b_8b_q8_0",
+                "llama_spm_decoder",
+                "mistral",
+            ])
         );
 
         for id in [
@@ -6912,11 +6984,14 @@ pub struct CatalogQuery {
     pub query: Option<String>,
 }
 
-async fn get_catalog(axum::extract::Query(q): axum::extract::Query<CatalogQuery>) -> Json<CatalogResponse> {
+async fn get_catalog(
+    axum::extract::Query(q): axum::extract::Query<CatalogQuery>,
+) -> Json<CatalogResponse> {
     let items = curated_catalog();
     let filtered = if let Some(query_str) = q.query {
         let qs = query_str.to_lowercase();
-        items.into_iter()
+        items
+            .into_iter()
             .filter(|item| {
                 item.name.to_lowercase().contains(&qs)
                     || item.repo_id.to_lowercase().contains(&qs)
@@ -6966,17 +7041,13 @@ async fn install_catalog_model(Json(req): Json<InstallCatalogRequest>) -> Respon
 
     std::fs::create_dir_all("models").ok();
     let dest_path = format!("models/{}", req.filename);
-    let url = format!("https://huggingface.co/{}/resolve/main/{}", req.repo_id, req.filename);
+    let url = format!(
+        "https://huggingface.co/{}/resolve/main/{}",
+        req.repo_id, req.filename
+    );
 
     match std::process::Command::new("curl")
-        .args(&[
-            "-L",
-            "-C",
-            "-",
-            "-o",
-            &dest_path,
-            &url,
-        ])
+        .args(&["-L", "-C", "-", "-o", &dest_path, &url])
         .spawn()
     {
         Ok(child) => {
@@ -7065,4 +7136,3 @@ async fn cancel_catalog_download(Json(req): Json<CancelDownloadRequest>) -> Resp
         (StatusCode::NOT_FOUND, "Download not found").into_response()
     }
 }
-

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -94,10 +94,7 @@ pub fn recv_activation_packet_limited<R: Read>(
     // Interpret the float vector buffer as a mutable byte buffer and read directly into it in one system call.
     let byte_count = float_count_usize * std::mem::size_of::<f32>();
     let payload_slice = unsafe {
-        std::slice::from_raw_parts_mut(
-            out_activations.as_mut_ptr() as *mut u8,
-            byte_count,
-        )
+        std::slice::from_raw_parts_mut(out_activations.as_mut_ptr() as *mut u8, byte_count)
     };
     reader.read_exact(payload_slice)?;
 
@@ -152,9 +149,8 @@ mod tests {
     use std::io::Cursor;
 
     use super::{
-        ACTIVATION_MAGIC, TOKEN_FEEDBACK_MAGIC, recv_activation_packet,
-        recv_activation_packet_limited, recv_token_feedback, send_activation_packet,
-        send_token_feedback,
+        recv_activation_packet, recv_activation_packet_limited, recv_token_feedback,
+        send_activation_packet, send_token_feedback, ACTIVATION_MAGIC, TOKEN_FEEDBACK_MAGIC,
     };
 
     #[test]

--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -3,22 +3,22 @@ use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
-use crate::error::{Result, BackendError};
-use crate::tensor::{CpuTensor, TensorShape, RuntimeDType};
+use crate::error::{BackendError, Result};
 use crate::inference::LlamaInferenceSession;
+use crate::tensor::{CpuTensor, RuntimeDType, TensorShape};
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct DistributedHeader {
     pub magic: u32,
-    pub is_prefill: u32,  // 0 = decode, 1 = prefill
+    pub is_prefill: u32, // 0 = decode, 1 = prefill
     pub seq_len: u32,
     pub position: u32,
 }
 
 impl DistributedHeader {
     pub const MAGIC: u32 = 0xCA9E111D;
-    
+
     pub fn to_bytes(self) -> [u8; 16] {
         let mut buf = [0u8; 16];
         buf[0..4].copy_from_slice(&self.magic.to_le_bytes());
@@ -27,7 +27,7 @@ impl DistributedHeader {
         buf[12..16].copy_from_slice(&self.position.to_le_bytes());
         buf
     }
-    
+
     pub fn from_bytes(buf: [u8; 16]) -> Self {
         Self {
             magic: u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]),
@@ -47,7 +47,7 @@ pub fn serialize_tensor<W: Write>(writer: &mut W, tensor: &CpuTensor) -> std::io
     }
     let data_len = tensor.data.len() as u32;
     writer.write_all(&data_len.to_le_bytes())?;
-    
+
     // Write data as raw bytes (Apple Silicon to Apple Silicon is safe)
     let byte_slice = unsafe {
         std::slice::from_raw_parts(
@@ -71,7 +71,7 @@ pub fn deserialize_tensor<R: Read>(reader: &mut R, name: String) -> std::io::Res
     reader.read_exact(&mut buf)?;
     let data_len = u32::from_le_bytes(buf) as usize;
     let mut data = vec![0.0f32; data_len];
-    
+
     // Read data as raw bytes
     let byte_slice = unsafe {
         std::slice::from_raw_parts_mut(
@@ -80,7 +80,7 @@ pub fn deserialize_tensor<R: Read>(reader: &mut R, name: String) -> std::io::Res
         )
     };
     reader.read_exact(byte_slice)?;
-    
+
     Ok(CpuTensor {
         name,
         shape: TensorShape { dims },
@@ -108,7 +108,7 @@ impl DistributedClient {
             stream: Mutex::new(stream),
         })
     }
-    
+
     pub fn forward_to_worker(
         &self,
         hidden: &CpuTensor,
@@ -119,45 +119,40 @@ impl DistributedClient {
         let mut stream = self.stream.lock().map_err(|_| {
             BackendError::RuntimeShapeMismatch("Failed to lock TCP stream mutex".to_string())
         })?;
-        
+
         let header = DistributedHeader {
             magic: DistributedHeader::MAGIC,
             is_prefill: if is_prefill { 1 } else { 0 },
             seq_len: seq_len as u32,
             position: position as u32,
         };
-        
+
         // Send header
-        stream.write_all(&header.to_bytes()).map_err(|source| {
-            BackendError::Io {
+        stream
+            .write_all(&header.to_bytes())
+            .map_err(|source| BackendError::Io {
                 path: PathBuf::from("distributed_tcp_client_write"),
                 source,
-            }
-        })?;
-        
+            })?;
+
         // Send tensor
-        serialize_tensor(&mut *stream, hidden).map_err(|source| {
-            BackendError::Io {
-                path: PathBuf::from("distributed_tcp_client_write_tensor"),
-                source,
-            }
+        serialize_tensor(&mut *stream, hidden).map_err(|source| BackendError::Io {
+            path: PathBuf::from("distributed_tcp_client_write_tensor"),
+            source,
         })?;
-        
-        stream.flush().map_err(|source| {
-            BackendError::Io {
-                path: PathBuf::from("distributed_tcp_client_flush"),
-                source,
-            }
+
+        stream.flush().map_err(|source| BackendError::Io {
+            path: PathBuf::from("distributed_tcp_client_flush"),
+            source,
         })?;
-        
+
         // Read response tensor
-        let response = deserialize_tensor(&mut *stream, "worker_response_tensor".to_string()).map_err(|source| {
-            BackendError::Io {
+        let response = deserialize_tensor(&mut *stream, "worker_response_tensor".to_string())
+            .map_err(|source| BackendError::Io {
                 path: PathBuf::from("distributed_tcp_client_read_response"),
                 source,
-            }
-        })?;
-        
+            })?;
+
         Ok(response)
     }
 }
@@ -168,7 +163,7 @@ pub static DISTRIBUTED_RANGE: OnceLock<(usize, usize)> = OnceLock::new();
 pub fn run_worker_loop(addr: &str, mut session: LlamaInferenceSession) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr)?;
     tracing::info!(addr = %addr, "Distributed Worker TCP server listening");
-    
+
     for stream in listener.incoming() {
         let mut stream = match stream {
             Ok(s) => s,
@@ -177,10 +172,10 @@ pub fn run_worker_loop(addr: &str, mut session: LlamaInferenceSession) -> anyhow
                 continue;
             }
         };
-        
+
         let _ = stream.set_nodelay(true);
         tracing::info!("Worker accepted connection from coordinator");
-        
+
         loop {
             let mut header_buf = [0u8; 16];
             if let Err(e) = stream.read_exact(&mut header_buf) {
@@ -191,23 +186,24 @@ pub fn run_worker_loop(addr: &str, mut session: LlamaInferenceSession) -> anyhow
                 }
                 break;
             }
-            
+
             let header = DistributedHeader::from_bytes(header_buf);
             if header.magic != DistributedHeader::MAGIC {
                 tracing::error!(magic = ?header.magic, "Received invalid magic header");
                 break;
             }
-            
-            let input_tensor = match deserialize_tensor(&mut stream, "coordinator_tensor".to_string()) {
-                Ok(t) => t,
-                Err(e) => {
-                    tracing::error!(error = %e, "Failed to deserialize input tensor");
-                    break;
-                }
-            };
-            
+
+            let input_tensor =
+                match deserialize_tensor(&mut stream, "coordinator_tensor".to_string()) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        tracing::error!(error = %e, "Failed to deserialize input tensor");
+                        break;
+                    }
+                };
+
             let is_prefill = header.is_prefill == 1;
-            
+
             let output_tensor = match session.forward_worker_layers(
                 input_tensor,
                 is_prefill,
@@ -220,7 +216,7 @@ pub fn run_worker_loop(addr: &str, mut session: LlamaInferenceSession) -> anyhow
                     break;
                 }
             };
-            
+
             if let Err(e) = serialize_tensor(&mut stream, &output_tensor) {
                 tracing::error!(error = %e, "Failed to serialize response tensor");
                 break;
@@ -260,7 +256,8 @@ pub fn run_network_benchmark_worker(addr: &str) -> anyhow::Result<()> {
             let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
             let test_type = u32::from_le_bytes([header[4], header[5], header[6], header[7]]);
             let count = u32::from_le_bytes([header[8], header[9], header[10], header[11]]) as usize;
-            let size = u32::from_le_bytes([header[12], header[13], header[14], header[15]]) as usize;
+            let size =
+                u32::from_le_bytes([header[12], header[13], header[14], header[15]]) as usize;
 
             if magic != DistributedHeader::MAGIC {
                 tracing::error!(magic = ?magic, "Received invalid magic benchmark header");
@@ -274,7 +271,11 @@ pub fn run_network_benchmark_worker(addr: &str) -> anyhow::Result<()> {
                 }
                 1 => {
                     // Latency Test
-                    tracing::info!(count = count, size = size, "Starting Latency Test loop as receiver");
+                    tracing::info!(
+                        count = count,
+                        size = size,
+                        "Starting Latency Test loop as receiver"
+                    );
                     let mut buf = vec![0u8; size];
                     for _ in 0..count {
                         stream.read_exact(&mut buf)?;
@@ -286,7 +287,11 @@ pub fn run_network_benchmark_worker(addr: &str) -> anyhow::Result<()> {
                 2 => {
                     // Bandwidth Test
                     let total_bytes = count * 1024 * 1024; // count is in MB
-                    tracing::info!(total_mb = count, chunk_size = size, "Starting Bandwidth Test loop as receiver");
+                    tracing::info!(
+                        total_mb = count,
+                        chunk_size = size,
+                        "Starting Bandwidth Test loop as receiver"
+                    );
                     let mut buf = vec![0u8; size];
                     let mut bytes_received = 0;
                     while bytes_received < total_bytes {
@@ -297,7 +302,10 @@ pub fn run_network_benchmark_worker(addr: &str) -> anyhow::Result<()> {
                     // Send 1-byte ACK
                     stream.write_all(&[1u8])?;
                     stream.flush()?;
-                    tracing::info!(bytes_received = bytes_received, "Bandwidth Test loop completed");
+                    tracing::info!(
+                        bytes_received = bytes_received,
+                        "Bandwidth Test loop completed"
+                    );
                 }
                 _ => {
                     tracing::error!(test_type = test_type, "Received unknown test type");
@@ -330,7 +338,8 @@ pub fn run_network_benchmark_coordinator(
         &1u32.to_le_bytes()[..], // test_type = 1
         &(ping_count as u32).to_le_bytes()[..],
         &(payload_size as u32).to_le_bytes()[..],
-    ].concat();
+    ]
+    .concat();
 
     stream.write_all(&header)?;
     stream.flush()?;
@@ -374,7 +383,8 @@ pub fn run_network_benchmark_coordinator(
         &2u32.to_le_bytes()[..], // test_type = 2
         &(total_mb as u32).to_le_bytes()[..],
         &(chunk_size as u32).to_le_bytes()[..],
-    ].concat();
+    ]
+    .concat();
 
     stream.write_all(&header)?;
     stream.flush()?;
@@ -402,8 +412,14 @@ pub fn run_network_benchmark_coordinator(
     let bandwidth_gbps = (bytes_sent as f64 * 8.0) / (duration_secs * 1_000_000_000.0);
 
     println!("--- Bandwidth Results ---");
-    println!("  Total Transferred: {:.2} MB in {:.4} seconds", mb_sent, duration_secs);
-    println!("  Throughput: {:.2} MB/s ({:.2} Gbps)", bandwidth_mb_s, bandwidth_gbps);
+    println!(
+        "  Total Transferred: {:.2} MB in {:.4} seconds",
+        mb_sent, duration_secs
+    );
+    println!(
+        "  Throughput: {:.2} MB/s ({:.2} Gbps)",
+        bandwidth_mb_s, bandwidth_gbps
+    );
 
     // --- Terminate Session ---
     let header = [
@@ -411,7 +427,8 @@ pub fn run_network_benchmark_coordinator(
         &0u32.to_le_bytes()[..], // test_type = 0 (Terminate)
         &0u32.to_le_bytes()[..],
         &0u32.to_le_bytes()[..],
-    ].concat();
+    ]
+    .concat();
     let _ = stream.write_all(&header);
     let _ = stream.flush();
 

--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -596,10 +596,7 @@ fn select_linux_x86_q8_plan(
     }
     reasons.push("validated Ubuntu/Linux x86_64 Rust Q8 runtime repack enabled".into());
     reasons.push("validated Rust AVX2 Q8 packed rows4 kernel selected".into());
-    reasons.push(
-        "attention, FFN, and output experiments enabled by default"
-            .into(),
-    );
+    reasons.push("attention, FFN, and output experiments enabled by default".into());
     if matches!(profile, ExecutionProfile::Experimental) {
         reasons.push("experimental profile active; support claims remain unchanged".into());
     }
@@ -1225,9 +1222,18 @@ mod tests {
         );
         assert_eq!(outcome.plan.profile, ExecutionProfile::Auto);
         assert_eq!(outcome.plan.selected_backend, "cpu_q8_runtime_repack");
-        assert_eq!(outcome.plan.selected_q8_path, "x86_experimental_q8_0_avx2_rust");
-        assert_eq!(outcome.env_updates.get("CAMELID_X86_Q8_KERNEL"), Some(&Some("avx2")));
-        assert_eq!(outcome.env_updates.get("CAMELID_X86_Q8_REPACK"), Some(&Some("on")));
+        assert_eq!(
+            outcome.plan.selected_q8_path,
+            "x86_experimental_q8_0_avx2_rust"
+        );
+        assert_eq!(
+            outcome.env_updates.get("CAMELID_X86_Q8_KERNEL"),
+            Some(&Some("avx2"))
+        );
+        assert_eq!(
+            outcome.env_updates.get("CAMELID_X86_Q8_REPACK"),
+            Some(&Some("on"))
+        );
         assert!(!outcome.env_updates.contains_key("CAMELID_MAC_Q8_REPACK"));
         assert_eq!(
             outcome
@@ -1758,7 +1764,10 @@ mod tests {
         );
         assert_eq!(outcome.plan.selected_backend, "cpu_reference");
         assert_eq!(outcome.plan.selected_q8_path, "safe_q8_0_block_dot");
-        assert_eq!(outcome.env_updates.get("CAMELID_X86_Q8_REPACK"), Some(&Some("off")));
+        assert_eq!(
+            outcome.env_updates.get("CAMELID_X86_Q8_REPACK"),
+            Some(&Some("off"))
+        );
         clear_profile_env();
     }
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -311,7 +311,9 @@ impl LlamaLoadedWeights {
 
         let mut layers = Vec::with_capacity(binding.layers.len());
         for (layer_idx, layer) in binding.layers.iter().enumerate() {
-            let is_owned = layer_range.as_ref().map_or(true, |r| r.contains(&layer_idx));
+            let is_owned = layer_range
+                .as_ref()
+                .map_or(true, |r| r.contains(&layer_idx));
             if is_owned {
                 let (ffn_gate, ffn_up, ffn_down, moe_router) = match &layer.ffn {
                     LlamaFfnTensors::Dense { gate, up, down } => (
@@ -346,36 +348,58 @@ impl LlamaLoadedWeights {
                 });
             } else {
                 layers.push(LlamaLayerWeights {
-                    attention_norm: CpuTensor::from_f32(&layer.attention_norm.name, vec![0], vec![])?,
+                    attention_norm: CpuTensor::from_f32(
+                        &layer.attention_norm.name,
+                        vec![0],
+                        vec![],
+                    )?,
                     attention_q: CpuTensor::from_f32(&layer.attention_q.name, vec![0], vec![])?,
                     attention_k: CpuTensor::from_f32(&layer.attention_k.name, vec![0], vec![])?,
                     attention_v: CpuTensor::from_f32(&layer.attention_v.name, vec![0], vec![])?,
-                    attention_output: CpuTensor::from_f32(&layer.attention_output.name, vec![0], vec![])?,
+                    attention_output: CpuTensor::from_f32(
+                        &layer.attention_output.name,
+                        vec![0],
+                        vec![],
+                    )?,
                     ffn_norm: CpuTensor::from_f32(&layer.ffn_norm.name, vec![0], vec![])?,
-                    ffn_gate: CpuTensor::from_f32(match &layer.ffn {
-                        LlamaFfnTensors::Dense { gate, .. } => &gate.name,
-                        LlamaFfnTensors::MoE { gate_experts, .. } => match gate_experts {
-                            LlamaMoeExpertTensors::Merged(desc) => &desc.name,
-                            LlamaMoeExpertTensors::Split(descs) => &descs[0].name,
+                    ffn_gate: CpuTensor::from_f32(
+                        match &layer.ffn {
+                            LlamaFfnTensors::Dense { gate, .. } => &gate.name,
+                            LlamaFfnTensors::MoE { gate_experts, .. } => match gate_experts {
+                                LlamaMoeExpertTensors::Merged(desc) => &desc.name,
+                                LlamaMoeExpertTensors::Split(descs) => &descs[0].name,
+                            },
                         },
-                    }, vec![0], vec![])?,
-                    ffn_up: CpuTensor::from_f32(match &layer.ffn {
-                        LlamaFfnTensors::Dense { up, .. } => &up.name,
-                        LlamaFfnTensors::MoE { up_experts, .. } => match up_experts {
-                            LlamaMoeExpertTensors::Merged(desc) => &desc.name,
-                            LlamaMoeExpertTensors::Split(descs) => &descs[0].name,
+                        vec![0],
+                        vec![],
+                    )?,
+                    ffn_up: CpuTensor::from_f32(
+                        match &layer.ffn {
+                            LlamaFfnTensors::Dense { up, .. } => &up.name,
+                            LlamaFfnTensors::MoE { up_experts, .. } => match up_experts {
+                                LlamaMoeExpertTensors::Merged(desc) => &desc.name,
+                                LlamaMoeExpertTensors::Split(descs) => &descs[0].name,
+                            },
                         },
-                    }, vec![0], vec![])?,
-                    ffn_down: CpuTensor::from_f32(match &layer.ffn {
-                        LlamaFfnTensors::Dense { down, .. } => &down.name,
-                        LlamaFfnTensors::MoE { down_experts, .. } => match down_experts {
-                            LlamaMoeExpertTensors::Merged(desc) => &desc.name,
-                            LlamaMoeExpertTensors::Split(descs) => &descs[0].name,
+                        vec![0],
+                        vec![],
+                    )?,
+                    ffn_down: CpuTensor::from_f32(
+                        match &layer.ffn {
+                            LlamaFfnTensors::Dense { down, .. } => &down.name,
+                            LlamaFfnTensors::MoE { down_experts, .. } => match down_experts {
+                                LlamaMoeExpertTensors::Merged(desc) => &desc.name,
+                                LlamaMoeExpertTensors::Split(descs) => &descs[0].name,
+                            },
                         },
-                    }, vec![0], vec![])?,
+                        vec![0],
+                        vec![],
+                    )?,
                     moe_router: match &layer.ffn {
                         LlamaFfnTensors::Dense { .. } => None,
-                        LlamaFfnTensors::MoE { router, .. } => Some(CpuTensor::from_f32(&router.name, vec![0], vec![])?),
+                        LlamaFfnTensors::MoE { router, .. } => {
+                            Some(CpuTensor::from_f32(&router.name, vec![0], vec![])?)
+                        }
                     },
                 });
             }
@@ -1203,11 +1227,25 @@ impl LlamaInferenceSession {
     ) -> Result<CpuTensor> {
         let runtime_plan = ResolvedRuntimePlan::from_env()?;
         let rms_norm_epsilon = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
-        let k = self.weights.layers.iter().position(|l| l.attention_norm.shape.dims[0] > 0).unwrap_or(0);
+        let k = self
+            .weights
+            .layers
+            .iter()
+            .position(|l| l.attention_norm.shape.dims[0] > 0)
+            .unwrap_or(0);
         let n = self.weights.layers.len();
-        tracing::info!("Worker forward_worker_layers: k = {}, n = {}, layers.len = {}", k, n, self.weights.layers.len());
+        tracing::info!(
+            "Worker forward_worker_layers: k = {}, n = {}, layers.len = {}",
+            k,
+            n,
+            self.weights.layers.len()
+        );
         for (i, l) in self.weights.layers.iter().enumerate() {
-            tracing::info!("  layer {}: attention_norm shape = {:?}", i, l.attention_norm.shape.dims);
+            tracing::info!(
+                "  layer {}: attention_norm shape = {:?}",
+                i,
+                l.attention_norm.shape.dims
+            );
         }
 
         if is_prefill {
@@ -1254,7 +1292,12 @@ impl LlamaInferenceSession {
                         &mut self.kv_cache,
                     )?;
                     chunk_input_buffer = hidden_chunk.data;
-                    copy_tensor_rows_into(&timed.output, &mut next_hidden, chunk_start, hidden_width)?;
+                    copy_tensor_rows_into(
+                        &timed.output,
+                        &mut next_hidden,
+                        chunk_start,
+                        hidden_width,
+                    )?;
                 }
                 std::mem::swap(&mut hidden.data, &mut next_hidden);
                 hidden.shape = TensorShape {
@@ -1349,7 +1392,8 @@ impl LlamaInferenceSession {
     pub fn forward_final_norm_and_logits(&self, out_hidden: &CpuTensor) -> Result<CpuTensor> {
         let rms_norm_epsilon = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
         let runtime_plan = ResolvedRuntimePlan::from_env()?;
-        let norm = out_hidden.rms_norm(&self.weights.output_norm, rms_norm_epsilon, "output_norm")?;
+        let norm =
+            out_hidden.rms_norm(&self.weights.output_norm, rms_norm_epsilon, "output_norm")?;
         let logits = output_projection_runtime_with_plan(
             &norm,
             self.weights.output_projection(),
@@ -1697,12 +1741,8 @@ impl LlamaInferenceSession {
             if let Some(range) = &self.weights.layer_range {
                 if !range.contains(&layer_idx) {
                     if let Some(client) = crate::distributed::DISTRIBUTED_CLIENT.get() {
-                        let worker_response = client.forward_to_worker(
-                            &hidden,
-                            false,
-                            1,
-                            self.kv_cache.position,
-                        )?;
+                        let worker_response =
+                            client.forward_to_worker(&hidden, false, 1, self.kv_cache.position)?;
                         hidden = worker_response;
                         break;
                     } else {
@@ -5089,7 +5129,10 @@ fn matmul_rhs_transposed_borrowed_with_precision_with_plan(
     }
     #[cfg(target_os = "macos")]
     {
-        if weight.source_type.is_none() && weight.q8_0_blocks.is_none() && weight.q8_0_file_backing.is_none() {
+        if weight.source_type.is_none()
+            && weight.q8_0_blocks.is_none()
+            && weight.q8_0_file_backing.is_none()
+        {
             let mut output = vec![0.0; rows * output_width];
             unsafe {
                 cblas_sgemm(
@@ -10544,18 +10587,32 @@ fn q8_0_packed_rows4_matmul_projection_pair_from_quantized(
             .for_each(|(row_idx, (left_row, right_row))| {
                 let input_start = row_idx * blocks_per_row;
                 let quantized_row = &quantized_inputs[input_start..input_start + blocks_per_row];
-                for (group_idx, output_chunk) in left_row[..left_output_width].chunks_exact_mut(4).enumerate() {
+                for (group_idx, output_chunk) in left_row[..left_output_width]
+                    .chunks_exact_mut(4)
+                    .enumerate()
+                {
                     let group_start = group_idx * blocks_per_row;
-                    let group_blocks = &left_packed.blocks[group_start..group_start + blocks_per_row];
-                    let sums =
-                        q8_0_packed_rows4_dot_i8_matmul(group_blocks, quantized_row, use_hoisted_avx2);
+                    let group_blocks =
+                        &left_packed.blocks[group_start..group_start + blocks_per_row];
+                    let sums = q8_0_packed_rows4_dot_i8_matmul(
+                        group_blocks,
+                        quantized_row,
+                        use_hoisted_avx2,
+                    );
                     output_chunk.copy_from_slice(&sums);
                 }
-                for (group_idx, output_chunk) in right_row[..right_output_groups_per_row * 4].chunks_exact_mut(4).enumerate() {
+                for (group_idx, output_chunk) in right_row[..right_output_groups_per_row * 4]
+                    .chunks_exact_mut(4)
+                    .enumerate()
+                {
                     let group_start = group_idx * blocks_per_row;
-                    let group_blocks = &right_packed.blocks[group_start..group_start + blocks_per_row];
-                    let sums =
-                        q8_0_packed_rows4_dot_i8_matmul(group_blocks, quantized_row, use_hoisted_avx2);
+                    let group_blocks =
+                        &right_packed.blocks[group_start..group_start + blocks_per_row];
+                    let sums = q8_0_packed_rows4_dot_i8_matmul(
+                        group_blocks,
+                        quantized_row,
+                        use_hoisted_avx2,
+                    );
                     output_chunk.copy_from_slice(&sums);
                 }
             });
@@ -10813,7 +10870,10 @@ fn q8_0_packed_rows4_matmul_projection_triplet_from_quantized(
             .for_each(|(row_idx, ((q_row, k_row), v_row))| {
                 let input_start = row_idx * blocks_per_row;
                 let quantized_row = &quantized_inputs[input_start..input_start + blocks_per_row];
-                for (group_idx, output_chunk) in q_row[..q_groups_per_row * 4].chunks_exact_mut(4).enumerate() {
+                for (group_idx, output_chunk) in q_row[..q_groups_per_row * 4]
+                    .chunks_exact_mut(4)
+                    .enumerate()
+                {
                     let group_start = group_idx * blocks_per_row;
                     output_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
                         &q_packed.blocks[group_start..group_start + blocks_per_row],
@@ -10821,7 +10881,10 @@ fn q8_0_packed_rows4_matmul_projection_triplet_from_quantized(
                         use_hoisted_avx2,
                     ));
                 }
-                for (group_idx, output_chunk) in k_row[..k_groups_per_row * 4].chunks_exact_mut(4).enumerate() {
+                for (group_idx, output_chunk) in k_row[..k_groups_per_row * 4]
+                    .chunks_exact_mut(4)
+                    .enumerate()
+                {
                     let group_start = group_idx * blocks_per_row;
                     output_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
                         &k_packed.blocks[group_start..group_start + blocks_per_row],
@@ -10829,7 +10892,10 @@ fn q8_0_packed_rows4_matmul_projection_triplet_from_quantized(
                         use_hoisted_avx2,
                     ));
                 }
-                for (group_idx, output_chunk) in v_row[..v_groups_per_row * 4].chunks_exact_mut(4).enumerate() {
+                for (group_idx, output_chunk) in v_row[..v_groups_per_row * 4]
+                    .chunks_exact_mut(4)
+                    .enumerate()
+                {
                     let group_start = group_idx * blocks_per_row;
                     output_chunk.copy_from_slice(&q8_0_packed_rows4_dot_i8_matmul(
                         &v_packed.blocks[group_start..group_start + blocks_per_row],
@@ -11543,8 +11609,9 @@ fn quantize_q8_0_blocks_into(input: &[f32], blocks: &mut Vec<Q8_0Block>) {
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn quantize_q8_0_block(block: &[f32]) -> Q8_0Block {
     use std::arch::aarch64::{
-        vld1q_f32, vabsq_f32, vmaxq_f32, vmax_f32, vget_low_f32, vget_high_f32, vdupq_n_f32, vmulq_f32,
-        vcvtaq_s32_f32, vmovn_s32, vcombine_s16, vqmovn_s16, vcombine_s8, vst1q_s8, vget_lane_f32,
+        vabsq_f32, vcombine_s16, vcombine_s8, vcvtaq_s32_f32, vdupq_n_f32, vget_high_f32,
+        vget_lane_f32, vget_low_f32, vld1q_f32, vmax_f32, vmaxq_f32, vmovn_s32, vmulq_f32,
+        vqmovn_s16, vst1q_s8,
     };
 
     debug_assert_eq!(block.len(), Q8_0_BLOCK_VALUES);
@@ -11677,9 +11744,8 @@ fn q8_row_dispatch_enabled() -> bool {
         #[cfg(not(test))]
         {
             static Q8_ROW_DISPATCH_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-            *Q8_ROW_DISPATCH_ENABLED.get_or_init(|| {
-                q8_0_env_flag_enabled_default_off("CAMELID_Q8_ROW_DISPATCH")
-            })
+            *Q8_ROW_DISPATCH_ENABLED
+                .get_or_init(|| q8_0_env_flag_enabled_default_off("CAMELID_Q8_ROW_DISPATCH"))
         }
     }
 }
@@ -11901,8 +11967,11 @@ unsafe fn q8_0_two_dot_rows_neon_dotprod(
     let mut first_sum = 0.0_f32;
     let mut second_sum = 0.0_f32;
 
-    for (idx, ((first_block, second_block), input_block)) in
-        first_weight.iter().zip(second_weight).zip(input).enumerate()
+    for (idx, ((first_block, second_block), input_block)) in first_weight
+        .iter()
+        .zip(second_weight)
+        .zip(input)
+        .enumerate()
     {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
@@ -12004,7 +12073,9 @@ fn q8_0_two_dot_rows(
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
             if aarch64_dotprod_enabled() {
-                return unsafe { q8_0_two_dot_rows_neon_dotprod(first_weight, second_weight, input) };
+                return unsafe {
+                    q8_0_two_dot_rows_neon_dotprod(first_weight, second_weight, input)
+                };
             }
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -15115,14 +15186,7 @@ fn dot_product_row(lhs: &[f32], rhs: &[f32]) -> f32 {
     {
         let mut sum = 0.0;
         unsafe {
-            vDSP_dotpr(
-                lhs.as_ptr(),
-                1,
-                rhs.as_ptr(),
-                1,
-                &mut sum,
-                lhs.len() as u64,
-            );
+            vDSP_dotpr(lhs.as_ptr(), 1, rhs.as_ptr(), 1, &mut sum, lhs.len() as u64);
         }
         sum
     }

--- a/src/inference/rope.rs
+++ b/src/inference/rope.rs
@@ -216,8 +216,8 @@ pub(super) fn apply_rope_batch(
     };
 
     let mut data = tensor.data.clone();
-    use rayon::prelude::*;
     use crate::tensor::should_parallelize_linear_output;
+    use rayon::prelude::*;
 
     if should_parallelize_linear_output(rows * width) {
         data.par_chunks_mut(width)
@@ -398,10 +398,9 @@ fn apply_rope_to_row(data: &mut [f32], position: usize, mut params: RopeParams<'
                     let dim0 = head_start + (pair_idx * 2);
                     (dim0, dim0 + 1)
                 }
-                RopePairing::SplitHalf => (
-                    head_start + pair_idx,
-                    head_start + pair_idx + half_rope_dim,
-                ),
+                RopePairing::SplitHalf => {
+                    (head_start + pair_idx, head_start + pair_idx + half_rope_dim)
+                }
             };
             let x0 = data[dim0];
             let x1 = data[dim1];

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -15,7 +15,7 @@ fn test_row_dispatch_adversarial_parity() {
     let _env_guard = env_lock();
 
     let n_blocks = 4;
-    
+
     let mut weight_blocks = Vec::with_capacity(n_blocks);
     let mut input_blocks = Vec::with_capacity(n_blocks);
 
@@ -23,15 +23,35 @@ fn test_row_dispatch_adversarial_parity() {
     let mut w0 = [0_i8; 32];
     let mut in0 = [0_i8; 32];
     for idx in 0..32 {
-        w0[idx] = if idx % 2 == 0 { (idx as i8) * 3 } else { -(idx as i8) * 4 };
-        in0[idx] = if idx % 3 == 0 { 29 - (idx as i8) } else { (idx as i8) - 45 };
+        w0[idx] = if idx % 2 == 0 {
+            (idx as i8) * 3
+        } else {
+            -(idx as i8) * 4
+        };
+        in0[idx] = if idx % 3 == 0 {
+            29 - (idx as i8)
+        } else {
+            (idx as i8) - 45
+        };
     }
-    weight_blocks.push(Q8_0Block { scale: 0.125, quants: w0 });
-    input_blocks.push(Q8_0Block { scale: 0.25, quants: in0 });
+    weight_blocks.push(Q8_0Block {
+        scale: 0.125,
+        quants: w0,
+    });
+    input_blocks.push(Q8_0Block {
+        scale: 0.25,
+        quants: in0,
+    });
 
     // Block 1: Zero block (all zeros, scale 0)
-    weight_blocks.push(Q8_0Block { scale: 0.0, quants: [0_i8; 32] });
-    input_blocks.push(Q8_0Block { scale: 0.0, quants: [0_i8; 32] });
+    weight_blocks.push(Q8_0Block {
+        scale: 0.0,
+        quants: [0_i8; 32],
+    });
+    input_blocks.push(Q8_0Block {
+        scale: 0.0,
+        quants: [0_i8; 32],
+    });
 
     // Block 2: Boundary case with i8::MIN (-128) and i8::MAX (127)
     let mut w2 = [0_i8; 32];
@@ -50,8 +70,14 @@ fn test_row_dispatch_adversarial_parity() {
             _ => 13,
         };
     }
-    weight_blocks.push(Q8_0Block { scale: 1.5, quants: w2 });
-    input_blocks.push(Q8_0Block { scale: 0.75, quants: in2 });
+    weight_blocks.push(Q8_0Block {
+        scale: 1.5,
+        quants: w2,
+    });
+    input_blocks.push(Q8_0Block {
+        scale: 0.75,
+        quants: in2,
+    });
 
     // Block 3: Mixed small values/subnormal scales
     let mut w3 = [0_i8; 32];
@@ -60,8 +86,14 @@ fn test_row_dispatch_adversarial_parity() {
         w3[idx] = (idx as i8) - 16;
         in3[idx] = 16 - (idx as i8);
     }
-    weight_blocks.push(Q8_0Block { scale: 1e-37, quants: w3 });
-    input_blocks.push(Q8_0Block { scale: 1e-38, quants: in3 });
+    weight_blocks.push(Q8_0Block {
+        scale: 1e-37,
+        quants: w3,
+    });
+    input_blocks.push(Q8_0Block {
+        scale: 1e-38,
+        quants: in3,
+    });
 
     // Test single-row dot product
     std::env::set_var("CAMELID_Q8_ROW_DISPATCH", "off");
@@ -78,26 +110,38 @@ fn test_row_dispatch_adversarial_parity() {
 
     // Test two-row dot product
     let mut second_weight_blocks = Vec::with_capacity(n_blocks);
-    
+
     let mut w0_2 = [0_i8; 32];
     for idx in 0..32 {
         w0_2[idx] = if idx % 2 == 0 { -10 } else { 12 };
     }
-    second_weight_blocks.push(Q8_0Block { scale: 0.5, quants: w0_2 });
-    
-    second_weight_blocks.push(Q8_0Block { scale: 0.0, quants: [0_i8; 32] });
-    
+    second_weight_blocks.push(Q8_0Block {
+        scale: 0.5,
+        quants: w0_2,
+    });
+
+    second_weight_blocks.push(Q8_0Block {
+        scale: 0.0,
+        quants: [0_i8; 32],
+    });
+
     let mut w2_2 = [0_i8; 32];
     for idx in 0..32 {
         w2_2[idx] = if idx % 3 == 0 { i8::MIN } else { 45 };
     }
-    second_weight_blocks.push(Q8_0Block { scale: 2.25, quants: w2_2 });
+    second_weight_blocks.push(Q8_0Block {
+        scale: 2.25,
+        quants: w2_2,
+    });
 
     let mut w3_2 = [0_i8; 32];
     for idx in 0..32 {
         w3_2[idx] = -(idx as i8);
     }
-    second_weight_blocks.push(Q8_0Block { scale: 1e-35, quants: w3_2 });
+    second_weight_blocks.push(Q8_0Block {
+        scale: 1e-35,
+        quants: w3_2,
+    });
 
     std::env::set_var("CAMELID_Q8_ROW_DISPATCH", "off");
     let scalar_two_dot = q8_0_two_dot_rows(&weight_blocks, &second_weight_blocks, &input_blocks);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,10 @@
-use std::{net::{SocketAddr, TcpListener, TcpStream}, path::PathBuf, time::Instant, io::Write, sync::Arc};
+use std::{
+    io::Write,
+    net::{SocketAddr, TcpListener, TcpStream},
+    path::PathBuf,
+    sync::Arc,
+    time::Instant,
+};
 
 #[cfg(target_os = "macos")]
 extern "C" {
@@ -10,12 +16,14 @@ extern "C" {
 
 use camelid::{
     api,
+    cluster::{
+        recv_activation_packet, recv_token_feedback, send_activation_packet, send_token_feedback,
+    },
     gguf::{read_metadata, GgufTensorType},
+    inference::{LlamaInferenceSession, LlamaLoadedWeights, LlamaSampler},
     metal::detect_metal_device,
     tensor::{CpuTensor, Q8_0TensorBlocks, TensorStore},
-    inference::{LlamaLoadedWeights, LlamaInferenceSession, LlamaSampler},
     tokenizer::Tokenizer,
-    cluster::{send_activation_packet, recv_activation_packet, send_token_feedback, recv_token_feedback},
 };
 use clap::{Parser, Subcommand};
 use rayon::ThreadPoolBuilder;
@@ -253,7 +261,7 @@ async fn main() -> anyhow::Result<()> {
             threads,
         } => {
             configure_rayon_threads(threads)?;
-            
+
             let parts: Vec<&str> = layer_range.split("..").collect();
             anyhow::ensure!(
                 parts.len() == 2,
@@ -265,21 +273,21 @@ async fn main() -> anyhow::Result<()> {
                 layer_start < layer_end,
                 "layer_start must be less than layer_end"
             );
-            
+
             let _ = camelid::distributed::DISTRIBUTED_RANGE.set((layer_start, layer_end));
 
             if role == "coordinator" {
                 let worker_addr_str = worker_addr.ok_or_else(|| {
                     anyhow::anyhow!("--worker-addr is required in coordinator mode")
                 })?;
-                
+
                 tracing::info!(worker_addr = %worker_addr_str, "Coordinator connecting to worker");
                 let client = camelid::distributed::DistributedClient::connect(&worker_addr_str)?;
-                camelid::distributed::DISTRIBUTED_CLIENT.set(client).map_err(|_| {
-                    anyhow::anyhow!("Failed to set global distributed client lock")
-                })?;
+                camelid::distributed::DISTRIBUTED_CLIENT
+                    .set(client)
+                    .map_err(|_| anyhow::anyhow!("Failed to set global distributed client lock"))?;
                 tracing::info!("Coordinator connected to worker successfully");
-                
+
                 #[cfg(target_os = "macos")]
                 unsafe {
                     pthread_set_qos_class_self_np(0x09, 0); // QOS_CLASS_BACKGROUND (forces network I/O onto E-cores)
@@ -290,8 +298,12 @@ async fn main() -> anyhow::Result<()> {
                 let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
                 let binding = camelid::model::LlamaTensorBinding::bind(&gguf, &config)?;
                 let store = camelid::tensor::TensorStore::open(&model, &gguf);
-                
-                tracing::info!("Worker loading partitioned weights (layers {}..{})", layer_start, layer_end);
+
+                tracing::info!(
+                    "Worker loading partitioned weights (layers {}..{})",
+                    layer_start,
+                    layer_end
+                );
                 let weights = camelid::inference::LlamaLoadedWeights::load_distributed(
                     &store,
                     &binding,
@@ -300,13 +312,10 @@ async fn main() -> anyhow::Result<()> {
                     false,
                     false,
                 )?;
-                
+
                 tracing::info!("Worker weights loaded successfully. Initializing session.");
-                let session = camelid::inference::LlamaInferenceSession::new(
-                    config,
-                    weights,
-                )?;
-                
+                let session = camelid::inference::LlamaInferenceSession::new(config, weights)?;
+
                 let addr_str = addr.to_string();
                 #[cfg(target_os = "macos")]
                 unsafe {
@@ -414,7 +423,8 @@ async fn main() -> anyhow::Result<()> {
             max_tokens,
             threads,
         } => {
-            run_distribute_master(path, worker_addr, layers, addr, prompt, max_tokens, threads).await?;
+            run_distribute_master(path, worker_addr, layers, addr, prompt, max_tokens, threads)
+                .await?;
         }
     }
     Ok(())
@@ -450,7 +460,10 @@ fn accept_connection(listener: &TcpListener) -> TcpStream {
 fn parse_layers_range(layers_str: &str) -> anyhow::Result<std::ops::Range<usize>> {
     let parts: Vec<&str> = layers_str.split("..").collect();
     if parts.len() != 2 {
-        return Err(anyhow::anyhow!("Invalid layers range format: {}", layers_str));
+        return Err(anyhow::anyhow!(
+            "Invalid layers range format: {}",
+            layers_str
+        ));
     }
     let start = parts[0].parse::<usize>()?;
     let end = parts[1].parse::<usize>()?;
@@ -520,7 +533,8 @@ async fn run_distribute_worker(
             ));
         }
         let rows = activations.len() / hidden_dim;
-        let hidden = CpuTensor::from_f32("activations", vec![rows, hidden_dim], activations.clone())?;
+        let hidden =
+            CpuTensor::from_f32("activations", vec![rows, hidden_dim], activations.clone())?;
 
         let out_hidden = session.forward_layer_range_from_hidden(
             &hidden,
@@ -535,8 +549,10 @@ async fn run_distribute_worker(
                 let logits = session.forward_final_norm_and_logits(&out_hidden)?;
                 let vocab_size = logits.dim(1)?;
                 let last_row_start = (header.seq_len as usize - 1) * vocab_size;
-                let last_row_data = logits.data[last_row_start..last_row_start + vocab_size].to_vec();
-                let last_row_logits = CpuTensor::from_f32("last_row_logits", vec![1, vocab_size], last_row_data)?;
+                let last_row_data =
+                    logits.data[last_row_start..last_row_start + vocab_size].to_vec();
+                let last_row_logits =
+                    CpuTensor::from_f32("last_row_logits", vec![1, vocab_size], last_row_data)?;
                 let token_id = LlamaSampler::Greedy.sample(&last_row_logits)?;
 
                 let is_finished = tokenizer.as_ref().map_or(false, |tok| {
@@ -592,10 +608,18 @@ async fn run_distribute_master(
     let mut pos = 0usize;
     let mut seq_len = token_ids.len();
 
-    let hidden = session.weights.token_embedding.embedding_lookup(&token_ids, "token_embedding_prefill")?;
+    let hidden = session
+        .weights
+        .token_embedding
+        .embedding_lookup(&token_ids, "token_embedding_prefill")?;
     let out_hidden = session.forward_layer_range_from_hidden(&hidden, pos, seq_len)?;
 
-    send_activation_packet(&mut downstream_stream, pos as u32, seq_len as u32, &out_hidden.data)?;
+    send_activation_packet(
+        &mut downstream_stream,
+        pos as u32,
+        seq_len as u32,
+        &out_hidden.data,
+    )?;
 
     let feedback = recv_token_feedback(&mut feedback_stream)?;
     let mut current_token = feedback.token_id;
@@ -609,9 +633,17 @@ async fn run_distribute_master(
 
     let mut generated = 1;
     while !is_finished && generated < max_tokens {
-        let hidden = session.weights.token_embedding.embedding_lookup(&[current_token], "token_embedding")?;
+        let hidden = session
+            .weights
+            .token_embedding
+            .embedding_lookup(&[current_token], "token_embedding")?;
         let out_hidden = session.forward_layer_range_from_hidden(&hidden, pos, seq_len)?;
-        send_activation_packet(&mut downstream_stream, pos as u32, seq_len as u32, &out_hidden.data)?;
+        send_activation_packet(
+            &mut downstream_stream,
+            pos as u32,
+            seq_len as u32,
+            &out_hidden.data,
+        )?;
 
         let feedback = recv_token_feedback(&mut feedback_stream)?;
         current_token = feedback.token_id;
@@ -1152,30 +1184,30 @@ fn log_acceleration_state() {
 }
 
 fn configure_rayon_threads(threads: Option<usize>) -> anyhow::Result<()> {
-        #[cfg(target_os = "macos")]
-        let should_configure = true;
-        #[cfg(not(target_os = "macos"))]
-        let should_configure = threads.is_some();
+    #[cfg(target_os = "macos")]
+    let should_configure = true;
+    #[cfg(not(target_os = "macos"))]
+    let should_configure = threads.is_some();
 
-        if should_configure {
-            let mut builder = ThreadPoolBuilder::new();
-            if let Some(t) = threads {
-                anyhow::ensure!(t > 0, "--threads must be greater than zero");
-                builder = builder.num_threads(t);
-            }
-            #[cfg(target_os = "macos")]
-            {
-                builder = builder.start_handler(|_| {
-                    unsafe {
-                        pthread_set_qos_class_self_np(0x21, 0); // QOS_CLASS_USER_INTERACTIVE (forces P-cores)
-                    }
-                });
-            }
-            builder
-                .build_global()
-                .map_err(|err| anyhow::anyhow!("failed to configure Rayon thread pool: {err}"))?;
+    if should_configure {
+        let mut builder = ThreadPoolBuilder::new();
+        if let Some(t) = threads {
+            anyhow::ensure!(t > 0, "--threads must be greater than zero");
+            builder = builder.num_threads(t);
         }
-        Ok(())
+        #[cfg(target_os = "macos")]
+        {
+            builder = builder.start_handler(|_| {
+                unsafe {
+                    pthread_set_qos_class_self_np(0x21, 0); // QOS_CLASS_USER_INTERACTIVE (forces P-cores)
+                }
+            });
+        }
+        builder
+            .build_global()
+            .map_err(|err| anyhow::anyhow!("failed to configure Rayon thread pool: {err}"))?;
+    }
+    Ok(())
 }
 
 fn average_timings(timings: &[DenseHotloopBenchTimings]) -> DenseHotloopBenchTimings {

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -84,7 +84,8 @@ impl MetalLinearCache {
         } else {
             let buffer = &self.scalar_buffers[self.scalar_index];
             if buffer.length() < needed as u64 {
-                self.scalar_buffers[self.scalar_index] = device.new_buffer(needed as u64, MTLResourceOptions::StorageModeShared);
+                self.scalar_buffers[self.scalar_index] =
+                    device.new_buffer(needed as u64, MTLResourceOptions::StorageModeShared);
             }
         }
         let buf = self.scalar_buffers[self.scalar_index].to_owned();
@@ -108,7 +109,12 @@ impl MetalLinearCache {
         self.get_scalar_buffer(device, needed)
     }
 
-    fn q8_input_scales_buffer(&mut self, device: &Device, needed: usize, ptr: *const f32) -> Buffer {
+    fn q8_input_scales_buffer(
+        &mut self,
+        device: &Device,
+        needed: usize,
+        ptr: *const f32,
+    ) -> Buffer {
         self.get_activation_buffer(device, needed, ptr.cast())
     }
 
@@ -120,7 +126,12 @@ impl MetalLinearCache {
         self.get_activation_buffer(device, needed, ptr.cast())
     }
 
-    fn q8_weight_scales_buffer(&mut self, device: &Device, needed: usize, ptr: *const f32) -> Buffer {
+    fn q8_weight_scales_buffer(
+        &mut self,
+        device: &Device,
+        needed: usize,
+        ptr: *const f32,
+    ) -> Buffer {
         self.get_activation_buffer(device, needed, ptr.cast())
     }
 
@@ -371,14 +382,15 @@ pub fn synchronize_active_session() {
         cb.commit();
         cb.wait_until_completed();
     }
-    
+
     let mut cache = metal_linear_cache()
         .lock()
         .expect("metal linear cache poisoned");
     let deferred = std::mem::take(&mut cache.deferred_reads);
     for read in deferred {
         unsafe {
-            let dest_slice = std::slice::from_raw_parts_mut(read.dest_ptr as *mut f32, read.dest_len);
+            let dest_slice =
+                std::slice::from_raw_parts_mut(read.dest_ptr as *mut f32, read.dest_len);
             read_buffer_f32(&read.buffer, dest_slice);
         }
     }
@@ -479,9 +491,17 @@ fn try_linear_row_impl(
     let mut cache = metal_linear_cache()
         .lock()
         .expect("metal linear cache poisoned");
-    let input_buffer = cache.input_buffer(&kernel.device, std::mem::size_of_val(input_row), input_row.as_ptr());
+    let input_buffer = cache.input_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_row),
+        input_row.as_ptr(),
+    );
     let weight_buffer = cache.weight_buffer(&kernel.device, weights);
-    let output_buffer = cache.output_buffer(&kernel.device, std::mem::size_of_val(output), output.as_mut_ptr());
+    let output_buffer = cache.output_buffer(
+        &kernel.device,
+        std::mem::size_of_val(output),
+        output.as_mut_ptr(),
+    );
     let scalar_buffer = cache.scalar_buffer(&kernel.device, 2 * std::mem::size_of::<u32>());
     write_buffer_f32(&input_buffer, input_row);
     write_buffer_f32(&output_buffer, output);
@@ -570,15 +590,31 @@ pub fn try_q8_0_encoded_linear_row(
     let mut cache = metal_linear_cache()
         .lock()
         .expect("metal linear cache poisoned");
-    let input_scales_buffer =
-        cache.q8_input_scales_buffer(&kernel.device, std::mem::size_of_val(input_scales), input_scales.as_ptr());
-    let input_quants_buffer =
-        cache.q8_input_quants_buffer(&kernel.device, std::mem::size_of_val(input_quants), input_quants.as_ptr());
-    let encoded_rows_buffer =
-        cache.q8_encoded_rows_buffer(&kernel.device, std::mem::size_of_val(encoded_rows), encoded_rows.as_ptr());
-    let weight_scales_buffer =
-        cache.q8_weight_scales_buffer(&kernel.device, std::mem::size_of_val(weight_scales), weight_scales.as_ptr());
-    let output_buffer = cache.output_buffer(&kernel.device, std::mem::size_of_val(output), output.as_mut_ptr());
+    let input_scales_buffer = cache.q8_input_scales_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_scales),
+        input_scales.as_ptr(),
+    );
+    let input_quants_buffer = cache.q8_input_quants_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_quants),
+        input_quants.as_ptr(),
+    );
+    let encoded_rows_buffer = cache.q8_encoded_rows_buffer(
+        &kernel.device,
+        std::mem::size_of_val(encoded_rows),
+        encoded_rows.as_ptr(),
+    );
+    let weight_scales_buffer = cache.q8_weight_scales_buffer(
+        &kernel.device,
+        std::mem::size_of_val(weight_scales),
+        weight_scales.as_ptr(),
+    );
+    let output_buffer = cache.output_buffer(
+        &kernel.device,
+        std::mem::size_of_val(output),
+        output.as_mut_ptr(),
+    );
     let scalar_buffer = cache.scalar_buffer(&kernel.device, 2 * std::mem::size_of::<u32>());
     write_buffer_f32(&input_scales_buffer, input_scales);
     write_buffer_i8(&input_quants_buffer, input_quants);
@@ -668,15 +704,31 @@ pub fn try_q8_0_encoded_linear_rows(
     let mut cache = metal_linear_cache()
         .lock()
         .expect("metal linear cache poisoned");
-    let input_scales_buffer =
-        cache.q8_input_scales_buffer(&kernel.device, std::mem::size_of_val(input_scales), input_scales.as_ptr());
-    let input_quants_buffer =
-        cache.q8_input_quants_buffer(&kernel.device, std::mem::size_of_val(input_quants), input_quants.as_ptr());
-    let encoded_rows_buffer =
-        cache.q8_encoded_rows_buffer(&kernel.device, std::mem::size_of_val(encoded_rows), encoded_rows.as_ptr());
-    let weight_scales_buffer =
-        cache.q8_weight_scales_buffer(&kernel.device, std::mem::size_of_val(weight_scales), weight_scales.as_ptr());
-    let output_buffer = cache.output_buffer(&kernel.device, std::mem::size_of_val(output), output.as_mut_ptr());
+    let input_scales_buffer = cache.q8_input_scales_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_scales),
+        input_scales.as_ptr(),
+    );
+    let input_quants_buffer = cache.q8_input_quants_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_quants),
+        input_quants.as_ptr(),
+    );
+    let encoded_rows_buffer = cache.q8_encoded_rows_buffer(
+        &kernel.device,
+        std::mem::size_of_val(encoded_rows),
+        encoded_rows.as_ptr(),
+    );
+    let weight_scales_buffer = cache.q8_weight_scales_buffer(
+        &kernel.device,
+        std::mem::size_of_val(weight_scales),
+        weight_scales.as_ptr(),
+    );
+    let output_buffer = cache.output_buffer(
+        &kernel.device,
+        std::mem::size_of_val(output),
+        output.as_mut_ptr(),
+    );
     let scalar_buffer = cache.scalar_buffer(&kernel.device, 3 * std::mem::size_of::<u32>());
     write_buffer_f32(&input_scales_buffer, input_scales);
     write_buffer_i8(&input_quants_buffer, input_quants);
@@ -768,12 +820,22 @@ pub fn try_q8_0_block_linear_row(
     let mut cache = metal_linear_cache()
         .lock()
         .expect("metal linear cache poisoned");
-    let input_scales_buffer =
-        cache.q8_input_scales_buffer(&kernel.device, std::mem::size_of_val(input_scales), input_scales.as_ptr());
-    let input_quants_buffer =
-        cache.q8_input_quants_buffer(&kernel.device, std::mem::size_of_val(input_quants), input_quants.as_ptr());
+    let input_scales_buffer = cache.q8_input_scales_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_scales),
+        input_scales.as_ptr(),
+    );
+    let input_quants_buffer = cache.q8_input_quants_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_quants),
+        input_quants.as_ptr(),
+    );
     let weight_blocks_buffer = cache.q8_block_weight_buffer(&kernel.device, weight_blocks);
-    let output_buffer = cache.output_buffer(&kernel.device, std::mem::size_of_val(output), output.as_mut_ptr());
+    let output_buffer = cache.output_buffer(
+        &kernel.device,
+        std::mem::size_of_val(output),
+        output.as_mut_ptr(),
+    );
     let scalar_buffer = cache.scalar_buffer(&kernel.device, 2 * std::mem::size_of::<u32>());
     write_buffer_f32(&input_scales_buffer, input_scales);
     write_buffer_i8(&input_quants_buffer, input_quants);
@@ -856,12 +918,22 @@ where
     let mut cache = metal_linear_cache()
         .lock()
         .expect("metal linear cache poisoned");
-    let input_scales_buffer =
-        cache.q8_input_scales_buffer(&kernel.device, std::mem::size_of_val(input_scales), input_scales.as_ptr());
-    let input_quants_buffer =
-        cache.q8_input_quants_buffer(&kernel.device, std::mem::size_of_val(input_quants), input_quants.as_ptr());
+    let input_scales_buffer = cache.q8_input_scales_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_scales),
+        input_scales.as_ptr(),
+    );
+    let input_quants_buffer = cache.q8_input_quants_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_quants),
+        input_quants.as_ptr(),
+    );
     let weight_blocks_buffer = cache.q8_block_weight_buffer(&kernel.device, weight_blocks);
-    let output_buffer = cache.output_buffer(&kernel.device, std::mem::size_of_val(output), output.as_mut_ptr());
+    let output_buffer = cache.output_buffer(
+        &kernel.device,
+        std::mem::size_of_val(output),
+        output.as_mut_ptr(),
+    );
     let scalar_buffer = cache.scalar_buffer(&kernel.device, 2 * std::mem::size_of::<u32>());
     write_buffer_f32(&input_scales_buffer, input_scales);
     write_buffer_i8(&input_quants_buffer, input_quants);
@@ -951,18 +1023,30 @@ where
     let mut cache = metal_linear_cache()
         .lock()
         .expect("metal linear cache poisoned");
-    let input_scales_buffer =
-        cache.q8_input_scales_buffer(&kernel.device, std::mem::size_of_val(input_scales), input_scales.as_ptr());
-    let input_quants_buffer =
-        cache.q8_input_quants_buffer(&kernel.device, std::mem::size_of_val(input_quants), input_quants.as_ptr());
+    let input_scales_buffer = cache.q8_input_scales_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_scales),
+        input_scales.as_ptr(),
+    );
+    let input_quants_buffer = cache.q8_input_quants_buffer(
+        &kernel.device,
+        std::mem::size_of_val(input_quants),
+        input_quants.as_ptr(),
+    );
     let first_weight_blocks_buffer =
         cache.q8_block_weight_buffer(&kernel.device, first_weight_blocks);
     let second_weight_blocks_buffer =
         cache.q8_block_weight_buffer(&kernel.device, second_weight_blocks);
-    let first_output_buffer =
-        cache.output_buffer(&kernel.device, std::mem::size_of_val(first_output), first_output.as_mut_ptr());
-    let second_output_buffer =
-        cache.aux_output_buffer(&kernel.device, std::mem::size_of_val(second_output), second_output.as_mut_ptr());
+    let first_output_buffer = cache.output_buffer(
+        &kernel.device,
+        std::mem::size_of_val(first_output),
+        first_output.as_mut_ptr(),
+    );
+    let second_output_buffer = cache.aux_output_buffer(
+        &kernel.device,
+        std::mem::size_of_val(second_output),
+        second_output.as_mut_ptr(),
+    );
     let scalar_buffer = cache.scalar_buffer(&kernel.device, 2 * std::mem::size_of::<u32>());
     write_buffer_f32(&input_scales_buffer, input_scales);
     write_buffer_i8(&input_quants_buffer, input_quants);

--- a/src/model.rs
+++ b/src/model.rs
@@ -29,7 +29,10 @@ pub struct LlamaModelConfig {
 impl LlamaModelConfig {
     pub fn from_gguf(gguf: &GgufFile) -> Result<Self> {
         let architecture = match gguf.architecture() {
-            Some(architecture @ ("llama" | "mistral" | "qwen2" | "qwen3" | "smollm3" | "gemma3" | "phi3" | "lfm2")) => architecture,
+            Some(
+                architecture @ ("llama" | "mistral" | "qwen2" | "qwen3" | "smollm3" | "gemma3"
+                | "phi3" | "lfm2"),
+            ) => architecture,
             Some(other) => return Err(BackendError::UnsupportedModelArchitecture(other.into())),
             None => {
                 return Err(BackendError::InvalidModelMetadata(

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1448,7 +1448,6 @@ impl CpuTensor {
         Self::from_f32(name, vec![m, n], out)
     }
 
-
     fn require_row_major_f32_data(&self, context: &str) -> Result<()> {
         let expected_len = self.shape.element_count()?;
         if self.data.len() == expected_len {
@@ -1490,7 +1489,7 @@ impl CpuTensor {
         } else {
             #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
             {
-                use std::arch::aarch64::{vld1q_f32, vaddq_f32, vst1q_f32};
+                use std::arch::aarch64::{vaddq_f32, vld1q_f32, vst1q_f32};
                 let mut i = 0;
                 unsafe {
                     while i + 4 <= len {
@@ -1605,47 +1604,48 @@ impl CpuTensor {
         Self::from_f32(name, self.shape.dims.clone(), out)
     }
 
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-#[inline(always)]
-unsafe fn rms_norm_neon(input: &[f32], weight: &[f32], out: &mut [f32], cols: usize, eps: f32) {
-    use std::arch::aarch64::{
-        vld1q_f32, vmulq_f32, vaddq_f32, vdupq_n_f32, vst1q_f32, vget_low_f32, vget_high_f32, vpadd_f32, vget_lane_f32
-    };
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    #[inline(always)]
+    unsafe fn rms_norm_neon(input: &[f32], weight: &[f32], out: &mut [f32], cols: usize, eps: f32) {
+        use std::arch::aarch64::{
+            vaddq_f32, vdupq_n_f32, vget_high_f32, vget_lane_f32, vget_low_f32, vld1q_f32,
+            vmulq_f32, vpadd_f32, vst1q_f32,
+        };
 
-    let mut sum_sq_vec = vdupq_n_f32(0.0);
-    let mut i = 0;
-    while i + 4 <= cols {
-        let v = vld1q_f32(input.as_ptr().add(i));
-        sum_sq_vec = vaddq_f32(sum_sq_vec, vmulq_f32(v, v));
-        i += 4;
-    }
-    let low = vget_low_f32(sum_sq_vec);
-    let high = vget_high_f32(sum_sq_vec);
-    let sum_2 = vpadd_f32(low, high);
-    let mut sum_sq = vget_lane_f32::<0>(sum_2) + vget_lane_f32::<1>(sum_2);
-    while i < cols {
-        let v = input[i];
-        sum_sq += v * v;
-        i += 1;
-    }
+        let mut sum_sq_vec = vdupq_n_f32(0.0);
+        let mut i = 0;
+        while i + 4 <= cols {
+            let v = vld1q_f32(input.as_ptr().add(i));
+            sum_sq_vec = vaddq_f32(sum_sq_vec, vmulq_f32(v, v));
+            i += 4;
+        }
+        let low = vget_low_f32(sum_sq_vec);
+        let high = vget_high_f32(sum_sq_vec);
+        let sum_2 = vpadd_f32(low, high);
+        let mut sum_sq = vget_lane_f32::<0>(sum_2) + vget_lane_f32::<1>(sum_2);
+        while i < cols {
+            let v = input[i];
+            sum_sq += v * v;
+            i += 1;
+        }
 
-    let mean_square = sum_sq / cols as f32;
-    let scale = 1.0 / (mean_square + eps).sqrt();
-    let scale_vec = vdupq_n_f32(scale);
+        let mean_square = sum_sq / cols as f32;
+        let scale = 1.0 / (mean_square + eps).sqrt();
+        let scale_vec = vdupq_n_f32(scale);
 
-    i = 0;
-    while i + 4 <= cols {
-        let v_in = vld1q_f32(input.as_ptr().add(i));
-        let v_w = vld1q_f32(weight.as_ptr().add(i));
-        let v_out = vmulq_f32(vmulq_f32(v_in, scale_vec), v_w);
-        vst1q_f32(out.as_mut_ptr().add(i), v_out);
-        i += 4;
+        i = 0;
+        while i + 4 <= cols {
+            let v_in = vld1q_f32(input.as_ptr().add(i));
+            let v_w = vld1q_f32(weight.as_ptr().add(i));
+            let v_out = vmulq_f32(vmulq_f32(v_in, scale_vec), v_w);
+            vst1q_f32(out.as_mut_ptr().add(i), v_out);
+            i += 4;
+        }
+        while i < cols {
+            out[i] = input[i] * scale * weight[i];
+            i += 1;
+        }
     }
-    while i < cols {
-        out[i] = input[i] * scale * weight[i];
-        i += 1;
-    }
-}
 
     pub fn rms_norm(&self, weight: &Self, eps: f32, name: impl Into<String>) -> Result<Self> {
         require_rank(self, 2, "rms_norm input")?;
@@ -1665,10 +1665,8 @@ unsafe fn rms_norm_neon(input: &[f32], weight: &[f32], out: &mut [f32], cols: us
             if should_parallelize_linear_output(self.data.len()) {
                 out.par_chunks_mut(cols)
                     .zip(self.data.par_chunks(cols))
-                    .for_each(|(out_row, in_row)| {
-                        unsafe {
-                            Self::rms_norm_neon(in_row, &weight.data, out_row, cols, eps);
-                        }
+                    .for_each(|(out_row, in_row)| unsafe {
+                        Self::rms_norm_neon(in_row, &weight.data, out_row, cols, eps);
                     });
             } else {
                 for row in 0..rows {
@@ -1768,7 +1766,6 @@ unsafe fn rms_norm_neon(input: &[f32], weight: &[f32], out: &mut [f32], cols: us
         }
         Self::from_f32(name, self.shape.dims.clone(), out)
     }
-
 
     pub fn embedding_lookup(&self, token_ids: &[u32], name: impl Into<String>) -> Result<Self> {
         require_rank(self, 2, "embedding weight")?;
@@ -2013,7 +2010,8 @@ fn require_rank(tensor: &CpuTensor, rank: usize, op: &str) -> Result<()> {
 pub(crate) fn dot_product(lhs: &[f32], rhs: &[f32]) -> f32 {
     debug_assert_eq!(lhs.len(), rhs.len());
     use std::arch::aarch64::{
-        vld1q_f32, vmulq_f32, vaddq_f32, vdupq_n_f32, vget_low_f32, vget_high_f32, vpadd_f32, vget_lane_f32
+        vaddq_f32, vdupq_n_f32, vget_high_f32, vget_lane_f32, vget_low_f32, vld1q_f32, vmulq_f32,
+        vpadd_f32,
     };
     let len = lhs.len();
     let mut idx = 0;
@@ -4159,7 +4157,8 @@ pub fn decode_iq4_nl_blocks(bytes: &[u8]) -> Result<Vec<IQ4NLBlock>> {
 
 // Flat dequantization to f32 helpers
 fn decode_q4_0_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q4_0_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q4_0_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let scale = block.scale_f32();
@@ -4171,7 +4170,8 @@ fn decode_q4_0_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q4_1_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q4_1_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q4_1_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let scale = block.scale_f32();
@@ -4184,7 +4184,8 @@ fn decode_q4_1_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q5_0_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q5_0_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q5_0_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let scale = block.scale_f32();
@@ -4196,7 +4197,8 @@ fn decode_q5_0_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q5_1_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q5_1_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q5_1_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let scale = block.scale_f32();
@@ -4209,7 +4211,8 @@ fn decode_q5_1_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q2_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q2_k_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q2_k_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let mut values = [0.0_f32; QK_K_BLOCK_SIZE];
@@ -4220,7 +4223,8 @@ fn decode_q2_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q3_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q3_k_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q3_k_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let mut values = [0.0_f32; QK_K_BLOCK_SIZE];
@@ -4231,7 +4235,8 @@ fn decode_q3_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q4_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q4_k_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q4_k_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let mut values = [0.0_f32; QK_K_BLOCK_SIZE];
@@ -4242,7 +4247,8 @@ fn decode_q4_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q5_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q5_k_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q5_k_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let mut values = [0.0_f32; QK_K_BLOCK_SIZE];
@@ -4253,7 +4259,8 @@ fn decode_q5_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q6_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q6_k_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q6_k_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let mut values = [0.0_f32; QK_K_BLOCK_SIZE];
@@ -4264,7 +4271,8 @@ fn decode_q6_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_q8_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_q8_k_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_q8_k_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let mut values = [0.0_f32; QK_K_BLOCK_SIZE];
@@ -4275,7 +4283,8 @@ fn decode_q8_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
 }
 
 fn decode_iq4_nl_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
-    let blocks = decode_iq4_nl_blocks(bytes).map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
+    let blocks = decode_iq4_nl_blocks(bytes)
+        .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
         let mut values = [0.0_f32; 32];

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -437,10 +437,7 @@ async fn capabilities_report_support_contract_and_planned_lanes() {
         mistral["generation_runs"],
         "api_completion_and_chat_smoke_plus_broader_50_token_api_smoke"
     );
-    assert_eq!(
-        mistral["frontend_load_path_verified"],
-        "validated"
-    );
+    assert_eq!(mistral["frontend_load_path_verified"], "validated");
     assert_eq!(
         mistral["tested_context"],
         "tokenizer_template_1tok_bounded_and_checked_512_1024_2048_4096_8192_context_packs"
@@ -466,22 +463,18 @@ async fn capabilities_report_support_contract_and_planned_lanes() {
         mistral["latest_checked_bucket"],
         "current_head_api_webui_rss_fail_closed"
     );
-    assert_eq!(
-        mistral["latest_checked_result"],
-        "pass"
-    );
-    assert_eq!(
-        mistral["bounded_context_8192_pack"],
-        "validated_fifth_pack"
-    );
+    assert_eq!(mistral["latest_checked_result"], "pass");
+    assert_eq!(mistral["bounded_context_8192_pack"], "validated_fifth_pack");
     assert_eq!(
         mistral["bounded_context_8192_pack_id"],
         "mistral-context-8192-max-ladder-v1"
     );
     let mistral_evidence = mistral["evidence"].as_str().unwrap();
-    assert!(mistral_evidence.contains("exact Mistral-7B-Instruct-v0.3.Q8_0.gguf GGUF has exact-row load"));
+    assert!(mistral_evidence
+        .contains("exact Mistral-7B-Instruct-v0.3.Q8_0.gguf GGUF has exact-row load"));
     let mistral_next_step = mistral["next_step"].as_str().unwrap();
-    assert!(mistral_next_step.contains("preserve exact-row smoke plus checked 512/1024/2048/4096/8192 context support"));
+    assert!(mistral_next_step
+        .contains("preserve exact-row smoke plus checked 512/1024/2048/4096/8192 context support"));
     let mixtral = compatibility
         .iter()
         .find(|item| item["id"] == "mixtral_8x7b_instruct_v0_1_q8_0")

--- a/tests/distributed_tests.rs
+++ b/tests/distributed_tests.rs
@@ -2,72 +2,74 @@ use std::{fs, path::Path};
 use tempfile::tempdir;
 
 use camelid::{
+    distributed::{run_worker_loop, DistributedClient, DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE},
     gguf::read_metadata,
     inference::{LlamaInferenceSession, LlamaLoadedWeights},
-    model::{LlamaTensorBinding, LlamaModelConfig},
+    model::{LlamaModelConfig, LlamaTensorBinding},
     tensor::TensorStore,
-    distributed::{DistributedClient, run_worker_loop, DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE},
 };
 
 #[test]
 fn test_distributed_pipeline_parallel_inference() {
     let dir = tempdir().unwrap();
     let model_path = dir.path().join("tiny_model.gguf");
-    
+
     // Write a tiny 2-layer model GGUF file
     write_tiny_llama_gguf(&model_path);
-    
+
     let gguf = read_metadata(&model_path).unwrap();
     let config = LlamaModelConfig::from_gguf(&gguf).unwrap();
     let binding = LlamaTensorBinding::bind(&gguf, &config).unwrap();
-    
+
     // 1. Worker Setup (Loads layer 1..2)
     let store_worker = TensorStore::open(&model_path, &gguf);
     let worker_weights = LlamaLoadedWeights::load_distributed(
         &store_worker,
         &binding,
-        1, // layer_start
-        2, // layer_end (2-layer model)
+        1,     // layer_start
+        2,     // layer_end (2-layer model)
         false, // load_embedding
         false, // load_output
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     let worker_config = LlamaModelConfig::from_gguf(&gguf).unwrap();
     let worker_session = LlamaInferenceSession::new(worker_config, worker_weights).unwrap();
-    
+
     // Spawn Worker in background thread
     let _worker_handle = std::thread::spawn(move || {
         let _ = run_worker_loop("127.0.0.1:8099", worker_session);
     });
-    
+
     // Wait for worker server to bind
     std::thread::sleep(std::time::Duration::from_millis(500));
-    
+
     // 2. Coordinator Setup (Loads layer 0..1)
     let client = DistributedClient::connect("127.0.0.1:8099").unwrap();
     let _ = DISTRIBUTED_CLIENT.set(client);
     let _ = DISTRIBUTED_RANGE.set((0, 1));
-    
+
     let store_coord = TensorStore::open(&model_path, &gguf);
     let coord_weights = LlamaLoadedWeights::load_distributed(
         &store_coord,
         &binding,
-        0, // layer_start
-        1, // layer_end
+        0,    // layer_start
+        1,    // layer_end
         true, // load_embedding
         true, // load_output
-    ).unwrap();
-    
+    )
+    .unwrap();
+
     let coord_config = LlamaModelConfig::from_gguf(&gguf).unwrap();
     let mut coord_session = LlamaInferenceSession::new(coord_config, coord_weights).unwrap();
-    
+
     // Run forward pass on coordinator (which will delegate layer 1 to worker!)
     let output = coord_session.forward_single_token(0).unwrap();
-    
+
     // Assert logits are computed and the dimensions are correct
     assert_eq!(output.logits.shape.dims, vec![1, 16]); // [1, vocab_size]
     assert_eq!(output.logits.data.len(), 16);
-    
+
     // Verify that all logits are valid finite floats
     for &val in &output.logits.data {
         assert!(val.is_finite());
@@ -80,19 +82,23 @@ fn test_network_benchmark() {
     let _worker_handle = std::thread::spawn(move || {
         let _ = camelid::distributed::run_network_benchmark_worker("127.0.0.1:8098");
     });
-    
+
     // Wait for worker server to bind
     std::thread::sleep(std::time::Duration::from_millis(200));
-    
+
     // Run coordinator benchmark locally
     let result = camelid::distributed::run_network_benchmark_coordinator(
         "127.0.0.1:8098",
-        10,    // ping_count
-        1024,  // payload_size
-        10,    // bandwidth_mb
+        10,   // ping_count
+        1024, // payload_size
+        10,   // bandwidth_mb
     );
-    
-    assert!(result.is_ok(), "Network benchmark coordinator failed: {:?}", result.err());
+
+    assert!(
+        result.is_ok(),
+        "Network benchmark coordinator failed: {:?}",
+        result.err()
+    );
 }
 
 // Helpers to write a tiny mock GGUF Llama model
@@ -122,10 +128,10 @@ fn write_tiny_llama_gguf(path: &Path) {
     push_kv_f32(&mut b, "llama.attention.layer_norm_rms_epsilon", 1e-5);
     push_kv_f32(&mut b, "llama.rope.freq_base", 10000.0);
     push_kv_u32(&mut b, "general.alignment", 32);
-    
+
     // Tokenizer metadata (minimal)
     push_kv_string(&mut b, "tokenizer.ggml.model", "llama");
-    
+
     // Add empty array of tokens to keep tokenizer parser happy
     push_string(&mut b, "tokenizer.ggml.tokens");
     push_u32(&mut b, 9); // array type
@@ -141,7 +147,6 @@ fn write_tiny_llama_gguf(path: &Path) {
         ("token_embd.weight", vec![16, 8]), // vocab x hidden
         ("output_norm.weight", vec![8]),
         ("output.weight", vec![8, 16]), // hidden x vocab
-        
         ("blk.0.attn_norm.weight", vec![8]),
         ("blk.0.attn_q.weight", vec![8, 8]),
         ("blk.0.attn_k.weight", vec![8, 8]),
@@ -151,7 +156,6 @@ fn write_tiny_llama_gguf(path: &Path) {
         ("blk.0.ffn_gate.weight", vec![8, 16]),
         ("blk.0.ffn_up.weight", vec![8, 16]),
         ("blk.0.ffn_down.weight", vec![16, 8]),
-        
         ("blk.1.attn_norm.weight", vec![8]),
         ("blk.1.attn_q.weight", vec![8, 8]),
         ("blk.1.attn_k.weight", vec![8, 8]),
@@ -172,7 +176,7 @@ fn write_tiny_llama_gguf(path: &Path) {
         }
         push_i32(&mut b, 0); // f32
         push_u64(&mut b, current_offset);
-        
+
         let elements: usize = dims.iter().product();
         current_offset += (elements * 4) as u64;
     }
@@ -180,13 +184,16 @@ fn write_tiny_llama_gguf(path: &Path) {
     while !b.len().is_multiple_of(32) {
         b.push(0);
     }
-    
+
     // Write actual float data (all 0.1f32 to be valid non-NaN)
-    let total_elements: usize = tensors.iter().map(|(_, dims)| dims.iter().product::<usize>()).sum();
+    let total_elements: usize = tensors
+        .iter()
+        .map(|(_, dims)| dims.iter().product::<usize>())
+        .sum();
     for _ in 0..total_elements {
         b.extend_from_slice(&0.1f32.to_le_bytes());
     }
-    
+
     fs::write(path, b).unwrap();
 }
 


### PR DESCRIPTION
## Summary

- run `cargo fmt --all` on current `main` after merge `21d3ba5`
- restore the repository to a rustfmt-clean state without changing behavior

## Why this change exists

Current `main` fails `cargo fmt --all -- --check` after the merged telemetry split landed. This follow-up keeps the branch tree aligned with the formatting gate before any further backend work stacks on top.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib q8_ffn_gate_up_consumer_matches_runtime_packed_baseline`

## Docs impact

- none
