### PR TITLE
Inference Observatory: live telemetry stream + real-time visualization tab

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -22,6 +22,7 @@ Read these first:
 - [`PARITY.md`](docs/benchmarks/PARITY.md) — exact-row parity proof map and audit trail
 - [`RECEIPTS.md`](RECEIPTS.md) — verifiable single-request parity receipts; a receipt never changes the support ledger
 - [`docs/CONFORMANCE.md`](docs/CONFORMANCE.md) — cross-runtime conformance: determinism, agreement, tokenizer parity, provability; methodology and current findings
+- [`docs/TELEMETRY.md`](docs/TELEMETRY.md) — live inference telemetry stream (`/api/telemetry/stream`): event schema, truthfulness contract, lane coverage; drives the UI's Inference Observatory
 - [`ROADMAP.md`](ROADMAP.md) — phase-level plan of record
 
 ## Contributor and project policy

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,80 @@
+# Live Inference Telemetry
+
+Camelid's server exposes a real-time event stream describing inference as it
+executes. The web UI's **Inference Observatory** tab renders this stream; any
+SSE client can consume it.
+
+```
+GET /api/telemetry/stream        (Server-Sent Events)
+```
+
+Each SSE message is named `telemetry` and carries one JSON object. The first
+message is a hello (`{"event":"hello","schema":"camelid.telemetry/v1",...}`);
+every subsequent message is an envelope:
+
+```json
+{
+  "seq": 17,
+  "t_ms": 237960,
+  "request_id": "49cb98e3-…",
+  "model_id": "Llama 3.2 3B Instruct",
+  "event": "decode_started",
+  "context_position": 15
+}
+```
+
+`seq` orders events, `t_ms` is milliseconds since the server started emitting,
+and `request_id`/`model_id` attribute the event to a generation request.
+
+## Truthfulness contract
+
+Every event is emitted from a real code path doing real work (see
+`src/telemetry.rs`). There is no synthetic, replayed, or decorative event
+source anywhere in the stack:
+
+- An idle server sends nothing besides the hello and SSE keep-alive comments.
+- Consumers must not animate inference activity without a backing event; the
+  Observatory's renderer modules only react inside their event handlers
+  (`frontend/scripts/observatory-smoke.mjs` enforces this).
+- If the stream drops events under load, a `lagged` notice is emitted rather
+  than papering over the gap.
+
+## Event vocabulary (`camelid.telemetry/v1`)
+
+| Event | Emitted when | Notable fields |
+| --- | --- | --- |
+| `inference_started` | A generation request enters the engine | `backend`, `quantization`, `architecture`, `prompt_tokens`, `max_tokens`, `context_length`, `temperature`, `stream` |
+| `inference_finished` | The request closes (any outcome) | `status` (`ok`/`error`/`disconnected`), `finish_reason`, `completion_tokens`, `total_ms`, `ttft_ms`, `decode_tps` |
+| `inference_error` | A real failure occurs while a generation is active | `code`, `message` |
+| `prefill_started` | Prompt evaluation begins | `prefill_tokens`, `path`, `layers_total` |
+| `prefill_progress` | A prefill chunk really completed | `tokens_done`, `tokens_total` |
+| `decode_started` | The first generated token's forward pass begins | `context_position` |
+| `layer_started` / `layer_completed` | A transformer layer executes on a CPU lane | `layer`, `layers_total`, `duration_us` |
+| `token_decoded` | The sampler (CPU or GPU lane) produced a token | `token_id`, `context_position`, `layers_total` |
+| `kv_cache_updated` | The KV cache advanced | `position`, `capacity`, `approx_bytes` |
+| `sampler_step` | A decode step sampled from real logits | `chosen_token_id`, `mode`, `candidates` (top-8 post-softmax) |
+| `receipt_written` | A parity receipt was sealed server-side | `receipt_id`, `reproducible`, `gguf_sha256` |
+| `worker_node_active` / `worker_node_idle` / `worker_node_error` | A distributed-worker TCP roundtrip starts / lands / fails | `node`, `detail`, `error` |
+
+## Lane coverage and granularity
+
+- **Llama serve lane** (primary): full vocabulary above. On GPU-resident
+  prefill/decode paths the engine has no per-layer visibility (layers run
+  inside one Metal command buffer), so `layer_*` events are simply absent
+  there — consumers should pace layer visuals from real `token_decoded`
+  cadence and `layers_total` instead. CPU lanes emit real `layer_*` events.
+- **Gemma 4 serve lane**: lifecycle events plus one `token_decoded` pulse per
+  really-generated token. Prompt token counts and context length are not
+  reported by that runtime and are recorded as `0` ("not reported"), never
+  estimated.
+- **Speculative decode** (`CAMELID_SPEC_DECODE`, default off): tokens accepted
+  in a speculation batch do not emit individual `token_decoded` events.
+
+## Rate limiting and cost
+
+High-frequency classes are throttled server-side (layer events ≥15 ms apart,
+KV ≥50 ms, sampler ≥80 ms, prefill progress ≥33 ms, worker active/idle
+≥100 ms); lifecycle, token, receipt, and error events always pass. With no
+subscriber connected, every emit short-circuits on one atomic load, so
+serving performance is unaffected when nothing is watching. Sampler top-k
+softmax is computed only while a subscriber is connected.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "smoke:ui": "node scripts/ui-regression-smoke.mjs",
     "smoke:streaming": "node scripts/streaming-parser-smoke.mjs",
     "smoke:capability-readiness": "node scripts/capability-readiness-smoke.mjs",
+    "smoke:observatory": "node scripts/observatory-smoke.mjs",
     "smoke:integration": "node scripts/frontend-integration-smoke.mjs",
     "smoke:tiny": "node scripts/smoke.mjs --load-tiny",
     "smoke:warm": "node scripts/smoke.mjs --chat-repeats 3"

