### PR TITLE
feat(inference): wire GPU-resident decode behind CAMELID_METAL_RESIDENT_DECODE (integration step 7b)

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1263,11 +1263,42 @@ pub struct LlamaGenerationStep {
     pub diagnostics: Option<LlamaForwardDiagnostics>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
 pub struct LlamaInferenceSession {
     pub config: LlamaModelConfig,
     pub weights: Arc<LlamaLoadedWeights>,
     pub kv_cache: LlamaKvCache,
+    /// Lazily-built GPU resident-decode session (a transient on-GPU cache; rebuilt on demand
+    /// and not part of the session's logical identity, so it is skipped by Clone/PartialEq/Debug).
+    resident_decode: Option<metal::ResidentDecodeState>,
+}
+
+impl Clone for LlamaInferenceSession {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            weights: self.weights.clone(),
+            kv_cache: self.kv_cache.clone(),
+            resident_decode: None,
+        }
+    }
+}
+
+impl PartialEq for LlamaInferenceSession {
+    fn eq(&self, other: &Self) -> bool {
+        self.config == other.config
+            && self.weights == other.weights
+            && self.kv_cache == other.kv_cache
+    }
+}
+
+impl std::fmt::Debug for LlamaInferenceSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LlamaInferenceSession")
+            .field("config", &self.config)
+            .field("weights", &self.weights)
+            .field("kv_cache", &self.kv_cache)
+            .finish_non_exhaustive()
+    }
 }
 
 impl LlamaInferenceSession {
@@ -1282,7 +1313,177 @@ impl LlamaInferenceSession {
             config,
             weights,
             kv_cache: LlamaKvCache::new(plan)?,
+            resident_decode: None,
         })
