### PR TITLE
feat(distributed): GPU-resident decode on pipeline nodes + hard Q8_0 residency gate

### DIFF
--- a/docs/benchmarks/camelid-distributed.md
+++ b/docs/benchmarks/camelid-distributed.md
@@ -141,3 +141,40 @@ MAX_TOKENS=64 bash tools/bench/distributed/two-mac-run.sh
 - Real two-Mac TB4 run: **done** — Llama-2-13B Q8 runs across two 16 GB minis (7.2 GB/node)
   that a single mini cannot load. Decode 1.48 tok/s (serial pipeline; throughput optimization
   is the next lever).
+
+## P2: GPU-resident pipeline decode (2026-06-03)
+
+Each node now holds its Q8_0 shard as plain RAM-resident blocks (enforced by a hard startup
+gate — a node refuses to run if any owned Q8_0 linear would stream from disk) and executes
+its layer range on the GPU in one command buffer per token, KV cache resident across tokens
+(`CAMELID_METAL_RESIDENT_DECODE=1` on both nodes).
+
+Steady-state per token, Llama-2-13B Q8 split 0..20 / 20..40 across two M4 16 GB minis over
+the Thunderbolt bridge (`CAMELID_DISTRIBUTED_TRACE=1` per-token traces):
+
+| stage | time |
+|---|---|
+| master GPU forward (20 layers, 6.82 GiB resident) | ~89 ms |
+| activation hop (TB) | ~0.1 ms |
+| worker GPU forward (20 layers) | ~85 ms |
+| worker final norm + logits (CPU) | ~22 ms |
+| feedback hop | ~1 ms |
+| **total** | **~197 ms ≈ 5.1 tok/s** |
+
+**5.1 tok/s steady-state vs 1.48 tok/s CPU pipeline = 3.4x**, with each node's forward at
+the per-node bandwidth expectation (~6.8 GiB / ~80 GB/s ≈ 85 ms). Loopback 3B parity:
+sharded resident output is byte-identical to the single-node resident stream (greedy).
+
+Known costs / next levers:
+
+- **First decode token pays a one-time per-node Metal buffer upload** of the full shard
+  (~6.8 GB copied CPU→GPU buffers). On a 16 GB node this doubles weight memory transiently
+  and the upload can page-thrash (24 s on an idle node; minutes on a loaded one), which
+  dominates short-run averages (a 63-token run reports 0.40 tok/s overall). Fix: no-copy
+  (page-aligned `newBufferWithBytesNoCopy`) weight buffers — removes both the copy and the
+  doubling.
+- Worker's final norm + logits projection still runs on the CPU (~22 ms/token for the 13B
+  output matrix); moving it into the worker's resident command buffer (as single-node decode
+  already does) saves most of it.
+- `REPACK=0` (default in `two-mac-run.sh`) is required: the resident path needs plain Q8_0
+  blocks, and the residency gate fails loudly on repacked storage.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -189,9 +189,71 @@ pub struct LlamaLoadedWeights {
     pub layer_range: Option<std::ops::Range<usize>>,
 }
 
