### PR TITLE
chore: fix two Linux-only clippy lints (green the ubuntu rust job)

### DIFF
--- a/src/chat/shell_sandbox.rs
+++ b/src/chat/shell_sandbox.rs
@@ -325,7 +325,7 @@ mod linux {
                     if libc::chroot(root_c.as_ptr()) != 0 {
                         return Err(io::Error::last_os_error());
                     }
-                    if libc::chdir(b"/\0".as_ptr().cast()) != 0 {
+                    if libc::chdir(c"/".as_ptr()) != 0 {
                         return Err(io::Error::last_os_error());
                     }
                 } else {
@@ -511,6 +511,6 @@ mod tests {
         if let Some(code) = status.code() {
             assert_eq!(code, 0, "raw socket creation was NOT blocked by seccomp");
         }
-        let _ = (&mut std::io::stdout()).flush();
+        let _ = std::io::stdout().flush();
     }
 }


### PR DESCRIPTION
Fixes the two remaining Linux-only clippy lints in `shell_sandbox.rs` seccomp code that fail the ubuntu `--all-features` clippy job (macos + windows rust jobs already green at e291e7c2). Both are clippy's own suggested rewrites: `b"/\0".as_ptr().cast()` -> `c"/".as_ptr()` and `(&mut std::io::stdout()).flush()` -> `std::io::stdout().flush()`. Verified fmt + parse locally; Linux build verified by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)