### PR TITLE
docs(desktop): note inherited GPU acceleration (Windows CUDA, incl. Gemma 4 E4B)

### DIFF
--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -17,6 +17,12 @@ parity contract, or the `camelid` server binary. **The web path remains the cano
   model availability and the **runtime-ready + exact-supported-row** chat gate come from the
   same authority as the web UI (`/api/capabilities`, the compatibility ledger). A model the
   existing gate refuses is refused here too — the gate is reused, not re-derived.
+- **Identical GPU acceleration.** Because the sidecar *is* the shipped `camelid` engine, it
+  uses the engine's GPU path unchanged: on a machine with an NVIDIA GPU it auto-engages the
+  bundled CUDA runtime (the same Windows CUDA-resident decode path the engine validates — the
+  Qwen3 Q8_0 rows and the Gemma 4 E4B-It Q8_0 row), and falls back to the CPU otherwise. The
+  app adds no GPU code and makes no separate performance claim; the authoritative supported-row
+  and GPU list is the engine's [`README.md`](../README.md) (*Windows CUDA*).
 - **No fabricated metrics.** Any tokens/sec or status readout is sourced from the same real
   generation events the server emits (the SSE `camelid.decode_tps` field). If a metric is
   unavailable it is shown as unavailable, never as a placeholder.


### PR DESCRIPTION
Follow-up to #317. Adds an "inherits" bullet to the Camelid Desktop README's **What it inherits (and does not change)** section noting that the app inherits the engine's GPU path unchanged — the bundled Windows CUDA-resident decode path (Qwen3 Q8_0 rows + the Gemma 4 E4B-It Q8_0 row), CPU fallback otherwise.

Kept consistent with the desktop README's add-on ethos: the app adds no GPU code and makes **no separate model/performance claim** — it points at the engine [`README.md`](../README.md) (*Windows CUDA*) as the authoritative supported-row/GPU list.

Docs-only, no EOL churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)