### PR TITLE
fix(distributed): load output weights on the last pipeline node

### DIFF
--- a/docs/benchmarks/camelid-distributed.md
+++ b/docs/benchmarks/camelid-distributed.md
@@ -1,0 +1,94 @@
+# Camelid Distributed (Pipeline-Parallel) — Validation & 2-Mac Runbook
+
+> Camelid's distinct lane vs. single-node MLX is not raw speed — it's running a model
+> **across several consumer Macs**, so each node holds only a fraction of the weights.
+> This documents the on-machine validation (including a real bug fixed in the process)
+> and the runbook for a real two-Mac measurement over Thunderbolt.
+
+## What was validated (single machine, loopback)
+
+Two Camelid processes on `127.0.0.1`, splitting Llama-3.2-3B-Instruct-Q8_0 (28 layers):
+
+- **master** owns layers `0..14` + the token embedding,
+- **worker** owns layers `14..28` + the final norm and output projection (it samples).
+
+Result (temperature 0, greedy):
+
+- **Correctness**: the distributed pipeline produced output **identical to single-node**
+  generation for the same prompt — e.g. *"The Rust borrow checker is a tool that prevents
+  the compiler from accepting code that would otherwise lead to memory safety issues…"*.
+  Greedy + same kernels ⇒ exact match is the correctness oracle.
+- **Memory split**: peak RSS was **master 1.76 GB / worker 2.19 GB** — neither process
+  holds the full ~3.5 GB model. (The worker is larger because Llama-3.2 ties the output
+  projection to the embedding, so the last node carries that ~1.5 GB weight.)
+
+### Bug found and fixed in the process
+
+The first loopback run crashed the worker with
+`rms_norm weight shape [0] ... input shape [13, 3072]`. Root cause: `LlamaLoadedWeights::load`
+and `validate_dense_shapes` loaded/validated `output_norm` and the output projection on the
+**first** node, but in this pipeline the **last** node computes the final norm + logits.
+So 2-node pipeline parallel could never complete. Fixed by gating those on `is_last_node`
+(the node owning the final transformer layer); single-node (no range) is both first and
+last, so it is unaffected. See `src/inference.rs`.
+
+## Honest framing
+
+- A single stream through a pipeline has **one request in flight**, so distributing a model
+  that already fits on one machine gives **no decode speedup** — the nodes run sequentially.
+  The win is **fit**: running a model too big for one Mac, with each node holding a fraction.
+- So the demonstrable advantage needs a model that does **not** fit comfortably on one node
+  (e.g. an 8B Q8 ≈ 8.5 GB across two 16 GB Macs ≈ ~4.3 GB/node), not the 3B used for the
+  correctness check above.
+- This is a *different shape* than single-node MLX, not a "faster than MLX" claim.
+
+## Reproduce the loopback validation
+
+```bash
+bash tools/bench/distributed/loopback-verify.sh <model>.gguf
+```
+
+## Two-Mac runbook (Thunderbolt 4)
+
+Thunderbolt 4 exposes a **Thunderbolt Bridge** network interface (~20–40 Gbps); the
+activation packets per token are small, so the link is not the bottleneck.
+
+1. **Connect** both Macs with a TB4 cable. Each gets a Thunderbolt Bridge interface.
+2. **Assign IPs** on the Thunderbolt Bridge (System Settings → Network → Thunderbolt Bridge →
+   Details → TCP/IP → Configure manually), e.g. Mac-A `10.0.0.1`, Mac-B `10.0.0.2`
+   (`/24`). Verify with `ifconfig bridge0` and `ping 10.0.0.2`.
+3. **Stage** the `camelid` binary and the GGUF model on both Macs. (Build on each Mac, or
+   copy a binary built for the same Apple-Silicon generation — note the i8mm prefill path is
+   opt-in and M2+ only; default decode uses dotprod, present on all Apple Silicon.)
+4. **Balance the split by memory.** For tied-embedding models the last node carries the big
+   output projection, so give it fewer transformer layers. For an 8B-class model across two
+   nodes, start near a 60/40 layer split favoring the first node.
+5. **Run** (example, 3B, 28 layers — adjust ranges/model for an 8B):
+
+   On **Mac-B** (worker, last node):
+   ```bash
+   camelid distribute-worker <model>.gguf \
+     --addr 10.0.0.2:5005 --layers 14..28 --master-addr 10.0.0.1:5006
+   ```
+   On **Mac-A** (master, first node):
+   ```bash
+   camelid distribute-master <model>.gguf \
+     --worker-addr 10.0.0.2:5005 --layers 0..14 --addr 10.0.0.1:5006 \
+     --prompt "Explain what a Rust borrow checker does." --max-tokens 64
+   ```
+6. **Network overhead**: `camelid bench-network` (coordinator/worker) measures per-hop RTT and
+   transfer size to confirm the TB link is not limiting.
+
+### What to measure for an honest distributed win
+
+- A model that **does not fit** on one 16 GB Mac (e.g. 8B Q8) running comfortably across two,
+  with per-node peak RSS well under 16 GB and usable TTFT / decode.
+- Compare against single-node MLX on the same model on one Mac (which must swap or cannot load
+  it) — that is the defensible, distinct claim: *Camelid runs locally what one machine can't.*
+
+## Status
+
+- Loopback 2-node pipeline parallel: **correct** (matches single-node) and **memory-split
+  confirmed**, after the last-node weight-loading fix.
+- Real two-Mac TB4 measurement: **pending hardware run** (needs the second Mac and, for a
+  meaningful win, a model larger than one Mac's RAM).

--- a/docs/benchmarks/camelid-distributed.md
+++ b/docs/benchmarks/camelid-distributed.md
@@ -55,8 +55,9 @@ activation packets per token are small, so the link is not the bottleneck.
 
 1. **Connect** both Macs with a TB4 cable. Each gets a Thunderbolt Bridge interface.
 2. **Assign IPs** on the Thunderbolt Bridge (System Settings → Network → Thunderbolt Bridge →
-   Details → TCP/IP → Configure manually), e.g. Mac-A `10.0.0.1`, Mac-B `10.0.0.2`
-   (`/24`). Verify with `ifconfig bridge0` and `ping 10.0.0.2`.
+   Details → TCP/IP → Configure manually) — pick two addresses on a private `/24` of your
+   choice; call them `MAC_A_IP` and `MAC_B_IP`. Verify with `ifconfig bridge0` and
+   `ping "$MAC_B_IP"`.
 3. **Stage** the `camelid` binary and the GGUF model on both Macs. (Build on each Mac, or
    copy a binary built for the same Apple-Silicon generation — note the i8mm prefill path is
    opt-in and M2+ only; default decode uses dotprod, present on all Apple Silicon.)
