### PR TITLE
perf(cuda): widen n-gram speculative verify batch (MAX_VERIFY_K 4→8) + tune default draft count

### DIFF
--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -837,13 +837,22 @@ fn launch_gemm_batched(
     k_tokens: usize,
     out: &mut CudaSlice<f32>,
 ) -> Result<(), cudarc::driver::DriverError> {
-    let block = 256u32;
-    let warps_per_block = block / 32;
+    // Each warp computes one output row; warps_per_block only sets how many rows a
+    // block handles, so it never changes the per-row block-order reduction (the
+    // result is bit-identical for any warps_per_block). Cap it so the
+    // [warp][token][block] ordered-sum scratch fits the 48 KiB default shared-mem
+    // limit — necessary once K grows (e.g. K=8, blocks_per_row=256 needs 6 warps,
+    // not the historic 8). Use a 46 KiB budget for headroom. The K=4 / small-row
+    // cases keep the full 8 warps/block (unchanged from before).
+    const SHARED_BUDGET: u32 = 46 * 1024;
+    let per_warp_bytes = (k_tokens as u32) * (blocks_per_row as u32) * 4;
+    let warps_per_block = (SHARED_BUDGET / per_warp_bytes.max(1)).clamp(1, 8);
+    let block = warps_per_block * 32;
     let cfg = LaunchConfig {
         grid_dim: ((rows as u32).div_ceil(warps_per_block), 1, 1),
         block_dim: (block, 1, 1),
         // [warp][token][block] ordered-sum scratch.
-        shared_mem_bytes: warps_per_block * (k_tokens as u32) * (blocks_per_row as u32) * 4,
+        shared_mem_bytes: warps_per_block * per_warp_bytes,
     };
     let (r, bpr, kt) = (rows as i32, blocks_per_row as i32, k_tokens as i32);
     let mut b = s.launch_builder(f);
@@ -1411,9 +1420,15 @@ pub struct CudaResidentDecode {
 }
 
 /// Max tokens verified per speculative round. The batched GEMM keeps the ordered
-/// per-(token,block) sum in shared memory, so `MAX_VERIFY_K * blocks_per_row *
-/// warps_per_block * 4` must fit (4 * 256 * 8 * 4 = 32 KiB for the 1B/3B FFN).
-pub(crate) const MAX_VERIFY_K: usize = 4;
+/// per-(token,block) sum in shared memory (`k * blocks_per_row * warps_per_block *
+/// 4` bytes). At K=8 the 3B FFN (blocks_per_row=256) would need 64 KiB at the
+/// historic 8 warps/block, past the 48 KiB default shared-mem limit, so
+/// `launch_gemm_batched` now caps warps/block to fit the budget (warps map to
+/// output rows, so fewer-warps-per-block changes only the grid shape, never the
+/// per-row block-order reduction — the result stays bit-identical). A larger K
+/// lets each weight read verify more drafts per round, raising the ceiling on
+/// repetitive/structured output where n-gram acceptance is high.
+pub(crate) const MAX_VERIFY_K: usize = 8;
 
 /// K-batched scratch buffers for `verify_batch`, sized `MAX_VERIFY_K * dim`.
 struct VerifyScratch {

--- a/src/inference/speculative.rs
+++ b/src/inference/speculative.rs
@@ -24,9 +24,15 @@
 use crate::inference::{LlamaInferenceSession, LlamaSampler};
 use crate::Result;
 
-/// Default drafted tokens per round for the n-gram drafter. Drafts are nearly
-/// free here, so a longer window is cheap; misses cost one wasted verify row.
-pub const DEFAULT_NGRAM_DRAFT_TOKENS: usize = 8;
+/// Default drafted tokens per round for the n-gram drafter. The n-gram lookup
+/// itself is nearly free, but each extra draft widens the batched verify GEMM, so
+/// over-drafting wastes work on partial-acceptance text (code, prose) without
+/// helping. Measured on a 3B Q8_0 GPU resident decode (RTX 3060): a draft count of
+/// 5 (verify batch k=6) sits at the sweet spot — within ~1% of the maximum
+/// repetitive-text speedup (~2.55x) while giving the best result on moderately
+/// repetitive code (~1.20x), where 7 drafts regress to ~1.09x. Bounded by
+/// `cuda_resident::MAX_VERIFY_K - 1`.
+pub const DEFAULT_NGRAM_DRAFT_TOKENS: usize = 5;
 
 /// Default drafted tokens per round for the draft-model drafter. Each draft
 /// token costs a sequential forward through the draft model, so the window


### PR DESCRIPTION
## What
GPU n-gram speculative decode batch-verifies `[last, drafts...]` in one resident forward, so a single weight read can emit several tokens. The verify batch was capped at `MAX_VERIFY_K=4`, clamping the n-gram drafter to 3 drafts/round and leaving throughput on the table for repetitive/structured output.

This PR widens the batch and tunes the default draft count to the measured sweet spot.

## Changes
- **`cuda_resident.rs`: `MAX_VERIFY_K` 4 → 8.** At K=8 the 3B FFN (blocks_per_row=256) would need 64 KiB shared mem at the historic 8 warps/block (> 48 KiB default limit), so `launch_gemm_batched` now caps `warps_per_block` to a 46 KiB budget. **Bit-identical by construction**: each warp computes one output row, so `warps_per_block` changes only the grid shape, never the per-row block-order reduction (the K=4 / small-row cases keep the full 8 warps, byte-unchanged). `q8_gemm_batched` is the only K-multiplied shared-mem kernel; `attention_batched` scales with sequence position, not K.
- **`speculative.rs`: `DEFAULT_NGRAM_DRAFT_TOKENS` 8 → 5.** A runtime draft-count sweep on Llama-3.2-3B Q8_0 (RTX 3060) found nd=5 (verify k=6) is the sweet spot.

## Measured (Llama-3.2-3B-Instruct Q8_0, GPU resident decode, baseline ~53 tok/s)
| Workload | Before (K=4) | After | Lossless |
|---|---|---|---|
| Repetitive | 2.29× | **2.58×** | ✓ |
| Code | 1.19× | **1.20×** | ✓ |
| Prose / Q&A | 0.99× | 0.99× (no regression) | ✓ |

Draft-count sweep showed nd=7 over-drafts and *regresses* code to 1.09×, hence the default of 5.

## Lossless / parity
`verify_batch` stays bit-identical to K sequential `forward_token` calls — every measured output was **token-identical to the non-spec baseline**.

## Gates
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --features cuda -- -D warnings` ✓
- `cargo test --features cuda --lib` (cuda_resident + execution_plan + inference) ✓
- `verify_batch_matches_sequential` GPU device test (`--ignored`, on RTX 3060) ✓
- speculative lib tests (default features) ✓

## Notes
Spec decode remains opt-in (`--spec-decode ngram` / `CAMELID_SPEC_NGRAM`) and greedy-only; no support claim or ledger change. Follow-up headroom: an *adaptive draft count* (the code already adapts n-gram length by acceptance EMA, not the count) would allow an even larger cap without the partial-acceptance waste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)