### PR TITLE
ci(windows): sign release binary and bundle NVRTC for self-contained GPU

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: write
 
+env:
+  # Any CUDA 12.x works: the NVRTC soname (nvrtc64_120_0.dll) is stable across the
+  # 12.x series and cudarc is pinned to the 12.x ABI (`cuda-12090`). The matching
+  # nvrtc-builtins ship in the same component, so the pair is always self-consistent.
+  CUDA_VERSION: '12.9.1'
+
 jobs:
   build:
     strategy:
@@ -73,8 +79,113 @@ jobs:
             camelid-${{ matrix.label }}.tar.gz
             camelid-${{ matrix.label }}.tar.gz.sha256
 
+  # Windows is built separately: its packaging differs from the unix matrix above
+  # because a self-contained Windows download must ship the NVRTC redistributable
+  # DLLs beside the exe (CUDA is the default Windows build; cudarc dynamic-loads,
+  # so no CUDA SDK is needed to compile — the toolkit below is only the source of
+  # those DLLs). Result: a user with only the NVIDIA driver gets GPU acceleration.
+  build-windows:
+    runs-on: windows-latest
+    # `environment: release` lets the Azure app registration use ONE federated
+    # credential (subject `repo:<owner>/<repo>:environment:release`) for every
+    # tagged release — GitHub OIDC subjects for tags are per-tag and can't be
+    # wildcarded, so an environment is the stable subject to bind the credential to.
+    environment: release
+    permissions:
+      id-token: write # mint the OIDC token for azure/login
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build web UI
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.87.0
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --locked --bin camelid
+
+      # windows-latest has no CUDA Toolkit; install just the NVRTC runtime
+      # component to source the redistributable DLLs (sets CUDA_PATH for packaging).
+      - name: Install CUDA NVRTC (packaging source)
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: ${{ env.CUDA_VERSION }}
+          method: network
+          sub-packages: '["nvrtc"]'
+
+      - name: Stage release files
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dist = 'camelid-windows-x64'
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+          Copy-Item target/release/camelid.exe $dist -Force
+          Copy-Item README.md, LICENSE, THIRD_PARTY_NOTICES.md $dist -Force
+          # Stage the NVRTC redistributables beside the exe (auto-detects the
+          # toolkit via the CUDA_PATH set by the step above).
+          ./scripts/package-windows-cuda.ps1 -OutDir $dist
+
+      # OIDC sign-in: no stored client secret. Needs the job's `id-token: write`
+      # permission above and a federated credential on the app registration whose
+      # subject is `repo:<owner>/<repo>:environment:release`.
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # Authenticode-sign camelid.exe so Windows shows your verified publisher and
+      # SmartScreen reputation can accrue. Only the exe is signed — the NVIDIA NVRTC
+      # DLLs are already NVIDIA-signed. Signs the staged copy BEFORE it is zipped.
+      # Set the three SIGNING_* repo variables once identity validation completes.
+      - name: Sign camelid.exe (Azure Artifact Signing)
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.SIGNING_ENDPOINT }} # e.g. https://wus2.codesigning.azure.net/
+          signing-account-name: ${{ vars.SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.SIGNING_PROFILE }}
+          files-folder: ${{ github.workspace }}\camelid-windows-x64
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Package zip + checksum
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dist = 'camelid-windows-x64'
+          Compress-Archive -Path "$dist/*" -DestinationPath "$dist.zip" -Force
+          $hash = (Get-FileHash -Algorithm SHA256 "$dist.zip").Hash.ToLower()
+          "$hash  $dist.zip" | Out-File -Encoding ascii -NoNewline "$dist.zip.sha256"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: camelid-windows-x64
+          path: |
+            camelid-windows-x64.zip
+            camelid-windows-x64.zip.sha256
+
   release:
