### PR TITLE
fix(ui): replace hardcoded "Hi Tim" hero greeting with a generic welcome

### DIFF
--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -188,7 +188,7 @@ export default function ChatWorkspace({
       : selectedModelIssue || selectedModelReadinessCopy
     : 'Choose a model before starting a Camelid chat.'
 
-  const productHeroTitle = selectedModelRunnable ? 'How can I help?' : "Hi Tim, let's get into it"
+  const productHeroTitle = selectedModelRunnable ? 'How can I help?' : "Hi there, let's get into it"
   const productHeroSummary = selectedModelRunnable
     ? 'Local chat is ready. Ask anything — responses stay grounded in the loaded model.'
     : apiUnavailable


### PR DESCRIPTION
The chat hero title was hardcoded to a personal name (`"Hi Tim, let's get into it"` in `ChatWorkspace.jsx`), so every downloaded build greeted all users by that name. Replaced with a neutral `"Hi there, let's get into it"`.\n\nFound while testing the packaged Windows release end-to-end. No smoke test pinned the string.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)