### PR TITLE
fix(api): serialize token generation to prevent concurrent-decode corruption

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -91,6 +91,14 @@ pub struct AppState {
     model_last_used: Arc<RwLock<HashMap<String, std::time::Instant>>>,
     cached_prompt_prefix: Arc<Mutex<Option<CachedPromptPrefix>>>,
     generation_sessions: Arc<RwLock<HashMap<String, GenerationSessionSummary>>>,
+    /// Serializes token generation across requests. The CUDA-resident Q8 runtime
+    /// keeps KV / decode state in GPU-resident buffers that are reached through
+    /// shared `Arc`s under read locks, so two decodes running at once clobber each
+    /// other's state — producing garbled "word-salad" output, non-deterministic
+    /// greedy decoding, and an intermittent out-of-bounds slice panic in the
+    /// worker. This lock is held for the full duration of every generation,
+    /// including the entire SSE stream, so only one decode is ever in flight.
+    generation_lock: Arc<tokio::sync::Mutex<()>>,
     planner_env: PlannerEnv,
     configured_threads: Option<usize>,
     /// Server-wide default for opt-in thinking mode (`serve --enable-thinking`).
@@ -111,6 +119,7 @@ impl Default for AppState {
             model_last_used: Arc::new(RwLock::new(HashMap::new())),
             cached_prompt_prefix: Arc::new(Mutex::new(None)),
             generation_sessions: Arc::new(RwLock::new(HashMap::new())),
+            generation_lock: Arc::new(tokio::sync::Mutex::new(())),
             planner_env: PlannerEnv::capture(),
             configured_threads: None,
             default_enable_thinking: false,
@@ -1897,6 +1906,9 @@ async fn llama_server_completion(
         unsupported_fields: req.unsupported_fields,
         default_max_tokens_cap: Some(DEFAULT_PUBLIC_CHAT_MAX_TOKENS),
     };
+    // Serialize generation so only one decode runs against the shared
+    // CUDA-resident KV state at a time (see AppState::generation_lock).
+    let _gen_guard = state.generation_lock.clone().lock_owned().await;
     let prepared = match prepare_generation(&state, req).await {
         Ok(prepared) => prepared,
         Err(response) => return response,
@@ -5089,14 +5101,19 @@ async fn completions(
         default_max_tokens_cap: None,
     };
     let stream = req.stream.unwrap_or(false);
+    // Serialize generation so only one decode runs against the shared
+    // CUDA-resident KV state at a time (see AppState::generation_lock).
+    let gen_guard = state.generation_lock.clone().lock_owned().await;
     let prepared = match prepare_generation(&state, req).await {
         Ok(prepared) => prepared,
         Err(response) => return response,
     };
     if stream {
-        return stream_completion(prepared, false);
+        return stream_completion(prepared, false, gen_guard);
     }
 
+    // Hold the generation lock until the non-streaming response is built.
+    let _gen_guard = gen_guard;
     let model_id = prepared.model_id.clone();
     let prompt_token_count = prepared.token_ids.len();
     let effective_max_tokens = prepared.max_tokens;
@@ -5242,14 +5259,19 @@ async fn chat_completions(
         default_max_tokens_cap: Some(DEFAULT_PUBLIC_CHAT_MAX_TOKENS),
     };
     let stream = req.stream.unwrap_or(false);
+    // Serialize generation so only one decode runs against the shared
+    // CUDA-resident KV state at a time (see AppState::generation_lock).
+    let gen_guard = state.generation_lock.clone().lock_owned().await;
     let prepared = match prepare_generation(&state, req).await {
         Ok(prepared) => prepared,
         Err(response) => return response,
     };
     if stream {
-        return stream_completion(prepared, true);
+        return stream_completion(prepared, true, gen_guard);
     }
 
+    // Hold the generation lock until the non-streaming response is built.
+    let _gen_guard = gen_guard;
     let model_id = prepared.model_id.clone();
     let prompt_token_count = prepared.token_ids.len();
     let effective_max_tokens = prepared.max_tokens;
@@ -7954,7 +7976,11 @@ fn stream_first_content_accounting_json(
     })
 }
 
-fn stream_completion(mut prepared: PreparedGeneration, chat: bool) -> Response {
+fn stream_completion(
+    mut prepared: PreparedGeneration,
+    chat: bool,
+    gen_guard: tokio::sync::OwnedMutexGuard<()>,
+) -> Response {
     // Speculation only runs in the non-streaming loop; streaming requests on
     // a spec-enabled server keep the unchanged vanilla path (including the
     // GPU-resident lanes the speculative pin would otherwise turn off).
@@ -7969,6 +7995,10 @@ fn stream_completion(mut prepared: PreparedGeneration, chat: bool) -> Response {
         format!("cmpl-{}", uuid::Uuid::new_v4())
     };
     let events = async_stream::stream! {
+        // Hold the generation lock for the entire stream so no other decode
+        // starts until this one finishes — or the client disconnects and the
+        // stream is dropped, releasing the guard. See AppState::generation_lock.
+        let _gen_guard = gen_guard;
         let stream_started = Instant::now();
         // Lifecycle telemetry for the streaming path. Dropping the stream
         // (client disconnect, error return) closes the run via the guard's
@@ -9342,6 +9372,50 @@ mod tests {
     };
 
     use super::*;
+
+    /// Regression test for the concurrent-decode corruption bug: the
+    /// CUDA-resident Q8 runtime shares decode / KV state across requests, so the
+    /// generation handlers (`completions`, `chat_completions`,
+    /// `llama_server_completion`) and `stream_completion` must hold
+    /// `AppState::generation_lock` for the whole decode. This verifies the lock
+    /// actually serializes — with many tasks acquiring it the way the handlers
+    /// do, never more than one is inside the critical section at a time.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn generation_lock_serializes_decoding() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let state = AppState::default();
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let lock = state.generation_lock.clone();
+            let active = active.clone();
+            let max_seen = max_seen.clone();
+            handles.push(tokio::spawn(async move {
+                // Same acquisition every generation handler performs per decode.
+                let _guard = lock.lock_owned().await;
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_seen.fetch_max(now, Ordering::SeqCst);
+                // Yield repeatedly while holding the guard. If the lock failed to
+                // serialize, another task would enter here and push `active` > 1.
+                for _ in 0..8 {
+                    tokio::task::yield_now().await;
+                }
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(
+            max_seen.load(Ordering::SeqCst),
+            1,
+            "generation_lock must serialize decoding: never more than one decode in flight",
+        );
+    }
 
     fn completion_request_with(
         prompt: Option<&str>,


### PR DESCRIPTION
Fixes #302.

## Problem

Concurrent generation requests corrupt each other's decode state. The CUDA-resident Q8 runtime keeps KV / decode state in GPU-resident buffers that are reached through shared `Arc`s under **read** locks, with no serialization of the decode itself. Two decodes running at once clobber that shared state, producing garbled "word-salad" output, non-deterministic greedy (`temperature: 0`) decoding, and an intermittent out-of-bounds slice panic in the worker (`range end index N out of range for slice of length N-128`, i.e. one attention head). Serving one request at a time is clean and deterministic even at long lengths; the corruption only appears under concurrency.

## Fix

Add `AppState::generation_lock` (an async `tokio::sync::Mutex<()>`) held for the **full duration of every generation, including the entire SSE stream**, so only one decode is ever in flight:

- Acquired at the top of `completions`, `chat_completions`, and `llama_server_completion`, before `prepare_generation`.
- Non-streaming responses hold the guard until the response is built.
- Streaming moves the `OwnedMutexGuard` into the `stream_completion` SSE generator, so it is released only when the stream finishes or the client disconnects (the stream is dropped).

This mirrors what the built-in UI already does implicitly (a single in-flight request) and matches the single-slot model the server advertises (`total_slots: 1`). The `verify-receipt` replay path (`replay_receipt_request`) uses its own isolated `AppState`, so it is unaffected.

### Trade-off

Requests now queue rather than run concurrently. Given the shared GPU-resident decode state, concurrency was unsafe anyway; queuing matches the single-slot model already exposed. A future improvement could give each request fully isolated decode state to allow true parallelism.

## Validation

- New regression test `api::tests::generation_lock_serializes_decoding` asserts the lock provides mutual exclusion (never more than one decode in the critical section).
- Full `cargo test` on this branch vs. a clean checkout of the same base: identical results aside from the new test — clean base `488 passed; 6 failed`, this branch `489 passed; 6 failed`. The 6 failures are pre-existing and unrelated (they panic inside `cudarc` on the test machine, in tests this change does not touch).
- Manual before/after against a live CUDA server: before — concurrent greedy requests produced divergent/garbled output and occasional `503` panics; after — concurrent requests are serialized (queued), all return `200`, and greedy output is identical across the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
