### PR TITLE
fix(gemma4): bind trimmed shared-KV exports (QAT first light on E4B Q4_0)

### DIFF
--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -342,11 +342,12 @@ fn apply_rope(
 struct LayerWeights {
     attn_norm: Vec<f32>,
     attn_q: WireQuant,
-    attn_k: WireQuant,
+    /// `None` on shared-KV layers in trimmed (QAT) exports — never read there.
+    attn_k: Option<WireQuant>,
     attn_v: Option<WireQuant>, // None on V-less layers (V = K projection)
     attn_output: WireQuant,
     q_norm: Vec<f32>,
-    k_norm: Vec<f32>,
+    k_norm: Option<Vec<f32>>,
     post_attn_norm: Vec<f32>,
     ffn_norm: Vec<f32>,
     ffn_gate: WireQuant,
@@ -479,11 +480,11 @@ impl Gemma4Runtime {
             layers.push(LayerWeights {
                 attn_norm: f32t(&l.attn_norm.name)?,
                 attn_q: q8(&l.attn_q.name)?,
-                attn_k: q8(&l.attn_k.name)?,
+                attn_k: l.attn_k.as_ref().map(|d| q8(&d.name)).transpose()?,
                 attn_v: l.attn_v.as_ref().map(|d| q8(&d.name)).transpose()?,
                 attn_output: q8(&l.attn_output.name)?,
                 q_norm: f32t(&l.attn_q_norm.name)?,
-                k_norm: f32t(&l.attn_k_norm.name)?,
+                k_norm: l.attn_k_norm.as_ref().map(|d| f32t(&d.name)).transpose()?,
                 post_attn_norm: f32t(&l.post_attention_norm.name)?,
                 ffn_norm: f32t(&l.ffn_norm.name)?,
                 ffn_gate: q8(&l.ffn_gate.name)?,
@@ -735,7 +736,11 @@ impl Gemma4Runtime {
             }
 
             if l < self.first_kv_shared {
-                let mut k = lw.attn_k.matvec_q(kv_dim, &xnq);
+                let mut k = lw
+                    .attn_k
+                    .as_ref()
+                    .expect("validate() guarantees owning layers bind attn_k")
+                    .matvec_q(kv_dim, &xnq);
                 // V-less layers (12B full attention) reuse the raw K projection
                 // as V — reference: `if v_proj is not present, use Kcur as Vcur`.
                 // V then takes the usual weightless norm and never RoPE.
@@ -745,7 +750,15 @@ impl Gemma4Runtime {
                 };
                 for hh in 0..kv_heads {
                     let s = &mut k[hh * head_dim..(hh + 1) * head_dim];
-                    s.copy_from_slice(&rms_norm(s, Some(&lw.k_norm), eps));
+                    s.copy_from_slice(&rms_norm(
+                        s,
+                        Some(
+                            lw.k_norm
+                                .as_deref()
+                                .expect("validate() guarantees owning layers bind attn_k_norm"),
+                        ),
+                        eps,
+                    ));
                     let sv = &mut v[hh * head_dim..(hh + 1) * head_dim];
                     sv.copy_from_slice(&rms_norm(sv, None, eps));
                 }
@@ -1070,12 +1083,32 @@ impl Gemma4GpuRuntime {
             let layer = crate::metal::Gemma4ResidentLayer::from_wire_pages(
                 f32t(&lb.attn_norm.name)?,
                 f32t(&lb.attn_q_norm.name)?,
-                f32t(&lb.attn_k_norm.name)?,
+                f32t(
+                    &lb.attn_k_norm
+                        .as_ref()
+                        .ok_or_else(|| {
+                            BackendError::UnsupportedTensorType(format!(
+                                "gemma4 GPU runtime requires attn_k_norm on every layer; \
+                             layer {l} omits it (trimmed shared-KV export)"
+                            ))
+                        })?
+                        .name,
+                )?,
                 f32t(&lb.post_attention_norm.name)?,
                 f32t(&lb.ffn_norm.name)?,
                 f32t(&lb.post_ffw_norm.name)?,
                 &pages(&lb.attn_q.name)?,
-                &pages(&lb.attn_k.name)?,
+                &pages(
+                    &lb.attn_k
+                        .as_ref()
+                        .ok_or_else(|| {
+                            BackendError::UnsupportedTensorType(format!(
+                                "gemma4 GPU runtime requires attn_k on every layer; \
+                             layer {l} omits it (trimmed shared-KV export)"
+                            ))
+                        })?
+                        .name,
+                )?,
                 lb.attn_v
                     .as_ref()
                     .map(|d| pages(&d.name))

--- a/src/model.rs
+++ b/src/model.rs
@@ -827,7 +827,11 @@ impl LlamaTensorBinding {
 pub struct Gemma4LayerTensors {
     pub attn_norm: GgufTensorDescriptor,
     pub attn_q: GgufTensorDescriptor,
-    pub attn_k: GgufTensorDescriptor,
+    /// `None` on shared-KV layers in exports that trim unused projections:
+    /// the QAT GGUFs omit `attn_k`/`attn_v`/`attn_k_norm` on layers that source
+    /// their cache from an earlier layer (the Q8_0 exports carry them unused).
+    /// Owning layers (`idx < first_kv_shared`) must always bind them.
+    pub attn_k: Option<GgufTensorDescriptor>,
     /// `None` on V-less layers: the 12B row's full-attention layers carry no
     /// `attn_v` tensor — the reference (llama.cpp `gemma4-iswa`) uses the K
     /// projection output as V (`if v_proj is not present, use Kcur as Vcur`),
@@ -835,7 +839,7 @@ pub struct Gemma4LayerTensors {
     pub attn_v: Option<GgufTensorDescriptor>,
     pub attn_output: GgufTensorDescriptor,
     pub attn_q_norm: GgufTensorDescriptor,
-    pub attn_k_norm: GgufTensorDescriptor,
+    pub attn_k_norm: Option<GgufTensorDescriptor>,
     pub post_attention_norm: GgufTensorDescriptor,
     pub ffn_norm: GgufTensorDescriptor,
     pub post_ffw_norm: GgufTensorDescriptor,
@@ -915,11 +919,11 @@ impl Gemma4Binding {
             layers.push(Gemma4LayerTensors {
                 attn_norm: req("attn_norm")?,
                 attn_q: req("attn_q")?,
-                attn_k: req("attn_k")?,
+                attn_k: opt("attn_k"),
                 attn_v: opt("attn_v"),
                 attn_output: req("attn_output")?,
                 attn_q_norm: req("attn_q_norm")?,
-                attn_k_norm: req("attn_k_norm")?,
+                attn_k_norm: opt("attn_k_norm"),
                 post_attention_norm: req("post_attention_norm")?,
                 ffn_norm: req("ffn_norm")?,
                 post_ffw_norm: req("post_ffw_norm")?,
@@ -974,12 +978,29 @@ impl Gemma4Binding {
                 heads * head_dim,
                 &format!("gemma4 layer {idx} attention q"),
             )?;
-            require_descriptor_matrix_shape(
-                &layer.attn_k,
-                emb,
-                kv_heads * head_dim,
-                &format!("gemma4 layer {idx} attention k"),
-            )?;
+            let first_kv_shared =
+                config.block_count as usize - gemma4.num_kv_shared_layers as usize;
+            match layer.attn_k.as_ref() {
+                Some(attn_k) => require_descriptor_matrix_shape(
+                    attn_k,
+                    emb,
+                    kv_heads * head_dim,
+                    &format!("gemma4 layer {idx} attention k"),
+                )?,
+                None if idx < first_kv_shared => {
+                    return Err(BackendError::InvalidModelMetadata(format!(
+                        "gemma4 layer {idx} owns its KV cache but binds no attn_k tensor                          (only shared-KV layers may omit K/V projections)"
+                    )))
+                }
+                // Shared-KV layers source K/V from an earlier layer; trimmed
+                // exports (QAT) legitimately omit the unused projections.
+                None => {}
+            }
+            if layer.attn_k_norm.is_none() && idx < first_kv_shared {
+                return Err(BackendError::InvalidModelMetadata(format!(
+                    "gemma4 layer {idx} owns its KV cache but binds no attn_k_norm tensor"
+                )));
+            }
             // V-less layers (12B full-attention) reuse the K projection as V;
             // when the tensor exists it must match the K geometry.
             if let Some(attn_v) = layer.attn_v.as_ref() {
@@ -1001,11 +1022,13 @@ impl Gemma4Binding {
                 &[head_dim],
                 &format!("gemma4 layer {idx} q_norm"),
             )?;
-            require_descriptor_shape(
-                &layer.attn_k_norm,
-                &[head_dim],
-                &format!("gemma4 layer {idx} k_norm"),
-            )?;
+            if let Some(attn_k_norm) = layer.attn_k_norm.as_ref() {
+                require_descriptor_shape(
+                    attn_k_norm,
+                    &[head_dim],
+                    &format!("gemma4 layer {idx} k_norm"),
+                )?;
+            }
             require_descriptor_shape(
                 &layer.attn_norm,
                 &[emb],

--- a/tests/gemma4_forward.rs
+++ b/tests/gemma4_forward.rs
@@ -227,18 +227,40 @@ fn gemma4_prefill_matches_oracle() {
             };
             stat(&attn_norm_w, "attn_norm[0]");
             let (qn, _) = load_f32(&store, &lt.attn_q_norm.name);
-            let (kn, _) = load_f32(&store, &lt.attn_k_norm.name);
+            let (kn, _) = load_f32(
+                &store,
+                &lt.attn_k_norm
+                    .as_ref()
+                    .expect("owning layer binds attn_k_norm")
+                    .name,
+            );
             stat(&qn, "q_norm[0]");
             stat(&kn, "k_norm[0]");
         }
         let (q_w, _) = load_f32(&store, &lt.attn_q.name);
-        let (k_w, _) = load_f32(&store, &lt.attn_k.name);
+        let (k_w, _) = load_f32(
+            &store,
+            &lt.attn_k.as_ref().expect("owning layer binds attn_k").name,
+        );
         // V-less layers (12B full attention) reuse the K projection as V; this
         // reference test exercises the E-series rows, which always carry V.
-        let (v_w, _) = load_f32(&store, &lt.attn_v.as_ref().unwrap_or(&lt.attn_k).name);
+        let (v_w, _) = load_f32(
+            &store,
+            &lt.attn_v
+                .as_ref()
+                .or(lt.attn_k.as_ref())
+                .expect("owning layer binds attn_k")
+                .name,
+        );
         let (o_w, _) = load_f32(&store, &lt.attn_output.name);
         let (qn_w, _) = load_f32(&store, &lt.attn_q_norm.name);
-        let (kn_w, _) = load_f32(&store, &lt.attn_k_norm.name);
+        let (kn_w, _) = load_f32(
+            &store,
+            &lt.attn_k_norm
+                .as_ref()
+                .expect("owning layer binds attn_k_norm")
+                .name,
+        );
         let (post_attn_w, _) = load_f32(&store, &lt.post_attention_norm.name);
         let (ffn_norm_w, _) = load_f32(&store, &lt.ffn_norm.name);
         let (gate_w, _) = load_f32(&store, &lt.ffn_gate.name);

--- a/tests/gemma4_vless_gpu.rs
+++ b/tests/gemma4_vless_gpu.rs
@@ -68,13 +68,18 @@ fn vless_gpu_layer_matches_cpu_on_real_12b_weights() {
 
     let attn_norm = f32t(&lb.attn_norm.name);
     let q_norm = f32t(&lb.attn_q_norm.name);
-    let k_norm = f32t(&lb.attn_k_norm.name);
+    let k_norm = f32t(
+        &lb.attn_k_norm
+            .as_ref()
+            .expect("12B layers bind attn_k_norm")
+            .name,
+    );
     let post_attn = f32t(&lb.post_attention_norm.name);
     let ffn_norm = f32t(&lb.ffn_norm.name);
     let post_ffw = f32t(&lb.post_ffw_norm.name);
     // (attn_q is loaded for the GPU side only — at position 0 the CPU reference
     // never needs Q: softmax over one position makes the attention weight 1.0.)
-    let k_w = f32t(&lb.attn_k.name);
+    let k_w = f32t(&lb.attn_k.as_ref().expect("12B layers bind attn_k").name);
     let o_w = f32t(&lb.attn_output.name);
     let gate_w = f32t(&lb.ffn_gate.name);
     let up_w = f32t(&lb.ffn_up.name);
@@ -148,7 +153,7 @@ fn vless_gpu_layer_matches_cpu_on_real_12b_weights() {
         ffn_norm.clone(),
         post_ffw.clone(),
         &wire(&lb.attn_q.name),
-        &wire(&lb.attn_k.name),
+        &wire(&lb.attn_k.as_ref().expect("12B layers bind attn_k").name),
         None, // V-less
         &wire(&lb.attn_output.name),
         &wire(&lb.ffn_gate.name),


### PR DESCRIPTION
The QAT GGUFs omit `attn_k`/`attn_v`/`attn_k_norm` on shared-KV layers (unused there — KV comes from the source layer's cache); the Q8_0 exports carry them unused. Binding now allows the omission on shared layers only; owning layers fail closed with a typed error, shapes still checked when present. CPU runtime threads the optionality (reads were already inside the owning-layer branch); GPU loader returns a typed unsupported error for trimmed exports.

First light post-fix: `gemma-4-E4B_q4_0-it.gguf` loads and greedily generates `The capital of France is Paris.` (ids `[9079, 236761]`, clean EOG stop) through Q4_0 layer GEMVs + the Q6_K tied head on CPU. Oracle parity for the QAT row not yet captured, not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)