### PR TITLE
fix(api): expose read-only llama props

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,6 +8,8 @@ Use this document to answer one release question: **may Camelid honestly say thi
 
 Practical reading rule: if a statement cannot be reduced to an exact row in this file, Camelid should not publish that statement as product truth.
 
+War-room claim discipline lives in [`docs/WAR_ROOM_EVIDENCE_INDEX.md`](docs/WAR_ROOM_EVIDENCE_INDEX.md). That policy is an index and checklist only; it does not promote support, benchmark, API capability, or WebUI readiness beyond the exact rows and evidence recorded here.
+
 ## Release-language definitions
 
 Treat the labels below as release language, not implementation optimism:
@@ -242,9 +244,24 @@ For **Llama 3 8B** specifically, the durable citation anchors are the current-he
 | `/v1/models`, `/api/models/load`, `/api/models/current` | Supported current gate; row-scoped Llama support | Local GGUF load/list/readiness path used by the frontend; exact Llama 3.2 1B and Llama 3 8B rows are verified within bounded envelopes, while the exact 3B row remains smoke-supported and all broader/full-support language still waits on normalized current-head reruns. |
 | `/api/capabilities` | Supported contract surface | Exposes explicit support contract, supported/planned quants, model families, and API features; row statuses must distinguish TinyLlama current-gate support, Llama 3.2 1B and Llama 3 8B bounded support, and Llama 3.2 3B exact-row smoke support. |
 | `/tokenize`, `/detokenize` | Partial llama-server utility compatibility | Bounded loaded-model tokenizer aliases are available for token-id encode/decode only. `/tokenize` does not yet support `with_pieces=true`, and tokenizer availability still depends on a loaded exact-row/tokenizer-supported GGUF. |
+| `/props` | Partial llama-server control-plane compatibility | Read-only public properties are available for WebUI/client discovery: default generation settings, slot count, chat-template metadata when a model is loaded, and fail-closed Camelid readiness notes. Local model paths are intentionally redacted, `POST /props` is unsupported, and this does not imply `/slots`, native `/completion`, embeddings, reranking, multimodal, or full llama-server WebUI parity. |
+| `/slots` | Unsupported | Add only after Camelid has explicit slot/session lifecycle semantics, cancellation behavior, prompt-cache visibility rules, and privacy-safe fields. |
+| Native `/completion` | Unsupported | Implement only after mapping llama-server `prompt` shapes, sampler aliases, streaming shape, cancellation, and typed unsupported fields without weakening the stable `/v1/completions` path. |
+| `/apply-template` | Planned | Useful next bounded route because it can expose chat-template rendering without inference; must stay loaded-model and exact-row scoped, with unsupported template behavior typed. |
+| Embeddings and reranking | Unsupported | No embeddings/reranking support claim until model/runtime support, OpenAI `/v1/embeddings` shape, native `/embedding` shape, and fail-closed capability rows are implemented and tested. |
 | Multi-choice generation | Unsupported | Keep typed unsupported until implemented/tested. |
 | Rich OpenAI-compatible logprobs | Partial/planned | Diagnostic logit surfaces exist; complete API parity remains Phase 14 work. |
 | Local OpenAI-compatible provider registration | Open integration verification | Verify registration/use by the target local client surface before calling integration complete. |
