### PR TITLE
fix(ui): match exact compatibility row by name+quant (unlock chat for any load)

### DIFF
--- a/frontend/src/lib/capabilities.js
+++ b/frontend/src/lib/capabilities.js
@@ -561,7 +561,7 @@ export function getTrackedCompatibilityTargets(capabilities, ids = TRACKED_FULL_
 }
 
 function getModelCapabilityFields(model, catalogItem) {
-  return [
+  const fields = [
     model?.id,
     model?.runtime_model_name,
     model?.name,
@@ -571,7 +571,32 @@ function getModelCapabilityFields(model, catalogItem) {
     catalogItem?.name,
     catalogItem?.repo_id,
     catalogItem?.filename,
-  ].filter(Boolean).map((value) => String(value))
+  ]
+  // Exact compatibility row ids concatenate the model name with its quant
+  // (e.g. "qwen3_4b_instruct_q8_0"). A model loaded outside the catalog — e.g. via
+  // `--model` at startup — exposes its GGUF name ("Qwen3 4B Instruct") and its quant
+  // ("Q8_0", carried in the filename/path) as SEPARATE fields, so neither matches the
+  // row id alone: chat then falls back to a non-exact family match and stays gated for
+  // every such model. Append name+quant combinations so the exact-row identity match
+  // resolves for any model regardless of how it was loaded. Use the RAW quant token
+  // (e.g. "Q8_0") rather than the capability-normalized key ("Q80", underscore
+  // stripped) so the combined string reproduces the row id exactly under
+  // normalizeExactRowIdentity. Additive only — never removes an existing candidate.
+  const quantPattern = /\b(q\d(?:_k_[ms]|_\d)?|iq\d[a-z0-9_]*|bf16|f16|f32)\b/i
+  const rawQuant =
+    [model?.quant, catalogItem?.quant]
+      .map((value) => (typeof value === 'string' ? value.match(quantPattern)?.[1] : null))
+      .find(Boolean)
+    || [model?.model_path, model?.path, model?.hf_filename, catalogItem?.filename]
+      .filter(Boolean)
+      .join(' ')
+      .match(quantPattern)?.[1]
+  if (rawQuant) {
+    for (const name of [model?.runtime_model_name, model?.name, model?.id, catalogItem?.name]) {
+      if (name) fields.push(`${name} ${rawQuant}`)
+    }
+  }
+  return fields.filter(Boolean).map((value) => String(value))
 }
 
 function getModelCapabilitySubject(model, catalogItem) {


### PR DESCRIPTION
The chat gate requires the loaded model to match an EXACT /api/capabilities compatibility row. Row ids concatenate name+quant (`qwen3_4b_instruct_q8_0`), but a model loaded via `--model` at startup exposes its GGUF name (`Qwen3 4B Instruct`) and quant (`Q8_0`, in the path) as separate fields — neither matches alone, so the match fell to a non-exact family hint and chat stayed gated (amber "support gated") for **every** such model, despite the backend reporting it supported and generation working.

`getModelCapabilityFields` now also emits name+quant combinations, using the RAW quant token (parsed from the record or filename/path) so the combined string reproduces the row id under `normalizeExactRowIdentity`. Additive only.

Verified against live `/api/capabilities`: Qwen3 0.6B/1.7B/4B/8B and Llama 3.2 1B/3B each resolve to their own exact row; unsupported rows (Q4_0 / 14B / made-up) correctly stay gated. Pre-existing UI bug, independent of the prefill/decode work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)