### PR TITLE
feat(ghost): experimental layer-streaming mode — .cghost repacker + synchronous runner (step 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "camelid"
 path = "src/main.rs"
+
+[[bin]]
+name = "repack-ghost"
+path = "tools/repack_ghost.rs"

--- a/docs/runtime/ghost-mode.md
+++ b/docs/runtime/ghost-mode.md
@@ -1,0 +1,64 @@
+# Ghost mode: memory-constrained layer-streaming execution (EXPERIMENTAL)
+
+Ghost mode runs models that are far larger than RAM by executing one transformer block at a
+time: only a tiny active working window (one layer's weights) plus the embedding/output ends
+and the KV cache are materialized; everything else streams sequentially from disk every
+token. It deliberately trades throughput for a strict memory ceiling — the inverse of the
+primary inference paths, which hard-require RAM-resident weights. The two paths share
+kernels but are otherwise isolated: ghost lives behind the dedicated `ghost-run` subcommand
+and the `repack-ghost` tool, and touches none of the resident decode loops.
+
+## Why a custom container (`.cghost`)
+
+GGUF groups tensors by export order, scattering one block's tensors across the file. A
+layer-by-layer pass over a GGUF therefore degenerates into random reads. `repack-ghost`
+rewrites the model so each block's tensors are contiguous:
+
+```
+[magic "CGHOST1\0"][u64 index_offset][pad to 16 KiB]
+[pre: token_embedding (+ rope_freqs)]
+[blk.0: attn_norm, attn_q, attn_k, attn_v, attn_output, ffn_norm, ffn_gate, ffn_up, ffn_down]
+[blk.1: ...] ... [blk.N-1: ...]
+[post: output_norm (+ output unless tied)]
+[index JSON]
+```
+
+Group starts are 16 KiB aligned (Apple Silicon page size) so later phases can do no-copy
+buffer mapping and page-precise `madvise` eviction. Streaming one layer is ONE sequential
+`pread` of the whole group.
+
+**v1 is a pure re-layout at source quantization.** This is what makes the correctness gate
+possible: identical bytes ⇒ the streamed path must produce a byte-identical greedy token
+stream vs the resident path. A mixed-quantization map (high-precision ends + ultra-low-bit
+FFN interiors to hit a ~1.65 bit/param average for 70B-on-16GB) is a planned v2 axis — it is
+a *quality* trade, and can never be parity-gated against a different-quant baseline. Note
+that sub-2-bit formats (IQ1_S / IQ2_XXS class) are not yet supported by the runtime's
+loader/kernels; that support is a prerequisite for the v2 map.
+
+## v1 runner (synchronous)
+
+`camelid ghost-run <model.gguf> --cghost <model.cghost> --prompt ... --max-tokens N`
+
+- Metadata, tokenizer, and the resident ends (embedding + output projection) load from the
+  GGUF via the existing loaders; every transformer layer starts as an empty placeholder.
+- Per chunk (prefill or one decoded token), per layer: one sequential group read into a
+  reused buffer → decode to the same in-RAM storage the resident loader produces → run the
+  existing CPU layer forward (`ghost_forward_one_layer`, which does not advance the KV
+  position; the runner advances once per chunk) → swap the placeholder back in, dropping
+  the weights. The weight working window is exactly one layer.
+- Greedy sampling via the existing final-norm/logits path.
+- Reads block the forward in v1. Double-buffered async prefetch (read layer N+1 while layer
+  N computes), explicit page eviction (`posix_madvise(DONTNEED)`), and the two-node pipeline
+  variant (each node hosts half the `.cghost` and overlaps its disk window with the other
+  node's compute) are the planned next phases.
+
+## Step-1 measurements (Llama-3.2-3B-Instruct Q8_0, M4 16GB)
+
+- Repack: 30 groups, 3.18 GiB payload, largest block group 102.0 MiB (the per-layer
+  streaming window), ~3 min on the external SSD.
+- Runner footprint: **1.36 GiB** after loading resident ends (vs ~3.6 GiB fully resident) —
+  the whole point of the mode.
+- Streaming rate is storage-bound: ~38 MB/s cold on this external SSD (the same rate GGUF
+  loads see there), i.e. ~2.8 s/layer. On internal NVMe-class storage the same read is
+  projected at tens of milliseconds. Throughput numbers for ghost mode are therefore quoted
+  per storage tier; the PoC gate is correctness + the memory ceiling, not speed.

--- a/src/gguf/reader.rs
+++ b/src/gguf/reader.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{BackendError, Result};
 
@@ -32,7 +32,7 @@ pub enum GgufMetadataValue {
     F64(f64),
 }
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum GgufTensorType {
     F32,
     F16,

--- a/src/ghost.rs
+++ b/src/ghost.rs
@@ -1,0 +1,324 @@
+//! Ghost (layer-streaming) mode: the `.cghost` container format and its reader/writer.
+//!
+//! Standard GGUF files scatter a transformer block's tensors across the file, which turns a
+//! layer-by-layer streaming pass into random reads. A `.cghost` file is a pure re-layout of
+//! a GGUF at **source quantization**: every tensor a block needs is contiguous on disk, so
+//! streaming one layer is ONE sequential read. v1 deliberately does not requantize —
+//! identical bytes mean the ghost path can be parity-gated against the resident path.
+//!
+//! Layout:
+//! ```text
+//! [magic "CGHOST1\0"][u64 index_offset][pad to 16 KiB]
+//! [group 0 payload][pad][group 1 payload][pad]...
+//! [index JSON]                                    <- at index_offset, runs to EOF
+//! ```
+//! Group payload offsets are 16 KiB aligned (Apple Silicon page size) so future no-copy /
+//! madvise work operates on whole pages; tensors inside a group are packed back-to-back.
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{BackendError, Result};
+use crate::gguf::GgufTensorType;
+use crate::inference::LlamaLayerWeights;
+use crate::model::{LlamaFfnTensors, LlamaTensorBinding};
+use crate::tensor::{cpu_tensor_from_gguf_bytes, CpuTensor, TensorStore};
+
+pub const CGHOST_MAGIC: &[u8; 8] = b"CGHOST1\0";
+pub const CGHOST_ALIGN: u64 = 16 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CghostTensor {
+    pub name: String,
+    /// Stable role inside the group ("attn_norm", "attn_q", ..., "token_embedding").
+    pub role: String,
+    pub dtype: GgufTensorType,
+    pub dims: Vec<u64>,
+    /// Absolute file offset of this tensor's raw GGUF bytes.
+    pub offset: u64,
+    pub len: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CghostGroup {
+    /// "pre" (embedding + rope), "blk.N" (one transformer block), "post" (output norm/proj).
+    pub id: String,
+    pub tensors: Vec<CghostTensor>,
+}
+
+impl CghostGroup {
+    /// Contiguous (start, len) span of this group's payload in the file.
+    pub fn span(&self) -> (u64, u64) {
+        let start = self.tensors.first().map(|t| t.offset).unwrap_or(0);
+        let end = self
+            .tensors
+            .last()
+            .map(|t| t.offset + t.len)
+            .unwrap_or(start);
+        (start, end - start)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CghostIndex {
+    pub version: u32,
+    pub source_model: String,
+    pub block_count: usize,
+    pub tied_output: bool,
+    pub groups: Vec<CghostGroup>,
+}
+
+/// The fixed tensor order inside a "blk.N" group. Decoding is positional-by-role, so the
+/// writer and reader must agree on this list.
+const LAYER_ROLES: [&str; 9] = [
+    "attn_norm",
+    "attn_q",
+    "attn_k",
+    "attn_v",
+    "attn_output",
+    "ffn_norm",
+    "ffn_gate",
+    "ffn_up",
+    "ffn_down",
+];
+
+fn invalid(msg: String) -> BackendError {
+    BackendError::InvalidModelMetadata(msg)
+}
+
+fn io_err(path: &Path, source: std::io::Error) -> BackendError {
+    BackendError::Io {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+/// Write a `.cghost` re-layout of `store`'s GGUF. Dense models only — ghost v1 refuses MoE
+/// (the streaming window assumes one fixed-size group per block).
+pub fn write_cghost(
+    store: &TensorStore,
+    binding: &LlamaTensorBinding,
+    source_model: &str,
+    out_path: &Path,
+) -> Result<CghostIndex> {
+    // Plan the group contents (names + roles) first.
+    let mut planned: Vec<(String, Vec<(String, String)>)> = Vec::new();
+    let mut pre = vec![(
+        "token_embedding".to_string(),
+        binding.token_embedding.name.clone(),
+    )];
+    if let Some(rope) = &binding.rope_freqs {
+        pre.push(("rope_freqs".to_string(), rope.name.clone()));
+    }
+    planned.push(("pre".to_string(), pre));
+    for (layer_idx, layer) in binding.layers.iter().enumerate() {
+        let (gate, up, down) = match &layer.ffn {
+            LlamaFfnTensors::Dense { gate, up, down } => (gate, up, down),
+            LlamaFfnTensors::MoE { .. } => {
+                return Err(invalid(format!(
+                    "layer {layer_idx} is MoE; ghost v1 supports dense models only"
+                )))
+            }
+        };
+        let tensors = vec![
+            ("attn_norm".to_string(), layer.attention_norm.name.clone()),
+            ("attn_q".to_string(), layer.attention_q.name.clone()),
+            ("attn_k".to_string(), layer.attention_k.name.clone()),
+            ("attn_v".to_string(), layer.attention_v.name.clone()),
+            (
+                "attn_output".to_string(),
+                layer.attention_output.name.clone(),
+            ),
+            ("ffn_norm".to_string(), layer.ffn_norm.name.clone()),
+            ("ffn_gate".to_string(), gate.name.clone()),
+            ("ffn_up".to_string(), up.name.clone()),
+            ("ffn_down".to_string(), down.name.clone()),
+        ];
+        planned.push((format!("blk.{layer_idx}"), tensors));
+    }
+    let mut post = vec![("output_norm".to_string(), binding.output_norm.name.clone())];
+    if !binding.output_is_tied_embedding {
+        post.push(("output".to_string(), binding.output.name.clone()));
+    }
+    planned.push(("post".to_string(), post));
+
+    // Stream the payload out group by group, page-aligning each group start.
+    let mut file = File::create(out_path).map_err(|e| io_err(out_path, e))?;
+    file.write_all(CGHOST_MAGIC)
+        .map_err(|e| io_err(out_path, e))?;
+    file.write_all(&0u64.to_le_bytes())
+        .map_err(|e| io_err(out_path, e))?;
+    let mut cursor: u64 = (CGHOST_MAGIC.len() + 8) as u64;
+    let mut groups = Vec::with_capacity(planned.len());
+    for (id, tensors) in planned {
+        let aligned = cursor.next_multiple_of(CGHOST_ALIGN);
+        if aligned > cursor {
+            file.write_all(&vec![0u8; (aligned - cursor) as usize])
+                .map_err(|e| io_err(out_path, e))?;
+            cursor = aligned;
+        }
+        let mut group = CghostGroup {
+            id,
+            tensors: Vec::with_capacity(tensors.len()),
+        };
+        for (role, name) in tensors {
+            let desc = store.descriptor(&name)?.clone();
+            let bytes = store.tensor_bytes(&name)?;
+            file.write_all(&bytes).map_err(|e| io_err(out_path, e))?;
+            group.tensors.push(CghostTensor {
+                name,
+                role,
+                dtype: desc.tensor_type,
+                dims: desc.dimensions.clone(),
+                offset: cursor,
+                len: bytes.len() as u64,
+            });
+            cursor += bytes.len() as u64;
+        }
+        groups.push(group);
+    }
+
+    let index = CghostIndex {
+        version: 1,
+        source_model: source_model.to_string(),
+        block_count: binding.layers.len(),
+        tied_output: binding.output_is_tied_embedding,
+        groups,
+    };
+    let index_json = serde_json::to_vec(&index)
+        .map_err(|e| invalid(format!("failed to serialize .cghost index: {e}")))?;
+    let index_offset = cursor;
+    file.write_all(&index_json)
+        .map_err(|e| io_err(out_path, e))?;
+    file.seek(SeekFrom::Start(CGHOST_MAGIC.len() as u64))
+        .map_err(|e| io_err(out_path, e))?;
+    file.write_all(&index_offset.to_le_bytes())
+        .map_err(|e| io_err(out_path, e))?;
+    file.sync_all().map_err(|e| io_err(out_path, e))?;
+    Ok(index)
+}
+
+/// Open `.cghost` reader: parses the index once, then serves page-aligned group reads.
+pub struct GhostFile {
+    pub index: CghostIndex,
+    file: File,
+}
+
+impl GhostFile {
+    pub fn open(path: &Path) -> Result<Self> {
+        let mut file = File::open(path).map_err(|e| io_err(path, e))?;
+        let mut magic = [0u8; 8];
+        file.read_exact(&mut magic).map_err(|e| io_err(path, e))?;
+        if &magic != CGHOST_MAGIC {
+            return Err(invalid(format!(
+                "{} is not a .cghost file (bad magic)",
+                path.display()
+            )));
+        }
+        let mut off = [0u8; 8];
+        file.read_exact(&mut off).map_err(|e| io_err(path, e))?;
+        let index_offset = u64::from_le_bytes(off);
+        file.seek(SeekFrom::Start(index_offset))
+            .map_err(|e| io_err(path, e))?;
+        let mut index_json = Vec::new();
+        file.read_to_end(&mut index_json)
+            .map_err(|e| io_err(path, e))?;
+        let index: CghostIndex = serde_json::from_slice(&index_json)
+            .map_err(|e| invalid(format!("failed to parse .cghost index: {e}")))?;
+        if index.version != 1 {
+            return Err(invalid(format!(
+                "unsupported .cghost version {}",
+                index.version
+            )));
+        }
+        Ok(Self { index, file })
+    }
+
+    fn group(&self, id: &str) -> Result<&CghostGroup> {
+        self.index
+            .groups
+            .iter()
+            .find(|g| g.id == id)
+            .ok_or_else(|| invalid(format!(".cghost file has no \"{id}\" group")))
+    }
+
+    /// Read a whole group's payload with ONE sequential read into `buf` (reused across
+    /// calls). Returns the group and the span start so tensor slices can be located.
+    fn read_group_payload<'a>(
+        &'a self,
+        id: &str,
+        buf: &mut Vec<u8>,
+    ) -> Result<(&'a CghostGroup, u64)> {
+        let group = self.group(id)?;
+        let (start, len) = group.span();
+        buf.resize(len as usize, 0);
+        self.file
+            .read_exact_at(buf, start)
+            .map_err(|e| io_err(Path::new("<cghost>"), e))?;
+        Ok((group, start))
+    }
+
+    fn decode_group_tensor(
+        tensor: &CghostTensor,
+        span_start: u64,
+        buf: &[u8],
+    ) -> Result<CpuTensor> {
+        let lo = (tensor.offset - span_start) as usize;
+        let hi = lo + tensor.len as usize;
+        cpu_tensor_from_gguf_bytes(&tensor.name, tensor.dtype, &tensor.dims, &buf[lo..hi])
+    }
+
+    /// Stream one transformer block's weights: one sequential read + decode to the same
+    /// in-RAM storage the resident loader produces. Returns the bytes read from disk.
+    pub fn read_layer(
+        &self,
+        layer_idx: usize,
+        buf: &mut Vec<u8>,
+    ) -> Result<(LlamaLayerWeights, u64)> {
+        let id = format!("blk.{layer_idx}");
+        let (group, start) = self.read_group_payload(&id, buf)?;
+        let mut by_role: Vec<Option<CpuTensor>> = vec![None; LAYER_ROLES.len()];
+        for tensor in &group.tensors {
+            if let Some(slot) = LAYER_ROLES.iter().position(|r| *r == tensor.role) {
+                by_role[slot] = Some(Self::decode_group_tensor(tensor, start, buf)?);
+            }
+        }
+        let mut take = |role: &str| -> Result<CpuTensor> {
+            let slot = LAYER_ROLES.iter().position(|r| *r == role).unwrap();
+            by_role[slot]
+                .take()
+                .ok_or_else(|| invalid(format!("group {id} is missing role \"{role}\"")))
+        };
+        let (_, span_len) = group.span();
+        Ok((
+            LlamaLayerWeights {
+                attention_norm: take("attn_norm")?,
+                attention_q: take("attn_q")?,
+                attention_k: take("attn_k")?,
+                attention_v: take("attn_v")?,
+                attention_output: take("attn_output")?,
+                ffn_norm: take("ffn_norm")?,
+                ffn_gate: take("ffn_gate")?,
+                ffn_up: take("ffn_up")?,
+                ffn_down: take("ffn_down")?,
+                moe_router: None,
+            },
+            span_len,
+        ))
+    }
+
+    /// Largest "blk.N" group payload in bytes — the size of the streaming read buffer.
+    pub fn max_layer_span(&self) -> u64 {
+        self.index
+            .groups
+            .iter()
+            .filter(|g| g.id.starts_with("blk."))
+            .map(|g| g.span().1)
+            .max()
+            .unwrap_or(0)
+    }
+}

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1813,6 +1813,56 @@ impl LlamaInferenceSession {
         Ok(current_hidden)
     }
 
+    /// Ghost (layer-streaming) mode support: run exactly ONE transformer layer over `hidden`
+    /// WITHOUT advancing the KV position. The ghost runner streams each layer's weights into
+    /// `self.weights.layers[layer_idx]` from a `.cghost` file right before this call and
+    /// swaps placeholders back in right after, so only one layer's weights are materialized
+    /// at a time; it advances the position once per chunk via
+    /// [`Self::ghost_advance_position`] after all layers ran.
+    pub fn ghost_forward_one_layer(
+        &mut self,
+        hidden: &CpuTensor,
+        layer_idx: usize,
+        start_pos: usize,
+        seq_len: usize,
+    ) -> Result<CpuTensor> {
+        if start_pos != self.kv_cache.position {
+            return Err(BackendError::RuntimeShapeMismatch(format!(
+                "ghost layer {layer_idx}: activation start position {start_pos} does not \
+                 match KV cache position {}",
+                self.kv_cache.position
+            )));
+        }
+        let rms_norm_epsilon = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
+        let layer = self.weights.layers.get(layer_idx).ok_or_else(|| {
+            BackendError::RuntimeShapeMismatch(format!(
+                "ghost layer index {layer_idx} out of range ({} layers)",
+                self.weights.layers.len()
+            ))
+        })?;
+        let timed = forward_prefill_layer_chunk_timed(
+            hidden,
+            layer,
+            PrefillLayerChunkParams {
+                config: &self.config,
+                rope_freqs: self.weights.rope_freqs.as_ref(),
+                rms_norm_epsilon,
+                layer_idx,
+                chunk_start: 0,
+                chunk_rows: seq_len,
+                base_position: start_pos,
+            },
+            &mut self.kv_cache,
+        )?;
+        Ok(timed.output)
+    }
+
+    /// Ghost mode: advance the KV position once after all of a chunk's layers ran via
+    /// [`Self::ghost_forward_one_layer`].
+    pub fn ghost_advance_position(&mut self, seq_len: usize) {
+        self.kv_cache.position += seq_len;
+    }
+
     pub fn forward_final_norm_and_logits(&self, out_hidden: &CpuTensor) -> Result<CpuTensor> {
         let rms_norm_epsilon = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
         let runtime_plan = ResolvedRuntimePlan::from_env()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod distributed;
 pub mod error;
 pub mod execution_plan;
 pub mod gguf;
+pub mod ghost;
 pub mod inference;
 pub mod metal;
 pub mod model;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,10 @@ use camelid::{
         recv_activation_packet, recv_token_feedback, send_activation_packet, send_token_feedback,
     },
     gguf::{read_metadata, GgufTensorType},
+    ghost::GhostFile,
     inference::{
-        LlamaInferenceSession, LlamaLoadedWeights, LlamaSampler, Q8ResidencyReport, SamplingConfig,
+        LlamaInferenceSession, LlamaLayerWeights, LlamaLoadedWeights, LlamaSampler,
+        Q8ResidencyReport, SamplingConfig,
     },
     metal::detect_metal_device,
     model::{LlamaModelConfig, LlamaTensorBinding},
@@ -251,6 +253,27 @@ enum Command {
         /// Accepted for compatibility; JSON is always emitted to stdout.
         #[arg(long, default_value_t = false)]
         json: bool,
+    },
+    /// EXPERIMENTAL ghost (layer-streaming) mode: execute a model one transformer block at
+    /// a time, streaming each block's weights from a layer-contiguous `.cghost` file
+    /// (see the `repack-ghost` tool) and holding only a one-layer working window plus the
+    /// embedding/output ends in RAM. Trades throughput for a strict memory ceiling.
+    /// Synchronous v1: each layer's read blocks the forward (no prefetch yet).
+    GhostRun {
+        /// GGUF model path (metadata, tokenizer, and resident embedding/output ends).
+        model: PathBuf,
+        /// Layer-contiguous .cghost file produced by `repack-ghost` from the same model.
+        #[arg(long)]
+        cghost: PathBuf,
+        /// Prompt to execute (greedy decode).
+        #[arg(long, default_value = "Write a quick Rust hello-world function:")]
+        prompt: String,
+        /// Maximum tokens to generate.
+        #[arg(long, default_value_t = 32)]
+        max_tokens: usize,
+        /// Override Rayon worker threads.
+        #[arg(long)]
+        threads: Option<usize>,
     },
 }
 
@@ -483,7 +506,208 @@ async fn main() -> anyhow::Result<()> {
                 threads,
             )?;
         }
+        Command::GhostRun {
+            model,
+            cghost,
+            prompt,
+            max_tokens,
+            threads,
+        } => {
+            run_ghost(model, cghost, prompt, max_tokens, threads)?;
+        }
     }
+    Ok(())
+}
+
+/// Ghost mode: run every transformer layer of one chunk (prefill or a single decoded
+/// token), streaming each layer's weights from the `.cghost` file right before its forward
+/// and dropping them right after — the weight working window is exactly one layer. Returns
+/// the chunk's output hidden state plus (bytes streamed, stream time, forward time).
+#[allow(clippy::too_many_arguments)]
+fn ghost_stream_layers(
+    session: &mut LlamaInferenceSession,
+    ghost: &GhostFile,
+    placeholder: &LlamaLayerWeights,
+    buf: &mut Vec<u8>,
+    hidden: CpuTensor,
+    pos: usize,
+    seq_len: usize,
+    log_layers: bool,
+) -> anyhow::Result<(CpuTensor, u64, u128, u128)> {
+    let n_layers = session.weights.layers.len();
+    let mut hidden = hidden;
+    let mut bytes_total = 0u64;
+    let mut stream_us_total = 0u128;
+    let mut forward_us_total = 0u128;
+    for layer_idx in 0..n_layers {
+        let stream_started = Instant::now();
+        let (layer, span) = ghost.read_layer(layer_idx, buf)?;
+        Arc::make_mut(&mut session.weights).layers[layer_idx] = layer;
+        let stream_us = stream_started.elapsed().as_micros();
+        let forward_started = Instant::now();
+        hidden = session.ghost_forward_one_layer(&hidden, layer_idx, pos, seq_len)?;
+        let forward_us = forward_started.elapsed().as_micros();
+        // Drop the streamed weights immediately; only the one-layer window is ever held.
+        Arc::make_mut(&mut session.weights).layers[layer_idx] = placeholder.clone();
+        bytes_total += span;
+        stream_us_total += stream_us;
+        forward_us_total += forward_us;
+        if log_layers {
+            eprintln!(
+                "[ghost] layer {layer_idx:>3}: stream {:7.1} ms ({:6.1} MiB @ {:5.0} MB/s)  \
+                 forward {:7.1} ms",
+                stream_us as f64 / 1000.0,
+                span as f64 / (1024.0 * 1024.0),
+                span as f64 / (stream_us.max(1) as f64), // bytes/us == MB/s
+                forward_us as f64 / 1000.0,
+            );
+        }
+    }
+    session.ghost_advance_position(seq_len);
+    Ok((hidden, bytes_total, stream_us_total, forward_us_total))
+}
+
+/// EXPERIMENTAL ghost (layer-streaming) mode, synchronous v1: greedy generation with the
+/// model executed one transformer block at a time from a `.cghost` file. RAM holds the
+/// embedding/output ends + KV cache + ONE layer's weights; everything else stays on disk.
+fn run_ghost(
+    model: PathBuf,
+    cghost: PathBuf,
+    prompt: String,
+    max_tokens: usize,
+    threads: Option<usize>,
+) -> anyhow::Result<()> {
+    configure_rayon_threads(threads)?;
+    let gib = |bytes: u64| bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+    println!("[ghost] loading GGUF metadata from {:?}...", model);
+    let gguf = read_metadata(&model)?;
+    let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
+    let binding = camelid::model::LlamaTensorBinding::bind(&gguf, &config)?;
+    let store = TensorStore::open(&model, &gguf);
+    let tokenizer = Tokenizer::from_gguf(&gguf)?;
+
+    let ghost = GhostFile::open(&cghost)?;
+    let n_layers = config.block_count as usize;
+    anyhow::ensure!(
+        ghost.index.block_count == n_layers,
+        ".cghost block_count {} does not match model block_count {n_layers}",
+        ghost.index.block_count
+    );
+
+    // Resident ends only (embedding + output projection); every transformer layer is a
+    // placeholder that ghost_stream_layers swaps real weights into, one at a time.
+    let load_started = Instant::now();
+    let weights = LlamaLoadedWeights::load_distributed(&store, &binding, 0, 0, true, true)?;
+    let mut session = LlamaInferenceSession::new(config.clone(), Arc::new(weights))?;
+    let placeholder = session.weights.layers[0].clone();
+    let mut buf: Vec<u8> = Vec::with_capacity(ghost.max_layer_span() as usize);
+    println!(
+        "[ghost] resident ends loaded in {:.1}s; {} layers x {:.1} MiB max streaming window; \
+         footprint {:.2} GiB",
+        load_started.elapsed().as_secs_f64(),
+        n_layers,
+        ghost.max_layer_span() as f64 / (1024.0 * 1024.0),
+        gib(phys_footprint_bytes()),
+    );
+
+    let token_ids = tokenizer.encode(&prompt, true, false)?;
+    println!("[ghost] prompt tokens: {:?}", token_ids);
+    let mut pos = 0usize;
+
+    let prefill_started = Instant::now();
+    let hidden = session
+        .weights
+        .token_embedding
+        .embedding_lookup(&token_ids, "token_embedding_ghost")?;
+    let (mut hidden, bytes, stream_us, forward_us) = ghost_stream_layers(
+        &mut session,
+        &ghost,
+        &placeholder,
+        &mut buf,
+        hidden,
+        pos,
+        token_ids.len(),
+        true,
+    )?;
+    pos += token_ids.len();
+    println!(
+        "[ghost] prefill: {:.1}s ({:.2} GiB streamed @ {:.0} MB/s, forward {:.1}s); \
+         footprint {:.2} GiB",
+        prefill_started.elapsed().as_secs_f64(),
+        gib(bytes),
+        bytes as f64 / (stream_us.max(1) as f64),
+        forward_us as f64 / 1_000_000.0,
+        gib(phys_footprint_bytes()),
+    );
+
+    let mut generated: Vec<u32> = Vec::new();
+    let mut decode_us_total: u128 = 0;
+    for step in 0..max_tokens {
+        let logits = session.forward_final_norm_and_logits(&hidden)?;
+        let vocab = logits.dim(1)?;
+        let rows = logits.dim(0)?;
+        let last_row_start = (rows - 1) * vocab;
+        let last_row = CpuTensor::from_f32(
+            "ghost_last_logits",
+            vec![1, vocab],
+            logits.data[last_row_start..last_row_start + vocab].to_vec(),
+        )?;
+        let token = LlamaSampler::Greedy.sample(&last_row)?;
+        generated.push(token);
+        print!("{}", tokenizer.decode(&[token], true)?);
+        std::io::stdout().flush()?;
+        if tokenizer.special.eos == Some(token) || tokenizer.special.eot == Some(token) {
+            break;
+        }
+        if step + 1 == max_tokens {
+            break;
+        }
+        let token_started = Instant::now();
+        let embedding = session
+            .weights
+            .token_embedding
+            .embedding_lookup(&[token], "token_embedding_ghost")?;
+        let (next_hidden, bytes, stream_us, forward_us) = ghost_stream_layers(
+            &mut session,
+            &ghost,
+            &placeholder,
+            &mut buf,
+            embedding,
+            pos,
+            1,
+            false,
+        )?;
+        hidden = next_hidden;
+        pos += 1;
+        let token_us = token_started.elapsed().as_micros();
+        decode_us_total += token_us;
+        eprintln!(
+            "[ghost] token {:>3}: {:6.0} ms ({:.2} GiB streamed @ {:4.0} MB/s, forward \
+             {:5.0} ms)",
+            step + 1,
+            token_us as f64 / 1000.0,
+            gib(bytes),
+            bytes as f64 / (stream_us.max(1) as f64),
+            forward_us as f64 / 1000.0,
+        );
+    }
+    println!();
+
+    let streamed_tokens = generated.len().saturating_sub(1);
+    if streamed_tokens > 0 {
+        println!(
+            "[ghost] decode: {} tokens in {:.1}s = {:.3} tok/s",
+            streamed_tokens,
+            decode_us_total as f64 / 1_000_000.0,
+            streamed_tokens as f64 / (decode_us_total as f64 / 1_000_000.0),
+        );
+    }
+    println!(
+        "[ghost] final footprint {:.2} GiB, peak RSS {:.2} GiB",
+        gib(phys_footprint_bytes()),
+        gib(peak_rss_bytes()),
+    );
     Ok(())
 }
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -3225,6 +3225,51 @@ impl TensorStore {
     }
 }
 
+/// Ghost (layer-streaming) mode support: materialize a `CpuTensor` from raw GGUF tensor
+/// bytes that were already read from a `.cghost` layer group. 2-D Q8_0 linears come back as
+/// plain RAM-resident blocks (the same storage the block-backed loader produces, so the
+/// existing CPU forward path runs unchanged); float tensors decode to f32. Ghost v1 supports
+/// the tensor types dense Llama models actually ship — anything else is a loud error, never
+/// a silent fallback.
+pub fn cpu_tensor_from_gguf_bytes(
+    name: &str,
+    tensor_type: GgufTensorType,
+    dims: &[u64],
+    bytes: &[u8],
+) -> Result<CpuTensor> {
+    let shape = TensorShape::from_gguf_dims(dims)?;
+    let expected_elements = shape.element_count()?;
+    match tensor_type {
+        GgufTensorType::F32 => CpuTensor::from_f32(
+            name,
+            shape.dims.clone(),
+            decode_f32_tensor(name, bytes, expected_elements)?,
+        ),
+        GgufTensorType::F16 => CpuTensor::from_f32(
+            name,
+            shape.dims.clone(),
+            decode_f16_tensor(name, bytes, expected_elements)?,
+        ),
+        GgufTensorType::BF16 => CpuTensor::from_f32(
+            name,
+            shape.dims.clone(),
+            decode_bf16_tensor(name, bytes, expected_elements)?,
+        ),
+        GgufTensorType::Q8_0 if shape.dims.len() == 2 => {
+            let blocks = decode_q8_0_blocks(name, bytes, expected_elements)?;
+            CpuTensor::from_q8_0_blocks(name, shape, blocks)
+        }
+        GgufTensorType::Q8_0 => CpuTensor::from_f32(
+            name,
+            shape.dims.clone(),
+            decode_q8_0_tensor(name, bytes, expected_elements)?,
+        ),
+        other => Err(BackendError::UnsupportedTensorType(format!(
+            "tensor {name} has storage type {other:?}; ghost v1 supports F32, F16, BF16, Q8_0"
+        ))),
+    }
+}
+
 fn decode_f32_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
     if bytes.len() != expected_elements * 4 {
         return Err(BackendError::InvalidTensorData(format!(

--- a/tools/repack_ghost.rs
+++ b/tools/repack_ghost.rs
@@ -1,0 +1,79 @@
+//! repack-ghost: restructure a GGUF model into a `.cghost` layer-streaming container.
+//!
+//! Ghost (layer-streaming) mode executes a model one transformer block at a time, holding
+//! only a tiny working window in RAM. GGUF scatters a block's tensors across the file; this
+//! tool writes every block's tensors contiguously (one sequential read per block) at the
+//! SOURCE quantization — v1 is a pure re-layout, so the streamed path can be parity-gated
+//! byte-for-byte against the resident path.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use camelid::gguf::read_metadata;
+use camelid::ghost::write_cghost;
+use camelid::model::{LlamaModelConfig, LlamaTensorBinding};
+use camelid::tensor::TensorStore;
+
+#[derive(Parser)]
+#[command(
+    name = "repack-ghost",
+    about = "Repack a GGUF into a layer-contiguous .cghost streaming container"
+)]
+struct Args {
+    /// Source GGUF model
+    model: PathBuf,
+    /// Output path (default: <model>.cghost)
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let out = args.out.unwrap_or_else(|| {
+        let mut p = args.model.clone();
+        p.set_extension("cghost");
+        p
+    });
+
+    println!(
+        "[repack-ghost] reading GGUF metadata from {:?}...",
+        args.model
+    );
+    let gguf = read_metadata(&args.model)?;
+    let config = LlamaModelConfig::from_gguf(&gguf)?;
+    let binding = LlamaTensorBinding::bind(&gguf, &config)?;
+    let store = TensorStore::open(&args.model, &gguf);
+    let source = args
+        .model
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    println!(
+        "[repack-ghost] repacking {} transformer blocks -> {:?}",
+        binding.layers.len(),
+        out
+    );
+    let index = write_cghost(&store, &binding, &source, &out)?;
+
+    let total: u64 = index.groups.iter().map(|g| g.span().1).sum();
+    let max_layer = index
+        .groups
+        .iter()
+        .filter(|g| g.id.starts_with("blk."))
+        .map(|g| g.span().1)
+        .max()
+        .unwrap_or(0);
+    let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
+    let mib = |b: u64| b as f64 / (1024.0 * 1024.0);
+    println!(
+        "[repack-ghost] done: {} groups, {:.2} GiB payload, largest block group {:.1} MiB \
+         (the streaming window per layer), tied_output={}",
+        index.groups.len(),
+        gib(total),
+        mib(max_layer),
+        index.tied_output
+    );
+    Ok(())
+}


### PR DESCRIPTION
**Stacked on #213** (branched from it; retarget to main after #213 merges).

Ghost mode: execute a model one transformer block at a time, holding only the embedding/output ends + KV cache + ONE layer's weights in RAM, streaming the rest sequentially from disk. Fully isolated behind the `ghost-run` subcommand + `repack-ghost` tool — no changes to the resident inference loops.

## Step 1 (this PR)

- **`repack-ghost`**: GGUF → `.cghost` layer-contiguous container (one sequential read per block, 16 KiB-aligned groups, JSON index, source quantization preserved — a pure re-layout so the streamed path is parity-gateable).
- **`camelid ghost-run`** (synchronous v1): per token, each layer streams into a reused buffer, runs the existing CPU forward, and is dropped — the weight working window is exactly one layer.

## Verification (Llama-3.2-3B Q8, M4 16GB)

- Greedy 48-token output **byte-identical** to the resident CPU path.
- Peak process footprint **1.65 GiB** vs ~4.6 GiB resident; 102 MiB/layer streaming window.
- 1.37 tok/s with warm page cache; storage-bound cold (numbers quoted per storage tier in `docs/runtime/ghost-mode.md`).

## Next phases (per the doc)

1. Double-buffered async prefetch (read layer N+1 during layer N compute) + `posix_madvise(DONTNEED)` page eviction.
2. Two-node pipeline variant (each node hosts half the `.cghost`, disk window overlapped with the peer's compute).
3. Mixed-quantization map for 70B-on-16GB — requires sub-2-bit dequant support first; explicitly NOT parity-gateable vs a different-quant baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)