### PR TITLE
perf(metal): GPU final norm + logits projection in resident decode (22 tok/s)

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1263,6 +1263,14 @@ pub struct LlamaGenerationStep {
     pub diagnostics: Option<LlamaForwardDiagnostics>,
 }
 
+/// Result of a GPU-resident decode step: either the post-layers hidden state (when logits
+/// weren't requested) or the `[1, vocab]` logits (when the final norm + output projection ran
+/// on the GPU too).
+enum ResidentForward {
+    Hidden(CpuTensor),
+    Logits(CpuTensor),
+}
+
 pub struct LlamaInferenceSession {
     pub config: LlamaModelConfig,
     pub weights: Arc<LlamaLoadedWeights>,
@@ -1350,7 +1358,24 @@ impl LlamaInferenceSession {
                 return Ok(false);
             }
         }
+        // The final stage (RMSNorm + output projection) also runs on the GPU, so the output
+        // weight must be plain Q8_0 and a real output_norm must be present.
+        if !is_q8(self.weights.output_projection()) {
+            return Ok(false);
+        }
         let dims = DenseLlamaDims::from_config(&self.config)?;
+        if self
+            .weights
+            .output_norm
+            .shape
+            .dims
+            .first()
+            .copied()
+            .unwrap_or(0)
+            != dims.embedding_length
+        {
+            return Ok(false);
+        }
         let n_heads = self.config.attention_head_count as usize;
         let q_dim = n_heads * dims.head_dim;
         Ok(dims.embedding_length != 0
@@ -1368,7 +1393,11 @@ impl LlamaInferenceSession {
     /// Run the whole token forward on the GPU resident-decode session. Returns Some(hidden) on
     /// success (the caller applies the existing final norm + output projection), or None to fall
     /// back to the CPU layer loop (ineligible config, unsupported RoPE, or Metal unavailable).
-    fn try_resident_decode_forward(&mut self, embedding: &CpuTensor) -> Result<Option<CpuTensor>> {
+    fn try_resident_decode_forward(
+        &mut self,
+        embedding: &CpuTensor,
+        compute_logits: bool,
+    ) -> Result<Option<ResidentForward>> {
         if !self.resident_decode_eligible()? {
             return Ok(None);
         }
@@ -1380,6 +1409,7 @@ impl LlamaInferenceSession {
         let hidden = dims.embedding_length;
         let ffn_dim = dims.feed_forward_length;
         let n_layers = dims.block_count;
+        let vocab = dims.vocab_size;
         // The on-GPU KV cache grows on demand up to `kv_cap` (the model context length); sizing
         // it to the full (often 128K) context up front would allocate tens of GB and thrash
         // unified memory. Start sized to the current need plus a chunk and let the session grow.
@@ -1467,6 +1497,20 @@ impl LlamaInferenceSession {
             })
             .collect();
 
+        // When logits are wanted, run the final RMSNorm + output projection on the GPU too
+        // (in the same command buffer) so the large vocab matmul stays off the CPU.
+        let logits_stage = if compute_logits {
+            Some(metal::LogitsStage {
+                final_norm: &weights.output_norm.data,
+                output_weight_blocks: q8_0_blocks_as_bytes(
+                    weights.output_projection().q8_0_blocks.as_ref().unwrap(),
+                ),
+                vocab_size: vocab,
+            })
+        } else {
+            None
+        };
+
         let session = self
             .resident_decode
             .as_mut()
@@ -1478,15 +1522,24 @@ impl LlamaInferenceSession {
             &tables.sin,
             position,
             scale,
+            logits_stage,
         ) {
             Some(o) => o,
             None => return Ok(None),
         };
-        Ok(Some(CpuTensor::from_f32(
-            "resident_hidden",
-            vec![1, hidden],
-            out,
-        )?))
+        if compute_logits {
+            Ok(Some(ResidentForward::Logits(CpuTensor::from_f32(
+                "resident_logits",
+                vec![1, vocab],
+                out,
+            )?)))
+        } else {
+            Ok(Some(ResidentForward::Hidden(CpuTensor::from_f32(
+                "resident_hidden",
+                vec![1, hidden],
+                out,
+            )?)))
+        }
     }
 
     pub fn forward_worker_layers(
@@ -2010,13 +2063,19 @@ impl LlamaInferenceSession {
         // GPU-resident decode: run all layers on the Metal GPU in one command buffer with the
         // KV cache resident across tokens. Only when not collecting diagnostics; falls back to
         // the CPU layer loop below when ineligible (returns None).
-        let resident_hidden = if collect_diagnostics {
+        let resident_out = if collect_diagnostics {
             None
         } else {
-            self.try_resident_decode_forward(&hidden)?
+            self.try_resident_decode_forward(&hidden, compute_logits)?
         };
-        if let Some(resident) = resident_hidden {
-            hidden = resident;
+        // When the resident path also produced logits on the GPU, carry them here and skip the
+        // CPU final norm + output projection below.
+        let mut resident_logits: Option<CpuTensor> = None;
+        if let Some(resident) = resident_out {
+            match resident {
+                ResidentForward::Logits(l) => resident_logits = Some(l),
+                ResidentForward::Hidden(h) => hidden = h,
+            }
         } else {
             for (layer_idx, layer) in self.weights.layers.iter().enumerate() {
                 if let Some(range) = &self.weights.layer_range {
@@ -2070,7 +2129,11 @@ impl LlamaInferenceSession {
             .then(|| LlamaTensorStats::from_tensor(&hidden))
             .transpose()?;
         let (norm, logits, final_norm_diagnostic, output_norm_stats, logits_stats) =
-            if compute_logits {
+            if let Some(resident_logits) = resident_logits {
+                // Logits already computed on the GPU; reuse the embedding tensor as the (unused,
+                // diagnostics-only) norm placeholder and skip the CPU final stage entirely.
+                (resident_logits.clone(), resident_logits, None, None, None)
+            } else if compute_logits {
                 let final_norm_started = Instant::now();
                 let norm = if self.weights.output_norm.shape.dims[0] == 0 {
                     hidden.clone()

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -3149,6 +3149,16 @@ pub struct ResidentLayerWeights<'a> {
     pub down_weight_blocks: &'a [u8],
 }
 
+/// Optional final stage for `forward_token`: when present, the session also runs the final
+/// RMSNorm + output (vocab) projection on the GPU in the same command buffer and returns the
+/// `[vocab_size]` logits instead of the hidden state — keeping the large output matmul off the
+/// CPU. `output_weight_blocks` is the Q8_0 output/embedding projection.
+pub struct LogitsStage<'a> {
+    pub final_norm: &'a [f32],
+    pub output_weight_blocks: &'a [u8],
+    pub vocab_size: usize,
+}
+
 /// A resident decode session that owns the on-GPU KV cache (per layer, sized to
 /// `max_positions`) and the reused hidden ping-pong buffers. A multi-token greedy decode runs
 /// each token in ONE command buffer with the KV cache persisting on the GPU across tokens --
@@ -3317,6 +3327,7 @@ impl ResidentDecodeState {
         sin_t: &[f32],
         position: usize,
         scale: f32,
+        logits_stage: Option<LogitsStage>,
     ) -> Option<Vec<f32>> {
         let half_rope = cos_t.len();
         // Grow the on-GPU KV cache if this token's position is past the current capacity.
@@ -3349,10 +3360,22 @@ impl ResidentDecodeState {
                 return None;
             }
         }
+        if let Some(s) = &logits_stage {
+            if s.vocab_size == 0
+                || s.final_norm.len() != self.hidden
+                || s.output_weight_blocks.len() != s.vocab_size * bpr_hidden * 36
+            {
+                return None;
+            }
+        }
         let k = metal_linear_kernel()?;
-        let resident: Vec<[Buffer; 7]> = {
+        // Resolve all resident weight buffers (layer weights + optional output stage) under one
+        // cache lock. They are keyed by (pointer, len), so they upload once and persist.
+        let resident: Vec<[Buffer; 7]>;
+        let stage_bufs: Option<(Buffer, Buffer)>;
+        {
             let mut cache = metal_linear_cache().lock().ok()?;
-            layers
+            resident = layers
                 .iter()
                 .map(|l| {
                     [
@@ -3365,11 +3388,19 @@ impl ResidentDecodeState {
                         cache.q8_block_weight_buffer(&k.device, l.down_weight_blocks),
                     ]
                 })
-                .collect()
-        };
+                .collect();
+            stage_bufs = logits_stage.as_ref().map(|s| {
+                (
+                    cache.q8_block_weight_buffer(&k.device, s.output_weight_blocks),
+                    cache.weight_buffer(&k.device, s.final_norm),
+                )
+            });
+        }
         let position_count = position + 1;
         write_buffer_f32(&self.buf_a, embedding);
         let mut keep = Vec::new();
+        let trace = std::env::var_os("CAMELID_RESIDENT_TRACE").is_some();
+        let encode_started = std::time::Instant::now();
         let cb = k.queue.new_command_buffer();
         let mut from_a = true;
         for (i, layer) in layers.iter().enumerate() {
@@ -3419,12 +3450,67 @@ impl ResidentDecodeState {
             );
             from_a = !from_a;
         }
+        let final_buf = if from_a { &self.buf_a } else { &self.buf_b };
+        // Optional final stage: RMSNorm + output (vocab) projection in the SAME command buffer,
+        // so the large logits matmul runs on the GPU instead of falling to the slow CPU path.
+        let logits_buf = if let (Some(s), Some((ow_buf, fnorm_buf))) = (&logits_stage, &stage_bufs)
+        {
+            let nb = |bytes: u64| {
+                k.device
+                    .new_buffer(bytes, MTLResourceOptions::StorageModeShared)
+            };
+            let rms_scalar = nb(8);
+            let lscales = nb((bpr_hidden * 4) as u64);
+            let lquants = nb(self.hidden as u64);
+            let lnblocks = nb(4);
+            let lmm_scalar = nb(8);
+            let logits_buf = nb((s.vocab_size * 4) as u64);
+            unsafe {
+                let p = rms_scalar.contents() as *mut u8;
+                *(p as *mut u32) = self.hidden as u32;
+                *(p.add(4) as *mut f32) = self.eps;
+                *(lnblocks.contents() as *mut u32) = bpr_hidden as u32;
+                let m = lmm_scalar.contents() as *mut u32;
+                *m = bpr_hidden as u32;
+                *m.add(1) = s.vocab_size as u32;
+            }
+            encode_rms_norm(cb, k, final_buf, fnorm_buf, &self.mid, &rms_scalar);
+            encode_quantize(cb, k, &self.mid, &lscales, &lquants, &lnblocks, bpr_hidden);
+            encode_q8_matmul(
+                cb,
+                k,
+                &lscales,
+                &lquants,
+                ow_buf,
+                &logits_buf,
+                &lmm_scalar,
+                s.vocab_size,
+            );
+            keep.extend([rms_scalar, lscales, lquants, lnblocks, lmm_scalar]);
+            Some(logits_buf)
+        } else {
+            None
+        };
+        let encode_us = encode_started.elapsed().as_micros();
+        let gpu_started = std::time::Instant::now();
         cb.commit();
         cb.wait_until_completed();
-        let final_buf = if from_a { &self.buf_a } else { &self.buf_b };
+        if trace {
+            let gpu_us = gpu_started.elapsed().as_micros();
+            eprintln!(
+                "[resident] pos={position} layers={} encode={encode_us}us commit_wait={gpu_us}us",
+                self.n_layers
+            );
+        }
+        self.filled = position + 1;
+        if let Some(logits_buf) = logits_buf {
+            let vocab = logits_stage.as_ref().map(|s| s.vocab_size).unwrap_or(0);
+            let mut out = vec![0.0f32; vocab];
+            read_buffer_f32(&logits_buf, &mut out);
+            return Some(out);
+        }
         let mut out = vec![0.0f32; self.hidden];
         read_buffer_f32(final_buf, &mut out);
-        self.filled = position + 1;
         Some(out)
     }
 
@@ -3547,6 +3633,7 @@ impl ResidentDecodeState {
         _sin_t: &[f32],
         _position: usize,
         _scale: f32,
+        _logits_stage: Option<LogitsStage>,
     ) -> Option<Vec<f32>> {
         None
     }
@@ -4670,7 +4757,7 @@ mod tests {
             .unwrap();
 
             let got = session
-                .forward_token(&emb, &weights, &cos_t, &sin_t, t, scale)
+                .forward_token(&emb, &weights, &cos_t, &sin_t, t, scale, None)
                 .unwrap();
             assert_eq!(got.len(), hidden);
             for (a, b) in got.iter().zip(&expected) {


### PR DESCRIPTION
## Run the final RMSNorm + logits projection on the GPU (resident decode 18.9 → 22.0 tok/s)

Part of the push to close the gap to MLX. Profiling the resident decode (new `CAMELID_RESIDENT_TRACE`) showed the GPU layer forward was already ~88 GB/s, but **~15 ms/token was on the CPU** — dominated by the final output projection: for Llama-3.2-3B the tied projection is a 128256×3072 Q8 matmul (~443 MB), and this build's CPU path (~25 GB/s) made it the largest non-layer cost.

### What
- `ResidentDecodeState::forward_token` gains an optional `LogitsStage`: it encodes `rms_norm → quantize → output matmul` into the **same command buffer** (output weight + final-norm resolved through `MetalLinearCache`, resident across tokens) and returns the `[vocab]` logits.
- `try_resident_decode_forward` builds the stage when logits are wanted (returns `ResidentForward::Logits`); `forward_single_token_timed_internal` then **skips the CPU final norm + projection**. Eligibility now also requires a Q8_0 output projection + real `output_norm`.

### Measured (Llama-3.2-3B-Q8, M4, greedy, byte-for-byte parity vs CPU)
**18.9 → 22.0 tok/s** (vs ~7 CPU). The whole per-token forward — all layers + final norm + logits — now runs on the GPU in one command buffer (~42 ms commit/wait, ~2–4 ms CPU encode).

### Also
- Adds `CAMELID_RESIDENT_TRACE` (per-token encode vs commit/wait timing).
- Tried char4-vectorised Q8 loads in the matmul kernel — no end-to-end change (already bandwidth-bound) — so not included.

### Honest status vs MLX
Still **22.0 vs MLX 28.9**. The remaining cost is now entirely the GPU matmul bandwidth (~86–99 GB/s); MLX needs ~104 GB/s. Closing it requires a faster Q8 matmul kernel than this design reaches (e.g. fp16 + `simdgroup_matrix`, or a redesigned Q8 layout) — a larger, separate effort.

### Gates
`cargo fmt --check` clean · `clippy` zero warnings · 334/334 lib tests pass · public-scrub exit 0. Flag default-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)