### PR TITLE
feat(diffusiongemma): recognize + fail closed (typed blocker, recon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Support is **per exact model row** (a specific GGUF at a specific quantization),
 | **Gemma 4 12B-It** | Q8_0 | two-Mac distributed | Distributed parity + serve/WebUI smoke |
 | **Gemma 4 26B-A4B-It QAT** | Q4_0 (128-expert MoE) | two-Mac distributed | Distributed parity + serve/WebUI smoke |
 
-> **Fails closed (by design):** Mixtral-8x7B v0.1 (validation-in-progress, one-token runtime only); Gemma 4 26B-A4B **Q8_0** (26.9 GB) and 31B (over the 2×16 GB envelope); Gemma 4 MTP/drafter rows; multimodal input; and all other quantizations in v0.1.
+> **Fails closed (by design):** Mixtral-8x7B v0.1 (validation-in-progress, one-token runtime only); Gemma 4 26B-A4B **Q8_0** (26.9 GB) and 31B (over the 2×16 GB envelope); Gemma 4 MTP/drafter rows; **DiffusionGemma 26B-A4B** (recognized, but a discrete block-diffusion encoder-decoder — not runnable on an autoregressive engine; see [recon](docs/recon/DIFFUSIONGEMMA_26B_A4B_RECON.md)); multimodal input; and all other quantizations in v0.1.
 
 Per-row detail and the exact evidence artifacts live in [`SUPPORT_MATRIX_v0.1.md`](SUPPORT_MATRIX_v0.1.md) and [`COMPATIBILITY.md`](COMPATIBILITY.md).
 

--- a/docs/recon/DIFFUSIONGEMMA_26B_A4B_RECON.md
+++ b/docs/recon/DIFFUSIONGEMMA_26B_A4B_RECON.md
@@ -1,0 +1,81 @@
+# DiffusionGemma 26B-A4B — architecture recon (recognized, fail-closed)
+
+> [!NOTE]
+> This is a design/recon note, not the public support ledger. For current
+> support truth use [`COMPATIBILITY.md`](../../COMPATIBILITY.md) and
+> [`STATUS.md`](../../STATUS.md). DiffusionGemma is **recognized and fails
+> closed** with a typed blocker; it is **not** a supported runtime row, and
+> nothing here is a support claim.
+
+## What it is
+
+`google/diffusiongemma-26B-A4B-it` — config `architectures:
+["DiffusionGemmaForBlockDiffusion"]`, `model_type: diffusion_gemma`. It is built
+on the Gemma 4 26B-A4B MoE foundation (the row Camelid *does* support, as Q4_0
+QAT over the two-Mac distributed lane), but the generation paradigm is
+fundamentally different — from Google's model card:
+
+- **Discrete text diffusion** — generation is block-autoregressive *multi-canvas
+  sampling*, not token-by-token autoregression. The model iteratively denoises a
+  block of tokens (a "canvas") in parallel with a diffusion sampler, appends the
+  finished canvas to the KV cache, then denoises the next canvas.
+- **Encoder-decoder** — an autoregressive encoder prefills the prompt and builds
+  the KV cache; a decoder applies **bidirectional attention** over the canvas and
+  reaches the prompt context via **cross-attention**.
+- **Entropy-Bound (EB) sampler** — the recommended diffusion sampler.
+- **Multimodal** — interleaved text + image (variable aspect/resolution) + video
+  inputs → text output.
+
+GGUF quants published (unsloth): BF16 50.5 GB, Q8_0 26.9 GB, Q6_K 22.6 GB,
+Q5_K_M 19.2 GB, Q4_K_M 16.8 GB.
+
+## Why Camelid fails closed on it (today)
+
+Camelid is a **decoder-only autoregressive** engine: causal attention, a
+per-layer KV cache, and greedy next-token decode. DiffusionGemma needs, none of
+which exist here:
+
+1. A **diffusion decode loop** — multi-canvas iterative denoising, not
+   next-token argmax.
+2. **Bidirectional decoder attention** over a denoising canvas (Camelid attention
+   is strictly causal).
+3. An **encoder-decoder split with cross-attention** (Camelid is decoder-only).
+4. The **Entropy-Bound diffusion sampler**.
+5. **Multimodal** image/video towers (Camelid fails closed on multimodal input).
+6. **No autoregressive reference comparator** — llama.cpp's autoregressive greedy
+   path cannot produce an oracle for diffusion sampling, so even a from-scratch
+   implementation could not be validated to Camelid's token-parity standard
+   without a different, diffusion-aware reference and a determinism contract.
+
+Memory/quant also rule out the easy paths: Q8_0 is 26.9 GB (same envelope block
+as the regular 26B A4B Q8_0), and the smaller files are K-quants
+(Q4_K_M/Q5_K_M/Q6_K) — formats Camelid's wire lane does not implement (it
+supports Q8_0, Q4_0, and Q6_K read-in-place wire blocks).
+
+Recognition + blocker live in `LlamaModelConfig::from_gguf` (any
+`general.architecture` containing `diffusion` → typed
+`UnsupportedModelArchitecture` naming the paradigm mismatch). Locked by
+`tests/gemma4_metadata.rs::diffusiongemma_architecture_fails_closed` across the
+`diffusion_gemma` / `diffusiongemma` / `gemma-diffusion` spellings.
+
+## The honest path to real support (a genuine new frontier)
+
+This is a substantial new lane, not a row addition. In rough order:
+
+1. **Decide the determinism/parity contract first.** Diffusion sampling is
+   iterative and sampler-dependent; define what "reproducible" and "parity"
+   mean (e.g. fixed EB-sampler schedule + seedless greedy-equivalent denoising)
+   and what reference produces the oracle. Without this there is no claimable
+   support, by repo doctrine.
+2. **Encoder path** — reuse the gemma4 autoregressive forward for the prompt
+   encoder + KV cache (largely existing).
+3. **Decoder path** — new: bidirectional attention over the canvas + cross-
+   attention to the encoder cache.
+4. **Diffusion sampler** — the multi-canvas denoising loop + EB sampler.
+5. **K-quant wire kernels** (Q4_K_M/Q5_K_M) or run Q8_0 distributed (26.9 GB →
+   two-Mac).
+6. **Multimodal** — out of scope until the text path is proven; stays
+   fail-closed.
+
+Until 1–4 exist and are proven against a diffusion-aware oracle, DiffusionGemma
+stays recognized-and-blocked — which is the correct, honest state for it now.

