### PR TITLE
perf: honest findings + dot-throughput harness; DiffusionGemma real-build status

### DIFF
--- a/docs/performance/perf-findings-2026-06-11.md
+++ b/docs/performance/perf-findings-2026-06-11.md
@@ -1,0 +1,54 @@
+# Performance findings (2026-06-11) — where the speed actually is
+
+> [!NOTE]
+> Honest snapshot from an overnight perf pass on an Apple M4 (10-core GPU,
+> 16 GB). Conclusions are evidence-backed; benchmark numbers trace to committed
+> bundles. No claim is made beyond what was measured.
+
+## TL;DR
+
+- **The CPU quant dot kernels are already at speed.** A direct micro-benchmark
+  (`perf_q4_q8_q6_dot`) shows Q4_0, Q8_0, and Q6_K row-dots within ~1.3× of each
+  other (Q4_0 ≈ Q8_0; Q6_K ~0.7–1.3×). There is **no slow-kernel bug**.
+- **The supported Q8_0 rows are at the hardware wall.** Llama 3.2 3B Q8_0,
+  same-host vs llama.cpp (Metal) and MLX-LM: prefill **587.3 vs 543.7 vs 577.9
+  tok/s** (Camelid fastest), decode **29.7 vs 29.1 vs 29.1 tok/s** (Camelid
+  fastest by a hair). Margins are narrow; this is the ~120 GB/s unified-memory
+  wall, where everyone lands. See [`BENCHMARKS.md`](../benchmarks/BENCHMARKS.md).
+- **"Slow" QAT decode was cold cache, not compute.** Gemma 4 E4B QAT Q4_0
+  (5 GB on the external T7/USB) measured **0.02 tok/s cold** but **1.34 tok/s on
+  the immediate warm re-run** — a 67× swing purely from OS page cache. Warm
+  per-step is ffn+ple ~164 ms, attention ~11 ms, Q6_K head ~9 ms. The cold cost
+  is reading the model from USB the first time, not the engine.
+
+## What that means for "make it faster"
+
+CPU decode is **memory-bandwidth-bound**, and a few CPU cores cannot saturate
+the full unified bandwidth the way the GPU can. The genuine levers, in order of
+honest payoff, are therefore not kernel micro-opts:
+
+1. **GPU-resident decode for every row.** The Q8_0 gemma4 path already runs
+   fully resident on Metal (~120 GB/s wall). The QAT (Q4_0 experts / Q6_K head)
+   and distributed rows have **no GPU kernels yet** — building Q4_0/Q6_K Metal
+   GEMV (mirroring the proven Q8 wire-nocopy path, parity-tested vs CPU) is the
+   largest real win for those rows. Substantial, parity-gated.
+2. **Speculative decode — "read less per token."** At the bandwidth wall the only
+   way past it is to read fewer weight bytes per accepted token. Camelid's
+   speculative path is byte-exact-proven and already shows ~+11–12% in draft
+   mode; widening its coverage is the honest decode win for the supported rows.
+3. **Cold-start residency.** First-run latency on USB-resident models is a real
+   UX cost (the 67× above). A background page-cache warmer at load would make the
+   first decode match the warm decode for models that fit RAM. Parity-neutral
+   (pure prefetch), but it does not move the warm/steady-state wall.
+
+## What is NOT a win (measured, ruled out)
+
+- Rewriting the Q4_0/Q6_K CPU dots — already Q8-class.
+- "Fixing" QAT decode speed in code — the cold number was a USB page-cache
+  artifact, reproducible-away with a warm run.
+
+## Methodology
+
+`perf_q4_q8_q6_dot` (in `src/inference` tests, `#[ignore]`d) times each wire
+row-dot in isolation. Gemma 4 phase timing via `CAMELID_GEMMA4_CPU_TIMING=1`.
+Same-host 3B comparison is the committed bundle behind `BENCHMARKS.md`.

--- a/docs/recon/DIFFUSIONGEMMA_26B_A4B_RECON.md
+++ b/docs/recon/DIFFUSIONGEMMA_26B_A4B_RECON.md
@@ -79,3 +79,26 @@ This is a substantial new lane, not a row addition. In rough order:
 
 Until 1–4 exist and are proven against a diffusion-aware oracle, DiffusionGemma
 stays recognized-and-blocked — which is the correct, honest state for it now.