@@ -68,12 +69,12 @@ activation packets per token are small, so the link is not the bottleneck.
    On **Mac-B** (worker, last node):
    ```bash
    camelid distribute-worker <model>.gguf \
-     --addr 10.0.0.2:5005 --layers 14..28 --master-addr 10.0.0.1:5006
+     --addr "$MAC_B_IP:5005" --layers 14..28 --master-addr "$MAC_A_IP:5006"
    ```
    On **Mac-A** (master, first node):
    ```bash
    camelid distribute-master <model>.gguf \
-     --worker-addr 10.0.0.2:5005 --layers 0..14 --addr 10.0.0.1:5006 \
+     --worker-addr "$MAC_B_IP:5005" --layers 0..14 --addr "$MAC_A_IP:5006" \
      --prompt "Explain what a Rust borrow checker does." --max-tokens 64
    ```
 6. **Network overhead**: `camelid bench-network` (coordinator/worker) measures per-hop RTT and

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -242,16 +242,41 @@ impl LlamaLoadedWeights {
         binding: &LlamaTensorBinding,
         layer_start: usize,
         layer_end: usize,
-        _load_embedding: bool,
-        _load_output: bool,
+        load_embedding: bool,
+        load_output: bool,
     ) -> Result<Self> {
-        Self::load(store, binding, Some(layer_start..layer_end))
+        // The distributed module's coordinator computes logits on the FIRST node, so
+        // ownership of the embedding/output weights is explicit here rather than
+        // positional. Honor the flags directly.
+        Self::load_with_ownership(
+            store,
+            binding,
+            Some(layer_start..layer_end),
+            load_embedding,
+            load_output,
+        )
     }
 
     pub fn load(
         store: &TensorStore,
         binding: &LlamaTensorBinding,
         layer_range: Option<std::ops::Range<usize>>,
+    ) -> Result<Self> {
+        // Single node (no range) is both first and last. In a pipeline-parallel split,
+        // the first node owns the token embedding and the last node owns output_norm +
+        // the output projection (it computes the final norm and logits).
+        let load_embedding = layer_range.as_ref().is_none_or(|r| r.start == 0);
+        let total_layers = binding.layers.len();
+        let load_output = layer_range.as_ref().is_none_or(|r| r.end >= total_layers);
+        Self::load_with_ownership(store, binding, layer_range, load_embedding, load_output)
+    }
+
+    fn load_with_ownership(
+        store: &TensorStore,
+        binding: &LlamaTensorBinding,
+        layer_range: Option<std::ops::Range<usize>>,
+        load_embedding: bool,
+        load_output: bool,
     ) -> Result<Self> {
         let auto_retain_q8_0_blocks = auto_retain_q8_0_blocks_for_fast_local_chat(binding);
         let load_linear = |name: &str| {
@@ -281,9 +306,7 @@ impl LlamaLoadedWeights {
                 )
             }
         };