-    needs: build
+    needs: [build, build-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Third-Party Notices
 
-Last updated: 2026-05-01
+Last updated: 2026-06-18
 
 ## Scope note
 
@@ -44,6 +44,26 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+
+### NVIDIA CUDA NVRTC runtime (prebuilt Windows GPU release)
+
+Camelid's prebuilt Windows release bundles the NVIDIA CUDA NVRTC runtime-compilation
+redistributable libraries (`nvrtc64_*.dll` and `nvrtc-builtins64_*.dll`) alongside the
+executable, so the GPU path works on a host that has only the NVIDIA display driver
+installed (no CUDA Toolkit). These libraries are NVIDIA's own work, are shipped
+unmodified, and are not part of Camelid. They are redistributed under the NVIDIA CUDA
+Toolkit End User License Agreement, which lists NVRTC among its redistributable
+components. The CUDA driver itself (`nvcuda.dll`) is **not** redistributed — it is
+provided by the user's installed NVIDIA GPU driver.
+
+This notice and the bundled libraries apply only to the prebuilt Windows download;
+building Camelid from source pulls no NVIDIA libraries (the CUDA runtime is loaded
+dynamically at runtime when present).
+
+- Product: NVIDIA CUDA NVRTC (runtime compilation library), a component of the NVIDIA CUDA Toolkit
+- Source: <https://developer.nvidia.com/cuda-toolkit>
+- License: NVIDIA CUDA Toolkit EULA — redistributable components (see Attachment A)
+- License text: <https://docs.nvidia.com/cuda/eula/index.html>
 
 ## Maintenance note
 

--- a/scripts/package-windows-cuda.ps1
+++ b/scripts/package-windows-cuda.ps1
@@ -1,0 +1,115 @@
+#requires -version 5
+<#
+.SYNOPSIS
+    Stage the NVRTC redistributable DLLs next to camelid.exe so a downloaded
+    Windows release runs on the GPU with only the NVIDIA *driver* installed
+    (no CUDA Toolkit required on the end-user's machine).
+
+.DESCRIPTION
+    camelid links cudarc with `fallback-dynamic-loading`, so it loads the CUDA
+    driver (nvcuda.dll, shipped with the GPU driver) and the NVRTC runtime
+    compiler dynamically at startup. The resident decode engine compiles its
+    kernels at runtime via NVRTC -- and NVRTC ships with the CUDA *Toolkit*, not
+    the driver. Without it, the GPU is detected but the kernel compile fails and
+    inference silently falls back to the CPU.
+
+    This script copies the NVRTC redistributables from an installed CUDA Toolkit
+    into the release directory next to camelid.exe. At launch,
+    `ensure_cuda_runtime_on_path()` (src/main.rs) puts the exe's own directory on
+    PATH first, so the shipped pair is found before any system toolkit.
+
+    The CUDA *driver* (nvcuda.dll) is NOT redistributable and is NOT copied -- it
+    is provided by the user's NVIDIA GPU driver, which any GeForce/RTX user has.
+
+.PARAMETER OutDir
+    Directory to stage the DLLs into (the folder that holds camelid.exe).
+    Defaults to <repo>/dist/Camelid.
+
+.PARAMETER CudaBin
+    CUDA Toolkit `bin` directory to copy from. Auto-detected from CUDA_PATH* and
+    the standard install root when omitted.
+
+.EXAMPLE
+    pwsh scripts/package-windows-cuda.ps1
+    pwsh scripts/package-windows-cuda.ps1 -OutDir C:\release\Camelid
+#>
+param(
+    [string]$OutDir,
+    [string]$CudaBin
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Repo root is the parent of this script's scripts/ directory.
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if (-not $OutDir) { $OutDir = Join-Path $repoRoot 'dist\Camelid' }
+
+# --- Locate the CUDA Toolkit bin directory ------------------------------------
+function Find-CudaBin {
+    # 1. Explicit CUDA_PATH / CUDA_PATH_V* environment variables.
+    $envPaths = Get-ChildItem Env: |
+        Where-Object { $_.Name -eq 'CUDA_PATH' -or $_.Name -like 'CUDA_PATH_V*' } |
+        ForEach-Object { Join-Path $_.Value 'bin' } |
+        Where-Object { Test-Path $_ }
+    if ($envPaths) { return ($envPaths | Select-Object -First 1) }
+
+    # 2. Standard install root: pick the newest vXX.Y\bin.
+    $root = 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA'
+    if (Test-Path $root) {
+        $newest = Get-ChildItem $root -Directory |
+            Sort-Object Name -Descending |
+            ForEach-Object { Join-Path $_.FullName 'bin' } |
+            Where-Object { Test-Path $_ } |
+            Select-Object -First 1
+        if ($newest) { return $newest }
+    }
+    return $null
+}
+
+if (-not $CudaBin) { $CudaBin = Find-CudaBin }
+if (-not $CudaBin -or -not (Test-Path $CudaBin)) {
+    Write-Error "Could not locate a CUDA Toolkit 'bin' directory. Install the CUDA Toolkit (>= 12.x) or pass -CudaBin <path>."
+}
+Write-Host "CUDA bin:  $CudaBin"
+
+# --- Resolve the NVRTC redistributable DLLs -----------------------------------
+# nvrtc64_*.dll      -> the runtime compiler (e.g. nvrtc64_120_0.dll [+ .alt])
+# nvrtc-builtins64_* -> its required builtins (e.g. nvrtc-builtins64_129.dll)
+$patterns = @('nvrtc64_*.dll', 'nvrtc-builtins64_*.dll')
+$dlls = foreach ($p in $patterns) {
+    $matches = Get-ChildItem -Path (Join-Path $CudaBin $p) -ErrorAction SilentlyContinue
+    if (-not $matches) {
+        Write-Warning "No files matched '$p' in $CudaBin"
+    }
+    $matches
+}
+$dlls = $dlls | Where-Object { $_ } | Sort-Object FullName -Unique
+if (-not $dlls) {
+    Write-Error "Found no NVRTC DLLs in $CudaBin -- nothing to package."
+}
+
+# --- Stage into the release directory -----------------------------------------
+if (-not (Test-Path $OutDir)) {
+    New-Item -ItemType Directory -Path $OutDir | Out-Null
+}
+$OutDir = (Resolve-Path $OutDir).Path
+Write-Host "Staging to: $OutDir`n"
+
+foreach ($dll in $dlls) {
+    Copy-Item -LiteralPath $dll.FullName -Destination $OutDir -Force
+    $mb = '{0:N1}' -f ($dll.Length / 1MB)
+    Write-Host ("  + {0,-32} {1,6} MB" -f $dll.Name, $mb)
+}
+
+# --- Sanity check: warn if the exe is missing or the core pair is incomplete ---
+$exe = Join-Path $OutDir 'camelid.exe'
+if (-not (Test-Path $exe)) {
+    Write-Warning "camelid.exe not found in $OutDir -- build it (cargo build --release --bin camelid) and place it here so the shipped NVRTC is loaded from the exe directory."
+}
+$haveNvrtc    = Get-ChildItem (Join-Path $OutDir 'nvrtc64_*.dll') -ErrorAction SilentlyContinue
+$haveBuiltins = Get-ChildItem (Join-Path $OutDir 'nvrtc-builtins64_*.dll') -ErrorAction SilentlyContinue
+if (-not $haveNvrtc -or -not $haveBuiltins) {
+    Write-Warning "NVRTC pair incomplete in $OutDir (need both nvrtc64_*.dll and nvrtc-builtins64_*.dll) -- the GPU path will fall back to CPU."
+} else {
+    Write-Host "`nDone. The release in $OutDir is self-contained: a user with only the NVIDIA driver gets GPU acceleration."
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,15 +113,33 @@ fn auto_select_model() -> Option<PathBuf> {
 }
 
 /// Windows + CUDA: make the NVIDIA runtime DLLs (NVRTC etc.) loadable without the
-/// user having to add the CUDA `bin` directory to PATH. Locates the installed
-/// toolkit (via `CUDA_PATH*` or the standard install root) and prepends its `bin`
-/// to the process PATH before any GPU code runs, so the shipped app finds the GPU
-/// on its own. No-op if the toolkit is absent (the engine then falls back to CPU).
+/// user having to add the CUDA `bin` directory to PATH. Looks in two places, in
+/// priority order: (1) the running exe's OWN directory, so a self-contained
+/// download that ships the NVRTC redistributable DLLs beside `camelid.exe` runs
+/// on the GPU with only the NVIDIA *driver* installed (no CUDA toolkit); and
+/// (2) an installed toolkit (via `CUDA_PATH*` or the standard install root). The
+/// matching `bin`/exe dirs are prepended to the process PATH before any GPU code
+/// runs. No-op if neither is present (the engine then falls back to CPU).
 #[cfg(all(windows, feature = "cuda"))]
 fn ensure_cuda_runtime_on_path() {
     use std::path::{Path, PathBuf};
 
     let mut candidates: Vec<PathBuf> = Vec::new();
+    // The exe's own directory goes FIRST so a shipped, version-matched NVRTC pair
+    // (staged by scripts/package-windows-cuda.ps1) wins over any — possibly
+    // mismatched — system-installed toolkit. Windows already searches the exe dir
+    // for `LoadLibrary`, but adding it to PATH explicitly is robust against
+    // altered DLL search policies and makes the self-contained path intentional.
+    // Only add it when NVRTC is actually present, to avoid polluting PATH (e.g. a
+    // dev build under target/debug, where the DLLs are not staged).
+    if let Some(dir) = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(Path::to_path_buf))
+    {
+        if dir_has_nvrtc(&dir) {
+            candidates.push(dir);
+        }
+    }
     for (key, value) in std::env::vars_os() {
         let key = key.to_string_lossy();
         if key == "CUDA_PATH" || key.starts_with("CUDA_PATH_V") {
@@ -163,6 +181,22 @@ fn ensure_cuda_runtime_on_path() {
     }
     prefix.push(current);
     std::env::set_var("PATH", prefix);
+}
+
+/// Whether `dir` contains an NVRTC runtime DLL (`nvrtc64_*.dll`). Used to decide
+/// if the exe's own directory carries a shipped, self-contained CUDA runtime.
+#[cfg(all(windows, feature = "cuda"))]
+fn dir_has_nvrtc(dir: &std::path::Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_string_lossy()
+            .to_ascii_lowercase()
+            .starts_with("nvrtc64_")
+    })
 }
 
 #[cfg(not(all(windows, feature = "cuda")))]


### PR DESCRIPTION
## What

Adds a Windows release pipeline that produces a **self-contained, code-signed** download: the binary runs on the GPU with only the NVIDIA driver installed (no CUDA Toolkit), and `camelid.exe` is Authenticode-signed so Windows shows a verified publisher.

## Why

CUDA is the default Windows build (cudarc dynamic-loads), but the GPU path compiles its kernels at runtime via **NVRTC**, which ships with the CUDA *Toolkit* — not the driver. Without it, a 4070/3060 user with just the driver gets silent CPU fallback. Bundling the NVRTC redistributable beside the exe fixes that. Signing removes the "Unknown publisher" / SmartScreen friction on download.

## Changes

- **`.github/workflows/release.yml`** — new `build-windows` job: build frontend + `cargo build --release --bin camelid`, install the NVRTC redistributable (`Jimver/cuda-toolkit`, `nvrtc` sub-package only), stage it beside the exe, then OIDC-login to Azure (`azure/login@v3`) and sign the exe (`azure/artifact-signing-action@v2`) **before** zipping. Wired into the existing release publish job.
- **`scripts/package-windows-cuda.ps1`** — stages `nvrtc64_*.dll` + `nvrtc-builtins64_*.dll` next to `camelid.exe` from an installed CUDA Toolkit (auto-detected via `CUDA_PATH`).
- **`src/main.rs`** — `ensure_cuda_runtime_on_path()` now checks the exe's own directory first, so a shipped NVRTC pair loads with no toolkit on the host.
- **`THIRD_PARTY_NOTICES.md`** — NVIDIA CUDA NVRTC redistribution notice (NVRTC ships under the CUDA Toolkit EULA).

## Signing infra (already provisioned, OIDC — no stored secret)

GitHub `release` environment + `AZURE_*` secrets and `SIGNING_*` variables are configured; Azure Artifact Signing account/profile + federated credential are live. Only the exe is signed (NVIDIA's DLLs are already NVIDIA-signed).

## Notes

- The driver (`nvcuda.dll`) is **not** redistributed — it comes from the user's GPU driver.
- SmartScreen reputation still accrues with download volume; signing is necessary but not an instant bypass.
- Triggered by a `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
