### PR TITLE
perf(metal): SIMD matmul + on-demand KV growth in resident decode (2.2x at short context)

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1380,11 +1380,13 @@ impl LlamaInferenceSession {
         let hidden = dims.embedding_length;
         let ffn_dim = dims.feed_forward_length;
         let n_layers = dims.block_count;
-        let max_positions = self.config.context_length as usize;
+        // The on-GPU KV cache grows on demand up to `kv_cap` (the model context length); sizing
+        // it to the full (often 128K) context up front would allocate tens of GB and thrash
+        // unified memory. Start sized to the current need plus a chunk and let the session grow.
+        let kv_cap = self.config.context_length as usize;
         let position = self.kv_cache.position;
-        if position >= max_positions
-            || embedding.data.len() != hidden
-            || weights.layers.len() != n_layers
+        let initial_positions = ((position + 1).max(512)).next_multiple_of(512).min(kv_cap);
+        if position >= kv_cap || embedding.data.len() != hidden || weights.layers.len() != n_layers
         {
             return Ok(None);
         }
@@ -1415,7 +1417,8 @@ impl LlamaInferenceSession {
                 head_dim,
                 hidden,
                 ffn_dim,
-                max_positions,
+                initial_positions,
+                kv_cap,
                 rms_eps,
                 tables.split_half_pairing,
             ) {

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -2122,14 +2122,28 @@ fn encode_q8_matmul(
     rows: usize,
 ) {
     let e = cb.new_compute_command_encoder();
-    e.set_compute_pipeline_state(&k.q8_0_block_pipeline);
+    // Use the SIMD-group GEMV (one threadgroup per output row, a 32-lane simd_sum reduction)
+    // rather than the scalar one-thread-per-row kernel: same bindings, far higher memory
+    // throughput, which dominates resident decode (one matmul per projection per layer).
+    e.set_compute_pipeline_state(&k.q8_0_block_simd_pipeline);
     e.set_buffer(0, Some(scales), 0);
     e.set_buffer(1, Some(quants), 0);
     e.set_buffer(2, Some(weight), 0);
     e.set_buffer(3, Some(out), 0);
     e.set_buffer(4, Some(scalar), 0);
     e.set_buffer(5, Some(scalar), 4);
-    dispatch_1d(e, &k.q8_0_block_pipeline, rows);
+    e.dispatch_thread_groups(
+        metal::MTLSize {
+            width: rows as u64,
+            height: 1,
+            depth: 1,
+        },
+        metal::MTLSize {
+            width: 32,
+            height: 1,
+            depth: 1,
+        },
+    );
     e.end_encoding();
 }
 
@@ -3127,7 +3141,10 @@ pub struct ResidentDecodeState {
     head_dim: usize,
     hidden: usize,
     ffn_dim: usize,
+    /// Positions the KV cache is currently allocated for; grown on demand toward `cap`.
     max_positions: usize,
+    /// Hard ceiling on `max_positions` (the model context length): growth never exceeds it.
+    cap: usize,
     eps: f32,
     split_half_pairing: bool,
     cache_k: Vec<Buffer>,
@@ -3142,8 +3159,9 @@ pub struct ResidentDecodeState {
 
 #[cfg(target_os = "macos")]
 impl ResidentDecodeState {
-    /// Allocate the session. `max_positions` is the context length the KV cache is sized for.
-    /// Returns None if Metal is unavailable or the dimensions are invalid.
+    /// Allocate the session. `max_positions` is the initial KV-cache capacity (grown on demand
+    /// up to `cap`, the model context length). Returns None if Metal is unavailable or the
+    /// dimensions are invalid.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         n_layers: usize,
@@ -3153,6 +3171,7 @@ impl ResidentDecodeState {
         hidden: usize,
         ffn_dim: usize,
         max_positions: usize,
+        cap: usize,
         eps: f32,
         split_half_pairing: bool,
     ) -> Option<Self> {
@@ -3169,6 +3188,7 @@ impl ResidentDecodeState {
             || ffn_dim == 0
             || !ffn_dim.is_multiple_of(32)
             || max_positions == 0
+            || cap < max_positions
         {
             return None;
         }
@@ -3188,6 +3208,7 @@ impl ResidentDecodeState {
             hidden,
             ffn_dim,
             max_positions,
+            cap,
             eps,
             split_half_pairing,
             cache_k,
@@ -3197,6 +3218,57 @@ impl ResidentDecodeState {
             mid: nb(hidden),
             filled: 0,
         })
+    }
+
+    /// Grow the KV cache to at least `needed` positions (capped at `self.cap`) by allocating
+    /// larger per-layer buffers and blitting the `filled` materialized slots across (the
+    /// per-head position stride changes with `max_positions`). GPU-to-GPU, no CPU readback.
+    /// Returns false if `needed` exceeds the cap or Metal is unavailable.
+    fn ensure_capacity(&mut self, needed: usize) -> bool {
+        if needed <= self.max_positions {
+            return true;
+        }
+        if needed > self.cap {
+            return false;
+        }
+        let new_max = (self.max_positions * 2).max(needed).min(self.cap);
+        let k = match metal_linear_kernel() {
+            Some(k) => k,
+            None => return false,
+        };
+        let kv_slots = self.n_kv_heads * new_max * self.head_dim;
+        let new_k: Vec<Buffer> = (0..self.n_layers)
+            .map(|_| {
+                k.device
+                    .new_buffer((kv_slots * 4) as u64, MTLResourceOptions::StorageModeShared)
+            })
+            .collect();
+        let new_v: Vec<Buffer> = (0..self.n_layers)
+            .map(|_| {
+                k.device
+                    .new_buffer((kv_slots * 4) as u64, MTLResourceOptions::StorageModeShared)
+            })
+            .collect();
+        if self.filled > 0 {
+            let run = (self.filled * self.head_dim * 4) as u64;
+            let cb = k.queue.new_command_buffer();
+            let blit = cb.new_blit_command_encoder();
+            for layer in 0..self.n_layers {
+                for h in 0..self.n_kv_heads {
+                    let src = (h * self.max_positions * self.head_dim * 4) as u64;
+                    let dst = (h * new_max * self.head_dim * 4) as u64;
+                    blit.copy_from_buffer(&self.cache_k[layer], src, &new_k[layer], dst, run);
+                    blit.copy_from_buffer(&self.cache_v[layer], src, &new_v[layer], dst, run);
+                }
+            }
+            blit.end_encoding();
+            cb.commit();
+            cb.wait_until_completed();
+        }
+        self.cache_k = new_k;
+        self.cache_v = new_v;
+        self.max_positions = new_max;
+        true
     }
 
     /// Positions currently materialized in the KV cache (seeded + appended).
@@ -3225,9 +3297,12 @@ impl ResidentDecodeState {
         scale: f32,
     ) -> Option<Vec<f32>> {
         let half_rope = cos_t.len();
+        // Grow the on-GPU KV cache if this token's position is past the current capacity.
+        if !self.ensure_capacity(position + 1) {
+            return None;
+        }
         if embedding.len() != self.hidden
             || layers.len() != self.n_layers
-            || position >= self.max_positions
             || sin_t.len() != half_rope
             || half_rope * 2 > self.head_dim
         {
@@ -3434,6 +3509,7 @@ impl ResidentDecodeState {
         _hidden: usize,
         _ffn_dim: usize,
         _max_positions: usize,
+        _cap: usize,
         _eps: f32,
         _split_half_pairing: bool,
     ) -> Option<Self> {
@@ -4498,6 +4574,9 @@ mod tests {
             head_dim,
             hidden,
             ffn,
+            // Tiny initial capacity with a larger cap so the multi-token loop exercises the
+            // on-demand growth (GPU->GPU blit of materialized slots) as well as appends.
+            2,
             max_positions,
             eps,
             false,


### PR DESCRIPTION
## Throughput tuning — resident decode is now 2.2× faster than CPU at typical context

Follows #205 (the resident decode wiring, which was correct but ~0.1 tok/s). Two changes make it fast while keeping exact greedy parity and correctness at any length.

### What
1. **SIMD-group matmul in the resident path** — `encode_q8_matmul` now uses `q8_0_block_simd_pipeline` (one threadgroup/row + 32-lane `simd_sum`) instead of the scalar one-thread-per-row kernel. Same bindings; the SIMD kernel already has CI parity coverage.
2. **On-demand KV growth (the actual unblock)** — the resident KV cache was sized to the **full model context** up front: 28 layers × 8 kv-heads × 131072 × 128 × 4B × 2 ≈ **29 GB**, which thrashed unified memory (~0.1 tok/s). `ResidentDecodeState` now starts small (inference sizes it to prompt + a 512 chunk) and **grows on demand** toward the context-length cap via a GPU→GPU blit of the materialized slots (`ensure_capacity`), mirroring the CPU cache's growth. `new()` gains a `cap` argument.

### Measured (Llama-3.2-3B-Instruct-Q8_0, M4, greedy, parity-identical to CPU)
| run | resident | CPU |
|---|---|---|
| 32-token decode | **15.4 tok/s** | 7.1 tok/s |
| 600-token decode | 4.8 tok/s (grows past initial capacity, completes correctly) | ~7 |

So: **2.2× at typical chat lengths**, and correct at any length (growth verified).

### Known follow-up (next tuning target)
The attention decode kernel is still **one-thread-per-head**, so its cost scales with context length and the resident path falls behind CPU at long contexts (~4.8 tok/s @ 600 tokens). Parallelizing attention over positions/heads is the next step.

### Tests / gates
- `metal_resident_decode_state_matches_full_upload` now starts at a tiny capacity so the multi-token loop exercises **growth** as well as appends (bit-exact vs full-upload).
- `cargo fmt --check` clean · `clippy` zero warnings · 334/334 lib tests pass · public-scrub exit 0.
- Flag remains **default-off**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)