-        let is_first_node = layer_range.as_ref().is_none_or(|r| r.start == 0);
-
-        let token_embedding = if is_first_node {
+        let token_embedding = if load_embedding {
             normalize_token_embedding_shape(
                 load_linear(&binding.token_embedding.name)?,
                 &binding.token_embedding.name,
@@ -292,13 +315,13 @@ impl LlamaLoadedWeights {
             CpuTensor::from_f32(&binding.token_embedding.name, vec![0], vec![])?
         };
 
-        let output_norm = if is_first_node {
+        let output_norm = if load_output {
             store.load_cpu_f32(&binding.output_norm.name)?
         } else {
             CpuTensor::from_f32(&binding.output_norm.name, vec![0], vec![])?
         };
 
-        let output = if is_first_node {
+        let output = if load_output {
             if binding.output_is_tied_embedding {
                 if auto_retain_q8_0_blocks {
                     Some(store.load_q8_0_block_backed_linear_as(
@@ -431,14 +454,19 @@ impl LlamaLoadedWeights {
 
     pub fn validate_dense_shapes(&self, config: &LlamaModelConfig) -> Result<()> {
         let dims = DenseLlamaDims::from_config(config)?;
-        let is_first_node = self.layer_range.as_ref().is_none_or(|r| r.start == 0);
+        // Validate whatever weights this node actually loaded. In a pipeline-parallel
+        // split, a node leaves the weights it does not own as empty (rank-0) tensors,
+        // and the owning node validates them. A single node loads/validates everything.
+        let is_loaded = |t: &CpuTensor| t.shape.dims != [0] && !t.shape.dims.is_empty();
 
-        if is_first_node {
+        if is_loaded(&self.token_embedding) {
             require_tensor_shape(
                 &self.token_embedding,
                 &[dims.vocab_size, dims.embedding_length],
                 "token embedding",
             )?;
+        }
+        if is_loaded(&self.output_norm) {
             require_tensor_shape(&self.output_norm, &[dims.embedding_length], "output norm")?;
             require_matrix_shape(
                 self.output_projection(),

--- a/tests/distributed_tests.rs
+++ b/tests/distributed_tests.rs
@@ -111,6 +111,50 @@ fn header(tensor_count: i64, metadata_count: i64) -> Vec<u8> {
     b
 }
 
+/// Regression: in a pipeline-parallel layer split, the first node owns the token
+/// embedding and the LAST node owns output_norm + the output projection (it computes
+/// the final norm and logits). A 2-node CLI pipeline was previously broken because the
+/// output weights were loaded on the first node, leaving the last node unable to
+/// produce logits (`rms_norm weight shape [0]`).
+#[test]
+fn pipeline_load_puts_output_weights_on_last_node() {
+    let dir = tempdir().unwrap();
+    let model_path = dir.path().join("tiny_model.gguf");
+    write_tiny_llama_gguf(&model_path);
+    let gguf = read_metadata(&model_path).unwrap();
+    let config = LlamaModelConfig::from_gguf(&gguf).unwrap();
+    let binding = LlamaTensorBinding::bind(&gguf, &config).unwrap();
+    let store = TensorStore::open(&model_path, &gguf);
+
+    // First node (layers 0..1): owns the embedding, not the output weights.
+    let first = LlamaLoadedWeights::load(&store, &binding, Some(0..1)).unwrap();
+    assert_ne!(
+        first.token_embedding.shape.dims,
+        vec![0],
+        "first node loads embedding"
+    );
+    assert_eq!(
+        first.output_norm.shape.dims,
+        vec![0],
+        "first node has no output_norm"
+    );
+    first.validate_dense_shapes(&config).unwrap();
+
+    // Last node (layers 1..2): owns output_norm + output, not the embedding.
+    let last = LlamaLoadedWeights::load(&store, &binding, Some(1..2)).unwrap();
+    assert_eq!(
+        last.token_embedding.shape.dims,
+        vec![0],
+        "last node has no embedding"
+    );
+    assert_ne!(
+        last.output_norm.shape.dims,
+        vec![0],
+        "last node loads output_norm"
+    );
+    last.validate_dense_shapes(&config).unwrap();
+}
+
 fn write_tiny_llama_gguf(path: &Path) {
     // 2 layers, tiny dimensions: hidden=8, vocab=16, ffn=16, heads=2, kv_heads=2
     // We have exactly 21 tensors: token_embedding, output_norm, output + 9 tensors per layer (18 total) = 21 tensors.

--- a/tools/bench/distributed/loopback-verify.sh
+++ b/tools/bench/distributed/loopback-verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Verify Camelid pipeline-parallel correctness on one machine: split a model across
+# two local processes (master 0..k, worker k..N) and confirm it generates and that
+# each node holds only part of the weights. Compare the printed text to a single-node
+# run of the same prompt (greedy ⇒ should match exactly).
+#
+# Usage: loopback-verify.sh <model.gguf> [layers_total] [split]
+set -euo pipefail
+MODEL="${1:?usage: loopback-verify.sh <model.gguf> [layers_total] [split]}"
+TOTAL="${2:-28}"      # transformer layers in the model (Llama-3.2-3B = 28)
+SPLIT="${3:-14}"      # master owns 0..SPLIT, worker owns SPLIT..TOTAL
+PROMPT="${PROMPT:-Explain what a Rust borrow checker does in two sentences.}"
+MAX_TOKENS="${MAX_TOKENS:-48}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+BIN="${CAMELID_BIN:-$REPO_ROOT/target/release/camelid}"
+[ -x "$BIN" ] || { echo "camelid binary not found at $BIN (build it or set CAMELID_BIN)" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+echo "[loopback] master 0..$SPLIT  worker $SPLIT..$TOTAL  model=$MODEL"
+
+/usr/bin/time -l "$BIN" distribute-worker "$MODEL" \
+  --addr 127.0.0.1:5005 --layers "$SPLIT..$TOTAL" --master-addr 127.0.0.1:5006 \
+  >"$WORK/worker.out" 2>"$WORK/worker.time" &
+WPID=$!
+
+"$BIN" distribute-master "$MODEL" \
+  --worker-addr 127.0.0.1:5005 --layers "0..$SPLIT" --addr 127.0.0.1:5006 \
+  --prompt "$PROMPT" --max-tokens "$MAX_TOKENS" >"$WORK/master.out" 2>&1 || true
+sleep 1; kill "$WPID" 2>/dev/null || true
+
+echo "--- distributed output ---"
+sed -n '/Encoded prompt/,$p' "$WORK/master.out"
+echo "--- per-node peak RSS ---"
+grep -i "maximum resident" "$WORK/worker.time" | awk '{printf "  worker: %.2f GB\n", $1/1073741824}'
+echo "--- compare to single node (greedy should match): ---"
+echo "  $BIN bench-generate $MODEL --prompt \"$PROMPT\" --max-tokens $MAX_TOKENS --temperature 0"
+echo "artifacts in $WORK"


### PR DESCRIPTION
## Summary

Fixes a real bug that made Camelid's two-node pipeline-parallel path (`distribute-master`/`distribute-worker`) unusable, and adds validation + docs for the distributed lane.

## The bug

The last pipeline node computes the final norm + logits, but `LlamaLoadedWeights::load` and `validate_dense_shapes` loaded/validated `output_norm` and the output projection on the **first** node. So the worker (last node) crashed with `rms_norm weight shape [0] ... input shape [N, hidden]` — 2-node inference could never complete.

## The fix

Refactor into `load_with_ownership(load_embedding, load_output)`:
- Range-based `load()` owns the **embedding on the first node** and **output_norm + output on the last node** (a single node with no range owns both).
- `load_distributed()` now honors its explicit `load_embedding`/`load_output` flags (the `distributed` module's coordinator computes logits on the *first* node — these flags were previously ignored).
- `validate_dense_shapes` validates whatever weights a node actually loaded (presence-based), so it's correct for both topologies.

## Verification

- 2-process loopback split of Llama-3.2-3B (master `0..14` → worker `14..28`) produces output **identical to single-node greedy**, with each node holding ~half the weights (master 1.76 GB / worker ~2 GB).
- New regression test `pipeline_load_puts_output_weights_on_last_node`.
- Existing `test_distributed_pipeline_parallel_inference` (coordinator-computes-logits topology) still passes.
- Full suite green; fmt + clippy `-D warnings` clean (ubuntu + macOS gates).

## Also added

- `docs/benchmarks/camelid-distributed.md` — validation writeup + a **Thunderbolt-4 two-Mac runbook** (the distributed lane's real measurement: run a model too big for one Mac across two).
- `tools/bench/distributed/loopback-verify.sh` — one-command loopback reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
