### PR TITLE
fix(models): real download progress + atomic completion (no instant-fake download)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camelid"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -552,21 +552,18 @@ export function useDashboardData({ showNotice, clearNotice }) {
                 status: newStatus,
                 bytes_downloaded: dl.bytes_downloaded,
                 total_bytes: dl.total_bytes,
-                progress,
+                progress: newStatus === 'registered' ? 100 : progress,
                 install_error: installError,
                 updated_at: nowIso(),
               }
             }
           } else {
-            // If the download has vanished from the active list without explicitly transitioning to failed,
-            // assume it completed successfully.
-            modelsUpdated = true
-            return {
-              ...model,
-              status: 'registered',
-              progress: 100,
-              updated_at: nowIso(),
-            }
+            // The download is not in the backend's active list. Do NOT assume it
+            // completed — a model is only marked ready when the backend reports
+            // status 'completed' (handled above). Leaving it 'downloading' avoids a
+            // premature "Downloaded"/loadable state when the list momentarily omits
+            // it (e.g. right after starting, or after a server restart).
+            return model
           }
         }
         return model

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13119,13 +13119,20 @@ async fn install_catalog_model(Json(req): Json<InstallCatalogRequest>) -> Respon
 
     std::fs::create_dir_all("models").ok();
     let dest_path = format!("models/{}", req.filename);
+    // Download into a `.part` file and only promote it to the final path once curl
+    // exits successfully. The loadable GGUF therefore never exists until the
+    // download is genuinely complete, so a half-downloaded model cannot be loaded.
+    let part_path = format!("{dest_path}.part");
     let url = format!(
         "https://huggingface.co/{}/resolve/main/{}",
         req.repo_id, req.filename
     );
 
+    // `-f` makes curl FAIL on an HTTP error (404/403/…) instead of writing the
+    // error page to the output file and exiting 0 — which previously looked like an
+    // instant successful download.
     match std::process::Command::new("curl")
-        .args(["-L", "-C", "-", "-o", &dest_path, &url])
+        .args(["-f", "-L", "-C", "-", "-o", &part_path, &url])
         .spawn()
     {
         Ok(child) => {
@@ -13142,17 +13149,22 @@ async fn install_catalog_model(Json(req): Json<InstallCatalogRequest>) -> Respon
             map.insert(req.catalog_id.clone(), download);
 
             let catalog_id_clone = req.catalog_id.clone();
+            let part_path_clone = part_path.clone();
+            let dest_path_clone = dest_path.clone();
             tokio::spawn(async move {
                 let mut child = child;
-                if let Ok(status) = child.wait() {
-                    let mut map = active_downloads_map().lock().unwrap();
-                    if let Some(dl) = map.get_mut(&catalog_id_clone) {
-                        if status.success() {
-                            dl.status = "completed";
-                        } else {
-                            dl.status = "failed";
-                        }
-                    }
+                let succeeded = matches!(child.wait(), Ok(status) if status.success());
+                // Completion is the curl exit code AND a successful promote of the
+                // .part file to the final path — never a size heuristic.
+                let promoted =
+                    succeeded && std::fs::rename(&part_path_clone, &dest_path_clone).is_ok();
+                if !promoted {
+                    // Leave nothing loadable behind on failure/cancel.
+                    std::fs::remove_file(&part_path_clone).ok();
+                }
+                let mut map = active_downloads_map().lock().unwrap();
+                if let Some(dl) = map.get_mut(&catalog_id_clone) {
+                    dl.status = if promoted { "completed" } else { "failed" };
                 }
             });
 
@@ -13175,12 +13187,13 @@ async fn get_catalog_downloads() -> Json<Vec<ActiveDownload>> {
             continue;
         }
 
-        let path = format!("models/{}", dl.filename);
-        if let Ok(metadata) = std::fs::metadata(&path) {
+        // Progress comes from the in-flight `.part` file. Completion is driven
+        // ONLY by curl's exit code (set in the spawn task above), never by a size
+        // comparison against the catalog's approximate `size_bytes`, which could
+        // flip a download to "completed" before it actually finished.
+        let part_path = format!("models/{}.part", dl.filename);
+        if let Ok(metadata) = std::fs::metadata(&part_path) {
             dl.bytes_downloaded = metadata.len();
-            if dl.bytes_downloaded >= dl.total_bytes {
-                dl.status = "completed";
-            }
         }
     }
 


### PR DESCRIPTION
## Bug
Clicking download on a model showed "downloaded" in ~1s without finishing, and a model could be loaded before its file was complete (confirmed on a clean machine).

## Root cause
- Backend ran `curl` **without `-f`**, so an HTTP error wrote an error page and curl exited 0 → looked like an instant success.
- Completion was inferred from a size comparison vs the catalog's approximate `size_bytes`.
- Frontend assumed a download missing from the active list had completed.

## Fix
- `curl -f` + download to `<name>.part`, renamed to the final `.gguf` only on success → **the loadable file never exists until the download is complete**, so a partial model can't be loaded.
- Completion driven solely by curl exit code.
- Frontend only marks a model ready on explicit backend `status=completed`.

## Tested (release binary, clean dir)
- **404 download** → `status=failed`, **nothing left on disk** (no instant fake "downloaded").
- **Real 640 MB download** → progress 5%→98%, only `.part` present mid-flight (final `.gguf` absent until done), then atomic completion to a 610 MB `.gguf`.

Bumps version to **0.1.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)