### PR TITLE
feat(ghost): two-node ghost mesh — stream pipeline shards from per-node .cghost files (task 3)

### DIFF
--- a/docs/runtime/ghost-mode.md
+++ b/docs/runtime/ghost-mode.md
@@ -72,3 +72,31 @@ loader/kernels; that support is a prerequisite for the v2 map.
   loads see there), i.e. ~2.8 s/layer. On internal NVMe-class storage the same read is
   projected at tens of milliseconds. Throughput numbers for ghost mode are therefore quoted
   per storage tier; the PoC gate is correctness + the memory ceiling, not speed.
+
+## Task 3: the two-node ghost mesh (2026-06-03)
+
+`distribute-master --cghost <shard>` / `distribute-worker --cghost <shard>`: each pipeline
+node streams its own layer shard per token from a node-local `.cghost` (made with
+`repack-ghost --layers a..b`), double-buffered, holding only the embedding (first node) or
+output ends (last node) resident. The cross-node overlap falls out of chunk priming: a node
+queues its next chunk during its own last layer, so its disk window runs while the OTHER
+node computes and the activations cross the bridge.
+
+Measured — Llama-2-13B Q8, two M4 16 GB minis over Thunderbolt, split 0..20 / 20..40, each
+shard 6.44 GiB on the node's internal NVMe (321.4 MiB/layer window):
+
+- **Peak RSS 1.80 GB per node** (resident pipeline needs 7.2–7.8 GB/node) — the fit story:
+  the mesh runs a model whose resident form nearly fills both machines, in ~an eighth of
+  the memory.
+- Greedy output identical to the resident pipeline's stream.
+- Steady state ~4.05 s/token = **0.24 tok/s**: master ~3.0 s (disk-bound: 6.44 GiB at
+  ~2.15 GB/s; its own window cannot hide behind anything), worker ~1.04 s visible (about
+  two-thirds of its window streams during its idle while the master computes), feedback
+  ~5 ms. Without the cross-node overlap the same token would cost ~6 s.
+- Split tuning is an open lever: the first node's window is unhideable, so giving it fewer
+  layers (e.g. 14/26) should shrink the critical path until the last node's residual
+  window surfaces.
+
+This is the throughput-for-memory trade at mesh scale: per-storage-tier numbers as always —
+faster NVMe (or smaller shards from a future low-bit map) moves the disk-bound term
+directly.

