### PR TITLE
test(ci): fix masked frontend smoke + api error-code checks (green main)

### DIFF
--- a/frontend/scripts/frontend-3b-closure-smoke.mjs
+++ b/frontend/scripts/frontend-3b-closure-smoke.mjs
@@ -285,7 +285,7 @@ assert.match(hookSource, /const quantLabel = active \? getLoadedModelQuantLabel\
 assert.match(loadedModelDisplaySource, /ggufFileTypeValueFromLabel[\s\S]*quantLabelFromGgufFileType[\s\S]*LLAMA32_3B_ACCEPTANCE_FILENAME[\s\S]*normalizeQuantLabel\(quantLabel\) === 'Q8_0'/, 'backend 3B display aliasing must stay exact-filename plus decoded Q8_0/file_type 7 gated')
 assert.match(hookSource, /resolveLoadedModelDisplayName/, 'dashboard model merge must use the shared exact-filename plus Q8_0 loaded-model display gate')
 assert.match(chatSource, /runnableModels\s*=\s*models\.filter\(\(model\) => getChatGateState\(capabilities, model, runtime\)\.chatUnlocked\)/, 'chat model picker must list only exact-row unlocked models')
-assert.match(chatSource, /canSubmit\s*=\s*Boolean\(composer\.trim\(\)\) && selectedModelRunnable && !generationActive/, 'composer send button must be blocked unless the exact-row chat gate unlocked')
+assert.match(chatSource, /canSubmit\s*=\s*Boolean\(composer\.trim\(\)\) && canChat && !generationActive/, 'composer send button must be blocked unless the chat gate (supported exact row or experimental lane) unlocked')
 assert.match(chatSource, /runtimeStatusCopy[\s\S]*loaded now and generation_ready=true/, 'chat readiness copy must name the runtime readiness requirement')
 assert.match(chatSource, /supportStatusCopy[\s\S]*COMPATIBILITY\.md and \/api\/capabilities agree/, 'chat readiness copy must name the support-contract requirement')
 assert.match(chatSource, /selectedRuntimeReady\s*=\s*selectedChatGate\.runtimeReady/, 'live 3B chat readiness must use the shared exact-row gate instead of stale browser runtime fields')

--- a/frontend/scripts/model-state-smoke.mjs
+++ b/frontend/scripts/model-state-smoke.mjs
@@ -386,6 +386,7 @@ assert.deepEqual(
     runtimeGenerationReady: true,
     contractSupported: true,
     chatUnlocked: true,
+    experimentalUnlocked: false,
     chatMode: 'supported',
     label: 'llama32_1b_instruct_q8_0: supported exact row smoke',
     copy: compatibilityHintCopy(llama32OneBHint),

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -3801,7 +3801,7 @@ async fn load_model_rejects_truncated_weight_payload() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let body: Value =
         serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
-    assert_eq!(body["error"]["code"], "invalid_model");
+    assert_eq!(body["error"]["code"], "invalid_gguf");
     assert!(body["error"]["message"]
         .as_str()
         .unwrap()


### PR DESCRIPTION
## What

Fixes the two red checks on `main` so CI goes green again.

## Root cause

The "experimental HF model lane" merge changed two contracts, but the assertions that guard them were **masked** — they live in steps that run *after* an earlier failing step in the same job, so CI stopped before reaching them. Once the first failure is fixed they surface, so both are addressed here.

## Changes (test/smoke expectations only — no production code change)

- **`tests/api_vertical_slice.rs`** — `load_model_rejects_truncated_weight_payload`: a truncated GGUF payload now maps to the more specific `BackendError::InvalidGguf` → `"invalid_gguf"` (the merge added that variant) instead of the generic `"invalid_model"` fallback. Expectation updated; the error-message assertion is unchanged.
- **`frontend/scripts/model-state-smoke.mjs`** — `getChatGateState` now returns an `experimentalUnlocked` field (`false` for supported exact rows). Added it to the snapshot.
- **`frontend/scripts/frontend-3b-closure-smoke.mjs`** — the composer send gate broadened from `selectedModelRunnable` to `canChat` (= supported exact row **or** experimental lane). Updated the regex to match the intended gate.

## Verification (local)

- `cargo test --test api_vertical_slice load_model_rejects_truncated_weight_payload` → ok
- `npm run smoke:model-state`, `smoke:3b-closure`, `smoke:integration` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
