### PR TITLE
GAIT: apply the persisted gait at model load (close the production loop)

### DIFF
--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -254,11 +254,18 @@ pub fn plan_for_model_with_platform(
     platform: PlanPlatform,
 ) -> ExecutionPlanOutcome {
     // GAIT selector (bring-up gate `CAMELID_GAIT`, default off): consult the
-    // per-(model × machine) gait store for a cached profile. With the gate off,
-    // or on any miss/empty store, this returns None and the existing default
-    // path runs unchanged — keeping this byte-identical to today.
-    let (profile, profile_reason) =
-        crate::gait::maybe_select_profile(gguf).unwrap_or_else(requested_profile);
+    // per-(model × machine) gait store for a cached gait. With the gate off, or
+    // on any miss/empty store, this returns None and the existing default path
+    // runs unchanged — keeping this byte-identical to today. When a gait is
+    // found, apply its scheduling substrate (the coarse profile is applied by
+    // the env machinery below).
+    let (profile, profile_reason) = match crate::gait::maybe_select_profile(gguf) {
+        Some(gait) => {
+            crate::gait::apply_selected_gait(&gait);
+            (gait.profile, gait.reason)
+        }
+        None => requested_profile(),
+    };
     let row = exact_model_row(model_path, gguf);
     let support_level = support_level(&row);
     let model_family = model_family(&row, gguf);

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -665,14 +665,31 @@ pub fn load_from(dir: &Path, key: &str) -> Option<GaitReceipt> {
     Some(receipt)
 }
 
+/// A gait selected for the current (model × machine): the coarse profile the
+/// planner should use plus the scheduling substrate to apply.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectedGait {
+    pub profile: ExecutionProfile,
+    pub reason: String,
+    pub eco_qos_opt_out: bool,
+}
+
+/// Whether a receipt's calibration selected the EcoQoS opt-out. A receipt with
+/// no calibration block (e.g. hand-written) defaults to false.
+pub(crate) fn receipt_eco_opt_out(receipt: &GaitReceipt) -> bool {
+    receipt
+        .calibration
+        .as_ref()
+        .map(|c| c.selected_eco_qos_opt_out)
+        .unwrap_or(false)
+}
+
 /// The selector consulted at the planner's decision site.
 ///
-/// Returns `Some((profile, reason))` only when the gate is on AND a valid cached
+/// Returns `Some(SelectedGait)` only when the gate is on AND a valid cached
 /// receipt exists for this model on this machine. In every other case it returns
-/// `None`, and the planner falls through to its existing default. In this
-/// skeleton the store is always empty, so this always returns `None` — the gate
-/// being on is, today, observably identical to it being off.
-pub fn maybe_select_profile(gguf: &GgufFile) -> Option<(ExecutionProfile, String)> {
+/// `None` and the planner falls through to its existing default.
+pub fn maybe_select_profile(gguf: &GgufFile) -> Option<SelectedGait> {
     if !gait_enabled() {
         return None;
     }
@@ -681,10 +698,27 @@ pub fn maybe_select_profile(gguf: &GgufFile) -> Option<(ExecutionProfile, String
     let key = gait_key(&model_sig, &machine_sig);
     let dir = gait_dir()?;
     let receipt = load_from(&dir, &key)?;
-    Some((
-        receipt.recorded_profile,
-        format!("gait: applied cached profile for {key}"),
-    ))
+    Some(SelectedGait {
+        eco_qos_opt_out: receipt_eco_opt_out(&receipt),
+        profile: receipt.recorded_profile,
+        reason: format!("gait: applied cached profile for {key}"),
+    })
+}
+
+/// Apply the scheduling substrate recorded in a selected gait. The coarse profile
+/// is applied by the planner's existing env machinery; this applies the Windows
+/// substrate (EcoQoS) and logs the live gait so it is observable. Best-effort and
+/// process-level. Only invoked when a gait was selected (gate on + receipt found).
+pub fn apply_selected_gait(gait: &SelectedGait) {
+    if gait.eco_qos_opt_out {
+        let status = substrate::set_eco_qos_opt_out(true);
+        eprintln!(
+            "[gait] applied profile={:?} + eco_qos opt-out -> {status:?}",
+            gait.profile
+        );
+    } else {
+        eprintln!("[gait] applied profile={:?}", gait.profile);
+    }
 }
 
 /// Measured memory characteristics — the roofline denominator (sustained DRAM
@@ -1149,5 +1183,39 @@ mod tests {
         // With the gate unset, the selector must not touch the store at all.
         std::env::remove_var(GAIT_GATE_ENV);
         assert!(maybe_select_profile(&sample_gguf()).is_none());
+    }
+
+    #[test]
+    fn receipt_eco_opt_out_defaults_false_without_calibration() {
+        let receipt = GaitReceipt::new(
+            ModelSig::from_gguf(&sample_gguf()),
+            MachineSig::detect(),
+            ExecutionProfile::Auto,
+        );
+        assert!(!receipt_eco_opt_out(&receipt));
+    }
+
+    #[test]
+    fn receipt_eco_opt_out_reads_calibration_choice() {
+        let outcome = calibrate::CalibrationOutcome {
+            selected_profile: ExecutionProfile::Auto,
+            reason: "test".to_string(),
+            baseline_tokens_per_s: 1.0,
+            selected_tokens_per_s: 1.0,
+            speedup: 1.0,
+            roofline_pct: 0.0,
+            fell_back: false,
+            parity_disqualified: Vec::new(),
+            selected_eco_qos_opt_out: true,
+            measured_rounds: 1,
+            samples: Vec::new(),
+        };
+        let receipt = GaitReceipt::new(
+            ModelSig::from_gguf(&sample_gguf()),
+            MachineSig::detect(),
+            ExecutionProfile::Auto,
+        )
+        .with_calibration(outcome);
+        assert!(receipt_eco_opt_out(&receipt));
     }
 }


### PR DESCRIPTION
Closes the GAIT production loop: a selected gait now takes effect on a real inference load, not just inside `gait-calibrate`. The coarse profile was already applied via the planner's env machinery; this adds the recorded Windows scheduling substrate (EcoQoS).

- `maybe_select_profile` returns `SelectedGait { profile, reason, eco_qos_opt_out }`.
- `apply_selected_gait` applies the substrate + logs the live gait, invoked at the planner decision site **only when a gait is selected** (gate on + receipt found). Gate-off path unchanged (parity-neutral).
- `receipt_eco_opt_out` helper + 2 tests.

**Validated end-to-end** (Qwen3-0.6B, CPU, release): `gait-calibrate` writes a receipt under the current machine key, then `bench-generate` with `CAMELID_GAIT=1` logs `[gait] applied profile=Auto` (a real customer path reads + applies it); without the gate there is no apply line (byte-identical to today). The selected gait is Auto/no-substrate here (the honest no-win result on this desktop), but the mechanism is wired; on hardware where calibration finds a win, the same path applies it. The fresh receipt also confirmed **power-plan drift**: the machine key changed vs the pre-power-plan receipt, so the stale one was ignored.

Full lib suite: 568 passed / 0 failed; 28 gait unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)