+
+## Real-build status (2026-06-11)
+
+Starting the actual diffusion runtime is gated on two things that do not exist
+yet, so the honest first deliverable is the design/contract, not unvalidatable
+engine code:
+
+1. **No parity oracle.** llama.cpp's autoregressive path cannot produce a
+   reference for diffusion sampling. The only reference today is the HF
+   `transformers` `DiffusionGemmaForBlockDiffusion` model (Python). Camelid's
+   engine stays Rust/no-Python, but *validation* tooling may shell out to a
+   Python reference to capture a determinism-pinned oracle — that capture rig is
+   prerequisite step 0.
+2. **No runnable weights in a supported format/size.** Published GGUFs are
+   BF16 50.5 GB, Q8_0 26.9 GB (two-Mac-distributed territory, like the regular
+   26B A4B Q8_0 — blocked single-node), and K-quants Q4_K_M/Q5_K_M/Q6_K — wire
+   formats Camelid does not implement. A genuine bring-up needs either the Q8_0
+   row over the two-Mac lane or new K-quant wire kernels.
+
+Until (0) a determinism-pinned diffusion oracle exists and (1) weights load,
+DiffusionGemma stays **recognized + fail-closed** — the accurate state. The
+engine work (bidirectional decoder, cross-attention, multi-canvas EB sampler)
+is scoped in the section above and is a multi-stage lane, not a status flip.

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -10981,24 +10981,40 @@ fn perf_q4_q8_q6_dot() {
     let xq = super::quantize_q8_0_blocks(&act);
     // Q8_0 weight row: 34 bytes/block
     let mut q8row: Vec<u8> = (0..nblk * 34).map(|i| (i % 251) as u8).collect();
-    for b in 0..nblk { q8row[b*34]=0x66; q8row[b*34+1]=0x2e; } // valid f16 ~0.1 scale
-    // Q4_0 weight row: 18 bytes/block
+    for b in 0..nblk {
+        q8row[b * 34] = 0x66;
+        q8row[b * 34 + 1] = 0x2e;
+    } // valid f16 ~0.1 scale
+      // Q4_0 weight row: 18 bytes/block
     let mut q4row: Vec<u8> = (0..nblk * 18).map(|i| (i % 251) as u8).collect();
-    for b in 0..nblk { q4row[b*18]=0x66; q4row[b*18+1]=0x2e; }
+    for b in 0..nblk {
+        q4row[b * 18] = 0x66;
+        q4row[b * 18 + 1] = 0x2e;
+    }
     // Q6_K: 210 bytes / 256-block; in_dim 2560 = 10 superblocks
     let q6blk = in_dim / 256;
     let mut q6row: Vec<u8> = (0..q6blk * 210).map(|i| (i % 251) as u8).collect();
-    for b in 0..q6blk { q6row[b*210+208]=0x66; q6row[b*210+209]=0x2e; } // f16 super-scale
+    for b in 0..q6blk {
+        q6row[b * 210 + 208] = 0x66;
+        q6row[b * 210 + 209] = 0x2e;
+    } // f16 super-scale
     let xqk = super::quantize_q8_k_blocks(&act);
     let iters = 200_000usize;
-    let t = Instant::now(); let mut s = 0f32;
-    for _ in 0..iters { s += super::q8_0_wire_row_dot(&q8row, &xq); }
+    let t = Instant::now();
+    let mut s = 0f32;
+    for _ in 0..iters {
+        s += super::q8_0_wire_row_dot(&q8row, &xq);
+    }
     let q8 = t.elapsed().as_secs_f64();
     let t = Instant::now();
-    for _ in 0..iters { s += super::q4_0_wire_row_dot(&q4row, &xq); }
+    for _ in 0..iters {
+        s += super::q4_0_wire_row_dot(&q4row, &xq);
+    }
     let q4 = t.elapsed().as_secs_f64();
     let t = Instant::now();
-    for _ in 0..iters { s += super::q6_k_wire_row_dot(&q6row, &xqk); }
+    for _ in 0..iters {
+        s += super::q6_k_wire_row_dot(&q6row, &xqk);
+    }
     let q6 = t.elapsed().as_secs_f64();
     eprintln!("[dotbench] {iters} iters @ in_dim {in_dim}: q8={:.3}s ({:.1} Mrow/s)  q4={:.3}s ({:.1} Mrow/s, {:.1}x q8)  q6={:.3}s ({:.1} Mrow/s, {:.1}x q8)  sink={s}",
         q8, iters as f64/q8/1e6, q4, iters as f64/q4/1e6, q4/q8, q6, iters as f64/q6/1e6, q6/q8);

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -10970,3 +10970,36 @@ fn q8_k_quantizer_mirrors_reference_semantics() {
     assert_eq!(z[0].d, 0.0);
     assert!(z[0].qs.iter().all(|&v| v == 0));
 }
+
+#[test]
+#[ignore] // perf micro-bench, run explicitly: cargo test --release perf_q4_q8_q6_dot -- --ignored --nocapture
+fn perf_q4_q8_q6_dot() {
+    use std::time::Instant;
+    let in_dim = 2560usize;
+    let nblk = in_dim / 32; // 80
+    let act: Vec<f32> = (0..in_dim).map(|i| ((i as f32) * 0.013).sin()).collect();
+    let xq = super::quantize_q8_0_blocks(&act);
+    // Q8_0 weight row: 34 bytes/block
+    let mut q8row: Vec<u8> = (0..nblk * 34).map(|i| (i % 251) as u8).collect();
+    for b in 0..nblk { q8row[b*34]=0x66; q8row[b*34+1]=0x2e; } // valid f16 ~0.1 scale
+    // Q4_0 weight row: 18 bytes/block
+    let mut q4row: Vec<u8> = (0..nblk * 18).map(|i| (i % 251) as u8).collect();
+    for b in 0..nblk { q4row[b*18]=0x66; q4row[b*18+1]=0x2e; }
+    // Q6_K: 210 bytes / 256-block; in_dim 2560 = 10 superblocks
+    let q6blk = in_dim / 256;
+    let mut q6row: Vec<u8> = (0..q6blk * 210).map(|i| (i % 251) as u8).collect();
+    for b in 0..q6blk { q6row[b*210+208]=0x66; q6row[b*210+209]=0x2e; } // f16 super-scale
+    let xqk = super::quantize_q8_k_blocks(&act);
+    let iters = 200_000usize;
+    let t = Instant::now(); let mut s = 0f32;
+    for _ in 0..iters { s += super::q8_0_wire_row_dot(&q8row, &xq); }
+    let q8 = t.elapsed().as_secs_f64();
+    let t = Instant::now();
+    for _ in 0..iters { s += super::q4_0_wire_row_dot(&q4row, &xq); }
+    let q4 = t.elapsed().as_secs_f64();
+    let t = Instant::now();
+    for _ in 0..iters { s += super::q6_k_wire_row_dot(&q6row, &xqk); }
+    let q6 = t.elapsed().as_secs_f64();
+    eprintln!("[dotbench] {iters} iters @ in_dim {in_dim}: q8={:.3}s ({:.1} Mrow/s)  q4={:.3}s ({:.1} Mrow/s, {:.1}x q8)  q6={:.3}s ({:.1} Mrow/s, {:.1}x q8)  sink={s}",
+        q8, iters as f64/q8/1e6, q4, iters as f64/q4/1e6, q4/q8, q6, iters as f64/q6/1e6, q6/q8);
+}


### PR DESCRIPTION
Overnight perf pass — evidence over hype.

**Findings (Apple M4, 16 GB):**
- CPU quant dot kernels are already at speed — micro-bench (`perf_q4_q8_q6_dot`, `#[ignore]`) shows Q4_0 ≈ Q8_0, Q6_K within ~1.3×. No slow-kernel bug.
- Supported Q8_0 rows are at the ~120 GB/s wall; the committed same-host 3B bundle has Camelid leading llama.cpp on prefill (587.3 vs 543.7) and decode (29.7 vs 29.1).
- The apparent QAT decode slowness was **cold page cache**, not compute: E4B QAT Q4_0 0.02 tok/s cold → 1.34 tok/s warm (67×), i.e. first-time USB read of the model. Ruled out as a code issue.

**Adds:** the committed dot-throughput harness, `docs/performance/perf-findings-2026-06-11.md` (real levers: GPU QAT kernels, speculative decode, cold-start residency — all parity-gated), and the DiffusionGemma real-build status (gated on a determinism-pinned diffusion oracle + runnable weights).

No behavioral/perf code change here — kernels are already fast; the substantial speed builds are scoped for review, not force-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)