### PR TITLE
fix(ci): sanitize chat parity diagnostics

### DIFF
--- a/scripts/chat-parity-llama3.mjs
+++ b/scripts/chat-parity-llama3.mjs
@@ -6,6 +6,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
 import { renderExpectedPrompt, resolveReferenceContext } from './lib/chat-parity-harness.mjs'
+import { sanitizeMessages, sanitizePath, sanitizeText, sanitizeUrl } from './lib/privacy-sanitize.mjs'
 
 const args = parseArgs(process.argv.slice(2))
 const backendBase = (args.get('backend') || process.env.CAMELID_API_BASE || 'http://127.0.0.1:8181').replace(/\/$/, '')
@@ -24,6 +25,7 @@ const requirePromptMatch = args.has('require-prompt-match') || process.env.LLAMA
 const requireGeneratedMatch = args.has('require-generated-match') || process.env.LLAMA3_CHAT_REQUIRE_GENERATED_MATCH === '1'
 const collectBackendDenseDiagnostics = args.has('backend-dense-diagnostics') || process.env.LLAMA3_CHAT_BACKEND_DENSE_DIAGNOSTICS === '1'
 const backendDenseDiagnosticGeneratedIndex = parseOptionalNonNegativeInt(args.get('backend-dense-diagnostic-generated-index') || process.env.LLAMA3_CHAT_BACKEND_DENSE_DIAGNOSTIC_GENERATED_INDEX, 'backend-dense-diagnostic-generated-index')
+const sanitizeDiagnostics = args.has('sanitize-diagnostics') || process.env.LLAMA3_CHAT_SANITIZE_DIAGNOSTICS === '1'
 const waitMs = Number.parseInt(args.get('wait-ms') || process.env.LLAMA3_WAIT_MS || '120000', 10)
 const explicitLlamaContext = parseOptionalPositiveInt(args.get('llama-context') || process.env.LLAMA3_LLAMA_CONTEXT, 'llama-context')
 const llamaFlashAttn = args.get('llama-flash-attn') || process.env.LLAMA3_LLAMA_FLASH_ATTN || 'off'
@@ -183,13 +185,13 @@ try {
     camelid: backendChat.camelid,
   }
 
-  console.log(`backend=${backendBase}`)
-  console.log(`llama_server=${llamaBase}`)
-  console.log(`model=${modelPath}`)
-  console.log(`message=${JSON.stringify(userMessage)}`)
-  console.log(`messages=${JSON.stringify(messages)}`)
+  console.log(`backend=${sanitizeDiagnostics ? 'redacted' : backendBase}`)
+  console.log(`llama_server=${sanitizeDiagnostics ? 'redacted' : llamaBase}`)
+  console.log(`model=${sanitizeDiagnostics ? JSON.stringify(sanitizePath(modelPath)) : modelPath}`)
+  console.log(`message=${sanitizeDiagnostics ? JSON.stringify(sanitizeText(userMessage)) : JSON.stringify(userMessage)}`)
+  console.log(`messages=${sanitizeDiagnostics ? JSON.stringify(sanitizeMessages(messages)) : JSON.stringify(messages)}`)
   console.log(`render_mode=${renderMode}`)
-  console.log(`expected_prompt=${JSON.stringify(expectedPrompt)}`)
+  console.log(`expected_prompt=${sanitizeDiagnostics ? JSON.stringify(sanitizeText(expectedPrompt)) : JSON.stringify(expectedPrompt)}`)
   console.log(`expected_prompt_char_count=${expectedPrompt.length}`)
   console.log(`reference_prompt_token_count=${referencePromptTokens.length}`)
   console.log(`reference_context=${referenceContext}`)