+
+### Llama-server compatibility sequence
+
+Camelid should keep the OpenAI-style subset stable while adding llama-server compatibility in this order:
+
+1. **Discovery/control-plane:** `/props`, then privacy-safe health/model metadata refinements, then `/slots` only after slot semantics exist.
+2. **Template utilities:** `/apply-template` for loaded supported rows, with exact renderer/source metadata and typed unsupported errors for arbitrary templates.
+3. **Native generation aliases:** `/completion` as a thin, tested mapping onto the existing generation path, preserving honest unsupported responses for llama-server sampler/control fields.
+4. **Embeddings/reranking:** implement only after backend support and separate capability rows exist; keep `/v1/embeddings`, `/embedding`, `/embeddings`, `/rerank`, and `/v1/reranking` fail-closed until then.
+5. **WebUI readiness:** keep frontend chat enabled only from `/api/capabilities` exact-row support plus `/v1/health loaded_now=true generation_ready=true`; native route presence alone must never unlock readiness.
 
 ## Phase 9-15 next actions and owners
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -407,6 +407,71 @@ pub struct LlamaServerDetokenizeResponse {
     pub content: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct LlamaServerPropsResponse {
+    pub default_generation_settings: LlamaServerDefaultGenerationSettings,
+    pub total_slots: u32,
+    pub model_path: Option<String>,
+    pub model_id: Option<String>,
+    pub chat_template: Option<String>,
+    pub chat_template_caps: serde_json::Value,
+    pub modalities: LlamaServerModalities,
+    pub build_info: &'static str,
+    pub is_sleeping: bool,
+    pub camelid: LlamaServerPropsCamelid,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LlamaServerDefaultGenerationSettings {
+    pub id: u32,
+    pub id_task: i32,
+    pub n_ctx: u32,
+    pub speculative: bool,
+    pub is_processing: bool,
+    pub params: LlamaServerDefaultGenerationParams,
+    pub prompt: &'static str,
+    pub next_token: LlamaServerNextTokenProps,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LlamaServerDefaultGenerationParams {
+    pub n_predict: i32,
+    pub seed: u32,
+    pub temperature: f32,
+    pub top_k: u32,
+    pub top_p: f32,
+    pub presence_penalty: f32,
+    pub frequency_penalty: f32,
+    pub stop: Vec<String>,
+    pub max_tokens: i32,
+    pub ignore_eos: bool,
+    pub stream: bool,
+    pub n_probs: u32,
+    pub samplers: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LlamaServerNextTokenProps {
+    pub has_next_token: bool,
+    pub has_new_line: bool,
+    pub n_remain: i32,
+    pub n_decoded: u32,
+    pub stopping_word: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LlamaServerModalities {
+    pub vision: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LlamaServerPropsCamelid {
+    pub compatibility: &'static str,
+    pub generation_ready: bool,
+    pub model_path_redacted: bool,
+    pub unsupported: Vec<&'static str>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct GenerationSessionRequest {
     pub model: Option<String>,
@@ -777,6 +842,7 @@ pub fn router_with_state(state: AppState) -> Router {
         .route("/api/models/tokenizer/decode", post(tokenizer_decode))
         .route("/tokenize", post(llama_server_tokenize))
         .route("/detokenize", post(llama_server_detokenize))
+        .route("/props", get(llama_server_props))
         .route(
             "/api/generation/sessions",
             get(generation_sessions).post(create_generation_session),
@@ -830,6 +896,75 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         active_model_id: active_id_lock.clone(),
         q8_runtime: q8_runtime_health(),
         execution_plan,
+    })
+}
+
+async fn llama_server_props(State(state): State<AppState>) -> Json<LlamaServerPropsResponse> {
+    let active_id_lock = state.active_model_id.read().await;
+    let loaded_models = state.loaded_models.read().await;
+    let model = active_id_lock.as_ref().and_then(|id| loaded_models.get(id));
+    let generation_ready = model.is_some_and(loaded_model_generation_ready);
+    let n_ctx = model
+        .and_then(|model| model.llama_config.as_ref())
+        .map(|config| config.context_length)
+        .unwrap_or(0);
+    let chat_template = model
+        .and_then(|model| model.tokenizer_runtime.as_ref())
+        .and_then(|tokenizer| tokenizer.chat_template.clone());
+    let model_id = model.map(|model| model.id.clone());
+
+    Json(LlamaServerPropsResponse {
+        default_generation_settings: LlamaServerDefaultGenerationSettings {
+            id: 0,
+            id_task: -1,
+            n_ctx,
+            speculative: false,
+            is_processing: false,
+            params: LlamaServerDefaultGenerationParams {
+                n_predict: -1,
+                seed: u32::MAX,
+                temperature: 0.0,
+                top_k: 0,
+                top_p: 1.0,
+                presence_penalty: 0.0,
+                frequency_penalty: 0.0,
+                stop: Vec::new(),
+                max_tokens: -1,
+                ignore_eos: false,
+                stream: true,
+                n_probs: 0,
+                samplers: vec!["greedy"],
+            },
+            prompt: "",
+            next_token: LlamaServerNextTokenProps {
+                has_next_token: generation_ready,
+                has_new_line: false,
+                n_remain: -1,
+                n_decoded: 0,
+                stopping_word: "",
+            },
+        },
+        total_slots: 1,
+        model_path: None,
+        model_id,
+        chat_template,
+        chat_template_caps: serde_json::json!({}),
+        modalities: LlamaServerModalities { vision: false },
+        build_info: "camelid",
+        is_sleeping: false,
+        camelid: LlamaServerPropsCamelid {
+            compatibility: "partial_llama_server_props_read_only",
+            generation_ready,
+            model_path_redacted: true,
+            unsupported: vec![
+                "post_props",
+                "slots",
+                "native_completion",
+                "embeddings",
+                "reranking",
+                "multimodal",
+            ],
+        },
     })
 }
 
@@ -1388,6 +1523,11 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 id: "llama_server_tokenizer_aliases",
                 status: "partial",
                 notes: "POST /tokenize and POST /detokenize are bounded loaded-model tokenizer aliases that return token ids/text only; piece metadata remains unsupported",
+            },
+            SupportItem {
+                id: "llama_server_props",
+                status: "partial",
+                notes: "GET /props returns read-only public server properties, default generation settings, chat-template metadata when a model is loaded, and fail-closed Camelid readiness notes. Local model paths are intentionally redacted, POST /props is unsupported, and this does not imply /slots, /completion, embeddings, or full llama-server WebUI parity.",
             },
             SupportItem {
                 id: "multi_choice_generation",

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -63,6 +63,62 @@ async fn capabilities_public_contract_omits_local_private_paths() {
 }
 
 #[tokio::test]
+async fn props_reports_public_fail_closed_llama_server_shape() {
+    let app = camelid::api::router();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/props")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["total_slots"], 1);
+    assert_eq!(body["model_path"], Value::Null);
+    assert_eq!(body["model_id"], Value::Null);
+    assert_eq!(body["chat_template"], Value::Null);
+    assert_eq!(body["default_generation_settings"]["n_ctx"], 0);
+    assert_eq!(
+        body["default_generation_settings"]["next_token"]["has_next_token"],
+        false
+    );
+    assert_eq!(
+        body["camelid"]["compatibility"],
+        "partial_llama_server_props_read_only"
+    );
+    assert_eq!(body["camelid"]["generation_ready"], false);
+    assert_eq!(body["camelid"]["model_path_redacted"], true);
+    assert!(body["camelid"]["unsupported"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|item| item == "native_completion"));
+
+    let serialized = body.to_string();
+    for forbidden in [
+        "/Users/",
+        "/home/",
+        "file://",
+        "file:\\",
+        "/Volumes/",
+        "/private/tmp/",
+        "C:\\Users\\",
+        "C:/Users/",
+        "\\Users\\",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "/props must not expose local/private path marker {forbidden:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn capabilities_report_support_contract_and_planned_lanes() {
     let app = camelid::api::router();
     let response = app
@@ -175,6 +231,15 @@ async fn capabilities_report_support_contract_and_planned_lanes() {
                 .as_str()
                 .unwrap()
                 .contains("POST /tokenize and POST /detokenize")
+    }));
+    assert!(body["api_features"].as_array().unwrap().iter().any(|item| {
+        item["id"] == "llama_server_props"
+            && item["status"] == "partial"
+            && item["notes"].as_str().unwrap().contains("GET /props")
+            && item["notes"]
+                .as_str()
+                .unwrap()
+                .contains("Local model paths are intentionally redacted")
     }));
     let compatibility = body["model_compatibility"].as_array().unwrap();
     let tinyllama = compatibility


### PR DESCRIPTION
## Summary

- add read-only `/props` discovery metadata for partial llama-server compatibility
- redact local model paths while exposing public readiness, slot, default generation, and chat-template fields
- advertise the partial `/props` surface in `/api/capabilities` and `COMPATIBILITY.md`

## Validation

- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `bash scripts/check-public-scrub.sh`
- `cargo test --test api_vertical_slice llama_server -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Notes

- No Ubuntu validation host is required for this API compatibility slice.
- This does not widen model support claims; `/props` remains read-only and fail-closed for `/slots`, native `/completion`, embeddings, reranking, and multimodal parity.