### PR TITLE
fix(api): add llama apply-template utility

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -247,7 +247,7 @@ For **Llama 3 8B** specifically, the durable citation anchors are the current-he
 | `/props` | Partial llama-server control-plane compatibility | Read-only public properties are available for WebUI/client discovery: default generation settings, slot count, chat-template metadata when a model is loaded, and fail-closed Camelid readiness notes. Local model paths are intentionally redacted, `POST /props` is unsupported, and this does not imply `/slots`, native `/completion`, embeddings, reranking, multimodal, or full llama-server WebUI parity. |
 | `/slots` | Unsupported | Add only after Camelid has explicit slot/session lifecycle semantics, cancellation behavior, prompt-cache visibility rules, and privacy-safe fields. |
 | Native `/completion` | Unsupported | Implement only after mapping llama-server `prompt` shapes, sampler aliases, streaming shape, cancellation, and typed unsupported fields without weakening the stable `/v1/completions` path. |
-| `/apply-template` | Planned | Useful next bounded route because it can expose chat-template rendering without inference; must stay loaded-model and exact-row scoped, with unsupported template behavior typed. |
+| `/apply-template` | Partial llama-server utility compatibility | Loaded-model chat-template rendering is available as a no-inference utility returning a `prompt` string. It is scoped to Camelid's supported tokenizer/template renderers, rejects unknown request fields with typed unsupported errors, and does not imply native `/completion`, `/slots`, arbitrary-template support, or WebUI readiness. |
 | Embeddings and reranking | Unsupported | No embeddings/reranking support claim until model/runtime support, OpenAI `/v1/embeddings` shape, native `/embedding` shape, and fail-closed capability rows are implemented and tested. |
 | Multi-choice generation | Unsupported | Keep typed unsupported until implemented/tested. |
 | Rich OpenAI-compatible logprobs | Partial/planned | Diagnostic logit surfaces exist; complete API parity remains Phase 14 work. |
@@ -258,7 +258,7 @@ For **Llama 3 8B** specifically, the durable citation anchors are the current-he
 Camelid should keep the OpenAI-style subset stable while adding llama-server compatibility in this order:
 
 1. **Discovery/control-plane:** `/props`, then privacy-safe health/model metadata refinements, then `/slots` only after slot semantics exist.
