### PR TITLE
feat(receipt): execution-trace rollup digest over the deterministic forward pass (Pillar Two)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -458,3 +458,43 @@ http_fetch result content alike.
 
 **Honesty.** No `tool_capable` flag is set; nothing in the docs claims tool-calling works on a row
 without a PASS receipt. The capability only ever moves on harness evidence.
+
+## D11 — Execution-trace rollup, Pillar Two (2026-06-14)
+
+Built on D9: now that the deterministic CPU forward pass is bit-exact, a receipt can carry a
+cryptographic **execution-trace rollup** — proof of *how* the computation ran, not just which
+tokens came out. This is the "later portable execution-trace feature" D9 was the foundation for.
+
+**Shape — single rollup (chosen over per-layer-localized or final-logits-only).** One streaming
+SHA-256 (`ExecutionTraceHasher`, `camelid.execution-trace/v1`, `sha256-rollup-v1`) folds, in
+forward order across every generated token, each transformer layer's output hidden state and the
+final logits (domain-separated by a kind byte + index + length prefix; little-endian f32 bytes).
+A mismatch on re-derivation proves the run differs but does not localize the token/layer — that
+is the single-rollup tradeoff, chosen for the simplest end-to-end slice. Runtime cost is
+negligible (the bytes are already materialized; SHA-256 is multi-GB/s — sub-1% of decode), so
+scope, not speed, drove the choice.
+
+**Only meaningful on the deterministic lane; fail-closed.** `LlamaInferenceSession::
+enable_execution_trace()` refuses to arm unless `deterministic_mode_enabled()` (RECEIPTS.md
+rule 2 — a digest over a non-reproducible run is meaningless). The default (non-deterministic)
+path never allocates the hasher and is byte-for-byte unchanged; the receipt field is
+`Option<ExecutionTraceBlock>` with `skip_serializing_if = None`, so non-traced receipts serialize
+and digest exactly as before (proven by `execution_trace_absent_keeps_receipt_byte_identical`).
+
+**Emission and verification cannot desync — they share one path.** Both the served generation and
+`verify-receipt`'s re-run funnel through `replay_receipt_request → generate_decoded_tokens`, where
+the rollup is armed (when deterministic) and captured once. When tracing, the prompt-prefix cache
+is bypassed (a cache hit would skip the prompt forwards on one side only). Verification re-derives
+the digest from an independent re-run and checks it matches; the rollup is included in the
+`receipt_id` digest, so it is itself tamper-evident.
+
+**ISA-pinned, not cross-ISA-portable.** The digest is reduction-order-stable on the deterministic
+CPU lane but ISA-specific (the Q8_0 dot rounds differently across ISAs), so the block records
+`lane` (`deterministic-cpu`) and `host_isa` (e.g. `aarch64-i8mm`). `verify-receipt` re-derives only
+when the verifier's ISA matches; otherwise it prints `SKIP execution-trace` rather than a false
+`FAIL`. The committed test digest is the M4/i8mm reference (i8mm-guarded), matching the D9 pattern.
+
+**Proof:** `tests/execution_trace.rs` (engine rollup: run-to-run + thread-count invariant +
+prompt-sensitive + pinned + fail-closed) and `tests/execution_trace_receipt.rs` (the full
+emit→re-derive round trip through the real API replay path). Not built here: per-layer/per-token
+localization, distributed (per-shard) trace chains, signing.

--- a/RECEIPTS.md
+++ b/RECEIPTS.md
@@ -37,6 +37,18 @@ A receipt does **not** prove: anything about other prompts, other context length
 quantizations, other models, performance, or general correctness. It does not change any row
 of the support ledger.
 
