### PR TITLE
chore: cargo fmt --all to green the CI Format check gate

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12456,9 +12456,7 @@ async fn local_models() -> Json<LocalModelsResponse> {
                                 }
                             }
                         }
-                        Err(err) => {
-                            c.admission_reason = Some(format!("GGUF parse failed: {err}"))
-                        }
+                        Err(err) => c.admission_reason = Some(format!("GGUF parse failed: {err}")),
                     }
                     local_meta_cache()
                         .lock()
@@ -12560,8 +12558,7 @@ async fn run_runnable_smoke(Json(req): Json<RunnableSmokeRequest>) -> Response {
         );
     }
     let path_str = path.to_string_lossy().to_string();
-    let result =
-        tokio::task::spawn_blocking(move || crate::runnable::smoke_admit(&path_str)).await;
+    let result = tokio::task::spawn_blocking(move || crate::runnable::smoke_admit(&path_str)).await;
     match result {
         Ok(Ok(report)) => {
             let out = runnable_smoke_receipt_path(&filename);

--- a/src/chat/agent.rs
+++ b/src/chat/agent.rs
@@ -573,8 +573,8 @@ pub fn run_agent(session: &mut Session, addr: SocketAddr, cfg: AgentConfig) -> a
         }
     };
 
-    let sandbox =
-        Sandbox::new(&cfg.workdir, cfg.allow_net, cfg.shell_timeout)?.with_shell_mode(cfg.shell_sandbox);
+    let sandbox = Sandbox::new(&cfg.workdir, cfg.allow_net, cfg.shell_timeout)?
+        .with_shell_mode(cfg.shell_sandbox);
     println!(
         "{}\n",
         banner::splash(
@@ -599,7 +599,10 @@ pub fn run_agent(session: &mut Session, addr: SocketAddr, cfg: AgentConfig) -> a
     // Surface the *actual* run_shell confinement, never a faked one (Task 1).
     match cfg.shell_sandbox {
         ShellSandbox::Disabled => {
-            println!("{}", banner::dim("· run_shell: disabled (tool not offered)"));
+            println!(
+                "{}",
+                banner::dim("· run_shell: disabled (tool not offered)")
+            );
         }
         ShellSandbox::Unrestricted => {
             println!(
@@ -1049,10 +1052,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sb = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
         let mut policy = resolve_policy(true, false).unwrap(); // auto_all on
-        let write =
-            tools::validate(&tc("write_file", json!({"path":"a.txt","content":"x"})), &sb).unwrap();
-        let shell =
-            tools::validate(&tc("run_shell", json!({"command":"echo hi"})), &sb).unwrap();
+        let write = tools::validate(
+            &tc("write_file", json!({"path":"a.txt","content":"x"})),
+            &sb,
+        )
+        .unwrap();
+        let shell = tools::validate(&tc("run_shell", json!({"command":"echo hi"})), &sb).unwrap();
         // Write (Confirm) is promoted to Auto; run_shell (Exec) is NOT.
         assert_eq!(policy.tier_for(&write), ApprovalTier::Auto);
         assert_eq!(policy.tier_for(&shell), ApprovalTier::Confirm);
@@ -1134,7 +1139,7 @@ mod tests {
         assert_eq!(events[1].event_name(), "agent.tool_result");
         assert_eq!(events[0].tool, "read_file");
         assert_eq!(events[0].tier, "auto"); // read_file is auto tier
-        // The args digest is a hash, not the raw path.
+                                            // The args digest is a hash, not the raw path.
         assert!(events[0].args_digest.starts_with("sha256:"));
         assert!(!events[0].args_digest.contains("f.txt"));
         // The result event carries outcome + duration; the call event does not.
@@ -1150,7 +1155,10 @@ mod tests {
         let sink = audit::InMemorySink::default();
         let mut driver = MockDriver {
             steps: vec![
-                ModelStep::Calls(vec![tc("write_file", json!({"path":"x.txt","content":"hi"}))]),
+                ModelStep::Calls(vec![tc(
+                    "write_file",
+                    json!({"path":"x.txt","content":"hi"}),
+                )]),
                 ModelStep::Text("won't".into()),
             ],
             idx: 0,
@@ -1178,8 +1186,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sb = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
         let mut policy = Policy::default();
-        let write =
-            tools::validate(&tc("write_file", json!({"path":"a.txt","content":"x"})), &sb).unwrap();
+        let write = tools::validate(
+            &tc("write_file", json!({"path":"a.txt","content":"x"})),
+            &sb,
+        )
+        .unwrap();
         assert_eq!(policy.tier_for(&write), ApprovalTier::Confirm);
         policy.grant("write_file");
         assert_eq!(policy.tier_for(&write), ApprovalTier::Auto);

--- a/src/chat/audit.rs
+++ b/src/chat/audit.rs
@@ -283,20 +283,31 @@ mod tests {
         assert!(!d.contains("hunter2"));
         assert!(!d.contains("secret.txt"));
         // Deterministic for equal args.
-        assert_eq!(d, digest_args(&json!({"path": "secret.txt", "token": "hunter2"})));
+        assert_eq!(
+            d,
+            digest_args(&json!({"path": "secret.txt", "token": "hunter2"}))
+        );
     }
 
     #[test]
     fn noop_sink_emits_nothing_observable() {
         let s = NoopSink;
-        s.emit(&AuditEvent::call("read_file", "auto", digest_args(&json!({}))));
+        s.emit(&AuditEvent::call(
+            "read_file",
+            "auto",
+            digest_args(&json!({})),
+        ));
         // No panic, no state — the point is it never errors.
     }
 
     #[test]
     fn in_memory_sink_records_payload_shape() {
         let s = InMemorySink::default();
-        s.emit(&AuditEvent::call("run_shell", "confirm", "sha256:abc".into()));
+        s.emit(&AuditEvent::call(
+            "run_shell",
+            "confirm",
+            "sha256:abc".into(),
+        ));
         let evs = s.events();
         assert_eq!(evs.len(), 1);
         let p = evs[0].to_json();

--- a/src/chat/shell_sandbox.rs
+++ b/src/chat/shell_sandbox.rs
@@ -129,9 +129,7 @@ pub fn configure_command(
     mode: ShellSandbox,
 ) -> Result<EnforcedShell, String> {
     match mode {
-        ShellSandbox::Disabled => {
-            Err("run_shell is disabled (shell_sandbox=disabled)".to_string())
-        }
+        ShellSandbox::Disabled => Err("run_shell is disabled (shell_sandbox=disabled)".to_string()),
         ShellSandbox::Unrestricted => {
             builder.current_dir(root);
             Ok(EnforcedShell::unrestricted())
@@ -153,7 +151,10 @@ pub fn describe_sandboxed(root: &Path) -> Result<EnforcedShell, String> {
 // Linux enforcement (x86_64 / aarch64). Built-and-gated; validated by Linux CI.
 // ===========================================================================
 
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 mod linux {
     use super::EnforcedShell;
     use std::ffi::CString;
@@ -177,7 +178,7 @@ mod linux {
     const BPF_LD_W_ABS: u16 = 0x20; // BPF_LD | BPF_W | BPF_ABS
     const BPF_JEQ_K: u16 = 0x15; // BPF_JMP | BPF_JEQ | BPF_K
     const BPF_RET_K: u16 = 0x06; // BPF_RET | BPF_K
-    // Offsets into `struct seccomp_data`.
+                                 // Offsets into `struct seccomp_data`.
     const SD_NR: u32 = 0;
     const SD_ARCH: u32 = 4;
 
@@ -187,7 +188,12 @@ mod linux {
     const AUDIT_ARCH: u32 = 0xC000_00B7; // AUDIT_ARCH_AARCH64
 
     fn bpf_stmt(code: u16, k: u32) -> libc::sock_filter {
-        libc::sock_filter { code, jt: 0, jf: 0, k }
+        libc::sock_filter {
+            code,
+            jt: 0,
+            jf: 0,
+            k,
+        }
     }
     fn bpf_jump(code: u16, k: u32, jt: u8, jf: u8) -> libc::sock_filter {
         libc::sock_filter { code, jt, jf, k }
@@ -389,12 +395,18 @@ mod linux {
 
 /// Sandboxed configuration dispatch. Linux (supported arch) wires the real
 /// enforcement; everywhere else fails closed.
-#[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 fn configure_sandboxed(builder: &mut Command, root: &Path) -> Result<EnforcedShell, String> {
     linux::configure(builder, root)
 }
 
-#[cfg(not(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"))))]
+#[cfg(not(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+)))]
 fn configure_sandboxed(_builder: &mut Command, _root: &Path) -> Result<EnforcedShell, String> {
     // Fail closed: no kernel mechanism to enforce the sandbox here. Refuse rather
     // than silently running unconfined.
@@ -414,8 +426,14 @@ mod tests {
 
     #[test]
     fn mode_parses_and_round_trips() {
-        assert_eq!("sandboxed".parse::<ShellSandbox>().unwrap(), ShellSandbox::Sandboxed);
-        assert_eq!("Disabled".parse::<ShellSandbox>().unwrap(), ShellSandbox::Disabled);
+        assert_eq!(
+            "sandboxed".parse::<ShellSandbox>().unwrap(),
+            ShellSandbox::Sandboxed
+        );
+        assert_eq!(
+            "Disabled".parse::<ShellSandbox>().unwrap(),
+            ShellSandbox::Disabled
+        );
         assert_eq!(
             "unrestricted".parse::<ShellSandbox>().unwrap(),
             ShellSandbox::Unrestricted
@@ -442,7 +460,10 @@ mod tests {
     // On a non-Linux (or unsupported-arch) host, sandboxed mode must FAIL CLOSED —
     // it must not silently run unconfined. This is the behavior exercised on the
     // Windows dev box.
-    #[cfg(not(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"))))]
+    #[cfg(not(all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    )))]
     #[test]
     fn sandboxed_fails_closed_off_linux() {
         let mut c = Command::new("true");
@@ -455,7 +476,10 @@ mod tests {
     // sandbox. We fork, install the filter via the same pre_exec path by running
     // a tiny shell command, and assert it cannot create a socket. Validated by
     // Linux CI (not run on the Windows dev box).
-    #[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
+    #[cfg(all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ))]
     #[test]
     fn socket_is_blocked_under_seccomp() {
         use std::io::Write;

--- a/src/chat/tools.rs
+++ b/src/chat/tools.rs
@@ -660,7 +660,8 @@ fn run_shell(sandbox: &Sandbox, command: &str) -> ToolOutcome {
         .stderr(Stdio::piped());
     // Apply confinement. A sandboxed mode that can't be enforced here returns an
     // error → refuse to run, never a silent unconfined fallback.
-    if let Err(e) = shell_sandbox::configure_command(&mut builder, &sandbox.root, sandbox.shell_mode)
+    if let Err(e) =
+        shell_sandbox::configure_command(&mut builder, &sandbox.root, sandbox.shell_mode)
     {
         return ToolOutcome::Err(format!("run_shell refused: {e}"));
     }
@@ -891,7 +892,10 @@ mod tests {
     // The default (sandboxed) mode is not kernel-enforceable off Linux, so
     // run_shell must refuse to run rather than execute unconfined. This is the
     // fail-closed behavior exercised on the Windows dev box.
-    #[cfg(not(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64"))))]
+    #[cfg(not(all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    )))]
     #[test]
     fn sandboxed_run_shell_fails_closed_off_linux() {
         use super::ShellSandbox;

--- a/src/cuda_parity.rs
+++ b/src/cuda_parity.rs
@@ -182,7 +182,11 @@ pub fn tokens_from_diag(v: &Value) -> Option<Vec<u32>> {
         "cuda_tokens",
     ] {
         if let Some(arr) = v.get(key).and_then(Value::as_array) {
-            return Some(arr.iter().filter_map(|x| x.as_u64().map(|n| n as u32)).collect());
+            return Some(
+                arr.iter()
+                    .filter_map(|x| x.as_u64().map(|n| n as u32))
+                    .collect(),
+            );
         }
     }
     None

--- a/src/cuda_vram.rs
+++ b/src/cuda_vram.rs
@@ -263,7 +263,11 @@ pub fn measure_contention(
         });
     }
 
-    Ok(summarize_contention(primary_bytes, second_bytes, &run_results))
+    Ok(summarize_contention(
+        primary_bytes,
+        second_bytes,
+        &run_results,
+    ))
 }
 
 /// Pure aggregation of contention runs (separated so it is testable without CUDA).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,9 @@ pub mod capability;
 pub mod catalog;
 pub mod cluster;
 pub mod cuda;
+pub mod cuda_parity;
 #[cfg(feature = "cuda")]
 pub mod cuda_resident;
-pub mod cuda_parity;
 pub mod cuda_vram;
 pub mod diffusion_gemma;
 pub mod distributed;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1006,7 +1006,9 @@ async fn main() -> anyhow::Result<()> {
                         report.prompt_token_count, report.logit_min, report.logit_max
                     );
                     eprintln!("  greedy: {:?}", report.generated_text);
-                    eprintln!("  (runnable receipt below — attests deterministic execution, not parity)");
+                    eprintln!(
+                        "  (runnable receipt below — attests deterministic execution, not parity)"
+                    );
                     // The runnable receipt (lane=runnable, never copper) to stdout.
                     println!("{}", serde_json::to_string_pretty(&report.receipt)?);
                 }

--- a/src/receipt/mod.rs
+++ b/src/receipt/mod.rs
@@ -624,7 +624,9 @@ mod tests {
             "absent lane must not appear in the canonical body: {body}"
         );
         assert!(!receipt.is_runnable());
-        receipt.verify_self_digest().expect("legacy digest verifies");
+        receipt
+            .verify_self_digest()
+            .expect("legacy digest verifies");
     }
 
     #[test]

--- a/src/runnable/admit.rs
+++ b/src/runnable/admit.rs
@@ -26,8 +26,7 @@ use crate::error::BackendError;
 use crate::gguf::{GgufFile, GgufTensorType};
 
 /// v1 covered architectures (`general.architecture`).
-pub const COVERED_ARCHITECTURES: &[&str] =
-    &["llama", "qwen2", "qwen3", "gemma2", "gemma3", "phi3"];
+pub const COVERED_ARCHITECTURES: &[&str] = &["llama", "qwen2", "qwen3", "gemma2", "gemma3", "phi3"];
 
 /// v1 covered tokenizer models (`tokenizer.ggml.model`), grouped by family below.
 /// SPM (sentencepiece/llama-style) + BPE (gpt2-style) are the two covered families.

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -268,7 +268,10 @@ impl RunnableModel {
             };
             // phi3 fuses gate+up into ffn_up [2*ffn] (gate first); split it.
             let (gate, up) = if find_tensor(&gguf, &p("ffn_gate")).is_ok() {
-                (load_raw(&mut f, &p("ffn_gate"))?, load_raw(&mut f, &p("ffn_up"))?)
+                (
+                    load_raw(&mut f, &p("ffn_gate"))?,
+                    load_raw(&mut f, &p("ffn_up"))?,
+                )
             } else {
                 let gu = load_raw(&mut f, &p("ffn_up"))?;
                 (gu.split_rows(0, ffn), gu.split_rows(ffn, ffn))
@@ -304,7 +307,13 @@ impl RunnableModel {
             let local = 10_000.0_f32;
             let pattern = 6usize;
             (0..n_layers)
-                .map(|i| if (i + 1) % pattern == 0 { global } else { local })
+                .map(|i| {
+                    if (i + 1) % pattern == 0 {
+                        global
+                    } else {
+                        local
+                    }
+                })
                 .collect()
         } else {
             vec![rope_base; n_layers]
@@ -345,7 +354,9 @@ impl RunnableModel {
     /// Pure f32, deterministic, no KV cache — recomputed each call.
     pub fn forward_logits(&self, tokens: &[u32]) -> Result<Vec<f32>> {
         if tokens.is_empty() {
-            return Err(BackendError::InvalidTensorData("empty token sequence".into()));
+            return Err(BackendError::InvalidTensorData(
+                "empty token sequence".into(),
+            ));
         }
         let seq = tokens.len();
         let dm = self.d_model;
@@ -723,7 +734,10 @@ fn rms_norm(x: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
     let n = x.len() as f32;
     let ss: f32 = x.iter().map(|v| v * v).sum();
     let inv = 1.0 / (ss / n + eps).sqrt();
-    x.iter().zip(weight.iter()).map(|(v, w)| v * inv * w).collect()
+    x.iter()
+        .zip(weight.iter())
+        .map(|(v, w)| v * inv * w)
+        .collect()
 }
 
 /// gelu with the tanh approximation (`gelu_pytorch_tanh`), gemma's FFN activation.

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -3467,7 +3467,11 @@ fn decode_bf16_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
         .collect())
 }
 
-pub(crate) fn decode_q8_0_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
+pub(crate) fn decode_q8_0_tensor(
+    name: &str,
+    bytes: &[u8],
+    expected_elements: usize,
+) -> Result<Vec<f32>> {
     let blocks = decode_q8_0_blocks(name, bytes, expected_elements)?;
     let mut out = Vec::with_capacity(expected_elements);
     for block in blocks {
@@ -4398,7 +4402,11 @@ pub fn decode_iq4_nl_blocks(bytes: &[u8]) -> Result<Vec<IQ4NLBlock>> {
 }
 
 // Flat dequantization to f32 helpers
-pub(crate) fn decode_q4_0_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
+pub(crate) fn decode_q4_0_tensor(
+    name: &str,
+    bytes: &[u8],
+    expected_elements: usize,
+) -> Result<Vec<f32>> {
     let blocks = decode_q4_0_blocks(bytes)
         .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
@@ -4476,7 +4484,11 @@ fn decode_q3_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Res
     Ok(out)
 }
 
-pub(crate) fn decode_q4_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
+pub(crate) fn decode_q4_k_tensor(
+    name: &str,
+    bytes: &[u8],
+    expected_elements: usize,
+) -> Result<Vec<f32>> {
     let blocks = decode_q4_k_blocks(bytes)
         .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
@@ -4488,7 +4500,11 @@ pub(crate) fn decode_q4_k_tensor(name: &str, bytes: &[u8], expected_elements: us
     Ok(out)
 }
 
-pub(crate) fn decode_q5_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
+pub(crate) fn decode_q5_k_tensor(
+    name: &str,
+    bytes: &[u8],
+    expected_elements: usize,
+) -> Result<Vec<f32>> {
     let blocks = decode_q5_k_blocks(bytes)
         .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);
@@ -4500,7 +4516,11 @@ pub(crate) fn decode_q5_k_tensor(name: &str, bytes: &[u8], expected_elements: us
     Ok(out)
 }
 
-pub(crate) fn decode_q6_k_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
+pub(crate) fn decode_q6_k_tensor(
+    name: &str,
+    bytes: &[u8],
+    expected_elements: usize,
+) -> Result<Vec<f32>> {
     let blocks = decode_q6_k_blocks(bytes)
         .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);

--- a/tests/cuda_cpu_parity.rs
+++ b/tests/cuda_cpu_parity.rs
@@ -30,12 +30,13 @@ fn read_tokens(path: &str) -> Vec<u32> {
 #[test]
 #[ignore = "needs CPU and CUDA token streams over the frozen fixtures; run on a CUDA host"]
 fn cpu_cuda_greedy_parity() {
-    let cpu_path =
-        std::env::var("CAMELID_PARITY_CPU_JSON").unwrap_or_else(|_| "qa/parity_cpu_diag.json".into());
+    let cpu_path = std::env::var("CAMELID_PARITY_CPU_JSON")
+        .unwrap_or_else(|_| "qa/parity_cpu_diag.json".into());
     let cuda_path = std::env::var("CAMELID_PARITY_CUDA_JSON")
         .unwrap_or_else(|_| "qa/parity_cuda_diag.json".into());
     let model = std::env::var("CAMELID_PARITY_MODEL").unwrap_or_else(|_| "validated-model".into());
-    let fixture = std::env::var("CAMELID_PARITY_FIXTURE").unwrap_or_else(|_| "frozen-fixture".into());
+    let fixture =
+        std::env::var("CAMELID_PARITY_FIXTURE").unwrap_or_else(|_| "frozen-fixture".into());
 
     let cpu = read_tokens(&cpu_path);
     let cuda = read_tokens(&cuda_path);

--- a/tests/phi3_smoke.rs
+++ b/tests/phi3_smoke.rs
@@ -3,15 +3,15 @@
 //! validated here by running greedy decode and checking the output is coherent
 //! (not NaN/garbage/repetition). Run with `--release`. Skips if absent.
 
-use std::path::Path;
 use camelid::gguf::read_metadata;
 use camelid::runnable::RunnableModel;
 use camelid::tokenizer::Tokenizer;
+use std::path::Path;
 
 #[test]
 fn phi3_greedy_is_coherent() {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("models/Phi-3-mini-4k-instruct-Q8_0.gguf");
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("models/Phi-3-mini-4k-instruct-Q8_0.gguf");
     if !path.exists() {
         eprintln!("SKIP: phi3 absent");
         return;
@@ -19,15 +19,27 @@ fn phi3_greedy_is_coherent() {
     let model = RunnableModel::load(path.to_str().unwrap()).expect("load");
     eprintln!(
         "loaded {} layers={} d_model={} heads={}/{} head_dim={} vocab={}",
-        model.architecture, model.n_layers, model.d_model, model.n_heads,
-        model.n_kv_heads, model.head_dim, model.vocab
+        model.architecture,
+        model.n_layers,
+        model.d_model,
+        model.n_heads,
+        model.n_kv_heads,
+        model.head_dim,
+        model.vocab
     );
     let tok = Tokenizer::from_gguf(&read_metadata(&path).unwrap()).expect("tok");
 
-    let prompt = tok.encode("The capital of France is", true, false).expect("encode");
+    let prompt = tok
+        .encode("The capital of France is", true, false)
+        .expect("encode");
     let logits = model.forward_logits(&prompt).expect("forward");
-    assert!(logits.iter().all(|v| v.is_finite()), "logits must be finite (no NaN/Inf)");
-    let (maxv, minv) = logits.iter().fold((f32::MIN, f32::MAX), |(mx, mn), &v| (mx.max(v), mn.min(v)));
+    assert!(
+        logits.iter().all(|v| v.is_finite()),
+        "logits must be finite (no NaN/Inf)"
+    );
+    let (maxv, minv) = logits
+        .iter()
+        .fold((f32::MIN, f32::MAX), |(mx, mn), &v| (mx.max(v), mn.min(v)));
     eprintln!("logit range = [{minv:.2}, {maxv:.2}]");
     assert!(maxv < 200.0 && minv > -200.0, "logit range must be sane");
 
@@ -38,5 +50,9 @@ fn phi3_greedy_is_coherent() {
 
     // Coherence: not a degenerate single-token repetition loop.
     let unique: std::collections::HashSet<_> = gen.iter().collect();
-    assert!(unique.len() >= 4, "greedy output is degenerate (only {} unique tokens)", unique.len());
+    assert!(
+        unique.len() >= 4,
+        "greedy output is degenerate (only {} unique tokens)",
+        unique.len()
+    );
 }

--- a/tests/runnable_admission.rs
+++ b/tests/runnable_admission.rs
@@ -62,10 +62,7 @@ fn dump_and_admit(filename: &str, expect_tokenizer: TokenizerFamily) {
 fn tinyllama_q8_parses_dumps_and_admits() {
     // Known-validated TinyLlama 1.1B Q8_0 — the spec's Gate 1 reference model.
     // SPM tokenizer (tokenizer.ggml.model = "llama").
-    dump_and_admit(
-        "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
-        TokenizerFamily::Spm,
-    );
+    dump_and_admit("tinyllama-1.1b-chat-v1.0.Q8_0.gguf", TokenizerFamily::Spm);
 }
 
 #[test]
@@ -106,7 +103,10 @@ fn diffusiongemma_real_file_is_refused() {
     eprintln!("contains an uncovered quant: {has_uncovered_quant}");
 
     let reject = admit(&file).expect_err("out-of-set model must be refused");
-    eprintln!("REFUSED: axis={:?} value={} :: {reject}", reject.axis, reject.offending_value);
+    eprintln!(
+        "REFUSED: axis={:?} value={} :: {reject}",
+        reject.axis, reject.offending_value
+    );
     assert_eq!(reject.axis, AdmissionAxis::Architecture);
     assert_eq!(reject.offending_value, arch.unwrap());
 }

--- a/tests/runnable_dequant.rs
+++ b/tests/runnable_dequant.rs
@@ -152,5 +152,8 @@ fn dequant_matches_ggml_reference() {
         }
     }
 
-    assert!(!any_fail, "dequant parity failed; see per-format lines above");
+    assert!(
+        !any_fail,
+        "dequant parity failed; see per-format lines above"
+    );
 }

--- a/tests/runnable_forward.rs
+++ b/tests/runnable_forward.rs
@@ -71,9 +71,7 @@ fn produces_logits_and_greedy_tokens_end_to_end() {
 #[test]
 fn forward_is_bit_exact_deterministic() {
     let Some((model, tok)) = load() else { return };
-    let prompt = tok
-        .encode("Hello, world!", true, false)
-        .expect("encode");
+    let prompt = tok.encode("Hello, world!", true, false).expect("encode");
 
     // Same input, two runs -> bit-identical logits.
     let a = model.forward_logits(&prompt).expect("run a");

--- a/tests/runnable_parity.rs
+++ b/tests/runnable_parity.rs
@@ -44,7 +44,12 @@ fn ref_f32(bits: &[String]) -> Vec<f32> {
 
 #[test]
 fn llama_matches_hf_transformers_greedy() {
-    run_parity("tinyllama.json", "tinyllama-parity.json", "llama", "llama_spm");
+    run_parity(
+        "tinyllama.json",
+        "tinyllama-parity.json",
+        "llama",
+        "llama_spm",
+    );
 }
 
 #[test]
@@ -63,9 +68,7 @@ fn phi3_matches_hf_transformers_greedy() {
 }
 
 fn run_parity(fixture_file: &str, artifact_file: &str, arch: &str, tokenizer_kind: &str) {
-    let fx_path = repo()
-        .join("tests/fixtures/hf_parity")
-        .join(fixture_file);
+    let fx_path = repo().join("tests/fixtures/hf_parity").join(fixture_file);
     if !fx_path.exists() {
         eprintln!("SKIP: HF parity fixtures absent ({})", fx_path.display());
         return;
@@ -126,12 +129,13 @@ fn run_parity(fixture_file: &str, artifact_file: &str, arch: &str, tokenizer_kin
         }));
     }
 
-    eprintln!(
-        "  ALL greedy match = {all_match}   max logit_abs_diff = {max_logit_abs_diff:.3e}"
-    );
+    eprintln!("  ALL greedy match = {all_match}   max logit_abs_diff = {max_logit_abs_diff:.3e}");
 
     // Parity artifact (lane=runnable), traceable to the exact GGUF bytes.
-    assert_eq!(model.architecture, arch, "fixture/model architecture mismatch");
+    assert_eq!(
+        model.architecture, arch,
+        "fixture/model architecture mismatch"
+    );
     let artifact = json!({
         "lane": "runnable",
         "architecture": model.architecture,


### PR DESCRIPTION
Run `cargo fmt --all` (rust 1.95.0 per rust-toolchain.toml) to green the CI `Format check` step, which was failing on pre-existing formatting debt across 19 files (already red on main before #284). Whitespace/layout only — semantics-preserving. Excludes the unrelated pre-existing `qa/runnable/smoke` change.

Note: this greens the Format check step; the rust job may then surface further pre-existing lint debt (e.g. a clippy `derivable_impls` in `shell_sandbox.rs`) behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)