### PR TITLE
fix(api): correct garbled streaming output under CUDA temperature sampling

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8028,7 +8028,15 @@ fn stream_completion(mut prepared: PreparedGeneration, chat: bool) -> Response {
         let mut forward_timings = LlamaForwardTimings::default();
         let mut sample = 0;
 
-        if !prepared.collect_dense_diagnostics {
+        // Bypass the prompt-prefix cache when the CUDA-resident engine drives
+        // decode: reusing a cached session reseeds the GPU KV from f16-rounded
+        // host history (a different reduction order than a clean GPU prefill),
+        // which corrupts the resumed decode — mild for greedy (a few near-tie
+        // flips) but catastrophic under temperature sampling, where it produces
+        // garbled, off-topic output. The non-streaming path already gates the
+        // cache this way (see resident_decode_cuda_active); the streaming path
+        // must too. The CPU lane is reduction-order-stable and keeps the cache.
+        if !prepared.collect_dense_diagnostics && !crate::inference::resident_decode_cuda_active() {
             if let Some(cached) = lookup_prompt_prefix_cache(&prepared) {
                 prepared.session = cached.session.clone();
                 input.clear();

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2340,7 +2340,15 @@ impl LlamaInferenceSession {
         token_id: u32,
         config: &SamplingConfig,
     ) -> Result<Option<(u32, u128)>> {
-        if !resident_decode_cuda_enabled()
+        // The resident GPU Gumbel-max temperature-sampling fast lane produces
+        // corrupted output in the streaming decode path (garbled, off-topic
+        // tokens for any temperature > 0; greedy/argmax and the CPU temperature
+        // sampler are unaffected). Disabled by default until the GPU
+        // sampling-state interaction is root-caused; opt back in with
+        // CAMELID_GPU_TEMP_SAMPLING. Declining here routes temperature sampling
+        // through the correct CPU sampler (one logits copy per token).
+        if !resident_gpu_temperature_sampling_enabled()
+            || !resident_decode_cuda_enabled()
             || config.temperature <= 0.0
             || config.top_k.is_some()
             || config.top_p.is_some_and(|p| p < 1.0)
@@ -10103,6 +10111,25 @@ fn build_resident_cuda_engine(
         .set_output(&weights.output_norm.data, raw(weights.output_projection())?)
         .ok()?;
     Some(engine)
+}
+
+/// Opt-in gate for the resident GPU Gumbel-max temperature-sampling fast lane.
+/// Default OFF: the fast lane corrupts output in the streaming decode path, so
+/// temperature sampling falls back to the (correct) CPU sampler. Set
+/// `CAMELID_GPU_TEMP_SAMPLING=1/true/on/yes` to re-enable for debugging once the
+/// GPU sampling-state interaction is fixed.
+fn resident_gpu_temperature_sampling_enabled() -> bool {
+    match std::env::var_os("CAMELID_GPU_TEMP_SAMPLING") {
+        Some(value) => {
+            let value = value.to_string_lossy();
+            let value = value.trim();
+            value.eq_ignore_ascii_case("1")
+                || value.eq_ignore_ascii_case("true")
+                || value.eq_ignore_ascii_case("on")
+                || value.eq_ignore_ascii_case("yes")
+        }
+        None => false,
+    }
 }
 
 /// CUDA GPU-resident decode gate (the NVIDIA analog of the Metal one). On


### PR DESCRIPTION
Fixes #310.

## Problem

On the CUDA-resident decode path, **streaming** generation produces garbled, off-topic "word-salad" output for **any temperature > 0**, while non-streaming (same temperature) and greedy streaming (`temperature: 0`) are clean. So it's specific to streaming + temperature sampling on the GPU.

## Root cause

1. **Resident GPU Gumbel-max temperature sampling** (`generate_next_token_sampled_resident` → `forward_token_sample` → `sample_gumbel`) yields corrupted tokens in the streaming decode loop. Greedy/argmax on the same forward is correct (logits are fine), and the **CPU** temperature sampler is correct (non-streaming uses it and is clean) — the fault is the resident GPU sampling fast lane in this path.
2. The streaming **prompt-prefix cache** path does not honor the `resident_decode_cuda_active()` bypass the non-streaming path already applies. Under the CUDA engine, reusing a cached session reseeds GPU KV from f16-rounded host history (a different reduction order than a clean GPU prefill), flipping near-tie tokens.

## Fix

- **`inference.rs`** — gate the resident GPU temperature-sampling fast lane behind `CAMELID_GPU_TEMP_SAMPLING` (default **OFF**). When off, `generate_next_token_sampled_resident` returns `Ok(None)`, so temperature sampling falls back to the verified CPU sampler. Greedy/argmax is untouched, so the GPU fast lane still serves the common greedy case. This is the fix for the garbled output; the env flag lets the fast lane be re-enabled once the GPU sampling-state interaction is root-caused.
- **`api/mod.rs`** — apply the same `resident_decode_cuda_active()` cache bypass to the streaming prompt-prefix path that the non-streaming path already uses.

## Validation

Verified on an RTX 5060 Laptop GPU with Qwen3 0.6B Q8_0:

- **Before:** streaming at temperature 0.2 / 0.5 / 0.7 / 1.0 → garbage.
- **After:** every temperature returns correct, coherent output; greedy unchanged.
- Full app (OpenAI-compatible client) streaming chat at temperature 1.0 is clean end-to-end.
- `cargo check` clean (no new warnings under the workspace's `-D warnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