+### Optional: the execution-trace rollup
+
+A receipt produced on the deterministic CPU lane (the server running with `--deterministic`)
+also carries an **execution-trace rollup** — a single SHA-256 over the whole forward pass
+(every layer's hidden state and the final logits, folded across every generated token). It
+proves not just that the *output tokens* match, but that the *internal computation* re-runs
+bit-for-bit: `verify-receipt` re-derives the digest from an independent run and checks it.
+This is only meaningful because the deterministic lane is reduction-order-stable. The digest
+is ISA-specific (the receipt records `host_isa`), so a verifier on a different CPU re-runs the
+tokens but reports `SKIP execution-trace` rather than a false mismatch. Receipts emitted on the
+default (non-deterministic, GPU) path carry no rollup and are unchanged.
+
 ## Verifying a receipt
 
 ```bash

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1179,6 +1179,8 @@ struct GeneratedText {
     completion_tokens: usize,
     finish_reason: &'static str,
     timings: GenerationTimings,
+    /// Execution-trace rollup `(digest, fold_count)` from a deterministic run, else `None`.
+    execution_trace: Option<(String, u64)>,
 }
 
 struct GeneratedTokens {
@@ -1192,6 +1194,9 @@ struct GeneratedTokens {
     dense_diagnostic_generated_index: Option<usize>,
     finish_reason: &'static str,
     timings: GenerationTimings,
+    /// Execution-trace rollup `(digest, fold_count)` captured during a deterministic run, or
+    /// `None` when the trace was not armed (any non-deterministic generation).
+    execution_trace: Option<(String, u64)>,
 }
 
 fn collect_dense_diagnostics_for_generated_index(
@@ -4492,6 +4497,7 @@ async fn completions(
                 completion_tokens,
                 finish_reason,
                 timings,
+                execution_trace: _,
             } = generated;
             (
                 StatusCode::OK,
@@ -4782,6 +4788,20 @@ async fn build_server_receipt(
         let models = state.loaded_models.read().await;
         models.get(model_id)?.lane.clone()
     };
+    // Attach the execution-trace rollup only for reproducible (deterministic, greedy) runs that
+    // actually captured one. Non-reproducible or non-deterministic runs leave it absent, so the
+    // receipt serializes and digests exactly as before.
+    let execution_trace = generated
+        .execution_trace
+        .as_ref()
+        .filter(|_| stamp.reproducible)
+        .map(|(digest, fold_count)| {
+            receipt::ExecutionTraceBlock::rollup_v1(
+                digest.clone(),
+                *fold_count,
+                generated.generated_token_ids.len(),
+            )
+        });
     let mut receipt = ParityReceipt {
         schema: RECEIPT_SCHEMA_V1.to_string(),
         receipt_id: String::new(),
@@ -4812,6 +4832,7 @@ async fn build_server_receipt(
             finish_reason: generated.finish_reason.to_string(),
         },
         parity: ParityBlock::not_compared(),
+        execution_trace,
         signature: None,
     };
     if let Err(err) = receipt.seal() {
@@ -4830,6 +4851,9 @@ async fn build_server_receipt(
 pub struct ReceiptReplay {
     pub lane: LaneIdentity,
     pub result: ReceiptResult,
+    /// Execution-trace rollup digest re-derived by this replay, when the replay ran on the
+    /// deterministic lane (else `None`). Verification compares it against the receipt's block.
+    pub execution_trace_digest: Option<String>,
 }
 
 /// Replay a receipt's request through the exact non-streaming generation path
@@ -4900,6 +4924,7 @@ pub async fn replay_receipt_request(
     };
     Ok(ReceiptReplay {
         lane: loaded.lane,
+        execution_trace_digest: generated.execution_trace.map(|(digest, _)| digest),
         result: ReceiptResult {
             prompt_token_ids: generated.prompt_token_ids,
             generated_token_ids: generated.generated_token_ids,
@@ -6356,6 +6381,7 @@ fn generate_decoded_tokens(
         dense_diagnostic_generated_index: generated.dense_diagnostic_generated_index,
         finish_reason: generated.finish_reason,
         timings: generated.timings,
+        execution_trace: generated.execution_trace,
     })
 }
 
@@ -6529,7 +6555,13 @@ fn generate_token_ids(
     let mut sample = 0;
     let mut reused_prompt_prefix = false;
 
-    if !prepared.collect_dense_diagnostics {
+    // The execution-trace rollup is captured only on the deterministic CPU lane (the only lane
+    // where it is reduction-order-stable). When it will be armed, bypass the prompt-prefix cache
+    // so the served run and any later verify re-run fold an identical forward (a cache hit skips
+    // the prompt forwards on one side only, which would desync the digest).
+    let want_execution_trace = crate::inference::deterministic_mode_enabled();
+
+    if !prepared.collect_dense_diagnostics && !want_execution_trace {
         if let Some(cached) = lookup_prompt_prefix_cache(&prepared) {
             prepared.session = cached.session.clone();
             // The cached session's resident-path pin reflects the request
@@ -6560,6 +6592,10 @@ fn generate_token_ids(
             }
         }
     }
+
+    // Arm the rollup now that the session is settled (past any prompt-cache swap). Fails closed
+    // unless deterministic mode is active, so non-deterministic generations never trace.
+    let tracing_armed = want_execution_trace && prepared.session.enable_execution_trace();
 
     for _ in generated.len() as u32..prepared.max_tokens {
         if finish_reason != "length" {
@@ -6835,6 +6871,16 @@ fn generate_token_ids(
         prepared.timings.q8_schedule = Some(snapshot_q8_schedule_telemetry());
     }
 
+    // Finalize the rollup before any field is moved out of `prepared`.
+    let execution_trace = if tracing_armed {
+        let fold_count = prepared.session.execution_trace_fold_count();
+        prepared
+            .session
+            .take_execution_trace_digest()
+            .zip(fold_count)
+    } else {
+        None
+    };
     Ok(GeneratedTokens {
         prompt_token_ids: prepared.token_ids,
         token_ids: generated,
@@ -6846,6 +6892,7 @@ fn generate_token_ids(
         dense_diagnostic_generated_index,
         finish_reason,
         timings: prepared.timings,
+        execution_trace,
     })
 }
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -12,6 +12,7 @@ use std::sync::OnceLock;
 
 use rayon::prelude::*;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::execution_plan::MAC_Q8_PREFILL_I8MM_MIN_ROWS;
@@ -1425,6 +1426,12 @@ pub struct LlamaInferenceSession {
     /// CPU KV buffers authoritative. Speculative decoding requires this: KV rollback after a
     /// rejected draft only exists for CPU state.
     resident_paths_disabled: bool,
+    /// When set, the deterministic forward pass folds each layer's output hidden state and the
+    /// final logits into a streaming SHA-256 rollup (an execution-trace digest). Transient
+    /// proof-carrying state, not part of the session's logical identity — skipped by
+    /// Clone/PartialEq/Debug like `resident_decode`. Only enabled in deterministic mode
+    /// (`enable_execution_trace`); the default path never allocates it.
+    execution_trace: Option<ExecutionTraceHasher>,
 }
 
 impl LlamaInferenceSession {
@@ -1450,6 +1457,7 @@ impl LlamaInferenceSession {
             ),
             resident_decode: self.resident_decode.take(),
             resident_paths_disabled: self.resident_paths_disabled,
+            execution_trace: self.execution_trace.take(),
         }
     }
 
@@ -1472,6 +1480,7 @@ impl Clone for LlamaInferenceSession {
             kv_cache: self.kv_cache.clone(),
             resident_decode: None,
             resident_paths_disabled: self.resident_paths_disabled,
+            execution_trace: None,
         }
     }
 }
@@ -1508,6 +1517,7 @@ impl LlamaInferenceSession {
             kv_cache: LlamaKvCache::new(plan)?,
             resident_decode: None,
             resident_paths_disabled: false,
+            execution_trace: None,
         })
     }
 
@@ -1529,6 +1539,39 @@ impl LlamaInferenceSession {
     /// pins sessions to CPU because KV rollback only exists for CPU state.
     pub fn set_resident_paths_disabled(&mut self, disabled: bool) {
         self.resident_paths_disabled = disabled;
+    }
+
+    /// Arm the execution-trace rollup: subsequent forward passes fold every layer's output
+    /// hidden state and the final logits into a streaming SHA-256 (see [`ExecutionTraceHasher`]).
+    /// Fails closed unless deterministic mode is active — the rollup is only meaningful on the
+    /// order-stable CPU lane (RECEIPTS.md rule 2), and arming it would otherwise advertise a
+    /// digest over a non-reproducible run. Returns whether the trace was armed.
+    pub fn enable_execution_trace(&mut self) -> bool {
+        if deterministic_mode_enabled() {
+            self.execution_trace
+                .get_or_insert_with(ExecutionTraceHasher::new);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Whether the execution-trace rollup is currently armed.
+    pub fn execution_trace_armed(&self) -> bool {
+        self.execution_trace.is_some()
+    }
+
+    /// Checkpoints folded so far by the armed rollup (layers + logits across all tokens), if any.
+    pub fn execution_trace_fold_count(&self) -> Option<u64> {
+        self.execution_trace.as_ref().map(|h| h.fold_count())
+    }
+
+    /// Finalize and take the execution-trace rollup digest (lowercase-hex SHA-256), if armed.
+    /// Consumes the accumulated hasher; a subsequent generation must re-arm.
+    pub fn take_execution_trace_digest(&mut self) -> Option<String> {
+        self.execution_trace
+            .take()
+            .map(ExecutionTraceHasher::finalize_hex)
     }
 
     /// Roll the sequence back to `position`, discarding newer KV entries.
@@ -2658,6 +2701,13 @@ impl LlamaInferenceSession {
             )));
         }
 
+        // Take the execution-trace rollup out for the duration of this forward so the per-layer
+        // fold is a plain local (no borrow conflict with the `self.weights.layers` loop). It is
+        // restored on the success path; an error path drops it (the generation failed anyway).
+        // Only ever Some in deterministic mode (see `enable_execution_trace`); on the default
+        // path this is None and adds nothing.
+        let mut execution_trace = self.execution_trace.take();
+
         let runtime_plan = ResolvedRuntimePlan::from_env()?;
         let total_started = Instant::now();
         if !collect_diagnostics {
@@ -2754,6 +2804,9 @@ impl LlamaInferenceSession {
                     &mut self.kv_cache,
                 )?;
                 hidden = timed.output;
+                if let Some(trace) = execution_trace.as_mut() {
+                    trace.fold_layer_hidden(layer_idx, &hidden.data);
+                }
                 telemetry::emit(telemetry::Event::LayerCompleted {
                     layer: layer_idx,
                     layers_total: self.weights.layers.len(),
@@ -2841,6 +2894,13 @@ impl LlamaInferenceSession {
                     None,
                 )
             };
+        // Fold the final logits and restore the rollup onto the session for the next token.
+        if compute_logits {
+            if let Some(trace) = execution_trace.as_mut() {
+                trace.fold_logits(&logits.data);
+            }
+        }
+        self.execution_trace = execution_trace;
         self.kv_cache.position += 1;
         if !collect_diagnostics {
             metal::end_inference_session();
@@ -3181,6 +3241,89 @@ fn env_flag_enabled(key: &str) -> bool {
 /// llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated against.
 pub fn deterministic_mode_enabled() -> bool {
     env_flag_enabled("CAMELID_DETERMINISTIC")
+}
+
+/// Schema tag for the execution-trace rollup digest carried in a parity receipt.
+pub const EXECUTION_TRACE_SCHEMA_V1: &str = "camelid.execution-trace/v1";
+/// Algorithm tag: a single streaming SHA-256 over the whole deterministic forward pass.
+pub const EXECUTION_TRACE_ALGORITHM_ROLLUP_V1: &str = "sha256-rollup-v1";
+
+/// Streaming SHA-256 rollup over a deterministic forward pass. It folds, in forward order
+/// across every generated token, each transformer layer's output hidden state and the final
+/// logits vector into one digest. The fold is domain-separated (a kind byte + index + length
+/// prefix per checkpoint) so the byte stream is unambiguous, and uses little-endian f32 bytes
+/// so it is reproducible on a given host.
+///
+/// This is a single *rollup*: a mismatch proves the run differs but does not localize which
+/// token or layer. It is only meaningful on the order-stable CPU lane (deterministic mode):
+/// the underlying values are reduction-order-stable there (see [`deterministic_mode_enabled`]
+/// and DECISIONS.md §D9), and byte-for-byte reproducibility requires greedy decoding
+/// (RECEIPTS.md rule 2). The digest is ISA-specific (i8mm vs scalar round differently), so it
+/// is re-derivable on the same deterministic lane/host, not portable across ISAs.
+#[derive(Clone)]
+pub struct ExecutionTraceHasher {
+    hasher: Sha256,
+    fold_count: u64,
+}
+
+impl ExecutionTraceHasher {
+    /// Kind byte for a per-layer output hidden-state checkpoint.
+    const KIND_LAYER_HIDDEN: u8 = 0;
+    /// Kind byte for a final logits checkpoint.
+    const KIND_LOGITS: u8 = 1;
+
+    pub fn new() -> Self {
+        Self {
+            hasher: Sha256::new(),
+            fold_count: 0,
+        }
+    }
+
+    /// Fold one f32 checkpoint, domain-separated by `kind` + `index` + length so adjacent
+    /// checkpoints can never alias. Bytes are little-endian (host-reproducible).
+    fn fold(&mut self, kind: u8, index: u64, data: &[f32]) {
+        self.hasher.update([kind]);
+        self.hasher.update(index.to_le_bytes());
+        self.hasher.update((data.len() as u64).to_le_bytes());
+        let mut buf = Vec::with_capacity(data.len() * 4);
+        for &value in data {
+            buf.extend_from_slice(&value.to_le_bytes());
+        }
+        self.hasher.update(&buf);
+        self.fold_count += 1;
+    }
+
+    /// Fold a transformer layer's output hidden state.
+    pub fn fold_layer_hidden(&mut self, layer_index: usize, hidden: &[f32]) {
+        self.fold(Self::KIND_LAYER_HIDDEN, layer_index as u64, hidden);
+    }
+
+    /// Fold a final logits vector.
+    pub fn fold_logits(&mut self, logits: &[f32]) {
+        self.fold(Self::KIND_LOGITS, 0, logits);
+    }
+
+    /// Number of checkpoints folded so far (layers + logits across all tokens).
+    pub fn fold_count(&self) -> u64 {
+        self.fold_count
+    }
+
+    /// Finalize to a lowercase-hex SHA-256 digest.
+    pub fn finalize_hex(self) -> String {
+        let digest = self.hasher.finalize();
+        let mut out = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            out.push(char::from_digit((byte >> 4) as u32, 16).unwrap());
+            out.push(char::from_digit((byte & 0x0f) as u32, 16).unwrap());
+        }
+        out
+    }
+}
+
+impl Default for ExecutionTraceHasher {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 fn prefill_chunk_token_count(prefill_count: usize) -> usize {

--- a/src/receipt/mod.rs
+++ b/src/receipt/mod.rs
@@ -77,6 +77,13 @@ pub struct ParityReceipt {
     pub reproducible: bool,
     pub result: ReceiptResult,
     pub parity: ParityBlock,
+    /// Optional execution-trace rollup digest over the deterministic forward pass
+    /// (`camelid.execution-trace/v1`). Present only for deterministic, reproducible runs
+    /// that opted into tracing; absent otherwise, so non-traced receipts serialize and
+    /// digest exactly as before. Verification re-derives the rollup from an independent
+    /// in-process re-run and checks it matches (see `verify`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_trace: Option<ExecutionTraceBlock>,
     /// Deferred signing seam: an optional detached signature over
     /// `receipt_id`. Absent in v1; present-but-optional so adding it later is
     /// not a schema-breaking change. Key management is intentionally not
@@ -295,6 +302,71 @@ impl ParityBlock {
     }
 }
 
+/// Execution-trace rollup carried in a receipt: a single streaming SHA-256 over the whole
+/// deterministic forward pass (every layer's output hidden state + the final logits, folded
+/// across every generated token). A mismatch on re-derivation proves the run differs but does
+/// not localize which token or layer (single rollup, by design).
+///
+/// The digest is reduction-order-stable on the deterministic CPU lane but ISA-specific (the
+/// Q8_0 dot kernel rounds differently across ISAs), so `lane` and `host_isa` pin the lane the
+/// digest is re-derivable on — it is portable to the same lane/host, not across ISAs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionTraceBlock {
+    /// Always `camelid.execution-trace/v1`.
+    pub schema: String,
+    /// Fold algorithm, e.g. `sha256-rollup-v1`.
+    pub algorithm: String,
+    /// The execution lane the digest commits to (e.g. `deterministic-cpu`).
+    pub lane: String,
+    /// ISA marker the digest is re-derivable on (e.g. `aarch64-i8mm`, `aarch64-dotprod`).
+    pub host_isa: String,
+    /// Lowercase-hex SHA-256 rollup digest.
+    pub digest: String,
+    /// Number of checkpoints folded (layers + logits across all generated tokens).
+    pub fold_count: u64,
+    /// Number of generated tokens the rollup covers.
+    pub generated_token_count: usize,
+}
+
+impl ExecutionTraceBlock {
+    /// Build a v1 rollup block from a finalized digest captured on the deterministic CPU lane.
+    pub fn rollup_v1(digest: String, fold_count: u64, generated_token_count: usize) -> Self {
+        Self {
+            schema: crate::inference::EXECUTION_TRACE_SCHEMA_V1.to_string(),
+            algorithm: crate::inference::EXECUTION_TRACE_ALGORITHM_ROLLUP_V1.to_string(),
+            lane: "deterministic-cpu".to_string(),
+            host_isa: host_isa_marker(),
+            digest,
+            fold_count,
+            generated_token_count,
+        }
+    }
+}
+
+/// A coarse ISA marker that captures the only axis that changes the deterministic Q8_0 dot
+/// rounding on a given build: presence of the i8mm packed-rows kernel on aarch64. Used to pin
+/// the lane an execution-trace digest is re-derivable on.
+pub fn host_isa_marker() -> String {
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("i8mm") {
+            "aarch64-i8mm".to_string()
+        } else if std::arch::is_aarch64_feature_detected!("dotprod") {
+            "aarch64-dotprod".to_string()
+        } else {
+            "aarch64-scalar".to_string()
+        }
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        "x86_64".to_string()
+    }
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        std::env::consts::ARCH.to_string()
+    }
+}
+
 /// Reserved for the deferred signing decision: a detached signature over
 /// `receipt_id`. Not produced by v1 emitters.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -493,6 +565,7 @@ mod tests {
                 generated_text_match: Some(true),
                 first_divergent_token_index: Some(NO_DIVERGENCE),
             },
+            execution_trace: None,
             signature: None,
         }
     }
@@ -504,6 +577,42 @@ mod tests {
         let json = serde_json::to_string(&receipt).expect("serialize");
         let back: ParityReceipt = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(receipt, back);
+    }
+
+    #[test]
+    fn execution_trace_absent_keeps_receipt_byte_identical() {
+        // A non-traced receipt must omit the key entirely, so existing receipts and their
+        // digests are unchanged by adding the field.
+        let mut receipt = sample_receipt();
+        assert!(receipt.execution_trace.is_none());
+        receipt.seal().expect("seal");
+        let json = serde_json::to_string(&receipt).expect("serialize");
+        assert!(
+            !json.contains("execution_trace"),
+            "absent execution trace must not serialize a key"
+        );
+    }
+
+    #[test]
+    fn execution_trace_present_round_trips_and_enters_the_digest() {
+        let mut without = sample_receipt();
+        without.seal().expect("seal");
+
+        let mut with = sample_receipt();
+        with.execution_trace = Some(ExecutionTraceBlock::rollup_v1("a".repeat(64), 1024, 16));
+        with.seal().expect("seal");
+
+        // The trace is part of the canonical body, so it changes receipt_id.
+        assert_ne!(
+            without.receipt_id, with.receipt_id,
+            "an execution trace must enter the receipt digest"
+        );
+        // And it survives a serialize/deserialize round trip.
+        let json = serde_json::to_string(&with).expect("serialize");
+        assert!(json.contains("camelid.execution-trace/v1"));
+        let back: ParityReceipt = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(with, back);
+        assert!(back.verify_self_digest().is_ok());
     }
 
     #[test]

--- a/src/receipt/verify.rs
+++ b/src/receipt/verify.rs
@@ -189,6 +189,18 @@ pub async fn run(options: VerifyOptions) -> VerifyOutcome {
     // and weights are owned within `replay_receipt_request` and dropped on
     // return.
     if options.mode != VerifyMode::ReferenceOnly {
+        // An execution-trace block pins the deterministic CPU lane and a host ISA. We can only
+        // re-derive its rollup on the same ISA (the Q8_0 dot rounds differently across ISAs),
+        // so check the trace only when this host matches; otherwise re-run on the normal lane
+        // and skip the digest comparison with an honest note.
+        let trace_check = receipt
+            .execution_trace
+            .as_ref()
+            .map(|trace| trace.host_isa == crate::receipt::host_isa_marker())
+            .unwrap_or(false);
+        if trace_check {
+            force_deterministic_lane();
+        }
         match crate::api::replay_receipt_request(&options.gguf, options.threads, &receipt.request)
             .await
         {
@@ -203,6 +215,41 @@ pub async fn run(options: VerifyOptions) -> VerifyOutcome {
                     replay.result.prompt_token_ids.len(),
                     replay.result.generated_token_ids.len()
                 );
+                if let Some(trace) = &receipt.execution_trace {
+                    if !trace_check {
+                        println!(
+                            "SKIP execution-trace: receipt rollup is for ISA {} but this host is {}; \
+                             the digest is ISA-specific and cannot be re-derived here",
+                            trace.host_isa,
+                            crate::receipt::host_isa_marker()
+                        );
+                    } else {
+                        match &replay.execution_trace_digest {
+                            Some(rederived) if *rederived == trace.digest => {
+                                println!(
+                                    "PASS execution-trace: re-derived the {} rollup digest \
+                                     identically (lane {}, ISA {}, {} checkpoints)",
+                                    trace.algorithm, trace.lane, trace.host_isa, trace.fold_count
+                                );
+                            }
+                            Some(rederived) => {
+                                println!(
+                                    "FAIL execution-trace: re-derived rollup {rederived} != receipt \
+                                     {}",
+                                    trace.digest
+                                );
+                                return not_verified("execution-trace");
+                            }
+                            None => {
+                                println!(
+                                    "FAIL execution-trace: the re-run produced no rollup (the \
+                                     deterministic lane did not arm)"
+                                );
+                                return not_verified("execution-trace");
+                            }
+                        }
+                    }
+                }
             }
             Err(err) => {
                 println!("FAIL camelid-rerun: {err}");
@@ -256,6 +303,31 @@ pub async fn run(options: VerifyOptions) -> VerifyOutcome {
 fn not_verified(step: &str) -> VerifyOutcome {
     println!("RECEIPT NOT VERIFIED (failed step: {step})");
     VerifyOutcome::NotVerified
+}
+
+/// Pin this verifier process to the deterministic CPU lane so a receipt's execution-trace
+/// rollup re-derives identically: enable deterministic mode and force the whole Metal/GPU
+/// stack off. Mirrors the CLI `--deterministic` arm; verify-receipt is a one-shot command, so
+/// mutating process env here is safe.
+fn force_deterministic_lane() {
+    std::env::set_var("CAMELID_DETERMINISTIC", "1");
+    for key in [
+        "CAMELID_METAL_RESIDENT_DECODE",
+        "CAMELID_METAL_F32Y",
+        "CAMELID_METAL_WIRE",
+        "CAMELID_METAL_WIRE_NSG8",
+        "CAMELID_METAL_ATTN2",
+        "CAMELID_METAL_RESIDENT_PREFILL",
+        "CAMELID_METAL_MM",
+        "CAMELID_METAL_LINEAR",
+        "CAMELID_METAL_Q8",
+        "CAMELID_METAL_Q8_RETAINED",
+        "CAMELID_HYBRID_Q8_RETAINED",
+        "CAMELID_METAL_NOCOPY",
+    ] {
+        std::env::set_var(key, "0");
+    }
+    std::env::set_var("CAMELID_NO_GPU_SAMPLE", "1");
 }
 
 /// Full verification as two isolated passes. Each pass invokes this same binary

--- a/tests/execution_trace.rs
+++ b/tests/execution_trace.rs
@@ -1,0 +1,146 @@
+//! Pillar Two regression — the deterministic forward pass produces a stable execution-trace
+//! rollup digest for the supported TinyLlama 1.1B Chat Q8_0 lane.
+//!
+//! The rollup (`camelid.execution-trace/v1`, `sha256-rollup-v1`) folds every transformer
+//! layer's output hidden state and the final logits, across every generated token, into one
+//! streaming SHA-256 (see `ExecutionTraceHasher`). It is only meaningful on the order-stable
+//! CPU lane (deterministic mode); this test asserts, with tolerance zero:
+//!   1. The digest is identical across two runs and across rayon thread counts (1 vs default).
+//!   2. A different prompt yields a different digest.
+//!   3. The digest equals the committed M4 / i8mm reference (regression pin, i8mm-guarded).
+//!   4. Arming the trace OUTSIDE deterministic mode fails closed (no digest).
+//!
+//! Env-gated on the real GGUF (self-skips without it), like `deterministic_forward`:
+//! ```text
+//! CAMELID_TINYLLAMA_Q8_GGUF=/path/tinyllama-1.1b-chat-v1.0.Q8_0.gguf \
+//!   cargo test --release --test execution_trace -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use camelid::gguf::read_metadata;
+use camelid::inference::{LlamaInferenceSession, LlamaLoadedWeights, LlamaSampler};
+use camelid::model::{LlamaModelConfig, LlamaTensorBinding};
+use camelid::tensor::TensorStore;
+use camelid::tokenizer::Tokenizer;
+
+const STREAM_TOKENS: usize = 24;
+
+/// Execution-trace rollup digest for prompt "hello", deterministic mode, Apple M4 (i8mm).
+/// Tolerance is exactly zero.
+const REF_HELLO_DIGEST: &str = "70649b4da0a1571a16deaa05c7b554a7256643e9f46b0f7a5c969668099f3f4c";
+
+fn host_has_i8mm() -> bool {
+    #[cfg(target_arch = "aarch64")]
+    {
+        std::arch::is_aarch64_feature_detected!("i8mm")
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        false
+    }
+}
+
+fn load(model: &PathBuf) -> (LlamaModelConfig, Arc<LlamaLoadedWeights>, Tokenizer) {
+    let gguf = read_metadata(model).expect("read gguf metadata");
+    let config = LlamaModelConfig::from_gguf(&gguf).expect("llama config");
+    let binding = LlamaTensorBinding::bind(&gguf, &config).expect("tensor binding");
+    let store = TensorStore::open(model, &gguf);
+    let tokenizer = Tokenizer::from_gguf(&gguf).expect("tokenizer");
+    let weights = Arc::new(LlamaLoadedWeights::load(&store, &binding, None).expect("weights"));
+    (config, weights, tokenizer)
+}
+
+/// Arm the execution-trace rollup, greedily decode `STREAM_TOKENS` tokens, return the digest.
+fn rollup_digest(
+    config: &LlamaModelConfig,
+    weights: &Arc<LlamaLoadedWeights>,
+    prompt_ids: &[u32],
+) -> String {
+    let mut session = LlamaInferenceSession::new(config.clone(), weights.clone()).expect("session");
+    assert!(
+        session.enable_execution_trace(),
+        "execution trace must arm in deterministic mode"
+    );
+    let step = session
+        .generate_next_token(prompt_ids, LlamaSampler::Greedy)
+        .expect("prefill step");
+    let mut last = step.next_token_id;
+    let mut count = 1;
+    while count < STREAM_TOKENS {
+        let step = session
+            .generate_next_token(&[last], LlamaSampler::Greedy)
+            .expect("decode step");
+        last = step.next_token_id;
+        count += 1;
+    }
+    session
+        .take_execution_trace_digest()
+        .expect("digest present after an armed deterministic run")
+}
+
+#[test]
+fn tinyllama_q8_execution_trace_rollup_is_stable_and_pinned() {
+    let Some(model) = std::env::var_os("CAMELID_TINYLLAMA_Q8_GGUF").map(PathBuf::from) else {
+        eprintln!(
+            "SKIP execution_trace: set CAMELID_TINYLLAMA_Q8_GGUF=/path/tinyllama-1.1b-chat-v1.0.Q8_0.gguf"
+        );
+        return;
+    };
+
+    std::env::set_var("CAMELID_DETERMINISTIC", "1");
+    let (config, weights, tokenizer) = load(&model);
+    let hello = tokenizer
+        .encode("hello", true, false)
+        .expect("encode hello");
+    let other = tokenizer
+        .encode("goodbye", true, false)
+        .expect("encode goodbye");
+
+    // Property 1a — two runs identical.
+    let d1 = rollup_digest(&config, &weights, &hello);
+    let d2 = rollup_digest(&config, &weights, &hello);
+    eprintln!("execution_trace: hello digest = {d1}");
+    assert_eq!(d1, d2, "rollup digest diverged between two runs");
+    assert_eq!(d1.len(), 64, "digest must be 64 lowercase-hex chars");
+
+    // Property 1b — thread-count invariant (1 worker vs the default pool).
+    let d_single = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .expect("1-thread pool")
+        .install(|| rollup_digest(&config, &weights, &hello));
+    assert_eq!(
+        d1, d_single,
+        "rollup digest changed with rayon thread count (must be output-partitioned/order-stable)"
+    );
+
+    // Property 2 — a different prompt yields a different digest.
+    let d_other = rollup_digest(&config, &weights, &other);
+    assert_ne!(
+        d1, d_other,
+        "different prompt must yield a different rollup"
+    );
+
+    // Property 3 — exact regression pin (M4 / i8mm). Skipped on other ISAs (internally
+    // deterministic but rounds differently); properties 1–2 still hold there.
+    if host_has_i8mm() {
+        assert_eq!(
+            d1, REF_HELLO_DIGEST,
+            "rollup digest drifted from the committed M4/i8mm reference (tolerance is zero)"
+        );
+    } else {
+        eprintln!("execution_trace: host lacks i8mm — skipped the M4 exact-digest pin");
+    }
+
+    // Property 4 — fail closed outside deterministic mode (reuses the loaded weights).
+    std::env::remove_var("CAMELID_DETERMINISTIC");
+    let mut plain = LlamaInferenceSession::new(config.clone(), weights.clone()).expect("session");
+    assert!(
+        !plain.enable_execution_trace(),
+        "execution trace must NOT arm outside deterministic mode"
+    );
+    assert!(!plain.execution_trace_armed());
+    assert!(plain.take_execution_trace_digest().is_none());
+}

--- a/tests/execution_trace_receipt.rs
+++ b/tests/execution_trace_receipt.rs
@@ -1,0 +1,103 @@
+//! Pillar Two — the execution-trace rollup survives the receipt emit→verify round trip.
+//!
+//! `replay_receipt_request` is the exact API generation path that BOTH receipt emission and
+//! `verify-receipt` re-run funnel through, so exercising it proves emission and verification
+//! cannot desync: a deterministic replay captures a rollup digest, and a second replay
+//! re-derives the identical digest (the verification guarantee). Off the deterministic lane the
+//! rollup is absent (fail closed).
+//!
+//! Env-gated on the real GGUF (self-skips without it):
+//! ```text
+//! CAMELID_TINYLLAMA_Q8_GGUF=/path/tinyllama-1.1b-chat-v1.0.Q8_0.gguf \
+//!   cargo test --release --test execution_trace_receipt -- --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use camelid::receipt::{host_isa_marker, ExecutionTraceBlock, ReceiptRequest};
+use serde_json::json;
+
+const METAL_KEYS: &[&str] = &[
+    "CAMELID_METAL_RESIDENT_DECODE",
+    "CAMELID_METAL_F32Y",
+    "CAMELID_METAL_WIRE",
+    "CAMELID_METAL_WIRE_NSG8",
+    "CAMELID_METAL_ATTN2",
+    "CAMELID_METAL_RESIDENT_PREFILL",
+    "CAMELID_METAL_MM",
+    "CAMELID_METAL_LINEAR",
+    "CAMELID_METAL_Q8",
+    "CAMELID_METAL_NOCOPY",
+];
+
+fn deterministic_lane_on() {
+    std::env::set_var("CAMELID_DETERMINISTIC", "1");
+    for key in METAL_KEYS {
+        std::env::set_var(key, "0");
+    }
+    std::env::set_var("CAMELID_NO_GPU_SAMPLE", "1");
+}
+
+fn request() -> ReceiptRequest {
+    ReceiptRequest {
+        endpoint: "/v1/completions".to_string(),
+        messages_or_prompt: json!("hello"),
+        max_tokens: 6,
+        temperature: 0.0,
+        top_p: None,
+        top_k: None,
+        seed: None,
+        stop: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn execution_trace_round_trips_through_replay() {
+    let Some(model) = std::env::var_os("CAMELID_TINYLLAMA_Q8_GGUF").map(PathBuf::from) else {
+        eprintln!("SKIP execution_trace_receipt: set CAMELID_TINYLLAMA_Q8_GGUF");
+        return;
+    };
+
+    // Emission lane: a deterministic replay captures a rollup digest.
+    deterministic_lane_on();
+    let replay1 = camelid::api::replay_receipt_request(&model, None, &request())
+        .await
+        .expect("deterministic replay");
+    let digest = replay1
+        .execution_trace_digest
+        .clone()
+        .expect("rollup digest present on the deterministic lane");
+    eprintln!("execution_trace_receipt: digest = {digest}");
+    assert_eq!(
+        digest.len(),
+        64,
+        "rollup digest must be 64 lowercase-hex chars"
+    );
+
+    // Verification guarantee: an independent re-run re-derives the identical digest.
+    let replay2 = camelid::api::replay_receipt_request(&model, None, &request())
+        .await
+        .expect("deterministic replay (re-derive)");
+    assert_eq!(
+        Some(&digest),
+        replay2.execution_trace_digest.as_ref(),
+        "rollup digest must re-derive identically (this is what verify-receipt checks)"
+    );
+
+    // The receipt block records the lane + this host's ISA so a verifier knows when it can
+    // re-derive the digest.
+    let block = ExecutionTraceBlock::rollup_v1(digest.clone(), 1, 6);
+    assert_eq!(block.schema, "camelid.execution-trace/v1");
+    assert_eq!(block.host_isa, host_isa_marker());
+    assert_eq!(block.digest, digest);
+
+    // Fail closed: off the deterministic lane no rollup is captured.
+    std::env::remove_var("CAMELID_DETERMINISTIC");
+    let replay_plain = camelid::api::replay_receipt_request(&model, None, &request())
+        .await
+        .expect("non-deterministic replay");
+    assert!(
+        replay_plain.execution_trace_digest.is_none(),
+        "no rollup may be produced off the deterministic lane"
+    );
+}


### PR DESCRIPTION
## Pillar Two — execution-trace rollup digest

Built on the deterministic CPU lane (#274 / D9). A parity receipt produced on that lane now carries an **execution-trace rollup**: one streaming SHA-256 (`camelid.execution-trace/v1`, `sha256-rollup-v1`) folding every transformer layer's output hidden state and the final logits, across every generated token. It proves not just that the *output tokens* match a reference, but that the *internal computation* re-runs **bit-for-bit** — meaningful only because the deterministic lane is reduction-order-stable.

### Design (DECISIONS.md §D11)
- **Fail-closed:** `ExecutionTraceHasher` arms only in deterministic mode; the default (non-deterministic) path never allocates it and is byte-for-byte unchanged.
- **Additive receipt field** `Option<ExecutionTraceBlock>` with `skip_serializing_if = None` — non-traced receipts serialize and digest exactly as before; the block enters the `receipt_id` digest (tamper-evident).
- **Emission & verify share one path** (`replay_receipt_request → generate_decoded_tokens`): armed and captured there, prompt-prefix cache bypassed while tracing so both sides fold an identical forward. `verify-receipt` re-derives and compares.
- **ISA-pinned:** the block records `lane` + `host_isa`; `verify-receipt` re-derives only on a matching ISA, otherwise prints `SKIP execution-trace` (never a false `FAIL`).

Single rollup by design — a mismatch proves the run differs but does not localize the token/layer. Per-layer localization, distributed per-shard chains, and signing are out of scope.

### Evidence — all gates green
- `tests/execution_trace.rs`: engine rollup is run-to-run + **thread-count invariant** + prompt-sensitive + pinned (M4/i8mm) + fail-closed.
- `tests/execution_trace_receipt.rs`: full **emit → re-derive round trip** through the real API replay path; absent off the lane.
- Receipt unit tests: absent omits the key (receipts byte-identical); present round-trips and enters the digest.
- `cargo fmt`, `clippy -D warnings`, `cargo test --all-targets` (692 passed / 0 failed), `cargo doc` all clean; default-path receipts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