--- a/src/ghost.rs
+++ b/src/ghost.rs
@@ -99,23 +99,41 @@ fn io_err(path: &Path, source: std::io::Error) -> BackendError {
 
 /// Write a `.cghost` re-layout of `store`'s GGUF. Dense models only — ghost v1 refuses MoE
 /// (the streaming window assumes one fixed-size group per block).
+///
+/// `layer_range` selects a pipeline shard: only those "blk.N" groups are written, the "pre"
+/// group (embedding) only when the range starts at layer 0, and the "post" group
+/// (output norm/projection) only when it ends at the last layer — so each mesh node hosts
+/// just its own half of the payload on local disk. `None` writes the whole model.
 pub fn write_cghost(
     store: &TensorStore,
     binding: &LlamaTensorBinding,
     source_model: &str,
     out_path: &Path,
+    layer_range: Option<std::ops::Range<usize>>,
 ) -> Result<CghostIndex> {
+    let total_layers = binding.layers.len();
+    let range = layer_range.unwrap_or(0..total_layers);
+    if range.start >= range.end || range.end > total_layers {
+        return Err(invalid(format!(
+            "layer range {range:?} is invalid for a {total_layers}-layer model"
+        )));
+    }
     // Plan the group contents (names + roles) first.
     let mut planned: Vec<(String, Vec<(String, String)>)> = Vec::new();
-    let mut pre = vec![(
-        "token_embedding".to_string(),
-        binding.token_embedding.name.clone(),
-    )];
-    if let Some(rope) = &binding.rope_freqs {
-        pre.push(("rope_freqs".to_string(), rope.name.clone()));
+    if range.start == 0 {
+        let mut pre = vec![(
+            "token_embedding".to_string(),
+            binding.token_embedding.name.clone(),
+        )];
+        if let Some(rope) = &binding.rope_freqs {
+            pre.push(("rope_freqs".to_string(), rope.name.clone()));
+        }
+        planned.push(("pre".to_string(), pre));
     }
-    planned.push(("pre".to_string(), pre));
     for (layer_idx, layer) in binding.layers.iter().enumerate() {
+        if !range.contains(&layer_idx) {
+            continue;
+        }
         let (gate, up, down) = match &layer.ffn {
             LlamaFfnTensors::Dense { gate, up, down } => (gate, up, down),
             LlamaFfnTensors::MoE { .. } => {
@@ -140,11 +158,13 @@ pub fn write_cghost(
         ];
         planned.push((format!("blk.{layer_idx}"), tensors));
     }
-    let mut post = vec![("output_norm".to_string(), binding.output_norm.name.clone())];
-    if !binding.output_is_tied_embedding {
-        post.push(("output".to_string(), binding.output.name.clone()));
+    if range.end == total_layers {
+        let mut post = vec![("output_norm".to_string(), binding.output_norm.name.clone())];
+        if !binding.output_is_tied_embedding {
+            post.push(("output".to_string(), binding.output.name.clone()));
+        }
+        planned.push(("post".to_string(), post));
     }
-    planned.push(("post".to_string(), post));
 
     // Stream the payload out group by group, page-aligning each group start.
     let mut file = File::create(out_path).map_err(|e| io_err(out_path, e))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,12 @@ enum Command {
         /// Override Rayon worker threads.
         #[arg(long)]
         threads: Option<usize>,
+        /// EXPERIMENTAL ghost mesh: stream this node's layer shard per token from a
+        /// `.cghost` file (double-buffered) instead of holding it resident. Only the
+        /// embedding/output ends stay in RAM; the shard's disk window overlaps the other
+        /// node's compute.
+        #[arg(long)]
+        cghost: Option<PathBuf>,
     },
     /// Start a distributed pipeline master node.
     DistributeMaster {
@@ -221,6 +227,12 @@ enum Command {
         /// Override Rayon worker threads.
         #[arg(long)]
         threads: Option<usize>,
+        /// EXPERIMENTAL ghost mesh: stream this node's layer shard per token from a
+        /// `.cghost` file (double-buffered) instead of holding it resident. Only the
+        /// embedding/output ends stay in RAM; the shard's disk window overlaps the other
+        /// node's compute.
+        #[arg(long)]
+        cghost: Option<PathBuf>,
     },
     /// Single-node generation microbenchmark. Loads a GGUF model once, generates
     /// from a prompt, and emits one JSON metrics object per measured iteration
@@ -478,8 +490,18 @@ async fn main() -> anyhow::Result<()> {
             layers,
             master_addr,
             threads,
+            cghost,
         } => {
-            run_distribute_worker(path, addr, forward_addr, layers, master_addr, threads).await?;
+            run_distribute_worker(
+                path,
+                addr,
+                forward_addr,
+                layers,
+                master_addr,
+                threads,
+                cghost,
+            )
+            .await?;
         }
         Command::DistributeMaster {
             path,
@@ -489,9 +511,19 @@ async fn main() -> anyhow::Result<()> {
             prompt,
             max_tokens,
             threads,
+            cghost,
         } => {
-            run_distribute_master(path, worker_addr, layers, addr, prompt, max_tokens, threads)
-                .await?;
+            run_distribute_master(
+                path,
+                worker_addr,
+                layers,
+                addr,
+                prompt,
+                max_tokens,
+                threads,
+                cghost,
+            )
+            .await?;
         }
         Command::BenchGenerate {
             model,
@@ -538,28 +570,46 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// How ghost mode gets each layer's weights off disk.
-enum GhostStreamer {
+/// How ghost mode gets each layer's weights off disk. `range` is the node's pipeline shard
+/// (the whole model on a single node); streaming cycles over it chunk after chunk.
+struct GhostStreamer {
+    range: std::ops::Range<usize>,
+    kind: GhostStreamerKind,
+}
+
+enum GhostStreamerKind {
     /// v1: the read + decode happens on the critical path, before each layer's forward.
     Sync { ghost: Arc<GhostFile>, buf: Vec<u8> },
     /// v2 double-buffered: a background worker reads + decodes layer N+1 while layer N's
     /// forward runs; the reported time is only the STALL waiting for the handoff. The
     /// rendezvous handoff bounds the weight working set to two layer windows.
-    Prefetched {
-        prefetcher: GhostPrefetcher,
-        n_layers: usize,
-    },
+    Prefetched { prefetcher: GhostPrefetcher },
 }
 
 impl GhostStreamer {
+    fn new_sync(ghost: Arc<GhostFile>, range: std::ops::Range<usize>) -> Self {
+        Self {
+            range,
+            kind: GhostStreamerKind::Sync {
+                buf: Vec::with_capacity(ghost.max_layer_span() as usize),
+                ghost,
+            },
+        }
+    }
+
+    fn new_prefetched(ghost: Arc<GhostFile>, range: std::ops::Range<usize>) -> Self {
+        Self {
+            range,
+            kind: GhostStreamerKind::Prefetched {
+                prefetcher: GhostPrefetcher::spawn(ghost),
+            },
+        }
+    }
+
     /// Queue the first chunk's layer reads (prefetched mode; no-op for sync).
     fn prime(&self) -> anyhow::Result<()> {
-        if let GhostStreamer::Prefetched {
-            prefetcher,
-            n_layers,
-        } = self
-        {
-            for layer_idx in 0..*n_layers {
+        if let GhostStreamerKind::Prefetched { prefetcher } = &self.kind {
+            for layer_idx in self.range.clone() {
                 prefetcher.request(layer_idx)?;
             }
         }
@@ -568,27 +618,26 @@ impl GhostStreamer {
 
     /// Produce layer `layer_idx`'s decoded weights: (weights, bytes streamed, blocked µs).
     /// On the chunk's last layer the prefetched mode queues the ENTIRE next chunk first, so
-    /// the worker is already rewinding to layer 0 of the next token while this layer's
-    /// forward (and the sampling between chunks) runs. The trailing chunk queued after the
-    /// final token is never consumed — the worker reads at most one extra layer, blocks on
-    /// the rendezvous, and is released by Drop.
+    /// the worker is already rewinding to the shard's first layer for the next token while
+    /// this layer's forward runs — on a mesh node that disk window overlaps the OTHER
+    /// node's compute and the network hops. The trailing chunk queued after the final token
+    /// is never consumed — the worker reads at most one extra layer, blocks on the
+    /// rendezvous, and is released by Drop.
     fn fetch(
         &mut self,
         layer_idx: usize,
         last_in_chunk: bool,
     ) -> anyhow::Result<(LlamaLayerWeights, u64, u128)> {
-        match self {
-            GhostStreamer::Sync { ghost, buf } => {
+        let range = self.range.clone();
+        match &mut self.kind {
+            GhostStreamerKind::Sync { ghost, buf } => {
                 let started = Instant::now();
                 let (layer, span) = ghost.read_layer(layer_idx, buf)?;
                 Ok((layer, span, started.elapsed().as_micros()))
             }
-            GhostStreamer::Prefetched {
-                prefetcher,
-                n_layers,
-            } => {
+            GhostStreamerKind::Prefetched { prefetcher } => {
                 if last_in_chunk {
-                    for next_idx in 0..*n_layers {
+                    for next_idx in range {
                         prefetcher.request(next_idx)?;
                     }
                 }
@@ -609,6 +658,36 @@ impl GhostStreamer {
     }
 }
 
+/// Build the ghost-mesh streaming context for a pipeline node: open the node's `.cghost`
+/// shard, spawn the double-buffered prefetcher over the node's layer range, and prime the
+/// first chunk. Returns None when the node runs the resident path. While this node waits on
+/// the network (the other node computing), its prefetch worker is already streaming the
+/// next token's layers — the disk window overlaps the peer's compute.
+fn make_ghost_node_ctx(
+    session: &LlamaInferenceSession,
+    cghost: Option<&std::path::Path>,
+    layer_range: std::ops::Range<usize>,
+) -> anyhow::Result<Option<(GhostStreamer, LlamaLayerWeights)>> {
+    let Some(path) = cghost else { return Ok(None) };
+    let ghost = Arc::new(GhostFile::open(path)?);
+    let n_layers = session.weights.layers.len();
+    anyhow::ensure!(
+        ghost.index.block_count == n_layers,
+        ".cghost block_count {} does not match model block_count {n_layers}",
+        ghost.index.block_count
+    );
+    let placeholder = session.weights.layers[0].clone();
+    let streamer = GhostStreamer::new_prefetched(Arc::clone(&ghost), layer_range.clone());
+    streamer.prime()?;
+    println!(
+        "[ghost] mesh node streams layers {:?} from {:?} ({:.1} MiB window, double-buffered)",
+        layer_range,
+        path,
+        ghost.max_layer_span() as f64 / (1024.0 * 1024.0),
+    );
+    Ok(Some((streamer, placeholder)))
+}
+
 /// Ghost mode: run every transformer layer of one chunk (prefill or a single decoded
 /// token), streaming each layer's weights from the `.cghost` file and dropping them right
 /// after the layer's forward — the weight working window is one layer (sync) or two
@@ -623,13 +702,13 @@ fn ghost_stream_layers(
     seq_len: usize,
     log_layers: bool,
 ) -> anyhow::Result<(CpuTensor, u64, u128, u128)> {
-    let n_layers = session.weights.layers.len();
+    let range = streamer.range.clone();
     let mut hidden = hidden;
     let mut bytes_total = 0u64;
     let mut wait_us_total = 0u128;
     let mut forward_us_total = 0u128;
-    for layer_idx in 0..n_layers {
-        let (layer, span, wait_us) = streamer.fetch(layer_idx, layer_idx + 1 == n_layers)?;
+    for layer_idx in range.clone() {
+        let (layer, span, wait_us) = streamer.fetch(layer_idx, layer_idx + 1 == range.end)?;
         Arc::make_mut(&mut session.weights).layers[layer_idx] = layer;
         let forward_started = Instant::now();
         hidden = session.ghost_forward_one_layer(&hidden, layer_idx, pos, seq_len)?;
@@ -690,15 +769,9 @@ fn run_ghost(
     let mut session = LlamaInferenceSession::new(config.clone(), Arc::new(weights))?;
     let placeholder = session.weights.layers[0].clone();
     let mut streamer = if sync_stream {
-        GhostStreamer::Sync {
-            buf: Vec::with_capacity(ghost.max_layer_span() as usize),
-            ghost: Arc::clone(&ghost),
-        }
+        GhostStreamer::new_sync(Arc::clone(&ghost), 0..n_layers)
     } else {
-        GhostStreamer::Prefetched {
-            prefetcher: GhostPrefetcher::spawn(Arc::clone(&ghost)),
-            n_layers,
-        }
+        GhostStreamer::new_prefetched(Arc::clone(&ghost), 0..n_layers)
     };
     println!(
         "[ghost] resident ends loaded in {:.1}s; {} layers x {:.1} MiB max streaming window \
@@ -1156,6 +1229,7 @@ fn parse_layers_range(layers_str: &str) -> anyhow::Result<std::ops::Range<usize>
     Ok(start..end)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_distribute_worker(
     path: PathBuf,
     addr: SocketAddr,
@@ -1163,6 +1237,7 @@ async fn run_distribute_worker(
     layers: String,
     master_addr: Option<SocketAddr>,
     threads: Option<usize>,
+    cghost: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     configure_rayon_threads(threads)?;
 
@@ -1176,13 +1251,16 @@ async fn run_distribute_worker(
     let layer_range = parse_layers_range(&layers)?;
     println!("Initializing worker session for layers {:?}", layer_range);
 
-    let weights = Arc::new(LlamaLoadedWeights::load(
-        &store,
-        &binding,
-        Some(layer_range.clone()),
-    )?);
+    let weights = Arc::new(if cghost.is_some() {
+        // Ghost mesh: only the output ends stay resident (this is the LAST node when it has
+        // no forward_addr); the layer shard streams from the .cghost per token.
+        LlamaLoadedWeights::load_distributed(&store, &binding, 0, 0, false, true)?
+    } else {
+        LlamaLoadedWeights::load(&store, &binding, Some(layer_range.clone()))?
+    });
     let mut session = LlamaInferenceSession::new(config.clone(), weights)?;
     assert_q8_0_weight_residency(&session.weights, "dist-worker");
+    let mut ghost_ctx = make_ghost_node_ctx(&session, cghost.as_deref(), layer_range.clone())?;
 
     let listener = TcpListener::bind(addr)?;
     println!("Worker listening on {}...", addr);
@@ -1225,11 +1303,24 @@ async fn run_distribute_worker(
             CpuTensor::from_f32("activations", vec![rows, hidden_dim], activations.clone())?;
 
         let forward_started = Instant::now();
-        let out_hidden = session.forward_layer_range_from_hidden(
-            &hidden,
-            header.pos as usize,
-            header.seq_len as usize,
-        )?;
+        let out_hidden = if let Some((streamer, placeholder)) = ghost_ctx.as_mut() {
+            let (out, _bytes, _wait_us, _forward_us) = ghost_stream_layers(
+                &mut session,
+                streamer,
+                placeholder,
+                hidden,
+                header.pos as usize,
+                header.seq_len as usize,
+                false,
+            )?;
+            out
+        } else {
+            session.forward_layer_range_from_hidden(
+                &hidden,
+                header.pos as usize,
+                header.seq_len as usize,
+            )?
+        };
         let forward_us = forward_started.elapsed().as_micros();
         let tail_started = Instant::now();
 
@@ -1268,6 +1359,7 @@ async fn run_distribute_worker(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_distribute_master(
     path: PathBuf,
     worker_addr: SocketAddr,
@@ -1276,6 +1368,7 @@ async fn run_distribute_master(
     prompt: String,
     max_tokens: usize,
     threads: Option<usize>,
+    cghost: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     configure_rayon_threads(threads)?;
 
@@ -1289,13 +1382,16 @@ async fn run_distribute_master(
     let layer_range = parse_layers_range(&layers)?;
     println!("Initializing master session for layers {:?}", layer_range);
 
-    let weights = Arc::new(LlamaLoadedWeights::load(
-        &store,
-        &binding,
-        Some(layer_range.clone()),
-    )?);
+    let weights = Arc::new(if cghost.is_some() {
+        // Ghost mesh: only the token embedding stays resident (the master is the FIRST
+        // node); the layer shard streams from the .cghost per token.
+        LlamaLoadedWeights::load_distributed(&store, &binding, 0, 0, true, false)?
+    } else {
+        LlamaLoadedWeights::load(&store, &binding, Some(layer_range.clone()))?
+    });
     let mut session = LlamaInferenceSession::new(config.clone(), weights)?;
     assert_q8_0_weight_residency(&session.weights, "dist-master");
+    let mut ghost_ctx = make_ghost_node_ctx(&session, cghost.as_deref(), layer_range.clone())?;
 
     let listener = TcpListener::bind(addr)?;
     println!("Master listening for feedback on {}...", addr);
@@ -1314,7 +1410,20 @@ async fn run_distribute_master(
         .weights
         .token_embedding
         .embedding_lookup(&token_ids, "token_embedding_prefill")?;
-    let out_hidden = session.forward_layer_range_from_hidden(&hidden, pos, seq_len)?;
+    let out_hidden = if let Some((streamer, placeholder)) = ghost_ctx.as_mut() {
+        ghost_stream_layers(
+            &mut session,
+            streamer,
+            placeholder,
+            hidden,
+            pos,
+            seq_len,
+            false,
+        )?
+        .0
+    } else {
+        session.forward_layer_range_from_hidden(&hidden, pos, seq_len)?
+    };
 
     send_activation_packet(
         &mut downstream_stream,
@@ -1342,7 +1451,20 @@ async fn run_distribute_master(
             .weights
             .token_embedding
             .embedding_lookup(&[current_token], "token_embedding")?;
-        let out_hidden = session.forward_layer_range_from_hidden(&hidden, pos, seq_len)?;
+        let out_hidden = if let Some((streamer, placeholder)) = ghost_ctx.as_mut() {
+            ghost_stream_layers(
+                &mut session,
+                streamer,
+                placeholder,
+                hidden,
+                pos,
+                seq_len,
+                false,
+            )?
+            .0
+        } else {
+            session.forward_layer_range_from_hidden(&hidden, pos, seq_len)?
+        };
         let compute_us = compute_started.elapsed().as_micros();
         let send_started = Instant::now();
         send_activation_packet(

--- a/tools/bench/distributed/two-mac-run.sh
+++ b/tools/bench/distributed/two-mac-run.sh
@@ -24,6 +24,12 @@ EXTRA_ENV="${EXTRA_ENV:-}"   # extra VAR=VAL pairs exported on BOTH nodes (e.g. 
 # Repack OFF by default: the GPU-resident decode path needs plain (un-packed) Q8_0 blocks,
 # and the nodes' residency gate hard-fails on repacked storage. Set REPACK=1 for CPU-decode runs.
 REPACK="${REPACK:-0}"
+# Ghost mesh: when set, each node streams its layer shard per token from its local .cghost
+# (made with `repack-ghost --layers a..b`) instead of holding it resident.
+MASTER_CGHOST="${MASTER_CGHOST:-}"   # local .cghost path for the master's 0..SPLIT shard
+WORKER_CGHOST="${WORKER_CGHOST:-}"   # REMOTE .cghost path for the worker's SPLIT..TOTAL shard
+MASTER_GHOST_ARGS=""; [ -n "$MASTER_CGHOST" ] && MASTER_GHOST_ARGS="--cghost $MASTER_CGHOST"
+WORKER_GHOST_ARGS=""; [ -n "$WORKER_CGHOST" ] && WORKER_GHOST_ARGS="--cghost $WORKER_CGHOST"
 REMOTE_MODEL="${REMOTE_MODEL:-$MODEL}"
 PORT_W=5005
 PORT_M=5006
@@ -52,7 +58,7 @@ fi
 # 2) Launch the worker (last node) on the remote, bound to its TB IP.
 echo "[two-mac] starting remote worker..."
 ssh "$WORKER_HOST" "CAMELID_MAC_Q8_REPACK=$REPACK $EXTRA_ENV /usr/bin/time -l '$REMOTE_BIN' distribute-worker '$REMOTE_MODEL' \
-  --addr $WORKER_TB_IP:$PORT_W --layers $SPLIT..$TOTAL_LAYERS --master-addr $MASTER_TB_IP:$PORT_M" \
+  --addr $WORKER_TB_IP:$PORT_W --layers $SPLIT..$TOTAL_LAYERS --master-addr $MASTER_TB_IP:$PORT_M $WORKER_GHOST_ARGS" \
   >/tmp/two_mac_worker.out 2>&1 &
 SSH_PID=$!
 
@@ -61,7 +67,8 @@ echo "[two-mac] starting master..."
 START=$(python3 -c 'import time;print(time.time())')
 env CAMELID_MAC_Q8_REPACK=$REPACK $EXTRA_ENV /usr/bin/time -l "$CAMELID_BIN" distribute-master "$MODEL" \
   --worker-addr "$WORKER_TB_IP:$PORT_W" --layers "0..$SPLIT" --addr "$MASTER_TB_IP:$PORT_M" \
-  --prompt "$PROMPT" --max-tokens "$MAX_TOKENS" >/tmp/two_mac_master.out 2>/tmp/two_mac_master.time || true
+  --prompt "$PROMPT" --max-tokens "$MAX_TOKENS" $MASTER_GHOST_ARGS \
+  >/tmp/two_mac_master.out 2>/tmp/two_mac_master.time || true
 END=$(python3 -c 'import time;print(time.time())')
 
 # 4) Clean up the remote worker.

--- a/tools/repack_ghost.rs
+++ b/tools/repack_ghost.rs
@@ -26,6 +26,17 @@ struct Args {
     /// Output path (default: <model>.cghost)
     #[arg(long)]
     out: Option<PathBuf>,
+    /// Pipeline shard: only write these transformer blocks (e.g. "0..20" or "20..40"),
+    /// plus the embedding group when starting at 0 and the output group when ending at the
+    /// last layer. Default: the whole model.
+    #[arg(long)]
+    layers: Option<String>,
+}
+
+fn parse_layers_range(layers: &str) -> anyhow::Result<std::ops::Range<usize>> {
+    let parts: Vec<&str> = layers.split("..").collect();
+    anyhow::ensure!(parts.len() == 2, "invalid layers range format: {layers}");
+    Ok(parts[0].parse::<usize>()?..parts[1].parse::<usize>()?)
 }
 
 fn main() -> anyhow::Result<()> {
@@ -50,12 +61,14 @@ fn main() -> anyhow::Result<()> {
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
 
+    let layer_range = args.layers.as_deref().map(parse_layers_range).transpose()?;
     println!(
-        "[repack-ghost] repacking {} transformer blocks -> {:?}",
+        "[repack-ghost] repacking blocks {:?} of {} -> {:?}",
+        layer_range.clone().unwrap_or(0..binding.layers.len()),
         binding.layers.len(),
         out
     );
-    let index = write_cghost(&store, &binding, &source, &out)?;
+    let index = write_cghost(&store, &binding, &source, &out, layer_range)?;
 
     let total: u64 = index.groups.iter().map(|g| g.span().1).sum();
     let max_layer = index


### PR DESCRIPTION
Ghost task 3: the two-node mesh. `repack-ghost --layers a..b` writes a pipeline shard (its blk groups + the embedding group iff starting at 0 / output group iff ending at the last layer); `distribute-master`/`distribute-worker --cghost <shard>` stream their layer range per token, double-buffered, holding only the embedding / output ends resident. Cross-node disk/compute overlap falls out of chunk priming: each node's prefetcher streams token N+1's layers while the OTHER node computes.

## Measured (Llama-2-13B Q8, 2× M4 16GB over Thunderbolt, 6.44 GiB shard per node on internal NVMe)

| metric | resident pipeline | ghost mesh |
|---|---|---|
| peak RSS / node | 7.2–7.8 GB | **1.80 GB** |
| decode | 5.1 tok/s (GPU) / 1.48 (CPU) | 0.24 tok/s |
| greedy output | reference | **identical** |

Steady state ~4.05 s/token: master ~3.0 s (disk-bound, unhideable first window), worker ~1.04 s visible (~⅔ of its 6.44 GiB window streams during its idle under the master's compute). Without the overlap the token would cost ~6 s. 3B loopback mesh parity: byte-identical to the resident CPU reference.

Known lever: asymmetric splits (first node fewer layers) shrink the unhideable window.

Note: CI on this branch may show the pre-existing flaky metal cache test until the standalone cache fix merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)