### PR TITLE
chore: bump crate version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camelid"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.87"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"


### PR DESCRIPTION
Match the published v0.1.1 release tag so the binary's embedded version (parity-receipt provenance) is consistent with the release.