### PR TITLE
fix(desktop): bump camelid-desktop to 0.1.7 (match release stamp)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
The v0.1.7 release published the desktop installer as `Camelid.Desktop_0.1.6_x64-setup.exe` — the Tauri app version (`camelid-desktop/Cargo.toml` + `tauri.conf.json`) wasn't bumped alongside the engine crate. This syncs it to 0.1.7 (+ the `camelid-desktop` entry in `Cargo.lock`).

After merge: re-cut the v0.1.7 release so the desktop installer is correctly stamped + signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)