### PR TITLE
refactor(inference): extract Metal resident-decode engine into metal_resident

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -16,6 +16,9 @@ use sha2::{Digest, Sha256};
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use crate::execution_plan::MAC_Q8_PREFILL_I8MM_MIN_ROWS;
+// Only the two cfg(macos) f32 Metal-linear fallbacks reference `metal::` directly now;
+// everything else routes through metal_seam / metal_resident.
+#[cfg(target_os = "macos")]
 use crate::metal;
 use crate::telemetry;
 
@@ -24,6 +27,7 @@ mod cpu_neon;
 mod diagnostic_config;
 pub(crate) mod gemma4;
 mod kv_cache;
+mod metal_resident;
 mod metal_seam;
 mod q8_block_reader;
 mod q8_runtime;
@@ -1559,7 +1563,7 @@ pub struct LlamaInferenceSession {
     pub kv_cache: LlamaKvCache,
     /// Lazily-built GPU resident-decode session (a transient on-GPU cache; rebuilt on demand
     /// and not part of the session's logical identity, so it is skipped by Clone/PartialEq/Debug).
-    resident_decode: Option<metal::ResidentDecodeState>,
+    resident_decode: Option<metal_resident::ResidentDecodeState>,
     /// CUDA analog of `resident_decode` (the GPU-resident decode engine on
     /// NVIDIA hardware). Same transient-cache role; skipped by Clone/PartialEq/Debug.
     /// When set, the session never takes the GPU-resident prefill/decode paths, keeping the
@@ -1891,7 +1895,7 @@ impl LlamaInferenceSession {
         }
         // Wire-page (fast-load) weights satisfy residency too, but only when the wire
         // kernels are active — their bytes exist solely in the 34-byte wire layout.
-        let wire_ok = metal::wire_mode_active();
+        let wire_ok = metal_seam::wire_mode_active();
         let is_q8 = |t: &CpuTensor| {
             t.source_type == Some(GgufTensorType::Q8_0)
                 && (t.q8_0_blocks.is_some() || (wire_ok && t.q8_0_wire_pages.is_some()))
@@ -1987,112 +1991,7 @@ impl LlamaInferenceSession {
         if resident_decode_cuda_enabled() {
             return self.try_resident_prefill_cuda(token_ids);
         }
-        if std::env::var("CAMELID_METAL_RESIDENT_PREFILL")
-            .map(|v| v != "1" && !v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true)
-            || token_ids.len() < 2
-            || token_ids.len() > 16384
-            || self.kv_cache.position != 0
-            || self.weights.layer_range.is_some()
-            || !self.resident_decode_eligible(false)?
-        {
-            return Ok(false);
-        }
-        let weights = Arc::clone(&self.weights);
-        let dims = DenseLlamaDims::from_config(&self.config)?;
-        let n_layers = dims.block_count;
-        let n_heads = self.config.attention_head_count as usize;
-        let n_kv = dims.attention_head_count_kv;
-        let head_dim = dims.head_dim;
-        let kv_cap = self.config.context_length as usize;
-        let n = token_ids.len();
-        if n >= kv_cap {
-            return Ok(false);
-        }
-        let rms_eps = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
-        let scale = attention_score_scale_value(head_dim, diagnostic_attention_score_scale()?);
-        // CAMELID_PREFILL_TIME=1: report the CPU-side edges around the GPU command buffer.
-        let time_edges = std::env::var_os("CAMELID_PREFILL_TIME").is_some();
-        let edge_started = Instant::now();
-
-        // Rope tables for every prefill position, flattened.
-        let tables = match rope::resident_prefill_rope_tables(
-            n,
-            head_dim,
-            &self.config,
-            weights.rope_freqs.as_ref(),
-        )? {
-            Some(t) => t,
-            None => return Ok(false),
-        };
-        let (cos_all, sin_all, split_half_pairing) =
-            (tables.cos, tables.sin, tables.split_half_pairing);
-
-        let rope_us = edge_started.elapsed().as_micros();
-        let session_started = Instant::now();
-        let initial_positions = (n + 1).next_multiple_of(512).min(kv_cap);
-        let mut session = match metal::ResidentDecodeState::new(
-            n_layers,
-            n_heads,
-            n_kv,
-            head_dim,
-            dims.embedding_length,
-            dims.feed_forward_length,
-            initial_positions,
-            kv_cap,
-            rms_eps,
-            split_half_pairing,
-        ) {
-            Some(s) => s,
-            None => return Ok(false),
-        };
-
-        let session_us = session_started.elapsed().as_micros();
-        let embed_started = Instant::now();
-        let embeddings = self
-            .weights
-            .token_embedding
-            .embedding_lookup(token_ids, "token_embedding_resident_prefill")?;
-        let layer_views: Vec<metal::ResidentLayerWeights> = weights
-            .layers
-            .iter()
-            .map(|l| metal::ResidentLayerWeights {
-                attn_norm: &l.attention_norm.data,
-                ffn_norm: &l.ffn_norm.data,
-                q_norm: l.attention_q_norm.as_ref().map(|t| t.data.as_slice()),
-                k_norm: l.attention_k_norm.as_ref().map(|t| t.data.as_slice()),
-                q_weight_blocks: resident_weight_bytes(&l.attention_q),
-                k_weight_blocks: resident_weight_bytes(&l.attention_k),
-                v_weight_blocks: resident_weight_bytes(&l.attention_v),
-                o_weight_blocks: resident_weight_bytes(&l.attention_output),
-                gate_weight_blocks: resident_weight_bytes(&l.ffn_gate),
-                up_weight_blocks: resident_weight_bytes(&l.ffn_up),
-                down_weight_blocks: resident_weight_bytes(&l.ffn_down),
-            })
-            .collect();
-
-        let embed_us = embed_started.elapsed().as_micros();
-        let gpu_started = Instant::now();
-        if session
-            .prefill_tokens(&embeddings.data, n, &layer_views, &cos_all, &sin_all, scale)
-            .is_none()
-        {
-            return Ok(false);
-        }
-        if time_edges {
-            eprintln!(
-                "[prefill-time] rope {:.1}ms | session {:.1}ms | embed+views {:.1}ms | prefill_tokens {:.1}ms | total {:.1}ms",
-                rope_us as f64 / 1000.0,
-                session_us as f64 / 1000.0,
-                embed_us as f64 / 1000.0,
-                gpu_started.elapsed().as_micros() as f64 / 1000.0,
-                edge_started.elapsed().as_micros() as f64 / 1000.0,
-            );
-        }
-        // GPU cache now holds positions 0..n; the resident decode continues this sequence.
-        self.kv_cache.position = n;
-        self.resident_decode = Some(session);
-        Ok(true)
+        self.try_metal_resident_prefill(token_ids)
     }
 
     /// CUDA GPU prefill: run the whole prompt through the resident engine on the
@@ -2850,188 +2749,6 @@ impl LlamaInferenceSession {
         sample: Option<(f32, u64)>,
     ) -> Result<Option<ResidentForward>> {
         Ok(None)
-    }
-
-    fn try_resident_decode_forward_metal(
-        &mut self,
-        embedding: &CpuTensor,
-        compute_logits: bool,
-        gpu_sample_token: Option<u32>,
-    ) -> Result<Option<ResidentForward>> {
-        if !self.resident_decode_eligible(compute_logits)? {
-            return Ok(None);
-        }
-        let weights = Arc::clone(&self.weights);
-        let dims = DenseLlamaDims::from_config(&self.config)?;
-        let n_heads = self.config.attention_head_count as usize;
-        let n_kv = dims.attention_head_count_kv;
-        let head_dim = dims.head_dim;
-        let hidden = dims.embedding_length;
-        let ffn_dim = dims.feed_forward_length;
-        // Pipeline-sharded nodes run only their owned layer range; the resident session is
-        // built over that subset (relative slots) while KV seeding uses absolute layer ids.
-        let range = weights.layer_range.clone().unwrap_or(0..dims.block_count);
-        let n_layers = range.len();
-        let vocab = dims.vocab_size;
-        // The on-GPU KV cache grows on demand up to `kv_cap` (the model context length); sizing
-        // it to the full (often 128K) context up front would allocate tens of GB and thrash
-        // unified memory. Start sized to the current need plus a chunk and let the session grow.
-        let kv_cap = self.config.context_length as usize;
-        let position = self.kv_cache.position;
-        let initial_positions = ((position + 1).max(512)).next_multiple_of(512).min(kv_cap);
-        if position >= kv_cap
-            || embedding.data.len() != hidden
-            || weights.layers.len() != dims.block_count
-            || range.end > weights.layers.len()
-        {
-            return Ok(None);
-        }
-        let rms_eps = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
-        let tables = match rope::resident_decode_rope_tables(
-            position,
-            head_dim,
-            &self.config,
-            weights.rope_freqs.as_ref(),
-        )? {
-            Some(t) => t,
-            None => return Ok(None),
-        };
-        let scale = attention_score_scale_value(head_dim, diagnostic_attention_score_scale()?);
-
-        // (Re)build + seed the session when starting a sequence (or resuming at a position the
-        // session has not materialized): copy the CPU KV history [0, position) into the GPU
-        // cache so resident decode can take over after the batched CPU prefill.
-        let rebuild = match &self.resident_decode {
-            Some(s) => s.filled() != position,
-            None => true,
-        };
-        if rebuild {
-            let mut session = match metal::ResidentDecodeState::new(
-                n_layers,
-                n_heads,
-                n_kv,
-                head_dim,
-                hidden,
-                ffn_dim,
-                initial_positions,
-                kv_cap,
-                rms_eps,
-                tables.split_half_pairing,
-            ) {
-                Some(s) => s,
-                None => return Ok(None),
-            };
-            if position > 0 {
-                let kv_dim = n_kv * head_dim;
-                for layer in 0..n_layers {
-                    let mut ck = vec![0.0f32; kv_dim * position];
-                    let mut cv = vec![0.0f32; kv_dim * position];
-                    for p in 0..position {
-                        for h in 0..n_kv {
-                            let src = self.kv_cache.offset(range.start + layer, p, h);
-                            let dst = (h * position + p) * head_dim;
-                            ck[dst..dst + head_dim]
-                                .copy_from_slice(&self.kv_cache.keys[src..src + head_dim]);
-                            cv[dst..dst + head_dim]
-                                .copy_from_slice(&self.kv_cache.values[src..src + head_dim]);
-                        }
-                    }
-                    if !session.seed_layer(layer, &ck, &cv, position) {
-                        return Ok(None);
-                    }
-                }
-            }
-            session.set_filled(position);
-            self.resident_decode = Some(session);
-        }
-
-        let layer_views: Vec<metal::ResidentLayerWeights> = weights.layers[range.clone()]
-            .iter()
-            .map(|l| metal::ResidentLayerWeights {
-                attn_norm: &l.attention_norm.data,
-                ffn_norm: &l.ffn_norm.data,
-                q_norm: l.attention_q_norm.as_ref().map(|t| t.data.as_slice()),
-                k_norm: l.attention_k_norm.as_ref().map(|t| t.data.as_slice()),
-                q_weight_blocks: resident_weight_bytes(&l.attention_q),
-                k_weight_blocks: resident_weight_bytes(&l.attention_k),
-                v_weight_blocks: resident_weight_bytes(&l.attention_v),
-                o_weight_blocks: resident_weight_bytes(&l.attention_output),
-                gate_weight_blocks: resident_weight_bytes(&l.ffn_gate),
-                up_weight_blocks: resident_weight_bytes(&l.ffn_up),
-                down_weight_blocks: resident_weight_bytes(&l.ffn_down),
-            })
-            .collect();
-
-        // When logits are wanted, run the final RMSNorm + output projection on the GPU too
-        // (in the same command buffer) so the large vocab matmul stays off the CPU.
-        let logits_stage = if compute_logits {
-            Some(metal::LogitsStage {
-                final_norm: &weights.output_norm.data,
-                output_weight_blocks: resident_weight_bytes(weights.output_projection()),
-                vocab_size: vocab,
-            })
-        } else {
-            None
-        };
-
-        // GPU-side greedy sampling stage: only when the caller asked for it, logits run on
-        // the GPU, and the token embedding table is plain Q8_0 (the gather reads its rows).
-        let sample_stage = match gpu_sample_token {
-            Some(_)
-                if compute_logits
-                    && weights.token_embedding.source_type == Some(GgufTensorType::Q8_0)
-                    && (weights.token_embedding.q8_0_blocks.is_some()
-                        || weights.token_embedding.q8_0_wire_pages.is_some()) =>
-            {
-                let embedding_blocks = resident_weight_bytes(&weights.token_embedding);
-                (embedding_blocks.block_count() == vocab * (hidden / 32))
-                    .then_some(metal::SampleStage { embedding_blocks })
-            }
-            _ => None,
-        };
-
-        // Rope tables for position+1 feed the encode-ahead pipeline: the session encodes
-        // the NEXT token's command buffer while this token executes on the GPU.
-        let next_tables = rope::resident_decode_rope_tables(
-            position + 1,
-            head_dim,
-            &self.config,
-            weights.rope_freqs.as_ref(),
-        )?;
-        let session = self
-            .resident_decode
-            .as_mut()
-            .expect("resident session built above");
-        let out = match session.forward_token(
-            &embedding.data,
-            &layer_views,
-            &tables.cos,
-            &tables.sin,
-            position,
-            scale,
-            logits_stage,
-            sample_stage,
-            gpu_sample_token.unwrap_or(u32::MAX),
-            next_tables
-                .as_ref()
-                .map(|t| (t.cos.as_slice(), t.sin.as_slice())),
-        ) {
-            Some(o) => o,
-            None => return Ok(None),
-        };
-        match out {
-            metal::ResidentTokenOut::Sampled(id) => Ok(Some(ResidentForward::Sampled(id))),
-            metal::ResidentTokenOut::Data(out) if compute_logits => {
-                Ok(Some(ResidentForward::Logits(CpuTensor::from_f32(
-                    "resident_logits",
-                    vec![1, vocab],
-                    out,
-                )?)))
-            }
-            metal::ResidentTokenOut::Data(out) => Ok(Some(ResidentForward::Hidden(
-                CpuTensor::from_f32("resident_hidden", vec![1, hidden], out)?,
-            ))),
-        }
     }
 
     pub fn forward_worker_layers(
@@ -14424,7 +14141,7 @@ fn matmul_rhs_transposed_q8_0_block_dot_with_plan(
                 if with_q8_0_block_scales_and_quants(
                     &quantized_input.blocks,
                     |input_scales, input_quants| {
-                        metal::try_q8_0_block_linear_row(
+                        metal_seam::try_block_linear_row(
                             input_scales,
                             input_quants,
                             weight_bytes,
@@ -15321,18 +15038,6 @@ fn q8_0_blocks_as_bytes(blocks: &[Q8_0Block]) -> &[u8] {
     // The Metal retained-Q8 kernel treats this exact byte layout as immutable input.
     unsafe {
         std::slice::from_raw_parts(blocks.as_ptr().cast::<u8>(), std::mem::size_of_val(blocks))
-    }
-}
-
-/// The resident stack's view of one weight's bytes: page-aligned wire pages when
-/// the fast-load path attached them (the GPU wraps them in place), else the
-/// materialized 36-byte CPU blocks.
-fn resident_weight_bytes(tensor: &CpuTensor) -> metal::ResidentWeightBytes<'_> {
-    match tensor.q8_0_wire_pages.as_ref() {
-        Some(pages) => metal::ResidentWeightBytes::WirePages(pages),
-        None => metal::ResidentWeightBytes::Blocks36(q8_0_blocks_as_bytes(
-            tensor.q8_0_blocks.as_ref().unwrap(),
-        )),
     }
 }
 

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -1,0 +1,315 @@
+//! Metal GPU resident-decode engine usage, relocated out of inference.rs so the
+//! shared inference path carries no `metal::` references. metal.rs provides
+//! non-macOS stubs for these types/fns, so this compiles on every target (dead
+//! off macOS, where ResidentDecodeState::new returns None). Verbatim relocation —
+//! reduction order and behaviour are byte-identical.
+
+use super::*;
+use crate::metal;
+
+pub(super) type ResidentDecodeState = metal::ResidentDecodeState;
+
+/// The resident stack's view of one weight's bytes: page-aligned wire pages when
+/// the fast-load path attached them (the GPU wraps them in place), else the
+/// materialized 36-byte CPU blocks.
+pub(super) fn resident_weight_bytes(tensor: &CpuTensor) -> metal::ResidentWeightBytes<'_> {
+    match tensor.q8_0_wire_pages.as_ref() {
+        Some(pages) => metal::ResidentWeightBytes::WirePages(pages),
+        None => metal::ResidentWeightBytes::Blocks36(q8_0_blocks_as_bytes(
+            tensor.q8_0_blocks.as_ref().unwrap(),
+        )),
+    }
+}
+
+impl super::LlamaInferenceSession {
+    pub(super) fn try_metal_resident_prefill(&mut self, token_ids: &[u32]) -> Result<bool> {
+        if std::env::var("CAMELID_METAL_RESIDENT_PREFILL")
+            .map(|v| v != "1" && !v.eq_ignore_ascii_case("true"))
+            .unwrap_or(true)
+            || token_ids.len() < 2
+            || token_ids.len() > 16384
+            || self.kv_cache.position != 0
+            || self.weights.layer_range.is_some()
+            || !self.resident_decode_eligible(false)?
+        {
+            return Ok(false);
+        }
+        let weights = Arc::clone(&self.weights);
+        let dims = DenseLlamaDims::from_config(&self.config)?;
+        let n_layers = dims.block_count;
+        let n_heads = self.config.attention_head_count as usize;
+        let n_kv = dims.attention_head_count_kv;
+        let head_dim = dims.head_dim;
+        let kv_cap = self.config.context_length as usize;
+        let n = token_ids.len();
+        if n >= kv_cap {
+            return Ok(false);
+        }
+        let rms_eps = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
+        let scale = attention_score_scale_value(head_dim, diagnostic_attention_score_scale()?);
+        // CAMELID_PREFILL_TIME=1: report the CPU-side edges around the GPU command buffer.
+        let time_edges = std::env::var_os("CAMELID_PREFILL_TIME").is_some();
+        let edge_started = Instant::now();
+
+        // Rope tables for every prefill position, flattened.
+        let tables = match rope::resident_prefill_rope_tables(
+            n,
+            head_dim,
+            &self.config,
+            weights.rope_freqs.as_ref(),
+        )? {
+            Some(t) => t,
+            None => return Ok(false),
+        };
+        let (cos_all, sin_all, split_half_pairing) =
+            (tables.cos, tables.sin, tables.split_half_pairing);
+
+        let rope_us = edge_started.elapsed().as_micros();
+        let session_started = Instant::now();
+        let initial_positions = (n + 1).next_multiple_of(512).min(kv_cap);
+        let mut session = match metal::ResidentDecodeState::new(
+            n_layers,
+            n_heads,
+            n_kv,
+            head_dim,
+            dims.embedding_length,
+            dims.feed_forward_length,
+            initial_positions,
+            kv_cap,
+            rms_eps,
+            split_half_pairing,
+        ) {
+            Some(s) => s,
+            None => return Ok(false),
+        };
+
+        let session_us = session_started.elapsed().as_micros();
+        let embed_started = Instant::now();
+        let embeddings = self
+            .weights
+            .token_embedding
+            .embedding_lookup(token_ids, "token_embedding_resident_prefill")?;
+        let layer_views: Vec<metal::ResidentLayerWeights> = weights
+            .layers
+            .iter()
+            .map(|l| metal::ResidentLayerWeights {
+                attn_norm: &l.attention_norm.data,
+                ffn_norm: &l.ffn_norm.data,
+                q_norm: l.attention_q_norm.as_ref().map(|t| t.data.as_slice()),
+                k_norm: l.attention_k_norm.as_ref().map(|t| t.data.as_slice()),
+                q_weight_blocks: resident_weight_bytes(&l.attention_q),
+                k_weight_blocks: resident_weight_bytes(&l.attention_k),
+                v_weight_blocks: resident_weight_bytes(&l.attention_v),
+                o_weight_blocks: resident_weight_bytes(&l.attention_output),
+                gate_weight_blocks: resident_weight_bytes(&l.ffn_gate),
+                up_weight_blocks: resident_weight_bytes(&l.ffn_up),
+                down_weight_blocks: resident_weight_bytes(&l.ffn_down),
+            })
+            .collect();
+
+        let embed_us = embed_started.elapsed().as_micros();
+        let gpu_started = Instant::now();
+        if session
+            .prefill_tokens(&embeddings.data, n, &layer_views, &cos_all, &sin_all, scale)
+            .is_none()
+        {
+            return Ok(false);
+        }
+        if time_edges {
+            eprintln!(
+                "[prefill-time] rope {:.1}ms | session {:.1}ms | embed+views {:.1}ms | prefill_tokens {:.1}ms | total {:.1}ms",
+                rope_us as f64 / 1000.0,
+                session_us as f64 / 1000.0,
+                embed_us as f64 / 1000.0,
+                gpu_started.elapsed().as_micros() as f64 / 1000.0,
+                edge_started.elapsed().as_micros() as f64 / 1000.0,
+            );
+        }
+        // GPU cache now holds positions 0..n; the resident decode continues this sequence.
+        self.kv_cache.position = n;
+        self.resident_decode = Some(session);
+        Ok(true)
+    }
+
+    pub(super) fn try_resident_decode_forward_metal(
+        &mut self,
+        embedding: &CpuTensor,
+        compute_logits: bool,
+        gpu_sample_token: Option<u32>,
+    ) -> Result<Option<ResidentForward>> {
+        if !self.resident_decode_eligible(compute_logits)? {
+            return Ok(None);
+        }
+        let weights = Arc::clone(&self.weights);
+        let dims = DenseLlamaDims::from_config(&self.config)?;
+        let n_heads = self.config.attention_head_count as usize;
+        let n_kv = dims.attention_head_count_kv;
+        let head_dim = dims.head_dim;
+        let hidden = dims.embedding_length;
+        let ffn_dim = dims.feed_forward_length;
+        // Pipeline-sharded nodes run only their owned layer range; the resident session is
+        // built over that subset (relative slots) while KV seeding uses absolute layer ids.
+        let range = weights.layer_range.clone().unwrap_or(0..dims.block_count);
+        let n_layers = range.len();
+        let vocab = dims.vocab_size;
+        // The on-GPU KV cache grows on demand up to `kv_cap` (the model context length); sizing
+        // it to the full (often 128K) context up front would allocate tens of GB and thrash
+        // unified memory. Start sized to the current need plus a chunk and let the session grow.
+        let kv_cap = self.config.context_length as usize;
+        let position = self.kv_cache.position;
+        let initial_positions = ((position + 1).max(512)).next_multiple_of(512).min(kv_cap);
+        if position >= kv_cap
+            || embedding.data.len() != hidden
+            || weights.layers.len() != dims.block_count
+            || range.end > weights.layers.len()
+        {
+            return Ok(None);
+        }
+        let rms_eps = diagnostic_rms_norm_epsilon(self.config.rms_norm_epsilon)?;
+        let tables = match rope::resident_decode_rope_tables(
+            position,
+            head_dim,
+            &self.config,
+            weights.rope_freqs.as_ref(),
+        )? {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+        let scale = attention_score_scale_value(head_dim, diagnostic_attention_score_scale()?);
+
+        // (Re)build + seed the session when starting a sequence (or resuming at a position the
+        // session has not materialized): copy the CPU KV history [0, position) into the GPU
+        // cache so resident decode can take over after the batched CPU prefill.
+        let rebuild = match &self.resident_decode {
+            Some(s) => s.filled() != position,
+            None => true,
+        };
+        if rebuild {
+            let mut session = match metal::ResidentDecodeState::new(
+                n_layers,
+                n_heads,
+                n_kv,
+                head_dim,
+                hidden,
+                ffn_dim,
+                initial_positions,
+                kv_cap,
+                rms_eps,
+                tables.split_half_pairing,
+            ) {
+                Some(s) => s,
+                None => return Ok(None),
+            };
+            if position > 0 {
+                let kv_dim = n_kv * head_dim;
+                for layer in 0..n_layers {
+                    let mut ck = vec![0.0f32; kv_dim * position];
+                    let mut cv = vec![0.0f32; kv_dim * position];
+                    for p in 0..position {
+                        for h in 0..n_kv {
+                            let src = self.kv_cache.offset(range.start + layer, p, h);
+                            let dst = (h * position + p) * head_dim;
+                            ck[dst..dst + head_dim]
+                                .copy_from_slice(&self.kv_cache.keys[src..src + head_dim]);
+                            cv[dst..dst + head_dim]
+                                .copy_from_slice(&self.kv_cache.values[src..src + head_dim]);
+                        }
+                    }
+                    if !session.seed_layer(layer, &ck, &cv, position) {
+                        return Ok(None);
+                    }
+                }
+            }
+            session.set_filled(position);
+            self.resident_decode = Some(session);
+        }
+
+        let layer_views: Vec<metal::ResidentLayerWeights> = weights.layers[range.clone()]
+            .iter()
+            .map(|l| metal::ResidentLayerWeights {
+                attn_norm: &l.attention_norm.data,
+                ffn_norm: &l.ffn_norm.data,
+                q_norm: l.attention_q_norm.as_ref().map(|t| t.data.as_slice()),
+                k_norm: l.attention_k_norm.as_ref().map(|t| t.data.as_slice()),
+                q_weight_blocks: resident_weight_bytes(&l.attention_q),
+                k_weight_blocks: resident_weight_bytes(&l.attention_k),
+                v_weight_blocks: resident_weight_bytes(&l.attention_v),
+                o_weight_blocks: resident_weight_bytes(&l.attention_output),
+                gate_weight_blocks: resident_weight_bytes(&l.ffn_gate),
+                up_weight_blocks: resident_weight_bytes(&l.ffn_up),
+                down_weight_blocks: resident_weight_bytes(&l.ffn_down),
+            })
+            .collect();
+
+        // When logits are wanted, run the final RMSNorm + output projection on the GPU too
+        // (in the same command buffer) so the large vocab matmul stays off the CPU.
+        let logits_stage = if compute_logits {
+            Some(metal::LogitsStage {
+                final_norm: &weights.output_norm.data,
+                output_weight_blocks: resident_weight_bytes(weights.output_projection()),
+                vocab_size: vocab,
+            })
+        } else {
+            None
+        };
+
+        // GPU-side greedy sampling stage: only when the caller asked for it, logits run on
+        // the GPU, and the token embedding table is plain Q8_0 (the gather reads its rows).
+        let sample_stage = match gpu_sample_token {
+            Some(_)
+                if compute_logits
+                    && weights.token_embedding.source_type == Some(GgufTensorType::Q8_0)
+                    && (weights.token_embedding.q8_0_blocks.is_some()
+                        || weights.token_embedding.q8_0_wire_pages.is_some()) =>
+            {
+                let embedding_blocks = resident_weight_bytes(&weights.token_embedding);
+                (embedding_blocks.block_count() == vocab * (hidden / 32))
+                    .then_some(metal::SampleStage { embedding_blocks })
+            }
+            _ => None,
+        };
+
+        // Rope tables for position+1 feed the encode-ahead pipeline: the session encodes
+        // the NEXT token's command buffer while this token executes on the GPU.
+        let next_tables = rope::resident_decode_rope_tables(
+            position + 1,
+            head_dim,
+            &self.config,
+            weights.rope_freqs.as_ref(),
+        )?;
+        let session = self
+            .resident_decode
+            .as_mut()
+            .expect("resident session built above");
+        let out = match session.forward_token(
+            &embedding.data,
+            &layer_views,
+            &tables.cos,
+            &tables.sin,
+            position,
+            scale,
+            logits_stage,
+            sample_stage,
+            gpu_sample_token.unwrap_or(u32::MAX),
+            next_tables
+                .as_ref()
+                .map(|t| (t.cos.as_slice(), t.sin.as_slice())),
+        ) {
+            Some(o) => o,
+            None => return Ok(None),
+        };
+        match out {
+            metal::ResidentTokenOut::Sampled(id) => Ok(Some(ResidentForward::Sampled(id))),
+            metal::ResidentTokenOut::Data(out) if compute_logits => {
+                Ok(Some(ResidentForward::Logits(CpuTensor::from_f32(
+                    "resident_logits",
+                    vec![1, vocab],
+                    out,
+                )?)))
+            }
+            metal::ResidentTokenOut::Data(out) => Ok(Some(ResidentForward::Hidden(
+                CpuTensor::from_f32("resident_hidden", vec![1, hidden], out)?,
+            ))),
+        }
+    }
+}

--- a/src/inference/metal_seam.rs
+++ b/src/inference/metal_seam.rs
@@ -46,6 +46,17 @@ pub(super) fn synchronize_active_session() {
 #[inline]
 pub(super) fn synchronize_active_session() {}
 
+#[cfg(target_os = "macos")]
+#[inline]
+pub(super) fn wire_mode_active() -> bool {
+    crate::metal::wire_mode_active()
+}
+#[cfg(not(target_os = "macos"))]
+#[inline]
+pub(super) fn wire_mode_active() -> bool {
+    false
+}
+
 // ---- Per-matmul Q8_0 offload (block reader, encoded single row) ----
 // Was inline in `matmul_rhs_transposed_q8_0_block_reader_with_flags` (~15868).
 
@@ -256,6 +267,39 @@ pub(super) fn try_block_two_linear_rows_with_cpu<F: FnOnce()>(
     _first_output: &mut [f32],
     _second_output: &mut [f32],
     _cpu_work: F,
+) -> bool {
+    false
+}
+
+// ---- Retained-block single-row decode offload (file-reader block-dot path) ----
+// 1:1 passthrough of metal::try_q8_0_block_linear_row, runtime-gated by metal_retained.
+
+#[cfg(target_os = "macos")]
+pub(super) fn try_block_linear_row(
+    input_scales: &[f32],
+    input_quants: &[i8],
+    weight_bytes: &[u8],
+    rows: usize,
+    blocks_per_row: usize,
+    output: &mut [f32],
+) -> bool {
+    crate::metal::try_q8_0_block_linear_row(
+        input_scales,
+        input_quants,
+        weight_bytes,
+        rows,
+        blocks_per_row,
+        output,
+    )
+}
+#[cfg(not(target_os = "macos"))]
+pub(super) fn try_block_linear_row(
+    _input_scales: &[f32],
+    _input_quants: &[i8],
+    _weight_bytes: &[u8],
+    _rows: usize,
+    _blocks_per_row: usize,
+    _output: &mut [f32],
 ) -> bool {
     false
 }


### PR DESCRIPTION
Follow-up to #305. Moves the Metal GPU **resident-decode engine** — the last macOS subsystem still living in `src/inference.rs` — into a new `src/inference/metal_resident.rs`.

## What moved
- `try_resident_decode_forward_metal` (the Metal decode-forward method) and the resident-prefill body (now `try_metal_resident_prefill`), as `impl LlamaInferenceSession` methods in the new module.
- The `resident_weight_bytes` helper.
- A `ResidentDecodeState` type alias so the session field is `Option<metal_resident::ResidentDecodeState>` instead of naming `metal::` directly.
- Seamed the remaining `wire_mode_active` call and a previously-missed `metal_retained` block-dot offload through `metal_seam`, and cfg(macOS)-gated the now-macOS-only `use crate::metal` import.

**Verbatim relocation — behaviour byte-identical on all targets** (the moved code compiles everywhere via metal.rs's non-macОS stubs; it's dead off macOS). The shared/x86/CUDA path in inference.rs is now **Metal-free**; the only `metal::` refs left are two `cfg(target_os="macos")` f32-linear fallbacks (behind a cfg(macOS) import).

`inference.rs` −291 lines.

## Verified on Windows (and this time I ran the test suite)
- `cargo check` + `clippy` — clean, no warnings.
- **`cargo test --lib` — 494 passed / 0 failed.** (The last PR's bug slipped through because I'd only run `cargo check`; not this time.)
- `cargo fmt --check` — clean; no EOL churn.

macОS Metal behaviour is verified by CI (the rust macos-latest job compiles + tests it), same as #305.