--- a/src/model.rs
+++ b/src/model.rs
@@ -56,6 +56,29 @@ impl LlamaModelConfig {
                         .into(),
                 ))
             }
+            // DiffusionGemma (general.architecture spellings: diffusion_gemma /
+            // diffusiongemma / gemma-diffusion). Despite the Gemma 4 26B-A4B MoE
+            // foundation, this is NOT an autoregressive model: it is a discrete
+            // block-diffusion encoder-decoder that generates by iteratively
+            // denoising a token "canvas" with bidirectional decoder attention and
+            // cross-attention to an encoder KV cache (multi-canvas sampling +
+            // Entropy-Bound diffusion sampler), and it is multimodal (image/video
+            // inputs). Camelid is a decoder-only autoregressive engine (causal
+            // attention, KV cache, greedy next-token decode) and cannot run the
+            // diffusion decode loop; there is also no autoregressive reference
+            // runtime to prove token parity against. Fail closed with the exact
+            // blocker rather than mis-binding the shared gemma4 tensors.
+            Some(other) if other.to_ascii_lowercase().contains("diffusion") => {
+                return Err(BackendError::UnsupportedModelArchitecture(format!(
+                    "{other} (DiffusionGemma): blocked — DiffusionGemma is a discrete \
+                     block-diffusion encoder-decoder (bidirectional attention over a \
+                     denoising token canvas, multi-canvas iterative sampling, \
+                     cross-attention, Entropy-Bound diffusion sampler) and is \
+                     multimodal; Camelid's autoregressive decoder-only engine cannot \
+                     run the diffusion decode loop, and there is no autoregressive \
+                     reference comparator to prove parity against. Fails closed by design"
+                )))
+            }
             Some(other) => return Err(BackendError::UnsupportedModelArchitecture(other.into())),
             None => {
                 return Err(BackendError::InvalidModelMetadata(

--- a/tests/gemma4_metadata.rs
+++ b/tests/gemma4_metadata.rs
@@ -137,6 +137,35 @@ fn per_layer_head_count_kv_array_parses() {
 }
 
 #[test]
+fn diffusiongemma_architecture_fails_closed() {
+    // DiffusionGemma reuses the Gemma 4 26B-A4B MoE foundation but is a discrete
+    // block-diffusion encoder-decoder, not an autoregressive model. Camelid must
+    // fail closed by name on any `*diffusion*` architecture spelling rather than
+    // mis-binding the shared gemma4 tensors.
+    for arch in ["diffusion_gemma", "diffusiongemma", "gemma-diffusion"] {
+        let mut gguf = synthetic_gemma4_gguf(4);
+        gguf.metadata.insert(
+            "general.architecture".into(),
+            GgufMetadataValue::String(arch.into()),
+        );
+        let err = LlamaModelConfig::from_gguf(&gguf)
+            .err()
+            .unwrap_or_else(|| panic!("DiffusionGemma arch {arch} must fail closed"));
+        match err {
+            BackendError::UnsupportedModelArchitecture(msg) => {
+                assert!(msg.contains("DiffusionGemma"), "names the model: {msg}");
+                assert!(msg.contains("blocked"), "states it is blocked: {msg}");
+                assert!(
+                    msg.contains("diffusion") || msg.contains("autoregressive"),
+                    "explains the paradigm mismatch: {msg}"
+                );
+            }
+            other => panic!("expected UnsupportedModelArchitecture for {arch}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn gemma4_assistant_mtp_architecture_fails_closed() {
     let mut gguf = synthetic_gemma4_gguf(4);
     gguf.metadata.insert(


### PR DESCRIPTION
DiffusionGemma 26B-A4B reuses the Gemma 4 MoE foundation but is a **discrete block-diffusion encoder-decoder** (bidirectional canvas attention, multi-canvas iterative denoising, cross-attention, Entropy-Bound sampler, multimodal) — architecturally unrunnable on Camelid's decoder-only autoregressive engine, with no autoregressive comparator to prove parity against. Per repo doctrine (no claim without evidence), the correct handling is **recognized + fail-closed with a typed blocker**, not a fabricated support row.

- `LlamaModelConfig::from_gguf` matches any `*diffusion*` architecture → typed `UnsupportedModelArchitecture` naming the paradigm mismatch.
- Locked by `tests/gemma4_metadata.rs::diffusiongemma_architecture_fails_closed` (all three arch spellings).
- Recon + honest path to real support in `docs/recon/DIFFUSIONGEMMA_26B_A4B_RECON.md`; README lists it under fails-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)