### PR TITLE
gemma4 QAT: skip the ~0.5GB GPU head-buffer upload on the CPU-head lane

### DIFF
--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -1345,13 +1345,17 @@ impl Gemma4GpuRuntime {
 
         let token_embd = q8(&binding.token_embedding.name)?;
         let output_norm = f32t(&binding.output_norm.name)?;
+        // QAT hybrid (Q6_K head on CPU): don't hand the tied table to the GPU head — pass
+        // an empty slice so no ~0.5 GB head buffer is uploaded. The all-Q8 lane passes the
+        // wire bytes for the GPU head as before.
+        let head_wire: &[u8] = if head_on_cpu { &[] } else { token_embd.bytes() };
         let model = crate::metal::Gemma4ResidentModel::new(
             layers,
             ple,
             layer_scales,
             owns_kv,
             kv_source,
-            token_embd.bytes(),
+            head_wire,
             output_norm.clone(),
             hidden,
             vocab,

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -5799,8 +5799,10 @@ pub struct Gemma4ResidentModel {
 #[cfg(target_os = "macos")]
 impl Gemma4ResidentModel {
     /// Build the resident model. `token_embd_wire` is the vocab-major Q8 table in
-    /// 34-byte wire blocks (copied once into a resident buffer; in the production
-    /// runtime pass a nocopy WirePages buffer instead). KV caches are allocated for
+    /// 34-byte wire blocks for the GPU logits head (copied once into a resident buffer;
+    /// in the production runtime pass a nocopy WirePages buffer instead). Pass an EMPTY
+    /// slice on the QAT hybrid lane (Q6_K head runs on the CPU) — no head buffer is
+    /// allocated and only `forward_token_hidden` is valid. KV caches are allocated for
     /// owning layers (`owns_kv[l]`) sized to that layer's head_dim. None on bad shapes.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -5844,8 +5846,13 @@ impl Gemma4ResidentModel {
                 caches.push(None);
             }
         }
-        let token_embd = mkbuf(token_embd_wire.len());
-        write_buffer_u8(&token_embd, token_embd_wire);
+        // Empty wire = QAT hybrid lane: the Q6_K head runs on the CPU, so don't upload
+        // the (large) tied table to the GPU. A 1-byte placeholder keeps the field valid;
+        // forward_inner only reads it on the want_head path, which the hybrid never takes.
+        let token_embd = mkbuf(token_embd_wire.len().max(1));
+        if !token_embd_wire.is_empty() {
+            write_buffer_u8(&token_embd, token_embd_wire);
+        }
         // Upload each layer's PLE matrices once into resident buffers.
         let upload = |v: &[f32]| {
             let b = mkbuf(v.len() * 4);


### PR DESCRIPTION
Follow-up to #247. On the QAT hybrid lane the Q6_K tied head runs on the CPU, so the GPU never reads `token_embd` — but `Gemma4ResidentModel::new` still uploaded the full vocab-major table (~0.5 GB for E4B) into a resident GPU buffer that was dead weight.

`new()` now treats an **empty** `token_embd_wire` as "no GPU head": 1-byte placeholder, no copy. The runtime passes an empty slice when `head_on_cpu`; the all-Q8 lane is unchanged. `forward_inner` only reads the buffer on the `want_head` path, which the hybrid never takes.

Verified: E4B QAT GPU == CPU still token-identical (32-token gen); peak RSS ~3.87 GB. 19 `metal_gemma4` lib tests pass; fmt + clippy clean; all test targets compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)