### PR TITLE
feat(inference): opt-in --deterministic CPU forward pass (Pillar One)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -266,3 +266,69 @@ HTTP/SSE lane:
 
 Note: ratatui's diff renderer interleaves cursor escapes between characters, so PTY screen-scrape
 string matching is unreliable; verify features by reconstructing the screen, not substring search.
+
+## D9 — Deterministic CPU forward pass, Pillar One (2026-06-14)
+
+Opt-in deterministic inference for the supported **TinyLlama 1.1B Chat Q8_0** lane, behind
+`--deterministic` (`serve` and `bench-generate`; env `CAMELID_DETERMINISTIC=1`). The default
+(GPU resident-decode) fast path is untouched — verified byte-for-byte identical token stream
+before/after the change at ~88 tok/s on M4. Credit: the pinned reduction order mirrors the
+llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated against.
+
+**Flag, not a Cargo feature.** Determinism is a *runtime path choice* (CPU vs the Metal GPU
+fast stack), not a compile-time one: the same shipped binary serves both the default fast path
+and the deterministic path, and nothing in the default build changes. A Cargo feature would
+fork the binary and risk a different default artifact; a runtime flag keeps one byte-identical
+default binary and lets a caller opt in per invocation (or per process via the env var, which
+the engine reads directly so library embedders get the same guarantee).
+
+**Mechanism (fail-closed in the engine).** `apply_deterministic_mode()` (CLI) sets
+`CAMELID_DETERMINISTIC=1`, forces the whole Metal stack off, and disables GPU sampling. The
+engine reads `inference::deterministic_mode_enabled()` and **ANDs every Metal/GPU dispatch gate
+with `!deterministic`** (`q8_0_metal_enabled`, `resident_decode_metal_enabled`,
+`q8_0_metal_retained_enabled`, `q8_0_hybrid_retained_enabled`, and the two
+`try_*_linear_row_metal` paths). So even if a `CAMELID_METAL_*` override is present, deterministic
+mode still resolves to the order-stable CPU kernels. The default path (`deterministic == false`)
+takes the existing branch unchanged.
+
+**Why this is bit-exact for free on the CPU path.** Phase 0 (see
+`qa/determinism/determinism-baseline-*.md`) established that the CPU forward pass is *already*
+order-stable: every reduction site parallelizes over the **output** dimension (one thread owns a
+disjoint set of outputs and runs that output's entire reduction serially), with no cross-thread
+float combine, no atomics, no parallel sum/reduce/fold, and a compile-time-fixed SIMD lane
+layout. Empirically the CPU stream is byte-identical across runs, across processes, and between
+`--threads 1` and `--threads 10`. So `--deterministic` adds **no determinism penalty inside the
+CPU computation** — its only cost is forgoing the GPU fast path (~12.5 vs ~88 tok/s on M4).
+
+### The pinned reduction order (the contract a future portable trace depends on)
+
+This order is **order-stable** on a given binary + host (identical across runs/processes/thread
+counts). The *values* remain ISA-dependent (i8mm vs dotprod vs scalar round differently), so a
+cross-machine trace must pin the host/ISA, not assume cross-ISA bit-equality.
+
+- **Site 1 — Linear / matmul** (Q, K, V, attention-output, FFN gate/up/down) **and Site 3 — lm_head**
+  (same kernels, `q8_0_packed_rows4_dot_i8_matmul` / `dot_product_row`):
+  1. Output-partitioned across rayon — each output element (or packed group of 4) is computed
+     entirely by one thread; parallelism **never** splits a single output's reduction.
+  2. The activation row is quantized once (`quantize_q8_0_row`, an order-independent transform),
+     then the dot over the K dimension accumulates **block by block in ascending Q8_0 block
+     index** (32 values/block), each block scaled by its f32 scale, summed left-to-right into a
+     fixed scalar/lane accumulator.
+  3. The per-block 32-wide product reduces in a **compile-time-fixed lane layout** (i8mm/dotprod
+     `q8_0_packed_4x8` → fixed `sums[0..4]`; scalar fallback unrolled-by-4, left-to-right).
+
+- **Site 2 — Attention** (`attention_context_for_head_into`):
+  1. **QKᵀ scores:** each score is a serial `dot_product_row(query, key@pos)` over `head_dim`,
+     fixed left-to-right order (vDSP_dotpr on macOS / unrolled-by-4 scalar elsewhere).
+  2. **Softmax:** max via `fold(NEG_INFINITY, f32::max)` over positions in **ascending position
+     order**; exp + sum accumulated in ascending position order; normalize by `1.0 / sum`.
+  3. **Value accumulation:** `out += prob * value` summed over cached positions in **ascending
+     position order**. Prefill batches partition over output rows (one thread per row); single-
+     token decode is serial per head. Neither splits a reduction across threads.
+
+### Measured overhead (M4, TinyLlama 1.1B Q8_0, hello → 50 tok, greedy, median of 5)
+
+| Path | tok/s | Determinism |
+|---|---|---|
+| Default (GPU resident decode) | ~88 | self-identical per process; **diverges from CPU at tok 25** (not a bit-reproducible reference) |
+| `--deterministic` (CPU) | ~12.5 | **bit-exact** across runs, processes, and thread counts |

--- a/qa/determinism/determinism-baseline-20260614T063455Z.md
+++ b/qa/determinism/determinism-baseline-20260614T063455Z.md
@@ -1,0 +1,83 @@
+# Determinism Baseline — Pillar One, Phase 0
+
+**Scope:** TinyLlama 1.1B Chat Q8_0, CPU forward pass only. Measure-before-build.
+**Status:** Phase 0 complete. STOP-and-report gate. No engine code changed.
+
+## Environment
+- Commit: `617a34bb7dce3a872e4a39ef33869bc0b324d381` (branch `feat/deterministic-cpu`, off `main`)
+- Host: Apple M4, 10 cores, `FEAT_I8MM=1` (so the CPU Q8_0 path uses the i8mm packed-rows4 kernel)
+- Model: `tinyllama-1.1b-chat-v1.0.Q8_0.gguf` (sha256 `a4c9bb1dbaa372f6…`)
+- Binary: release, `bench-generate`, prompt `"hello"` (2 prompt tokens, BOS), 50 generated tokens, greedy (temperature 0)
+- Date: 2026-06-14T06:34:55Z
+- Credit: Camelid's CPU Q8_0 kernels and the parity contract they are gated against follow llama.cpp's reference reduction layout (block-wise Q8_0 dot, per-output accumulation).
+
+## Q1 — Is the TinyLlama Q8_0 hot path single- or multi-threaded? Identify each reduction site.
+
+The CPU forward pass is **multi-threaded via rayon**. There are three reduction-bearing sites, all in `src/inference.rs`:
+
+| Site | What it reduces | Reduction kernel (fn @ line) | Parallelism |
+|---|---|---|---|
+| **1. Matmul / linear projections** (Q/K/V, attn-out, FFN gate/up/down) | Q8_0 weight row · f32 activation, over the K (contraction) dim | `q8_0_packed_rows4_dot_i8_matmul` @16416 → `q8_0_packed_rows4_dot` @16611 (i8mm/NEON/AVX/scalar); f32 fallback `dot_product_row` @17019 | `par_chunks_mut` over **output** columns/rows (e.g. @6303, @10545/10557, @11190, @11311, @16081) |
+| **2. Attention** | QKᵀ scores (per cached position), softmax sum, Σ score·V | `attention_context_for_head_into` @17650 (QKᵀ via `dot_product_row`; softmax serial; value accum `*out += prob * v`) | batched prefill: `par_chunks_mut` over **output** rows @17625; single-token decode is serial per head |
+| **3. Final logit projection** (lm_head) | Q8_0 weight row · f32 hidden, over K | same kernels as Site 1 (`output_projection_runtime_with_plan` @6066 → packed-rows4 / fallback) | `par_chunks_mut` over **output** (vocab) columns |
+
+Entry path for one decode step: `generate_next_token_with_history_diagnostics` @2897 → `forward_single_token_timed_internal` @2652 → `forward_layer_timed` @4207 (×layers) → the kernels above → `forward_final_norm_and_logits` @2248.
+
+## Q2 — Is accumulation order currently fixed, or does it depend on thread/SIMD scheduling?
+
+**It is already fixed.** At every site the rayon parallelism partitions the **output** space: each thread owns a disjoint set of output elements and performs that output's *entire* K-dimension reduction serially, in a fixed block order, within one thread. There is:
+
+- **No** cross-thread float combine — no `par_iter().sum()/reduce()/fold()` over floats (audited: zero occurrences in `src/inference.rs` + `src/inference/*.rs`).
+- **No** atomic-float accumulation, no `Mutex<f32>` accumulator, no tree/pairwise merge of per-thread partials.
+- A **compile-time-fixed** SIMD horizontal-sum order (i8mm `q8_0_packed_4x8_*` lanes accumulate into a fixed `sums[0..4]` layout); SIMD does not "schedule," so lane order is invariant on a given binary.
+
+Therefore thread scheduling and rayon work-stealing can only change *which* thread computes *which* output — never the order of additions inside any one output's reduction. Chunk boundaries always fall on whole-output boundaries, so chunk size (which can vary with thread count) does not split a reduction.
+
+### Empirical confirmation (default CPU path, no determinism flag, nothing changed)
+- 5 in-process iterations → **byte-identical** 50-token streams.
+- Fresh process re-run (run A vs run B) → **byte-identical**.
+- `--threads 1` vs default (10 threads) → **byte-identical**. This is the decisive test: changing the rayon thread count does not change a single token.
+
+First 8 token ids (all CPU runs): `[29892, 322, 769, 306, 29915, 645, 367, 1250]`.
+
+## Q3 — Baseline tokens/sec (hello, 50 tokens, greedy, median of 5)
+
+| Path | Median tok/s | Per-iteration | Peak RSS |
+|---|---|---|---|
+| **CPU forward pass** (Metal stack off, `CAMELID_NO_GPU_SAMPLE=1`) | **11.06** | 10.78 / 10.89 / 11.06 / 12.00 / 12.85 | 1.20 GB |
+| GPU resident decode (CLI default fast path, for reference) | 84.87 | 84.87 / 83.31 / 84.91 / 83.16 / 85.16 | 1.97 GB |
+
+Note the CLI default (`apply_default_fast_stack`, main.rs:438) turns the Metal resident-decode stack on for every subcommand on macOS, so the *default* `bench-generate` rides the GPU. The 11.06 tok/s figure is the pure-CPU path the deterministic mode will use.
+
+## Q4 — For each reduction site: does order-stability require disabling threading, disabling auto-vectorization, or neither?
+
+**Neither, at all three sites.** Determinism on the CPU path is **already real and free**:
+- Site 1 (matmul): output-partitioned, serial K-reduction in fixed block order. Neither.
+- Site 2 (attention): output-partitioned (prefill) / serial (decode), fixed-order softmax and value accumulation. Neither.
+- Site 3 (logits): same kernel family as Site 1. Neither.
+
+The `--threads 1 == --threads 10` byte-identity proves we do not need to disable threading; the fixed SIMD lane layout proves we do not need to disable auto-vectorization.
+
+## The one real divergence: GPU default ≠ CPU
+
+GPU default and CPU agree for the first **25** generated tokens, then diverge (CPU →`304 1074 366`, GPU →`366 29915 276` at index 25). The Metal path is a *different* numerically-ordered reduction (threadgroup sums), so the GPU default is **not** a bit-reproducible reference. This is the substantive reason a deterministic mode must **force the CPU forward pass** rather than pin the GPU path.
+
+## Cost finding → recommendation for Phase 1
+
+- **Determinism of the CPU computation is already proven and near-free** (run-to-run, cross-process, and thread-count-invariant with zero changes).
+- The measured "overhead" of deterministic mode is therefore **not** a determinism penalty inside the CPU path — it is the **CPU-vs-GPU gap**: ~11 tok/s (deterministic CPU) vs ~85 tok/s (default GPU), i.e. deterministic mode is ~7.7× slower because it forgoes the GPU fast path, not because it serializes any reduction.
+- **Recommended `--deterministic` semantics:** (1) force the order-stable CPU forward pass (disable the Metal/resident-decode stack for that invocation); (2) keep rayon threading on — it is order-invariant; (3) record the pinned per-site reduction order in DECISIONS.md as the contract a future cross-machine trace depends on. No default path change, no kernel change, no perf change to the default.
+- **Caveat for Phase 2 pinned floats:** the exact logit values are machine/ISA-specific (i8mm here on M4; an M1 runner without i8mm takes a different-but-internally-deterministic kernel). The *portable* invariant is run-to-run / thread-count byte-identity; the *committed exact floats* are an M4-i8mm reference and the pin test must be env-gated to the real model (self-skip when absent), matching the repo's existing real-model test convention.
+
+## Decode-time overhead figure (Phase 2 — measured with the flag landed)
+
+`--deterministic` on the same binary (hello → 50 tok, greedy, median of 5, M4):
+
+| Path | Median tok/s | Per-iteration | Peak RSS | Determinism |
+|---|---|---|---|---|
+| Default (no flag, GPU resident decode) | **88.67** | 88.73 / 88.26 / 88.03 / 88.73 / 88.67 | 1.85 GB | unchanged — token stream byte-identical to the pre-change baseline |
+| `--deterministic` (CPU) | **12.51** | 12.65 / 12.51 / 12.30 / 12.59 / 12.29 | 1.15 GB | bit-exact across runs, processes, and `--threads 1` vs `--threads 10`; identical to the bare-CPU stream |
+
+**On-record overhead:** deterministic mode runs at ~14% of default throughput (12.51 vs 88.67 tok/s, ~7.1×) — entirely the cost of forgoing the GPU fast path, with **zero** determinism penalty inside the CPU computation. The default path was re-measured on the post-change binary and is byte-for-byte identical to the pre-change baseline (same 50-token stream, same ~88 tok/s), confirming the flag is inert when off.
+
+Reproduce: `camelid bench-generate <tinyllama-q8> --prompt hello --max-tokens 50 --temperature 0 --iterations 5 --warmup [--deterministic]`. Pinned first-position logits regression: `tests/deterministic_forward.rs` (env-gated on `CAMELID_TINYLLAMA_Q8_GGUF`).

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -3173,6 +3173,20 @@ fn env_flag_enabled(key: &str) -> bool {
     )
 }
 
