### PR TITLE
gemma4 CUDA serve: cross-request prefix cache + 4096 context window

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4295,7 +4295,11 @@ async fn load_gemma4_serve_runtime(
             #[cfg(feature = "cuda")]
             {
                 if gemma4_cuda_enabled() {
-                    return crate::gemma4_runtime::Gemma4CudaResident::load(&load_path, 2048)
+                    // KV-cache context window. 4096 fits the 6 GB card (the attention
+                    // kernel's shared memory is (2*head_dim + max_positions)*4 bytes, well
+                    // under 48 KB, and the f16 KV adds only ~100-200 MB) and gives real
+                    // multi-turn headroom; overflow past it is guarded in the runtime.
+                    return crate::gemma4_runtime::Gemma4CudaResident::load(&load_path, 4096)
                         .map(|r| Gemma4ServeRuntime::Cuda(std::sync::Mutex::new(r)));
                 }
             }

--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -2372,6 +2372,11 @@ pub struct Gemma4CudaResident {
     // Per-owning-layer f16 KV caches ([kv_head][pos][head_dim]); None on shared layers.
     cache_k: Vec<Option<cudarc::driver::CudaSlice<u16>>>,
     cache_v: Vec<Option<cudarc::driver::CudaSlice<u16>>>,
+    /// Token sequence currently represented in the persistent KV cache (the last request's
+    /// prompt + its generated tokens). On the next request the longest matching prefix is
+    /// reused, so only the genuinely new tokens are prefilled — this keeps multi-turn TTFT
+    /// roughly constant instead of growing with conversation length.
+    cached_tokens: Vec<u32>,
     // Reused per-token/per-layer device scratch (sized to per-layer maxima).
     d_hidden: cudarc::driver::CudaSlice<f32>,
     d_normed: cudarc::driver::CudaSlice<f32>,
@@ -2643,6 +2648,7 @@ impl Gemma4CudaResident {
             warmed: false,
             cache_k,
             cache_v,
+            cached_tokens: Vec::new(),
             d_hidden: alloc_f(hidden).map_err(cu)?,
             d_normed: alloc_f(hidden).map_err(cu)?,
             d_inq: alloc_i(hidden).map_err(cu)?,
@@ -3451,14 +3457,43 @@ impl Gemma4CudaResident {
     }
 
     /// Greedy-generate up to `max_new` tokens (mirrors the Metal runtime loop).
+    /// Prefill `prompt_tokens`, reusing the longest prefix already present in the KV cache
+    /// from the previous request (cross-request prefix cache) and only running
+    /// `forward_token` for the new suffix. Returns the logits predicting the first new
+    /// token. Output-equivalent to a full re-prefill: the KV for shared-prefix positions is
+    /// identical (same tokens, same positions), so only redundant compute is skipped. The
+    /// caller extends `cached_tokens` with any tokens it then generates. Disable with
+    /// `CAMELID_GEMMA4_NO_PREFIX_CACHE=1`.
+    fn prefill_reusing_cache(&mut self, prompt_tokens: &[u32]) -> Result<Vec<f32>> {
+        let n = prompt_tokens.len();
+        debug_assert!(n >= 1);
+        let disabled = std::env::var("CAMELID_GEMMA4_NO_PREFIX_CACHE").is_ok_and(|v| v == "1");
+        let mut p = 0usize;
+        if !disabled {
+            let cap = self.max_positions.min(n);
+            while p < cap
+                && p < self.cached_tokens.len()
+                && prompt_tokens[p] == self.cached_tokens[p]
+            {
+                p += 1;
+            }
+        }
+        // Always run at least the final prompt token to produce its logits.
+        let start = p.min(n - 1);
+        let last = n - 1;
+        let mut logits = Vec::new();
+        for pos in start..n {
+            logits = self.forward_token(prompt_tokens[pos], pos, pos == last)?;
+        }
+        self.cached_tokens.clear();
+        self.cached_tokens.extend_from_slice(prompt_tokens);
+        Ok(logits)
+    }
+
     pub fn generate_greedy(&mut self, prompt: &str, max_new: usize) -> Result<(String, Vec<u32>)> {
         let prompt_tokens = self.cpu.tokenizer.encode(prompt, true, true)?;
         let eot = gemma4_stop_token_ids(&self.cpu.tokenizer);
-        let mut logits = Vec::new();
-        let last_prompt = prompt_tokens.len().saturating_sub(1);
-        for (pos, &tok) in prompt_tokens.iter().enumerate() {
-            logits = self.forward_token(tok, pos, pos == last_prompt)?;
-        }
+        let mut logits = self.prefill_reusing_cache(&prompt_tokens)?;
         let mut generated = Vec::new();
         for pos in prompt_tokens.len()..prompt_tokens.len() + max_new {
             let next = logits
@@ -3473,6 +3508,9 @@ impl Gemma4CudaResident {
             generated.push(next);
             logits = self.forward_token(next, pos, true)?;
         }
+        // The cache now also holds the generated tokens — record them so the next request
+        // can reuse this turn's full sequence as a prefix.
+        self.cached_tokens.extend_from_slice(&generated);
         let text = self.cpu.tokenizer.decode(&generated, true)?;
         Ok((text, generated))
     }
@@ -3488,11 +3526,7 @@ impl Gemma4CudaResident {
     ) -> Result<(String, Vec<u32>)> {
         let prompt_tokens = self.cpu.tokenizer.encode(prompt, true, true)?;
         let eot = gemma4_stop_token_ids(&self.cpu.tokenizer);
-        let mut logits = Vec::new();
-        let last_prompt = prompt_tokens.len().saturating_sub(1);
-        for (pos, &tok) in prompt_tokens.iter().enumerate() {
-            logits = self.forward_token(tok, pos, pos == last_prompt)?;
-        }
+        let mut logits = self.prefill_reusing_cache(&prompt_tokens)?;
         let mut generated = Vec::new();
         let mut prev_text = String::new();
         for pos in prompt_tokens.len()..prompt_tokens.len() + max_new {
@@ -3513,6 +3547,7 @@ impl Gemma4CudaResident {
             prev_text = text;
             logits = self.forward_token(next, pos, true)?;
         }
+        self.cached_tokens.extend_from_slice(&generated);
         Ok((prev_text, generated))
     }
 }

--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -3467,6 +3467,16 @@ impl Gemma4CudaResident {
     fn prefill_reusing_cache(&mut self, prompt_tokens: &[u32]) -> Result<Vec<f32>> {
         let n = prompt_tokens.len();
         debug_assert!(n >= 1);
+        // Hard cap: the prompt must leave at least one slot for a generated token, and the
+        // KV cache is bounded by `max_positions`. Without this, prefilling past the cache
+        // overflowed it and the generation silently produced nothing.
+        if n >= self.max_positions {
+            return Err(BackendError::InvalidModelMetadata(format!(
+                "conversation is {n} tokens, which exceeds the gemma4 {}-token context \
+                 window — please start a new chat",
+                self.max_positions
+            )));
+        }
         let disabled = std::env::var("CAMELID_GEMMA4_NO_PREFIX_CACHE").is_ok_and(|v| v == "1");
         let mut p = 0usize;
         if !disabled {
@@ -3495,7 +3505,8 @@ impl Gemma4CudaResident {
         let eot = gemma4_stop_token_ids(&self.cpu.tokenizer);
         let mut logits = self.prefill_reusing_cache(&prompt_tokens)?;
         let mut generated = Vec::new();
-        for pos in prompt_tokens.len()..prompt_tokens.len() + max_new {
+        let decode_end = (prompt_tokens.len() + max_new).min(self.max_positions);
+        for pos in prompt_tokens.len()..decode_end {
             let next = logits
                 .iter()
                 .enumerate()
@@ -3529,7 +3540,8 @@ impl Gemma4CudaResident {
         let mut logits = self.prefill_reusing_cache(&prompt_tokens)?;
         let mut generated = Vec::new();
         let mut prev_text = String::new();
-        for pos in prompt_tokens.len()..prompt_tokens.len() + max_new {
+        let decode_end = (prompt_tokens.len() + max_new).min(self.max_positions);
+        for pos in prompt_tokens.len()..decode_end {
             let next = logits
                 .iter()
                 .enumerate()


### PR DESCRIPTION
Fixes two issues in the gemma4 CUDA serve lane found while testing E4B Q8_0 on a 6 GB RTX 3060.

## 1. Multi-turn TTFT (`8bfca087`)
The lane re-prefilled the entire conversation token-by-token on every request (no cross-request KV reuse), so chat TTFT grew with history length (1.5 → 3.3 → 4.4s over three turns). The GPU KV caches already persist on the device — they were just always overwritten.

Added a **cross-request prefix cache**: track the token sequence currently in the cache (`cached_tokens`) and, on each request, reuse the longest matching prefix — only `forward_token` the new suffix. **Verified bit-identical**: the same 3-turn chat produces identical response hashes with the cache on vs. off (`CAMELID_GEMMA4_NO_PREFIX_CACHE=1`), while TTFT drops to a flat ~0.7s.

## 2. Context overflow / "Generation stopped" (`b943a8c8`)
The KV cache was capped at 2048 positions with no guard, so a conversation past it overflowed and the generation **silently produced nothing** (the WebUI's "Generation stopped before Camelid returned a complete reply"). Raised the cap to **4096** (fits the 6 GB card — attention shared-mem stays under 48 KB, f16 KV adds ~100 MB; loads at 5.56 GB used / 438 MB free), reject an over-long prompt with a clear message instead of failing silently, and cap decode at `max_positions`.

## Verified
- Bit-identical output (cache on vs off), flat TTFT.
- 8-turn conversation runs clean, no errors.
- Loads on the 6 GB GPU at 4096.

Note: also documented that the Windows GPU lane is gated by `CAMELID_GEMMA4_CUDA=1` (not the macOS-only `CAMELID_GEMMA4_GPU`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)