### PR TITLE
fix(serve): route Q4_K/Q6_K resident-eligible models through the GPU engine (8B chats in the web UI)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5875,7 +5875,65 @@ fn estimate_cpu_weight_materialization_bytes(binding: &LlamaTensorBinding) -> cr
     Ok(total)
 }
 
+/// Whether this model's linears are all GPU-resident-eligible quants (Q8_0 / Q4_K /
+/// Q6_K) in a dense (non-MoE) layout. Such a model is loaded WIRE-ONLY: K-quant 2-D
+/// linears keep only their packed super-block wire bytes (see `load_kquant_wire_linear`
+/// in `LlamaLoadedWeights::load_with_ownership`) and Q8_0 linears keep their 36-byte
+/// blocks/pages — neither materializes the f32 the CPU-budget guard estimates. The CUDA
+/// resident decode engine reads those packed bytes in place (q8_gemv / q4k_gemv /
+/// q6k_gemv), so the f32 quantity the guard sizes is never produced for this model.
+///
+/// This is the binding-level mirror of `LlamaInferenceSession::resident_decode_eligible`
+/// (which needs a built session); it intentionally checks only what the guard needs —
+/// the per-tensor quant types and the dense layout. Anything else (an f16/f32 linear, a
+/// MoE router/expert stack) keeps the eager-f32 CPU path and stays under the guard.
+fn binding_all_resident_quant_linears(binding: &LlamaTensorBinding) -> bool {
+    let is_resident_quant = |desc: &GgufTensorDescriptor| {
+        matches!(
+            desc.tensor_type,
+            GgufTensorType::Q8_0 | GgufTensorType::Q4K | GgufTensorType::Q6K
+        )
+    };
+    if !is_resident_quant(&binding.token_embedding) {
+        return false;
+    }
+    if !binding.output_is_tied_embedding && !is_resident_quant(&binding.output) {
+        return false;
+    }
+    binding.layers.iter().all(|layer| {
+        let dense = match &layer.ffn {
+            LlamaFfnTensors::Dense { gate, up, down } => {
+                is_resident_quant(gate) && is_resident_quant(up) && is_resident_quant(down)
+            }
+            // MoE is not resident-eligible; its experts take the eager-f32 CPU path,
+            // which the guard must keep protecting.
+            LlamaFfnTensors::MoE { .. } => false,
+        };
+        dense
+            && is_resident_quant(&layer.attention_q)
+            && is_resident_quant(&layer.attention_k)
+            && is_resident_quant(&layer.attention_v)
+            && is_resident_quant(&layer.attention_output)
+    })
+}
+
+/// Whether the GPU-resident decode engine will run this model — and therefore the
+/// CPU f32 weight materialization the budget guard estimates is never produced. True
+/// only when CUDA resident decode is active for this process AND every linear is a
+/// resident-eligible quant (`binding_all_resident_quant_linears`). On non-CUDA builds
+/// `resident_decode_cuda_active()` is `false`, so the guard always applies there.
+fn binding_runs_on_resident_gpu(binding: &LlamaTensorBinding) -> bool {
+    crate::inference::resident_decode_cuda_active() && binding_all_resident_quant_linears(binding)
+}
+
 fn guard_cpu_weight_materialization_budget(binding: &LlamaTensorBinding) -> crate::Result<u64> {
+    // Resident-GPU models load wire-only (packed Q8_0/Q4_K/Q6_K bytes the CUDA engine
+    // reads in place) and never materialize the f32 weights this guard sizes. Bypass the
+    // CPU budget for them — but ONLY them; genuinely CPU-bound large models (or any
+    // build/host without the resident GPU path) still hit the guard below.
+    if binding_runs_on_resident_gpu(binding) {
+        return Ok(0);
+    }
     let estimated_bytes = estimate_cpu_weight_materialization_bytes(binding)?;
     let limit_bytes = cpu_weight_materialization_limit_bytes()?;
     if estimated_bytes > limit_bytes {
@@ -10579,6 +10637,37 @@ mod tests {
 
         assert!(err.contains("invalid CAMELID_MAX_CPU_WEIGHT_MATERIALIZATION_BYTES"));
         std::env::remove_var(CPU_WEIGHT_MATERIALIZATION_LIMIT_ENV);
+    }
+
+    #[test]
+    fn binding_all_resident_quant_linears_accepts_kquant_and_q8_dense() {
+        // Q4_K / Q6_K / Q8_0 dense bindings load wire-only and run on the resident
+        // GPU engine, so they must classify as resident-eligible (the f32 guard's
+        // estimate never materializes for them).
+        for ty in [
+            GgufTensorType::Q8_0,
+            GgufTensorType::Q4K,
+            GgufTensorType::Q6K,
+        ] {
+            let binding = materialization_binding(false, ty, vec![256, 256]);
+            assert!(
+                binding_all_resident_quant_linears(&binding),
+                "{ty:?} dense binding should classify as resident-eligible"
+            );
+        }
+    }
+
+    #[test]
+    fn binding_all_resident_quant_linears_rejects_non_quant_linears() {
+        // An f32/f16 linear is NOT resident-eligible — it takes the eager-f32 CPU path,
+        // which the guard must keep protecting.
+        for ty in [GgufTensorType::F32, GgufTensorType::F16] {
+            let binding = materialization_binding(false, ty, vec![256, 256]);
+            assert!(
+                !binding_all_resident_quant_linears(&binding),
+                "{ty:?} binding must not bypass the CPU materialization guard"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Follow-up to #312. The velocity-campaign branch added resident Q4_K/Q6_K decode (proven via `bench-generate` / `residency_check.sh`), but the **chat server** (`serve`) refused K-quant models with `cpu_weight_materialization_exceeds_budget` and fell back to the CPU path. This wires `serve` to run resident-eligible models on the GPU engine, so you can chat with an **8B-Q4_K fully resident on a 6 GB card** in the web UI.

## The bug
`guard_cpu_weight_materialization_budget` (src/api/mod.rs) estimated **f32 CPU** weight size (4 bytes/elem ≈ **32 GB** for 8B-Q4_K) and ran **before** the resident decision — blowing the 6 GB budget. But the resident GPU path never materializes f32: the K-quant loader (`load_kquant_wire_linear`) keeps **packed wire bytes only** and `q4k_gemv`/`q6k_gemv` read them in place. The guard was gating on a quantity the resident path never produces.

## The fix (src/api/mod.rs, +89 lines, +2 tests)
- `binding_all_resident_quant_linears` — binding-level mirror of `inference::resident_decode_eligible`: every linear is Q8_0/Q4_K/Q6_K and dense (MoE ⇒ false).
- `binding_runs_on_resident_gpu = resident_decode_cuda_active() && binding_all_resident_quant_linears(...)` (false on non-CUDA hosts).
- `guard_cpu_weight_materialization_budget` early-returns `Ok(0)` when that's true — bypassing the f32 budget **only** for models the GPU resident engine will actually run. CPU / MoE / f16→f32 / non-CUDA paths stay guarded; **Q8_0 serve unchanged**. Both guard call sites covered.
- No `plan_for_model` change — resident routing is decided at runtime; the guard was the sole server-side blocker.

## Verified
- `serve --model Qwen3-8B-Q4_K_M.gguf`: serve.log `all 36 layers resident in VRAM — full GPU speed`, **no** materialization error, VRAM ~4.7 GB, **~94–99% GPU util** during generation, coherent chat. Confirmed first-hand via `/v1/chat/completions`.
- Q8 no-regression: `serve --model Qwen3-4B-Q8_0.gguf` still loads resident + chats.
- CI gates: `fmt --all -- --check`, `clippy --all-targets --all-features -- -D warnings` (0 warnings), `test --all-features`, `public-scrub` — all green locally.

## Note
Server `--spec-decode` remains `ngram`/`draft`; the tree-verify lane is still CLI-only (`CAMELID_SPEC_TREE`). Stacks on #312's base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)