### PR TITLE
GAIT: flagless per-(model×machine) parity-gated execution profiles (Windows CPU)

### DIFF
--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, env, path::Path};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::gguf::{GgufFile, GgufTensorType};
 
@@ -75,7 +75,7 @@ const MANAGED_PASSTHROUGH_ENV_KEYS: &[ManagedPassthroughEnvKey] = &[
 
 pub const MAC_Q8_PREFILL_I8MM_MIN_ROWS: usize = 4;
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecutionProfile {
     Safe,
@@ -253,7 +253,12 @@ pub fn plan_for_model_with_platform(
     threads: Option<usize>,
     platform: PlanPlatform,
 ) -> ExecutionPlanOutcome {
-    let (profile, profile_reason) = requested_profile();
+    // GAIT selector (bring-up gate `CAMELID_GAIT`, default off): consult the
+    // per-(model × machine) gait store for a cached profile. With the gate off,
+    // or on any miss/empty store, this returns None and the existing default
+    // path runs unchanged — keeping this byte-identical to today.
+    let (profile, profile_reason) =
+        crate::gait::maybe_select_profile(gguf).unwrap_or_else(requested_profile);
     let row = exact_model_row(model_path, gguf);
     let support_level = support_level(&row);
     let model_family = model_family(&row, gguf);

--- a/src/gait/calibrate.rs
+++ b/src/gait/calibrate.rs
@@ -86,6 +86,10 @@ fn is_matmul_stage(class: &str) -> bool {
 pub struct Candidate {
     pub label: String,
     pub profile: ExecutionProfile,
+    /// Whether this candidate disables EcoQoS execution-speed throttling (a
+    /// Windows scheduling-substrate dimension). The engine only records it; the
+    /// trial closure applies it before timing.
+    pub eco_qos_opt_out: bool,
 }
 
 /// The result of timing one candidate: its throughput and a parity token. Two
@@ -124,6 +128,11 @@ pub struct CalibrationOutcome {
     pub fell_back: bool,
     /// Candidate labels disqualified for diverging from baseline parity.
     pub parity_disqualified: Vec<String>,
+    /// Whether the selected configuration disables EcoQoS throttling. Recorded so
+    /// the gait can be reproduced. Defaults to false for receipts written before
+    /// the substrate dimension existed.
+    #[serde(default)]
+    pub selected_eco_qos_opt_out: bool,
 }
 
 fn roofline_pct(tokens_per_s: f64, weight_bytes_per_token: u64, stream_gbs: f64) -> f64 {
@@ -161,6 +170,7 @@ pub fn run_tournament(
                 roofline_pct: 0.0,
                 fell_back: true,
                 parity_disqualified: Vec::new(),
+                selected_eco_qos_opt_out: baseline.eco_qos_opt_out,
             };
         }
     };
@@ -193,6 +203,7 @@ pub fn run_tournament(
                 roofline_pct: super::round_sig6(roofline_pct(tok, weight_bytes_per_token, gbs)),
                 fell_back: false,
                 parity_disqualified: disqualified,
+                selected_eco_qos_opt_out: winner.eco_qos_opt_out,
             }
         }
         _ => CalibrationOutcome {
@@ -209,6 +220,7 @@ pub fn run_tournament(
             )),
             fell_back: true,
             parity_disqualified: disqualified,
+            selected_eco_qos_opt_out: baseline.eco_qos_opt_out,
         },
     }
 }
@@ -286,7 +298,11 @@ mod tests {
     }
 
     fn cand(label: &str, profile: ExecutionProfile) -> Candidate {
-        Candidate { label: label.to_string(), profile }
+        Candidate {
+            label: label.to_string(),
+            profile,
+            eco_qos_opt_out: false,
+        }
     }
 
     fn mem() -> MemoryMeasurement {
@@ -340,6 +356,28 @@ mod tests {
         assert!((outcome.speedup - 1.3).abs() < 1e-9);
         assert!(outcome.parity_disqualified.contains(&"faster_diverges".to_string()));
         assert!(outcome.roofline_pct > 0.0);
+    }
+
+    #[test]
+    fn records_selected_substrate_dimension() {
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let mut winner = cand("auto+ecoqos", ExecutionProfile::Auto);
+        winner.eco_qos_opt_out = true;
+        let outcome = run_tournament(
+            &baseline,
+            &[winner],
+            &TournamentConfig::default(),
+            1_000_000,
+            &mem(),
+            |c| {
+                Some(match c.label.as_str() {
+                    "auto" => TrialResult { tokens_per_s: 10.0, parity_token: "A".into() },
+                    _ => TrialResult { tokens_per_s: 12.0, parity_token: "A".into() },
+                })
+            },
+        );
+        assert!(!outcome.fell_back);
+        assert!(outcome.selected_eco_qos_opt_out);
     }
 
     #[test]

--- a/src/gait/calibrate.rs
+++ b/src/gait/calibrate.rs
@@ -107,12 +107,37 @@ pub struct TournamentConfig {
     /// A candidate must beat baseline by at least this factor to win; otherwise
     /// the tournament fails closed to baseline. Slower-but-correct always wins.
     pub min_speedup: f64,
+    /// Measured rounds per variant. Each round times every variant once, in the
+    /// same order, so any two share a thermal/clock neighborhood (matched-clock
+    /// A/B by interleaving). The per-variant statistic is the median across
+    /// rounds, which rejects the run-to-run outliers a single trial cannot.
+    pub rounds: usize,
+    /// Leading rounds discarded as warmup (cache/clock settling).
+    pub warmup_rounds: usize,
 }
 
 impl Default for TournamentConfig {
     fn default() -> Self {
-        Self { min_speedup: 1.05 }
+        Self {
+            min_speedup: 1.05,
+            rounds: 5,
+            warmup_rounds: 1,
+        }
     }
+}
+
+/// Per-variant measurement spread, recorded as honest evidence so a reader can
+/// see the noise behind the selection rather than just a single number.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CandidateSamples {
+    pub label: String,
+    pub median_tokens_per_s: f64,
+    pub min_tokens_per_s: f64,
+    pub max_tokens_per_s: f64,
+    pub measured_rounds: usize,
+    /// True when every round reproduced this variant's parity token AND it
+    /// matched the baseline's (eligible); false means it was disqualified.
+    pub parity_ok: bool,
 }
 
 /// The evidence a calibration produced — recorded into the gait receipt.
@@ -133,6 +158,12 @@ pub struct CalibrationOutcome {
     /// the substrate dimension existed.
     #[serde(default)]
     pub selected_eco_qos_opt_out: bool,
+    /// Measured rounds per variant behind the medians.
+    #[serde(default)]
+    pub measured_rounds: usize,
+    /// Per-variant measurement spread (baseline first), for evidence.
+    #[serde(default)]
+    pub samples: Vec<CandidateSamples>,
 }
 
 fn roofline_pct(tokens_per_s: f64, weight_bytes_per_token: u64, stream_gbs: f64) -> f64 {
@@ -142,11 +173,37 @@ fn roofline_pct(tokens_per_s: f64, weight_bytes_per_token: u64, stream_gbs: f64)
     (tokens_per_s * weight_bytes_per_token as f64) / (stream_gbs * 1e9)
 }
 
