### PR TITLE
feat(ui): show Supported models before the Hugging Face catalog

### DIFF
--- a/frontend/src/views/ModelsView.jsx
+++ b/frontend/src/views/ModelsView.jsx
@@ -565,6 +565,14 @@ export default function ModelsView({
         capabilities={capabilities}
         refreshKey={localRefreshKey}
       />
+      <SupportedModels
+        models={models}
+        runtime={runtime}
+        installCatalogModel={installCatalogModel}
+        cancelModelDownload={cancelModelDownload}
+        activateModel={activateModel}
+        loadingModelId={loadingModelId}
+      />
       <CatalogLaneBrowse
         apiBase={catalogApiBase || apiBase}
         capabilities={capabilities}
@@ -644,15 +652,6 @@ export default function ModelsView({
           </button>
         </div>
       </div>
-
-      <SupportedModels
-        models={models}
-        runtime={runtime}
-        installCatalogModel={installCatalogModel}
-        cancelModelDownload={cancelModelDownload}
-        activateModel={activateModel}
-        loadingModelId={loadingModelId}
-      />
 
       <section className="models-status-grid" aria-label="Camelid runtime model readiness">
         <div className="cxv-card cxv-panel">


### PR DESCRIPTION
Moves the curated **Supported models** grid above the **Hugging Face catalog** browse on the models page, so the supported/runnable options appear first.

Pure reorder of existing components in `ModelsView.jsx` — no behavior change. Frontend builds clean; `smoke:model-state`, `smoke:3b-closure`, and `smoke:integration` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)