### PR TITLE
ci: run workflow on feature branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- broaden the CI push trigger from only `main` to all branches
- keep the existing `pull_request` and manual `workflow_dispatch` triggers unchanged
- restore automatic CI runs for pushed feature branches before or without an open PR

## Validation

- `git diff --check`

## Notes

- No Ubuntu validation host is required for this workflow-trigger-only change.
- This does not change any CI job contents or support claims.