@@ -202,9 +204,9 @@ try {
   console.log(`llama_generated_tokens=${JSON.stringify(llamaGeneratedTokens)}`)
   console.log(`generated_tokens_match=${generatedTokensMatch}`)
   console.log(`backend_dense_diagnostic_generated_index=${backendChat.camelid?.dense_diagnostic_generated_index ?? null}`)
-  console.log(`first_generated_token_logit_comparison=${JSON.stringify(firstGeneratedTokenLogitComparison)}`)
-  console.log(`backend_text=${JSON.stringify(backendText)}`)
-  console.log(`llama_text=${JSON.stringify(llamaText)}`)
+  console.log(`first_generated_token_logit_comparison=${JSON.stringify(sanitizeDiagnostics ? stripComparisonTokenText(firstGeneratedTokenLogitComparison) : firstGeneratedTokenLogitComparison)}`)
+  console.log(`backend_text=${sanitizeDiagnostics ? JSON.stringify(sanitizeText(backendText)) : JSON.stringify(backendText)}`)
+  console.log(`llama_text=${sanitizeDiagnostics ? JSON.stringify(sanitizeText(llamaText)) : JSON.stringify(llamaText)}`)
   console.log(`generated_text_match=${textMatch}`)
   console.log(`backend_usage=${JSON.stringify(backendChat.usage)}`)
   console.log(`llama_usage=${JSON.stringify(llamaCompletion.timings)}`)
@@ -212,8 +214,8 @@ try {
   if (diagnosticsOut) {
     const diagnosticsPath = resolve(diagnosticsOut)
     await mkdir(dirname(diagnosticsPath), { recursive: true })
-    await writeFile(diagnosticsPath, `${JSON.stringify(report, null, 2)}\n`)
-    console.log(`diagnostics_out=${diagnosticsPath}`)
+    await writeFile(diagnosticsPath, `${JSON.stringify(sanitizeDiagnostics ? sanitizeParityReport(report) : report, null, 2)}\n`)
+    console.log(`diagnostics_out=${sanitizeDiagnostics ? JSON.stringify(sanitizePath(diagnosticsPath)) : diagnosticsPath}`)
   }
 
   if (requirePromptMatch && !promptMatch) process.exitCode = 1
@@ -407,6 +409,79 @@ function compareFirstGeneratedTokenLogits({ backendGeneratedTokens, backendTopLo
     backend_rows: [backendForBackendToken, backendForLlamaToken].filter(Boolean),
     llama_rows: [llamaForBackendToken, llamaForLlamaToken].filter(Boolean),
   }
+}
+
+function sanitizeParityReport(report) {
+  const camelid = report.camelid ? {
+    prompt_token_ids: report.camelid.prompt_token_ids ?? [],
+    generated_token_ids: report.camelid.generated_token_ids ?? [],
+    dense_metadata: report.camelid.dense_metadata ?? null,
+    dense_diagnostic_generated_index: report.camelid.dense_diagnostic_generated_index ?? null,
+    top_logits: stripDiagnosticTokenText(report.camelid.top_logits ?? []),
+    step_top_logits: (report.camelid.step_top_logits ?? []).map(stripDiagnosticTokenText),
+    output_projection: report.camelid.output_projection ?? [],
+    dense: report.camelid.dense ?? null,
+  } : null
+  return {
+    schema: 'camelid.chat-parity-sanitized.v1',
+    backend: sanitizeUrl(report.backend),
+    llama_server: sanitizeUrl(report.llama_server),
+    model: sanitizePath(report.model),
+    model_id: 'redacted',
+    message: sanitizeText(report.message),
+    messages: sanitizeMessages(report.messages),
+    render_mode: report.render_mode,
+    expected_prompt: sanitizeText(report.expected_prompt),
+    expected_prompt_char_count: report.expected_prompt_char_count,
+    reference_prompt_token_count: report.reference_prompt_token_count,
+    reference_context: report.reference_context,
+    llama_flash_attn: report.llama_flash_attn,
+    llama_completion_prompt_kind: report.llama_completion_prompt_kind,
+    prompt_tokens_match: report.prompt_tokens_match,
+    generated_tokens_match: report.generated_tokens_match,
+    generated_text_match: report.generated_text_match,
+    first_generated_token_diff_index: report.first_generated_token_diff_index,
+    first_generated_text_diff_index: report.first_generated_text_diff_index,
+    backend_dense_diagnostic_generated_index: report.backend_dense_diagnostic_generated_index,
+    first_generated_token_logit_comparison: stripComparisonTokenText(report.first_generated_token_logit_comparison),
+    backend_prompt_tokens: report.backend_prompt_tokens,
+    reference_prompt_tokens: report.reference_prompt_tokens,
+    prompt_position_ids: positionIds(report.backend_prompt_tokens),
+    backend_generated_tokens: report.backend_generated_tokens,
+    llama_generated_tokens: report.llama_generated_tokens,
+    generated_position_ids: positionIds(
+      report.backend_generated_tokens,
+      Array.isArray(report.backend_prompt_tokens) ? report.backend_prompt_tokens.length : 0,
+    ),
+    llama_top_logprobs: stripLogprobTokenText(report.llama_top_logprobs),
+    backend_diagnostic_token_ids: report.backend_diagnostic_token_ids,
+    backend_text: sanitizeText(report.backend_text),
+    llama_text: sanitizeText(report.llama_text),
+    backend_usage: report.backend_usage,
+    llama_usage: report.llama_usage,
+    camelid,
+  }
+}
+
+function stripComparisonTokenText(value) {
+  if (!value) return null
+  return {
+    ...value,
+    backend_rows: stripDiagnosticTokenText(value.backend_rows ?? []),
+    llama_rows: stripLogprobTokenText(value.llama_rows ?? []),
+  }
+}
+
+function stripDiagnosticTokenText(rows) {
+  return rows.map(({ text, ...row }) => row)
+}
+
+function stripLogprobTokenText(rows) {
+  return rows.map(({ token, ...row }) => row)
+}
+
+function positionIds(tokens, start = 0) {
+  return Array.isArray(tokens) ? tokens.map((_, index) => start + index) : null
 }
 
 function firstStringDifference(left, right) {

--- a/scripts/chat-parity-mixtral.mjs
+++ b/scripts/chat-parity-mixtral.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const argv = process.argv.slice(2)
+const relayArgs = [...argv]
+if (!hasFlag(argv, 'render-mode')) relayArgs.push('--render-mode', 'mistral_instruct')
+if (!hasFlag(argv, 'model') && process.env.MIXTRAL_GGUF) relayArgs.push('--model', process.env.MIXTRAL_GGUF)
+if (!hasFlag(argv, 'model-id') && process.env.MIXTRAL_MODEL_ID) relayArgs.push('--model-id', process.env.MIXTRAL_MODEL_ID)
+if (!hasFlag(argv, 'llama-url') && process.env.MIXTRAL_LLAMA_SERVER_URL) relayArgs.push('--llama-url', process.env.MIXTRAL_LLAMA_SERVER_URL)
+if (!hasFlag(argv, 'llama-server') && process.env.MIXTRAL_LLAMA_SERVER) relayArgs.push('--llama-server', process.env.MIXTRAL_LLAMA_SERVER)
+if (!hasFlag(argv, 'llama-tokenize') && process.env.MIXTRAL_LLAMA_TOKENIZE) relayArgs.push('--llama-tokenize', process.env.MIXTRAL_LLAMA_TOKENIZE)
+if (!hasFlag(argv, 'messages-json') && process.env.MIXTRAL_CHAT_MESSAGES_JSON) relayArgs.push('--messages-json', process.env.MIXTRAL_CHAT_MESSAGES_JSON)
+if (!hasFlag(argv, 'message') && process.env.MIXTRAL_CHAT_MESSAGE) relayArgs.push('--message', process.env.MIXTRAL_CHAT_MESSAGE)
+if (!hasFlag(argv, 'max-tokens') && process.env.MIXTRAL_CHAT_MAX_TOKENS) relayArgs.push('--max-tokens', process.env.MIXTRAL_CHAT_MAX_TOKENS)
+if (!hasFlag(argv, 'diagnostics-out') && process.env.MIXTRAL_CHAT_DIAGNOSTICS_OUT) relayArgs.push('--diagnostics-out', process.env.MIXTRAL_CHAT_DIAGNOSTICS_OUT)
+if (!hasFlag(argv, 'sanitize-diagnostics')) relayArgs.push('--sanitize-diagnostics')
+if (!hasFlag(argv, 'backend-dense-diagnostic-generated-index') && process.env.MIXTRAL_CHAT_BACKEND_DENSE_DIAGNOSTIC_GENERATED_INDEX) relayArgs.push('--backend-dense-diagnostic-generated-index', process.env.MIXTRAL_CHAT_BACKEND_DENSE_DIAGNOSTIC_GENERATED_INDEX)
+if (!hasFlag(argv, 'llama-context') && process.env.MIXTRAL_LLAMA_CONTEXT) relayArgs.push('--llama-context', process.env.MIXTRAL_LLAMA_CONTEXT)
+if (!hasFlag(argv, 'wait-ms') && process.env.MIXTRAL_WAIT_MS) relayArgs.push('--wait-ms', process.env.MIXTRAL_WAIT_MS)
+
+const child = spawn(process.execPath, [resolve('scripts/chat-parity-llama3.mjs'), ...relayArgs], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    LLAMA3_GGUF: process.env.LLAMA3_GGUF || process.env.MIXTRAL_GGUF,
+    LLAMA3_MODEL_ID: process.env.LLAMA3_MODEL_ID || process.env.MIXTRAL_MODEL_ID,
+    LLAMA3_LLAMA_SERVER_URL: process.env.LLAMA3_LLAMA_SERVER_URL || process.env.MIXTRAL_LLAMA_SERVER_URL,
+    LLAMA3_LLAMA_SERVER: process.env.LLAMA3_LLAMA_SERVER || process.env.MIXTRAL_LLAMA_SERVER,
+    LLAMA3_LLAMA_TOKENIZE: process.env.LLAMA3_LLAMA_TOKENIZE || process.env.MIXTRAL_LLAMA_TOKENIZE,
+    LLAMA3_CHAT_MESSAGES_JSON: process.env.LLAMA3_CHAT_MESSAGES_JSON || process.env.MIXTRAL_CHAT_MESSAGES_JSON,
+    LLAMA3_CHAT_MESSAGE: process.env.LLAMA3_CHAT_MESSAGE || process.env.MIXTRAL_CHAT_MESSAGE,
+    LLAMA3_CHAT_MAX_TOKENS: process.env.LLAMA3_CHAT_MAX_TOKENS || process.env.MIXTRAL_CHAT_MAX_TOKENS,
+    LLAMA3_CHAT_DIAGNOSTICS_OUT: process.env.LLAMA3_CHAT_DIAGNOSTICS_OUT || process.env.MIXTRAL_CHAT_DIAGNOSTICS_OUT,
+    LLAMA3_CHAT_SANITIZE_DIAGNOSTICS: process.env.LLAMA3_CHAT_SANITIZE_DIAGNOSTICS || '1',
+    LLAMA3_CHAT_BACKEND_DENSE_DIAGNOSTIC_GENERATED_INDEX: process.env.LLAMA3_CHAT_BACKEND_DENSE_DIAGNOSTIC_GENERATED_INDEX || process.env.MIXTRAL_CHAT_BACKEND_DENSE_DIAGNOSTIC_GENERATED_INDEX,
+    LLAMA3_LLAMA_CONTEXT: process.env.LLAMA3_LLAMA_CONTEXT || process.env.MIXTRAL_LLAMA_CONTEXT,
+    LLAMA3_WAIT_MS: process.env.LLAMA3_WAIT_MS || process.env.MIXTRAL_WAIT_MS,
+  },
+})
+
+child.once('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal)
+  else process.exit(code ?? 0)
+})
+child.once('error', (err) => {
+  console.error(err)
+  process.exit(1)
+})
+
+function hasFlag(args, flag) {
+  return args.some((arg) => arg === `--${flag}` || arg.startsWith(`--${flag}=`))
+}