-/// Run the tournament. `trial` times one candidate and returns its throughput +
-/// parity token (or `None` if that candidate could not be run). The baseline is
-/// timed first and is the parity reference; every candidate must reproduce its
-/// parity token to be eligible. The fastest eligible candidate that clears
-/// `min_speedup` wins; otherwise the result fails closed to baseline.
+fn median(samples: &[f64]) -> Option<f64> {
+    if samples.is_empty() {
+        return None;
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = sorted.len() / 2;
+    Some(if sorted.len() % 2 == 0 {
+        (sorted[mid - 1] + sorted[mid]) / 2.0
+    } else {
+        sorted[mid]
+    })
+}
+
+/// Per-variant accumulation across interleaved rounds.
+struct VariantStats {
+    tok_samples: Vec<f64>,
+    parity_token: Option<String>,
+    parity_consistent: bool,
+}
+
+/// Run the tournament with interleaved, matched-clock rounds. Each round times
+/// every variant once in a fixed order (baseline first), so any two are measured
+/// in the same thermal/clock neighborhood; the per-variant statistic is the
+/// median across measured rounds. `trial` times one variant and returns its
+/// throughput + parity token (or `None` if it could not be run that round).
+///
+/// A candidate is eligible only if it reproduced its own parity token across all
+/// rounds AND that token equals the baseline's. The fastest eligible candidate
+/// whose median clears `min_speedup` wins; otherwise the tournament fails closed
+/// to baseline. Slower-but-correct always wins.
 pub fn run_tournament(
     baseline: &Candidate,
     candidates: &[Candidate],
@@ -157,71 +214,128 @@ pub fn run_tournament(
 ) -> CalibrationOutcome {
     let gbs = memory.stream_triad_gbs;
 
-    let base = trial(baseline);
-    let base = match base {
-        Some(r) if r.tokens_per_s > 0.0 => r,
+    // Index 0 is the baseline; the rest are candidates, measured interleaved.
+    let variants: Vec<&Candidate> = std::iter::once(baseline).chain(candidates).collect();
+    let mut stats: Vec<VariantStats> = variants
+        .iter()
+        .map(|_| VariantStats {
+            tok_samples: Vec::new(),
+            parity_token: None,
+            parity_consistent: true,
+        })
+        .collect();
+
+    let measured = config.rounds.max(1);
+    let total_rounds = config.warmup_rounds + measured;
+    for round in 0..total_rounds {
+        for (i, variant) in variants.iter().enumerate() {
+            let Some(result) = trial(variant) else { continue };
+            match &stats[i].parity_token {
+                None => stats[i].parity_token = Some(result.parity_token.clone()),
+                Some(token) if *token != result.parity_token => {
+                    stats[i].parity_consistent = false;
+                }
+                _ => {}
+            }
+            if round >= config.warmup_rounds && result.tokens_per_s > 0.0 {
+                stats[i].tok_samples.push(result.tokens_per_s);
+            }
+        }
+    }
+
+    let base_parity = stats[0].parity_token.clone();
+    let base_median = median(&stats[0].tok_samples);
+
+    // Evidence: per-variant spread, baseline first.
+    let samples: Vec<CandidateSamples> = variants
+        .iter()
+        .zip(stats.iter())
+        .map(|(variant, stat)| {
+            let med = median(&stat.tok_samples).unwrap_or(0.0);
+            let min = stat.tok_samples.iter().cloned().fold(f64::INFINITY, f64::min);
+            let max = stat.tok_samples.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            let parity_ok = stat.parity_consistent && stat.parity_token == base_parity;
+            CandidateSamples {
+                label: variant.label.clone(),
+                median_tokens_per_s: super::round_sig6(med),
+                min_tokens_per_s: super::round_sig6(if min.is_finite() { min } else { 0.0 }),
+                max_tokens_per_s: super::round_sig6(if max.is_finite() { max } else { 0.0 }),
+                measured_rounds: stat.tok_samples.len(),
+                parity_ok,
+            }
+        })
+        .collect();
+
+    let fail_closed = |reason: String, base_tok: f64, disq: Vec<String>| CalibrationOutcome {
+        selected_profile: baseline.profile.clone(),
+        reason,
+        baseline_tokens_per_s: super::round_sig6(base_tok),
+        selected_tokens_per_s: super::round_sig6(base_tok),
+        speedup: 1.0,
+        roofline_pct: super::round_sig6(roofline_pct(base_tok, weight_bytes_per_token, gbs)),
+        fell_back: true,
+        parity_disqualified: disq,
+        selected_eco_qos_opt_out: baseline.eco_qos_opt_out,
+        measured_rounds: measured,
+        samples: samples.clone(),
+    };
+
+    let base_tok = match base_median {
+        Some(t) if t > 0.0 => t,
         _ => {
-            return CalibrationOutcome {
-                selected_profile: baseline.profile.clone(),
-                reason: "baseline trial failed; failing closed to baseline".to_string(),
-                baseline_tokens_per_s: 0.0,
-                selected_tokens_per_s: 0.0,
-                speedup: 1.0,
-                roofline_pct: 0.0,
-                fell_back: true,
-                parity_disqualified: Vec::new(),
-                selected_eco_qos_opt_out: baseline.eco_qos_opt_out,
-            };
+            return fail_closed(
+                "baseline trial failed; failing closed to baseline".to_string(),
+                0.0,
+                Vec::new(),
+            );
         }
     };
 
+    // Evaluate candidates (indices 1..) on their medians.
     let mut best: Option<(&Candidate, f64)> = None;
     let mut disqualified = Vec::new();
-    for candidate in candidates {
-        let Some(result) = trial(candidate) else {
-            continue; // could not run this candidate — simply skip it
-        };
-        if result.parity_token != base.parity_token {
+    for (i, candidate) in candidates.iter().enumerate() {
+        let stat = &stats[i + 1];
+        if stat.tok_samples.is_empty() {
+            continue; // never ran — skip silently
+        }
+        let eligible = stat.parity_consistent && stat.parity_token == base_parity;
+        if !eligible {
             disqualified.push(candidate.label.clone()); // PARITY GATE
             continue;
         }
+        let med = median(&stat.tok_samples).unwrap_or(0.0);
         match best {
-            Some((_, best_tok)) if result.tokens_per_s <= best_tok => {}
-            _ => best = Some((candidate, result.tokens_per_s)),
+            Some((_, best_tok)) if med <= best_tok => {}
+            _ => best = Some((candidate, med)),
         }
     }
 
     match best {
-        Some((winner, tok)) if tok >= base.tokens_per_s * config.min_speedup => {
-            let speedup = tok / base.tokens_per_s;
+        Some((winner, tok)) if tok >= base_tok * config.min_speedup => {
+            let speedup = tok / base_tok;
             CalibrationOutcome {
                 selected_profile: winner.profile.clone(),
-                reason: format!("gait: {} won at {speedup:.3}x over baseline", winner.label),
-                baseline_tokens_per_s: super::round_sig6(base.tokens_per_s),
+                reason: format!(
+                    "gait: {} won at {speedup:.3}x over baseline (median of {measured} rounds)",
+                    winner.label
+                ),
+                baseline_tokens_per_s: super::round_sig6(base_tok),
                 selected_tokens_per_s: super::round_sig6(tok),
                 speedup: super::round_sig6(speedup),
                 roofline_pct: super::round_sig6(roofline_pct(tok, weight_bytes_per_token, gbs)),
                 fell_back: false,
                 parity_disqualified: disqualified,
                 selected_eco_qos_opt_out: winner.eco_qos_opt_out,
+                measured_rounds: measured,
+                samples,
             }
         }
-        _ => CalibrationOutcome {
-            selected_profile: baseline.profile.clone(),
-            reason: "no parity-clean candidate beat baseline by margin; keeping baseline"
-                .to_string(),
-            baseline_tokens_per_s: super::round_sig6(base.tokens_per_s),
-            selected_tokens_per_s: super::round_sig6(base.tokens_per_s),
-            speedup: 1.0,
-            roofline_pct: super::round_sig6(roofline_pct(
-                base.tokens_per_s,
-                weight_bytes_per_token,
-                gbs,
-            )),
-            fell_back: true,
-            parity_disqualified: disqualified,
-            selected_eco_qos_opt_out: baseline.eco_qos_opt_out,
-        },
+        _ => fail_closed(
+            "no parity-clean candidate beat baseline by margin; keeping baseline".to_string(),
+            base_tok,
+            disqualified,
+        ),
     }
 }
 
@@ -356,6 +470,64 @@ mod tests {
         assert!((outcome.speedup - 1.3).abs() < 1e-9);
         assert!(outcome.parity_disqualified.contains(&"faster_diverges".to_string()));
         assert!(outcome.roofline_pct > 0.0);
+    }
+
+    #[test]
+    fn median_rejects_single_round_outlier() {
+        // The candidate is genuinely faster (median 13) but one round spikes low.
+        // A single back-to-back trial that happened to hit the 4 would miss it;
+        // the interleaved median does not.
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let candidates = vec![cand("fast", ExecutionProfile::Experimental)];
+        let cfg = TournamentConfig {
+            min_speedup: 1.05,
+            rounds: 3,
+            warmup_rounds: 0,
+        };
+        let mut fast_calls = 0;
+        let outcome = run_tournament(&baseline, &candidates, &cfg, 1_000_000, &mem(), |c| {
+            match c.label.as_str() {
+                "auto" => Some(TrialResult { tokens_per_s: 10.0, parity_token: "A".into() }),
+                _ => {
+                    fast_calls += 1;
+                    let tps = if fast_calls == 2 { 4.0 } else { 13.0 };
+                    Some(TrialResult { tokens_per_s: tps, parity_token: "A".into() })
+                }
+            }
+        });
+        assert!(!outcome.fell_back);
+        assert_eq!(outcome.selected_profile, ExecutionProfile::Experimental);
+        assert_eq!(outcome.measured_rounds, 3);
+        assert_eq!(outcome.samples.len(), 2); // baseline + candidate
+        let fast = outcome.samples.iter().find(|s| s.label == "fast").unwrap();
+        assert_eq!(fast.median_tokens_per_s, 13.0);
+        assert_eq!(fast.min_tokens_per_s, 4.0);
+    }
+
+    #[test]
+    fn inconsistent_parity_across_rounds_disqualifies() {
+        // A fast candidate whose output flips between rounds is non-deterministic
+        // and must be disqualified, not selected.
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let candidates = vec![cand("flaky", ExecutionProfile::Experimental)];
+        let cfg = TournamentConfig {
+            min_speedup: 1.05,
+            rounds: 2,
+            warmup_rounds: 0,
+        };
+        let mut n = 0;
+        let outcome = run_tournament(&baseline, &candidates, &cfg, 0, &mem(), |c| {
+            match c.label.as_str() {
+                "auto" => Some(TrialResult { tokens_per_s: 10.0, parity_token: "A".into() }),
+                _ => {
+                    n += 1;
+                    let token = if n == 1 { "A" } else { "B" };
+                    Some(TrialResult { tokens_per_s: 20.0, parity_token: token.into() })
+                }
+            }
+        });
+        assert!(outcome.fell_back);
+        assert!(outcome.parity_disqualified.contains(&"flaky".to_string()));
     }
 
     #[test]

--- a/src/gait/calibrate.rs
+++ b/src/gait/calibrate.rs
@@ -1,0 +1,416 @@
+//! The parity-gated calibration tournament (Lane B).
+//!
+//! On first encounter of a `gait_key`, calibration discovers the fastest
+//! execution configuration for *this* model on *this* machine, then persists it.
+//! The engine here owns the hard part — extracting the model's real stage
+//! shapes, running candidates through a **parity gate** (a faster candidate that
+//! diverges is disqualified, full stop), picking a winner only if it beats
+//! baseline by a margin, computing the roofline %, and failing closed to the
+//! proven baseline otherwise.
+//!
+//! The act of *timing real decode* is an injected seam (`trial`): production
+//! passes a closure that runs the engine under a candidate's configuration and
+//! returns its tok/s plus a parity token (the greedy-output digest, matching the
+//! `qa/speed` methodology); tests pass deterministic stubs. This keeps the
+//! selection logic fully testable without ever fabricating a throughput number.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::{gait_dir, store_in, GaitReceipt, MachineSig, MemoryMeasurement, ModelSig};
+use crate::execution_plan::ExecutionProfile;
+use crate::gguf::GgufFile;
+
+/// A representative tensor shape for one inference stage class — the geometry a
+/// candidate kernel is timed against. Calibration tunes on the model's *actual*
+/// shapes, not synthetic ones.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StageShape {
+    pub stage: String,
+    pub dims: Vec<u64>,
+    pub quant: String,
+}
+
+/// One representative shape per matmul stage class present in the model.
+pub fn stage_shapes(gguf: &GgufFile) -> Vec<StageShape> {
+    let mut by_class: BTreeMap<&'static str, StageShape> = BTreeMap::new();
+    for tensor in &gguf.tensors {
+        if tensor.dimensions.len() != 2 {
+            continue; // GEMV/GEMM stages are rank-2 weights.
+        }
+        let class = super::tensor_class(&tensor.name);
+        if !is_matmul_stage(class) {
+            continue;
+        }
+        by_class.entry(class).or_insert_with(|| StageShape {
+            stage: class.to_string(),
+            dims: tensor.dimensions.clone(),
+            quant: format!("{:?}", tensor.tensor_type),
+        });
+    }
+    by_class.into_values().collect()
+}
+
+/// Total quantized weight bytes read per decoded token — the numerator of the
+/// roofline ratio (achieved bytes/s ÷ measured DRAM bytes/s). Sums the matmul
+/// weight tensors a decode step streams once.
+pub fn decode_weight_bytes(gguf: &GgufFile) -> u64 {
+    gguf.tensors
+        .iter()
+        .filter(|t| is_matmul_stage(super::tensor_class(&t.name)))
+        .map(|t| t.n_bytes)
+        .sum()
+}
+
+fn is_matmul_stage(class: &str) -> bool {
+    matches!(
+        class,
+        "attn_q"
+            | "attn_k"
+            | "attn_v"
+            | "attn_qkv"
+            | "attn_output"
+            | "ffn_gate"
+            | "ffn_up"
+            | "ffn_down"
+            | "output"
+    )
+}
+
+/// A configuration to evaluate. `profile` is what gets recorded and later
+/// applied; `label` is for evidence/logs. (As the campaign matures, candidates
+/// will also carry the per-stage `MANAGED_ENV_KEYS` struct.)
+#[derive(Debug, Clone)]
+pub struct Candidate {
+    pub label: String,
+    pub profile: ExecutionProfile,
+}
+
+/// The result of timing one candidate: its throughput and a parity token. Two
+/// candidates are parity-equal iff their tokens are equal — the gate that
+/// disqualifies a fast-but-divergent candidate.
+#[derive(Debug, Clone)]
+pub struct TrialResult {
+    pub tokens_per_s: f64,
+    pub parity_token: String,
+}
+
+/// Tournament knobs.
+#[derive(Debug, Clone, Copy)]
+pub struct TournamentConfig {
+    /// A candidate must beat baseline by at least this factor to win; otherwise
+    /// the tournament fails closed to baseline. Slower-but-correct always wins.
+    pub min_speedup: f64,
+}
+
+impl Default for TournamentConfig {
+    fn default() -> Self {
+        Self { min_speedup: 1.05 }
+    }
+}
+
+/// The evidence a calibration produced — recorded into the gait receipt.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CalibrationOutcome {
+    pub selected_profile: ExecutionProfile,
+    pub reason: String,
+    pub baseline_tokens_per_s: f64,
+    pub selected_tokens_per_s: f64,
+    pub speedup: f64,
+    pub roofline_pct: f64,
+    /// True when no candidate qualified and the proven baseline was kept.
+    pub fell_back: bool,
+    /// Candidate labels disqualified for diverging from baseline parity.
+    pub parity_disqualified: Vec<String>,
+}
+
+fn roofline_pct(tokens_per_s: f64, weight_bytes_per_token: u64, stream_gbs: f64) -> f64 {
+    if stream_gbs <= 0.0 || weight_bytes_per_token == 0 {
+        return 0.0;
+    }
+    (tokens_per_s * weight_bytes_per_token as f64) / (stream_gbs * 1e9)
+}
+
+/// Run the tournament. `trial` times one candidate and returns its throughput +
+/// parity token (or `None` if that candidate could not be run). The baseline is
+/// timed first and is the parity reference; every candidate must reproduce its
+/// parity token to be eligible. The fastest eligible candidate that clears
+/// `min_speedup` wins; otherwise the result fails closed to baseline.
+pub fn run_tournament(
+    baseline: &Candidate,
+    candidates: &[Candidate],
+    config: &TournamentConfig,
+    weight_bytes_per_token: u64,
+    memory: &MemoryMeasurement,
+    mut trial: impl FnMut(&Candidate) -> Option<TrialResult>,
+) -> CalibrationOutcome {
+    let gbs = memory.stream_triad_gbs;
+
+    let base = trial(baseline);
+    let base = match base {
+        Some(r) if r.tokens_per_s > 0.0 => r,
+        _ => {
+            return CalibrationOutcome {
+                selected_profile: baseline.profile.clone(),
+                reason: "baseline trial failed; failing closed to baseline".to_string(),
+                baseline_tokens_per_s: 0.0,
+                selected_tokens_per_s: 0.0,
+                speedup: 1.0,
+                roofline_pct: 0.0,
+                fell_back: true,
+                parity_disqualified: Vec::new(),
+            };
+        }
+    };
+
+    let mut best: Option<(&Candidate, f64)> = None;
+    let mut disqualified = Vec::new();
+    for candidate in candidates {
+        let Some(result) = trial(candidate) else {
+            continue; // could not run this candidate — simply skip it
+        };
+        if result.parity_token != base.parity_token {
+            disqualified.push(candidate.label.clone()); // PARITY GATE
+            continue;
+        }
+        match best {
+            Some((_, best_tok)) if result.tokens_per_s <= best_tok => {}
+            _ => best = Some((candidate, result.tokens_per_s)),
+        }
+    }
+
+    match best {
+        Some((winner, tok)) if tok >= base.tokens_per_s * config.min_speedup => {
+            let speedup = tok / base.tokens_per_s;
+            CalibrationOutcome {
+                selected_profile: winner.profile.clone(),
+                reason: format!("gait: {} won at {speedup:.3}x over baseline", winner.label),
+                baseline_tokens_per_s: super::round_sig6(base.tokens_per_s),
+                selected_tokens_per_s: super::round_sig6(tok),
+                speedup: super::round_sig6(speedup),
+                roofline_pct: super::round_sig6(roofline_pct(tok, weight_bytes_per_token, gbs)),
+                fell_back: false,
+                parity_disqualified: disqualified,
+            }
+        }
+        _ => CalibrationOutcome {
+            selected_profile: baseline.profile.clone(),
+            reason: "no parity-clean candidate beat baseline by margin; keeping baseline"
+                .to_string(),
+            baseline_tokens_per_s: super::round_sig6(base.tokens_per_s),
+            selected_tokens_per_s: super::round_sig6(base.tokens_per_s),
+            speedup: 1.0,
+            roofline_pct: super::round_sig6(roofline_pct(
+                base.tokens_per_s,
+                weight_bytes_per_token,
+                gbs,
+            )),
+            fell_back: true,
+            parity_disqualified: disqualified,
+        },
+    }
+}
+
+/// End-to-end: fingerprint the model + machine, measure memory, run the
+/// tournament, and persist a sealed gait receipt under `dir`. Returns the
+/// outcome and the receipt path (`None` if the store write failed — fail-closed,
+/// never panics). The caller supplies the timing `trial`.
+pub fn calibrate_and_store(
+    dir: &Path,
+    gguf: &GgufFile,
+    baseline: &Candidate,
+    candidates: &[Candidate],
+    config: &TournamentConfig,
+    trial: impl FnMut(&Candidate) -> Option<TrialResult>,
+) -> (CalibrationOutcome, Option<PathBuf>) {
+    let model_sig = ModelSig::from_gguf(gguf);
+    let machine_sig = MachineSig::detect();
+    let memory = super::measure_memory();
+    let weight_bytes = decode_weight_bytes(gguf);
+
+    let outcome = run_tournament(baseline, candidates, config, weight_bytes, &memory, trial);
+
+    let receipt = GaitReceipt::new(model_sig, machine_sig, outcome.selected_profile.clone())
+        .with_memory(memory)
+        .with_calibration(outcome.clone());
+    let path = store_in(dir, &receipt).ok();
+    (outcome, path)
+}
+
+/// Convenience: the default store directory for calibration output.
+pub fn default_store_dir() -> Option<PathBuf> {
+    gait_dir()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gguf::{GgufFile, GgufMetadataValue, GgufTensorDescriptor, GgufTensorType};
+    use std::collections::BTreeMap as Map;
+    use std::path::PathBuf;
+
+    fn descriptor(name: &str, ty: GgufTensorType, dims: Vec<u64>, n_bytes: u64) -> GgufTensorDescriptor {
+        GgufTensorDescriptor {
+            name: name.to_string(),
+            dimensions: dims,
+            tensor_type: ty,
+            relative_offset: 0,
+            absolute_offset: 0,
+            n_bytes,
+        }
+    }
+
+    fn sample_gguf() -> GgufFile {
+        let mut metadata = Map::new();
+        metadata.insert(
+            "general.architecture".to_string(),
+            GgufMetadataValue::String("llama".to_string()),
+        );
+        GgufFile {
+            path: PathBuf::from("sample.gguf"),
+            version: 3,
+            tensor_count: 4,
+            metadata_count: metadata.len() as i64,
+            alignment: 32,
+            data_start_offset: 0,
+            metadata,
+            tensors: vec![
+                descriptor("token_embd.weight", GgufTensorType::Q8_0, vec![16, 128], 4096),
+                descriptor("blk.0.attn_q.weight", GgufTensorType::Q8_0, vec![16, 16], 256),
+                descriptor("blk.0.ffn_down.weight", GgufTensorType::Q4K, vec![32, 16], 288),
+                descriptor("blk.0.attn_norm.weight", GgufTensorType::F32, vec![16], 64),
+            ],
+        }
+    }
+
+    fn cand(label: &str, profile: ExecutionProfile) -> Candidate {
+        Candidate { label: label.to_string(), profile }
+    }
+
+    fn mem() -> MemoryMeasurement {
+        MemoryMeasurement { stream_triad_gbs: 30.0, dram_latency_ns: 80.0 }
+    }
+
+    #[test]
+    fn stage_shapes_are_matmul_only_and_deduped() {
+        let shapes = stage_shapes(&sample_gguf());
+        let stages: Vec<&str> = shapes.iter().map(|s| s.stage.as_str()).collect();
+        // attn_q and ffn_down are matmul stages; token_embd and norm are not.
+        assert!(stages.contains(&"attn_q"));
+        assert!(stages.contains(&"ffn_down"));
+        assert!(!stages.contains(&"token_embd"));
+        assert!(!stages.contains(&"norm"));
+    }
+
+    #[test]
+    fn decode_weight_bytes_sums_matmul_weights_only() {
+        // attn_q (256) + ffn_down (288); token_embd and norm excluded.
+        assert_eq!(decode_weight_bytes(&sample_gguf()), 256 + 288);
+    }
+
+    #[test]
+    fn parity_gate_beats_raw_speed() {
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let candidates = vec![
+            cand("fast_clean", ExecutionProfile::Experimental),
+            cand("faster_diverges", ExecutionProfile::Debug),
+            cand("slow_clean", ExecutionProfile::Safe),
+        ];
+        let outcome = run_tournament(
+            &baseline,
+            &candidates,
+            &TournamentConfig::default(),
+            1_000_000,
+            &mem(),
+            |c| {
+                Some(match c.label.as_str() {
+                    "auto" => TrialResult { tokens_per_s: 10.0, parity_token: "A".into() },
+                    "fast_clean" => TrialResult { tokens_per_s: 13.0, parity_token: "A".into() },
+                    // Faster, but DIVERGES — must be disqualified despite winning on speed.
+                    "faster_diverges" => TrialResult { tokens_per_s: 20.0, parity_token: "B".into() },
+                    "slow_clean" => TrialResult { tokens_per_s: 9.0, parity_token: "A".into() },
+                    _ => unreachable!(),
+                })
+            },
+        );
+        assert!(!outcome.fell_back);
+        assert_eq!(outcome.selected_profile, ExecutionProfile::Experimental);
+        assert!((outcome.speedup - 1.3).abs() < 1e-9);
+        assert!(outcome.parity_disqualified.contains(&"faster_diverges".to_string()));
+        assert!(outcome.roofline_pct > 0.0);
+    }
+
+    #[test]
+    fn fails_closed_when_nothing_beats_margin() {
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let candidates = vec![cand("marginal", ExecutionProfile::Experimental)];
+        let outcome = run_tournament(
+            &baseline,
+            &candidates,
+            &TournamentConfig::default(),
+            1_000_000,
+            &mem(),
+            |c| {
+                Some(match c.label.as_str() {
+                    "auto" => TrialResult { tokens_per_s: 10.0, parity_token: "A".into() },
+                    // Only +2%, below the 5% margin.
+                    _ => TrialResult { tokens_per_s: 10.2, parity_token: "A".into() },
+                })
+            },
+        );
+        assert!(outcome.fell_back);
+        assert_eq!(outcome.selected_profile, ExecutionProfile::Auto);
+        assert_eq!(outcome.speedup, 1.0);
+    }
+
+    #[test]
+    fn fails_closed_when_baseline_trial_fails() {
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let outcome = run_tournament(
+            &baseline,
+            &[cand("x", ExecutionProfile::Experimental)],
+            &TournamentConfig::default(),
+            0,
+            &mem(),
+            |_| None,
+        );
+        assert!(outcome.fell_back);
+        assert_eq!(outcome.selected_profile, ExecutionProfile::Auto);
+    }
+
+    #[test]
+    fn calibrate_and_store_persists_a_readable_receipt() {
+        let dir = std::env::temp_dir().join(format!("camelid_gait_calib_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let candidates = vec![cand("fast_clean", ExecutionProfile::Experimental)];
+        let (outcome, path) = calibrate_and_store(
+            &dir,
+            &sample_gguf(),
+            &baseline,
+            &candidates,
+            &TournamentConfig::default(),
+            |c| {
+                Some(match c.label.as_str() {
+                    "auto" => TrialResult { tokens_per_s: 10.0, parity_token: "A".into() },
+                    _ => TrialResult { tokens_per_s: 14.0, parity_token: "A".into() },
+                })
+            },
+        );
+        assert_eq!(outcome.selected_profile, ExecutionProfile::Experimental);
+        let path = path.expect("receipt stored");
+        assert!(path.exists());
+
+        // The stored receipt round-trips and carries the calibration evidence.
+        let text = std::fs::read_to_string(&path).unwrap();
+        let receipt: GaitReceipt = serde_json::from_str(&text).unwrap();
+        assert!(receipt.verify_self_digest());
+        assert_eq!(receipt.recorded_profile, ExecutionProfile::Experimental);
+        assert_eq!(receipt.calibration.unwrap().selected_profile, ExecutionProfile::Experimental);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -28,6 +28,8 @@ use crate::execution_plan::ExecutionProfile;
 use crate::gguf::GgufFile;
 use crate::receipt::{canonical_json, sha256_hex};
 
+pub mod calibrate;
+
 /// Schema identifier stamped into every v1 gait receipt. Mirrors the
 /// `camelid.parity-receipt/v1` family so receipts are cited by fingerprint and
 /// trivially checked for tampering.
@@ -142,7 +144,7 @@ impl ModelSig {
 /// Classify a tensor by its inference stage from its GGUF name. Coarse but
 /// deterministic; norm tensors are matched first so QK-norm weights do not fall
 /// into the attention-projection buckets.
-fn tensor_class(name: &str) -> &'static str {
+pub(crate) fn tensor_class(name: &str) -> &'static str {
     let n = name.to_ascii_lowercase();
     if n.contains("norm") {
         "norm"
@@ -498,6 +500,12 @@ pub struct GaitReceipt {
     /// receipts written before a measurement was taken.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory: Option<MemoryMeasurement>,
+    /// The calibration evidence that selected `recorded_profile` — the
+    /// matched-trial speedup over baseline, roofline %, and any parity-
+    /// disqualified candidates. Absent for a hand-set or not-yet-calibrated
+    /// receipt. Part of the canonical body, so bound into `receipt_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub calibration: Option<calibrate::CalibrationOutcome>,
 }
 
 impl GaitReceipt {
@@ -512,6 +520,7 @@ impl GaitReceipt {
             machine_sig,
             recorded_profile,
             memory: None,
+            calibration: None,
         };
         receipt.seal();
         receipt
@@ -521,6 +530,13 @@ impl GaitReceipt {
     /// canonical body).
     pub fn with_memory(mut self, memory: MemoryMeasurement) -> Self {
         self.memory = Some(memory);
+        self.seal();
+        self
+    }
+
+    /// Attach the calibration evidence and re-seal.
+    pub fn with_calibration(mut self, calibration: calibrate::CalibrationOutcome) -> Self {
+        self.calibration = Some(calibration);
         self.seal();
         self
     }
@@ -640,9 +656,23 @@ pub struct MemoryMeasurement {
 /// decode path actually sees.
 pub fn measure_memory() -> MemoryMeasurement {
     MemoryMeasurement {
-        stream_triad_gbs: measure_stream_triad_gbs(),
-        dram_latency_ns: measure_dram_latency_ns(),
+        stream_triad_gbs: round_sig6(measure_stream_triad_gbs()),
+        dram_latency_ns: round_sig6(measure_dram_latency_ns()),
     }
+}
+
+/// Round to 6 significant figures. serde_json's default parser is not bit-exact
+/// for full-precision f64 (off by ~1 ULP on the hardest cases), which would
+/// break a content-addressed receipt's self-digest after a file round-trip.
+/// Measured/derived evidence does not need more than 6 figures, and short
+/// decimals deserialize exactly — so this keeps gait receipts verifiable.
+pub(crate) fn round_sig6(x: f64) -> f64 {
+    if x == 0.0 || !x.is_finite() {
+        return x;
+    }
+    let digits = 5 - x.abs().log10().floor() as i32;
+    let factor = 10f64.powi(digits);
+    (x * factor).round() / factor
 }
 
 #[inline(never)]

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -29,6 +29,7 @@ use crate::gguf::GgufFile;
 use crate::receipt::{canonical_json, sha256_hex};
 
 pub mod calibrate;
+pub mod substrate;
 
 /// Schema identifier stamped into every v1 gait receipt. Mirrors the
 /// `camelid.parity-receipt/v1` family so receipts are cited by fingerprint and

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -1,0 +1,1048 @@
+//! GAIT — per-(model × machine) execution-profile selection.
+//!
+//! The campaign goal is a flagless, measured, persisted execution configuration
+//! discovered once per (model-fingerprint × machine-fingerprint) pair and reused
+//! instantly forever after. This module is the **spine skeleton**: the two
+//! fingerprints, their combined key, a fail-closed on-disk store of
+//! `camelid.gait-receipt/v1` records, and a selector consulted at the execution
+//! planner's decision site.
+//!
+//! This first slice is deliberately **parity-neutral**. The selector only runs
+//! when the `CAMELID_GAIT` bring-up gate is set, and with an empty store (the
+//! only state this slice can produce) it returns `None`, so the planner falls
+//! through to the existing `requested_profile()` / `Auto` path unchanged. The
+//! richer per-stage kernel/chunk configuration (the `MANAGED_ENV_KEYS` surface)
+//! is **not** wired here — that is a later lane. Nothing in this module mutates
+//! the environment or alters any decode/math path.
+//!
+//! The fingerprints intentionally hash *geometry*, not weights: two checkpoints
+//! of the same shape and quantization share a gait, so a fine-tune reuses its
+//! base model's profile.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::execution_plan::ExecutionProfile;
+use crate::gguf::GgufFile;
+use crate::receipt::{canonical_json, sha256_hex};
+
+/// Schema identifier stamped into every v1 gait receipt. Mirrors the
+/// `camelid.parity-receipt/v1` family so receipts are cited by fingerprint and
+/// trivially checked for tampering.
+pub const GAIT_RECEIPT_SCHEMA_V1: &str = "camelid.gait-receipt/v1";
+
+/// Environment gate for the GAIT selector. Bring-up scaffold only: the end state
+/// of the campaign has no user flag. When unset (the default), the planner is
+/// byte-identical to today.
+pub const GAIT_GATE_ENV: &str = "CAMELID_GAIT";
+
+/// True when the GAIT selector is enabled for this process. Recognizes the usual
+/// truthy spellings; anything else (including unset) is off.
+pub fn gait_enabled() -> bool {
+    matches!(
+        std::env::var(GAIT_GATE_ENV).ok().as_deref(),
+        Some("1") | Some("on") | Some("true") | Some("yes")
+    )
+}
+
+/// The inference-shaping geometry of a model, derived from GGUF metadata. Two
+/// models with identical shape + quantization hash identically.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelSig {
+    pub arch: Option<String>,
+    pub n_layers: Option<u32>,
+    pub n_embd: Option<u32>,
+    pub n_heads: Option<u32>,
+    pub n_kv_heads: Option<u32>,
+    pub head_dim: Option<u32>,
+    pub n_ff: Option<u32>,
+    pub vocab_size: Option<u32>,
+    pub rope_dim: Option<u32>,
+    pub sliding_window: Option<u32>,
+    pub qk_norm: bool,
+    /// Per-stage-class set of quantization types present (e.g. `attn_q -> {Q8_0}`,
+    /// `ffn_down -> {Q4K}`). Ordered containers keep serialization deterministic.
+    pub quant_classes: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl ModelSig {
+    /// Derive the signature directly from GGUF metadata + tensor descriptors.
+    ///
+    /// Reads the same architecture-prefixed keys the model loader uses
+    /// (`{arch}.block_count`, `{arch}.attention.head_count`, …) but stays
+    /// fail-closed: every field is optional and a missing/odd value is simply
+    /// `None` rather than an error, so this never fails for an unsupported or
+    /// partially-described model.
+    pub fn from_gguf(gguf: &GgufFile) -> Self {
+        let arch = gguf.architecture().map(|s| s.to_string());
+        let mu = |suffix: &str| -> Option<u32> {
+            arch.as_deref()
+                .and_then(|a| gguf.metadata_u32(&format!("{a}.{suffix}")))
+        };
+
+        let mut quant_classes: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        let mut qk_norm = false;
+        let mut token_embd_vocab: Option<u32> = None;
+        for tensor in &gguf.tensors {
+            let class = tensor_class(&tensor.name);
+            quant_classes
+                .entry(class.to_string())
+                .or_default()
+                .insert(format!("{:?}", tensor.tensor_type));
+            let lower = tensor.name.to_ascii_lowercase();
+            if lower.contains("attn_q_norm") || lower.contains("attn_k_norm") {
+                qk_norm = true;
+            }
+            if class == "token_embd" {
+                // token_embd.weight is [n_embd, vocab]; the larger dim is vocab.
+                if let Some(max) = tensor.dimensions.iter().copied().max() {
+                    token_embd_vocab = u32::try_from(max).ok();
+                }
+            }
+        }
+
+        // Resolve every metadata-derived field before moving `arch` into the
+        // struct, so the `mu` closure's borrow of `arch` has ended.
+        let n_layers = mu("block_count");
+        let n_embd = mu("embedding_length");
+        let n_heads = mu("attention.head_count");
+        let n_kv_heads = mu("attention.head_count_kv");
+        let head_dim = mu("attention.key_length");
+        let n_ff = mu("feed_forward_length");
+        let vocab_size = mu("vocab_size").or(token_embd_vocab);
+        let rope_dim = mu("rope.dimension_count");
+        let sliding_window = mu("attention.sliding_window");
+
+        ModelSig {
+            arch,
+            n_layers,
+            n_embd,
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            n_ff,
+            vocab_size,
+            rope_dim,
+            sliding_window,
+            qk_norm,
+            quant_classes,
+        }
+    }
+
+    /// Lowercase-hex SHA-256 of the canonical serialization. Stable across runs
+    /// for identical inputs and independent of field declaration order.
+    pub fn digest(&self) -> String {
+        let value = serde_json::to_value(self).expect("ModelSig serializes to JSON");
+        sha256_hex(canonical_json(&value).as_bytes())
+    }
+}
+
+/// Classify a tensor by its inference stage from its GGUF name. Coarse but
+/// deterministic; norm tensors are matched first so QK-norm weights do not fall
+/// into the attention-projection buckets.
+fn tensor_class(name: &str) -> &'static str {
+    let n = name.to_ascii_lowercase();
+    if n.contains("norm") {
+        "norm"
+    } else if n.contains("attn_qkv") {
+        "attn_qkv"
+    } else if n.contains("attn_q") {
+        "attn_q"
+    } else if n.contains("attn_k") {
+        "attn_k"
+    } else if n.contains("attn_v") {
+        "attn_v"
+    } else if n.contains("attn_output") || n.contains("attn_out") {
+        "attn_output"
+    } else if n.contains("ffn_gate") {
+        "ffn_gate"
+    } else if n.contains("ffn_up") {
+        "ffn_up"
+    } else if n.contains("ffn_down") {
+        "ffn_down"
+    } else if n.contains("token_embd") || n.contains("tok_embeddings") {
+        "token_embd"
+    } else if n.contains("lm_head") || n.contains("output.weight") {
+        "output"
+    } else {
+        "other"
+    }
+}
+
+/// The inference-relevant fingerprint of the host machine.
+///
+/// Captures the facts that change which gait is fastest: precise CPU ISA, the
+/// physical/SMT topology, and cache sizes. Read-only detection — it shapes the
+/// fingerprint, never decode behavior.
+///
+/// Three campaign inputs are deliberately still absent and tracked for later
+/// lanes: per-core **EfficiencyClass** (P/E split — needs the variable-length
+/// `GetLogicalProcessorInformationEx` walk, Lane D), **measured STREAM
+/// bandwidth / DRAM latency** (Lane B calibration), and the **Windows power-plan
+/// GUID** (Lane F drift detection). Their omission keeps this slice read-only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MachineSig {
+    pub os: String,
+    pub arch: String,
+    pub logical_cores: usize,
+    /// Physical core count (SMT siblings collapsed). `None` if the query failed.
+    pub physical_cores: Option<usize>,
+    /// True when any physical core exposes SMT siblings.
+    pub smt: Option<bool>,
+    /// Distinct per-core EfficiencyClass values (sorted). On a hybrid CPU the
+    /// higher class is the P-core; a single value means a uniform topology.
+    /// Empty when the query is unavailable. This is the input to the eventual
+    /// P/E role partition.
+    pub efficiency_classes: Vec<u8>,
+    /// True when more than one EfficiencyClass is present (a hybrid CPU). `None`
+    /// when efficiency classes could not be read.
+    pub hybrid: Option<bool>,
+    /// Sorted list of detected CPU ISA tokens (e.g. `avx2`, `avx512vnni`; `neon`
+    /// on aarch64). Precise where the coarse `SimdCaps` was not.
+    pub isa: Vec<String>,
+    /// Per-core L1 data cache size in bytes (representative max), if known.
+    pub l1d_bytes: Option<u32>,
+    pub l2_bytes: Option<u32>,
+    /// Shared L3 cache size in bytes, if known.
+    pub l3_bytes: Option<u32>,
+}
+
+impl MachineSig {
+    /// Probe the host cheaply (no CUDA context, unlike `HardwareProfile::detect`).
+    pub fn detect() -> Self {
+        let topo = detect_topology();
+        let efficiency_classes = detect_efficiency_classes();
+        let hybrid = if efficiency_classes.is_empty() {
+            None
+        } else {
+            Some(efficiency_classes.len() > 1)
+        };
+        MachineSig {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            logical_cores: std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1),
+            physical_cores: topo.physical_cores,
+            smt: topo.smt,
+            efficiency_classes,
+            hybrid,
+            isa: detect_isa(),
+            l1d_bytes: topo.l1d_bytes,
+            l2_bytes: topo.l2_bytes,
+            l3_bytes: topo.l3_bytes,
+        }
+    }
+
+    /// Build from an already-detected [`crate::capability::HardwareProfile`],
+    /// reusing its coarse SIMD probe. Topology/cache fields are left `None` (the
+    /// profile does not carry them); call [`MachineSig::detect`] for the full
+    /// fingerprint.
+    pub fn from_hardware(profile: &crate::capability::HardwareProfile) -> Self {
+        let mut isa = Vec::new();
+        if profile.simd.avx2 {
+            isa.push("avx2".to_string());
+        }
+        if profile.simd.fma {
+            isa.push("fma".to_string());
+        }
+        if profile.simd.avx512f {
+            isa.push("avx512f".to_string());
+        }
+        if profile.simd.neon {
+            isa.push("neon".to_string());
+        }
+        isa.sort();
+        MachineSig {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            logical_cores: profile.cpu_logical_cores,
+            physical_cores: None,
+            smt: None,
+            efficiency_classes: Vec::new(),
+            hybrid: None,
+            isa,
+            l1d_bytes: None,
+            l2_bytes: None,
+            l3_bytes: None,
+        }
+    }
+
+    /// Lowercase-hex SHA-256 of the canonical serialization.
+    pub fn digest(&self) -> String {
+        let value = serde_json::to_value(self).expect("MachineSig serializes to JSON");
+        sha256_hex(canonical_json(&value).as_bytes())
+    }
+}
+
+/// Precise CPU ISA tokens, runtime-detected. On x86-64 this resolves the
+/// AVX-512 sub-features the coarse `SimdCaps { avx512f }` could not distinguish.
+#[cfg(target_arch = "x86_64")]
+fn detect_isa() -> Vec<String> {
+    // `is_x86_feature_detected!` requires a direct string literal — it cannot be
+    // driven by a macro metavariable, so each probe is spelled out.
+    let mut isa = Vec::new();
+    if std::is_x86_feature_detected!("avx2") {
+        isa.push("avx2".to_string());
+    }
+    if std::is_x86_feature_detected!("fma") {
+        isa.push("fma".to_string());
+    }
+    if std::is_x86_feature_detected!("avx512f") {
+        isa.push("avx512f".to_string());
+    }
+    if std::is_x86_feature_detected!("avx512bw") {
+        isa.push("avx512bw".to_string());
+    }
+    if std::is_x86_feature_detected!("avx512vl") {
+        isa.push("avx512vl".to_string());
+    }
+    if std::is_x86_feature_detected!("avx512dq") {
+        isa.push("avx512dq".to_string());
+    }
+    if std::is_x86_feature_detected!("avx512cd") {
+        isa.push("avx512cd".to_string());
+    }
+    if std::is_x86_feature_detected!("avx512vbmi") {
+        isa.push("avx512vbmi".to_string());
+    }
+    if std::is_x86_feature_detected!("avx512vnni") {
+        isa.push("avx512vnni".to_string());
+    }
+    if std::is_x86_feature_detected!("avx512bf16") {
+        isa.push("avx512bf16".to_string());
+    }
+    isa.sort();
+    isa
+}
+
+#[cfg(target_arch = "aarch64")]
+fn detect_isa() -> Vec<String> {
+    let mut isa = Vec::new();
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        isa.push("neon".to_string());
+    }
+    isa
+}
+
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+fn detect_isa() -> Vec<String> {
+    Vec::new()
+}
+
+/// Physical topology + cache, collapsed from the OS processor map.
+#[derive(Default)]
+struct Topology {
+    physical_cores: Option<usize>,
+    smt: Option<bool>,
+    l1d_bytes: Option<u32>,
+    l2_bytes: Option<u32>,
+    l3_bytes: Option<u32>,
+}
+
+/// Windows x86-64: walk the fixed-size `GetLogicalProcessorInformation` records
+/// (the same proven API the Rayon sizing uses) for physical cores, SMT, and
+/// L1d/L2/L3 cache sizes. Best-effort: any failure leaves the field `None`.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn detect_topology() -> Topology {
+    use windows_sys::Win32::System::SystemInformation::{
+        CacheData, CacheUnified, GetLogicalProcessorInformation,
+        SYSTEM_LOGICAL_PROCESSOR_INFORMATION,
+    };
+    const RELATION_PROCESSOR_CORE: i32 = 0;
+    const RELATION_CACHE: i32 = 2;
+    const LTP_PC_SMT: u8 = 0x1;
+
+    let mut topo = Topology::default();
+    // SAFETY: standard two-call sizing pattern; union fields are read only for
+    // the record relationship that defines them.
+    unsafe {
+        let mut len: u32 = 0;
+        GetLogicalProcessorInformation(std::ptr::null_mut(), &mut len);
+        if len == 0 {
+            return topo;
+        }
+        let count = len as usize / std::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION>();
+        if count == 0 {
+            return topo;
+        }
+        let mut buf: Vec<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> = Vec::with_capacity(count);
+        if GetLogicalProcessorInformation(buf.as_mut_ptr(), &mut len) == 0 {
+            return topo;
+        }
+        buf.set_len(count);
+
+        let mut physical = 0usize;
+        let mut smt = false;
+        let (mut l1d, mut l2, mut l3): (u32, u32, u32) = (0, 0, 0);
+        for info in &buf {
+            if info.Relationship == RELATION_PROCESSOR_CORE {
+                physical += 1;
+                if info.Anonymous.ProcessorCore.Flags & LTP_PC_SMT != 0 {
+                    smt = true;
+                }
+            } else if info.Relationship == RELATION_CACHE {
+                let cache = info.Anonymous.Cache;
+                match cache.Level {
+                    1 if cache.Type == CacheData || cache.Type == CacheUnified => {
+                        l1d = l1d.max(cache.Size)
+                    }
+                    2 => l2 = l2.max(cache.Size),
+                    3 => l3 = l3.max(cache.Size),
+                    _ => {}
+                }
+            }
+        }
+        if physical > 0 {
+            topo.physical_cores = Some(physical);
+            topo.smt = Some(smt);
+        }
+        if l1d > 0 {
+            topo.l1d_bytes = Some(l1d);
+        }
+        if l2 > 0 {
+            topo.l2_bytes = Some(l2);
+        }
+        if l3 > 0 {
+            topo.l3_bytes = Some(l3);
+        }
+    }
+    topo
+}
+
+#[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+fn detect_topology() -> Topology {
+    Topology::default()
+}
+
+/// Windows x86-64: distinct per-core EfficiencyClass values (sorted), via the
+/// variable-length `GetLogicalProcessorInformationEx` records walked by their
+/// `Size` field. A hybrid CPU reports more than one class (the higher is the
+/// P-core); a uniform CPU reports one. Best-effort: returns empty on any failure.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn detect_efficiency_classes() -> Vec<u8> {
+    use windows_sys::Win32::System::SystemInformation::{
+        GetLogicalProcessorInformationEx, RelationProcessorCore,
+        SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+    };
+    let mut classes = BTreeSet::new();
+    // SAFETY: standard two-call sizing; records are walked by their self-reported
+    // `Size`, and union/field reads use `read_unaligned` since the byte buffer is
+    // only 1-aligned. Only RelationProcessorCore records were requested.
+    unsafe {
+        let mut len: u32 = 0;
+        GetLogicalProcessorInformationEx(RelationProcessorCore, std::ptr::null_mut(), &mut len);
+        if len == 0 {
+            return Vec::new();
+        }
+        let mut buf = vec![0u8; len as usize];
+        let ok = GetLogicalProcessorInformationEx(
+            RelationProcessorCore,
+            buf.as_mut_ptr() as *mut SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+            &mut len,
+        );
+        if ok == 0 {
+            return Vec::new();
+        }
+        let total = len as usize;
+        let mut offset = 0usize;
+        // Each record begins with Relationship (u32) + Size (u32).
+        while offset + 8 <= total {
+            let rec = buf.as_ptr().add(offset) as *const SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX;
+            let size = std::ptr::read_unaligned(std::ptr::addr_of!((*rec).Size)) as usize;
+            if size == 0 || offset + size > total {
+                break;
+            }
+            let relationship = std::ptr::read_unaligned(std::ptr::addr_of!((*rec).Relationship));
+            if relationship == RelationProcessorCore {
+                let eff = std::ptr::read_unaligned(std::ptr::addr_of!(
+                    (*rec).Anonymous.Processor.EfficiencyClass
+                ));
+                classes.insert(eff);
+            }
+            offset += size;
+        }
+    }
+    classes.into_iter().collect()
+}
+
+#[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+fn detect_efficiency_classes() -> Vec<u8> {
+    Vec::new()
+}
+
+/// The flagless selection key: `H(model_sig):H(machine_sig)`. No flags
+/// participate.
+pub fn gait_key(model: &ModelSig, machine: &MachineSig) -> String {
+    format!("{}:{}", model.digest(), machine.digest())
+}
+
+/// One persisted execution profile per `gait_key`. The skeleton records only the
+/// coarse [`ExecutionProfile`]; the measured per-stage kernel struct is added by
+/// a later lane. `receipt_id` is the SHA-256 of the canonical body (every field
+/// except itself), so the record is self-verifying.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GaitReceipt {
+    pub schema: String,
+    pub receipt_id: String,
+    pub gait_key: String,
+    pub model_sig: ModelSig,
+    pub machine_sig: MachineSig,
+    pub recorded_profile: ExecutionProfile,
+    /// Measured memory characteristics at calibration time — the roofline
+    /// denominator and resonance target. Recorded in the body (so it is bound
+    /// into `receipt_id`) but **deliberately not part of `gait_key`**: a noisy
+    /// measured float would make the cache lookup miss every run. Absent for
+    /// receipts written before a measurement was taken.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory: Option<MemoryMeasurement>,
+}
+
+impl GaitReceipt {
+    /// Construct and seal a receipt for the given fingerprints + chosen profile.
+    pub fn new(model_sig: ModelSig, machine_sig: MachineSig, recorded_profile: ExecutionProfile) -> Self {
+        let gait_key = gait_key(&model_sig, &machine_sig);
+        let mut receipt = GaitReceipt {
+            schema: GAIT_RECEIPT_SCHEMA_V1.to_string(),
+            receipt_id: String::new(),
+            gait_key,
+            model_sig,
+            machine_sig,
+            recorded_profile,
+            memory: None,
+        };
+        receipt.seal();
+        receipt
+    }
+
+    /// Attach a memory measurement and re-seal (the measurement is part of the
+    /// canonical body).
+    pub fn with_memory(mut self, memory: MemoryMeasurement) -> Self {
+        self.memory = Some(memory);
+        self.seal();
+        self
+    }
+
+    /// Recompute the digest the `receipt_id` field should hold.
+    pub fn compute_receipt_id(&self) -> String {
+        let mut value = serde_json::to_value(self).expect("GaitReceipt serializes to JSON");
+        if let serde_json::Value::Object(map) = &mut value {
+            map.remove("receipt_id");
+        }
+        sha256_hex(canonical_json(&value).as_bytes())
+    }
+
+    /// Populate `receipt_id` from the canonical body. Call after every other
+    /// field is final.
+    pub fn seal(&mut self) {
+        self.receipt_id = self.compute_receipt_id();
+    }
+
+    /// True when the stored `receipt_id` matches the recomputed digest.
+    pub fn verify_self_digest(&self) -> bool {
+        self.compute_receipt_id() == self.receipt_id
+    }
+}
+
+/// Resolve the gait store root. Windows: `%LOCALAPPDATA%\Camelid\gait`. Other
+/// platforms get an XDG-ish / temp fallback so the module compiles and is inert
+/// everywhere. Returns `None` only if no base directory can be determined.
+pub fn gait_dir() -> Option<PathBuf> {
+    let base = std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("XDG_DATA_HOME").map(PathBuf::from))
+        .or_else(|| {
+            std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local").join("share"))
+        })
+        .unwrap_or_else(std::env::temp_dir);
+    Some(base.join("Camelid").join("gait"))
+}
+
+/// File name for a key. The key contains `:` (invalid on Windows), so it is
+/// sanitized; the full key is also recorded inside the receipt and re-checked on
+/// load.
+fn key_filename(key: &str) -> String {
+    format!("{}.gait.json", key.replace(':', "_"))
+}
+
+/// Persist a receipt under `dir`. Fail-closed: returns the error to the caller,
+/// who logs and degrades rather than propagating.
+pub fn store_in(dir: &Path, receipt: &GaitReceipt) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(key_filename(&receipt.gait_key));
+    let json = serde_json::to_string_pretty(receipt)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(&path, json)?;
+    Ok(path)
+}
+
+/// Load a receipt for `key` from `dir`. Returns `None` on any failure — missing
+/// file, parse error, schema mismatch, digest mismatch, or key mismatch — so a
+/// corrupt or stale store can never alter behavior beyond "no cached profile".
+pub fn load_from(dir: &Path, key: &str) -> Option<GaitReceipt> {
+    let path = dir.join(key_filename(key));
+    let text = std::fs::read_to_string(&path).ok()?;
+    let receipt: GaitReceipt = serde_json::from_str(&text).ok()?;
+    if receipt.schema != GAIT_RECEIPT_SCHEMA_V1 {
+        return None;
+    }
+    if receipt.gait_key != key {
+        return None;
+    }
+    if !receipt.verify_self_digest() {
+        return None;
+    }
+    Some(receipt)
+}
+
+/// The selector consulted at the planner's decision site.
+///
+/// Returns `Some((profile, reason))` only when the gate is on AND a valid cached
+/// receipt exists for this model on this machine. In every other case it returns
+/// `None`, and the planner falls through to its existing default. In this
+/// skeleton the store is always empty, so this always returns `None` — the gate
+/// being on is, today, observably identical to it being off.
+pub fn maybe_select_profile(gguf: &GgufFile) -> Option<(ExecutionProfile, String)> {
+    if !gait_enabled() {
+        return None;
+    }
+    let model_sig = ModelSig::from_gguf(gguf);
+    let machine_sig = MachineSig::detect();
+    let key = gait_key(&model_sig, &machine_sig);
+    let dir = gait_dir()?;
+    let receipt = load_from(&dir, &key)?;
+    Some((
+        receipt.recorded_profile,
+        format!("gait: applied cached profile for {key}"),
+    ))
+}
+
+/// Measured memory characteristics — the roofline denominator (sustained DRAM
+/// bandwidth) and the latency the resonance tuning must hide. Measured at
+/// calibration, not guessed, and never folded into the gait key.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct MemoryMeasurement {
+    /// Sustained STREAM-Triad bandwidth in GB/s (10^9 bytes).
+    pub stream_triad_gbs: f64,
+    /// Dependent-load (pointer-chase) DRAM latency in nanoseconds.
+    pub dram_latency_ns: f64,
+}
+
+/// Measure sustained bandwidth and idle latency. Tens of milliseconds of work;
+/// run once at calibration. Buffers are sized past any client LLC so the kernels
+/// hit DRAM rather than cache.
+///
+/// Single-threaded probe. The bandwidth figure is only meaningful in an
+/// optimized build (an unoptimized build is overhead-bound, not memory-bound) —
+/// which is the build that runs calibration, so this matches the roofline the
+/// decode path actually sees.
+pub fn measure_memory() -> MemoryMeasurement {
+    MemoryMeasurement {
+        stream_triad_gbs: measure_stream_triad_gbs(),
+        dram_latency_ns: measure_dram_latency_ns(),
+    }
+}
+
+#[inline(never)]
+fn triad(a: &mut [f64], b: &[f64], c: &[f64], scalar: f64) {
+    for i in 0..a.len() {
+        a[i] = b[i] + scalar * c[i];
+    }
+}
+
+fn measure_stream_triad_gbs() -> f64 {
+    // 32 MiB per array (> a 24-30 MiB client L3); three arrays touched per pass.
+    const N: usize = 4 * 1024 * 1024;
+    let mut a = vec![0.0f64; N];
+    let b = vec![1.0f64; N];
+    let c = vec![2.0f64; N];
+    let scalar = 3.0;
+    triad(&mut a, &b, &c, scalar); // warm caches/TLB
+    let iters = 8;
+    let start = std::time::Instant::now();
+    for _ in 0..iters {
+        triad(&mut a, &b, &c, scalar);
+    }
+    let secs = start.elapsed().as_secs_f64();
+    std::hint::black_box(a[N - 1]);
+    // Triad moves 24 bytes per element (read b, read c, write a).
+    let bytes = 24.0 * N as f64 * iters as f64;
+    if secs > 0.0 {
+        bytes / secs / 1e9
+    } else {
+        0.0
+    }
+}
+
+fn measure_dram_latency_ns() -> f64 {
+    // 64 MiB index ring (> LLC). A coprime stride builds one Hamiltonian cycle,
+    // so each load depends on the previous and prefetchers cannot hide latency.
+    const N: usize = 16 * 1024 * 1024;
+    let mut next = vec![0u32; N];
+    let stride = 9973usize; // odd prime -> coprime with the power-of-two N
+    let mut idx = 0usize;
+    for _ in 0..N {
+        let nxt = (idx + stride) % N;
+        next[idx] = nxt as u32;
+        idx = nxt;
+    }
+    let mut p = 0usize;
+    for _ in 0..(N / 8) {
+        p = next[p] as usize; // warm
+    }
+    let start = std::time::Instant::now();
+    for _ in 0..N {
+        p = next[p] as usize;
+    }
+    let secs = start.elapsed().as_secs_f64();
+    std::hint::black_box(p);
+    secs * 1e9 / N as f64
+}
+
+/// Row-dot parity oracles for the K-quant formats.
+///
+/// The calibration tournament (Lane B) disqualifies any candidate kernel whose
+/// row·input dot diverges from a reference. Q8_0 already has one
+/// (`Q8_0TensorBlocks::dot_row_f32`); this provides the missing Q4_K and Q6_K
+/// references. Each reuses the *validated* super-block `dequantize` path and
+/// accumulates in f32 — it is a reference, not a fast path, so clarity and
+/// faithfulness beat speed.
+pub mod oracle {
+    use crate::tensor::{
+        Q4KBlock, Q6KBlock, QK_K_BLOCK_SIZE, Q4_K_BLOCK_BYTES, Q6_K_BLOCK_BYTES,
+    };
+
+    /// Reference dot of one quantized matrix row against `input`.
+    ///
+    /// `row_bytes` is the contiguous quantized bytes of a single row; `input`
+    /// has one value per column and its length must be a positive multiple of
+    /// the 256-element super-block. Returns `Err` on a shape/length mismatch.
+    fn dot_row_kquant(
+        row_bytes: &[u8],
+        input: &[f32],
+        block_bytes: usize,
+        dequant: impl Fn(&[u8], &mut [f32; QK_K_BLOCK_SIZE]),
+    ) -> Result<f32, String> {
+        if input.is_empty() || input.len() % QK_K_BLOCK_SIZE != 0 {
+            return Err(format!(
+                "row-dot input width {} is not a positive multiple of {QK_K_BLOCK_SIZE}",
+                input.len()
+            ));
+        }
+        let n_blocks = input.len() / QK_K_BLOCK_SIZE;
+        let need = n_blocks * block_bytes;
+        if row_bytes.len() < need {
+            return Err(format!(
+                "row-dot needs {need} quantized bytes for {n_blocks} super-blocks, got {}",
+                row_bytes.len()
+            ));
+        }
+        let mut decoded = [0.0f32; QK_K_BLOCK_SIZE];
+        let mut sum = 0.0f32;
+        for block in 0..n_blocks {
+            let chunk = &row_bytes[block * block_bytes..(block + 1) * block_bytes];
+            dequant(chunk, &mut decoded);
+            let base = block * QK_K_BLOCK_SIZE;
+            for (j, &weight) in decoded.iter().enumerate() {
+                sum += weight * input[base + j];
+            }
+        }
+        Ok(sum)
+    }
+
+    /// Q4_K row·input reference dot.
+    pub fn dot_row_q4k(row_bytes: &[u8], input: &[f32]) -> Result<f32, String> {
+        dot_row_kquant(row_bytes, input, Q4_K_BLOCK_BYTES, |chunk, out| {
+            let bytes: &[u8; Q4_K_BLOCK_BYTES] =
+                chunk.try_into().expect("chunk sized to Q4_K_BLOCK_BYTES");
+            Q4KBlock::from_bytes(bytes).dequantize(out);
+        })
+    }
+
+    /// Q6_K row·input reference dot.
+    pub fn dot_row_q6k(row_bytes: &[u8], input: &[f32]) -> Result<f32, String> {
+        dot_row_kquant(row_bytes, input, Q6_K_BLOCK_BYTES, |chunk, out| {
+            let bytes: &[u8; Q6_K_BLOCK_BYTES] =
+                chunk.try_into().expect("chunk sized to Q6_K_BLOCK_BYTES");
+            Q6KBlock::from_bytes(bytes).dequantize(out);
+        })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        // A deterministic, finite super-block: scale = 1.0 (f16 0x3C00), min = 0,
+        // with varied scale/value bytes. Any byte pattern decodes without panic;
+        // finite scales keep the result NaN-free so equality checks are valid.
+        fn synth_block(n: usize, seed: u8) -> Vec<u8> {
+            let mut b = vec![0u8; n];
+            b[0] = 0x00;
+            b[1] = 0x3C; // f16 1.0 scale
+            b[2] = 0x00;
+            b[3] = 0x3C; // f16 1.0 min
+            for (i, byte) in b.iter_mut().enumerate().skip(4) {
+                *byte = (i as u8).wrapping_mul(31).wrapping_add(seed);
+            }
+            b
+        }
+
+        fn naive_reference(
+            row_bytes: &[u8],
+            input: &[f32],
+            block_bytes: usize,
+            dequant: impl Fn(&[u8], &mut [f32; QK_K_BLOCK_SIZE]),
+        ) -> f32 {
+            let n_blocks = input.len() / QK_K_BLOCK_SIZE;
+            let mut decoded = [0.0f32; QK_K_BLOCK_SIZE];
+            let mut sum = 0.0f32;
+            for block in 0..n_blocks {
+                let chunk = &row_bytes[block * block_bytes..(block + 1) * block_bytes];
+                dequant(chunk, &mut decoded);
+                for j in 0..QK_K_BLOCK_SIZE {
+                    sum += decoded[j] * input[block * QK_K_BLOCK_SIZE + j];
+                }
+            }
+            sum
+        }
+
+        #[test]
+        fn q4k_oracle_matches_direct_dequant_two_blocks() {
+            let mut bytes = synth_block(Q4_K_BLOCK_BYTES, 7);
+            bytes.extend(synth_block(Q4_K_BLOCK_BYTES, 19));
+            let input: Vec<f32> = (0..2 * QK_K_BLOCK_SIZE)
+                .map(|i| ((i % 13) as f32) * 0.5 - 3.0)
+                .collect();
+            let got = dot_row_q4k(&bytes, &input).expect("q4k dot");
+            let want = naive_reference(&bytes, &input, Q4_K_BLOCK_BYTES, |c, o| {
+                let a: &[u8; Q4_K_BLOCK_BYTES] = c.try_into().unwrap();
+                Q4KBlock::from_bytes(a).dequantize(o);
+            });
+            assert_eq!(got.to_bits(), want.to_bits());
+            assert!(got.is_finite());
+        }
+
+        #[test]
+        fn q6k_oracle_matches_direct_dequant() {
+            let bytes = synth_block(Q6_K_BLOCK_BYTES, 5);
+            let input: Vec<f32> = (0..QK_K_BLOCK_SIZE).map(|i| (i as f32) * 0.01).collect();
+            let got = dot_row_q6k(&bytes, &input).expect("q6k dot");
+            let want = naive_reference(&bytes, &input, Q6_K_BLOCK_BYTES, |c, o| {
+                let a: &[u8; Q6_K_BLOCK_BYTES] = c.try_into().unwrap();
+                Q6KBlock::from_bytes(a).dequantize(o);
+            });
+            assert_eq!(got.to_bits(), want.to_bits());
+        }
+
+        #[test]
+        fn rejects_misaligned_width() {
+            assert!(dot_row_q4k(&[0u8; Q4_K_BLOCK_BYTES], &[1.0; 100]).is_err());
+            assert!(dot_row_q4k(&[], &[]).is_err());
+        }
+
+        #[test]
+        fn rejects_short_byte_buffer() {
+            // One super-block of input but zero bytes of weights.
+            assert!(dot_row_q6k(&[], &[1.0; QK_K_BLOCK_SIZE]).is_err());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gguf::{GgufFile, GgufMetadataValue, GgufTensorDescriptor, GgufTensorType};
+
+    fn descriptor(name: &str, ty: GgufTensorType, dims: Vec<u64>) -> GgufTensorDescriptor {
+        GgufTensorDescriptor {
+            name: name.to_string(),
+            dimensions: dims,
+            tensor_type: ty,
+            relative_offset: 0,
+            absolute_offset: 0,
+            n_bytes: 0,
+        }
+    }
+
+    fn sample_gguf() -> GgufFile {
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            "general.architecture".to_string(),
+            GgufMetadataValue::String("llama".to_string()),
+        );
+        metadata.insert("llama.block_count".to_string(), GgufMetadataValue::U32(2));
+        metadata.insert(
+            "llama.embedding_length".to_string(),
+            GgufMetadataValue::U32(16),
+        );
+        metadata.insert(
+            "llama.attention.head_count".to_string(),
+            GgufMetadataValue::U32(4),
+        );
+        metadata.insert(
+            "llama.attention.head_count_kv".to_string(),
+            GgufMetadataValue::U32(2),
+        );
+        metadata.insert(
+            "llama.feed_forward_length".to_string(),
+            GgufMetadataValue::U32(32),
+        );
+        GgufFile {
+            path: PathBuf::from("sample.gguf"),
+            version: 3,
+            tensor_count: 3,
+            metadata_count: metadata.len() as i64,
+            alignment: 32,
+            data_start_offset: 0,
+            metadata,
+            tensors: vec![
+                descriptor("token_embd.weight", GgufTensorType::Q8_0, vec![16, 128]),
+                descriptor("blk.0.attn_q.weight", GgufTensorType::Q8_0, vec![16, 16]),
+                descriptor("blk.0.ffn_down.weight", GgufTensorType::Q4K, vec![32, 16]),
+            ],
+        }
+    }
+
+    #[test]
+    fn model_sig_reads_geometry_and_quant_classes() {
+        let sig = ModelSig::from_gguf(&sample_gguf());
+        assert_eq!(sig.arch.as_deref(), Some("llama"));
+        assert_eq!(sig.n_layers, Some(2));
+        assert_eq!(sig.n_embd, Some(16));
+        assert_eq!(sig.n_heads, Some(4));
+        assert_eq!(sig.n_kv_heads, Some(2));
+        assert_eq!(sig.n_ff, Some(32));
+        // vocab falls back to the larger token_embd dimension.
+        assert_eq!(sig.vocab_size, Some(128));
+        assert_eq!(
+            sig.quant_classes.get("attn_q"),
+            Some(&BTreeSet::from(["Q8_0".to_string()]))
+        );
+        assert_eq!(
+            sig.quant_classes.get("ffn_down"),
+            Some(&BTreeSet::from(["Q4K".to_string()]))
+        );
+    }
+
+    #[test]
+    fn digests_are_deterministic_and_sensitive() {
+        let a = ModelSig::from_gguf(&sample_gguf());
+        let b = ModelSig::from_gguf(&sample_gguf());
+        assert_eq!(a.digest(), b.digest());
+        assert_eq!(a.digest().len(), 64);
+
+        let mut c = a.clone();
+        c.n_layers = Some(99);
+        assert_ne!(a.digest(), c.digest());
+    }
+
+    #[test]
+    fn machine_sig_detect_is_stable() {
+        let a = MachineSig::detect();
+        let b = MachineSig::detect();
+        assert_eq!(a.digest(), b.digest());
+        assert_eq!(a.os, std::env::consts::OS);
+    }
+
+    #[test]
+    fn memory_measurement_is_sane() {
+        let m = measure_memory();
+        assert!(
+            m.stream_triad_gbs > 0.5 && m.stream_triad_gbs < 5000.0,
+            "implausible bandwidth: {} GB/s",
+            m.stream_triad_gbs
+        );
+        assert!(
+            m.dram_latency_ns > 0.0 && m.dram_latency_ns < 100_000.0,
+            "implausible latency: {} ns",
+            m.dram_latency_ns
+        );
+    }
+
+    #[test]
+    fn receipt_with_memory_reseals_and_round_trips() {
+        let dir = std::env::temp_dir().join(format!("camelid_gait_mem_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let base = GaitReceipt::new(
+            ModelSig::from_gguf(&sample_gguf()),
+            MachineSig::detect(),
+            ExecutionProfile::Auto,
+        );
+        let with_mem = base.clone().with_memory(MemoryMeasurement {
+            stream_triad_gbs: 30.0,
+            dram_latency_ns: 80.0,
+        });
+        // Attaching a measurement changes the sealed digest but not the key.
+        assert_ne!(with_mem.receipt_id, base.receipt_id);
+        assert_eq!(with_mem.gait_key, base.gait_key);
+        assert!(with_mem.verify_self_digest());
+
+        store_in(&dir, &with_mem).expect("store");
+        let loaded = load_from(&dir, &with_mem.gait_key).expect("load");
+        assert_eq!(loaded, with_mem);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn machine_sig_topology_is_coherent() {
+        let m = MachineSig::detect();
+        assert!(m.logical_cores >= 1);
+        if let Some(p) = m.physical_cores {
+            assert!(p >= 1 && p <= m.logical_cores);
+        }
+        // A per-core L2 never exceeds the shared L3, when both are known.
+        if let (Some(l2), Some(l3)) = (m.l2_bytes, m.l3_bytes) {
+            assert!(l2 <= l3);
+        }
+        // `hybrid` must agree with the number of distinct efficiency classes.
+        if !m.efficiency_classes.is_empty() {
+            assert_eq!(m.hybrid, Some(m.efficiency_classes.len() > 1));
+        }
+    }
+
+    #[test]
+    fn gait_key_combines_both_digests() {
+        let model = ModelSig::from_gguf(&sample_gguf());
+        let machine = MachineSig::detect();
+        let key = gait_key(&model, &machine);
+        assert_eq!(key, format!("{}:{}", model.digest(), machine.digest()));
+    }
+
+    #[test]
+    fn receipt_round_trips_through_the_store() {
+        let dir = std::env::temp_dir().join(format!("camelid_gait_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let receipt = GaitReceipt::new(
+            ModelSig::from_gguf(&sample_gguf()),
+            MachineSig::detect(),
+            ExecutionProfile::Auto,
+        );
+        assert!(receipt.verify_self_digest());
+
+        let path = store_in(&dir, &receipt).expect("store");
+        assert!(path.exists());
+
+        let loaded = load_from(&dir, &receipt.gait_key).expect("load");
+        assert_eq!(loaded, receipt);
+        assert!(loaded.verify_self_digest());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_misses_on_empty_store() {
+        let dir = std::env::temp_dir().join(format!("camelid_gait_miss_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(load_from(&dir, "deadbeef:cafef00d").is_none());
+    }
+
+    #[test]
+    fn selector_is_none_when_gate_disabled() {
+        // With the gate unset, the selector must not touch the store at all.
+        std::env::remove_var(GAIT_GATE_ENV);
+        assert!(maybe_select_profile(&sample_gguf()).is_none());
+    }
+}

--- a/src/gait/substrate.rs
+++ b/src/gait/substrate.rs
@@ -1,0 +1,103 @@
+//! Windows scheduling substrate (Lane C).
+//!
+//! Cross-platform-first engines omit the Windows-native QoS controls that keep
+//! inference threads off the efficiency/background track. The highest-leverage,
+//! least-known of these is the **EcoQoS power-throttling opt-out**: by default
+//! Windows may classify a long-running compute process's threads as background
+//! work and park/downclock them, which silently caps sustained decode. Opting
+//! out keeps the process at full execution speed.
+//!
+//! Every call here is best-effort and `cfg(windows)`-gated: on any other target,
+//! or if the Win32 call fails, it returns [`EcoQosStatus::Unavailable`] and the
+//! engine runs exactly as before. This module changes scheduling only — never
+//! the math — so it cannot affect parity.
+
+use serde::{Deserialize, Serialize};
+
+/// Outcome of an EcoQoS control request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EcoQosStatus {
+    /// Throttling explicitly disabled: the process runs at full execution speed.
+    OptedOut,
+    /// Reverted to OS-managed throttling.
+    OsManaged,
+    /// The control was unavailable (non-Windows host, or the API rejected it).
+    Unavailable,
+}
+
+/// Process-level EcoQoS control. `opt_out = true` disables execution-speed
+/// throttling for the whole process — every thread, including the Rayon decode
+/// pool — so Windows cannot park or downclock inference as "background" work.
+/// `opt_out = false` returns to OS-managed throttling.
+///
+/// Best-effort and idempotent: returns [`EcoQosStatus::Unavailable`] rather than
+/// erroring, so callers never have to handle a failure path.
+#[cfg(windows)]
+pub fn set_eco_qos_opt_out(opt_out: bool) -> EcoQosStatus {
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentProcess, SetProcessInformation, ProcessPowerThrottling,
+        PROCESS_POWER_THROTTLING_CURRENT_VERSION, PROCESS_POWER_THROTTLING_EXECUTION_SPEED,
+        PROCESS_POWER_THROTTLING_STATE,
+    };
+
+    // opt-out: control EXECUTION_SPEED, state cleared => "do not throttle".
+    // OS-managed: control 0 => "let Windows decide".
+    let control_mask = if opt_out {
+        PROCESS_POWER_THROTTLING_EXECUTION_SPEED
+    } else {
+        0
+    };
+    let state = PROCESS_POWER_THROTTLING_STATE {
+        Version: PROCESS_POWER_THROTTLING_CURRENT_VERSION,
+        ControlMask: control_mask,
+        StateMask: 0,
+    };
+
+    // SAFETY: `state` outlives the call; size is the struct's own size.
+    let ok = unsafe {
+        SetProcessInformation(
+            GetCurrentProcess(),
+            ProcessPowerThrottling,
+            &state as *const PROCESS_POWER_THROTTLING_STATE as *const core::ffi::c_void,
+            std::mem::size_of::<PROCESS_POWER_THROTTLING_STATE>() as u32,
+        )
+    };
+    if ok != 0 {
+        if opt_out {
+            EcoQosStatus::OptedOut
+        } else {
+            EcoQosStatus::OsManaged
+        }
+    } else {
+        EcoQosStatus::Unavailable
+    }
+}
+
+#[cfg(not(windows))]
+pub fn set_eco_qos_opt_out(_opt_out: bool) -> EcoQosStatus {
+    EcoQosStatus::Unavailable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eco_qos_round_trip_does_not_panic() {
+        // The call must always return a status, never panic, on any host.
+        let on = set_eco_qos_opt_out(true);
+        let off = set_eco_qos_opt_out(false);
+        #[cfg(windows)]
+        {
+            // Windows 10/11 supports ProcessPowerThrottling, so the opt-out applies.
+            assert_eq!(on, EcoQosStatus::OptedOut);
+            assert_eq!(off, EcoQosStatus::OsManaged);
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(on, EcoQosStatus::Unavailable);
+            assert_eq!(off, EcoQosStatus::Unavailable);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod diffusion_gemma;
 pub mod distributed;
 pub mod error;
 pub mod execution_plan;
+pub mod gait;
 pub mod gemma4_distributed;
 pub mod gemma4_runtime;
 pub mod gguf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -742,6 +742,13 @@ enum Command {
         /// Tokens to generate per trial (greedy/deterministic).
         #[arg(long, default_value_t = 64)]
         max_tokens: usize,
+        /// Measured interleaved rounds per variant (median is taken). More rounds
+        /// reject thermal/clock noise at the cost of calibration time.
+        #[arg(long, default_value_t = 4)]
+        rounds: usize,
+        /// Leading rounds discarded as warmup.
+        #[arg(long, default_value_t = 1)]
+        warmup: usize,
         /// Override Rayon worker threads.
         #[arg(long)]
         threads: Option<usize>,
@@ -1466,9 +1473,11 @@ async fn main() -> anyhow::Result<()> {
             prompt_file,
             prompt,
             max_tokens,
+            rounds,
+            warmup,
             threads,
         } => {
-            run_gait_calibrate(model, prompt_file, prompt, max_tokens, threads)?;
+            run_gait_calibrate(model, prompt_file, prompt, max_tokens, rounds, warmup, threads)?;
         }
         Command::BenchSpeculative {
             model,
@@ -1942,8 +1951,13 @@ fn gait_profile_trial(
     // Apply this candidate's Windows scheduling substrate before timing, so the
     // measured decode reflects it. Process-level, covers the Rayon pool.
     let eco_status = camelid::gait::substrate::set_eco_qos_opt_out(candidate.eco_qos_opt_out);
-    if candidate.eco_qos_opt_out {
-        eprintln!("[gait]   {} eco_qos opt-out -> {eco_status:?}", candidate.label);
+    if candidate.eco_qos_opt_out
+        && eco_status != camelid::gait::substrate::EcoQosStatus::OptedOut
+    {
+        eprintln!(
+            "[gait]   {} eco_qos opt-out unavailable -> {eco_status:?}",
+            candidate.label
+        );
     }
 
     let gguf = read_metadata(model)?;
@@ -1984,6 +1998,8 @@ fn run_gait_calibrate(
     prompt_file: Option<PathBuf>,
     prompt: Option<String>,
     max_tokens: usize,
+    rounds: usize,
+    warmup: usize,
     threads: Option<usize>,
 ) -> anyhow::Result<()> {
     use camelid::gait::calibrate::{
@@ -1992,6 +2008,7 @@ fn run_gait_calibrate(
     use camelid::execution_plan::ExecutionProfile;
 
     anyhow::ensure!(max_tokens >= 1, "--max-tokens must be at least 1");
+    anyhow::ensure!(rounds >= 1, "--rounds must be at least 1");
     // Calibration must measure the candidates we choose — never let a previously
     // cached gait receipt override the candidate's profile mid-trial.
     std::env::remove_var("CAMELID_GAIT");
@@ -2033,9 +2050,16 @@ fn run_gait_calibrate(
     let store_dir = default_store_dir()
         .ok_or_else(|| anyhow::anyhow!("could not resolve the gait store directory"))?;
 
+    let config = TournamentConfig {
+        rounds,
+        warmup_rounds: warmup,
+        ..TournamentConfig::default()
+    };
     eprintln!(
-        "[gait] calibrating {} candidates (+baseline) on {} ...",
+        "[gait] calibrating {} candidates (+baseline), {} measured rounds (+{} warmup), interleaved, on {} ...",
         candidates.len(),
+        config.rounds,
+        config.warmup_rounds,
         model.display()
     );
     let trial = |candidate: &Candidate| -> Option<camelid::gait::calibrate::TrialResult> {
@@ -2056,14 +2080,7 @@ fn run_gait_calibrate(
         }
     };
 
-    let (outcome, path) = calibrate_and_store(
-        &store_dir,
-        &gguf,
-        &baseline,
-        &candidates,
-        &TournamentConfig::default(),
-        trial,
-    );
+    let (outcome, path) = calibrate_and_store(&store_dir, &gguf, &baseline, &candidates, &config, trial);
 
     println!("{}", serde_json::to_string_pretty(&outcome)?);
     match path {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1939,6 +1939,12 @@ fn gait_profile_trial(
     candidate: &camelid::gait::calibrate::Candidate,
 ) -> anyhow::Result<camelid::gait::calibrate::TrialResult> {
     std::env::set_var("CAMELID_PROFILE", gait_profile_env_value(&candidate.profile));
+    // Apply this candidate's Windows scheduling substrate before timing, so the
+    // measured decode reflects it. Process-level, covers the Rayon pool.
+    let eco_status = camelid::gait::substrate::set_eco_qos_opt_out(candidate.eco_qos_opt_out);
+    if candidate.eco_qos_opt_out {
+        eprintln!("[gait]   {} eco_qos opt-out -> {eco_status:?}", candidate.label);
+    }
 
     let gguf = read_metadata(model)?;
     // Apply this candidate's plan before loading weights, exactly as bench-generate does.
@@ -2003,18 +2009,24 @@ fn run_gait_calibrate(
     let prompt_token_ids = tokenizer.encode(&prompt_text, true, false)?;
     anyhow::ensure!(!prompt_token_ids.is_empty(), "prompt encoded to zero tokens");
 
+    // Baseline = today's behavior (Auto profile, OS-managed throttling). The
+    // candidates vary the EcoQoS substrate (and profile) so the tournament
+    // measures whether disabling throttling helps on this machine, parity-held.
     let baseline = Candidate {
         label: "auto".to_string(),
         profile: ExecutionProfile::Auto,
+        eco_qos_opt_out: false,
     };
     let candidates = vec![
         Candidate {
-            label: "safe".to_string(),
-            profile: ExecutionProfile::Safe,
+            label: "auto+ecoqos".to_string(),
+            profile: ExecutionProfile::Auto,
+            eco_qos_opt_out: true,
         },
         Candidate {
-            label: "experimental".to_string(),
+            label: "experimental+ecoqos".to_string(),
             profile: ExecutionProfile::Experimental,
+            eco_qos_opt_out: true,
         },
     ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -723,6 +723,29 @@ enum Command {
         #[arg(long, env = "CAMELID_DETERMINISTIC", default_value_t = false)]
         deterministic: bool,
     },
+    /// GAIT: run the parity-gated calibration tournament for this model on this
+    /// machine. Times the supported execution profiles, disqualifies any whose
+    /// greedy output diverges, picks the fastest parity-clean one that beats the
+    /// baseline by a margin (else fails closed to baseline), and persists a
+    /// `camelid.gait-receipt/v1`. Writes only a receipt; changes no decode path.
+    /// The receipt is consumed later only when `CAMELID_GAIT` is set.
+    #[command(hide = true)]
+    GaitCalibrate {
+        /// GGUF model path.
+        model: PathBuf,
+        /// Read the prompt from this UTF-8 file. Takes precedence over --prompt.
+        #[arg(long)]
+        prompt_file: Option<PathBuf>,
+        /// Inline prompt text (used when --prompt-file is absent).
+        #[arg(long)]
+        prompt: Option<String>,
+        /// Tokens to generate per trial (greedy/deterministic).
+        #[arg(long, default_value_t = 64)]
+        max_tokens: usize,
+        /// Override Rayon worker threads.
+        #[arg(long)]
+        threads: Option<usize>,
+    },
     /// SPEC_RECHECK measurement harness: run lossless greedy speculative decode and a plain
     /// greedy baseline back-to-back on one prompt, and emit a single JSON record with the
     /// per-run economics (acceptance rate, draft/verify latency split, f_draft, S_sync) plus
@@ -1438,6 +1461,15 @@ async fn main() -> anyhow::Result<()> {
                 threads,
             )?;
         }
+        Command::GaitCalibrate {
+            model,
+            prompt_file,
+            prompt,
+            max_tokens,
+            threads,
+        } => {
+            run_gait_calibrate(model, prompt_file, prompt, max_tokens, threads)?;
+        }
         Command::BenchSpeculative {
             model,
             drafter,
@@ -1882,6 +1914,159 @@ struct BenchGenerateRecord {
     offload: Option<camelid::offload::OffloadRunStatus>,
     output_text: String,
     output_token_ids: Vec<u32>,
+}
+
+fn gait_profile_env_value(profile: &camelid::execution_plan::ExecutionProfile) -> &'static str {
+    use camelid::execution_plan::ExecutionProfile::*;
+    match profile {
+        Auto => "auto",
+        Safe => "safe",
+        Experimental => "experimental",
+        Debug => "debug",
+    }
+}
+
+/// Time one candidate: select its profile for the planner, reload weights (the
+/// Q8 repack / kernel choice happens at load time, so each candidate needs its
+/// own load), run one unmeasured warmup, then a measured greedy decode. The
+/// parity token is the SHA-256 of the greedy output token ids — a candidate that
+/// changes the output is disqualified by the tournament.
+fn gait_profile_trial(
+    model: &std::path::Path,
+    threads: Option<usize>,
+    prompt_token_ids: &[u32],
+    max_tokens: usize,
+    candidate: &camelid::gait::calibrate::Candidate,
+) -> anyhow::Result<camelid::gait::calibrate::TrialResult> {
+    std::env::set_var("CAMELID_PROFILE", gait_profile_env_value(&candidate.profile));
+
+    let gguf = read_metadata(model)?;
+    // Apply this candidate's plan before loading weights, exactly as bench-generate does.
+    let plan = camelid::execution_plan::plan_for_model(model, &gguf, threads);
+    camelid::execution_plan::PlannerEnv::capture().apply(&plan.env_updates);
+
+    let config = LlamaModelConfig::from_gguf(&gguf)?;
+    let binding = LlamaTensorBinding::bind(&gguf, &config)?;
+    let store = TensorStore::open(model, &gguf);
+    let tokenizer = Tokenizer::from_gguf(&gguf)?;
+    let weights = Arc::new(LlamaLoadedWeights::load(&store, &binding, None)?);
+    let sampler = LlamaSampler::Greedy;
+
+    let _ = generate_run(&config, &weights, &tokenizer, prompt_token_ids, &sampler, max_tokens)?;
+    camelid::inference::reset_stage_timings();
+    let run = generate_run(&config, &weights, &tokenizer, prompt_token_ids, &sampler, max_tokens)?;
+
+    let decode_tokens = run.generated.len().saturating_sub(1);
+    let tokens_per_s = if run.decode_ms > 0.0 && decode_tokens > 0 {
+        decode_tokens as f64 / (run.decode_ms / 1000.0)
+    } else {
+        0.0
+    };
+    let mut id_bytes = Vec::with_capacity(run.generated.len() * 4);
+    for id in &run.generated {
+        id_bytes.extend_from_slice(&id.to_le_bytes());
+    }
+    let parity_token = camelid::receipt::sha256_hex(&id_bytes);
+    Ok(camelid::gait::calibrate::TrialResult {
+        tokens_per_s,
+        parity_token,
+    })
+}
+
+fn run_gait_calibrate(
+    model: PathBuf,
+    prompt_file: Option<PathBuf>,
+    prompt: Option<String>,
+    max_tokens: usize,
+    threads: Option<usize>,
+) -> anyhow::Result<()> {
+    use camelid::gait::calibrate::{
+        calibrate_and_store, default_store_dir, Candidate, TournamentConfig,
+    };
+    use camelid::execution_plan::ExecutionProfile;
+
+    anyhow::ensure!(max_tokens >= 1, "--max-tokens must be at least 1");
+    // Calibration must measure the candidates we choose — never let a previously
+    // cached gait receipt override the candidate's profile mid-trial.
+    std::env::remove_var("CAMELID_GAIT");
+    configure_rayon_threads(threads)?;
+    camelid::capability::HardwareProfile::detect().log();
+
+    let prompt_text = match (&prompt_file, &prompt) {
+        (Some(path), _) => std::fs::read_to_string(path)?,
+        (None, Some(text)) => text.clone(),
+        (None, None) => anyhow::bail!("provide --prompt-file <path> or --prompt <text>"),
+    };
+
+    let gguf = read_metadata(&model)?;
+    let tokenizer = Tokenizer::from_gguf(&gguf)?;
+    let prompt_token_ids = tokenizer.encode(&prompt_text, true, false)?;
+    anyhow::ensure!(!prompt_token_ids.is_empty(), "prompt encoded to zero tokens");
+
+    let baseline = Candidate {
+        label: "auto".to_string(),
+        profile: ExecutionProfile::Auto,
+    };
+    let candidates = vec![
+        Candidate {
+            label: "safe".to_string(),
+            profile: ExecutionProfile::Safe,
+        },
+        Candidate {
+            label: "experimental".to_string(),
+            profile: ExecutionProfile::Experimental,
+        },
+    ];
+
+    let store_dir = default_store_dir()
+        .ok_or_else(|| anyhow::anyhow!("could not resolve the gait store directory"))?;
+
+    eprintln!(
+        "[gait] calibrating {} candidates (+baseline) on {} ...",
+        candidates.len(),
+        model.display()
+    );
+    let trial = |candidate: &Candidate| -> Option<camelid::gait::calibrate::TrialResult> {
+        match gait_profile_trial(&model, threads, &prompt_token_ids, max_tokens, candidate) {
+            Ok(result) => {
+                eprintln!(
+                    "[gait] {:<13} {:>7.2} tok/s  parity {}",
+                    candidate.label,
+                    result.tokens_per_s,
+                    &result.parity_token[..12]
+                );
+                Some(result)
+            }
+            Err(err) => {
+                eprintln!("[gait] {:<13} trial failed: {err}", candidate.label);
+                None
+            }
+        }
+    };
+
+    let (outcome, path) = calibrate_and_store(
+        &store_dir,
+        &gguf,
+        &baseline,
+        &candidates,
+        &TournamentConfig::default(),
+        trial,
+    );
+
+    println!("{}", serde_json::to_string_pretty(&outcome)?);
+    match path {
+        Some(p) => eprintln!(
+            "[gait] selected {:?} :: {} :: receipt {}",
+            outcome.selected_profile,
+            outcome.reason,
+            p.display()
+        ),
+        None => eprintln!(
+            "[gait] selected {:?} :: {} :: receipt NOT stored (store write failed)",
+            outcome.selected_profile, outcome.reason
+        ),
+    }
+    Ok(())
 }
 
 struct GenerationRun {


### PR DESCRIPTION
Lays down the GAIT campaign spine and Lane B/C/F machinery for flagless, per-(model × machine), parity-gated execution-profile selection on Windows CPU. **Entirely additive and parity-neutral**: the selector runs only behind the `CAMELID_GAIT` bring-up gate and, with an empty store, falls through to today's `requested_profile()` / Auto path unchanged. No decode/math path is altered. Full lib suite: 564 passed / 0 failed; 24 gait unit tests.

## Commits
- **Spine + detection** (`ac9d2bb6`): `ModelSig` (GGUF geometry + per-stage quant map, fail-closed), `MachineSig` (precise ISA via CPUID feature detection; physical cores/SMT/L1d-L2-L3 cache via `GetLogicalProcessorInformation`; per-core EfficiencyClass/hybrid via the variable-length `…InformationEx` walk), `gait_key`, fail-closed `%LOCALAPPDATA%` store, `camelid.gait-receipt/v1` (self-sealing SHA-256, reusing the `receipt` module), gated selector at the `execution_plan` decision site, STREAM bandwidth/latency measurement, Q4_K/Q6_K row-dot parity oracles.
- **Tournament engine** (`2de78c2f`): parity-gated selection — a faster candidate whose greedy output diverges is disqualified; fastest parity-clean candidate that clears a margin wins, else fail closed. Roofline % from the measured STREAM denominator.
- **gait-calibrate CLI** (`12250b99`): drives **real decode trials** — per candidate, applies its profile, reloads weights, times greedy generate, parity token = `sha256(greedy ids)`.
- **EcoQoS substrate** (`4bf3fb27`): process-level power-throttling opt-out, wired as a measured tournament dimension.
- **Matched-clock measurement** (`f9da2e09`): interleaved multi-round trials + median, per-round parity, recorded spread.

## Honest findings on the dev box (i7-11800H)
On this plugged-in desktop, **both levers explored (kernel profiles, EcoQoS) find no real win** — decode is memory-bandwidth-bound and the box doesn't throttle inference threads. The matched-clock harness specifically **exposed an earlier EcoQoS "11% slower" reading as a noise artifact** (interleaved: all variants within ~1%, bit-identical parity → keeps Auto). No fabricated speedup anywhere; the machinery correctly refuses to claim a win it can't measure. Demonstrating an actual gait win realistically needs a throttling laptop (EcoQoS) or a different bottleneck.

## Not yet done
- Production auto-apply of a selected substrate/profile at model load under `CAMELID_GAIT` (selector currently chooses the coarse profile; the persisted struct application is a follow-up).
- Adversarial multi-agent review did not run (API overload during the session); validated by the full test suite + a real end-to-end calibration run, not independent reviewers.
- Per-stage `MANAGED_ENV_KEYS` knob candidates; Lane D E-core weight-stream; Lane F power-plan drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)