### PR TITLE
gemma4 GPU: warm the embedding mmap at load (match the CPU lane)

### DIFF
--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -1228,6 +1228,15 @@ impl Gemma4GpuRuntime {
         // it never forces the anonymous GPU WirePages to swap). GPU layer weights load
         // separately as page-aligned WirePages.
         let mmap = GgufWireMmap::map(path)?;
+        // Warm the embedding mmap off the loading thread (matching the CPU lane): the
+        // QAT hybrid head reads the whole Q6_K tied table every token on the CPU, and
+        // every row gather hits this mapping, so the first token would otherwise pay the
+        // cold page-fault cost serially. madvise(WILLNEED) on a USB-backed volume blocks
+        // until the range is paged in, so it MUST NOT run on the loading thread.
+        {
+            let mmap = mmap.clone();
+            std::thread::spawn(move || mmap.advise_willneed());
+        }
         let q8 = |name: &str| WireQuant::new(&store, &mmap, name);
         let f32t = |name: &str| -> Result<Vec<f32>> { Ok(store.load_cpu_f32(name)?.data) };
 


### PR DESCRIPTION
The GPU-resident load eagerly reads layer weights into RAM (warm on first forward), but the `token_embd`/`per_layer_token_embd` mmap was never prefetched. On the QAT hybrid lane the CPU head reads the whole Q6_K tied table every token, so the first token paid the cold page-fault serially.

Mirrors the CPU lane (`gemma4_runtime.rs:533`): spawn a background `madvise(WILLNEED)` on the embedding mmap right after mapping — kept off the loading thread because on USB-backed volumes madvise blocks until the range is paged in. Pure prefetch advisory, parity-neutral.

E4B QAT GPU == CPU still token-identical; fmt + clippy clean; all test targets compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)