### PR TITLE
feat(ghost): double-buffered async prefetch + strict page-cache eviction mode (task 2)

### DIFF
--- a/docs/runtime/ghost-mode.md
+++ b/docs/runtime/ghost-mode.md
@@ -47,10 +47,20 @@ loader/kernels; that support is a prerequisite for the v2 map.
   position; the runner advances once per chunk) → swap the placeholder back in, dropping
   the weights. The weight working window is exactly one layer.
 - Greedy sampling via the existing final-norm/logits path.
-- Reads block the forward in v1. Double-buffered async prefetch (read layer N+1 while layer
-  N computes), explicit page eviction (`posix_madvise(DONTNEED)`), and the two-node pipeline
-  variant (each node hosts half the `.cghost` and overlaps its disk window with the other
-  node's compute) are the planned next phases.
+- v1 (`--sync-stream`) blocks the forward on each read. v2 (the default) double-buffers:
+  a background worker reads + decodes layer N+1 while the main thread runs layer N's
+  forward, handing off over a rendezvous channel so at most TWO layer windows exist at any
+  instant. The worker is also primed with the next chunk before the current one finishes,
+  so the disk is already rewinding to layer 0 of token N+1 during the last forwards (and
+  the sampling) of token N. The trace reports the residual stall ("blocked") separately
+  from forward time.
+- Strict memory ceiling mode: `--evict-page-cache` sets `F_NOCACHE` on the `.cghost`
+  handle so streamed pages bypass the page cache entirely. Off by default — when the model
+  fits in RAM the cache is a free win; for the over-RAM models ghost targets, the cache can
+  only thrash. (`posix_madvise(DONTNEED)` does not apply to this design — that is for
+  mmap'd ranges, and the streamer uses positioned reads.)
+- The two-node pipeline variant (each node hosts half the `.cghost` and overlaps its disk
+  window with the other node's compute) is the next phase.
 
 ## Step-1 measurements (Llama-3.2-3B-Instruct Q8_0, M4 16GB)
 

--- a/src/ghost.rs
+++ b/src/ghost.rs
@@ -209,6 +209,20 @@ pub struct GhostFile {
 }
 
 impl GhostFile {
+    /// Open with optional strict-ceiling mode: `evict_page_cache` sets `F_NOCACHE` on the
+    /// handle (macOS) so streamed reads bypass the page cache entirely. For models that fit
+    /// in RAM the cache is a free win (leave this off); for the over-RAM models ghost mode
+    /// targets, the cache can only thrash and the OS must not accumulate the file's pages.
+    /// (`posix_madvise(DONTNEED)` does not apply here — that is for mmap'd ranges, and the
+    /// streamer uses positioned reads.)
+    pub fn open_with_options(path: &Path, evict_page_cache: bool) -> Result<Self> {
+        let this = Self::open(path)?;
+        if evict_page_cache {
+            crate::tensor::disable_file_cache_best_effort(&this.file);
+        }
+        Ok(this)
+    }
+
     pub fn open(path: &Path) -> Result<Self> {
         let mut file = File::open(path).map_err(|e| io_err(path, e))?;
         let mut magic = [0u8; 8];
@@ -320,5 +334,95 @@ impl GhostFile {
             .map(|g| g.span().1)
             .max()
             .unwrap_or(0)
+    }
+}
+
+/// One layer's weights, read + decoded off the critical path by [`GhostPrefetcher`].
+pub struct PrefetchedLayer {
+    pub layer_idx: usize,
+    pub weights: LlamaLayerWeights,
+    /// Bytes read from disk for this layer's group.
+    pub bytes: u64,
+    /// Wall time the worker spent reading + decoding (overlapped with the main thread's
+    /// forward, so it only shows up in token latency when it exceeds the compute time).
+    pub worker_us: u128,
+}
+
+/// Double-buffered streaming: a background worker reads + decodes layer N+1 from the
+/// `.cghost` file while the main thread runs layer N's forward. The result channel is a
+/// rendezvous (capacity 0), so at most TWO layer windows exist at any instant — one in the
+/// session being computed, one finished in the worker's hand awaiting handoff. The worker
+/// fulfills requests strictly in order; the main thread queues each chunk's layer indices
+/// ahead of consuming them (and primes the next chunk before the current one finishes, so
+/// the disk is already rewinding to layer 0 of token N+1 during the last forwards of
+/// token N).
+pub struct GhostPrefetcher {
+    request_tx: Option<std::sync::mpsc::Sender<usize>>,
+    result_rx: Option<std::sync::mpsc::Receiver<Result<PrefetchedLayer>>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl GhostPrefetcher {
+    pub fn spawn(ghost: std::sync::Arc<GhostFile>) -> Self {
+        let (request_tx, request_rx) = std::sync::mpsc::channel::<usize>();
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel::<Result<PrefetchedLayer>>(0);
+        let worker = std::thread::Builder::new()
+            .name("ghost-prefetch".to_string())
+            .spawn(move || {
+                let mut buf: Vec<u8> = Vec::with_capacity(ghost.max_layer_span() as usize);
+                while let Ok(layer_idx) = request_rx.recv() {
+                    let started = std::time::Instant::now();
+                    let result = ghost
+                        .read_layer(layer_idx, &mut buf)
+                        .map(|(weights, bytes)| PrefetchedLayer {
+                            layer_idx,
+                            weights,
+                            bytes,
+                            worker_us: started.elapsed().as_micros(),
+                        });
+                    // The receiver dropping mid-stream (generation ended) is a normal exit.
+                    if result_tx.send(result).is_err() {
+                        break;
+                    }
+                }
+            })
+            .expect("failed to spawn ghost-prefetch thread");
+        Self {
+            request_tx: Some(request_tx),
+            result_rx: Some(result_rx),
+            worker: Some(worker),
+        }
+    }
+
+    /// Queue a layer to be read + decoded. Requests are fulfilled strictly in order.
+    pub fn request(&self, layer_idx: usize) -> Result<()> {
+        self.request_tx
+            .as_ref()
+            .expect("prefetcher closed")
+            .send(layer_idx)
+            .map_err(|_| invalid("ghost-prefetch worker exited unexpectedly".to_string()))
+    }
+
+    /// Block until the next requested layer is ready (instant when the worker finished
+    /// while the previous layer was computing — the double-buffered steady state).
+    pub fn next(&self) -> Result<PrefetchedLayer> {
+        self.result_rx
+            .as_ref()
+            .expect("prefetcher closed")
+            .recv()
+            .map_err(|_| invalid("ghost-prefetch worker exited unexpectedly".to_string()))?
+    }
+}
+
+impl Drop for GhostPrefetcher {
+    fn drop(&mut self) {
+        // Close BOTH channel ends before joining: dropping the request sender ends the
+        // worker's request loop, and dropping the result receiver releases a worker that
+        // is blocked mid-handoff on the rendezvous send (otherwise the join deadlocks).
+        drop(self.request_tx.take());
+        drop(self.result_rx.take());
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
     }
 }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -41,10 +41,16 @@ pub use diagnostic_config::{
 pub use kv_cache::{LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, LlamaKvCacheTrace};
 pub use q8_block_reader::Q8BlockReader;
 use q8_runtime::{
-    q8_0_env_flag_disabled, q8_0_env_flag_enabled_default_off,
-    q8_0_env_flag_enabled_default_on_fail_closed, Q8PackedRows4MatmulSchedule, Q8RuntimeFlags,
-    ResolvedRuntimePlan,
+    q8_0_env_flag_enabled_default_off, q8_0_env_flag_enabled_default_on_fail_closed,
+    Q8PackedRows4MatmulSchedule, Q8RuntimeFlags, ResolvedRuntimePlan,
 };
+// All remaining callers are arch/OS-gated (aarch64 dotprod dispatch, Apple Accelerate), so
+// this import is unused on other targets.
+#[cfg_attr(
+    not(any(target_arch = "aarch64", target_os = "macos")),
+    allow(unused_imports)
+)]
+use q8_runtime::q8_0_env_flag_disabled;
 use q8_telemetry::*;
 pub use q8_telemetry::{
     q8_schedule_telemetry_enabled, reset_q8_schedule_telemetry, snapshot_q8_schedule_telemetry,

--- a/src/inference/q8_runtime.rs
+++ b/src/inference/q8_runtime.rs
@@ -240,6 +240,12 @@ pub(super) fn q8_0_env_flag_enabled_default_off(key: &str) -> bool {
         .unwrap_or(false)
 }
 
+// All callers are arch/OS-gated (aarch64 dotprod dispatch, Apple Accelerate), so this is
+// dead code on other targets.
+#[cfg_attr(
+    not(any(target_arch = "aarch64", target_os = "macos")),
+    allow(dead_code)
+)]
 pub(super) fn q8_0_env_flag_disabled(key: &str) -> bool {
     env::var(key)
         .map(|value| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use camelid::{
         recv_activation_packet, recv_token_feedback, send_activation_packet, send_token_feedback,
     },
     gguf::{read_metadata, GgufTensorType},
-    ghost::GhostFile,
+    ghost::{GhostFile, GhostPrefetcher},
     inference::{
         LlamaInferenceSession, LlamaLayerWeights, LlamaLoadedWeights, LlamaSampler,
         Q8ResidencyReport, SamplingConfig,
@@ -274,6 +274,15 @@ enum Command {
         /// Override Rayon worker threads.
         #[arg(long)]
         threads: Option<usize>,
+        /// Disable the double-buffered prefetch worker and read each layer synchronously
+        /// on the critical path (the v1 behavior; useful for A/B comparison).
+        #[arg(long, default_value_t = false)]
+        sync_stream: bool,
+        /// Strict memory ceiling mode: bypass the OS page cache for `.cghost` reads
+        /// (F_NOCACHE) so streamed pages never accumulate. Leave off when the model fits
+        /// in RAM — the cache is a free win there.
+        #[arg(long, default_value_t = false)]
+        evict_page_cache: bool,
     },
 }
 
@@ -512,23 +521,103 @@ async fn main() -> anyhow::Result<()> {
             prompt,
             max_tokens,
             threads,
+            sync_stream,
+            evict_page_cache,
         } => {
-            run_ghost(model, cghost, prompt, max_tokens, threads)?;
+            run_ghost(
+                model,
+                cghost,
+                prompt,
+                max_tokens,
+                threads,
+                sync_stream,
+                evict_page_cache,
+            )?;
         }
     }
     Ok(())
 }
 
+/// How ghost mode gets each layer's weights off disk.
+enum GhostStreamer {
+    /// v1: the read + decode happens on the critical path, before each layer's forward.
+    Sync { ghost: Arc<GhostFile>, buf: Vec<u8> },
+    /// v2 double-buffered: a background worker reads + decodes layer N+1 while layer N's
+    /// forward runs; the reported time is only the STALL waiting for the handoff. The
+    /// rendezvous handoff bounds the weight working set to two layer windows.
+    Prefetched {
+        prefetcher: GhostPrefetcher,
+        n_layers: usize,
+    },
+}
+
+impl GhostStreamer {
+    /// Queue the first chunk's layer reads (prefetched mode; no-op for sync).
+    fn prime(&self) -> anyhow::Result<()> {
+        if let GhostStreamer::Prefetched {
+            prefetcher,
+            n_layers,
+        } = self
+        {
+            for layer_idx in 0..*n_layers {
+                prefetcher.request(layer_idx)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Produce layer `layer_idx`'s decoded weights: (weights, bytes streamed, blocked µs).
+    /// On the chunk's last layer the prefetched mode queues the ENTIRE next chunk first, so
+    /// the worker is already rewinding to layer 0 of the next token while this layer's
+    /// forward (and the sampling between chunks) runs. The trailing chunk queued after the
+    /// final token is never consumed — the worker reads at most one extra layer, blocks on
+    /// the rendezvous, and is released by Drop.
+    fn fetch(
+        &mut self,
+        layer_idx: usize,
+        last_in_chunk: bool,
+    ) -> anyhow::Result<(LlamaLayerWeights, u64, u128)> {
+        match self {
+            GhostStreamer::Sync { ghost, buf } => {
+                let started = Instant::now();
+                let (layer, span) = ghost.read_layer(layer_idx, buf)?;
+                Ok((layer, span, started.elapsed().as_micros()))
+            }
+            GhostStreamer::Prefetched {
+                prefetcher,
+                n_layers,
+            } => {
+                if last_in_chunk {
+                    for next_idx in 0..*n_layers {
+                        prefetcher.request(next_idx)?;
+                    }
+                }
+                let started = Instant::now();
+                let prefetched = prefetcher.next()?;
+                anyhow::ensure!(
+                    prefetched.layer_idx == layer_idx,
+                    "prefetcher returned layer {} but layer {layer_idx} was expected",
+                    prefetched.layer_idx
+                );
+                Ok((
+                    prefetched.weights,
+                    prefetched.bytes,
+                    started.elapsed().as_micros(),
+                ))
+            }
+        }
+    }
+}
+
 /// Ghost mode: run every transformer layer of one chunk (prefill or a single decoded
-/// token), streaming each layer's weights from the `.cghost` file right before its forward
-/// and dropping them right after — the weight working window is exactly one layer. Returns
-/// the chunk's output hidden state plus (bytes streamed, stream time, forward time).
-#[allow(clippy::too_many_arguments)]
+/// token), streaming each layer's weights from the `.cghost` file and dropping them right
+/// after the layer's forward — the weight working window is one layer (sync) or two
+/// (prefetched). Returns the chunk's output hidden state plus (bytes streamed, time blocked
+/// on streaming, forward time).
 fn ghost_stream_layers(
     session: &mut LlamaInferenceSession,
-    ghost: &GhostFile,
+    streamer: &mut GhostStreamer,
     placeholder: &LlamaLayerWeights,
-    buf: &mut Vec<u8>,
     hidden: CpuTensor,
     pos: usize,
     seq_len: usize,
@@ -537,45 +626,44 @@ fn ghost_stream_layers(
     let n_layers = session.weights.layers.len();
     let mut hidden = hidden;
     let mut bytes_total = 0u64;
-    let mut stream_us_total = 0u128;
+    let mut wait_us_total = 0u128;
     let mut forward_us_total = 0u128;
     for layer_idx in 0..n_layers {
-        let stream_started = Instant::now();
-        let (layer, span) = ghost.read_layer(layer_idx, buf)?;
+        let (layer, span, wait_us) = streamer.fetch(layer_idx, layer_idx + 1 == n_layers)?;
         Arc::make_mut(&mut session.weights).layers[layer_idx] = layer;
-        let stream_us = stream_started.elapsed().as_micros();
         let forward_started = Instant::now();
         hidden = session.ghost_forward_one_layer(&hidden, layer_idx, pos, seq_len)?;
         let forward_us = forward_started.elapsed().as_micros();
-        // Drop the streamed weights immediately; only the one-layer window is ever held.
+        // Drop the streamed weights immediately; the window never accumulates.
         Arc::make_mut(&mut session.weights).layers[layer_idx] = placeholder.clone();
         bytes_total += span;
-        stream_us_total += stream_us;
+        wait_us_total += wait_us;
         forward_us_total += forward_us;
         if log_layers {
             eprintln!(
-                "[ghost] layer {layer_idx:>3}: stream {:7.1} ms ({:6.1} MiB @ {:5.0} MB/s)  \
-                 forward {:7.1} ms",
-                stream_us as f64 / 1000.0,
+                "[ghost] layer {layer_idx:>3}: wait {:7.1} ms ({:6.1} MiB)  forward {:7.1} ms",
+                wait_us as f64 / 1000.0,
                 span as f64 / (1024.0 * 1024.0),
-                span as f64 / (stream_us.max(1) as f64), // bytes/us == MB/s
                 forward_us as f64 / 1000.0,
             );
         }
     }
     session.ghost_advance_position(seq_len);
-    Ok((hidden, bytes_total, stream_us_total, forward_us_total))
+    Ok((hidden, bytes_total, wait_us_total, forward_us_total))
 }
 
-/// EXPERIMENTAL ghost (layer-streaming) mode, synchronous v1: greedy generation with the
-/// model executed one transformer block at a time from a `.cghost` file. RAM holds the
-/// embedding/output ends + KV cache + ONE layer's weights; everything else stays on disk.
+/// EXPERIMENTAL ghost (layer-streaming) mode: greedy generation with the model executed one
+/// transformer block at a time from a `.cghost` file. RAM holds the embedding/output ends +
+/// KV cache + the streaming window (one layer sync, two prefetched); everything else stays
+/// on disk.
 fn run_ghost(
     model: PathBuf,
     cghost: PathBuf,
     prompt: String,
     max_tokens: usize,
     threads: Option<usize>,
+    sync_stream: bool,
+    evict_page_cache: bool,
 ) -> anyhow::Result<()> {
     configure_rayon_threads(threads)?;
     let gib = |bytes: u64| bytes as f64 / (1024.0 * 1024.0 * 1024.0);
@@ -587,7 +675,7 @@ fn run_ghost(
     let store = TensorStore::open(&model, &gguf);
     let tokenizer = Tokenizer::from_gguf(&gguf)?;
 
-    let ghost = GhostFile::open(&cghost)?;
+    let ghost = Arc::new(GhostFile::open_with_options(&cghost, evict_page_cache)?);
     let n_layers = config.block_count as usize;
     anyhow::ensure!(
         ghost.index.block_count == n_layers,
@@ -601,13 +689,29 @@ fn run_ghost(
     let weights = LlamaLoadedWeights::load_distributed(&store, &binding, 0, 0, true, true)?;
     let mut session = LlamaInferenceSession::new(config.clone(), Arc::new(weights))?;
     let placeholder = session.weights.layers[0].clone();
-    let mut buf: Vec<u8> = Vec::with_capacity(ghost.max_layer_span() as usize);
+    let mut streamer = if sync_stream {
+        GhostStreamer::Sync {
+            buf: Vec::with_capacity(ghost.max_layer_span() as usize),
+            ghost: Arc::clone(&ghost),
+        }
+    } else {
+        GhostStreamer::Prefetched {
+            prefetcher: GhostPrefetcher::spawn(Arc::clone(&ghost)),
+            n_layers,
+        }
+    };
     println!(
-        "[ghost] resident ends loaded in {:.1}s; {} layers x {:.1} MiB max streaming window; \
-         footprint {:.2} GiB",
+        "[ghost] resident ends loaded in {:.1}s; {} layers x {:.1} MiB max streaming window \
+         ({}, page cache {}); footprint {:.2} GiB",
         load_started.elapsed().as_secs_f64(),
         n_layers,
         ghost.max_layer_span() as f64 / (1024.0 * 1024.0),
+        if sync_stream {
+            "sync"
+        } else {
+            "double-buffered prefetch"
+        },
+        if evict_page_cache { "evicted" } else { "on" },
         gib(phys_footprint_bytes()),
     );
 
@@ -616,15 +720,15 @@ fn run_ghost(
     let mut pos = 0usize;
 
     let prefill_started = Instant::now();
+    streamer.prime()?;
     let hidden = session
         .weights
         .token_embedding
         .embedding_lookup(&token_ids, "token_embedding_ghost")?;
-    let (mut hidden, bytes, stream_us, forward_us) = ghost_stream_layers(
+    let (mut hidden, bytes, wait_us, forward_us) = ghost_stream_layers(
         &mut session,
-        &ghost,
+        &mut streamer,
         &placeholder,
-        &mut buf,
         hidden,
         pos,
         token_ids.len(),
@@ -632,11 +736,11 @@ fn run_ghost(
     )?;
     pos += token_ids.len();
     println!(
-        "[ghost] prefill: {:.1}s ({:.2} GiB streamed @ {:.0} MB/s, forward {:.1}s); \
+        "[ghost] prefill: {:.1}s ({:.2} GiB streamed, blocked {:.1}s, forward {:.1}s); \
          footprint {:.2} GiB",
         prefill_started.elapsed().as_secs_f64(),
         gib(bytes),
-        bytes as f64 / (stream_us.max(1) as f64),
+        wait_us as f64 / 1_000_000.0,
         forward_us as f64 / 1_000_000.0,
         gib(phys_footprint_bytes()),
     );
@@ -668,11 +772,10 @@ fn run_ghost(
             .weights
             .token_embedding
             .embedding_lookup(&[token], "token_embedding_ghost")?;
-        let (next_hidden, bytes, stream_us, forward_us) = ghost_stream_layers(
+        let (next_hidden, bytes, wait_us, forward_us) = ghost_stream_layers(
             &mut session,
-            &ghost,
+            &mut streamer,
             &placeholder,
-            &mut buf,
             embedding,
             pos,
             1,
@@ -683,12 +786,12 @@ fn run_ghost(
         let token_us = token_started.elapsed().as_micros();
         decode_us_total += token_us;
         eprintln!(
-            "[ghost] token {:>3}: {:6.0} ms ({:.2} GiB streamed @ {:4.0} MB/s, forward \
+            "[ghost] token {:>3}: {:6.0} ms ({:.2} GiB streamed, blocked {:5.0} ms, forward \
              {:5.0} ms)",
             step + 1,
             token_us as f64 / 1000.0,
             gib(bytes),
-            bytes as f64 / (stream_us.max(1) as f64),
+            wait_us as f64 / 1000.0,
             forward_us as f64 / 1000.0,
         );
     }


### PR DESCRIPTION
Ghost task 2: hide the disk latency. A background worker reads + decodes layer N+1 while the main thread runs layer N's forward; rendezvous handoff bounds the working set to exactly **two layer windows**; the next chunk is primed before the current one ends, so the disk rewinds to layer 0 of token N+1 during the last forwards + sampling of token N. `--sync-stream` preserves v1 for A/B; `--evict-page-cache` (F_NOCACHE) is the strict-ceiling mode for over-RAM models.

## A/B (3B Q8, M4 16GB, warm page cache, 47 tokens)

| mode | blocked | forward | total/token | tok/s |
|---|---|---|---|---|
| sync (v1) | 419 ms | 327 ms | 746 ms | 1.343 |
| **prefetch (default)** | **116 ms** | 365 ms | **483 ms** | **2.067 (1.54×)** |

Prefill stall fully hidden (0.0 s). Peak footprint 1.75 GiB vs 1.65 sync — exactly the one extra window. Greedy output **byte-identical** to the resident CPU path in both modes. Residual stall = the slice of read+decode exceeding the forward; both phases are bandwidth-bound (forward inflates ~10% under contention), so the ceiling on CPU is max(read,forward), not zero.

Shutdown drops both channel ends before joining so a worker blocked mid-rendezvous can't deadlock the join.

Next phase: two-node ghost pipeline (each node hosts half the `.cghost`, disk window overlapped with the peer's compute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)