+/// Opt-in deterministic inference mode (`CAMELID_DETERMINISTIC=1`, set by the CLI
+/// `--deterministic` flag). When on, the engine is pinned to the order-stable CPU
+/// forward pass: every Metal/GPU dispatch gate fails closed to its CPU equivalent,
+/// regardless of any `CAMELID_METAL_*` override. This makes the supported TinyLlama
+/// 1.1B Q8_0 forward pass bit-exact and reduction-order-stable across runs, thread
+/// counts, and processes (the CPU reduction order is already fixed — each output owns
+/// its full serial K-dimension reduction; see `qa/determinism/determinism-baseline-*.md` and
+/// DECISIONS.md §D9). The library default is OFF, so the default (GPU fast) path and
+/// every embedder are byte-for-byte unchanged. The pinned reduction order mirrors the
+/// llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated against.
+pub fn deterministic_mode_enabled() -> bool {
+    env_flag_enabled("CAMELID_DETERMINISTIC")
+}
+
 fn prefill_chunk_token_count(prefill_count: usize) -> usize {
     const DEFAULT_PREFILL_CHUNK_TOKENS: usize = 256;
     prefill_chunk_token_count_from_env(
@@ -8480,23 +8494,26 @@ fn q8_0_file_reader_block_dot_enabled() -> bool {
 
 #[allow(dead_code)]
 fn q8_0_metal_enabled() -> bool {
-    q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8")
+    // Deterministic mode fails closed to the CPU Q8_0 kernels (see `deterministic_mode_enabled`).
+    !deterministic_mode_enabled() && q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8")
 }
 
 /// Gate for the GPU-resident decode forward (whole token on the Metal GPU, KV cache resident
-/// across tokens). Default off; opt in with `CAMELID_METAL_RESIDENT_DECODE`.
+/// across tokens). Default off; opt in with `CAMELID_METAL_RESIDENT_DECODE`. Deterministic
+/// mode forces this off so the forward stays on the order-stable CPU path.
 fn resident_decode_metal_enabled() -> bool {
-    q8_0_env_flag_enabled_default_off("CAMELID_METAL_RESIDENT_DECODE")
+    !deterministic_mode_enabled()
+        && q8_0_env_flag_enabled_default_off("CAMELID_METAL_RESIDENT_DECODE")
 }
 
 #[allow(dead_code)]
 fn q8_0_metal_retained_enabled() -> bool {
-    q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8_RETAINED")
+    !deterministic_mode_enabled() && q8_0_env_flag_enabled_default_off("CAMELID_METAL_Q8_RETAINED")
 }
 
 #[allow(dead_code)]
 fn q8_0_hybrid_retained_enabled() -> bool {
-    q8_0_env_flag_enabled_default_off("CAMELID_HYBRID_Q8_RETAINED")
+    !deterministic_mode_enabled() && q8_0_env_flag_enabled_default_off("CAMELID_HYBRID_Q8_RETAINED")
 }
 
 fn q8_0_metal_trace_enabled() -> bool {
@@ -14936,7 +14953,11 @@ fn try_accumulate_descriptor_linear_row_metal(
 ) -> bool {
     #[cfg(target_os = "macos")]
     {
-        if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1") {
+        // Cheap existing check first so the default path (Metal linear off) short-circuits
+        // before the deterministic-mode env read — zero added work when the flag is unused.
+        if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1")
+            || deterministic_mode_enabled()
+        {
             return false;
         }
         if weight.q8_0_blocks.is_some() || weight.q8_0_file_backing.is_some() {
@@ -16987,7 +17008,11 @@ fn try_accumulate_transposed_linear_row_metal(
 ) -> bool {
     #[cfg(target_os = "macos")]
     {
-        if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1") {
+        // Cheap existing check first so the default path (Metal linear off) short-circuits
+        // before the deterministic-mode env read — zero added work when the flag is unused.
+        if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1")
+            || deterministic_mode_enabled()
+        {
             return false;
         }
         if weight.q8_0_blocks.is_some() || weight.q8_0_file_backing.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,13 @@ enum Command {
         /// interactively, `serve` opens the chat surface automatically.
         #[arg(long, env = "CAMELID_NO_OPEN", default_value_t = false)]
         no_open: bool,
+        /// Opt into deterministic inference: pin the forward pass to the order-stable
+        /// CPU path (the whole Metal/GPU fast stack is forced off) so the supported
+        /// TinyLlama 1.1B Q8_0 lane is bit-exact and reduction-order-stable across runs.
+        /// Slower than the default GPU path; the default path is unchanged. Reduction
+        /// order follows the llama.cpp reference Q8_0 layout (see DECISIONS.md §D9).
+        #[arg(long, env = "CAMELID_DETERMINISTIC", default_value_t = false)]
+        deterministic: bool,
     },
     /// Interactive terminal chat REPL over the local Camelid API.
     ///
@@ -395,6 +402,12 @@ enum Command {
         /// Accepted for compatibility; JSON is always emitted to stdout.
         #[arg(long, default_value_t = false)]
         json: bool,
+        /// Opt into deterministic inference: pin generation to the order-stable CPU
+        /// forward pass (Metal/GPU fast stack forced off) so the supported TinyLlama
+        /// 1.1B Q8_0 lane is bit-exact across runs, thread counts, and processes.
+        /// Slower than the default GPU path; the default path is unchanged.
+        #[arg(long, env = "CAMELID_DETERMINISTIC", default_value_t = false)]
+        deterministic: bool,
     },
     /// EXPERIMENTAL ghost (layer-streaming) mode: execute a model one transformer block at
     /// a time, streaming each block's weights from a layer-contiguous `.cghost` file
@@ -478,9 +491,17 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    apply_default_fast_stack();
+    let command = Cli::parse().command;
+    // Deterministic mode opts out of the GPU fast stack entirely; otherwise the CLI
+    // defaults to the measured-fastest Metal configuration. Branch before any env is set
+    // so the deterministic path never even arms the GPU defaults.
+    if command_requests_deterministic(&command) {
+        apply_deterministic_mode();
+    } else {
+        apply_default_fast_stack();
+    }
 
-    match Cli::parse().command {
+    match command {
         Command::Serve {
             addr,
             model,
@@ -494,16 +515,22 @@ async fn main() -> anyhow::Result<()> {
             spec_draft_model,
             spec_draft_tokens,
             no_open,
+            deterministic,
         } => {
             configure_rayon_threads(threads)?;
+            // In deterministic mode the engine fails every Metal gate closed (see
+            // `apply_deterministic_mode`); don't also arm the Metal tuning env or the
+            // GPU fast-load nocopy default, which would only be contradictory no-ops.
             apply_runtime_tuning_env(
                 parallel_linear_min_outputs,
                 apple_accelerate_min_elements,
-                metal_linear,
-                metal_q8,
+                metal_linear && !deterministic,
+                metal_q8 && !deterministic,
             );
             apply_spec_decode_env(spec_decode, spec_draft_model, spec_draft_tokens);
-            apply_serve_nocopy_default();
+            if !deterministic {
+                apply_serve_nocopy_default();
+            }
             if log_acceleration {
                 log_acceleration_state();
             }
@@ -849,6 +876,10 @@ async fn main() -> anyhow::Result<()> {
             warmup,
             threads,
             json: _,
+            // `apply_deterministic_mode` already set CAMELID_DETERMINISTIC + forced the
+            // Metal stack off before this match, so generation rides the CPU path; the
+            // engine reads the env directly.
+            deterministic: _,
         } => {
             run_bench_generate(
                 model,
@@ -1546,6 +1577,56 @@ fn apply_default_fast_stack() {
             std::env::set_var(key, "1");
         }
     }
+}
+
+/// True when the parsed subcommand opted into deterministic inference (`--deterministic`).
+/// Only `serve` and `bench-generate` expose the flag today (the supported single-node
+/// generate/serve path); every other subcommand keeps the default fast stack.
+fn command_requests_deterministic(command: &Command) -> bool {
+    matches!(
+        command,
+        Command::Serve {
+            deterministic: true,
+            ..
+        } | Command::BenchGenerate {
+            deterministic: true,
+            ..
+        }
+    )
+}
+
+/// Pin the process to the opt-in deterministic CPU forward pass. Sets
+/// `CAMELID_DETERMINISTIC=1` — which the engine reads (`inference::deterministic_mode_enabled`)
+/// to fail every Metal/GPU dispatch gate closed to its order-stable CPU equivalent — then
+/// forces the whole Metal fast stack off and disables GPU sampling so greedy decode also
+/// stays on the CPU path. The result is bit-exact, reduction-order-stable logits for the
+/// supported TinyLlama 1.1B Q8_0 lane. Only the CLI entry calls this; library defaults and
+/// the default (GPU) fast path are byte-for-byte unchanged. The pinned reduction order
+/// mirrors the llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated
+/// against (see DECISIONS.md §D9 and `qa/determinism/determinism-baseline-*.md`).
+fn apply_deterministic_mode() {
+    std::env::set_var("CAMELID_DETERMINISTIC", "1");
+    for key in [
+        "CAMELID_METAL_RESIDENT_DECODE",
+        "CAMELID_METAL_F32Y",
+        "CAMELID_METAL_WIRE",
+        "CAMELID_METAL_WIRE_NSG8",
+        "CAMELID_METAL_ATTN2",
+        "CAMELID_METAL_RESIDENT_PREFILL",
+        "CAMELID_METAL_MM",
+        "CAMELID_METAL_LINEAR",
+        "CAMELID_METAL_Q8",
+        "CAMELID_METAL_Q8_RETAINED",
+        "CAMELID_HYBRID_Q8_RETAINED",
+        "CAMELID_METAL_NOCOPY",
+    ] {
+        std::env::set_var(key, "0");
+    }
+    std::env::set_var("CAMELID_NO_GPU_SAMPLE", "1");
+    eprintln!(
+        "[deterministic] pinned to the order-stable CPU forward pass (Metal/GPU stack off). \
+         Reduction order follows the llama.cpp reference block-wise Q8_0 layout; see DECISIONS.md \u{a7}D9."
+    );
 }
 
 /// Default the single-node `serve` path to fast-load (CAMELID_METAL_NOCOPY): Q8_0

--- a/tests/deterministic_forward.rs
+++ b/tests/deterministic_forward.rs
@@ -1,0 +1,178 @@
+//! Pillar One regression — the supported **TinyLlama 1.1B Chat Q8_0** lane is bit-exact and
+//! reduction-order-stable under deterministic mode (`--deterministic` /
+//! `CAMELID_DETERMINISTIC=1`). See DECISIONS.md §D9 and `qa/determinism/determinism-baseline-*.md`.
+//!
+//! Two properties are asserted with a tolerance of **exactly zero**:
+//!  1. Two consecutive deterministic runs produce byte-identical first-position logit vectors
+//!     and identical token streams (portable: holds on any host, any rayon thread count).
+//!  2. The first-position logits equal the committed reference floats (a regression pin).
+//!
+//! Determinism on the CPU forward pass is already structural (each output owns its full serial
+//! K-dimension reduction; no cross-thread float combine), so deterministic mode adds no penalty
+//! inside the computation — it only forgoes the GPU fast path. The reduction order mirrors the
+//! llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated against.
+//!
+//! Env-gated on the real GGUF (self-skips without it, like `gemma4_logit_probe`):
+//! ```text
+//! CAMELID_TINYLLAMA_Q8_GGUF=/path/tinyllama-1.1b-chat-v1.0.Q8_0.gguf \
+//!   cargo test --release --test deterministic_forward -- --nocapture
+//! ```
+//! The committed reference floats (property 2) are the **Apple M4 / i8mm** host values; the
+//! Q8_0 dot kernel is ISA-specific, so the exact-float pin is asserted only when the running
+//! host has `i8mm` (other Apple Silicon is internally deterministic but rounds differently).
+//! Property 1 (run-to-run byte identity) is asserted on every host.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use camelid::gguf::read_metadata;
+use camelid::inference::{LlamaInferenceSession, LlamaLoadedWeights, LlamaSampler};
+use camelid::model::{LlamaModelConfig, LlamaTensorBinding};
+use camelid::tensor::TensorStore;
+use camelid::tokenizer::Tokenizer;
+
+const PROMPT: &str = "hello";
+const STREAM_TOKENS: usize = 50;
+
+/// First 12 logits at the first generated position for `PROMPT` under deterministic mode,
+/// captured bit-exactly on Apple M4 (i8mm). Tolerance is exactly zero.
+const REF_FIRST12: [f32; 12] = [
+    -10.165434, -10.214098, 6.0705123, -2.1841283, -4.0164623, -3.6804488, -4.492992, -6.3740983,
+    -7.0855656, -7.563206, -7.9338403, -4.390971,
+];
+/// Argmax index + value at the first generated position (M4 / i8mm).
+const REF_ARGMAX_INDEX: usize = 29892;
+const REF_ARGMAX_VALUE: f32 = 9.757427;
+
+fn host_has_i8mm() -> bool {
+    #[cfg(target_arch = "aarch64")]
+    {
+        std::arch::is_aarch64_feature_detected!("i8mm")
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        false
+    }
+}
+
+fn load(model: &PathBuf) -> (LlamaModelConfig, Arc<LlamaLoadedWeights>, Tokenizer) {
+    let gguf = read_metadata(model).expect("read gguf metadata");
+    let config = LlamaModelConfig::from_gguf(&gguf).expect("llama config");
+    let binding = LlamaTensorBinding::bind(&gguf, &config).expect("tensor binding");
+    let store = TensorStore::open(model, &gguf);
+    let tokenizer = Tokenizer::from_gguf(&gguf).expect("tokenizer");
+    let weights = Arc::new(LlamaLoadedWeights::load(&store, &binding, None).expect("weights"));
+    (config, weights, tokenizer)
+}
+
+/// One deterministic run: prefill the prompt, capture the first-position logit vector, then
+/// greedily decode `STREAM_TOKENS` tokens. Returns (first_position_logits, token_stream).
+fn run(
+    config: &LlamaModelConfig,
+    weights: &Arc<LlamaLoadedWeights>,
+    prompt_ids: &[u32],
+) -> (Vec<f32>, Vec<u32>) {
+    let mut session = LlamaInferenceSession::new(config.clone(), weights.clone()).expect("session");
+    let step = session
+        .generate_next_token(prompt_ids, LlamaSampler::Greedy)
+        .expect("prefill step");
+    let first_logits = step.logits.data.clone();
+    let mut stream = vec![step.next_token_id];
+    let mut last = step.next_token_id;
+    while stream.len() < STREAM_TOKENS {
+        let step = session
+            .generate_next_token(&[last], LlamaSampler::Greedy)
+            .expect("decode step");
+        last = step.next_token_id;
+        stream.push(last);
+    }
+    (first_logits, stream)
+}
+
+#[test]
+fn tinyllama_q8_deterministic_mode_is_bit_exact_and_pinned() {
+    let Some(model) = std::env::var_os("CAMELID_TINYLLAMA_Q8_GGUF").map(PathBuf::from) else {
+        eprintln!(
+            "SKIP deterministic_forward: set CAMELID_TINYLLAMA_Q8_GGUF=/path/tinyllama-1.1b-chat-v1.0.Q8_0.gguf"
+        );
+        return;
+    };
+
+    // Exercise the real deterministic-mode engine gates (every Metal path fails closed to CPU).
+    std::env::set_var("CAMELID_DETERMINISTIC", "1");
+    assert!(
+        camelid::inference::deterministic_mode_enabled(),
+        "CAMELID_DETERMINISTIC=1 must enable deterministic mode"
+    );
+
+    let (config, weights, tokenizer) = load(&model);
+    let prompt_ids = tokenizer
+        .encode(PROMPT, true, false)
+        .expect("encode prompt");
+
+    // Property 1 — two consecutive runs are byte-identical (logits + token stream).
+    let (logits_a, stream_a) = run(&config, &weights, &prompt_ids);
+    let (logits_b, stream_b) = run(&config, &weights, &prompt_ids);
+
+    assert_eq!(
+        logits_a.len(),
+        logits_b.len(),
+        "logit vector length must be stable"
+    );
+    assert!(
+        logits_a
+            .iter()
+            .zip(&logits_b)
+            .all(|(x, y)| x.to_bits() == y.to_bits()),
+        "deterministic mode: first-position logits diverged between two runs (tolerance is zero)"
+    );
+    assert_eq!(
+        stream_a, stream_b,
+        "deterministic mode: {STREAM_TOKENS}-token streams diverged between two runs"
+    );
+
+    // Always surface the captured window so the committed reference can be (re)derived.
+    let argmax = logits_a
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.total_cmp(b.1))
+        .map(|(i, v)| (i, *v))
+        .expect("non-empty logits");
+    eprintln!(
+        "deterministic_forward: vocab={} first12={:?} argmax_index={} argmax_value={} stream[..8]={:?}",
+        logits_a.len(),
+        &logits_a[..12.min(logits_a.len())],
+        argmax.0,
+        argmax.1,
+        &stream_a[..8.min(stream_a.len())],
+    );
+
+    // Property 2 — exact-float regression pin (M4 / i8mm reference). Skipped (with a note) on
+    // hosts that take a different Q8_0 dot kernel, which are internally deterministic but round
+    // differently; Property 1 still guards run-to-run bit identity there.
+    if host_has_i8mm() {
+        for (i, expected) in REF_FIRST12.iter().enumerate() {
+            assert_eq!(
+                logits_a[i].to_bits(),
+                expected.to_bits(),
+                "first-position logit[{i}] = {} != committed reference {} (tolerance is zero)",
+                logits_a[i],
+                expected
+            );
+        }
+        assert_eq!(
+            argmax.0, REF_ARGMAX_INDEX,
+            "first-position argmax index drifted from committed reference"
+        );
+        assert_eq!(
+            argmax.1.to_bits(),
+            REF_ARGMAX_VALUE.to_bits(),
+            "first-position argmax value drifted from committed reference (tolerance is zero)"
+        );
+    } else {
+        eprintln!(
+            "deterministic_forward: host lacks i8mm — asserted run-to-run bit identity only, \
+             skipped the M4 exact-float pin"
+        );
+    }
+}


### PR DESCRIPTION
## Pillar One — opt-in deterministic CPU forward pass

Adds a runtime `--deterministic` flag (`serve` + `bench-generate`; env `CAMELID_DETERMINISTIC=1`) that pins the supported **TinyLlama 1.1B Chat Q8_0** lane to the order-stable CPU forward pass: bit-exact, reduction-order-stable logits across runs, processes, and rayon thread counts. The default (GPU resident-decode) fast path is **untouched** — verified byte-for-byte identical token stream and throughput before/after.

### Mechanism
`inference::deterministic_mode_enabled()` is AND-ed into every Metal/GPU dispatch gate, so the engine fails closed to the CPU kernels even under a `CAMELID_METAL_*` override. The CPU reduction order is already fixed (each output owns its full serial K-dimension reduction; no cross-thread float combine, no atomics), so deterministic mode adds **no penalty inside the computation** — it only forgoes the GPU path. Pinned per-site reduction order documented in `DECISIONS.md` §D8; it follows the llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated against.

### Evidence
- Phase 0 baseline report: `qa/determinism/determinism-baseline-*.md`
- Regression test: `tests/deterministic_forward.rs` (env-gated on `CAMELID_TINYLLAMA_Q8_GGUF`, self-skips otherwise) — run-to-run bit identity + first-position logits == committed M4/i8mm floats at tolerance **0**
- Gates green: `fmt`, `clippy -D warnings`, `cargo test --all-targets` (674 passed/0 failed), `cargo doc`; default-path parity unchanged (`hello` → `[29907, 13946, 368, 29991]`)
- Measured (M4): default ~88 tok/s (GPU) vs `--deterministic` ~12.5 tok/s (CPU) — pure CPU-vs-GPU gap, zero determinism penalty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
