### PR TITLE
ci: update GitHub action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for private operator details
         run: bash scripts/check-public-scrub.sh
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -43,7 +43,7 @@ jobs:
     needs: public-scrub
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.87.0
@@ -70,10 +70,10 @@ jobs:
     needs: public-scrub
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -93,10 +93,10 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: npm


### PR DESCRIPTION
## Summary
- update `actions/checkout` from v4 to v6 across CI jobs
- update `actions/setup-node` from v4 to v6 across CI jobs
- keep the existing CI job graph and Node 22 runtime unchanged

## Validation
- `git diff --check -- .github/workflows/ci.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`

This addresses the current non-blocking Node 20 action-runtime deprecation annotations seen on otherwise-green CI runs.