### PR TITLE
docs: remove TinyLlama verified-gate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![Language: Rust](https://img.shields.io/badge/language-Rust-orange.svg)
 ![Platform: macOS · Linux · Windows](https://img.shields.io/badge/platform-macOS%20·%20Linux%20·%20Windows-lightgrey.svg)
-![Verified gate: TinyLlama 1.1B Q8_0](https://img.shields.io/badge/verified%20gate-TinyLlama%201.1B%20Q8__0-success.svg)
 
 </div>
 


### PR DESCRIPTION
Removes the shields.io "verified gate: TinyLlama 1.1B Q8_0" badge from the README header per maintainer preference. The verified-gate status remains documented in the Supported models table ("Current verified gate"), so no support claim is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)