+    }
+
+    /// Whether the GPU-resident decode forward may run for this model+config: flag on, dense
+    /// (no MoE), not distributed-sharded, all default diagnostic modes the kernel implements
+    /// (Grouped GQA, 1/sqrt(head_dim) scale, gate*swish(up) order), every layer a plain Q8_0
+    /// row-major weight, and dims satisfying the kernel's modulo constraints. Anything else
+    /// keeps the unchanged CPU layer loop.
+    fn resident_decode_eligible(&self) -> Result<bool> {
+        if !resident_decode_metal_enabled() {
+            return Ok(false);
+        }
+        if self.weights.layer_range.is_some() || self.config.moe.is_some() {
+            return Ok(false);
+        }
+        if diagnostic_gqa_head_mapping()? != GqaHeadMapping::Grouped
+            || diagnostic_attention_score_scale()? != AttentionScoreScale::HeadDim
+            || diagnostic_ffn_gate_up_order()? != FfnGateUpOrder::GateUp
+        {
+            return Ok(false);
+        }
+        let is_q8 =
+            |t: &CpuTensor| t.source_type == Some(GgufTensorType::Q8_0) && t.q8_0_blocks.is_some();
+        for layer in &self.weights.layers {
+            if layer.moe_router.is_some()
+                || !is_q8(&layer.attention_q)
+                || !is_q8(&layer.attention_k)
+                || !is_q8(&layer.attention_v)
+                || !is_q8(&layer.attention_output)
+                || !is_q8(&layer.ffn_gate)
+                || !is_q8(&layer.ffn_up)
+                || !is_q8(&layer.ffn_down)
+            {
+                return Ok(false);
+            }
+        }
+        let dims = DenseLlamaDims::from_config(&self.config)?;
+        let n_heads = self.config.attention_head_count as usize;
+        let q_dim = n_heads * dims.head_dim;
+        Ok(dims.embedding_length != 0
+            && dims.embedding_length.is_multiple_of(32)
+            && q_dim.is_multiple_of(32)
+            && dims.head_dim != 0
+            && dims.head_dim.is_multiple_of(2)
+            && dims.feed_forward_length != 0
+            && dims.feed_forward_length.is_multiple_of(32)
+            && n_heads != 0
+            && dims.attention_head_count_kv != 0
+            && n_heads.is_multiple_of(dims.attention_head_count_kv))
+    }
+
+    /// Run the whole token forward on the GPU resident-decode session. Returns Some(hidden) on
+    /// success (the caller applies the existing final norm + output projection), or None to fall
+    /// back to the CPU layer loop (ineligible config, unsupported RoPE, or Metal unavailable).
+    fn try_resident_decode_forward(&mut self, embedding: &CpuTensor) -> Result<Option<CpuTensor>> {
+        if !self.resident_decode_eligible()? {
+            return Ok(None);
+        }
+        let weights = Arc::clone(&self.weights);
+        let dims = DenseLlamaDims::from_config(&self.config)?;
+        let n_heads = self.config.attention_head_count as usize;
+        let n_kv = dims.attention_head_count_kv;
+        let head_dim = dims.head_dim;
+        let hidden = dims.embedding_length;
+        let ffn_dim = dims.feed_forward_length;
+        let n_layers = dims.block_count;
+        let max_positions = self.config.context_length as usize;
+        let position = self.kv_cache.position;
+        if position >= max_positions
+            || embedding.data.len() != hidden
+            || weights.layers.len() != n_layers
+        {
+            return Ok(None);
+        }
+        let rms_eps = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
+        let tables = match rope::resident_decode_rope_tables(
+            position,
+            head_dim,
+            &self.config,
+            weights.rope_freqs.as_ref(),
+        )? {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+        let scale = attention_score_scale_value(head_dim, diagnostic_attention_score_scale()?);
+
+        // (Re)build + seed the session when starting a sequence (or resuming at a position the
+        // session has not materialized): copy the CPU KV history [0, position) into the GPU
+        // cache so resident decode can take over after the batched CPU prefill.
+        let rebuild = match &self.resident_decode {
+            Some(s) => s.filled() != position,
+            None => true,
+        };
+        if rebuild {
+            let mut session = match metal::ResidentDecodeState::new(
+                n_layers,
+                n_heads,
+                n_kv,
+                head_dim,
+                hidden,
+                ffn_dim,
+                max_positions,
+                rms_eps,
+                tables.split_half_pairing,
+            ) {
+                Some(s) => s,
+                None => return Ok(None),
+            };
+            if position > 0 {
+                let kv_dim = n_kv * head_dim;
+                for layer in 0..n_layers {
+                    let mut ck = vec![0.0f32; kv_dim * position];
+                    let mut cv = vec![0.0f32; kv_dim * position];
+                    for p in 0..position {
+                        for h in 0..n_kv {
+                            let src = self.kv_cache.offset(layer, p, h);
+                            let dst = (h * position + p) * head_dim;
+                            ck[dst..dst + head_dim]
+                                .copy_from_slice(&self.kv_cache.keys[src..src + head_dim]);
+                            cv[dst..dst + head_dim]
+                                .copy_from_slice(&self.kv_cache.values[src..src + head_dim]);
+                        }
+                    }
+                    if !session.seed_layer(layer, &ck, &cv, position) {
+                        return Ok(None);
+                    }
+                }
+            }
+            session.set_filled(position);
+            self.resident_decode = Some(session);
+        }
+
+        let layer_views: Vec<metal::ResidentLayerWeights> = weights
+            .layers
+            .iter()
+            .map(|l| metal::ResidentLayerWeights {
+                attn_norm: &l.attention_norm.data,
+                ffn_norm: &l.ffn_norm.data,
+                q_weight_blocks: q8_0_blocks_as_bytes(l.attention_q.q8_0_blocks.as_ref().unwrap()),
+                k_weight_blocks: q8_0_blocks_as_bytes(l.attention_k.q8_0_blocks.as_ref().unwrap()),
+                v_weight_blocks: q8_0_blocks_as_bytes(l.attention_v.q8_0_blocks.as_ref().unwrap()),
+                o_weight_blocks: q8_0_blocks_as_bytes(
+                    l.attention_output.q8_0_blocks.as_ref().unwrap(),
+                ),
+                gate_weight_blocks: q8_0_blocks_as_bytes(l.ffn_gate.q8_0_blocks.as_ref().unwrap()),
+                up_weight_blocks: q8_0_blocks_as_bytes(l.ffn_up.q8_0_blocks.as_ref().unwrap()),
+                down_weight_blocks: q8_0_blocks_as_bytes(l.ffn_down.q8_0_blocks.as_ref().unwrap()),
+            })
+            .collect();
+
+        let session = self
+            .resident_decode
+            .as_mut()
+            .expect("resident session built above");
+        let out = match session.forward_token(
+            &embedding.data,
+            &layer_views,
+            &tables.cos,
+            &tables.sin,
+            position,
+            scale,
+        ) {
+            Some(o) => o,
+            None => return Ok(None),
+        };
+        Ok(Some(CpuTensor::from_f32(
+            "resident_hidden",
+            vec![1, hidden],
+            out,
+        )?))
     }
 
     pub fn forward_worker_layers(
@@ -1803,43 +2004,59 @@ impl LlamaInferenceSession {
             collect_diagnostics.then(|| Vec::with_capacity(self.weights.layers.len()));
         let layers_started = Instant::now();
         let rms_norm_epsilon = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
-        for (layer_idx, layer) in self.weights.layers.iter().enumerate() {
-            if let Some(range) = &self.weights.layer_range {
-                if !range.contains(&layer_idx) {
-                    if let Some(client) = crate::distributed::DISTRIBUTED_CLIENT.get() {
-                        let worker_response =
-                            client.forward_to_worker(&hidden, false, 1, self.kv_cache.position)?;
-                        hidden = worker_response;
-                        break;
-                    } else {
-                        continue;
+        // GPU-resident decode: run all layers on the Metal GPU in one command buffer with the
+        // KV cache resident across tokens. Only when not collecting diagnostics; falls back to
+        // the CPU layer loop below when ineligible (returns None).
+        let resident_hidden = if collect_diagnostics {
+            None
+        } else {
+            self.try_resident_decode_forward(&hidden)?
+        };
+        if let Some(resident) = resident_hidden {
+            hidden = resident;
+        } else {
+            for (layer_idx, layer) in self.weights.layers.iter().enumerate() {
+                if let Some(range) = &self.weights.layer_range {
+                    if !range.contains(&layer_idx) {
+                        if let Some(client) = crate::distributed::DISTRIBUTED_CLIENT.get() {
+                            let worker_response = client.forward_to_worker(
+                                &hidden,
+                                false,
+                                1,
+                                self.kv_cache.position,
+                            )?;
+                            hidden = worker_response;
+                            break;
+                        } else {
+                            continue;
+                        }
                     }
                 }
-            }
-            trace_forward_memory(&format!("layer_{layer_idx}_start"));
-            let timed = forward_layer_timed(
-                &hidden,
-                layer,
-                ForwardLayerParams {
-                    config: &self.config,
-                    rope_freqs: self.weights.rope_freqs.as_ref(),
-                    rms_norm_epsilon,
-                    layer_idx,
-                    collect_diagnostics,
-                    runtime_plan: &runtime_plan,
-                },
-                &mut self.kv_cache,
-            )?;
-            hidden = timed.output;
-            trace_forward_memory(&format!("layer_{layer_idx}_done"));
-            if let (Some(memory), Some(layer_memory)) = (&mut memory, &timed.timings.memory) {
-                memory.record_layer(layer_memory.clone());
-            }
-            timings.layers.push(timed.timings);
-            if let (Some(layer_diagnostics), Some(diagnostics)) =
-                (&mut layer_diagnostics, timed.diagnostics)
-            {
-                layer_diagnostics.push(diagnostics);
+                trace_forward_memory(&format!("layer_{layer_idx}_start"));
+                let timed = forward_layer_timed(
+                    &hidden,
+                    layer,
+                    ForwardLayerParams {
+                        config: &self.config,
+                        rope_freqs: self.weights.rope_freqs.as_ref(),
+                        rms_norm_epsilon,
+                        layer_idx,
+                        collect_diagnostics,
+                        runtime_plan: &runtime_plan,
+                    },
+                    &mut self.kv_cache,
+                )?;
+                hidden = timed.output;
+                trace_forward_memory(&format!("layer_{layer_idx}_done"));
+                if let (Some(memory), Some(layer_memory)) = (&mut memory, &timed.timings.memory) {
+                    memory.record_layer(layer_memory.clone());
+                }
+                timings.layers.push(timed.timings);
+                if let (Some(layer_diagnostics), Some(diagnostics)) =
+                    (&mut layer_diagnostics, timed.diagnostics)
+                {
+                    layer_diagnostics.push(diagnostics);
+                }
             }
         }
         timings.layers_total = layers_started.elapsed().as_micros();
@@ -7327,6 +7544,12 @@ fn q8_0_file_reader_block_dot_enabled() -> bool {
 #[allow(dead_code)]
 fn q8_0_metal_enabled() -> bool {
     q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8")
+}
+
+/// Gate for the GPU-resident decode forward (whole token on the Metal GPU, KV cache resident
+/// across tokens). Default off; opt in with `CAMELID_METAL_RESIDENT_DECODE`.
+fn resident_decode_metal_enabled() -> bool {
+    q8_0_env_flag_enabled_default_off("CAMELID_METAL_RESIDENT_DECODE")
 }
 
 #[allow(dead_code)]

--- a/src/inference/rope.rs
+++ b/src/inference/rope.rs
@@ -439,6 +439,73 @@ fn rope_pair_frequency(pair_idx: usize, params: &RopeParams<'_>) -> f32 {
     }
 }
 
+/// RoPE cos/sin tables for a single position, for the GPU resident-decode kernel (which
+/// consumes per-pair cos/sin and applies the rotation itself). Mirrors `apply_rope_to_row`'s
+/// angle math exactly — same `rope_pair_frequency` (incl. llama3 scaling and `rope_freqs`)
+/// and `effective_position` — so the GPU rotation matches the CPU path bit-for-bit given the
+/// same projected K/Q. Returns Ok(None) when the configured RoPE direction is Inverse (the
+/// kernel is forward-only), signalling the caller to fall back to the CPU path.
+pub(super) struct ResidentRopeTables {
+    pub(super) cos: Vec<f32>,
+    pub(super) sin: Vec<f32>,
+    pub(super) split_half_pairing: bool,
+}
+
+pub(super) fn resident_decode_rope_tables(
+    position: usize,
+    head_dim: usize,
+    config: &LlamaModelConfig,
+    rope_freqs: Option<&CpuTensor>,
+) -> Result<Option<ResidentRopeTables>> {
+    let rope_dim = config.rope_dimension_count.unwrap_or(head_dim as u32) as usize;
+    if rope_dim == 0 || rope_dim > head_dim || !rope_dim.is_multiple_of(2) {
+        return Err(BackendError::InvalidModelMetadata(format!(
+            "RoPE dimension count {rope_dim} must be even and within head dimension {head_dim}"
+        )));
+    }
+    let freq_base = config.rope_freq_base.unwrap_or(10_000.0);
+    if freq_base <= 0.0 || !freq_base.is_finite() {
+        return Err(BackendError::InvalidModelMetadata(format!(
+            "RoPE frequency base {freq_base} must be finite and positive"
+        )));
+    }
+    if diagnostic_rope_direction()? != RopeDirection::Forward {
+        return Ok(None);
+    }
+    let pairing = diagnostic_rope_pairing()?;
+    let position_mode = diagnostic_rope_position_mode()?;
+    let scaling = rope_scaling_from_config(config)?;
+    let rope_freqs = rope_freqs
+        .map(|freqs| validate_rope_frequency_tensor(freqs, rope_dim))
+        .transpose()?;
+    let params = RopeParams {
+        position,
+        head_count: 1,
+        head_dim,
+        rope_dim,
+        freq_base,
+        pairing,
+        direction: RopeDirection::Forward,
+        position_mode,
+        scaling,
+        rope_freqs,
+    };
+    let half = rope_dim / 2;
+    let eff = position_mode.effective_position(position) as f32;
+    let mut cos = Vec::with_capacity(half);
+    let mut sin = Vec::with_capacity(half);
+    for pair in 0..half {
+        let (s, c) = (eff * rope_pair_frequency(pair, &params)).sin_cos();
+        cos.push(c);
+        sin.push(s);
+    }
+    Ok(Some(ResidentRopeTables {
+        cos,
+        sin,
+        split_half_pairing: matches!(pairing, RopePairing::SplitHalf),
+    }))
+}
+
 fn llama3_scaled_rope_frequency(frequency: f32, scaling: RopeScaling) -> f32 {
     let original_context_length = scaling
         .original_context_length

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -3135,6 +3135,9 @@ pub struct ResidentDecodeState {
     buf_a: Buffer,
     buf_b: Buffer,
     mid: Buffer,
+    /// Number of KV positions currently materialized in the cache (seeded history + appended
+    /// tokens). The caller uses this to detect a new sequence and reseed.
+    filled: usize,
 }
 
 #[cfg(target_os = "macos")]
@@ -3192,7 +3195,18 @@ impl ResidentDecodeState {
             buf_a: nb(hidden),
             buf_b: nb(hidden),
             mid: nb(hidden),
+            filled: 0,
         })
+    }
+
+    /// Positions currently materialized in the KV cache (seeded + appended).
+    pub fn filled(&self) -> usize {
+        self.filled
+    }
+
+    /// Mark `n` positions as materialized (called after seeding history from a CPU cache).
+    pub fn set_filled(&mut self, n: usize) {
+        self.filled = n;
     }
 
     /// Decode one token at sequence position `position` (0-based): append this token's K/V to
@@ -3313,7 +3327,68 @@ impl ResidentDecodeState {
         let final_buf = if from_a { &self.buf_a } else { &self.buf_b };
         let mut out = vec![0.0f32; self.hidden];
         read_buffer_f32(final_buf, &mut out);
+        self.filled = position + 1;
         Some(out)
+    }
+
+    /// Seed `seed_positions` history slots of layer `layer` from contiguous
+    /// `[kv_head][seed_positions][head_dim]` (already-roped) K and (raw) V — e.g. the prompt's
+    /// K/V copied out of a CPU KV cache after a batched prefill, so resident decode can take
+    /// over with the history already on the GPU. Returns false on dimension mismatch.
+    pub fn seed_layer(
+        &mut self,
+        layer: usize,
+        keys: &[f32],
+        values: &[f32],
+        seed_positions: usize,
+    ) -> bool {
+        if layer >= self.n_layers
+            || seed_positions > self.max_positions
+            || keys.len() != self.n_kv_heads * seed_positions * self.head_dim
+            || values.len() != keys.len()
+        {
+            return false;
+        }
+        Self::seed_into(
+            &self.cache_k[layer],
+            keys,
+            self.n_kv_heads,
+            self.max_positions,
+            self.head_dim,
+            seed_positions,
+        );
+        Self::seed_into(
+            &self.cache_v[layer],
+            values,
+            self.n_kv_heads,
+            self.max_positions,
+            self.head_dim,
+            seed_positions,
+        );
+        true
+    }
+
+    /// Scatter contiguous `[kv_head][seed_positions][head_dim]` source data into a persistent
+    /// `[kv_head][max_positions][head_dim]` cache buffer (the per-head position stride differs).
+    fn seed_into(
+        buf: &Buffer,
+        src: &[f32],
+        n_kv_heads: usize,
+        max_positions: usize,
+        head_dim: usize,
+        seed_positions: usize,
+    ) {
+        let run = seed_positions * head_dim;
+        // SAFETY: shared-storage buffer of n_kv_heads*max_positions*head_dim f32; each head's
+        // `run` floats land at a disjoint slot well within that capacity.
+        unsafe {
+            let dst = buf.contents() as *mut f32;
+            for h in 0..n_kv_heads {
+                let s = h * seed_positions * head_dim;
+                let d = h * max_positions * head_dim;
+                std::ptr::copy_nonoverlapping(src[s..s + run].as_ptr(), dst.add(d), run);
+            }
+        }
     }
 
     /// Read back layer `layer`'s first `position_count` cached K positions as a contiguous
@@ -3377,6 +3452,22 @@ impl ResidentDecodeState {
     ) -> Option<Vec<f32>> {
         None
     }
+
+    pub fn seed_layer(
+        &mut self,
+        _layer: usize,
+        _keys: &[f32],
+        _values: &[f32],
+        _seed_positions: usize,
+    ) -> bool {
+        false
+    }
+
+    pub fn filled(&self) -> usize {
+        0
+    }
+
+    pub fn set_filled(&mut self, _n: usize) {}
 }
 
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## Integration step 7b — wire GPU-resident decode behind a flag (parity-validated)

Final wiring of the GPU-resident decode effort (`docs/runtime/gpu-resident-decode-plan.md`), after the metal foundation in #200–#204. Routes the per-token decode forward through `ResidentDecodeState` when `CAMELID_METAL_RESIDENT_DECODE=1` and the model is eligible; otherwise the **unchanged** CPU layer loop runs. **Flag defaults OFF.**

### What
- `resident_decode_metal_enabled()` flag.
- `rope::resident_decode_rope_tables()` — per-position cos/sin tables, reusing the existing `rope_pair_frequency`/`effective_position` so it matches the CPU RoPE exactly (incl. **llama3 scaling** + `rope_freqs`); returns None for Inverse direction → CPU fallback.
- `resident_decode_eligible()` — flag on, dense (no MoE), not distributed-sharded, default GQA(Grouped)/scale(HeadDim)/gate-up(GateUp), every layer plain Q8_0, kernel dim constraints met.
- `try_resident_decode_forward()` — builds the session lazily, **seeds its GPU KV cache from the CPU cache** after the batched prefill, runs `forward_token` per token; existing final-norm + output projection reused unchanged.
- `ResidentDecodeState` gains `seed_layer()`/`filled()`/`set_filled()`. `LlamaInferenceSession` holds the session as a transient cache (manual `Clone`/`PartialEq`/`Debug` skip it).

### Correctness — validated on `Llama-3.2-3B-Instruct-Q8_0`
Greedy decode flag-off vs flag-on is **byte-for-byte identical**:
```
CPU : [12366, 13, 578, 6864, 315, 15704, 374, 22463, 13, 578, 6864, 315, 18157, 374, 25048, 13, ...]
GPU : [12366, 13, 578, 6864, 315, 15704, 374, 22463, 13, 578, 6864, 315, 18157, 374, 25048, 13, ...]
```
This confirms the wiring, RoPE tables, KV seeding, and GQA mapping end-to-end. The f32(GPU)-vs-f16(CPU) KV difference did not flip any tokens. (CI can't run a 3B model, so this is validated locally; the metal session itself has bit-exact CI parity tests from #204.)

### ⚠️ Performance — not yet a win
The resident path is currently **~0.1 tok/s vs ~7 tok/s** (CPU) on an M4, because the Metal kernels are the **parity-first, untuned** versions (scalar Q8 matmul via `q8_0_block_pipeline`, one-thread-per-head attention) — exactly the "revisit after parity for throughput" item the plan deferred. **This PR is a correctness foundation only**; default-off means zero impact.

### Next milestone — throughput tuning
- Use the SIMD-group Q8 GEMV (`q8_0_block_simd_pipeline`) in the resident matmul path.
- Tune RMSNorm/attention threadgroup sizing for occupancy.
- Re-measure `bench-generate` decode tok/s vs CPU.

### Gates (M4)
`cargo fmt --check` clean · `clippy --all-targets --all-features` zero warnings · 334/334 lib tests pass · public-scrub exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)