### PR TITLE
feat(distributed): two-Mac Thunderbolt run — Llama-2-13B Q8 a single mini cannot load

### DIFF
--- a/docs/benchmarks/camelid-distributed.md
+++ b/docs/benchmarks/camelid-distributed.md
@@ -87,9 +87,57 @@ activation packets per token are small, so the link is not the bottleneck.
 - Compare against single-node MLX on the same model on one Mac (which must swap or cannot load
   it) — that is the defensible, distinct claim: *Camelid runs locally what one machine can't.*
 
+## Two-Mac result (real hardware, 2026-06-03)
+
+Two **Mac mini M4 (16 GB)** connected over a **Thunderbolt bridge** (~1 ms RTT, all traffic
+on `169.254.x`, verified to egress the TB interface — no Wi-Fi). Model:
+**Llama-2-13B-chat Q8_0** (13 GB, 40 layers, llama/SPM), split `0..20` (master) / `20..40`
+(worker). Driven by `tools/bench/distributed/two-mac-run.sh`, decode path
+`CAMELID_MAC_Q8_REPACK=1`.
+
+**The win — a single 16 GB mini cannot run this model at all:**
+
+| | Llama-2-13B **Q8** (13 GB) on one 16 GB mini | Two minis (Camelid, Thunderbolt) |
+| --- | --- | --- |
+| llama.cpp (Metal) | ❌ **fails to load** | — |
+| MLX | ❌ only ships this 13B at 4-bit (same ceiling) | — |
+| **Camelid** | — | ✅ **runs at full Q8** |
+| Peak RAM / node | n/a (fails) | **master 7.23 GB · worker 7.33 GB** |
+| Decode | 0 (can't) | **1.48 tok/s** |
+
+llama.cpp on one mini reports `recommendedMaxWorkingSetSize = 12713 MB` and then
+`test_prompt: failed to decode prompt batch, res = -3` — Metal's working-set ceiling on a
+16 GB mini (~12.7 GB) is below the 13 GB model. MLX hits the same unified-memory ceiling,
+which is why mlx-community publishes this 13B only at 4-bit.
+
+Camelid split the model across the two minis (≈7.2–7.3 GB resident per node — **neither node
+holds the full 13 GB**) and produced correct, coherent output over Thunderbolt:
+
+> "The sky appears blue because of a phenomenon called Rayleigh scattering, in which shorter
+> (blue) wavelengths of light are scattered more than longer (red) wavelengths by the tiny
+> molecules of gases in the atmosphere…"
+
+**The honest claim:** *Camelid runs, at full Q8 precision across two commodity 16 GB Macs, a
+model that a single mini (and therefore single-node MLX/llama.cpp) physically cannot load.*
+
+Decode (1.48 tok/s) is latency-bound: the pipeline runs one request in flight, so master and
+worker execute serially per token over two TB hops. That is a throughput lever (microbatching
+to overlap the stages, or the GPU-resident forward pass), not a correctness limit — the
+capability (running the otherwise-unrunnable model) is the result.
+
+### Reproduce
+
+```bash
+MODEL=<13B-Q8>.gguf REMOTE_MODEL=<path-on-worker>.gguf \
+CAMELID_BIN=<local camelid> REMOTE_BIN=/tmp/camelid WORKER_HOST=<ssh host> \
+MASTER_TB_IP=<this TB ip> WORKER_TB_IP=<worker TB ip> TOTAL_LAYERS=40 SPLIT=20 \
+MAX_TOKENS=64 bash tools/bench/distributed/two-mac-run.sh
+```
+
 ## Status
 
 - Loopback 2-node pipeline parallel: **correct** (matches single-node) and **memory-split
   confirmed**, after the last-node weight-loading fix.
-- Real two-Mac TB4 measurement: **pending hardware run** (needs the second Mac and, for a
-  meaningful win, a model larger than one Mac's RAM).
+- Real two-Mac TB4 run: **done** — Llama-2-13B Q8 runs across two 16 GB minis (7.2 GB/node)
+  that a single mini cannot load. Decode 1.48 tok/s (serial pipeline; throughput optimization
+  is the next lever).

--- a/src/main.rs
+++ b/src/main.rs
@@ -730,8 +730,11 @@ fn connect_with_retry(addr: SocketAddr) -> TcpStream {
                 return stream;
             }
             Err(e) => {
-                if start.elapsed().as_secs() > 30 {
-                    panic!("Failed to connect to {} after 30 seconds: {}", addr, e);
+                // Pipeline nodes bind their sockets only after loading their weight
+                // shard, which can take minutes for large models (especially when one
+                // node streams from slower storage). Keep retrying well past that.
+                if start.elapsed().as_secs() > 600 {
+                    panic!("Failed to connect to {} after 600 seconds: {}", addr, e);
                 }
                 std::thread::sleep(std::time::Duration::from_millis(500));
             }
@@ -918,6 +921,7 @@ async fn run_distribute_master(
     pos += seq_len;
     seq_len = 1;
 
+    let decode_start = Instant::now();
     let mut generated = 1;
     while !is_finished && generated < max_tokens {
         let hidden = session
@@ -943,6 +947,17 @@ async fn run_distribute_master(
         generated += 1;
     }
     println!();
+
+    let decode_secs = decode_start.elapsed().as_secs_f64();
+    let decode_tokens = generated.saturating_sub(1);
+    if decode_tokens > 0 && decode_secs > 0.0 {
+        println!(
+            "[distributed] decode: {} tokens in {:.2}s = {:.2} tok/s",
+            decode_tokens,
+            decode_secs,
+            decode_tokens as f64 / decode_secs
+        );
+    }
 
     Ok(())
 }

--- a/tools/bench/distributed/two-mac-run.sh
+++ b/tools/bench/distributed/two-mac-run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Run Camelid pipeline-parallel across two Macs over the Thunderbolt bridge, and
+# print the generated text + per-node peak RSS. The master runs on THIS machine; the
+# worker (last node) runs on $WORKER_HOST via ssh. Each node needs the camelid binary
+# and the GGUF model present; this stages them to the worker if missing.
+#
+# Required env:
+#   MODEL          GGUF path (must be identical on both nodes; staged to worker here)
+#   CAMELID_BIN    path to the camelid release binary on this machine
+#   WORKER_HOST    ssh host for the worker (e.g. tims-mac-mini-2.local)
+#   MASTER_TB_IP   this machine's Thunderbolt-bridge IP (e.g. 169.254.147.29)
+#   WORKER_TB_IP   worker's Thunderbolt-bridge IP (e.g. 169.254.156.89)
+#   TOTAL_LAYERS   transformer layers in the model (Llama-2-13B = 40)
+# Optional:
+#   SPLIT (default TOTAL_LAYERS/2)  PROMPT  MAX_TOKENS (default 64)
+#   REMOTE_BIN (default /tmp/camelid)  REMOTE_MODEL (default same path as MODEL)
+set -euo pipefail
+: "${MODEL:?}" "${CAMELID_BIN:?}" "${WORKER_HOST:?}" "${MASTER_TB_IP:?}" "${WORKER_TB_IP:?}" "${TOTAL_LAYERS:?}"
+SPLIT="${SPLIT:-$((TOTAL_LAYERS/2))}"
+PROMPT="${PROMPT:-Explain what a Rust borrow checker does in two sentences.}"
+MAX_TOKENS="${MAX_TOKENS:-64}"
+REMOTE_BIN="${REMOTE_BIN:-/tmp/camelid}"
+REMOTE_MODEL="${REMOTE_MODEL:-$MODEL}"
+PORT_W=5005
+PORT_M=5006
+
+echo "[two-mac] master 0..$SPLIT on $(hostname -s) ($MASTER_TB_IP)"
+echo "[two-mac] worker $SPLIT..$TOTAL_LAYERS on $WORKER_HOST ($WORKER_TB_IP)"
+
+# 1) Stage binary + model to the worker if missing (over the fast TB link).
+ssh "$WORKER_HOST" "mkdir -p \"\$(dirname '$REMOTE_MODEL')\""
+if ! ssh "$WORKER_HOST" "test -x '$REMOTE_BIN'"; then
+  echo "[two-mac] copying binary -> $WORKER_HOST:$REMOTE_BIN"
+  scp -q "$CAMELID_BIN" "$WORKER_HOST:$REMOTE_BIN"
+fi
+remote_size="$(ssh "$WORKER_HOST" "stat -f%z '$REMOTE_MODEL' 2>/dev/null || echo 0")"
+local_size="$(stat -f%z "$MODEL")"
+if [ "$remote_size" != "$local_size" ]; then
+  echo "[two-mac] copying model ($(echo "$local_size" | awk '{printf "%.1f GB", $1/1073741824}')) -> $WORKER_HOST:$REMOTE_MODEL (over Thunderbolt)"
+  scp -q "$MODEL" "$WORKER_HOST:$REMOTE_MODEL"
+fi
+
+# 2) Launch the worker (last node) on the remote, bound to its TB IP.
+echo "[two-mac] starting remote worker..."
+ssh "$WORKER_HOST" "CAMELID_MAC_Q8_REPACK=1 /usr/bin/time -l '$REMOTE_BIN' distribute-worker '$REMOTE_MODEL' \
+  --addr $WORKER_TB_IP:$PORT_W --layers $SPLIT..$TOTAL_LAYERS --master-addr $MASTER_TB_IP:$PORT_M" \
+  >/tmp/two_mac_worker.out 2>&1 &
+SSH_PID=$!
+
+# 3) Run the master (first node) here; it connects to the worker over TB.
+echo "[two-mac] starting master..."
+START=$(python3 -c 'import time;print(time.time())')
+CAMELID_MAC_Q8_REPACK=1 /usr/bin/time -l "$CAMELID_BIN" distribute-master "$MODEL" \
+  --worker-addr "$WORKER_TB_IP:$PORT_W" --layers "0..$SPLIT" --addr "$MASTER_TB_IP:$PORT_M" \
+  --prompt "$PROMPT" --max-tokens "$MAX_TOKENS" >/tmp/two_mac_master.out 2>/tmp/two_mac_master.time || true
+END=$(python3 -c 'import time;print(time.time())')
+
+# 4) Clean up the remote worker.
+ssh "$WORKER_HOST" "pkill -f distribute-worker" 2>/dev/null || true
+kill "$SSH_PID" 2>/dev/null || true
+
+echo "=== generated text ==="
+sed -n '/Encoded prompt/,$p' /tmp/two_mac_master.out
+echo "=== timing: $(python3 -c "print(f'{$END-$START:.1f}s total (incl. load)')") ==="
+echo "=== master peak RSS ==="; grep -i "maximum resident" /tmp/two_mac_master.time | awk '{printf "  %.2f GB\n",$1/1073741824}'
+echo "=== worker peak RSS (remote) ==="; grep -i "maximum resident" /tmp/two_mac_worker.out | tail -1 | awk '{printf "  %.2f GB\n",$1/1073741824}'
+echo "=== decode rate ==="; grep -i "\[distributed\] decode" /tmp/two_mac_master.out || true
+echo "(worker stdout: /tmp/two_mac_worker.out)"


### PR DESCRIPTION
## Summary

Real two-Mac result: **Camelid runs Llama-2-13B at full Q8 across two 16 GB Mac minis over Thunderbolt — a model a single 16 GB mini cannot load.**

| | Llama-2-13B Q8 (13 GB), one 16 GB mini | Two minis (Camelid, TB) |
| --- | --- | --- |
| llama.cpp (Metal) | ❌ fails (`recommendedMaxWorkingSetSize 12713 MB` < 13 GB → `failed to decode prompt batch`) | — |
| MLX | ❌ only ships this 13B at 4-bit (same Metal ceiling) | — |
| Camelid | — | ✅ runs at full Q8, correct output |
| Peak RAM/node | n/a (fails) | master 7.23 GB · worker 7.33 GB |
| Decode | 0 (can't) | 1.48 tok/s |

Neither mini holds the full model; output is coherent ("…Rayleigh scattering…"). All traffic over the Thunderbolt bridge (`169.254.x`, verified to egress the TB interface).

## Changes

- **`connect_with_retry`: 30s → 600s.** Pipeline nodes bind their socket only after loading their weight shard, which takes minutes for large models; the 30s window failed when the master streamed its shard from slower storage (`Connection refused` before the peer was up).
- **`distribute-master`: report decode tokens/sec.**
- **`tools/bench/distributed/two-mac-run.sh`**: stages binary + model to the worker over the TB link, launches worker (wrapped in `/usr/bin/time` for RSS) + master, prints output, per-node peak RSS, and decode rate.
- **`docs/benchmarks/camelid-distributed.md`**: real two-Mac results + reproduce steps.

## Notes

- Decode (1.48 tok/s) is latency-bound — the pipeline runs one request in flight (master then worker serially per token, two TB hops). That's a throughput lever (microbatching / GPU-resident forward), not a correctness limit. The capability — running the otherwise-unrunnable model at full precision — is the result.
- fmt / clippy `-D warnings` / public-scrub / lib tests clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