--- a/scripts/lib/privacy-sanitize.mjs
+++ b/scripts/lib/privacy-sanitize.mjs
@@ -1,0 +1,98 @@
+import crypto from 'node:crypto'
+import path from 'node:path'
+
+export function sha256(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex')
+}
+
+export function sanitizeText(value) {
+  const text = String(value ?? '')
+  return {
+    char_count: text.length,
+    sha256: sha256(text),
+  }
+}
+
+export function sanitizeMessages(messages) {
+  const normalized = Array.isArray(messages) ? messages : []
+  return {
+    message_count: normalized.length,
+    roles: normalized.map(message => String(message?.role ?? '')),
+    content_char_counts: normalized.map(message => String(message?.content ?? '').length),
+    content_sha256: normalized.map(message => sha256(message?.content ?? '')),
+    combined_sha256: sha256(JSON.stringify(normalized)),
+  }
+}
+
+export function sanitizePath(value) {
+  if (!value) return null
+  return {
+    basename: path.basename(String(value)),
+    sha256: sha256(String(value)),
+  }
+}
+
+export function sanitizeUrl(value) {
+  if (!value) return null
+  try {
+    const url = new URL(String(value))
+    return {
+      protocol: url.protocol.replace(/:$/, ''),
+      host: 'redacted',
+      port_present: Boolean(url.port),
+      path: url.pathname || '/',
+    }
+  } catch {
+    return {
+      raw: 'redacted',
+      sha256: sha256(String(value)),
+    }
+  }
+}
+
+export function sanitizeSseEvent(event) {
+  const parsed = event?.parsed
+  const choice = parsed?.choices?.[0]
+  const delta = choice?.delta
+  const content = typeof delta?.content === 'string'
+    ? delta.content
+    : typeof choice?.text === 'string'
+      ? choice.text
+      : null
+  const error = parsed?.error
+  return {
+    elapsed_ms: event?.elapsed_ms ?? null,
+    event: event?.event ?? 'message',
+    data_kind: event?.data === '[DONE]' ? 'done' : parsed ? 'json' : 'non_json',
+    object: typeof parsed?.object === 'string' ? parsed.object : null,
+    choice_index: Number.isInteger(choice?.index) ? choice.index : null,
+    role: typeof delta?.role === 'string' ? delta.role : null,
+    finish_reason: choice?.finish_reason ?? null,
+    content: content === null ? null : sanitizeText(content),
+    error: error ? sanitizeError(error) : null,
+  }
+}
+
+function sanitizeError(error) {
+  return {
+    code: typeof error.code === 'string' ? error.code : null,
+    type: typeof error.type === 'string' ? error.type : null,
+    param: typeof error.param === 'string' ? error.param : null,
+    message: typeof error.message === 'string' ? sanitizeText(error.message) : null,
+    timeout_trace: sanitizeTimeoutTrace(error.timeout_trace),
+  }
+}
+
+export function sanitizeTimeoutTrace(timeoutTrace) {
+  if (!timeoutTrace || typeof timeoutTrace !== 'object') return null
+  return {
+    timeout_ms: integerOrNull(timeoutTrace.timeout_ms),
+    elapsed_ms: integerOrNull(timeoutTrace.elapsed_ms),
+    generated_tokens: integerOrNull(timeoutTrace.generated_tokens),
+    timeout_env: typeof timeoutTrace.timeout_env === 'string' ? timeoutTrace.timeout_env : null,
+  }
+}
+
+function integerOrNull(value) {
+  return Number.isInteger(value) ? value : null
+}

