### PR TITLE
docs: lead README with the two-command install-and-chat flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Camelid loads GGUF models directly, serves them over a local OpenAI-style API, a
 
 ---
 
+## Get started in two commands
+
+Grab the binary for your platform from the [latest release](https://github.com/timtoole02/Camelid/releases/latest) (the chat UI is built in), then:
+
+```bash
+./camelid pull llama32_3b      # download a supported model into ./models
+./camelid serve --model models/Llama-3.2-3B-Instruct-Q8_0.gguf
+```
+
+`serve` opens the chat UI in your browser automatically. **No Python, no Node, no Docker, no separate server** — one static binary that serves the OpenAI-style API and the web UI on the same port. Full details in [Install](#install) and [Quickstart](#quickstart).
+
+---
+
 ## Why Camelid
 
 | | |


### PR DESCRIPTION
Adds a "Get started in two commands" block under the hero so visitors immediately see how easy Camelid is to install and run: download the binary, `camelid pull` a model, `camelid serve` (the chat UI opens itself), one static binary with no Python/Node/Docker. Links to the existing Install and Quickstart sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)