-2. **Template utilities:** `/apply-template` for loaded supported rows, with exact renderer/source metadata and typed unsupported errors for arbitrary templates.
+2. **Template utilities:** `/apply-template` now has a bounded loaded-model no-inference route; next hardening is renderer/source metadata and broader negative fixtures for arbitrary template inputs.
 3. **Native generation aliases:** `/completion` as a thin, tested mapping onto the existing generation path, preserving honest unsupported responses for llama-server sampler/control fields.
 4. **Embeddings/reranking:** implement only after backend support and separate capability rows exist; keep `/v1/embeddings`, `/embedding`, `/embeddings`, `/rerank`, and `/v1/reranking` fail-closed until then.
 5. **WebUI readiness:** keep frontend chat enabled only from `/api/capabilities` exact-row support plus `/v1/health loaded_now=true generation_ready=true`; native route presence alone must never unlock readiness.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -407,6 +407,18 @@ pub struct LlamaServerDetokenizeResponse {
     pub content: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LlamaServerApplyTemplateRequest {
+    pub messages: Option<Vec<ChatMessage>>,
+    #[serde(flatten)]
+    pub unsupported_fields: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LlamaServerApplyTemplateResponse {
+    pub prompt: String,
+}
+
 #[derive(Debug, Serialize)]
 pub struct LlamaServerPropsResponse {
     pub default_generation_settings: LlamaServerDefaultGenerationSettings,
@@ -842,6 +854,7 @@ pub fn router_with_state(state: AppState) -> Router {
         .route("/api/models/tokenizer/decode", post(tokenizer_decode))
         .route("/tokenize", post(llama_server_tokenize))
         .route("/detokenize", post(llama_server_detokenize))
+        .route("/apply-template", post(llama_server_apply_template))
         .route("/props", get(llama_server_props))
         .route(
             "/api/generation/sessions",
@@ -1530,6 +1543,11 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 notes: "GET /props returns read-only public server properties, default generation settings, chat-template metadata when a model is loaded, and fail-closed Camelid readiness notes. Local model paths are intentionally redacted, POST /props is unsupported, and this does not imply /slots, /completion, embeddings, or full llama-server WebUI parity.",
             },
             SupportItem {
+                id: "llama_server_apply_template",
+                status: "partial",
+                notes: "POST /apply-template renders loaded-model chat messages to a prompt string without inference. It is scoped to Camelid's supported tokenizer/template renderers and returns typed unsupported errors for unknown request fields or unsupported templates.",
+            },
+            SupportItem {
                 id: "multi_choice_generation",
                 status: "unsupported",
                 notes: "typed unsupported until implemented and tested",
@@ -2169,6 +2187,100 @@ async fn llama_server_detokenize(
             Some("tokens"),
         ),
     }
+}
+
+async fn llama_server_apply_template(
+    State(state): State<AppState>,
+    payload: std::result::Result<Json<LlamaServerApplyTemplateRequest>, JsonRejection>,
+) -> Response {
+    let Json(req) = match payload {
+        Ok(payload) => payload,
+        Err(err) => return malformed_json_error(err),
+    };
+    if !req.unsupported_fields.is_empty() {
+        let mut fields = req
+            .unsupported_fields
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        fields.sort_unstable();
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "unsupported_parameter",
+            format!(
+                "/apply-template unsupported request field(s): {}",
+                fields.join(", ")
+            ),
+            Some("request"),
+        );
+    }
+    let messages = match req.messages {
+        Some(messages) if !messages.is_empty() => messages,
+        Some(_) => {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                "empty_chat_messages",
+                "/apply-template messages must contain at least one chat message".to_string(),
+                Some("messages"),
+            )
+        }
+        None => {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                "missing_chat_messages",
+                "/apply-template request requires a messages field".to_string(),
+                Some("messages"),
+            )
+        }
+    };
+    if let Err(response) = validate_chat_messages(&messages) {
+        return *response;
+    }
+
+    let model = match get_or_load_model(&state, None).await {
+        Ok(model) => model,
+        Err(response) => return response,
+    };
+    let tokenizer = match model.tokenizer_runtime.clone() {
+        Some(tokenizer) => tokenizer,
+        None => match Tokenizer::from_gguf(&model.gguf) {
+            Ok(tokenizer) => Arc::new(tokenizer),
+            Err(err) => {
+                return api_error(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    tokenizer_error_code(&err),
+                    err.to_string(),
+                    None,
+                )
+            }
+        },
+    };
+    let rendered = match render_chat_prompt_for_tokenization_for_model_result(
+        &messages,
+        &tokenizer,
+        Some(&model.id),
+    ) {
+        Ok(rendered) => rendered,
+        Err(err) => {
+            return api_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "unsupported_chat_template",
+                format!(
+                    "chat template rendering failed for loaded model {:?}: {err}",
+                    model.id
+                ),
+                Some("messages"),
+            )
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(LlamaServerApplyTemplateResponse {
+            prompt: rendered.text,
+        }),
+    )
+        .into_response()
 }
 
 async fn v1_models(State(state): State<AppState>) -> Json<ModelListResponse> {
@@ -3330,7 +3442,13 @@ async fn generate_decoded_tokens_blocking(
 ) -> std::result::Result<GeneratedText, Box<Response>> {
     let timeout = generation_timeout_duration()?;
     let started = Instant::now();
-    let handle = tokio::task::spawn_blocking(move || generate_decoded_tokens(prepared));
+    let test_sleep = generation_step_test_sleep_duration();
+    let handle = tokio::task::spawn_blocking(move || {
+        if let Some(duration) = test_sleep {
+            std::thread::sleep(duration);
+        }
+        generate_decoded_tokens(prepared)
+    });
     match tokio::time::timeout(timeout, handle).await {
         Ok(Ok(result)) => result,
         Ok(Err(err)) => Err(Box::new(api_error(
@@ -5840,6 +5958,43 @@ mod tests {
             Err(GenerationStepBlockingError::Response(_)) => panic!("expected timeout error"),
             Ok(_) => panic!("expected stream step to time out"),
         }
+    }
+
+    #[tokio::test]
+    async fn non_streaming_generation_timeout_returns_scrubbed_trace() {
+        let _env_guard = crate::test_support::env_lock();
+        std::env::set_var(GENERATION_TIMEOUT_ENV, "1");
+        std::env::set_var("CAMELID_TEST_GENERATION_STEP_SLEEP_MS", "25");
+        let session = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
+        let prepared = prepared_for_cache("tiny", "model-a.gguf", vec![1, 2], session);
+
+        let result = generate_decoded_tokens_blocking(prepared).await;
+
+        std::env::remove_var(GENERATION_TIMEOUT_ENV);
+        std::env::remove_var("CAMELID_TEST_GENERATION_STEP_SLEEP_MS");
+        let response = match result {
+            Err(response) => *response,
+            Ok(_) => panic!("expected non-streaming generation timeout"),
+        };
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["error"]["code"], "generation_timeout");
+        assert_eq!(body["error"]["param"], "max_tokens");
+        assert_eq!(body["error"]["timeout_trace"]["timeout_ms"], 1);
+        assert_eq!(
+            body["error"]["timeout_trace"]["timeout_env"],
+            GENERATION_TIMEOUT_ENV
+        );
+        assert!(body["error"]["timeout_trace"]["generated_tokens"].is_null());
+        let serialized = body.to_string();
+        assert!(!serialized.contains("://"));
+        assert!(!serialized.contains(&["/Users", "/"].concat()));
+        assert!(!serialized.contains("models/"));
     }
 
     #[test]

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -241,6 +241,14 @@ async fn capabilities_report_support_contract_and_planned_lanes() {
                 .unwrap()
                 .contains("Local model paths are intentionally redacted")
     }));
+    assert!(body["api_features"].as_array().unwrap().iter().any(|item| {
+        item["id"] == "llama_server_apply_template"
+            && item["status"] == "partial"
+            && item["notes"]
+                .as_str()
+                .unwrap()
+                .contains("without inference")
+    }));
     let compatibility = body["model_compatibility"].as_array().unwrap();
     let tinyllama = compatibility
         .iter()
@@ -1945,6 +1953,74 @@ async fn llama_server_tokenize_alias_fails_closed_for_piece_metadata() {
 }
 
 #[tokio::test]
+async fn llama_server_apply_template_renders_loaded_model_chat_prompt() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tokenizer.gguf");
+    write_tokenizer_gguf_with_chat_template(
+        &path,
+        "llama",
+        true,
+        false,
+        true,
+        "<|system|>{{ system }}<|user|>{{ user }}<|assistant|>{{ assistant }}",
+    );
+
+    let app = camelid::api::router();
+    let body = serde_json::json!({"path": path, "id": "tiny-tokenizer"});
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/models/load")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/apply-template")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"messages":[{"role":"user","content":"hello"}]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["prompt"], "<|user|>\nhello</s>\n<|assistant|>\n");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/apply-template")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"messages":[{"role":"user","content":"hello"}],"template":"custom"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["error"]["code"], "unsupported_parameter");
+    assert_eq!(body["error"]["param"], "request");
+}
+
+#[tokio::test]
 async fn tokenizer_encode_requires_loaded_model() {
     let app = camelid::api::router();
     let response = app
@@ -3204,6 +3280,42 @@ fn write_tokenizer_gguf(
     add_eos: bool,
     add_space_prefix: bool,
 ) {
+    write_tokenizer_gguf_with_optional_chat_template(
+        path,
+        model,
+        add_bos,
+        add_eos,
+        add_space_prefix,
+        None,
+    );
+}
+
+fn write_tokenizer_gguf_with_chat_template(
+    path: &std::path::Path,
+    model: &str,
+    add_bos: bool,
+    add_eos: bool,
+    add_space_prefix: bool,
+    chat_template: &str,
+) {
+    write_tokenizer_gguf_with_optional_chat_template(
+        path,
+        model,
+        add_bos,
+        add_eos,
+        add_space_prefix,
+        Some(chat_template),
+    );
+}
+
+fn write_tokenizer_gguf_with_optional_chat_template(
+    path: &std::path::Path,
+    model: &str,
+    add_bos: bool,
+    add_eos: bool,
+    add_space_prefix: bool,
+    chat_template: Option<&str>,
+) {
     let tokens = ["<unk>", "<s>", "</s>", "▁hello", "hello", "<0x21>", "▁"];
     let scores = [0.0, 0.0, 0.0, 10.0, 2.0, 0.0, 1.0];
     let token_types = [2, 3, 3, 1, 1, 6, 1];
@@ -3212,7 +3324,7 @@ fn write_tokenizer_gguf(
     b.extend_from_slice(b"GGUF");
     push_u32(&mut b, 3);
     push_i64(&mut b, 0);
-    push_i64(&mut b, 10);
+    push_i64(&mut b, if chat_template.is_some() { 11 } else { 10 });
 
     push_kv_string(&mut b, "general.architecture", "llama");
     push_kv_string(&mut b, "tokenizer.ggml.model", model);
@@ -3224,6 +3336,9 @@ fn write_tokenizer_gguf(
     push_kv_bool(&mut b, "tokenizer.ggml.add_bos_token", add_bos);
     push_kv_bool(&mut b, "tokenizer.ggml.add_eos_token", add_eos);
     push_kv_bool(&mut b, "tokenizer.ggml.add_space_prefix", add_space_prefix);
+    if let Some(chat_template) = chat_template {
+        push_kv_string(&mut b, "tokenizer.chat_template", chat_template);
+    }
 
     while !b.len().is_multiple_of(32) {
         b.push(0);


### PR DESCRIPTION
## Summary
- Add bounded llama-server `POST /apply-template` support for loaded-model chat prompt rendering without inference.
- Advertise the new partial support lane in capabilities and compatibility docs.
- Add API coverage for apply-template validation and non-streaming generation timeout telemetry.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --test api_vertical_slice llama_server_apply_template -- --nocapture`
- `cargo test non_streaming_generation_timeout_returns_scrubbed_trace -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `node scripts/check-public-evidence-claims.mjs`
- `bash scripts/check-public-scrub.sh`

## Notes
- No external validation host requirement for this change.
- Strict evidence-bundle privacy audit is still blocked by existing historical bundle findings and is not changed by this PR.