+/// Result of [`LlamaLoadedWeights::q8_0_residency_report`]: how many Q8_0 linears hold plain
+/// RAM-resident blocks (and their total block bytes), plus a per-tensor description of every
+/// Q8_0 linear that does NOT (file-backed streaming or repacked-without-blocks storage).
+#[derive(Debug, Default)]
+pub struct Q8ResidencyReport {
+    pub resident_tensors: usize,
+    pub resident_block_bytes: u64,
+    pub violations: Vec<String>,
+}
+
 impl LlamaLoadedWeights {
     pub fn output_projection(&self) -> &CpuTensor {
         self.output.as_ref().unwrap_or(&self.token_embedding)
+    }
+
+    /// Audit where this node's Q8_0 weights physically live. Every owned dense Q8_0 linear
+    /// must hold plain RAM-resident blocks (`q8_0_blocks`); anything file-backed or
+    /// runtime-repacked-without-blocks is reported as a violation so callers (the
+    /// distributed CLI nodes) can hard-fail instead of silently streaming weights from disk
+    /// per token. Unowned pipeline layers are zero-element placeholders with no
+    /// `source_type` and are skipped naturally. MoE expert tensors are file-backed by
+    /// design and are excluded (the resident decode path rejects MoE models anyway).
+    pub fn q8_0_residency_report(&self) -> Q8ResidencyReport {
+        let mut report = Q8ResidencyReport::default();
+        let mut audit = |tensor: &CpuTensor| {
+            if tensor.source_type != Some(GgufTensorType::Q8_0) {
+                return;
+            }
+            match &tensor.q8_0_blocks {
+                Some(blocks) => {
+                    report.resident_tensors += 1;
+                    report.resident_block_bytes +=
+                        (blocks.len() * mem::size_of::<Q8_0Block>()) as u64;
+                }
+                None => {
+                    let how = if tensor.q8_0_file_backing.is_some()
+                        || tensor.q8_0_split_file_backing.is_some()
+                    {
+                        "file-backed (streams from disk per token; unset CAMELID_LAZY_Q8_0_LINEAR)"
+                    } else if tensor.q8_0_runtime_storage.is_some() {
+                        "runtime-repacked without plain blocks (set CAMELID_MAC_Q8_REPACK=0 \
+                         for the GPU-resident path)"
+                    } else {
+                        "materialized without retained Q8_0 blocks"
+                    };
+                    report.violations.push(format!("{}: {how}", tensor.name));
+                }
+            }
+        };
+        audit(&self.token_embedding);
+        if let Some(output) = &self.output {
+            audit(output);
+        }
+        for layer in &self.layers {
+            audit(&layer.attention_q);
+            audit(&layer.attention_k);
+            audit(&layer.attention_v);
+            audit(&layer.attention_output);
+            if layer.moe_router.is_none() {
+                audit(&layer.ffn_gate);
+                audit(&layer.ffn_up);
+                audit(&layer.ffn_down);
+            }
+        }
+        report
     }
 
     fn has_lazy_q8_0_file_backing(&self) -> bool {
@@ -278,14 +340,24 @@ impl LlamaLoadedWeights {
         load_embedding: bool,
         load_output: bool,
     ) -> Result<Self> {
-        let auto_retain_q8_0_blocks = auto_retain_q8_0_blocks_for_fast_local_chat(binding);
+        // Q8_0 linears are ALWAYS retained as plain RAM-resident blocks. The old policy
+        // estimated a retention budget over the WHOLE binding — even on a pipeline-sharded
+        // node that loads only its layer range — and silently fell back to per-token file
+        // streaming when the estimate crossed a cap: ~100x slower decode, and it disqualified
+        // the GPU-resident path (which requires q8_0_blocks). The only way off the resident
+        // path now is the explicit CAMELID_LAZY_Q8_0_LINEAR opt-out, and it is loud.
+        let force_lazy_q8_0 = lazy_q8_0_linear_forced();
+        if force_lazy_q8_0 {
+            eprintln!(
+                "[camelid] WARNING: CAMELID_LAZY_Q8_0_LINEAR is set; Q8_0 weights will stream \
+                 from disk per token instead of residing in RAM (expect ~100x slower decode)"
+            );
+        }
         let load_linear = |name: &str| {
-            if auto_retain_q8_0_blocks {
-                store.load_q8_0_block_backed_linear(name)
-            } else if lazy_q8_0_linear_enabled() {
+            if force_lazy_q8_0 {
                 store.load_q8_0_file_backed_linear(name)
             } else {
-                store.load_cpu_f32(name)
+                store.load_q8_0_block_backed_linear(name)
             }
         };
         let load_moe_experts = |experts: &LlamaMoeExpertTensors| match experts {
@@ -323,18 +395,16 @@ impl LlamaLoadedWeights {
 
         let output = if load_output {
             if binding.output_is_tied_embedding {
-                if auto_retain_q8_0_blocks {
-                    Some(store.load_q8_0_block_backed_linear_as(
-                        &binding.token_embedding.name,
-                        "output.weight",
-                    )?)
-                } else if lazy_q8_0_linear_enabled() {
+                if force_lazy_q8_0 {
                     Some(store.load_q8_0_file_backed_tensor_as(
                         &binding.token_embedding.name,
                         "output.weight",
                     )?)
                 } else {
-                    None
+                    Some(store.load_q8_0_block_backed_linear_as(
+                        &binding.token_embedding.name,
+                        "output.weight",
+                    )?)
                 }
             } else {
                 Some(load_linear(&binding.output.name)?)
@@ -1330,11 +1400,11 @@ impl LlamaInferenceSession {
     /// (Grouped GQA, 1/sqrt(head_dim) scale, gate*swish(up) order), every layer a plain Q8_0
     /// row-major weight, and dims satisfying the kernel's modulo constraints. Anything else
     /// keeps the unchanged CPU layer loop.
-    fn resident_decode_eligible(&self) -> Result<bool> {
+    fn resident_decode_eligible(&self, want_logits: bool) -> Result<bool> {
         if !resident_decode_metal_enabled() {
             return Ok(false);
         }
-        if self.weights.layer_range.is_some() || self.config.moe.is_some() {
+        if self.config.moe.is_some() {
             return Ok(false);
         }
         if diagnostic_gqa_head_mapping()? != GqaHeadMapping::Grouped
@@ -1345,7 +1415,16 @@ impl LlamaInferenceSession {
         }
         let is_q8 =
             |t: &CpuTensor| t.source_type == Some(GgufTensorType::Q8_0) && t.q8_0_blocks.is_some();
-        for layer in &self.weights.layers {
+        // On a pipeline-sharded node only the owned layer range is materialized.
+        let range = self
+            .weights
+            .layer_range
+            .clone()
+            .unwrap_or(0..self.weights.layers.len());
+        if range.end > self.weights.layers.len() || range.is_empty() {
+            return Ok(false);
+        }
+        for layer in &self.weights.layers[range] {
             if layer.moe_router.is_some()
                 || !is_q8(&layer.attention_q)
                 || !is_q8(&layer.attention_k)
@@ -1358,23 +1437,27 @@ impl LlamaInferenceSession {
                 return Ok(false);
             }
         }
-        // The final stage (RMSNorm + output projection) also runs on the GPU, so the output
-        // weight must be plain Q8_0 and a real output_norm must be present.
-        if !is_q8(self.weights.output_projection()) {
-            return Ok(false);
-        }
         let dims = DenseLlamaDims::from_config(&self.config)?;
-        if self
-            .weights
-            .output_norm
-            .shape
-            .dims
-            .first()
-            .copied()
-            .unwrap_or(0)
-            != dims.embedding_length
-        {
-            return Ok(false);
+        // When the GPU also runs the final stage (RMSNorm + output projection), the output
+        // weight must be plain Q8_0 and a real output_norm present. Sharded nodes that only
+        // produce hidden state (want_logits=false) skip these (a first/middle node does not
+        // even own the output tensors).
+        if want_logits {
+            if !is_q8(self.weights.output_projection()) {
+                return Ok(false);
+            }
+            if self
+                .weights
+                .output_norm
+                .shape
+                .dims
+                .first()
+                .copied()
+                .unwrap_or(0)
+                != dims.embedding_length
+            {
+                return Ok(false);
+            }
         }
         let n_heads = self.config.attention_head_count as usize;
         let q_dim = n_heads * dims.head_dim;
@@ -1398,7 +1481,7 @@ impl LlamaInferenceSession {
         embedding: &CpuTensor,
         compute_logits: bool,
     ) -> Result<Option<ResidentForward>> {
-        if !self.resident_decode_eligible()? {
+        if !self.resident_decode_eligible(compute_logits)? {
             return Ok(None);
         }
         let weights = Arc::clone(&self.weights);
@@ -1408,7 +1491,10 @@ impl LlamaInferenceSession {
         let head_dim = dims.head_dim;
         let hidden = dims.embedding_length;
         let ffn_dim = dims.feed_forward_length;
-        let n_layers = dims.block_count;
+        // Pipeline-sharded nodes run only their owned layer range; the resident session is
+        // built over that subset (relative slots) while KV seeding uses absolute layer ids.
+        let range = weights.layer_range.clone().unwrap_or(0..dims.block_count);
+        let n_layers = range.len();
         let vocab = dims.vocab_size;
         // The on-GPU KV cache grows on demand up to `kv_cap` (the model context length); sizing
         // it to the full (often 128K) context up front would allocate tens of GB and thrash
@@ -1416,7 +1502,10 @@ impl LlamaInferenceSession {
         let kv_cap = self.config.context_length as usize;
         let position = self.kv_cache.position;
         let initial_positions = ((position + 1).max(512)).next_multiple_of(512).min(kv_cap);
-        if position >= kv_cap || embedding.data.len() != hidden || weights.layers.len() != n_layers
+        if position >= kv_cap
+            || embedding.data.len() != hidden
+            || weights.layers.len() != dims.block_count
+            || range.end > weights.layers.len()
         {
             return Ok(None);
         }
@@ -1462,7 +1551,7 @@ impl LlamaInferenceSession {
                     let mut cv = vec![0.0f32; kv_dim * position];
                     for p in 0..position {
                         for h in 0..n_kv {
-                            let src = self.kv_cache.offset(layer, p, h);
+                            let src = self.kv_cache.offset(range.start + layer, p, h);
                             let dst = (h * position + p) * head_dim;
                             ck[dst..dst + head_dim]
                                 .copy_from_slice(&self.kv_cache.keys[src..src + head_dim]);
@@ -1479,8 +1568,7 @@ impl LlamaInferenceSession {
             self.resident_decode = Some(session);
         }
 
-        let layer_views: Vec<metal::ResidentLayerWeights> = weights
-            .layers
+        let layer_views: Vec<metal::ResidentLayerWeights> = weights.layers[range.clone()]
             .iter()
             .map(|l| metal::ResidentLayerWeights {
                 attn_norm: &l.attention_norm.data,
@@ -1680,6 +1768,18 @@ impl LlamaInferenceSession {
                 "activation start position {} does not match KV cache position {}",
                 start_pos, self.kv_cache.position
             )));
+        }
+
+        // Decode steps (one token) route through the GPU-resident session over this node's
+        // layer range (one command buffer per token, weights + KV resident on the GPU);
+        // prefill and ineligible configs take the CPU chunk path below.
+        if seq_len == 1 {
+            if let Some(ResidentForward::Hidden(out)) =
+                self.try_resident_decode_forward(hidden, false)?
+            {
+                self.kv_cache.position += 1;
+                return Ok(out);
+            }
         }
 
         let mut current_hidden = hidden.clone();
@@ -2063,7 +2163,9 @@ impl LlamaInferenceSession {
         // GPU-resident decode: run all layers on the Metal GPU in one command buffer with the
         // KV cache resident across tokens. Only when not collecting diagnostics; falls back to
         // the CPU layer loop below when ineligible (returns None).
-        let resident_out = if collect_diagnostics {
+        let resident_out = if collect_diagnostics || self.weights.layer_range.is_some() {
+            // Sharded nodes use the resident path via forward_layer_range_from_hidden; here it
+            // would swallow the distributed worker dispatch inside the layer loop below.
             None
         } else {
             self.try_resident_decode_forward(&hidden, compute_logits)?
@@ -7677,100 +7779,18 @@ fn q8_0_hybrid_retained_gpu_rows(output_rows: usize) -> usize {
         .min(output_rows.saturating_sub(1))
 }
 
-fn auto_retain_q8_0_blocks_for_fast_local_chat(binding: &LlamaTensorBinding) -> bool {
-    const DEFAULT_FAST_RETAINED_Q8_0_MAX_BYTES: usize = 6 * 1024 * 1024 * 1024;
-
-    if env::var("CAMELID_LAZY_Q8_0_LINEAR").is_ok() {
-        return false;
-    }
-    if q8_0_env_flag_disabled("CAMELID_RETAIN_Q8_0_BLOCKS") {
-        return false;
-    }
-    let max_bytes = parse_byte_count_env("CAMELID_FAST_RETAINED_Q8_0_MAX_BYTES")
-        .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_FAST_RETAINED_Q8_0_MAX_BYTES);
-
-    let mut estimated_bytes = 0usize;
-    let mut saw_q8_linear = false;
-    let mut add_linear = |desc: &crate::gguf::GgufTensorDescriptor| -> Option<()> {
-        let element_count = desc
-            .dimensions
-            .iter()
-            .try_fold(1usize, |acc, dim| acc.checked_mul(*dim as usize))?;
-        estimated_bytes = estimated_bytes.checked_add(element_count.checked_mul(4)?)?;
-        if desc.tensor_type == GgufTensorType::Q8_0 {
-            saw_q8_linear = true;
-            let block_count = element_count.checked_add(Q8_0_BLOCK_VALUES - 1)? / Q8_0_BLOCK_VALUES;
-            // Fast local chat keeps Q8_0 linear tensors as compact retained blocks and
-            // executes the block-dot path directly. Do not budget a second f32 copy here;
-            // the old f32+Q8 retention shape made 3B fall back to repeated lazy disk reads.
-            estimated_bytes = estimated_bytes.checked_sub(element_count.checked_mul(4)?)?;
-            estimated_bytes = estimated_bytes
-                .checked_add(block_count.checked_mul(mem::size_of::<Q8_0Block>())?)?;
-        }
-        Some(())
-    };
-
-    if add_linear(&binding.token_embedding).is_none() {
-        return false;
-    }
-    if !binding.output_is_tied_embedding && add_linear(&binding.output).is_none() {
-        return false;
-    }
-    for layer in &binding.layers {
-        for desc in [
-            &layer.attention_q,
-            &layer.attention_k,
-            &layer.attention_v,
-            &layer.attention_output,
-        ] {
-            if add_linear(desc).is_none() {
-                return false;
-            }
-        }
-        match &layer.ffn {
-            LlamaFfnTensors::Dense { gate, up, down } => {
-                for desc in [gate, up, down] {
-                    if add_linear(desc).is_none() {
-                        return false;
-                    }
-                }
-            }
-            LlamaFfnTensors::MoE {
-                router,
-                gate_experts,
-                up_experts,
-                down_experts,
-            } => {
-                for desc in std::iter::once(router)
-                    .chain(gate_experts.descriptors())
-                    .chain(up_experts.descriptors())
-                    .chain(down_experts.descriptors())
-                {
-                    if add_linear(desc).is_none() {
-                        return false;
-                    }
-                }
-            }
-        }
-    }
-
-    saw_q8_linear && estimated_bytes <= max_bytes
-}
-
-fn lazy_q8_0_linear_enabled() -> bool {
-    match env::var("CAMELID_LAZY_Q8_0_LINEAR") {
+/// Explicit (and loud) opt-out from RAM-resident Q8_0 blocks: only an affirmatively set
+/// `CAMELID_LAZY_Q8_0_LINEAR` forces the per-token file-streaming path. Absence — and any
+/// disabled spelling — means weights are retained in RAM. There is no auto/budget fallback.
+fn lazy_q8_0_linear_forced() -> bool {
+    matches!(
+        env::var("CAMELID_LAZY_Q8_0_LINEAR"),
         Ok(value)
-            if value.eq_ignore_ascii_case("0")
+            if !(value.eq_ignore_ascii_case("0")
                 || value.eq_ignore_ascii_case("false")
                 || value.eq_ignore_ascii_case("off")
-                || value.eq_ignore_ascii_case("disabled") =>
-        {
-            false
-        }
-        Ok(_) | Err(env::VarError::NotPresent) => true,
-        Err(_) => true,
-    }
+                || value.eq_ignore_ascii_case("disabled"))
+    )
 }
 
 const Q8_0_BLOCK_VALUES: usize = 32;

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -10530,3 +10530,45 @@ fn mixtral_moe_ffn_captures_router_logits_and_selected_experts() {
     let selected_sum = trace.rows[0].selected_weights.iter().sum::<f32>();
     assert!((selected_sum - 1.0).abs() < 1.0e-6, "{trace:?}");
 }
+
+#[test]
+fn q8_0_residency_report_counts_resident_blocks_and_flags_file_backed() {
+    let shape = TensorShape { dims: vec![2, 32] };
+    let blocks = vec![
+        Q8_0Block {
+            scale: 1.0,
+            quants: [0; 32],
+        };
+        2
+    ];
+    let resident = CpuTensor::from_q8_0_blocks("resident.weight", shape.clone(), blocks).unwrap();
+    let file_backed = CpuTensor::q8_0_file_backed_linear(
+        "lazy.weight",
+        shape,
+        Q8_0FileBacking::new(std::path::PathBuf::from("/nonexistent.gguf"), 0, 2),
+    );
+    let placeholder = CpuTensor::from_f32("placeholder", vec![0], vec![]).unwrap();
+
+    let weights = LlamaLoadedWeights {
+        token_embedding: resident,
+        output_norm: placeholder,
+        output: Some(file_backed),
+        rope_freqs: None,
+        layers: Vec::new(),
+        layer_range: None,
+    };
+
+    let report = weights.q8_0_residency_report();
+    assert_eq!(report.resident_tensors, 1);
+    assert_eq!(
+        report.resident_block_bytes,
+        (2 * std::mem::size_of::<Q8_0Block>()) as u64
+    );
+    assert_eq!(report.violations.len(), 1);
+    assert!(
+        report.violations[0].contains("lazy.weight")
+            && report.violations[0].contains("file-backed"),
+        "{:?}",
+        report.violations
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,9 @@ use camelid::{
         recv_activation_packet, recv_token_feedback, send_activation_packet, send_token_feedback,
     },
     gguf::{read_metadata, GgufTensorType},
-    inference::{LlamaInferenceSession, LlamaLoadedWeights, LlamaSampler, SamplingConfig},
+    inference::{
+        LlamaInferenceSession, LlamaLoadedWeights, LlamaSampler, Q8ResidencyReport, SamplingConfig,
+    },
     metal::detect_metal_device,
     model::{LlamaModelConfig, LlamaTensorBinding},
     tensor::{CpuTensor, Q8_0TensorBlocks, TensorStore},
@@ -701,6 +703,71 @@ fn infer_quantization(path: &std::path::Path) -> String {
     "unknown".to_string()
 }
 
+/// Hard residency gate for pipeline nodes: every owned Q8_0 linear must hold plain
+/// RAM-resident blocks, and the process memory footprint must account for them. Panics with
+/// a per-tensor trace otherwise — a node is NEVER allowed to silently fall back to streaming
+/// weights from disk per token (~100x slower decode, and it disqualifies the GPU-resident path).
+fn assert_q8_0_weight_residency(weights: &LlamaLoadedWeights, node: &str) {
+    let gib = |bytes: u64| bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    let report: Q8ResidencyReport = weights.q8_0_residency_report();
+    if !report.violations.is_empty() {
+        eprintln!("[{node}] Q8_0 residency violations:");
+        for violation in &report.violations {
+            eprintln!("  - {violation}");
+        }
+        panic!(
+            "[{node}] {} Q8_0 tensor(s) are NOT RAM-resident plain blocks; refusing to run",
+            report.violations.len()
+        );
+    }
+    // The retained blocks must show up in this process's physical footprint. The threshold
+    // derives from the node's actual owned shard (a fixed floor would false-fail small
+    // models and sharded splits); 90% slack covers allocator/OS accounting noise. A node
+    // that silently fell back to disk streaming sits at a few hundred MB and misses this by
+    // a wide margin. Footprint (not RSS) is the metric: macOS compresses untouched pages
+    // under memory pressure, which drops them out of RSS while they are still materialized.
+    let footprint = phys_footprint_bytes();
+    let min_footprint = report.resident_block_bytes / 10 * 9;
+    if footprint < min_footprint {
+        panic!(
+            "[{node}] memory footprint {:.2} GiB < required {:.2} GiB for {} retained Q8_0 \
+             tensors ({:.2} GiB of blocks) — weights did not actually materialize in RAM",
+            gib(footprint),
+            gib(min_footprint),
+            report.resident_tensors,
+            gib(report.resident_block_bytes)
+        );
+    }
+    println!(
+        "[{node}] Q8_0 residency OK: {} tensors, {:.2} GiB retained blocks, footprint {:.2} GiB",
+        report.resident_tensors,
+        gib(report.resident_block_bytes),
+        gib(footprint)
+    );
+}
+
+/// Current physical memory footprint of this process in bytes — the metric Activity Monitor
+/// and `/usr/bin/time -l`'s "memory footprint" report. Unlike RSS it includes pages the OS
+/// compressed under memory pressure, so freshly-materialized weights are counted even on a
+/// loaded machine. Falls back to peak RSS where unavailable.
+fn phys_footprint_bytes() -> u64 {
+    #[cfg(target_os = "macos")]
+    {
+        let mut info: libc::rusage_info_v2 = unsafe { std::mem::zeroed() };
+        let ret = unsafe {
+            libc::proc_pid_rusage(
+                std::process::id() as libc::c_int,
+                libc::RUSAGE_INFO_V2,
+                &mut info as *mut libc::rusage_info_v2 as *mut libc::rusage_info_t,
+            )
+        };
+        if ret == 0 && info.ri_phys_footprint > 0 {
+            return info.ri_phys_footprint;
+        }
+    }
+    peak_rss_bytes()
+}
+
 /// Peak resident set size of this process. macOS reports bytes; Linux kilobytes.
 fn peak_rss_bytes() -> u64 {
     let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
@@ -788,6 +855,7 @@ async fn run_distribute_worker(
         Some(layer_range.clone()),
     )?);
     let mut session = LlamaInferenceSession::new(config.clone(), weights)?;
+    assert_q8_0_weight_residency(&session.weights, "dist-worker");
 
     let listener = TcpListener::bind(addr)?;
     println!("Worker listening on {}...", addr);
@@ -801,9 +869,11 @@ async fn run_distribute_worker(
     let mut client_stream = accept_connection(&listener);
 
     println!("Cluster worker execution loop active!");
+    let trace = std::env::var_os("CAMELID_DISTRIBUTED_TRACE").is_some();
     let mut activations = Vec::new();
 
     loop {
+        let idle_started = Instant::now();
         let header = match recv_activation_packet(&mut client_stream, &mut activations) {
             Ok(h) => h,
             Err(e) => {
@@ -823,14 +893,18 @@ async fn run_distribute_worker(
             ));
         }
         let rows = activations.len() / hidden_dim;
+        let idle_us = idle_started.elapsed().as_micros();
         let hidden =
             CpuTensor::from_f32("activations", vec![rows, hidden_dim], activations.clone())?;
 
+        let forward_started = Instant::now();
         let out_hidden = session.forward_layer_range_from_hidden(
             &hidden,
             header.pos as usize,
             header.seq_len as usize,
         )?;
+        let forward_us = forward_started.elapsed().as_micros();
+        let tail_started = Instant::now();
 
         if let Some(ref mut ds) = downstream_stream {
             if forward_addr.is_some() {
@@ -851,6 +925,16 @@ async fn run_distribute_worker(
 
                 send_token_feedback(ds, token_id, is_finished)?;
             }
+        }
+        if trace {
+            eprintln!(
+                "[dist-worker] pos={} rows={} idle={}us forward={}us logits_send={}us",
+                header.pos,
+                rows,
+                idle_us,
+                forward_us,
+                tail_started.elapsed().as_micros()
+            );
         }
     }
 
@@ -884,6 +968,7 @@ async fn run_distribute_master(
         Some(layer_range.clone()),
     )?);
     let mut session = LlamaInferenceSession::new(config.clone(), weights)?;
+    assert_q8_0_weight_residency(&session.weights, "dist-master");
 
     let listener = TcpListener::bind(addr)?;
     println!("Master listening for feedback on {}...", addr);
@@ -921,22 +1006,33 @@ async fn run_distribute_master(
     pos += seq_len;
     seq_len = 1;
 
+    let trace = std::env::var_os("CAMELID_DISTRIBUTED_TRACE").is_some();
     let decode_start = Instant::now();
     let mut generated = 1;
     while !is_finished && generated < max_tokens {
+        let compute_started = Instant::now();
         let hidden = session
             .weights
             .token_embedding
             .embedding_lookup(&[current_token], "token_embedding")?;
         let out_hidden = session.forward_layer_range_from_hidden(&hidden, pos, seq_len)?;
+        let compute_us = compute_started.elapsed().as_micros();
+        let send_started = Instant::now();
         send_activation_packet(
             &mut downstream_stream,
             pos as u32,
             seq_len as u32,
             &out_hidden.data,
         )?;
-
+        let send_us = send_started.elapsed().as_micros();
+        let wait_started = Instant::now();
         let feedback = recv_token_feedback(&mut feedback_stream)?;
+        if trace {
+            eprintln!(
+                "[dist-master] pos={pos} compute={compute_us}us send={send_us}us wait={}us",
+                wait_started.elapsed().as_micros()
+            );
+        }
         current_token = feedback.token_id;
         is_finished = feedback.is_finished;
 

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -33,6 +33,7 @@ struct MetalLinearKernel {
     q8_0_block_pipeline: ComputePipelineState,
     q8_0_block_simd_pipeline: ComputePipelineState,
     q8_0_block_simd_mr_pipeline: ComputePipelineState,
+    q8_0_block_simd_qmv4_pipeline: ComputePipelineState,
     rms_norm_pipeline: ComputePipelineState,
     residual_add_pipeline: ComputePipelineState,
     silu_mul_pipeline: ComputePipelineState,
@@ -380,6 +381,96 @@ kernel void q8_0_block_linear_row_simd_mr(
     float total = simd_sum(partial);
     if (lane == 0) {
         output[row] = total;
+    }
+}
+
+// MLX-layout Q8_0 GEMV: two simdgroups per threadgroup, FOUR output rows per simdgroup.
+// Each lane caches its 32-value input block (quants + scale) in registers once per block
+// iteration, then runs four independent dot-product chains against four weight-row streams:
+// 4x the outstanding weight loads and four independent accumulators per lane for memory
+// latency hiding (the layout MLX's qmv uses; results_per_simdgroup=4, no threadgroup
+// memory, no pragmas). Same per-row arithmetic as q8_0_block_linear_row_simd.
+// Requires rows % 4 == 0 (every decode projection satisfies this); callers fall back to
+// the single-row kernel otherwise.
+kernel void q8_0_block_linear_row_simd_qmv4(
+    device const float* input_scales [[buffer(0)]],
+    device const char* input_quants [[buffer(1)]],
+    device const char* weight_blocks [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    constant uint& blocks_per_row [[buffer(4)]],
+    constant uint& rows [[buffer(5)]],
+    uint tg [[threadgroup_position_in_grid]],
+    uint sg [[simdgroup_index_in_threadgroup]],
+    uint sgs [[simdgroups_per_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]
+) {
+    constexpr uint block_values = 32;
+    constexpr uint q8_block_bytes = 36;
+    uint row0 = (tg * sgs + sg) * 4;
+    if (row0 >= rows) return;
+    uint row_stride = blocks_per_row * q8_block_bytes;
+    uint base0 = row0 * row_stride;
+    float acc0 = 0.0;
+    float acc1 = 0.0;
+    float acc2 = 0.0;
+    float acc3 = 0.0;
+    for (uint block_idx = lane; block_idx < blocks_per_row; block_idx += 32) {
+        char xq[32];
+        uint input_base = block_idx * block_values;
+        for (uint l = 0; l < block_values; ++l) {
+            xq[l] = input_quants[input_base + l];
+        }
+        float x_scale = input_scales[block_idx];
+        uint b0 = base0 + block_idx * q8_block_bytes;
+        {
+            device const float* wsc = reinterpret_cast<device const float*>(weight_blocks + b0);
+            uint q = b0 + 4;
+            int isum = 0;
+            for (uint l = 0; l < block_values; ++l) {
+                isum += int(weight_blocks[q + l]) * int(xq[l]);
+            }
+            acc0 += float(isum) * (*wsc) * x_scale;
+        }
+        {
+            uint b = b0 + row_stride;
+            device const float* wsc = reinterpret_cast<device const float*>(weight_blocks + b);
+            uint q = b + 4;
+            int isum = 0;
+            for (uint l = 0; l < block_values; ++l) {
+                isum += int(weight_blocks[q + l]) * int(xq[l]);
+            }
+            acc1 += float(isum) * (*wsc) * x_scale;
+        }
+        {
+            uint b = b0 + 2u * row_stride;
+            device const float* wsc = reinterpret_cast<device const float*>(weight_blocks + b);
+            uint q = b + 4;
+            int isum = 0;
+            for (uint l = 0; l < block_values; ++l) {
+                isum += int(weight_blocks[q + l]) * int(xq[l]);
+            }
+            acc2 += float(isum) * (*wsc) * x_scale;
+        }
+        {
+            uint b = b0 + 3u * row_stride;
+            device const float* wsc = reinterpret_cast<device const float*>(weight_blocks + b);
+            uint q = b + 4;
+            int isum = 0;
+            for (uint l = 0; l < block_values; ++l) {
+                isum += int(weight_blocks[q + l]) * int(xq[l]);
+            }
+            acc3 += float(isum) * (*wsc) * x_scale;
+        }
+    }
+    float t0 = simd_sum(acc0);
+    float t1 = simd_sum(acc1);
+    float t2 = simd_sum(acc2);
+    float t3 = simd_sum(acc3);
+    if (lane == 0) {
+        output[row0] = t0;
+        output[row0 + 1u] = t1;
+        output[row0 + 2u] = t2;
+        output[row0 + 3u] = t3;
     }
 }
 "#;
@@ -792,6 +883,12 @@ fn metal_linear_kernel() -> Option<&'static MetalLinearKernel> {
             let q8_0_block_simd_mr_pipeline = device
                 .new_compute_pipeline_state_with_function(&q8_0_block_simd_mr_function)
                 .ok()?;
+            let q8_0_block_simd_qmv4_function = library
+                .get_function("q8_0_block_linear_row_simd_qmv4", None)
+                .ok()?;
+            let q8_0_block_simd_qmv4_pipeline = device
+                .new_compute_pipeline_state_with_function(&q8_0_block_simd_qmv4_function)
+                .ok()?;
             let queue = device.new_command_queue();
             Some(MetalLinearKernel {
                 device,
@@ -803,6 +900,7 @@ fn metal_linear_kernel() -> Option<&'static MetalLinearKernel> {
                 q8_0_block_pipeline,
                 q8_0_block_simd_pipeline,
                 q8_0_block_simd_mr_pipeline,
+                q8_0_block_simd_qmv4_pipeline,
                 rms_norm_pipeline,
                 residual_add_pipeline,
                 silu_mul_pipeline,
@@ -2329,11 +2427,22 @@ fn encode_q8_matmul(
     scalar: &Buffer,
     rows: usize,
 ) {
-    // SIMD-group GEMV with several rows per threadgroup (one row per SIMD group): keeps more
-    // weight reads in flight per threadgroup for better memory-latency hiding on the
-    // bandwidth-bound decode path.
+    // MLX-layout GEMV (two simdgroups per TG, four rows per simdgroup, input cached in
+    // registers, four independent accumulator chains) when rows divide evenly; otherwise the
+    // one-row-per-simdgroup kernel. Both are parity-identical per row.
     const SIMD_GROUPS_PER_TG: u64 = 2;
-    e.set_compute_pipeline_state(&k.q8_0_block_simd_mr_pipeline);
+    let qmv4 = rows.is_multiple_of(4);
+    let pipeline = if qmv4 {
+        &k.q8_0_block_simd_qmv4_pipeline
+    } else {
+        &k.q8_0_block_simd_mr_pipeline
+    };
+    let rows_per_tg = if qmv4 {
+        SIMD_GROUPS_PER_TG * 4
+    } else {
+        SIMD_GROUPS_PER_TG
+    };
+    e.set_compute_pipeline_state(pipeline);
     e.set_buffer(0, Some(scales), 0);
     e.set_buffer(1, Some(quants), 0);
     e.set_buffer(2, Some(weight), 0);
@@ -2342,7 +2451,7 @@ fn encode_q8_matmul(
     e.set_buffer(5, Some(scalar), 4);
     e.dispatch_thread_groups(
         metal::MTLSize {
-            width: (rows as u64).div_ceil(SIMD_GROUPS_PER_TG),
+            width: (rows as u64).div_ceil(rows_per_tg),
             height: 1,
             depth: 1,
         },

--- a/tools/bench/distributed/two-mac-run.sh
+++ b/tools/bench/distributed/two-mac-run.sh
@@ -20,6 +20,10 @@ SPLIT="${SPLIT:-$((TOTAL_LAYERS/2))}"
 PROMPT="${PROMPT:-Explain what a Rust borrow checker does in two sentences.}"
 MAX_TOKENS="${MAX_TOKENS:-64}"
 REMOTE_BIN="${REMOTE_BIN:-/tmp/camelid}"
+EXTRA_ENV="${EXTRA_ENV:-}"   # extra VAR=VAL pairs exported on BOTH nodes (e.g. CAMELID_DISTRIBUTED_TRACE=1)
+# Repack OFF by default: the GPU-resident decode path needs plain (un-packed) Q8_0 blocks,
+# and the nodes' residency gate hard-fails on repacked storage. Set REPACK=1 for CPU-decode runs.
+REPACK="${REPACK:-0}"
 REMOTE_MODEL="${REMOTE_MODEL:-$MODEL}"
 PORT_W=5005
 PORT_M=5006
@@ -29,9 +33,14 @@ echo "[two-mac] worker $SPLIT..$TOTAL_LAYERS on $WORKER_HOST ($WORKER_TB_IP)"
 
 # 1) Stage binary + model to the worker if missing (over the fast TB link).
 ssh "$WORKER_HOST" "mkdir -p \"\$(dirname '$REMOTE_MODEL')\""
-if ! ssh "$WORKER_HOST" "test -x '$REMOTE_BIN'"; then
+# Re-stage the binary whenever it differs (size check) — a stale worker binary silently
+# running old code is exactly the class of failure the residency gate exists to kill.
+remote_bin_size="$(ssh "$WORKER_HOST" "stat -f%z '$REMOTE_BIN' 2>/dev/null || echo 0")"
+local_bin_size="$(stat -f%z "$CAMELID_BIN")"
+if [ "$remote_bin_size" != "$local_bin_size" ]; then
   echo "[two-mac] copying binary -> $WORKER_HOST:$REMOTE_BIN"
   scp -q "$CAMELID_BIN" "$WORKER_HOST:$REMOTE_BIN"
+  ssh "$WORKER_HOST" "chmod +x '$REMOTE_BIN'"
 fi
 remote_size="$(ssh "$WORKER_HOST" "stat -f%z '$REMOTE_MODEL' 2>/dev/null || echo 0")"
 local_size="$(stat -f%z "$MODEL")"
@@ -42,7 +51,7 @@ fi
 
 # 2) Launch the worker (last node) on the remote, bound to its TB IP.
 echo "[two-mac] starting remote worker..."
-ssh "$WORKER_HOST" "CAMELID_MAC_Q8_REPACK=1 /usr/bin/time -l '$REMOTE_BIN' distribute-worker '$REMOTE_MODEL' \
+ssh "$WORKER_HOST" "CAMELID_MAC_Q8_REPACK=$REPACK $EXTRA_ENV /usr/bin/time -l '$REMOTE_BIN' distribute-worker '$REMOTE_MODEL' \
   --addr $WORKER_TB_IP:$PORT_W --layers $SPLIT..$TOTAL_LAYERS --master-addr $MASTER_TB_IP:$PORT_M" \
   >/tmp/two_mac_worker.out 2>&1 &
 SSH_PID=$!
@@ -50,7 +59,7 @@ SSH_PID=$!
 # 3) Run the master (first node) here; it connects to the worker over TB.
 echo "[two-mac] starting master..."
 START=$(python3 -c 'import time;print(time.time())')
-CAMELID_MAC_Q8_REPACK=1 /usr/bin/time -l "$CAMELID_BIN" distribute-master "$MODEL" \
+env CAMELID_MAC_Q8_REPACK=$REPACK $EXTRA_ENV /usr/bin/time -l "$CAMELID_BIN" distribute-master "$MODEL" \
   --worker-addr "$WORKER_TB_IP:$PORT_W" --layers "0..$SPLIT" --addr "$MASTER_TB_IP:$PORT_M" \
   --prompt "$PROMPT" --max-tokens "$MAX_TOKENS" >/tmp/two_mac_master.out 2>/tmp/two_mac_master.time || true
 END=$(python3 -c 'import time;print(time.time())')


### PR DESCRIPTION
## What

- **Sharded pipeline nodes decode on the GPU-resident session** over their owned layer range (one command buffer/token, weights + KV resident across tokens). Prefill and ineligible configs keep the CPU path.
- **Q8_0 linears always load as plain RAM-resident blocks.** The whole-binding retention budget silently dropped sharded nodes to per-token file streaming even when the owned shard fit; it is removed. `CAMELID_LAZY_Q8_0_LINEAR` remains as an explicit, loud opt-out.
- **Hard residency gate on both distributed nodes:** refuse to run unless every owned Q8_0 linear holds resident blocks and the process phys_footprint accounts for them. No silent disk-streaming fallbacks.
- `CAMELID_DISTRIBUTED_TRACE=1` per-token pipeline traces; `two-mac-run.sh` gains `REPACK`/`EXTRA_ENV` and re-stages stale worker binaries.

## Results (two M4 16GB minis, TB bridge, Llama-2-13B Q8, split 0..20/20..40)

| stage | time |
|---|---|
| master GPU forward | ~89 ms |
| worker GPU forward | ~85 ms |
| worker CPU final logits | ~22 ms |
| **steady-state total** | **~197 ms ≈ 5.1 tok/s** |

**3.4× the 1.48 tok/s CPU pipeline baseline.** 3B loopback parity: sharded resident output byte-identical to the single-node resident stream (greedy). 514 tests pass; clippy -D warnings clean; scrub clean.

## Known follow-ups

- First decode token pays a one-time ~6.8 GB/node CPU→GPU buffer upload (transient memory doubling; page-thrash on loaded nodes). Fix: page-aligned no-copy weight buffers.
- Worker final norm + logits still on CPU (~22 ms/token); move into the resident command buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)