--- a/scripts/test-privacy-sanitize.mjs
+++ b/scripts/test-privacy-sanitize.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+
+import {
+  sanitizeMessages,
+  sanitizePath,
+  sanitizeSseEvent,
+  sanitizeText,
+  sanitizeTimeoutTrace,
+  sanitizeUrl,
+} from './lib/privacy-sanitize.mjs'
+
+const text = sanitizeText('secret prompt')
+assert.equal(text.char_count, 13)
+assert.equal(text.sha256.length, 64)
+assert.notEqual(text.sha256, 'secret prompt')
+
+const messages = sanitizeMessages([
+  { role: 'system', content: 'private rule' },
+  { role: 'user', content: 'private question' },
+])
+assert.deepEqual(messages.roles, ['system', 'user'])
+assert.deepEqual(messages.content_char_counts, [12, 16])
+assert.equal(messages.content_sha256.length, 2)
+assert.equal(messages.combined_sha256.length, 64)
+
+assert.deepEqual(sanitizeUrl('http://private-host.local:8181/v1/chat/completions'), {
+  protocol: 'http',
+  host: 'redacted',
+  port_present: true,
+  path: '/v1/chat/completions',
+})
+const sanitizedPath = sanitizePath('/private/models/Mixtral-8x7B-Instruct-v0.1.Q8_0.gguf')
+assert.equal(sanitizedPath.basename, 'Mixtral-8x7B-Instruct-v0.1.Q8_0.gguf')
+assert.equal(sanitizedPath.sha256.length, 64)
+assert.equal(JSON.stringify(sanitizedPath).includes('/private/models'), false)
+
+const contentEvent = sanitizeSseEvent({
+  elapsed_ms: 25,
+  event: 'message',
+  data: '{"choices":[{"index":0,"delta":{"content":"private token text"},"finish_reason":null}]}',
+  parsed: {
+    object: 'chat.completion.chunk',
+    choices: [{
+      index: 0,
+      delta: { content: 'private token text' },
+      finish_reason: null,
+    }],
+  },
+})
+assert.equal(contentEvent.data_kind, 'json')
+assert.equal(contentEvent.object, 'chat.completion.chunk')
+assert.equal(contentEvent.content.char_count, 18)
+assert.equal(contentEvent.content.sha256.length, 64)
+assert.equal(JSON.stringify(contentEvent).includes('private token text'), false)
+
+const timeoutTrace = { timeout_ms: 7, elapsed_ms: 11, generated_tokens: 3, timeout_env: 'CAMELID_GENERATION_TIMEOUT_MS' }
+assert.deepEqual(sanitizeTimeoutTrace(timeoutTrace), timeoutTrace)
+const timeoutEvent = sanitizeSseEvent({
+  elapsed_ms: 11,
+  event: 'error',
+  data: '{"error":{"code":"generation_timeout","message":"private host failed","timeout_trace":{"timeout_ms":7,"elapsed_ms":11,"generated_tokens":3,"timeout_env":"CAMELID_GENERATION_TIMEOUT_MS"}}}',
+  parsed: {
+    error: {
+      code: 'generation_timeout',
+      message: 'private host failed',
+      timeout_trace: timeoutTrace,
+    },
+  },
+})
+assert.equal(timeoutEvent.error.code, 'generation_timeout')
+assert.equal(timeoutEvent.error.message.char_count, 19)
+assert.deepEqual(timeoutEvent.error.timeout_trace, timeoutTrace)
+assert.equal(JSON.stringify(timeoutEvent).includes('private host failed'), false)
+
+assert.equal(sanitizeSseEvent({ elapsed_ms: 30, event: 'message', data: '[DONE]', parsed: null }).data_kind, 'done')
+
+console.log('privacy-sanitize self-test passed')


### PR DESCRIPTION
## Summary
- add a reusable privacy sanitizer for chat parity diagnostics
- default the Mixtral chat parity wrapper to sanitized diagnostics
- include a sanitizer self-test in the existing validation-script loop
- strip token text from the logit-comparison console line when sanitized mode is enabled

## Validation
- `node --check scripts/chat-parity-llama3.mjs`
- `node --check scripts/chat-parity-mixtral.mjs`
- `node scripts/test-privacy-sanitize.mjs`
- `git diff --check`
- `bash scripts/check-public-scrub.sh`

Existing GitHub evidence before this PR: current `origin/main` CI run 26751491439 succeeded across public-scrub, rust, validation-scripts, and frontend.