--- a/frontend/scripts/observatory-smoke.mjs
+++ b/frontend/scripts/observatory-smoke.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/* Inference Observatory smoke: guards the truthfulness contract and the
+   store's event reduction.
+
+   1. The telemetry store reduces a realistic real-event sequence correctly
+      (lifecycle, prefill, decode, KV, sampler, receipt, workers, errors).
+   2. The view renders the honest empty states ("Waiting for live Camelid
+      telemetry." / "Start a local inference to watch Camelid work.").
+   3. No renderer module spawns activity outside onEvent — visual activity
+      may only originate from real backend events. */
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+let failures = 0
+const check = (name, fn) => {
+  try {
+    fn()
+    console.log(`ok   ${name}`)
+  } catch (err) {
+    failures += 1
+    console.error(`FAIL ${name}\n     ${err.message}`)
+  }
+}
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const { createInferenceTelemetryStore, CONNECTION } = await server.ssrLoadModule('/src/lib/inferenceTelemetry.js')
+  const { default: InferenceObservatoryView } = await server.ssrLoadModule('/src/views/InferenceObservatoryView.jsx')
+
+  // --- 1. store reduction over a realistic captured sequence -------------
+  const store = createInferenceTelemetryStore()
+  const sequence = [
+    { event: 'hello', schema: 'camelid.telemetry/v1' },
+    { event: 'inference_started', request_id: 'r1', model_id: 'Llama 3.2 3B Instruct', backend: 'metal_resident_q8_runtime', quantization: 'Q8_0', architecture: 'llama', prompt_tokens: 16, max_tokens: 24, context_length: 131072, temperature: 0, stream: true },
+    { event: 'prefill_started', prefill_tokens: 15, path: 'auto', layers_total: 28 },
+    { event: 'prefill_progress', tokens_done: 15, tokens_total: 15 },
+    { event: 'decode_started', context_position: 15 },
+    { event: 'sampler_step', chosen_token_id: 16, mode: 'greedy', candidates: [{ token_id: 16, prob: 0.56 }, { token_id: 8586, prob: 0.36 }] },
+    { event: 'token_decoded', token_id: 16, context_position: 16, layers_total: 28 },
+    { event: 'kv_cache_updated', position: 16, capacity: 131072, approx_bytes: 3670016 },
+    { event: 'token_decoded', token_id: 271, context_position: 17, layers_total: 28 },
+    { event: 'worker_node_active', node: '169.254.156.89:9300', detail: 'decode @ position 17' },
+    { event: 'worker_node_idle', node: '169.254.156.89:9300' },
+    { event: 'receipt_written', receipt_id: 'abc123def456', reproducible: true, gguf_sha256: 'f00d'.repeat(16) },
+    { event: 'inference_finished', status: 'ok', finish_reason: 'length', completion_tokens: 24, total_ms: 1065, ttft_ms: 211, decode_tps: 26.9 },
+  ]
+  sequence.forEach((evt) => store.ingest(evt))
+
+  check('store: run identity captured from inference_started', () => {
+    const run = store.getLastRun()
+    assert.equal(run.modelId, 'Llama 3.2 3B Instruct')
+    assert.equal(run.backend, 'metal_resident_q8_runtime')
+    assert.equal(run.quantization, 'Q8_0')
+    assert.equal(run.promptTokens, 16)
+    assert.equal(run.contextLength, 131072)
+  })
+  check('store: prefill/decode/kv/sampler state reduced', () => {
+    const run = store.getLastRun()
+    assert.equal(run.prefill.done, 15)
+    assert.equal(run.decode.tokens, 2)
+    assert.deepEqual(run.generatedTokenIds, [16, 271])
+    assert.equal(run.kv.position, 17)
+    assert.equal(run.kv.approxBytes, 3670016)
+    assert.equal(run.lastSampler.chosenTokenId, 16)
+    assert.equal(run.layersTotal, 28)
+  })
+  check('store: finish + receipt + workers recorded', () => {
+    const run = store.getLastRun()
+    assert.equal(run.finish.status, 'ok')
+    assert.equal(run.finish.ttftMs, 211)
+    assert.equal(run.receipt.reproducible, true)
+    assert.equal(run.active, false)
+    const worker = store.getWorkers().get('169.254.156.89:9300')
+    assert.equal(worker.status, 'idle')
+  })
+  check('store: inference_error surfaces and marks the run', () => {
+    const s2 = createInferenceTelemetryStore()
+    s2.ingest({ event: 'inference_started', request_id: 'r2', model_id: 'm', backend: 'b', quantization: 'q', architecture: 'a', prompt_tokens: 1, max_tokens: 8, context_length: 64, temperature: 0, stream: false })
+    s2.ingest({ event: 'inference_error', code: 'generation_step_failed', message: 'boom' })
+    assert.equal(s2.getRun().phase, 'error')
+    assert.equal(s2.getRun().errors.length, 1)
+  })
+  check('store: joining mid-run activates from run-scoped events', () => {
+    const s4 = createInferenceTelemetryStore()
+    // Tab opened while a generation is already in flight: no inference_started seen.
+    s4.ingest({ event: 'token_decoded', token_id: 42, context_position: 9, layers_total: 28, request_id: 'r9', model_id: 'mid-run-model' })
+    assert.equal(s4.getRun().active, true)
+    assert.equal(s4.getRun().modelId, 'mid-run-model')
+    s4.ingest({ event: 'inference_finished', status: 'ok', finish_reason: 'stop', completion_tokens: 3, total_ms: 100, request_id: 'r9' })
+    assert.equal(s4.getRun().active, false)
+    // Trailing throttled event of the closed run must not reactivate it.
+    s4.ingest({ event: 'kv_cache_updated', position: 10, capacity: 64, request_id: 'r9' })
+    assert.equal(s4.getRun().active, false)
+  })
+  check('store: idle store reports no run and drains nothing', () => {
+    const s3 = createInferenceTelemetryStore()
+    assert.equal(s3.getRun().active, false)
+    assert.deepEqual(s3.drainEvents(), [])
+    assert.equal(s3.getConnection(), CONNECTION.CONNECTING)
+  })
+
+  // --- 2. honest empty states render --------------------------------------
+  check('view: waiting state copy renders before telemetry connects', () => {
+    const html = renderToStaticMarkup(React.createElement(InferenceObservatoryView, { apiBase: 'http://127.0.0.1:1' }))
+    assert.ok(html.includes('Waiting for live Camelid telemetry.'), 'waiting copy missing')
+    assert.ok(html.includes('Inference Observatory'), 'title missing')
+    assert.ok(html.includes('observatory-canvas'), 'canvas missing')
+  })
+  check('view: idle invitation copy exists in source', () => {
+    const source = readFileSync(resolve(frontendRoot, 'src/views/InferenceObservatoryView.jsx'), 'utf8')
+    assert.ok(source.includes('Start a local inference to watch Camelid work.'))
+  })
+
+  // --- 3. renderers only animate from real events --------------------------
+  check('renderers: particle spawns happen only in onEvent handlers', () => {
+    const source = readFileSync(resolve(frontendRoot, 'src/lib/observatory/tokenParticles.js'), 'utf8')
+    const drawBody = source.slice(source.indexOf('draw(ctx, frame)'))
+    assert.ok(!/spawn/i.test(drawBody), 'draw() must not spawn particles; only onEvent may')
+  })
+  check('renderers: no module fabricates telemetry', () => {
+    for (const file of ['tokenParticles.js', 'layerVisualizer.js', 'kvCacheTrail.js', 'samplerBloom.js', 'clusterConstellation.js']) {
+      const source = readFileSync(resolve(frontendRoot, `src/lib/observatory/${file}`), 'utf8')
+      assert.ok(!/(mock|simulate|fake|demoEvent)/i.test(source), `${file} contains a simulation marker`)
+    }
+    const storeSource = readFileSync(resolve(frontendRoot, 'src/lib/inferenceTelemetry.js'), 'utf8')
+    assert.ok(!/setInterval\([^)]*ingest/.test(storeSource), 'store must not self-feed events')
+  })
+} finally {
+  await server.close()
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} observatory smoke check(s) failed`)
+  process.exit(1)
+}
+console.log('\nobservatory smoke: all checks passed')

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,9 +18,10 @@ import ApiView from './views/ApiView'
 import SystemView from './views/SystemView'
 import SettingsView from './views/SettingsView'
 import ClusterView from './views/ClusterView'
+import InferenceObservatoryView from './views/InferenceObservatoryView'
 
 const DEMO_UI = import.meta.env?.VITE_CAMELID_DEMO_UI === 'true'
-const HASH_TABS = new Set(['chat', 'library', 'api', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster'])
+const HASH_TABS = new Set(['chat', 'library', 'api', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster', 'observatory'])
 
 function App() {
   const { notice, noticeTone, showNotice, clearNotice } = useNotice()
@@ -199,7 +200,7 @@ function App() {
           <BackendBanner backend={backend} onOpenSettings={() => navigateTab('settings')} />
         )}
 
-        <div className={`camelid-view ${(tab === 'chat' || tab === 'cluster') ? 'camelid-view--chat' : 'camelid-view--page'}`}>
+        <div className={`camelid-view ${(tab === 'chat' || tab === 'cluster' || tab === 'observatory') ? 'camelid-view--chat' : 'camelid-view--page'}`}>
           {tab === 'chat' && (
             <ChatWorkspace
               selectedConversation={selectedConversation}
@@ -296,6 +297,8 @@ function App() {
           )}
 
           {tab === 'cluster' && <ClusterView showNotice={showNotice} />}
+
+          {tab === 'observatory' && <InferenceObservatoryView apiBase={apiBase} />}
         </div>
       </main>
 

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -15,6 +15,7 @@ const TITLES = {
   system: 'System',
   settings: 'Settings',
   cluster: 'Cluster Topology',
+  observatory: 'Inference Observatory',
 }
 
 /* Slim top bar. Chat tab shows the conversation title + a compact model status

--- a/frontend/src/components/layout/SidebarRail.jsx
+++ b/frontend/src/components/layout/SidebarRail.jsx
@@ -6,7 +6,7 @@ import { Tooltip } from '../ui/Tooltip'
 import { ConversationListItem } from './ConversationListItem'
 import {
   IconAnalytics, IconApi, IconChat, IconHistory, IconMemory, IconModels,
-  IconNetwork, IconNewChat, IconSearch, IconSettings, IconSidebar, IconSystem,
+  IconNetwork, IconNewChat, IconObservatory, IconSearch, IconSettings, IconSidebar, IconSystem,
 } from '../ui/icons'
 
 const NAV = [
@@ -17,6 +17,7 @@ const NAV = [
   { tab: 'system', label: 'System', Icon: IconSystem },
   { tab: 'api', label: 'API', Icon: IconApi },
   { tab: 'cluster', label: 'Cluster', Icon: IconNetwork },
+  { tab: 'observatory', label: 'Inference Observatory', Icon: IconObservatory },
   { tab: 'settings', label: 'Settings', Icon: IconSettings },
 ]
 

--- a/frontend/src/components/observatory/DetailsPanel.jsx
+++ b/frontend/src/components/observatory/DetailsPanel.jsx
@@ -1,0 +1,80 @@
+/* DetailsPanel — collapsible right-side readout of the current (or most
+   recent) run, plus live errors. All values originate from telemetry. */
+
+function fmt(value, suffix = '') {
+  if (value == null || value === '' || Number.isNaN(value)) return '—'
+  return `${value}${suffix}`
+}
+
+function fmtRate(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(1)} tok/s` : '—'
+}
+
+function fmtBytes(bytes) {
+  if (!bytes) return '—'
+  if (bytes > 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+  if (bytes > 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / 1024).toFixed(0)} KB`
+}
+
+export default function DetailsPanel({ store, collapsed, onToggle }) {
+  const live = store.getRun()
+  const run = live.startedAtMs ? live : store.getLastRun() || live
+  const workers = store.getWorkers()
+  const finish = run.finish
+  const decodeTps = finish?.decodeTps ?? store.liveDecodeTps()
+  const prefillTps = finish?.prefillTps ?? store.livePrefillTps()
+  const ttft = finish?.ttftMs
+    ?? (!run.joinedMidRun && run.decode.startedAtMs && run.startedAtMs ? Math.round(run.decode.startedAtMs - run.startedAtMs) : null)
+  const activeNodes = [...workers.values()].filter((w) => w.status === 'active')
+  const errors = run.errors
+
+  const statusLabel = live.active
+    ? (store.isRunStale() ? 'stalled — no events' : `running · ${run.phase}`)
+    : finish
+      ? `${finish.status}${finish.finishReason ? ` · ${finish.finishReason}` : ''}`
+      : 'idle'
+
+  return (
+    <aside className={`observatory-details ${collapsed ? 'is-collapsed' : ''}`}>
+      <button type="button" className="observatory-details__toggle" onClick={onToggle} aria-expanded={!collapsed}>
+        {collapsed ? '‹' : '›'}
+        <span className="sr-only">{collapsed ? 'Open details panel' : 'Collapse details panel'}</span>
+      </button>
+      {!collapsed && (
+        <div className="observatory-details__body">
+          <h2>Run details</h2>
+          <dl>
+            <div><dt>Status</dt><dd data-status={live.active ? 'running' : finish?.status || 'idle'}>{statusLabel}</dd></div>
+            <div><dt>Model</dt><dd>{fmt(run.modelId)}</dd></div>
+            <div><dt>Quantization</dt><dd>{fmt(run.quantization)}</dd></div>
+            <div><dt>Backend path</dt><dd>{fmt(run.backend)}</dd></div>
+            <div><dt>Prompt tokens</dt><dd>{fmt(run.promptTokens || null)}</dd></div>
+            <div><dt>Generated tokens</dt><dd>{fmt(finish?.completionTokens ?? (run.decode.tokens || null))}</dd></div>
+            <div><dt>Prefill</dt><dd>{fmtRate(prefillTps)}</dd></div>
+            <div><dt>Decode</dt><dd>{fmtRate(decodeTps)}</dd></div>
+            <div><dt>TTFT</dt><dd>{ttft != null ? `${ttft} ms` : '—'}</dd></div>
+            <div><dt>KV cache</dt><dd>{run.kv.position ? `${run.kv.position} pos · ${fmtBytes(run.kv.approxBytes)}` : '—'}</dd></div>
+            <div><dt>Cluster nodes</dt><dd>{workers.size ? `${activeNodes.length} active of ${workers.size}` : 'local only'}</dd></div>
+            <div>
+              <dt>Receipt</dt>
+              <dd>{run.receipt ? `✓ sealed${run.receipt.reproducible ? ' · reproducible' : ''}` : 'none'}</dd>
+            </div>
+          </dl>
+          {errors.length > 0 && (
+            <div className="observatory-details__errors">
+              <h3>Errors</h3>
+              <ul>
+                {errors.slice(-6).map((err, i) => (
+                  <li key={`${err.atMs}-${i}`}>
+                    <code>{err.code}</code> {err.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/frontend/src/components/observatory/InferenceCanvas.jsx
+++ b/frontend/src/components/observatory/InferenceCanvas.jsx
@@ -1,0 +1,118 @@
+/* InferenceCanvas — the rendering surface of the Inference Observatory.
+   A single requestAnimationFrame loop draws the renderer modules over a dark
+   field. Every animated element is driven by the telemetry store (real
+   backend events); the only standing motion is the explicitly-idle ambient
+   starfield behind the resting geometry. */
+
+import { useEffect, useRef } from 'react'
+import { TokenParticleSystem } from '../../lib/observatory/tokenParticles'
+import { LayerVisualizer } from '../../lib/observatory/layerVisualizer'
+import { KVCacheTrail } from '../../lib/observatory/kvCacheTrail'
+import { SamplerBloom } from '../../lib/observatory/samplerBloom'
+import { ClusterConstellation } from '../../lib/observatory/clusterConstellation'
+
+const STAR_COUNT = 90
+
+function makeStars() {
+  return Array.from({ length: STAR_COUNT }, () => ({
+    x: Math.random(),
+    y: Math.random(),
+    r: 0.4 + Math.random() * 1.1,
+    a: 0.04 + Math.random() * 0.1,
+    drift: 0.000004 + Math.random() * 0.000012,
+  }))
+}
+
+export default function InferenceCanvas({ store, showLabels = false }) {
+  const canvasRef = useRef(null)
+  const storeRef = useRef(store)
+  const labelsRef = useRef(showLabels)
+  storeRef.current = store
+  labelsRef.current = showLabels
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return undefined
+    const ctx = canvas.getContext('2d')
+    const modules = [
+      new KVCacheTrail(),
+      new LayerVisualizer(),
+      new SamplerBloom(),
+      new TokenParticleSystem(),
+      new ClusterConstellation(),
+    ]
+    const stars = makeStars()
+    let raf = 0
+    let lastT = performance.now()
+    let dpr = window.devicePixelRatio || 1
+
+    const resize = () => {
+      dpr = window.devicePixelRatio || 1
+      const rect = canvas.getBoundingClientRect()
+      canvas.width = Math.max(1, Math.round(rect.width * dpr))
+      canvas.height = Math.max(1, Math.round(rect.height * dpr))
+    }
+    resize()
+    const observer = new ResizeObserver(resize)
+    observer.observe(canvas)
+
+    const tick = (t) => {
+      raf = window.requestAnimationFrame(tick)
+      const dt = Math.min(t - lastT, 50)
+      lastT = t
+      const s = storeRef.current
+      const w = canvas.width / dpr
+      const h = canvas.height / dpr
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+
+      const frame = {
+        w,
+        h,
+        t,
+        dt,
+        cx: w * 0.5,
+        cy: h * 0.5,
+        R: Math.min(w, h) * 0.17,
+        run: s.getRun(),
+        workers: s.getWorkers(),
+        connection: s.getConnection(),
+        showLabels: labelsRef.current,
+      }
+
+      // Background: deep field with a soft vignette.
+      ctx.fillStyle = '#04060c'
+      ctx.fillRect(0, 0, w, h)
+      const vignette = ctx.createRadialGradient(frame.cx, frame.cy, 0, frame.cx, frame.cy, Math.max(w, h) * 0.75)
+      vignette.addColorStop(0, 'rgba(13, 20, 38, 0.55)')
+      vignette.addColorStop(1, 'rgba(2, 3, 7, 0)')
+      ctx.fillStyle = vignette
+      ctx.fillRect(0, 0, w, h)
+
+      // Idle ambient: slow starfield (present in every state; it is the sky,
+      // not an inference signal).
+      stars.forEach((star) => {
+        star.x = (star.x + star.drift * dt) % 1
+        ctx.fillStyle = `rgba(170, 196, 230, ${star.a})`
+        ctx.beginPath()
+        ctx.arc(star.x * w, star.y * h, star.r, 0, Math.PI * 2)
+        ctx.fill()
+      })
+
+      // Real events drained once per frame, fanned to every module.
+      const events = s.drainEvents()
+      for (const evt of events) {
+        for (const mod of modules) {
+          if (mod.onEvent) mod.onEvent(evt, frame)
+        }
+      }
+      for (const mod of modules) mod.draw(ctx, frame)
+    }
+    raf = window.requestAnimationFrame(tick)
+    return () => {
+      window.cancelAnimationFrame(raf)
+      observer.disconnect()
+    }
+  }, [])
+
+  return <canvas ref={canvasRef} className="observatory-canvas" aria-label="Live inference visualization" />
+}

--- a/frontend/src/components/observatory/MetricsOverlay.jsx
+++ b/frontend/src/components/observatory/MetricsOverlay.jsx
@@ -1,0 +1,53 @@
+/* MetricsOverlay — Engineer Mode: live numbers straight from telemetry.
+   Every value is either a real reported number or an em dash; nothing is
+   estimated client-side beyond rates computed from real event timestamps. */
+
+function fmtTps(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? `${value.toFixed(1)} tok/s` : '—'
+}
+
+function fmtMs(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? `${Math.round(value)} ms` : '—'
+}
+
+function fmtBytes(bytes) {
+  if (!bytes) return '—'
+  if (bytes > 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+  if (bytes > 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / 1024).toFixed(0)} KB`
+}
+
+export default function MetricsOverlay({ store }) {
+  const run = store.getRun()
+  const finish = run.finish
+  const decodeTps = finish?.decodeTps ?? store.liveDecodeTps()
+  const prefillTps = finish?.prefillTps ?? store.livePrefillTps()
+  const ttft = finish?.ttftMs
+    ?? (!run.joinedMidRun && run.decode.startedAtMs && run.startedAtMs ? run.decode.startedAtMs - run.startedAtMs : null)
+  const workers = store.getWorkers()
+  const activeNodes = [...workers.values()].filter((wkr) => wkr.status === 'active').length
+
+  const cells = [
+    ['decode', fmtTps(decodeTps)],
+    ['prefill', fmtTps(prefillTps)],
+    ['ttft', fmtMs(ttft)],
+    ['tokens', run.decode.tokens ? `${run.decode.tokens} out · ${run.promptTokens} in` : run.promptTokens ? `${run.promptTokens} in` : '—'],
+    ['context', run.kv.position ? `${run.kv.position} / ${run.contextLength || run.kv.capacity || '—'}` : '—'],
+    ['kv cache', fmtBytes(run.kv.approxBytes)],
+    ['layer', run.layerEventsSeen && run.activeLayer != null ? `${run.activeLayer + 1} / ${run.layersTotal}` : run.layersTotal ? `${run.layersTotal} (resident)` : '—'],
+    ['backend', run.backend || '—'],
+    ['quant', run.quantization || '—'],
+    ['nodes', workers.size ? `${activeNodes} active / ${workers.size}` : 'local only'],
+  ]
+
+  return (
+    <div className="observatory-metrics" role="status">
+      {cells.map(([label, value]) => (
+        <div key={label} className="observatory-metric">
+          <span className="observatory-metric__label">{label}</span>
+          <span className="observatory-metric__value">{value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/observatory/ProofOverlay.jsx
+++ b/frontend/src/components/observatory/ProofOverlay.jsx
@@ -1,0 +1,54 @@
+/* ProofOverlay — Proof Mode: the verifiable identity of what just ran.
+   Hashes and token ids come from telemetry (lane identity captured at model
+   load, receipt sealed server-side). Receipt status is shown only when a
+   receipt was really written. */
+
+function shortHash(hash) {
+  return hash ? `${hash.slice(0, 12)}…${hash.slice(-6)}` : '—'
+}
+
+export default function ProofOverlay({ store }) {
+  const run = store.getRun()
+  const shown = run.startedAtMs ? run : store.getLastRun() || run
+  const receipt = shown.receipt
+  const ids = shown.generatedTokenIds
+
+  return (
+    <div className="observatory-proof">
+      <div className="observatory-proof__row">
+        <span>model</span>
+        <code>{shown.modelId || '—'}</code>
+      </div>
+      <div className="observatory-proof__row">
+        <span>model hash</span>
+        <code title={receipt?.ggufSha256 || ''}>{shortHash(receipt?.ggufSha256)}</code>
+      </div>
+      <div className="observatory-proof__row">
+        <span>quantization</span>
+        <code>{shown.quantization || '—'}</code>
+      </div>
+      <div className="observatory-proof__row">
+        <span>architecture</span>
+        <code>{shown.architecture || '—'}</code>
+      </div>
+      <div className="observatory-proof__row">
+        <span>prompt tokens</span>
+        <code>{shown.promptTokens || '—'}</code>
+      </div>
+      <div className="observatory-proof__row observatory-proof__row--ids">
+        <span>generated ids</span>
+        <code>{ids.length ? `[${ids.slice(-24).join(', ')}${ids.length > 24 ? ' …' : ''}]` : '—'}</code>
+      </div>
+      <div className={`observatory-proof__row observatory-proof__seal ${receipt ? 'is-sealed' : ''}`}>
+        <span>receipt</span>
+        {receipt ? (
+          <code title={receipt.receiptId}>
+            ✓ sealed · {receipt.reproducible ? 'reproducible' : 'recorded'} · {shortHash(receipt.receiptId)}
+          </code>
+        ) : (
+          <code>none for this run (request with camelid_receipt)</code>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/icons.jsx
+++ b/frontend/src/components/ui/icons.jsx
@@ -73,6 +73,8 @@ export const IconWindows = (p) => <Svg {...p}><path d="M3 5.5 10.5 4.4v7.1H3V5.5
 export const IconLinux = (p) => <Svg {...p}><path d="M12 2c-2.2 0-3.5 1.9-3.5 4.2 0 1.4.4 2.2.4 3.3 0 .9-.7 1.6-1.6 3-1 1.6-2 3-2 4.7 0 1.4.9 2.1 2 2.4.4.9 1.2 1.9 2.4 2 .9.1 1.6-.3 2.3-.3s1.4.4 2.3.3c1.2-.1 2-1.1 2.4-2 1.1-.3 2-1 2-2.4 0-1.7-1-3.1-2-4.7-.9-1.4-1.6-2.1-1.6-3 0-1.1.4-1.9.4-3.3C15.5 3.9 14.2 2 12 2zm-1.5 4.1c.5 0 .9.5.9 1.1s-.4 1.1-.9 1.1-.9-.5-.9-1.1.4-1.1.9-1.1zm3 0c.5 0 .9.5.9 1.1s-.4 1.1-.9 1.1-.9-.5-.9-1.1.4-1.1.9-1.1zM12 9.4c.9 0 2 .6 2 1.2 0 .4-.6.7-1.1 1-.4.2-.7.5-.9.5s-.5-.3-.9-.5c-.5-.3-1.1-.6-1.1-1 0-.6 1.1-1.2 2-1.2z" /></Svg>
 export const IconRaspberryPi = (p) => <Svg {...p} strokeIcon><rect x="3" y="6" width="18" height="12" rx="1.5" /><path d="M6 6V4M9 6V4M12 6V4M15 6V4M18 6V4" /><rect x="6.5" y="9.5" width="4" height="4" rx="0.5" /><path d="M14 10h4M14 12.5h4M14 15h4" /></Svg>
 export const IconNetwork = (p) => <Svg {...p} strokeIcon><circle cx="12" cy="5" r="2.4" /><circle cx="5" cy="18" r="2.4" /><circle cx="19" cy="18" r="2.4" /><path d="M10.6 6.9 6.4 16M13.4 6.9 17.6 16M7.4 18h9.2" /></Svg>
+/* observatory: an orbit ring around a core */
+export const IconObservatory = (p) => <Svg {...p} strokeIcon><circle cx="12" cy="12" r="2.6" /><ellipse cx="12" cy="12" rx="9.5" ry="3.8" transform="rotate(-24 12 12)" /><circle cx="18.6" cy="8.3" r="1" fill="currentColor" stroke="none" /></Svg>
 /* canvas controls */
 export const IconZoomIn = (p) => <Svg {...p} strokeIcon><circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5M11 8v6M8 11h6" /></Svg>
 export const IconZoomOut = (p) => <Svg {...p} strokeIcon><circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5M8 11h6" /></Svg>

--- a/frontend/src/hooks/useInferenceTelemetry.js
+++ b/frontend/src/hooks/useInferenceTelemetry.js
@@ -1,0 +1,33 @@
+/* React binding for the InferenceTelemetryStore: one store instance per
+   mount, connected to the active API base. Lifecycle events re-render
+   immediately via the store's subscription; fast-changing live metrics are
+   sampled on a coarse interval so token-rate events never thrash React. */
+
+import { useEffect, useMemo, useReducer } from 'react'
+import { createInferenceTelemetryStore } from '../lib/inferenceTelemetry'
+
+const LIVE_SAMPLE_MS = 250
+
+export function useInferenceTelemetry(apiBase) {
+  const store = useMemo(() => createInferenceTelemetryStore(), [])
+  const [, bump] = useReducer((n) => n + 1, 0)
+
+  useEffect(() => {
+    store.connect(apiBase)
+    const unsubscribe = store.subscribe(bump)
+    return () => {
+      unsubscribe()
+      store.disconnect()
+    }
+  }, [store, apiBase])
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      const run = store.getRun()
+      if (run.active || store.getConnection() !== 'live') bump()
+    }, LIVE_SAMPLE_MS)
+    return () => window.clearInterval(interval)
+  }, [store])
+
+  return store
+}

--- a/frontend/src/lib/inferenceTelemetry.js
+++ b/frontend/src/lib/inferenceTelemetry.js
@@ -1,0 +1,322 @@
+/* InferenceTelemetryStore — the single source of truth for the Inference
+   Observatory. It subscribes to the backend's live SSE stream
+   (`GET /api/telemetry/stream`) and reduces real runtime events into a
+   renderable snapshot.
+
+   Truthfulness contract (mirrors src/telemetry.rs on the backend): this store
+   never synthesizes, replays, or simulates events. If the stream is not
+   connected the state is `unavailable`; if connected but no inference is
+   running the state is `idle`. The canvas renders from this store only. */
+
+const MAX_ERRORS = 20
+const MAX_RECENT_EVENTS = 4096
+/* If no run-scoped event arrives for this long after the last one, and no
+   inference_finished was seen (e.g. the server died mid-run), the run is
+   marked stale so the UI does not show inference as still happening. */
+const RUN_STALE_MS = 30000
+
+export const CONNECTION = {
+  CONNECTING: 'connecting',
+  LIVE: 'live',
+  UNAVAILABLE: 'unavailable',
+}
+
+function emptyRun() {
+  return {
+    active: false,
+    requestId: null,
+    modelId: null,
+    backend: null,
+    quantization: null,
+    architecture: null,
+    promptTokens: 0,
+    maxTokens: 0,
+    contextLength: 0,
+    temperature: null,
+    stream: null,
+    startedAtMs: null,
+    joinedMidRun: false,
+    phase: 'idle', // idle | prefill | decode | finished | error
+    prefill: { tokens: 0, done: 0, path: null, startedAtMs: null, endedAtMs: null },
+    decode: { startedAtMs: null, tokens: 0, lastTokenAtMs: null, tokenIntervalMs: null },
+    layersTotal: null,
+    activeLayer: null,
+    layerEventsSeen: false,
+    kv: { position: 0, capacity: 0, approxBytes: 0 },
+    lastSampler: null, // { chosenTokenId, mode, candidates }
+    generatedTokenIds: [],
+    finish: null, // { status, finishReason, completionTokens, totalMs, ttftMs, decodeTps, prefillTps, error }
+    receipt: null, // { receiptId, reproducible, ggufSha256, atMs }
+    errors: [],
+  }
+}
+
+export function createInferenceTelemetryStore() {
+  let eventSource = null
+  let connection = CONNECTION.CONNECTING
+  let connectedBase = null
+  let lastEventAtMs = null
+  let run = emptyRun()
+  let lastRun = null // most recent finished run, kept for the details panel
+  const workers = new Map() // node -> { status: 'active'|'idle'|'error', detail, error, lastSeenMs }
+  const pending = [] // raw events drained by the canvas each frame
+  const listeners = new Set()
+
+  function notify() {
+    listeners.forEach((listener) => listener())
+  }
+
+  function pushPending(event) {
+    pending.push(event)
+    if (pending.length > MAX_RECENT_EVENTS) pending.splice(0, pending.length - MAX_RECENT_EVENTS)
+  }
+
+  function prefillTps(r) {
+    if (!r.prefill.startedAtMs || !r.prefill.endedAtMs || !r.prefill.tokens) return null
+    const ms = r.prefill.endedAtMs - r.prefill.startedAtMs
+    return ms > 0 ? (r.prefill.tokens * 1000) / ms : null
+  }
+
+  function decodeTps(r) {
+    if (!r.decode.startedAtMs || r.decode.tokens < 2 || !r.decode.lastTokenAtMs) return null
+    const ms = r.decode.lastTokenAtMs - r.decode.startedAtMs
+    return ms > 0 ? ((r.decode.tokens - 1) * 1000) / ms : null
+  }
+
+  const RUN_SCOPED_EVENTS = new Set([
+    'prefill_started', 'prefill_progress', 'decode_started', 'layer_started',
+    'layer_completed', 'token_decoded', 'kv_cache_updated', 'sampler_step',
+  ])
+
+  /* Joining mid-run: if run-scoped events arrive without a preceding
+     inference_started (the tab was opened while a generation was already in
+     flight), the run is activated from the event's own attribution. These
+     events are real inference activity; identity fields not yet observed
+     stay null rather than being guessed. */
+  function joinRunInProgress(evt, now) {
+    if (!RUN_SCOPED_EVENTS.has(evt.event) || run.active) return false
+    const sameRun = Boolean(evt.request_id) && run.requestId === evt.request_id
+    if (sameRun && run.finish) return false // trailing events of a closed run
+    if (!sameRun && run.finish) {
+      lastRun = run
+      run = emptyRun()
+    }
+    run.active = true
+    run.phase = 'running'
+    run.startedAtMs = run.startedAtMs || now
+    run.requestId = evt.request_id || run.requestId
+    run.modelId = evt.model_id || run.modelId
+    // The start was not observed, so durations measured from it (TTFT,
+    // wall-clock totals) must not be claimed for this run.
+    run.joinedMidRun = true
+    return true
+  }
+
+  function applyEvent(evt) {
+    const now = performance.now()
+    lastEventAtMs = now
+    const joined = joinRunInProgress(evt, now)
+    const changed = (() => {
+    switch (evt.event) {
+      case 'hello':
+        return false
+      case 'lagged':
+        // The stream dropped events under load; surface it, never paper over it.
+        run.errors.push({ code: 'telemetry_lagged', message: `Telemetry stream skipped ${evt.skipped} event(s) under load.`, atMs: now })
+        return true
+      case 'inference_started':
+        run = emptyRun()
+        run.active = true
+        run.phase = 'running'
+        run.requestId = evt.request_id || null
+        run.modelId = evt.model_id || null
+        run.backend = evt.backend || null
+        run.quantization = evt.quantization || null
+        run.architecture = evt.architecture || null
+        run.promptTokens = evt.prompt_tokens || 0
+        run.maxTokens = evt.max_tokens || 0
+        run.contextLength = evt.context_length || 0
+        run.temperature = typeof evt.temperature === 'number' ? evt.temperature : null
+        run.stream = Boolean(evt.stream)
+        run.startedAtMs = now
+        return true
+      case 'prefill_started':
+        run.phase = 'prefill'
+        run.prefill = { tokens: evt.prefill_tokens || 0, done: 0, path: evt.path || null, startedAtMs: now, endedAtMs: null }
+        if (evt.layers_total) run.layersTotal = evt.layers_total
+        return true
+      case 'prefill_progress':
+        run.prefill.done = evt.tokens_done || 0
+        if (!run.prefill.tokens) run.prefill.tokens = evt.tokens_total || 0
+        return false
+      case 'decode_started':
+        run.phase = 'decode'
+        run.prefill.endedAtMs = run.prefill.endedAtMs || now
+        run.decode.startedAtMs = run.decode.startedAtMs || now
+        if (typeof evt.context_position === 'number') run.kv.position = evt.context_position
+        return true
+      case 'layer_started':
+      case 'layer_completed':
+        run.layerEventsSeen = true
+        run.activeLayer = evt.layer
+        if (evt.layers_total) run.layersTotal = evt.layers_total
+        return false
+      case 'token_decoded': {
+        run.phase = 'decode'
+        run.decode.startedAtMs = run.decode.startedAtMs || now
+        if (run.decode.lastTokenAtMs != null) {
+          run.decode.tokenIntervalMs = now - run.decode.lastTokenAtMs
+        }
+        run.decode.lastTokenAtMs = now
+        run.decode.tokens += 1
+        if (typeof evt.token_id === 'number') run.generatedTokenIds.push(evt.token_id)
+        if (typeof evt.context_position === 'number') run.kv.position = evt.context_position
+        if (evt.layers_total) run.layersTotal = evt.layers_total
+        return false
+      }
+      case 'kv_cache_updated':
+        run.kv = {
+          position: evt.position || 0,
+          capacity: evt.capacity || 0,
+          approxBytes: evt.approx_bytes || 0,
+        }
+        return false
+      case 'sampler_step':
+        run.lastSampler = {
+          chosenTokenId: evt.chosen_token_id,
+          mode: evt.mode,
+          candidates: Array.isArray(evt.candidates) ? evt.candidates : [],
+        }
+        return false
+      case 'inference_error':
+        run.errors.push({ code: evt.code || 'error', message: evt.message || 'Unknown inference error', atMs: now })
+        if (run.errors.length > MAX_ERRORS) run.errors.splice(0, run.errors.length - MAX_ERRORS)
+        run.phase = 'error'
+        return true
+      case 'inference_finished':
+        run.active = false
+        run.phase = evt.status === 'ok' ? 'finished' : 'error'
+        run.finish = {
+          status: evt.status,
+          finishReason: evt.finish_reason || null,
+          completionTokens: evt.completion_tokens || 0,
+          totalMs: evt.total_ms || null,
+          ttftMs: typeof evt.ttft_ms === 'number' ? evt.ttft_ms : null,
+          decodeTps: typeof evt.decode_tps === 'number' ? evt.decode_tps : decodeTps(run),
+          prefillTps: typeof evt.prefill_tps === 'number' ? evt.prefill_tps : prefillTps(run),
+          error: evt.error || null,
+        }
+        if (evt.error) {
+          run.errors.push({ code: evt.status, message: evt.error, atMs: now })
+        }
+        lastRun = run
+        return true
+      case 'receipt_written':
+        run.receipt = {
+          receiptId: evt.receipt_id,
+          reproducible: Boolean(evt.reproducible),
+          ggufSha256: evt.gguf_sha256 || null,
+          atMs: now,
+        }
+        if (lastRun && lastRun.requestId === run.requestId) lastRun.receipt = run.receipt
+        return true
+      case 'worker_node_active':
+        workers.set(evt.node, { status: 'active', detail: evt.detail || null, error: null, lastSeenMs: now })
+        return true
+      case 'worker_node_idle':
+        workers.set(evt.node, { ...(workers.get(evt.node) || {}), status: 'idle', error: null, lastSeenMs: now })
+        return true
+      case 'worker_node_error':
+        workers.set(evt.node, { ...(workers.get(evt.node) || {}), status: 'error', error: evt.error || 'unknown error', lastSeenMs: now })
+        run.errors.push({ code: 'worker_node_error', message: `${evt.node}: ${evt.error || 'unknown error'}`, atMs: now })
+        return true
+      default:
+        return false
+    }
+    })()
+    return joined || changed
+  }
+
+  /* Single ingestion point for backend events: the SSE transport and the
+     test harness both land here. Nothing else feeds the store — there is no
+     simulation path. */
+  function ingest(evt) {
+    pushPending({ ...evt, receivedAtMs: performance.now() })
+    if (applyEvent(evt)) notify()
+  }
+
+  function handleMessage(raw) {
+    let evt
+    try {
+      evt = JSON.parse(raw)
+    } catch {
+      return
+    }
+    ingest(evt)
+  }
+
+  function connect(apiBase) {
+    const base = (apiBase || '').replace(/\/$/, '')
+    if (eventSource && connectedBase === base) return
+    disconnect()
+    connectedBase = base
+    connection = CONNECTION.CONNECTING
+    notify()
+    try {
+      eventSource = new EventSource(`${base}/api/telemetry/stream`)
+    } catch {
+      connection = CONNECTION.UNAVAILABLE
+      notify()
+      return
+    }
+    eventSource.onopen = () => {
+      connection = CONNECTION.LIVE
+      notify()
+    }
+    eventSource.onerror = () => {
+      // EventSource retries on its own; reflect the gap honestly meanwhile.
+      connection = eventSource && eventSource.readyState === EventSource.CLOSED
+        ? CONNECTION.UNAVAILABLE
+        : CONNECTION.CONNECTING
+      notify()
+    }
+    eventSource.addEventListener('telemetry', (event) => handleMessage(event.data))
+  }
+
+  function disconnect() {
+    if (eventSource) {
+      eventSource.close()
+      eventSource = null
+    }
+    connectedBase = null
+  }
+
+  function isRunStale() {
+    return run.active && lastEventAtMs != null && performance.now() - lastEventAtMs > RUN_STALE_MS
+  }
+
+  return {
+    connect,
+    disconnect,
+    /* Test seam only: feeds the exact same reducer the SSE stream uses.
+       Production code must never call this — the observatory renders real
+       backend events exclusively. */
+    ingest,
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    /* Drain raw events accumulated since the last call (canvas, once per frame). */
+    drainEvents() {
+      if (!pending.length) return []
+      return pending.splice(0, pending.length)
+    },
+    getConnection: () => connection,
+    getRun: () => run,
+    getLastRun: () => lastRun,
+    getWorkers: () => workers,
+    isRunStale,
+    liveDecodeTps: () => decodeTps(run),
+    livePrefillTps: () => prefillTps(run),
+  }
+}

--- a/frontend/src/lib/observatory/clusterConstellation.js
+++ b/frontend/src/lib/observatory/clusterConstellation.js
@@ -1,0 +1,109 @@
+/* ClusterConstellation — the local compute fabric as a small constellation
+   in the lower-left sky. Node identity comes from the Cluster Topology
+   page's saved model; node activity comes only from real worker telemetry
+   (worker_node_active/idle/error). The serving machine is always present.
+   Nodes with no live signal render as quiet stars — never as "working". */
+
+import { loadTopology } from '../clusterModel'
+
+const REFRESH_MS = 5000
+
+export class ClusterConstellation {
+  constructor() {
+    this.nodes = []
+    this.lastLoad = 0
+    this.pulse = new Map() // key -> intensity
+  }
+
+  refresh(t) {
+    if (t - this.lastLoad < REFRESH_MS && this.nodes.length) return
+    this.lastLoad = t
+    try {
+      const topology = loadTopology()
+      this.nodes = (topology?.nodes || []).slice(0, 12)
+    } catch {
+      this.nodes = []
+    }
+  }
+
+  matchKey(workerNode) {
+    // Worker telemetry identifies nodes by "host:port"; topology nodes by ip/hostname.
+    const host = String(workerNode || '').split(':')[0]
+    const hit = this.nodes.find((n) => n.ip_address === host || n.hostname === host)
+    return hit ? hit.id : workerNode
+  }
+
+  onEvent(evt) {
+    if (evt.event === 'worker_node_active') this.pulse.set(this.matchKey(evt.node), 1)
+    if (evt.event === 'worker_node_error') this.pulse.set(this.matchKey(evt.node), -1)
+    if (evt.event === 'worker_node_idle') {
+      const key = this.matchKey(evt.node)
+      if ((this.pulse.get(key) || 0) > 0.4) this.pulse.set(key, 0.4)
+    }
+  }
+
+  draw(ctx, frame) {
+    const { w, h, t, dt, run, workers, connection, showLabels } = frame
+    this.refresh(t)
+
+    // Stars: the local serving node first, then topology nodes.
+    const stars = [{ id: '__local', label: 'this machine', live: run.active }]
+    this.nodes.forEach((n) => stars.push({ id: n.id, label: n.display_name || n.hostname || n.id, status: n.status }))
+    // Workers seen on telemetry but absent from the topology still appear.
+    workers.forEach((state, node) => {
+      const key = this.matchKey(node)
+      if (!stars.some((s) => s.id === key)) stars.push({ id: key, label: node, status: 'unknown' })
+    })
+    if (stars.length === 1 && !run.active && workers.size === 0) {
+      // Single quiet machine and nothing distributed: skip the constellation
+      // rather than imply a cluster exists.
+      return
+    }
+
+    const originX = w * 0.085
+    const originY = h * 0.86
+    ctx.save()
+    stars.forEach((star, i) => {
+      const angle = -0.2 - i * 0.42
+      const dist = i === 0 ? 0 : 46 + (i % 3) * 30
+      const x = originX + Math.cos(angle) * dist + i * 16
+      const y = originY + Math.sin(angle) * dist * 0.5
+      star.x = x
+      star.y = y
+
+      let intensity = this.pulse.get(star.id) || 0
+      if (star.id === '__local' && run.active) intensity = Math.max(intensity, 0.85)
+      const isError = intensity < 0
+      const mag = Math.abs(intensity)
+
+      // Link lines back to the local star.
+      if (i > 0) {
+        ctx.strokeStyle = `rgba(126, 231, 255, ${0.05 + mag * 0.25})`
+        ctx.lineWidth = 1
+        ctx.beginPath()
+        ctx.moveTo(stars[0].x, stars[0].y)
+        ctx.lineTo(x, y)
+        ctx.stroke()
+      }
+
+      const base = connection === 'live' ? 0.35 : 0.15
+      const color = isError ? '255, 107, 107' : star.status === 'offline' ? '110, 120, 140' : '126, 231, 255'
+      ctx.globalCompositeOperation = 'lighter'
+      ctx.fillStyle = `rgba(${color}, ${base + mag * 0.6})`
+      ctx.beginPath()
+      ctx.arc(x, y, 2.2 + mag * 2.4, 0, Math.PI * 2)
+      ctx.fill()
+      ctx.globalCompositeOperation = 'source-over'
+
+      if (showLabels || isError) {
+        ctx.fillStyle = `rgba(196, 208, 224, ${isError ? 0.9 : 0.45})`
+        ctx.font = '10px "SF Mono", "JetBrains Mono", Menlo, monospace'
+        ctx.fillText(isError ? `${star.label} · error` : star.label, x + 7, y + 3)
+      }
+
+      if (intensity > 0) this.pulse.set(star.id, Math.max(0, intensity - dt * 0.0006))
+      if (intensity < 0) this.pulse.set(star.id, Math.min(0, intensity + dt * 0.0002))
+    })
+    ctx.restore()
+  }
+}

--- a/frontend/src/lib/observatory/kvCacheTrail.js
+++ b/frontend/src/lib/observatory/kvCacheTrail.js
@@ -1,0 +1,57 @@
+/* KVCacheTrail — the memory ring: an arc around the core whose filled extent
+   tracks the run's real KV cache position. The scale is the run's own
+   working window (prompt + max_tokens), so growth is visible at chat scale
+   while the absolute numbers stay truthful in the overlays. */
+
+export class KVCacheTrail {
+  constructor() {
+    this.displayFill = 0
+    this.headGlow = 0
+  }
+
+  onEvent(evt) {
+    if (evt.event === 'kv_cache_updated' || evt.event === 'token_decoded') this.headGlow = 1
+    if (evt.event === 'inference_started') {
+      this.displayFill = 0
+      this.headGlow = 0
+    }
+  }
+
+  draw(ctx, frame) {
+    const { cx, cy, R, dt, run, connection } = frame
+    const radius = R * 1.62
+    const start = -Math.PI / 2
+
+    const windowTokens = Math.max(run.promptTokens + run.maxTokens, 64)
+    const targetFill = run.kv.position > 0 ? Math.min(run.kv.position / windowTokens, 1) : 0
+    this.displayFill += (targetFill - this.displayFill) * Math.min(dt * 0.01, 1)
+
+    ctx.save()
+    // Track (always visible, faint).
+    ctx.strokeStyle = connection === 'live' ? 'rgba(126, 231, 255, 0.08)' : 'rgba(126, 231, 255, 0.04)'
+    ctx.lineWidth = 3
+    ctx.beginPath()
+    ctx.arc(cx, cy, radius, 0, Math.PI * 2)
+    ctx.stroke()
+
+    if (this.displayFill > 0.002) {
+      const end = start + this.displayFill * Math.PI * 2
+      ctx.strokeStyle = `rgba(154, 123, 255, ${0.4 + this.headGlow * 0.25})`
+      ctx.lineWidth = 3
+      ctx.lineCap = 'round'
+      ctx.beginPath()
+      ctx.arc(cx, cy, radius, start, end)
+      ctx.stroke()
+      // Glowing head where memory is being appended right now.
+      const hx = cx + Math.cos(end) * radius
+      const hy = cy + Math.sin(end) * radius
+      ctx.globalCompositeOperation = 'lighter'
+      ctx.fillStyle = `rgba(213, 196, 255, ${0.25 + this.headGlow * 0.6})`
+      ctx.beginPath()
+      ctx.arc(hx, hy, 3 + this.headGlow * 3, 0, Math.PI * 2)
+      ctx.fill()
+    }
+    this.headGlow = Math.max(0, this.headGlow - dt * 0.002)
+    ctx.restore()
+  }
+}

--- a/frontend/src/lib/observatory/layerVisualizer.js
+++ b/frontend/src/lib/observatory/layerVisualizer.js
@@ -1,0 +1,102 @@
+/* LayerVisualizer — the model core: concentric glass rings, one per
+   transformer layer. Rings energize from real layer events when the engine
+   reports them (CPU lanes), or as a sweep paced by each really-decoded
+   token's measured interval on GPU-resident lanes (where per-layer timing is
+   not observable — the token genuinely traversed every layer, the sweep just
+   distributes it across the rings). Idle = rings at rest. */
+
+const SWEEP_FALLBACK_MS = 320
+
+export class LayerVisualizer {
+  constructor() {
+    this.energies = []
+    this.sweep = null // { startT, durationMs }
+    this.prefillGlow = 0
+    this.errorFlash = 0
+  }
+
+  ensureLayers(count) {
+    while (this.energies.length < count) this.energies.push(0)
+    if (this.energies.length > count) this.energies.length = count
+  }
+
+  onEvent(evt, frame) {
+    const total = frame.run.layersTotal || this.energies.length || 0
+    if (total) this.ensureLayers(total)
+    if (evt.event === 'layer_started' || evt.event === 'layer_completed') {
+      if (typeof evt.layer === 'number' && evt.layer < this.energies.length) {
+        this.energies[evt.layer] = 1
+      }
+    }
+    if (evt.event === 'token_decoded' && !frame.run.layerEventsSeen && this.energies.length) {
+      const interval = frame.run.decode.tokenIntervalMs
+      this.sweep = {
+        startT: frame.t,
+        durationMs: Math.min(Math.max(interval || SWEEP_FALLBACK_MS, 120), 900),
+      }
+    }
+    if (evt.event === 'prefill_started') this.prefillGlow = 1
+    if (evt.event === 'decode_started') this.prefillGlow = 0
+    if (evt.event === 'inference_error' || evt.event === 'worker_node_error') this.errorFlash = 1
+  }
+
+  draw(ctx, frame) {
+    const { cx, cy, R, t, dt, run, connection } = frame
+    const total = this.energies.length
+    const live = connection === 'live'
+    const idleAlpha = live ? 0.16 : 0.07
+
+    // Sweep wave position (GPU-resident lanes): 0..1 through the ring stack.
+    let sweepPos = -1
+    if (this.sweep) {
+      const elapsed = t - this.sweep.startT
+      if (elapsed <= this.sweep.durationMs) sweepPos = elapsed / this.sweep.durationMs
+      else this.sweep = null
+    }
+
+    const ringCount = total || 12 // resting geometry before a model reports its depth
+    const inner = R * 0.55
+    const outer = R * 1.35
+    ctx.save()
+    for (let i = 0; i < ringCount; i += 1) {
+      const frac = ringCount > 1 ? i / (ringCount - 1) : 0
+      const radius = inner + (outer - inner) * frac
+      let energy = total ? this.energies[i] : 0
+      if (sweepPos >= 0) {
+        const d = Math.abs(frac - sweepPos)
+        energy = Math.max(energy, Math.max(0, 1 - d * 6))
+      }
+      if (this.prefillGlow > 0 && run.prefill.tokens > 0) {
+        const progress = run.prefill.done / Math.max(run.prefill.tokens, 1)
+        if (frac <= progress) energy = Math.max(energy, 0.5 * this.prefillGlow)
+      }
+      const alpha = idleAlpha + energy * 0.65
+      const hue = this.errorFlash > 0.3 ? '255, 107, 107' : '126, 231, 255'
+      ctx.strokeStyle = `rgba(${hue}, ${alpha})`
+      ctx.lineWidth = 1 + energy * 1.8
+      ctx.beginPath()
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2)
+      ctx.stroke()
+      if (total) this.energies[i] = Math.max(0, this.energies[i] - dt * 0.0035)
+    }
+
+    // Core: a soft glass orb that is lit only while a run is active.
+    const coreLit = run.active ? 1 : 0
+    const breathe = 0.5 + 0.5 * Math.sin(t * 0.0006)
+    const coreAlpha = live
+      ? 0.05 + 0.03 * breathe + coreLit * 0.3
+      : 0.03
+    const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, inner)
+    grad.addColorStop(0, `rgba(154, 123, 255, ${coreAlpha})`)
+    grad.addColorStop(0.7, `rgba(126, 231, 255, ${coreAlpha * 0.5})`)
+    grad.addColorStop(1, 'rgba(126, 231, 255, 0)')
+    ctx.fillStyle = grad
+    ctx.beginPath()
+    ctx.arc(cx, cy, inner, 0, Math.PI * 2)
+    ctx.fill()
+
+    this.prefillGlow = Math.max(0, this.prefillGlow - dt * 0.0004)
+    this.errorFlash = Math.max(0, this.errorFlash - dt * 0.0008)
+    ctx.restore()
+  }
+}

--- a/frontend/src/lib/observatory/samplerBloom.js
+++ b/frontend/src/lib/observatory/samplerBloom.js
@@ -1,0 +1,64 @@
+/* SamplerBloom — a probability bloom for the candidates the sampler really
+   considered at a decode step. Petals fan out above the core, length and
+   brightness proportional to each candidate's true post-softmax probability;
+   the chosen token's petal is highlighted. Fades unless refreshed by real
+   sampler_step events. */
+
+const BLOOM_TTL_MS = 1100
+
+export class SamplerBloom {
+  constructor() {
+    this.bloom = null // { candidates, chosen, bornT }
+  }
+
+  onEvent(evt, frame) {
+    if (evt.event === 'sampler_step' && Array.isArray(evt.candidates) && evt.candidates.length) {
+      this.bloom = {
+        candidates: evt.candidates.slice(0, 8),
+        chosen: evt.chosen_token_id,
+        bornT: frame.t,
+      }
+    }
+    if (evt.event === 'inference_finished') this.bloom = null
+  }
+
+  draw(ctx, frame) {
+    if (!this.bloom) return
+    const { cx, cy, R, t } = frame
+    const age = t - this.bloom.bornT
+    if (age > BLOOM_TTL_MS) {
+      this.bloom = null
+      return
+    }
+    const fade = 1 - age / BLOOM_TTL_MS
+    const { candidates, chosen } = this.bloom
+    const spread = Math.PI * 0.7
+    const baseAngle = -Math.PI / 2 - spread / 2
+    const innerR = R * 1.42
+
+    ctx.save()
+    ctx.globalCompositeOperation = 'lighter'
+    candidates.forEach((cand, i) => {
+      const angle = baseAngle + (candidates.length > 1 ? (i / (candidates.length - 1)) * spread : spread / 2)
+      const len = R * 0.18 + R * 0.5 * Math.sqrt(Math.max(cand.prob, 0))
+      const isChosen = cand.token_id === chosen
+      const x0 = cx + Math.cos(angle) * innerR
+      const y0 = cy + Math.sin(angle) * innerR
+      const x1 = cx + Math.cos(angle) * (innerR + len)
+      const y1 = cy + Math.sin(angle) * (innerR + len)
+      const alpha = fade * (isChosen ? 0.85 : 0.18 + cand.prob * 0.5)
+      ctx.strokeStyle = isChosen ? `rgba(236, 244, 255, ${alpha})` : `rgba(126, 231, 255, ${alpha})`
+      ctx.lineWidth = isChosen ? 2.2 : 1.2
+      ctx.lineCap = 'round'
+      ctx.beginPath()
+      ctx.moveTo(x0, y0)
+      ctx.lineTo(x1, y1)
+      ctx.stroke()
+      ctx.fillStyle = ctx.strokeStyle
+      ctx.beginPath()
+      ctx.arc(x1, y1, isChosen ? 2.6 : 1.6, 0, Math.PI * 2)
+      ctx.fill()
+    })
+    ctx.restore()
+  }
+}

--- a/frontend/src/lib/observatory/tokenParticles.js
+++ b/frontend/src/lib/observatory/tokenParticles.js
@@ -1,0 +1,140 @@
+/* TokenParticleSystem — prompt tokens flowing into the core during prefill,
+   one bright outbound particle per really-decoded token, and a golden burst
+   when a receipt is sealed. Spawning is driven exclusively by telemetry
+   events; with no events the field is empty. */
+
+const MAX_PARTICLES = 480
+
+function rand(min, max) {
+  return min + Math.random() * (max - min)
+}
+
+export class TokenParticleSystem {
+  constructor() {
+    this.particles = []
+    this.prefillCarry = 0
+  }
+
+  spawnPromptWave(frame, count) {
+    const n = Math.min(count, 24)
+    for (let i = 0; i < n; i += 1) {
+      if (this.particles.length >= MAX_PARTICLES) break
+      const edgeY = rand(frame.h * 0.18, frame.h * 0.82)
+      this.particles.push({
+        kind: 'prompt',
+        x: -12,
+        y: edgeY,
+        tx: frame.cx,
+        ty: frame.cy + rand(-frame.R * 0.4, frame.R * 0.4),
+        life: 1,
+        speed: rand(0.55, 0.95),
+        size: rand(1.1, 2.4),
+        wobble: rand(0, Math.PI * 2),
+      })
+    }
+  }
+
+  spawnDecodedToken(frame) {
+    if (this.particles.length >= MAX_PARTICLES) return
+    this.particles.push({
+      kind: 'token',
+      x: frame.cx + frame.R * 0.2,
+      y: frame.cy + rand(-frame.R * 0.18, frame.R * 0.18),
+      vx: rand(0.16, 0.24),
+      vy: rand(-0.025, 0.025),
+      life: 1,
+      size: rand(2.2, 3.4),
+      trail: [],
+    })
+  }
+
+  spawnReceiptBurst(frame) {
+    for (let i = 0; i < 26; i += 1) {
+      if (this.particles.length >= MAX_PARTICLES) break
+      const angle = (i / 26) * Math.PI * 2
+      this.particles.push({
+        kind: 'seal',
+        x: frame.cx,
+        y: frame.cy,
+        vx: Math.cos(angle) * rand(0.05, 0.12),
+        vy: Math.sin(angle) * rand(0.05, 0.12),
+        life: 1,
+        size: rand(1.2, 2.0),
+      })
+    }
+  }
+
+  onEvent(evt, frame) {
+    if (evt.event === 'token_decoded') this.spawnDecodedToken(frame)
+    if (evt.event === 'receipt_written') this.spawnReceiptBurst(frame)
+    if (evt.event === 'prefill_progress') {
+      // One visible mote per ~2 really-prefilled tokens, capped per event.
+      const delta = Math.max(0, (evt.tokens_done || 0) - this.lastPrefillDone || 0)
+      this.lastPrefillDone = evt.tokens_done || 0
+      this.prefillCarry += delta / 2
+      const toSpawn = Math.floor(this.prefillCarry)
+      if (toSpawn > 0) {
+        this.prefillCarry -= toSpawn
+        this.spawnPromptWave(frame, toSpawn)
+      }
+    }
+    if (evt.event === 'prefill_started') {
+      this.lastPrefillDone = 0
+      this.spawnPromptWave(frame, Math.min(16, Math.max(6, Math.floor((evt.prefill_tokens || 8) / 4))))
+    }
+  }
+
+  draw(ctx, frame) {
+    const { dt } = frame
+    ctx.save()
+    ctx.globalCompositeOperation = 'lighter'
+    for (let i = this.particles.length - 1; i >= 0; i -= 1) {
+      const p = this.particles[i]
+      if (p.kind === 'prompt') {
+        p.wobble += dt * 0.004
+        const dx = p.tx - p.x
+        const dy = p.ty - p.y
+        const dist = Math.hypot(dx, dy)
+        if (dist < frame.R * 0.5) {
+          p.life -= dt * 0.005
+        }
+        p.x += (dx / Math.max(dist, 1)) * p.speed * dt * 0.22 + Math.sin(p.wobble) * 0.3
+        p.y += (dy / Math.max(dist, 1)) * p.speed * dt * 0.22 + Math.cos(p.wobble * 0.8) * 0.3
+        ctx.fillStyle = `rgba(126, 231, 255, ${0.55 * p.life})`
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2)
+        ctx.fill()
+      } else if (p.kind === 'token') {
+        p.x += p.vx * dt
+        p.y += p.vy * dt
+        p.life -= dt * 0.00038
+        p.trail.push({ x: p.x, y: p.y })
+        if (p.trail.length > 14) p.trail.shift()
+        for (let t = 0; t < p.trail.length; t += 1) {
+          const seg = p.trail[t]
+          const a = (t / p.trail.length) * 0.35 * p.life
+          ctx.fillStyle = `rgba(154, 123, 255, ${a})`
+          ctx.beginPath()
+          ctx.arc(seg.x, seg.y, p.size * (t / p.trail.length), 0, Math.PI * 2)
+          ctx.fill()
+        }
+        ctx.fillStyle = `rgba(236, 244, 255, ${0.9 * p.life})`
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2)
+        ctx.fill()
+      } else if (p.kind === 'seal') {
+        p.x += p.vx * dt
+        p.y += p.vy * dt
+        p.life -= dt * 0.0012
+        ctx.fillStyle = `rgba(255, 211, 123, ${0.8 * p.life})`
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2)
+        ctx.fill()
+      }
+      if (p.life <= 0 || p.x > frame.w + 24 || p.y < -24 || p.y > frame.h + 24) {
+        this.particles.splice(i, 1)
+      }
+    }
+    ctx.restore()
+  }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -9,3 +9,4 @@
 @import './styles/chat.css';
 @import './styles/views.css';
 @import './styles/cluster.css';
+@import './styles/observatory.css';

--- a/frontend/src/styles/observatory.css
+++ b/frontend/src/styles/observatory.css
@@ -1,0 +1,410 @@
+/* Inference Observatory — a deliberately dark surface in both themes: the
+   canvas is the instrument, the chrome floats over it as glass. */
+
+.observatory {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  background: #04060c;
+  border-radius: var(--radius-lg);
+  color: #c4d0e0;
+}
+
+.camelid-view--chat .observatory {
+  border-radius: 0;
+}
+
+.observatory-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ---- floating toolbar ---- */
+.observatory-toolbar {
+  position: absolute;
+  top: var(--space-4);
+  left: var(--space-5);
+  right: var(--space-5);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  z-index: 3;
+  pointer-events: none;
+}
+
+.observatory-toolbar__title,
+.observatory-toolbar__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  pointer-events: auto;
+}
+
+.observatory-toolbar h1 {
+  margin: 0;
+  font-size: var(--text-md, 1rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #ecf2fb;
+}
+
+.observatory-live-badge {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(126, 231, 255, 0.18);
+  color: rgba(196, 208, 224, 0.6);
+  background: rgba(10, 16, 30, 0.55);
+  backdrop-filter: blur(8px);
+}
+
+.observatory-live-badge.is-live {
+  color: #7ee7ff;
+  border-color: rgba(126, 231, 255, 0.45);
+}
+
+.observatory-mode-switch {
+  display: flex;
+  padding: 3px;
+  border-radius: 999px;
+  border: 1px solid rgba(126, 231, 255, 0.14);
+  background: rgba(10, 16, 30, 0.55);
+  backdrop-filter: blur(8px);
+}
+
+.observatory-mode-switch button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: rgba(196, 208, 224, 0.65);
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 4px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-standard), color var(--dur-fast) var(--ease-standard);
+}
+
+.observatory-mode-switch button.is-active {
+  background: rgba(126, 231, 255, 0.14);
+  color: #ecf2fb;
+}
+
+.observatory-presentation-toggle {
+  appearance: none;
+  border: 1px solid rgba(126, 231, 255, 0.14);
+  background: rgba(10, 16, 30, 0.55);
+  color: rgba(196, 208, 224, 0.8);
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+}
+
+.observatory-presentation-toggle:hover {
+  border-color: rgba(126, 231, 255, 0.4);
+  color: #ecf2fb;
+}
+
+.observatory-presentation-hint {
+  position: absolute;
+  bottom: var(--space-3);
+  right: var(--space-4);
+  z-index: 3;
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: rgba(196, 208, 224, 0.28);
+}
+
+/* ---- state line ---- */
+.observatory-status {
+  position: absolute;
+  left: 50%;
+  bottom: 16%;
+  transform: translateX(-50%);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  color: rgba(196, 208, 224, 0.78);
+  background: rgba(8, 12, 24, 0.5);
+  border: 1px solid rgba(126, 231, 255, 0.1);
+  border-radius: 999px;
+  padding: 8px 18px;
+  backdrop-filter: blur(10px);
+  white-space: nowrap;
+}
+
+.observatory-status__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(126, 231, 255, 0.7);
+}
+
+.observatory-status.is-waiting .observatory-status__dot {
+  background: rgba(255, 196, 110, 0.85);
+}
+
+.observatory-status.is-error {
+  border-color: rgba(255, 107, 107, 0.35);
+  color: #ffb1b1;
+}
+
+.observatory-status.is-error .observatory-status__dot {
+  background: #ff6b6b;
+}
+
+/* ---- engineer metrics ---- */
+.observatory-metrics {
+  position: absolute;
+  left: var(--space-5);
+  bottom: var(--space-5);
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(96px, auto));
+  gap: 1px;
+  border: 1px solid rgba(126, 231, 255, 0.12);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: rgba(126, 231, 255, 0.08);
+  backdrop-filter: blur(10px);
+}
+
+.observatory-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
+  background: rgba(8, 12, 24, 0.72);
+}
+
+.observatory-metric__label {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(126, 231, 255, 0.55);
+}
+
+.observatory-metric__value {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: #ecf2fb;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---- proof overlay ---- */
+.observatory-proof {
+  position: absolute;
+  left: var(--space-5);
+  bottom: var(--space-5);
+  z-index: 2;
+  max-width: min(520px, calc(100% - 360px));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+  border: 1px solid rgba(126, 231, 255, 0.12);
+  border-radius: var(--radius-md);
+  background: rgba(8, 12, 24, 0.72);
+  backdrop-filter: blur(10px);
+  font-size: 0.74rem;
+}
+
+.observatory-proof__row {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.observatory-proof__row > span {
+  flex: 0 0 110px;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(126, 231, 255, 0.55);
+}
+
+.observatory-proof__row > code {
+  font-family: var(--font-mono);
+  color: #d7e1ef;
+  word-break: break-all;
+}
+
+.observatory-proof__row--ids > code {
+  color: rgba(215, 225, 239, 0.75);
+}
+
+.observatory-proof__seal.is-sealed > code {
+  color: #ffd37b;
+}
+
+/* ---- details panel ---- */
+.observatory-details {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 4;
+  width: 304px;
+  display: flex;
+  align-items: stretch;
+  transition: width var(--dur-base) var(--ease-standard);
+}
+
+.observatory-details.is-collapsed {
+  width: 28px;
+}
+
+.observatory-details__toggle {
+  appearance: none;
+  border: 0;
+  width: 28px;
+  flex: 0 0 28px;
+  background: transparent;
+  color: rgba(196, 208, 224, 0.5);
+  font-size: 1rem;
+  cursor: pointer;
+  align-self: center;
+  height: 72px;
+  border-radius: 8px 0 0 8px;
+}
+
+.observatory-details__toggle:hover {
+  color: #ecf2fb;
+  background: rgba(126, 231, 255, 0.08);
+}
+
+.observatory-details__body {
+  flex: 1;
+  min-width: 0;
+  margin: var(--space-4) var(--space-4) var(--space-4) 0;
+  padding: var(--space-4);
+  overflow-y: auto;
+  border: 1px solid rgba(126, 231, 255, 0.12);
+  border-radius: var(--radius-lg);
+  background: rgba(8, 12, 24, 0.78);
+  backdrop-filter: blur(12px);
+}
+
+.observatory-details__body h2 {
+  margin: 0 0 var(--space-3);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(126, 231, 255, 0.7);
+}
+
+.observatory-details__body dl {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.observatory-details__body dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.observatory-details__body dt {
+  color: rgba(196, 208, 224, 0.55);
+  font-size: 0.74rem;
+}
+
+.observatory-details__body dd {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: #ecf2fb;
+  text-align: right;
+  word-break: break-word;
+  font-variant-numeric: tabular-nums;
+}
+
+.observatory-details__body dd[data-status='running'] {
+  color: #7ee7ff;
+}
+
+.observatory-details__body dd[data-status='error'] {
+  color: #ff8d8d;
+}
+
+.observatory-details__errors {
+  margin-top: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid rgba(255, 107, 107, 0.25);
+}
+
+.observatory-details__errors h3 {
+  margin: 0 0 8px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #ff8d8d;
+}
+
+.observatory-details__errors ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.observatory-details__errors li {
+  font-size: 0.72rem;
+  color: rgba(255, 177, 177, 0.9);
+  word-break: break-word;
+}
+
+.observatory-details__errors code {
+  color: #ff8d8d;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+}
+
+/* presentation mode hides everything but the sky and the state line */
+.observatory.is-presentation .observatory-status {
+  background: transparent;
+  border-color: transparent;
+  backdrop-filter: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 900px) {
+  .observatory-metrics {
+    grid-template-columns: repeat(2, minmax(96px, auto));
+  }
+  .observatory-details {
+    width: 256px;
+  }
+}

--- a/frontend/src/views/InferenceObservatoryView.jsx
+++ b/frontend/src/views/InferenceObservatoryView.jsx
@@ -1,0 +1,130 @@
+/* Inference Observatory — a live, truthful visualization of Camelid
+   inference. The canvas is a renderer over the real telemetry stream
+   (`/api/telemetry/stream`); it never animates inference that is not
+   happening. States:
+     - telemetry unavailable  → "Waiting for live Camelid telemetry."
+     - connected, idle        → ambient sky + invitation to run an inference
+     - connected, running     → the canvas follows real events
+     - error                  → the failure is shown and listed in details */
+
+import { useEffect, useState } from 'react'
+import InferenceCanvas from '../components/observatory/InferenceCanvas'
+import MetricsOverlay from '../components/observatory/MetricsOverlay'
+import ProofOverlay from '../components/observatory/ProofOverlay'
+import DetailsPanel from '../components/observatory/DetailsPanel'
+import { useInferenceTelemetry } from '../hooks/useInferenceTelemetry'
+import { CONNECTION } from '../lib/inferenceTelemetry'
+
+const MODES = [
+  { id: 'art', label: 'Art' },
+  { id: 'engineer', label: 'Engineer' },
+  { id: 'proof', label: 'Proof' },
+]
+const MODE_KEY = 'camelid.observatory.mode'
+
+export default function InferenceObservatoryView({ apiBase }) {
+  const store = useInferenceTelemetry(apiBase)
+  const [mode, setMode] = useState(() => {
+    if (typeof window === 'undefined') return 'art'
+    // ?obsmode=engineer|proof|art deep-links a display mode (handy when
+    // recording); otherwise the last choice is restored.
+    const fromUrl = new URLSearchParams(window.location.search).get('obsmode')
+    if (MODES.some((m) => m.id === fromUrl)) return fromUrl
+    const saved = window.localStorage.getItem(MODE_KEY)
+    return MODES.some((m) => m.id === saved) ? saved : 'art'
+  })
+  const [presentation, setPresentation] = useState(false)
+  const [detailsCollapsed, setDetailsCollapsed] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') window.localStorage.setItem(MODE_KEY, mode)
+  }, [mode])
+
+  // Presentation mode: Esc leaves it, so the hidden controls stay reachable.
+  useEffect(() => {
+    if (!presentation) return undefined
+    const onKey = (e) => {
+      if (e.key === 'Escape') setPresentation(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [presentation])
+
+  const connection = store.getConnection()
+  const run = store.getRun()
+  const live = connection === CONNECTION.LIVE
+  const running = live && run.active && !store.isRunStale()
+  const errored = run.phase === 'error' || (run.finish && run.finish.status === 'error')
+
+  let statusText = null
+  if (!live) {
+    statusText = 'Waiting for live Camelid telemetry.'
+  } else if (!running && !errored) {
+    statusText = 'Start a local inference to watch Camelid work.'
+  } else if (errored && !running) {
+    statusText = 'Inference failed — see details.'
+  }
+
+  return (
+    <div className={`observatory ${presentation ? 'is-presentation' : ''}`} data-mode={mode}>
+      <InferenceCanvas store={store} showLabels={mode === 'engineer' && !presentation} />
+
+      {statusText && (
+        <div className={`observatory-status ${!live ? 'is-waiting' : errored ? 'is-error' : 'is-idle'}`}>
+          <span className="observatory-status__dot" aria-hidden="true" />
+          {statusText}
+        </div>
+      )}
+
+      {mode === 'engineer' && <MetricsOverlay store={store} />}
+      {mode === 'proof' && <ProofOverlay store={store} />}
+
+      {!presentation && (
+        <header className="observatory-toolbar">
+          <div className="observatory-toolbar__title">
+            <h1>Inference Observatory</h1>
+            <span className={`observatory-live-badge ${live ? 'is-live' : ''}`}>
+              {live ? (running ? 'live · inference' : 'live') : 'no telemetry'}
+            </span>
+          </div>
+          <div className="observatory-toolbar__controls">
+            <div className="observatory-mode-switch" role="tablist" aria-label="Display mode">
+              {MODES.map((m) => (
+                <button
+                  key={m.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={mode === m.id}
+                  className={mode === m.id ? 'is-active' : ''}
+                  onClick={() => setMode(m.id)}
+                >
+                  {m.label}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="observatory-presentation-toggle"
+              onClick={() => setPresentation(true)}
+              title="Hide controls for a clean recording (Esc to exit)"
+            >
+              Presentation
+            </button>
+          </div>
+        </header>
+      )}
+
+      {!presentation && (
+        <DetailsPanel
+          store={store}
+          collapsed={detailsCollapsed}
+          onToggle={() => setDetailsCollapsed((v) => !v)}
+        />
+      )}
+
+      {presentation && (
+        <div className="observatory-presentation-hint">Esc to exit</div>
+      )}
+    </div>
+  )
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -47,6 +47,7 @@ use crate::{
         self, LaneIdentity, ParityBlock, ParityReceipt, ReceiptResult, ReferenceIdentity,
         RECEIPT_SCHEMA_V1,
     },
+    telemetry,
     tensor::{parse_byte_count_env, CpuTensor, Q8_0Block, TensorStore},
     tokenizer::Tokenizer,
     BackendError,
@@ -1118,6 +1119,9 @@ struct PreparedGeneration {
     timings: GenerationTimings,
     cached_prompt_prefix: Arc<Mutex<Option<CachedPromptPrefix>>>,
     speculative: Option<PreparedSpeculative>,
+    /// Captured request identity for the live telemetry stream; taken by the
+    /// generation path that actually runs (streaming or blocking).
+    telemetry: Option<telemetry::RequestStart>,
 }
 
 /// Server-level speculative decoding mode (`CAMELID_SPEC_DECODE`).
@@ -1226,6 +1230,7 @@ pub fn router_with_state(state: AppState) -> Router {
         .route("/health", get(health))
         .route("/v1/health", get(health))
         .route("/api/capabilities", get(capabilities))
+        .route("/api/telemetry/stream", get(telemetry_stream))
         .route("/execution-plan", get(execution_plan))
         .route("/api/execution-plan", get(execution_plan))
         .route("/api/models/load", post(load_model))
@@ -1296,6 +1301,41 @@ pub async fn serve(
     let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!(%addr, "camelid server listening");
     axum::serve(listener, router_with_state(state)).await
+}
+
+/// Live inference telemetry stream (SSE). Subscribers receive only events
+/// emitted by real inference work (see `crate::telemetry`); an idle server
+/// sends nothing beyond the initial hello and keep-alive comments.
+async fn telemetry_stream() -> Response {
+    let mut rx = telemetry::hub().subscribe();
+    let events = async_stream::stream! {
+        let hello = serde_json::json!({
+            "event": "hello",
+            "schema": telemetry::TELEMETRY_SCHEMA,
+            "engine": "camelid",
+        });
+        yield Ok::<Event, Infallible>(Event::default().event("telemetry").data(hello.to_string()));
+        loop {
+            match rx.recv().await {
+                Ok(envelope) => match serde_json::to_string(&envelope) {
+                    Ok(json) => yield Ok(Event::default().event("telemetry").data(json)),
+                    Err(_) => continue,
+                },
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    let notice = serde_json::json!({ "event": "lagged", "skipped": skipped });
+                    yield Ok(Event::default().event("telemetry").data(notice.to_string()));
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    };
+    Sse::new(events)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(Duration::from_secs(10))
+                .text("ping"),
+        )
+        .into_response()
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
@@ -3097,28 +3137,45 @@ async fn gemma4_chat_nonstreaming(
     let prompt = gemma4_chat_prompt(&messages, req.camelid_enable_thinking.unwrap_or(false));
     let max_tokens = req.max_tokens.unwrap_or(256).min(4096) as usize;
     let t_generate = std::time::Instant::now();
+    // Lifecycle telemetry only on this lane: the gemma4 runtime does not
+    // (yet) report prompt token counts or per-layer events, so those fields
+    // stay at their "not reported" zero values rather than being estimated.
+    let telemetry_guard =
+        telemetry::RequestGuard::begin(gemma4_telemetry_start(&id, max_tokens as u32, false));
     let result =
         tokio::task::spawn_blocking(move || runtime.generate_greedy(&prompt, max_tokens)).await;
     let generate_ms = t_generate.elapsed().as_secs_f64() * 1e3;
     let (text, ids) = match result {
         Ok(Ok(out)) => out,
         Ok(Err(e)) => {
+            telemetry_guard.finish(gemma4_telemetry_error(e.to_string()));
             return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "generation_error",
                 e.to_string(),
                 None,
-            )
+            );
         }
         Err(e) => {
+            let message = format!("gemma4 generation task panicked: {e}");
+            telemetry_guard.finish(gemma4_telemetry_error(message.clone()));
             return api_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "generation_error",
-                format!("gemma4 generation task panicked: {e}"),
+                message,
                 None,
-            )
+            );
         }
     };
+    telemetry_guard.finish(telemetry::RequestFinish {
+        status: "ok",
+        finish_reason: Some("stop".to_string()),
+        completion_tokens: ids.len(),
+        ttft_ms: None,
+        decode_tps: None,
+        prefill_tps: None,
+        error: None,
+    });
     let body = serde_json::json!({
         "id": "chatcmpl-gemma4",
         "object": "chat.completion",
@@ -3147,6 +3204,40 @@ async fn gemma4_chat_nonstreaming(
     (StatusCode::OK, Json(body)).into_response()
 }
 
+/// Telemetry request identity for the gemma4 serve lane. Prompt token count
+/// and context length are not reported by this runtime, so they are recorded
+/// as 0 ("not reported") instead of being estimated.
+fn gemma4_telemetry_start(
+    model_id: &str,
+    max_tokens: u32,
+    stream: bool,
+) -> telemetry::RequestStart {
+    telemetry::RequestStart {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        model_id: model_id.to_string(),
+        backend: "gemma4-runtime".to_string(),
+        quantization: String::new(),
+        architecture: "gemma4".to_string(),
+        prompt_tokens: 0,
+        max_tokens,
+        context_length: 0,
+        temperature: 0.0,
+        stream,
+    }
+}
+
+fn gemma4_telemetry_error(message: String) -> telemetry::RequestFinish {
+    telemetry::RequestFinish {
+        status: "error",
+        finish_reason: None,
+        completion_tokens: 0,
+        ttft_ms: None,
+        decode_tps: None,
+        prefill_tps: None,
+        error: Some(message),
+    }
+}
+
 /// Streaming Gemma 4 chat (SSE). Mirrors the OpenAI `chat.completion.chunk`
 /// shape: a role chunk, one content delta per generated token, a final
 /// finish_reason chunk, then `[DONE]`. Generation runs on a blocking thread and
@@ -3173,6 +3264,14 @@ async fn gemma4_chat_streaming(
     });
 
     let events = async_stream::stream! {
+        // Lifecycle telemetry; a dropped stream (client disconnect) closes
+        // the run via the guard's Drop.
+        let mut telemetry_guard = Some(telemetry::RequestGuard::begin(gemma4_telemetry_start(
+            &id,
+            max_tokens as u32,
+            true,
+        )));
+        let mut telemetry_tokens = 0usize;
         // Role chunk.
         let role = serde_json::json!({
             "id": "chatcmpl-gemma4",
@@ -3188,6 +3287,15 @@ async fn gemma4_chat_streaming(
         while let Some(item) = rx.recv().await {
             match item {
                 Ok(delta) => {
+                    // One delta per really-decoded token on this lane (the
+                    // runtime invokes the callback per generated token), so
+                    // this pulse maps 1:1 to real decode work.
+                    telemetry_tokens += 1;
+                    telemetry::emit(telemetry::Event::TokenDecoded {
+                        token_id: None,
+                        context_position: None,
+                        layers_total: None,
+                    });
                     // Suppress thinking-channel spans; an empty visible delta
                     // emits nothing.
                     let visible = channel_filter.filter(&delta);
@@ -3204,6 +3312,9 @@ async fn gemma4_chat_streaming(
                     yield Ok(Event::default().data(chunk.to_string()));
                 }
                 Err(e) => {
+                    if let Some(guard) = telemetry_guard.take() {
+                        guard.finish(gemma4_telemetry_error(e.clone()));
+                    }
                     let err = serde_json::json!({ "error": { "message": e, "type": "generation_error" } });
                     yield Ok(Event::default().data(err.to_string()));
                     errored = true;
@@ -3213,6 +3324,17 @@ async fn gemma4_chat_streaming(
         }
 
         if !errored {
+            if let Some(guard) = telemetry_guard.take() {
+                guard.finish(telemetry::RequestFinish {
+                    status: "ok",
+                    finish_reason: Some("stop".to_string()),
+                    completion_tokens: telemetry_tokens,
+                    ttft_ms: None,
+                    decode_tps: None,
+                    prefill_tps: None,
+                    error: None,
+                });
+            }
             let done = serde_json::json!({
                 "id": "chatcmpl-gemma4",
                 "object": "chat.completion.chunk",
@@ -4618,6 +4740,11 @@ async fn build_server_receipt(
         tracing::warn!(error = %err, "failed to seal camelid_receipt; omitting receipt");
         return None;
     }
+    telemetry::emit(telemetry::Event::ReceiptWritten {
+        receipt_id: receipt.receipt_id.clone(),
+        reproducible: receipt.reproducible,
+        gguf_sha256: Some(receipt.lane.gguf_sha256.clone()),
+    });
     Some(receipt)
 }
 
@@ -5248,6 +5375,26 @@ async fn prepare_generation(
     // session stays off the GPU-resident prefill/decode paths.
     session.set_resident_paths_disabled(speculative.is_some());
 
+    let telemetry_backend = {
+        let plans = state.execution_plans.read().await;
+        plans
+            .get(&model.id)
+            .map(|plan| plan.selected_backend.clone())
+            .unwrap_or_else(|| "llama".to_string())
+    };
+    let telemetry_start = telemetry::RequestStart {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        model_id: model.id.clone(),
+        backend: telemetry_backend,
+        quantization: model.lane.quantization.clone(),
+        architecture: model.lane.architecture.clone(),
+        prompt_tokens: token_ids.len(),
+        max_tokens,
+        context_length,
+        temperature: f64::from(req.temperature.unwrap_or(0.0)),
+        stream: req.stream.unwrap_or(false),
+    };
+
     Ok(PreparedGeneration {
         model_id: model.id,
         model_path: model.path,
@@ -5266,6 +5413,7 @@ async fn prepare_generation(
         timings,
         cached_prompt_prefix: state.cached_prompt_prefix.clone(),
         speculative,
+        telemetry: Some(telemetry_start),
     })
 }
 
@@ -5859,6 +6007,13 @@ fn gpu_sampled_generation_step(
     next_token_id: u32,
     forward_us: u128,
 ) -> crate::Result<LlamaGenerationStep> {
+    // This step's token was really sampled (on the GPU); the engine-level
+    // sampler hook never runs for it, so the decode pulse is emitted here.
+    telemetry::emit(telemetry::Event::TokenDecoded {
+        token_id: Some(next_token_id),
+        context_position: None,
+        layers_total: None,
+    });
     Ok(LlamaGenerationStep {
         prompt_token_count: 1,
         prefill_token_count: 0,
@@ -6041,11 +6196,28 @@ fn generation_timeout_duration() -> std::result::Result<Duration, Box<Response>>
 }
 
 fn generate_decoded_tokens(
-    prepared: PreparedGeneration,
+    mut prepared: PreparedGeneration,
 ) -> std::result::Result<GeneratedText, Box<Response>> {
+    // Lifecycle telemetry for the blocking (non-streaming) path. If the
+    // generation errors out, the guard's Drop closes the run on the stream.
+    let telemetry_guard = prepared
+        .telemetry
+        .take()
+        .map(telemetry::RequestGuard::begin);
     let tokenizer = prepared.tokenizer.clone();
     let stop_sequences = prepared.stop_sequences.clone();
     let generated = generate_token_ids(prepared)?;
+    if let Some(guard) = telemetry_guard {
+        guard.finish(telemetry::RequestFinish {
+            status: "ok",
+            finish_reason: Some(generated.finish_reason.to_string()),
+            completion_tokens: generated.token_ids.len(),
+            ttft_ms: None,
+            decode_tps: None,
+            prefill_tps: None,
+            error: None,
+        });
+    }
     let mut text = tokenizer
         .decode(&generated.token_ids, true)
         .map_err(|err| {
@@ -6919,6 +7091,10 @@ fn stream_completion(mut prepared: PreparedGeneration, chat: bool) -> Response {
     };
     let events = async_stream::stream! {
         let stream_started = Instant::now();
+        // Lifecycle telemetry for the streaming path. Dropping the stream
+        // (client disconnect, error return) closes the run via the guard's
+        // Drop, so the observatory never shows a stale "running" state.
+        let telemetry_guard = prepared.telemetry.take().map(telemetry::RequestGuard::begin);
         let mut stream_event_timings = StreamEventTimings {
             poll_yield_enabled: stream_poll_yield,
             ..StreamEventTimings::default()
@@ -7174,6 +7350,25 @@ fn stream_completion(mut prepared: PreparedGeneration, chat: bool) -> Response {
         prepared.timings.memory = forward_timings.memory;
         if collect_q8_schedule {
             prepared.timings.q8_schedule = Some(snapshot_q8_schedule_telemetry());
+        }
+        if let Some(guard) = telemetry_guard {
+            let ttft_ms = first_content_ms.map(|ms| ms as u64);
+            let decode_tps = match (first_content_ms, generated.len()) {
+                (Some(first_ms), count) if count > 1 => {
+                    let decode_ms = generation_started.elapsed().as_millis().saturating_sub(first_ms);
+                    (decode_ms > 0).then(|| (count - 1) as f64 * 1000.0 / decode_ms as f64)
+                }
+                _ => None,
+            };
+            guard.finish(telemetry::RequestFinish {
+                status: "ok",
+                finish_reason: Some(finish_reason.to_string()),
+                completion_tokens: generated.len(),
+                ttft_ms,
+                decode_tps,
+                prefill_tps: None,
+                error: None,
+            });
         }
         stream_event_timings.final_yield = Some(stream_started.elapsed().as_millis());
         let camelid_diagnostics = stream_timing_diagnostics
@@ -7786,6 +7981,16 @@ fn api_error(
     message: String,
     param: Option<&'static str>,
 ) -> Response {
+    // Surface failures that happen while a generation is live on the
+    // telemetry stream. Errors raised outside an active generation
+    // (request validation, model management) are not inference errors and
+    // stay off the stream.
+    if telemetry::hub().request_active() {
+        telemetry::emit(telemetry::Event::InferenceError {
+            code: code.to_string(),
+            message: message.clone(),
+        });
+    }
     let error_type = match status {
         StatusCode::NOT_IMPLEMENTED => "not_implemented",
         StatusCode::SERVICE_UNAVAILABLE => "runtime_unavailable",
@@ -10320,6 +10525,7 @@ mod tests {
             timings: GenerationTimings::default(),
             cached_prompt_prefix: Arc::new(Mutex::new(None)),
             speculative: None,
+            telemetry: None,
         }
     }
 

--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -100,6 +100,7 @@ pub fn deserialize_tensor<R: Read>(reader: &mut R, name: String) -> std::io::Res
 
 pub struct DistributedClient {
     stream: Mutex<TcpStream>,
+    addr: String,
 }
 
 impl DistributedClient {
@@ -108,10 +109,42 @@ impl DistributedClient {
         stream.set_nodelay(true)?;
         Ok(Self {
             stream: Mutex::new(stream),
+            addr: addr.to_string(),
         })
     }
 
     pub fn forward_to_worker(
+        &self,
+        hidden: &CpuTensor,
+        is_prefill: bool,
+        seq_len: usize,
+        position: usize,
+    ) -> Result<CpuTensor> {
+        // Worker telemetry wraps the real TCP roundtrip: active when the
+        // activation ships out, idle when the response lands, error on any
+        // wire failure.
+        crate::telemetry::emit(crate::telemetry::Event::WorkerNodeActive {
+            node: self.addr.clone(),
+            detail: Some(if is_prefill {
+                format!("prefill seq_len {seq_len} @ position {position}")
+            } else {
+                format!("decode @ position {position}")
+            }),
+        });
+        let result = self.forward_to_worker_inner(hidden, is_prefill, seq_len, position);
+        match &result {
+            Ok(_) => crate::telemetry::emit(crate::telemetry::Event::WorkerNodeIdle {
+                node: self.addr.clone(),
+            }),
+            Err(err) => crate::telemetry::emit(crate::telemetry::Event::WorkerNodeError {
+                node: self.addr.clone(),
+                error: err.to_string(),
+            }),
+        }
+        result
+    }
+
+    fn forward_to_worker_inner(
         &self,
         hidden: &CpuTensor,
         is_prefill: bool,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::execution_plan::MAC_Q8_PREFILL_I8MM_MIN_ROWS;
 use crate::metal;
+use crate::telemetry;
 
 mod diagnostic_config;
 pub(crate) mod gemma4;
@@ -2492,6 +2493,11 @@ impl LlamaInferenceSession {
             if next_hidden.len() != hidden.data.len() {
                 next_hidden.resize(hidden.data.len(), 0.0);
             }
+            telemetry::emit(telemetry::Event::LayerStarted {
+                layer: layer_idx,
+                layers_total: self.weights.layers.len(),
+            });
+            let layer_telemetry_started = Instant::now();
             let mut layer_timings = LlamaLayerTimings {
                 layer_index: layer_idx,
                 ..LlamaLayerTimings::default()
@@ -2572,6 +2578,11 @@ impl LlamaInferenceSession {
             hidden.q8_0_packed_rows4_4x8 = None;
             hidden.q8_0_runtime_storage = None;
             hidden.q8_0_file_backing = None;
+            telemetry::emit(telemetry::Event::LayerCompleted {
+                layer: layer_idx,
+                layers_total: self.weights.layers.len(),
+                duration_us: layer_telemetry_started.elapsed().as_micros() as u64,
+            });
             trace_forward_memory(&format!("prefill_layer_major_layer_{layer_idx}_done"));
         }
         timings.layers_total = layers_started.elapsed().as_micros();
@@ -2681,6 +2692,10 @@ impl LlamaInferenceSession {
                     }
                 }
                 trace_forward_memory(&format!("layer_{layer_idx}_start"));
+                telemetry::emit(telemetry::Event::LayerStarted {
+                    layer: layer_idx,
+                    layers_total: self.weights.layers.len(),
+                });
                 let timed = forward_layer_timed(
                     &hidden,
                     layer,
@@ -2695,6 +2710,11 @@ impl LlamaInferenceSession {
                     &mut self.kv_cache,
                 )?;
                 hidden = timed.output;
+                telemetry::emit(telemetry::Event::LayerCompleted {
+                    layer: layer_idx,
+                    layers_total: self.weights.layers.len(),
+                    duration_us: timed.timings.total as u64,
+                });
                 trace_forward_memory(&format!("layer_{layer_idx}_done"));
                 if let (Some(memory), Some(layer_memory)) = (&mut memory, &timed.timings.memory) {
                     memory.record_layer(layer_memory.clone());
@@ -2855,6 +2875,17 @@ impl LlamaInferenceSession {
         let mut first_token_timings = LlamaForwardTimings::default();
         let prefill_count = token_ids.len().saturating_sub(1);
         let prefill_chunk_tokens = prefill_chunk_token_count(prefill_count);
+        let telemetry_layers_total = self.weights.layers.len();
+        if prefill_count > 0 {
+            telemetry::emit(telemetry::Event::PrefillStarted {
+                prefill_tokens: prefill_count,
+                // The lane resolves just below (GPU-resident first, then
+                // layer-major / chunked / single-token); the progress and
+                // layer events that follow come from the lane that ran.
+                path: "auto",
+                layers_total: telemetry_layers_total,
+            });
+        }
         let resident_prefill_started = Instant::now();
         if prefill_count > 1 && self.try_resident_prefill(&token_ids[..prefill_count])? {
             // Whole prompt prefilled on the GPU in one command buffer; the last prompt
@@ -2863,6 +2894,10 @@ impl LlamaInferenceSession {
             let resident_prefill_us = resident_prefill_started.elapsed().as_micros();
             timings.total += resident_prefill_us;
             prefill_timings.total += resident_prefill_us;
+            telemetry::emit(telemetry::Event::PrefillProgress {
+                tokens_done: prefill_count,
+                tokens_total: prefill_count,
+            });
         } else if prefill_count > 0
             && prefill_chunk_tokens > 1
             && prefill_layer_major_enabled(&self.weights)
@@ -2874,18 +2909,33 @@ impl LlamaInferenceSession {
             timings.add_assign(&layer_major_timings);
             prefill_timings.add_assign(&layer_major_timings);
         } else if prefill_count > 0 && prefill_chunk_tokens > 1 {
+            let mut telemetry_tokens_done = 0usize;
             for chunk in token_ids[..prefill_count].chunks(prefill_chunk_tokens) {
                 let chunk_timings = self.forward_prefill_chunk_timed_fast(chunk)?;
                 timings.add_assign(&chunk_timings);
                 prefill_timings.add_assign(&chunk_timings);
+                telemetry_tokens_done += chunk.len();
+                telemetry::emit(telemetry::Event::PrefillProgress {
+                    tokens_done: telemetry_tokens_done,
+                    tokens_total: prefill_count,
+                });
             }
         } else {
-            for token_id in &token_ids[..prefill_count] {
+            for (telemetry_done, token_id) in token_ids[..prefill_count].iter().enumerate() {
                 add_q8_schedule_counter(&Q8_SCHED_PREFILL_SINGLE_TOKEN_FALLBACKS, 1);
                 let timed = self.forward_single_token_timed_internal(*token_id, false, false)?;
                 timings.add_assign(&timed.timings);
                 prefill_timings.add_assign(&timed.timings);
+                telemetry::emit(telemetry::Event::PrefillProgress {
+                    tokens_done: telemetry_done + 1,
+                    tokens_total: prefill_count,
+                });
             }
+        }
+        if prefill_count > 0 {
+            telemetry::emit(telemetry::Event::DecodeStarted {
+                context_position: self.kv_cache.position,
+            });
         }
 
         let last_token_id = *token_ids.last().expect("non-empty token_ids checked above");
@@ -2904,6 +2954,35 @@ impl LlamaInferenceSession {
         let sample_started = Instant::now();
         let next_token_id = sampler.sample_with_history(&logits, token_history)?;
         let sample = sample_started.elapsed().as_micros();
+        if telemetry::active() {
+            // Candidate probabilities are computed from the real logits of
+            // this step, and only while a telemetry subscriber is connected.
+            telemetry::emit(telemetry::Event::SamplerStep {
+                chosen_token_id: next_token_id,
+                mode: match &sampler {
+                    LlamaSampler::Greedy => "greedy",
+                    LlamaSampler::Sampling(_) => "sampling",
+                },
+                candidates: telemetry::top_k_candidates(&logits.data, 8),
+            });
+        }
+        telemetry::emit(telemetry::Event::TokenDecoded {
+            token_id: Some(next_token_id),
+            context_position: Some(self.kv_cache.position),
+            layers_total: Some(telemetry_layers_total),
+        });
+        telemetry::emit(telemetry::Event::KvCacheUpdated {
+            position: self.kv_cache.position,
+            capacity: self.kv_cache.plan.max_sequence_length,
+            approx_bytes: Some(
+                (self.kv_cache.position
+                    * self.kv_cache.plan.layer_count
+                    * self.kv_cache.plan.kv_head_count
+                    * self.kv_cache.plan.head_dim
+                    * 2
+                    * std::mem::size_of::<f32>()) as u64,
+            ),
+        });
         Ok(LlamaGenerationStep {
             prompt_token_count: token_ids.len(),
             prefill_token_count: token_ids.len().saturating_sub(1),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod metal;
 pub mod model;
 pub mod model_source;
 pub mod receipt;
+pub mod telemetry;
 pub mod tensor;
 pub mod tokenizer;
 pub mod wire_mmap;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,475 @@
+//! Live inference telemetry: a process-wide broadcast hub that the engine
+//! emits real runtime events into and the HTTP layer streams to subscribers
+//! over SSE (`GET /api/telemetry/stream`).
+//!
+//! Truthfulness contract: every event is emitted from a real code path doing
+//! real work — there is no synthetic, replayed, or decorative event source.
+//! If nothing is running, the stream carries nothing (besides SSE
+//! keep-alives). Consumers (the Inference Observatory) render state from
+//! these events only.
+//!
+//! Cost contract: when no subscriber is connected, `emit` is a single atomic
+//! load (`receiver_count == 0`) and returns immediately, so the hot decode
+//! loop pays nothing in normal serving. High-frequency event classes (layer,
+//! KV cache, sampler, prefill progress) are additionally rate-limited per
+//! class so a fast decode loop cannot flood the channel; lifecycle events
+//! (started/finished/receipt/error) always pass through.
+
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Mutex, OnceLock,
+};
+use std::time::Instant;
+
+use serde::Serialize;
+use tokio::sync::broadcast;
+
+pub const TELEMETRY_SCHEMA: &str = "camelid.telemetry/v1";
+/// Broadcast ring capacity. Slow subscribers that fall more than this many
+/// events behind observe a `Lagged` gap (surfaced to them as a `lagged`
+/// notice) rather than slowing the engine down.
+const CHANNEL_CAPACITY: usize = 8192;
+
+/// Minimum spacing for throttled event classes, in microseconds.
+const LAYER_EVENT_MIN_GAP_US: u64 = 15_000;
+const KV_EVENT_MIN_GAP_US: u64 = 50_000;
+const SAMPLER_EVENT_MIN_GAP_US: u64 = 80_000;
+const PREFILL_PROGRESS_MIN_GAP_US: u64 = 33_000;
+const WORKER_EVENT_MIN_GAP_US: u64 = 100_000;
+
+/// How a generation request is identified across its event stream.
+#[derive(Clone, Debug, Serialize)]
+pub struct RequestContext {
+    pub request_id: String,
+    pub model_id: String,
+}
+
+/// One telemetry event, wrapped with ordering and attribution metadata.
+#[derive(Clone, Debug, Serialize)]
+pub struct Envelope {
+    pub seq: u64,
+    /// Milliseconds since this server process started emitting telemetry.
+    pub t_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(flatten)]
+    pub event: Event,
+}
+
+/// A top-k sampler candidate at one decode step (post-softmax probability).
+#[derive(Clone, Debug, Serialize)]
+pub struct SamplerCandidate {
+    pub token_id: u32,
+    pub prob: f32,
+}
+
+/// The runtime event vocabulary. Field values come straight from the engine
+/// state at the emit site; nothing here is estimated after the fact.
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum Event {
+    InferenceStarted {
+        backend: String,
+        quantization: String,
+        architecture: String,
+        prompt_tokens: usize,
+        max_tokens: u32,
+        context_length: usize,
+        temperature: f64,
+        stream: bool,
+    },
+    InferenceFinished {
+        status: &'static str, // "ok" | "error" | "disconnected"
+        #[serde(skip_serializing_if = "Option::is_none")]
+        finish_reason: Option<String>,
+        completion_tokens: usize,
+        total_ms: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        ttft_ms: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        decode_tps: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        prefill_tps: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    PrefillStarted {
+        prefill_tokens: usize,
+        /// Which real prefill lane ran: "gpu_resident" | "layer_major" |
+        /// "chunked" | "single_token".
+        path: &'static str,
+        layers_total: usize,
+    },
+    PrefillProgress {
+        tokens_done: usize,
+        tokens_total: usize,
+    },
+    DecodeStarted {
+        context_position: usize,
+    },
+    LayerStarted {
+        layer: usize,
+        layers_total: usize,
+    },
+    LayerCompleted {
+        layer: usize,
+        layers_total: usize,
+        duration_us: u64,
+    },
+    TokenDecoded {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        token_id: Option<u32>,
+        /// Sequence position after this token (KV position), when known.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        context_position: Option<usize>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        layers_total: Option<usize>,
+    },
+    KvCacheUpdated {
+        position: usize,
+        capacity: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        approx_bytes: Option<u64>,
+    },
+    SamplerStep {
+        chosen_token_id: u32,
+        mode: &'static str, // "greedy" | "sampling"
+        candidates: Vec<SamplerCandidate>,
+    },
+    /// A real failure observed while a generation request was active. Emitted
+    /// alongside (not instead of) the closing `InferenceFinished`.
+    InferenceError {
+        code: String,
+        message: String,
+    },
+    ReceiptWritten {
+        receipt_id: String,
+        reproducible: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gguf_sha256: Option<String>,
+    },
+    WorkerNodeActive {
+        node: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+    },
+    WorkerNodeIdle {
+        node: String,
+    },
+    WorkerNodeError {
+        node: String,
+        error: String,
+    },
+}
+
+impl Event {
+    /// Throttle class index, or `None` for events that always pass.
+    fn throttle_class(&self) -> Option<usize> {
+        match self {
+            Event::LayerStarted { .. } | Event::LayerCompleted { .. } => Some(0),
+            Event::KvCacheUpdated { .. } => Some(1),
+            Event::SamplerStep { .. } => Some(2),
+            Event::PrefillProgress { .. } => Some(3),
+            // Worker errors always pass; only the per-roundtrip active/idle
+            // chatter is throttled.
+            Event::WorkerNodeActive { .. } | Event::WorkerNodeIdle { .. } => Some(4),
+            _ => None,
+        }
+    }
+}
+
+const THROTTLE_CLASSES: usize = 5;
+const THROTTLE_MIN_GAP_US: [u64; THROTTLE_CLASSES] = [
+    LAYER_EVENT_MIN_GAP_US,
+    KV_EVENT_MIN_GAP_US,
+    SAMPLER_EVENT_MIN_GAP_US,
+    PREFILL_PROGRESS_MIN_GAP_US,
+    WORKER_EVENT_MIN_GAP_US,
+];
+
+pub struct TelemetryHub {
+    tx: broadcast::Sender<Envelope>,
+    seq: AtomicU64,
+    started: Instant,
+    request: Mutex<Option<RequestContext>>,
+    last_emit_us: [AtomicU64; THROTTLE_CLASSES],
+}
+
+impl TelemetryHub {
+    fn new() -> Self {
+        let (tx, _) = broadcast::channel(CHANNEL_CAPACITY);
+        Self {
+            tx,
+            seq: AtomicU64::new(0),
+            started: Instant::now(),
+            request: Mutex::new(None),
+            last_emit_us: [
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+            ],
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Envelope> {
+        self.tx.subscribe()
+    }
+
+    pub fn has_subscribers(&self) -> bool {
+        self.tx.receiver_count() > 0
+    }
+
+    /// Mark the request whose engine-level events should be attributed until
+    /// `clear_request`. The serve path runs one generation at a time; if a
+    /// second request overlaps, its events attribute to the most recent
+    /// `set_request`, which is the truthful best effort without threading a
+    /// handle through the engine.
+    pub fn set_request(&self, ctx: RequestContext) {
+        if let Ok(mut guard) = self.request.lock() {
+            *guard = Some(ctx);
+        }
+    }
+
+    pub fn clear_request(&self) {
+        if let Ok(mut guard) = self.request.lock() {
+            *guard = None;
+        }
+    }
+
+    /// True while a generation request is attributed (between `set_request`
+    /// and `clear_request`).
+    pub fn request_active(&self) -> bool {
+        self.request
+            .lock()
+            .map(|guard| guard.is_some())
+            .unwrap_or(false)
+    }
+
+    pub fn emit(&self, event: Event) {
+        if self.tx.receiver_count() == 0 {
+            return;
+        }
+        if let Some(class) = event.throttle_class() {
+            let now_us = self.started.elapsed().as_micros() as u64;
+            let last = self.last_emit_us[class].load(Ordering::Relaxed);
+            if now_us.saturating_sub(last) < THROTTLE_MIN_GAP_US[class] {
+                return;
+            }
+            self.last_emit_us[class].store(now_us, Ordering::Relaxed);
+        }
+        let (request_id, model_id) = match self.request.lock() {
+            Ok(guard) => match guard.as_ref() {
+                Some(ctx) => (Some(ctx.request_id.clone()), Some(ctx.model_id.clone())),
+                None => (None, None),
+            },
+            Err(_) => (None, None),
+        };
+        let envelope = Envelope {
+            seq: self.seq.fetch_add(1, Ordering::Relaxed),
+            t_ms: self.started.elapsed().as_millis() as u64,
+            request_id,
+            model_id,
+            event,
+        };
+        let _ = self.tx.send(envelope);
+    }
+}
+
+static HUB: OnceLock<TelemetryHub> = OnceLock::new();
+
+pub fn hub() -> &'static TelemetryHub {
+    HUB.get_or_init(TelemetryHub::new)
+}
+
+/// Emit one event into the hub. Near-free when nothing is subscribed.
+pub fn emit(event: Event) {
+    hub().emit(event)
+}
+
+/// True when at least one telemetry subscriber is connected. Use to skip
+/// work that only exists to enrich telemetry (e.g. top-k softmax).
+pub fn active() -> bool {
+    hub().has_subscribers()
+}
+
+/// Scoped attribution + guaranteed lifecycle closure for one generation
+/// request. Emits `InferenceStarted` on construction. If the owner drops the
+/// guard without calling [`RequestGuard::finish`] (client disconnect,
+/// panic-free early return), an `InferenceFinished { status: "disconnected" }`
+/// event is emitted so the stream never shows a generation as still running
+/// when it is not.
+pub struct RequestGuard {
+    started: Instant,
+    finished: bool,
+}
+
+pub struct RequestStart {
+    pub request_id: String,
+    pub model_id: String,
+    pub backend: String,
+    pub quantization: String,
+    pub architecture: String,
+    pub prompt_tokens: usize,
+    pub max_tokens: u32,
+    pub context_length: usize,
+    pub temperature: f64,
+    pub stream: bool,
+}
+
+pub struct RequestFinish {
+    pub status: &'static str,
+    pub finish_reason: Option<String>,
+    pub completion_tokens: usize,
+    pub ttft_ms: Option<u64>,
+    pub decode_tps: Option<f64>,
+    pub prefill_tps: Option<f64>,
+    pub error: Option<String>,
+}
+
+impl RequestGuard {
+    pub fn begin(start: RequestStart) -> Self {
+        hub().set_request(RequestContext {
+            request_id: start.request_id,
+            model_id: start.model_id,
+        });
+        emit(Event::InferenceStarted {
+            backend: start.backend,
+            quantization: start.quantization,
+            architecture: start.architecture,
+            prompt_tokens: start.prompt_tokens,
+            max_tokens: start.max_tokens,
+            context_length: start.context_length,
+            temperature: start.temperature,
+            stream: start.stream,
+        });
+        Self {
+            started: Instant::now(),
+            finished: false,
+        }
+    }
+
+    pub fn finish(mut self, finish: RequestFinish) {
+        self.emit_finished(finish);
+        self.finished = true;
+        hub().clear_request();
+    }
+
+    fn emit_finished(&self, finish: RequestFinish) {
+        emit(Event::InferenceFinished {
+            status: finish.status,
+            finish_reason: finish.finish_reason,
+            completion_tokens: finish.completion_tokens,
+            total_ms: self.started.elapsed().as_millis() as u64,
+            ttft_ms: finish.ttft_ms,
+            decode_tps: finish.decode_tps,
+            prefill_tps: finish.prefill_tps,
+            error: finish.error,
+        });
+    }
+}
+
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.emit_finished(RequestFinish {
+                status: "disconnected",
+                finish_reason: None,
+                completion_tokens: 0,
+                ttft_ms: None,
+                decode_tps: None,
+                prefill_tps: None,
+                error: None,
+            });
+            hub().clear_request();
+        }
+    }
+}
+
+/// Compute the top-k post-softmax candidates from a raw logit slice. Only
+/// called when a telemetry subscriber is connected; one linear scan plus a
+/// small partial sort.
+pub fn top_k_candidates(logits: &[f32], k: usize) -> Vec<SamplerCandidate> {
+    if logits.is_empty() || k == 0 {
+        return Vec::new();
+    }
+    let mut top: Vec<(usize, f32)> = Vec::with_capacity(k + 1);
+    for (idx, &value) in logits.iter().enumerate() {
+        if top.len() < k {
+            top.push((idx, value));
+            if top.len() == k {
+                top.sort_by(|a, b| b.1.total_cmp(&a.1));
+            }
+        } else if value > top[k - 1].1 {
+            top[k - 1] = (idx, value);
+            let mut i = k - 1;
+            while i > 0 && top[i].1 > top[i - 1].1 {
+                top.swap(i, i - 1);
+                i -= 1;
+            }
+        }
+    }
+    if top.len() < k {
+        top.sort_by(|a, b| b.1.total_cmp(&a.1));
+    }
+    // Softmax over the full logit slice for honest probabilities.
+    let max_logit = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    let denom: f32 = logits.iter().map(|&v| (v - max_logit).exp()).sum();
+    top.into_iter()
+        .map(|(idx, value)| SamplerCandidate {
+            token_id: idx as u32,
+            prob: if denom > 0.0 {
+                (value - max_logit).exp() / denom
+            } else {
+                0.0
+            },
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_k_orders_by_probability() {
+        let logits = vec![0.0, 3.0, 1.0, 2.0];
+        let candidates = top_k_candidates(&logits, 2);
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].token_id, 1);
+        assert_eq!(candidates[1].token_id, 3);
+        assert!(candidates[0].prob > candidates[1].prob);
+        assert!(candidates[0].prob <= 1.0);
+    }
+
+    #[test]
+    fn emit_without_subscribers_is_a_noop() {
+        // Must not panic or allocate envelopes when nobody listens.
+        emit(Event::DecodeStarted {
+            context_position: 0,
+        });
+        assert!(!active() || hub().has_subscribers());
+    }
+
+    #[test]
+    fn subscriber_receives_lifecycle_events() {
+        let mut rx = hub().subscribe();
+        emit(Event::PrefillStarted {
+            prefill_tokens: 7,
+            path: "chunked",
+            layers_total: 28,
+        });
+        // The hub is process-global, so other tests may interleave events;
+        // drain until ours shows up.
+        loop {
+            let envelope = rx.try_recv().expect("our event should be broadcast");
+            if let Event::PrefillStarted { prefill_tokens, .. } = envelope.event {
+                assert_eq!(prefill_tokens, 7);
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a real-time, truthful visualization of Camelid inference, backend-first.

## Backend — `camelid.telemetry/v1`
- `src/telemetry.rs`: process-wide broadcast hub with a typed event schema (inference lifecycle, prefill, decode, layer, token, KV cache, sampler, receipt, worker-node events), per-class rate limiting, and a request guard that closes every run (`ok`/`error`/`disconnected`) on the stream.
- `GET /api/telemetry/stream` (SSE): hello + envelopes (`seq`, `t_ms`, request attribution); `lagged` notices instead of silent gaps.
- Emits wired into real execution paths only: llama serve lane (streaming + blocking + GPU-sampled greedy fast lane), gemma4 serve lane (lifecycle + per-token pulses), distributed worker TCP roundtrips, and server-side receipt sealing.
- Zero overhead with no subscriber: every emit short-circuits on one atomic load. Sampler top-k softmax is computed only while someone is watching.

## Frontend — Inference Observatory tab
- `InferenceTelemetryStore` reduces the live stream into a renderable run snapshot (mid-run join from event attribution, stale-run detection, honest unknowns). The canvas renders from this store exclusively.
- Renderer modules: `TokenParticleSystem`, `LayerVisualizer`, `KVCacheTrail`, `SamplerBloom`, `ClusterConstellation` over a dark glass field.
- Art / Engineer / Proof display modes (`?obsmode=` deep-link), Presentation toggle, collapsible run-details panel (model, quant, backend path, token counts, prefill/decode tok/s, TTFT, KV size, nodes, receipt status, errors).
- Truthful states: idle ambient, telemetry-unavailable, and error surfacing. **No simulated telemetry anywhere** — `npm run smoke:observatory` enforces that renderers may only animate from real events.

## Truthfulness contract
GPU-resident lanes execute all layers in one Metal command buffer, so per-layer events genuinely do not exist there; the UI paces the layer sweep from real token cadence + `layers_total` instead, and CPU lanes emit true per-layer events. The gemma4 lane records unreported fields as 0, never estimated. Documented in `docs/TELEMETRY.md`.

## Verification
- Live on Llama 3.2 3B Instruct Q8_0: idle stream provably silent; streaming, non-streaming, and receipt runs emit the full real sequence (TTFT 211 ms, 26.9 decode tok/s, real top-8 sampler probabilities, sealed receipt id + GGUF hash on `camelid_receipt` requests).
- `cargo fmt` / `clippy --all-targets --all-features -D warnings` / `test --all-targets --all-features` (422 lib + all targets) / `doc` green; public scrub + evidence audits green; frontend build + model-state, 3b-closure, integration, and new observatory smokes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)