### PR TITLE
chore: green the CI rust job (clippy allow + stale tokenizer test)

### DIFF
--- a/src/chat/shell_sandbox.rs
+++ b/src/chat/shell_sandbox.rs
@@ -46,6 +46,11 @@ pub enum ShellSandbox {
     Unrestricted,
 }
 
+// Kept as an explicit impl (not `#[derive(Default)]` + `#[default]`) so the secure
+// default is stated in code next to its rationale and cannot be silently flipped by a
+// future variant reorder — `Sandboxed` is the 2nd variant, so a plain derive would
+// default to `Disabled`.
+#[allow(clippy::derivable_impls)]
 impl Default for ShellSandbox {
     fn default() -> Self {
         // Secure by default: confinement on, fail closed where unenforceable.

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -2363,9 +2363,12 @@ async fn llama_server_tokenize_detokenize_aliases_use_loaded_tokenizer() {
     assert_eq!(response.status(), StatusCode::OK);
     let body: Value =
         serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    // `add_space_prefix=true` unconditionally prepends a space, so the already
+    // space-led " hello!" tokenizes with a leading double-space (id 6 twice).
     assert_eq!(
         body["tokens"].as_array().unwrap(),
         &[
+            serde_json::json!(6),
             serde_json::json!(6),
             serde_json::json!(4),
             serde_json::json!(5)
@@ -2390,6 +2393,7 @@ async fn llama_server_tokenize_detokenize_aliases_use_loaded_tokenizer() {
     assert_eq!(
         body["tokens"].as_array().unwrap(),
         &[
+            serde_json::json!({"id":6,"piece":" "}),
             serde_json::json!({"id":6,"piece":" "}),
             serde_json::json!({"id":4,"piece":"hello"}),
             serde_json::json!({"id":5,"piece":"!"})


### PR DESCRIPTION
Greens the remaining two steps of the CI `rust` job, both pre-existing failures that were hidden behind the red fmt gate (now fixed in #285) and unrelated to the batched-prefill work in #284:

- **Clippy** (`derivable_impls` on `ShellSandbox::default`): kept the explicit impl (`Sandboxed` is the 2nd variant, so a plain `#[derive(Default)]` would silently default to `Disabled`) and `#[allow]`-ed the lint, with a comment.
- **Tests** (`llama_server_tokenize_detokenize_aliases_use_loaded_tokenizer`): `add_space_prefix=true` unconditionally prepends a space, so the already space-led ` hello!` tokenizes to `[6,6,4,5]` ([space, space, hello, !]). The encode is correct (SentencePiece add-dummy-prefix); the test expectation was stale. Updated the plain + with_pieces assertions.

Verified locally: `cargo fmt --all --check` clean, `cargo clippy --all-targets` (default and `--all-features`) clean under `-D warnings`, the test passes, `cargo doc` clean. After this the rust job should be green on all three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)