### PR TITLE
GAIT v2 host-safety hardening (Waves 1-3) + gated Q4_K CPU decode

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1412,7 +1412,14 @@ pub async fn serve(
     let warm_model_id = state.active_model_id.read().await.clone();
     let server = tokio::spawn(async move { axum::serve(listener, router_with_state(state)).await });
     if let Some(model_id) = warm_model_id {
-        eprintln!("\n  🐪 Warming up the GPU (building the resident engine, one-time)…");
+        // Word the banner for the device that will actually serve — saying "GPU"
+        // on a CPU-only run (e.g. CUDA_VISIBLE_DEVICES=-1) was misleading.
+        let warming_msg = if crate::cuda::gpu_accel_enabled() {
+            "🐪 Warming up the GPU (building the resident engine, one-time)…"
+        } else {
+            "🐪 Warming up the model (building the engine, one-time)…"
+        };
+        eprintln!("\n  {warming_msg}");
         warmup_generation_blocking(addr, model_id).await;
     }
     print_ready_banner(&url);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6951,7 +6951,14 @@ async fn generate_decoded_tokens_blocking(
         generate_decoded_tokens(prepared)
     });
     match tokio::time::timeout(timeout, handle).await {
-        Ok(Ok(result)) => result,
+        Ok(Ok(result)) => {
+            // §4 safe-boot: a decode ran to completion under the applied gait
+            // without wedging the host, so clear the in-progress marker. Cheap
+            // and idempotent (a no-op after the first call, or when no gait was
+            // applied), so it is safe on the hot path.
+            crate::gait::sentinel::mark_healthy();
+            result
+        }
         Ok(Err(err)) => Err(Box::new(api_error(
             StatusCode::SERVICE_UNAVAILABLE,
             "generation_worker_failed",

--- a/src/diffusion_gemma.rs
+++ b/src/diffusion_gemma.rs
@@ -28,7 +28,7 @@ pub mod chat;
 #[cfg(feature = "cuda")]
 mod cuda;
 mod reff16;
-mod refmath;
+pub(crate) mod refmath;
 pub mod refrng;
 
 /// GPU soft-embedding matmul (`emb_t @ probs`) for the self-conditioning

--- a/src/gait/calibrate.rs
+++ b/src/gait/calibrate.rs
@@ -150,6 +150,9 @@ pub struct TrialResult {
 pub struct TournamentConfig {
     /// A candidate must beat baseline by at least this factor to win; otherwise
     /// the tournament fails closed to baseline. Slower-but-correct always wins.
+    /// The default (1.10) sits above the per-trial variance of the §1.4
+    /// child-process trials, so a sub-10% median gap — indistinguishable from
+    /// measurement noise on this execution model — never persists a gait.
     pub min_speedup: f64,
     /// Measured rounds per variant. Each round times every variant once, in the
     /// same order, so any two share a thermal/clock neighborhood (matched-clock
@@ -163,7 +166,7 @@ pub struct TournamentConfig {
 impl Default for TournamentConfig {
     fn default() -> Self {
         Self {
-            min_speedup: 1.05,
+            min_speedup: 1.10,
             rounds: 5,
             warmup_rounds: 1,
         }
@@ -233,6 +236,21 @@ fn median(samples: &[f64]) -> Option<f64> {
     } else {
         sorted[mid]
     })
+}
+
+/// An outlier-robust *low* estimate: the worst round after discarding a single
+/// unlucky outlier (the median's companion for the downside). For `>= 2` samples
+/// this is the second-smallest; for one sample it is that sample. Used by the
+/// significance gate so a single bad round does not veto a genuine win, while a
+/// broadly-noisy candidate (several rounds below baseline) is still caught.
+fn robust_low(samples: &[f64]) -> f64 {
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    if sorted.len() >= 2 {
+        sorted[1]
+    } else {
+        sorted.first().copied().unwrap_or(0.0)
+    }
 }
 
 /// Per-variant accumulation across interleaved rounds.
@@ -340,9 +358,20 @@ pub fn run_tournament(
         }
     };
 
-    // Evaluate candidates (indices 1..) on their medians.
+    // Evaluate candidates (indices 1..). A candidate wins only if it clears BOTH
+    // gates: (a) MARGIN — its median beats the baseline median by `min_speedup`;
+    // and (b) SIGNIFICANCE — even after discarding a single unlucky round, its
+    // worst remaining round still beats the baseline median (`robust_low`).
+    //
+    // The significance gate exists because the §1.4 child-process trials carry
+    // wide per-trial variance (each trial is a fresh process: fresh load, fresh
+    // page-cache and scheduler placement). A margin-only gate would crown a noise
+    // winner on a lucky median and persist it. Requiring the candidate to stay
+    // above baseline even on its near-worst round rejects that, while the
+    // outlier-robust `robust_low` still admits a real win that had one bad round.
     let mut best: Option<(&Candidate, f64)> = None;
     let mut disqualified = Vec::new();
+    let mut margin_but_noisy = false;
     for (i, candidate) in candidates.iter().enumerate() {
         let stat = &stats[i + 1];
         if stat.tok_samples.is_empty() {
@@ -354,6 +383,13 @@ pub fn run_tournament(
             continue;
         }
         let med = median(&stat.tok_samples).unwrap_or(0.0);
+        if med < base_tok * config.min_speedup {
+            continue; // MARGIN GATE
+        }
+        if robust_low(&stat.tok_samples) < base_tok {
+            margin_but_noisy = true; // SIGNIFICANCE GATE — the win is within noise
+            continue;
+        }
         match best {
             Some((_, best_tok)) if med <= best_tok => {}
             _ => best = Some((candidate, med)),
@@ -361,12 +397,12 @@ pub fn run_tournament(
     }
 
     match best {
-        Some((winner, tok)) if tok >= base_tok * config.min_speedup => {
+        Some((winner, tok)) => {
             let speedup = tok / base_tok;
             CalibrationOutcome {
                 selected_profile: winner.profile.clone(),
                 reason: format!(
-                    "gait: {} won at {speedup:.3}x over baseline (median of {measured} rounds)",
+                    "gait: {} won at {speedup:.3}x over baseline (median of {measured} rounds, noise-significant)",
                     winner.label
                 ),
                 baseline_tokens_per_s: super::round_sig6(base_tok),
@@ -381,11 +417,15 @@ pub fn run_tournament(
                 samples,
             }
         }
-        _ => fail_closed(
-            "no parity-clean candidate beat baseline by margin; keeping baseline".to_string(),
-            base_tok,
-            disqualified,
-        ),
+        None => {
+            let reason = if margin_but_noisy {
+                "a candidate beat the margin but not the measurement noise (a round dipped below baseline); keeping baseline"
+                    .to_string()
+            } else {
+                "no parity-clean candidate beat baseline by margin; keeping baseline".to_string()
+            };
+            fail_closed(reason, base_tok, disqualified)
+        }
     }
 }
 
@@ -632,6 +672,96 @@ mod tests {
         let fast = outcome.samples.iter().find(|s| s.label == "fast").unwrap();
         assert_eq!(fast.median_tokens_per_s, 13.0);
         assert_eq!(fast.min_tokens_per_s, 4.0);
+    }
+
+    #[test]
+    fn noisy_candidate_rejected_despite_high_median() {
+        // High median (14 > baseline 10, clears even a 1.05 margin) but BROADLY
+        // noisy: multiple rounds dip below the baseline median, so the median is a
+        // lucky-rounds artifact, not a real win. This is the §5 child-process
+        // noise case — the significance gate (not the margin) must fail-close.
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let candidates = vec![cand("noisy", ExecutionProfile::Experimental)];
+        let cfg = TournamentConfig {
+            min_speedup: 1.05,
+            rounds: 5,
+            warmup_rounds: 0,
+        };
+        // sorted [8,9,14,14,14] -> median 14, robust_low (2nd-smallest) 9 < 10.
+        let noisy = [14.0, 9.0, 14.0, 8.0, 14.0];
+        let mut n = 0;
+        let outcome = run_tournament(&baseline, &candidates, &cfg, 1_000_000, &mem(), |c| {
+            match c.label.as_str() {
+                "auto" => Some(TrialResult { tokens_per_s: 10.0, parity_token: "A".into() }),
+                _ => {
+                    let v = noisy[n % noisy.len()];
+                    n += 1;
+                    Some(TrialResult { tokens_per_s: v, parity_token: "A".into() })
+                }
+            }
+        });
+        assert!(outcome.fell_back, "a broadly-noisy candidate must fail-close");
+        assert_eq!(outcome.selected_profile, ExecutionProfile::Auto);
+        assert!(
+            outcome.reason.contains("measurement noise"),
+            "reason should name the noise gate, got: {}",
+            outcome.reason
+        );
+    }
+
+    #[test]
+    fn clean_win_survives_significance() {
+        // A stable, genuinely-faster candidate: every round clears the baseline
+        // median, even discounting the slowest. Both gates pass — it wins.
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let candidates = vec![cand("fast", ExecutionProfile::Experimental)];
+        let cfg = TournamentConfig {
+            min_speedup: 1.10,
+            rounds: 5,
+            warmup_rounds: 0,
+        };
+        let fast = [12.0, 12.0, 13.0, 12.0, 12.0]; // median 12 = 1.2x, robust_low 12
+        let mut n = 0;
+        let outcome = run_tournament(&baseline, &candidates, &cfg, 1_000_000, &mem(), |c| {
+            match c.label.as_str() {
+                "auto" => Some(TrialResult { tokens_per_s: 10.0, parity_token: "A".into() }),
+                _ => {
+                    let v = fast[n % fast.len()];
+                    n += 1;
+                    Some(TrialResult { tokens_per_s: v, parity_token: "A".into() })
+                }
+            }
+        });
+        assert!(!outcome.fell_back);
+        assert_eq!(outcome.selected_profile, ExecutionProfile::Experimental);
+    }
+
+    #[test]
+    fn default_margin_rejects_small_stable_win() {
+        // A clean, stable but SMALL win (1.06x) — below the noise-robust default
+        // margin (1.10). It passes significance but not the margin, so it must
+        // fail-close: a sub-10% gait is not worth persisting under child-process
+        // measurement variance.
+        let baseline = cand("auto", ExecutionProfile::Auto);
+        let candidates = vec![cand("slightly_faster", ExecutionProfile::Experimental)];
+        let outcome = run_tournament(
+            &baseline,
+            &candidates,
+            &TournamentConfig::default(),
+            1_000_000,
+            &mem(),
+            |c| {
+                Some(match c.label.as_str() {
+                    "auto" => TrialResult { tokens_per_s: 10.0, parity_token: "A".into() },
+                    _ => TrialResult { tokens_per_s: 10.6, parity_token: "A".into() },
+                })
+            },
+        );
+        assert!(
+            outcome.fell_back,
+            "a sub-margin win must fail-close under the default 1.10 margin"
+        );
+        assert_eq!(outcome.selected_profile, ExecutionProfile::Auto);
     }
 
     #[test]

--- a/src/gait/calibrate.rs
+++ b/src/gait/calibrate.rs
@@ -94,8 +94,9 @@ pub struct Candidate {
 
 /// The result of timing one candidate: its throughput and a parity token. Two
 /// candidates are parity-equal iff their tokens are equal — the gate that
-/// disqualifies a fast-but-divergent candidate.
-#[derive(Debug, Clone)]
+/// disqualifies a fast-but-divergent candidate. Serializable so a supervised
+/// child-process trial (§1.4 crash isolation) can hand it back over stdout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrialResult {
     pub tokens_per_s: f64,
     pub parity_token: String,
@@ -368,6 +369,53 @@ pub fn calibrate_and_store(
 /// Convenience: the default store directory for calibration output.
 pub fn default_store_dir() -> Option<PathBuf> {
     gait_dir()
+}
+
+/// Outcome of supervising a child-process trial under a hard timeout (§1.4).
+#[derive(Debug)]
+pub enum WatchdogOutcome {
+    /// The child exited on its own; carries its captured output.
+    Completed(std::process::Output),
+    /// The child overran the timeout and was killed — abandoned and disqualified.
+    TimedOut,
+    /// Could not wait on / collect the child (OS error).
+    Errored,
+}
+
+/// Supervise a child trial under a HARD `timeout`, polling every `poll` interval.
+///
+/// This is the §1.4 crash-isolation valve: candidate kernels run in a separate
+/// process, so a candidate that **segfaults** cannot take down the calibrating
+/// (or serving) process — it surfaces as a non-success exit — and a candidate
+/// that **hangs** is KILLED at the deadline rather than waited on forever. Either
+/// way the supervisor returns and the bad candidate is disqualified upstream;
+/// it is never persisted. The child should be spawned with stdout piped if the
+/// caller needs the [`TrialResult`] it prints.
+pub fn supervise(
+    mut child: std::process::Child,
+    timeout: std::time::Duration,
+    poll: std::time::Duration,
+) -> WatchdogOutcome {
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => {
+                return match child.wait_with_output() {
+                    Ok(output) => WatchdogOutcome::Completed(output),
+                    Err(_) => WatchdogOutcome::Errored,
+                };
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return WatchdogOutcome::TimedOut;
+                }
+                std::thread::sleep(poll);
+            }
+            Err(_) => return WatchdogOutcome::Errored,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/gait/calibrate.rs
+++ b/src/gait/calibrate.rs
@@ -359,9 +359,20 @@ pub fn calibrate_and_store(
 
     let outcome = run_tournament(baseline, candidates, config, weight_bytes, &memory, trial);
 
+    // §6F: attest the host-safety posture (the §1.2 cap + §1.1/§1.2 invariants) and
+    // record the measured free-RAM headroom, so the receipt audits how this gait
+    // runs. Read physical_cores before machine_sig is moved into the receipt.
+    let scheduling = super::Scheduling::attest(
+        machine_sig.physical_cores,
+        outcome.selected_eco_qos_opt_out,
+    );
+    let host_safety = super::HostSafety::capture();
+
     let receipt = GaitReceipt::new(model_sig, machine_sig, outcome.selected_profile.clone())
         .with_memory(memory)
-        .with_calibration(outcome.clone());
+        .with_calibration(outcome.clone())
+        .with_scheduling(scheduling)
+        .with_host_safety(host_safety);
     let path = store_in(dir, &receipt).ok();
     (outcome, path)
 }

--- a/src/gait/calibrate.rs
+++ b/src/gait/calibrate.rs
@@ -79,9 +79,49 @@ fn is_matmul_stage(class: &str) -> bool {
     )
 }
 
+/// §5: the three managed x86 Q8 `groups_per_chunk` tiling knobs
+/// (`MANAGED_ENV_KEYS`). Tiling only — the arithmetic is unchanged, so varying
+/// these is parity-neutral *by construction* (and the tournament's parity gate
+/// enforces it regardless). The defaults match the kernel readers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GroupsPerChunk {
+    pub attn_qkv_decode: usize,
+    pub ffn_gate_up_decode: usize,
+    pub packed_rows4_matmul: usize,
+}
+
+/// The kernel defaults — the center of the bounded search.
+pub const GPC_CENTER: GroupsPerChunk = GroupsPerChunk {
+    attn_qkv_decode: 16,
+    ffn_gate_up_decode: 16,
+    packed_rows4_matmul: 8,
+};
+
+/// A bounded coordinate-neighbor set around [`GPC_CENTER`] — a *short local
+/// search*, not a full grid, so the (expensive, child-process) trial count stays
+/// small. Each point keeps all knobs `> 0` as the kernel readers require.
+pub fn groups_per_chunk_neighbors() -> Vec<GroupsPerChunk> {
+    vec![
+        GPC_CENTER,
+        GroupsPerChunk {
+            attn_qkv_decode: 8,
+            ffn_gate_up_decode: 8,
+            ..GPC_CENTER
+        },
+        GroupsPerChunk {
+            attn_qkv_decode: 32,
+            ffn_gate_up_decode: 32,
+            ..GPC_CENTER
+        },
+        GroupsPerChunk {
+            packed_rows4_matmul: 16,
+            ..GPC_CENTER
+        },
+    ]
+}
+
 /// A configuration to evaluate. `profile` is what gets recorded and later
-/// applied; `label` is for evidence/logs. (As the campaign matures, candidates
-/// will also carry the per-stage `MANAGED_ENV_KEYS` struct.)
+/// applied; `label` is for evidence/logs.
 #[derive(Debug, Clone)]
 pub struct Candidate {
     pub label: String,
@@ -90,6 +130,9 @@ pub struct Candidate {
     /// Windows scheduling-substrate dimension). The engine only records it; the
     /// trial closure applies it before timing.
     pub eco_qos_opt_out: bool,
+    /// §5: per-stage `groups_per_chunk` tiling overrides. `None` uses the
+    /// profile's kernel defaults; `Some` is applied (and recorded) by the trial.
+    pub groups_per_chunk: Option<GroupsPerChunk>,
 }
 
 /// The result of timing one candidate: its throughput and a parity token. Two
@@ -159,6 +202,10 @@ pub struct CalibrationOutcome {
     /// the substrate dimension existed.
     #[serde(default)]
     pub selected_eco_qos_opt_out: bool,
+    /// §5: the `groups_per_chunk` tiling the winner used (`None` = kernel defaults
+    /// / baseline). Recorded so the selected gait reproduces the chosen tiling.
+    #[serde(default)]
+    pub selected_groups_per_chunk: Option<GroupsPerChunk>,
     /// Measured rounds per variant behind the medians.
     #[serde(default)]
     pub measured_rounds: usize,
@@ -277,6 +324,7 @@ pub fn run_tournament(
         fell_back: true,
         parity_disqualified: disq,
         selected_eco_qos_opt_out: baseline.eco_qos_opt_out,
+        selected_groups_per_chunk: baseline.groups_per_chunk,
         measured_rounds: measured,
         samples: samples.clone(),
     };
@@ -328,6 +376,7 @@ pub fn run_tournament(
                 fell_back: false,
                 parity_disqualified: disqualified,
                 selected_eco_qos_opt_out: winner.eco_qos_opt_out,
+                selected_groups_per_chunk: winner.groups_per_chunk,
                 measured_rounds: measured,
                 samples,
             }
@@ -475,6 +524,28 @@ mod tests {
             label: label.to_string(),
             profile,
             eco_qos_opt_out: false,
+            groups_per_chunk: None,
+        }
+    }
+
+    #[test]
+    fn gpc_neighbors_are_bounded_distinct_and_positive() {
+        let neighbors = groups_per_chunk_neighbors();
+        // A short local search, never a runaway grid.
+        assert!(
+            (2..=8).contains(&neighbors.len()),
+            "search must stay bounded, got {}",
+            neighbors.len()
+        );
+        assert!(neighbors.contains(&GPC_CENTER), "the center must be probed");
+        let mut seen = std::collections::BTreeSet::new();
+        for g in &neighbors {
+            // Every knob must stay > 0 (the kernel readers reject 0).
+            assert!(g.attn_qkv_decode > 0 && g.ffn_gate_up_decode > 0 && g.packed_rows4_matmul > 0);
+            assert!(
+                seen.insert((g.attn_qkv_decode, g.ffn_gate_up_decode, g.packed_rows4_matmul)),
+                "search points must be distinct"
+            );
         }
     }
 

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -559,6 +559,13 @@ pub struct GaitReceipt {
     /// receipt. Part of the canonical body, so bound into `receipt_id`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub calibration: Option<calibrate::CalibrationOutcome>,
+    /// §6F host-safety scheduling attestation (the §1.2 cap + the §1.1/§1.2
+    /// invariants). Absent for receipts written before this lane.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduling: Option<Scheduling>,
+    /// §6F measured host-safety posture (free-RAM headroom at calibration).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host_safety: Option<HostSafety>,
 }
 
 impl GaitReceipt {
@@ -574,6 +581,8 @@ impl GaitReceipt {
             recorded_profile,
             memory: None,
             calibration: None,
+            scheduling: None,
+            host_safety: None,
         };
         receipt.seal();
         receipt
@@ -590,6 +599,20 @@ impl GaitReceipt {
     /// Attach the calibration evidence and re-seal.
     pub fn with_calibration(mut self, calibration: calibrate::CalibrationOutcome) -> Self {
         self.calibration = Some(calibration);
+        self.seal();
+        self
+    }
+
+    /// Attach the §6F scheduling attestation and re-seal.
+    pub fn with_scheduling(mut self, scheduling: Scheduling) -> Self {
+        self.scheduling = Some(scheduling);
+        self.seal();
+        self
+    }
+
+    /// Attach the §6F measured host-safety posture and re-seal.
+    pub fn with_host_safety(mut self, host_safety: HostSafety) -> Self {
+        self.host_safety = Some(host_safety);
         self.seal();
         self
     }
@@ -824,6 +847,72 @@ pub fn host_ram_status() -> Option<(u64, u64)> {
 #[cfg(not(windows))]
 pub fn host_ram_status() -> Option<(u64, u64)> {
     None
+}
+
+/// The host-safety scheduling posture recorded in a gait receipt (§6F) — an
+/// attestation of the guarantees Waves 1–2 enforce, so a reader can audit *how* a
+/// gait runs without trusting prose. Every field is honestly derived: the cap
+/// from the topology, the constants from architectural invariants.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Scheduling {
+    /// The §1.2 compute-thread cap (`budget.threads`) — the most workers this gait
+    /// will use. `None` if the physical-core count was unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compute_threads: Option<usize>,
+    /// Cores reserved for the OS under that cap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reserved_cores: Option<usize>,
+    /// Whether the EcoQoS execution-speed opt-out is applied (compute pool only).
+    pub eco_qos_opt_out: bool,
+    /// Always `"none"` — GAIT never page-locks the weight arena (§1.1).
+    pub memory_locking: String,
+    /// Always `"untouched"` — GAIT never alters processor-performance / thermal
+    /// limits (§1.2).
+    pub thermal_limits: String,
+    /// Software weight-stream prefetch depth (0 = baseline; `>0` once §6D lands).
+    pub stream_prefetch_depth: u32,
+    /// CPU-set the compute pool is pinned to (empty until §1.2 CPU-set pinning).
+    pub compute_cpuset: Vec<u32>,
+}
+
+impl Scheduling {
+    /// Build the scheduling attestation from the machine's physical-core count and
+    /// the selected EcoQoS choice: records the §1.2 cap and the §1.1/§1.2
+    /// architectural constants.
+    pub fn attest(physical_cores: Option<usize>, eco_qos_opt_out: bool) -> Self {
+        let budget = physical_cores.map(compute_thread_budget);
+        Scheduling {
+            compute_threads: budget.map(|b| b.threads),
+            reserved_cores: budget.map(|b| b.reserved),
+            eco_qos_opt_out,
+            memory_locking: "none".to_string(),
+            thermal_limits: "untouched".to_string(),
+            stream_prefetch_depth: 0,
+            compute_cpuset: Vec::new(),
+        }
+    }
+}
+
+/// The measured host-safety posture at calibration time (§6F). Only fields GAIT
+/// genuinely measures are recorded — throttle-event counting and UI-responsiveness
+/// monitoring are deliberately ABSENT until the §1.2 throttle valve exists, so the
+/// receipt never attests a safety number it did not actually measure.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct HostSafety {
+    /// Free physical RAM observed at calibration, in GiB (the §1.1 headroom).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ram_headroom_gib: Option<f64>,
+}
+
+impl HostSafety {
+    /// Capture the current host-safety posture (free-RAM headroom). The float is
+    /// `round_sig6`-normalized so the content-addressed receipt's self-digest
+    /// survives a file round-trip (see [`round_sig6`]).
+    pub fn capture() -> Self {
+        let ram_headroom_gib = host_ram_status()
+            .map(|(_total, avail)| round_sig6(avail as f64 / (1024.0 * 1024.0 * 1024.0)));
+        HostSafety { ram_headroom_gib }
+    }
 }
 
 /// Measured memory characteristics — the roofline denominator (sustained DRAM
@@ -1287,6 +1376,56 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("camelid_gait_miss_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         assert!(load_from(&dir, "deadbeef:cafef00d").is_none());
+    }
+
+    #[test]
+    fn scheduling_attest_records_cap_and_constants() {
+        let s = Scheduling::attest(Some(8), true);
+        assert_eq!(s.compute_threads, Some(6)); // 8 - 2 reserve on a small box
+        assert_eq!(s.reserved_cores, Some(2));
+        assert!(s.eco_qos_opt_out);
+        assert_eq!(s.memory_locking, "none");
+        assert_eq!(s.thermal_limits, "untouched");
+        assert_eq!(s.stream_prefetch_depth, 0);
+        assert!(s.compute_cpuset.is_empty());
+        // Unknown topology -> no thread numbers, but the invariants still hold.
+        let u = Scheduling::attest(None, false);
+        assert_eq!(u.compute_threads, None);
+        assert_eq!(u.reserved_cores, None);
+        assert_eq!(u.memory_locking, "none");
+    }
+
+    #[test]
+    fn receipt_with_scheduling_and_host_safety_round_trips() {
+        let dir = std::env::temp_dir().join(format!("camelid_gait_sched_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let base = GaitReceipt::new(
+            ModelSig::from_gguf(&sample_gguf()),
+            MachineSig::detect(),
+            ExecutionProfile::Auto,
+        );
+        // 9.5 is an exact binary fraction, so it survives the JSON round-trip the
+        // content-addressed self-digest depends on.
+        let enriched = base
+            .clone()
+            .with_scheduling(Scheduling::attest(Some(8), false))
+            .with_host_safety(HostSafety {
+                ram_headroom_gib: Some(9.5),
+            });
+        // Enrichment changes the sealed digest but not the key, and stays verifiable.
+        assert_ne!(enriched.receipt_id, base.receipt_id);
+        assert_eq!(enriched.gait_key, base.gait_key);
+        assert!(enriched.verify_self_digest());
+
+        store_in(&dir, &enriched).expect("store");
+        let loaded = load_from(&dir, &enriched.gait_key).expect("load");
+        assert_eq!(loaded, enriched);
+        assert_eq!(
+            loaded.scheduling.as_ref().unwrap().thermal_limits,
+            "untouched"
+        );
+        assert_eq!(loaded.host_safety.unwrap().ram_headroom_gib, Some(9.5));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -1460,6 +1460,7 @@ mod tests {
             fell_back: false,
             parity_disqualified: Vec::new(),
             selected_eco_qos_opt_out: true,
+            selected_groups_per_chunk: None,
             measured_rounds: 1,
             samples: Vec::new(),
         };

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -29,6 +29,7 @@ use crate::gguf::GgufFile;
 use crate::receipt::{canonical_json, sha256_hex};
 
 pub mod calibrate;
+pub mod sentinel;
 pub mod substrate;
 
 /// Schema identifier stamped into every v1 gait receipt. Mirrors the
@@ -630,8 +631,9 @@ pub fn gait_dir() -> Option<PathBuf> {
 
 /// File name for a key. The key contains `:` (invalid on Windows), so it is
 /// sanitized; the full key is also recorded inside the receipt and re-checked on
-/// load.
-fn key_filename(key: &str) -> String {
+/// load. Crate-visible so the safe-boot sentinel addresses the same receipt file
+/// when quarantining a suspect gait.
+pub(crate) fn key_filename(key: &str) -> String {
     format!("{}.gait.json", key.replace(':', "_"))
 }
 
@@ -669,6 +671,10 @@ pub fn load_from(dir: &Path, key: &str) -> Option<GaitReceipt> {
 /// planner should use plus the scheduling substrate to apply.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SelectedGait {
+    /// The `gait_key` this profile was selected for — the safe-boot sentinel
+    /// records it in the `.applying` marker so a crashing gait can be quarantined
+    /// by key on the next launch.
+    pub gait_key: String,
     pub profile: ExecutionProfile,
     pub reason: String,
     pub eco_qos_opt_out: bool,
@@ -690,18 +696,34 @@ pub(crate) fn receipt_eco_opt_out(receipt: &GaitReceipt) -> bool {
 /// receipt exists for this model on this machine. In every other case it returns
 /// `None` and the planner falls through to its existing default.
 pub fn maybe_select_profile(gguf: &GgufFile) -> Option<SelectedGait> {
+    let dir = gait_dir()?;
+    maybe_select_profile_in(&dir, gguf)
+}
+
+/// `dir`-explicit core of [`maybe_select_profile`], so the gate / `DISABLE` /
+/// quarantine behavior is testable against a temporary store. Returns `None`
+/// (the baseline path) when the gate is off, the `DISABLE` kill-file is present,
+/// or no loadable receipt exists for this `(model × machine)` — a quarantined
+/// receipt has been moved out of `dir`, so it simply misses here.
+pub(crate) fn maybe_select_profile_in(dir: &Path, gguf: &GgufFile) -> Option<SelectedGait> {
     if !gait_enabled() {
+        return None;
+    }
+    // §1.3 kill-file: while `DISABLE` exists, serve the baseline unconditionally —
+    // no cached profile and no substrate.
+    if sentinel::disable_present(dir) {
         return None;
     }
     let model_sig = ModelSig::from_gguf(gguf);
     let machine_sig = MachineSig::detect();
     let key = gait_key(&model_sig, &machine_sig);
-    let dir = gait_dir()?;
-    let receipt = load_from(&dir, &key)?;
+    let receipt = load_from(dir, &key)?;
+    let reason = format!("gait: applied cached profile for {key}");
     Some(SelectedGait {
+        gait_key: key,
         eco_qos_opt_out: receipt_eco_opt_out(&receipt),
         profile: receipt.recorded_profile,
-        reason: format!("gait: applied cached profile for {key}"),
+        reason,
     })
 }
 
@@ -710,6 +732,26 @@ pub fn maybe_select_profile(gguf: &GgufFile) -> Option<SelectedGait> {
 /// substrate (EcoQoS) and logs the live gait so it is observable. Best-effort and
 /// process-level. Only invoked when a gait was selected (gate on + receipt found).
 pub fn apply_selected_gait(gait: &SelectedGait) {
+    // §4 safe-boot: record the in-progress apply BEFORE touching the host, so a
+    // crash/freeze/wedge during apply or early use leaves a marker that the next
+    // launch detects and quarantines. The marker is cleared once a real decode
+    // completes (`sentinel::mark_healthy`) or on an orderly exit
+    // (`sentinel::clean_shutdown`).
+    //
+    // WAVE 2: the healthy-clear currently fires on the first completed decode,
+    // which fully guards the apply window and a parity-gated profile (a profile
+    // is only ever persisted after it decoded cleanly on this exact machine
+    // during calibration). When non-parity-gated, host-touching levers land
+    // (CPU-set pinning, the sustained-throttle valve, live in-process
+    // calibration), move the clear-point to *after a sustained-healthy window*
+    // so a gait that wedges the host mid-session is still caught.
+    if let Some(dir) = gait_dir() {
+        let mut layers: Vec<&str> = vec!["gait"];
+        if gait.eco_qos_opt_out {
+            layers.push("substrate");
+        }
+        sentinel::begin_apply(&dir, &gait.gait_key, &layers);
+    }
     if gait.eco_qos_opt_out {
         let status = substrate::set_eco_qos_opt_out(true);
         eprintln!(
@@ -966,6 +1008,12 @@ pub mod oracle {
     }
 }
 
+/// Serializes the tests that mutate the process-global `CAMELID_GAIT` env var so
+/// they cannot race each other (Rust runs tests in parallel by default). Held for
+/// the duration of any test that sets or clears the gate.
+#[cfg(test)]
+pub(crate) static GAIT_TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1180,6 +1228,9 @@ mod tests {
 
     #[test]
     fn selector_is_none_when_gate_disabled() {
+        let _env = GAIT_TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         // With the gate unset, the selector must not touch the store at all.
         std::env::remove_var(GAIT_GATE_ENV);
         assert!(maybe_select_profile(&sample_gguf()).is_none());
@@ -1217,5 +1268,158 @@ mod tests {
         )
         .with_calibration(outcome);
         assert!(receipt_eco_opt_out(&receipt));
+    }
+}
+
+/// §9 host-safety gates. These assert the prime-directive guard rails the v2
+/// campaign adds, not just the happy path. Run with:
+/// `cargo test --lib -- --include-ignored gait_safety`.
+#[cfg(test)]
+mod gait_safety {
+    use super::*;
+    use crate::gguf::{GgufFile, GgufMetadataValue, GgufTensorDescriptor, GgufTensorType};
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        GAIT_TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "camelid_gait_safety_{tag}_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn sample_gguf() -> GgufFile {
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            "general.architecture".to_string(),
+            GgufMetadataValue::String("llama".to_string()),
+        );
+        metadata.insert("llama.block_count".to_string(), GgufMetadataValue::U32(4));
+        metadata.insert(
+            "llama.embedding_length".to_string(),
+            GgufMetadataValue::U32(64),
+        );
+        GgufFile {
+            path: PathBuf::from("safety.gguf"),
+            version: 3,
+            tensor_count: 1,
+            metadata_count: metadata.len() as i64,
+            alignment: 32,
+            data_start_offset: 0,
+            metadata,
+            tensors: vec![GgufTensorDescriptor {
+                name: "blk.0.attn_q.weight".to_string(),
+                dimensions: vec![64, 64],
+                tensor_type: GgufTensorType::Q8_0,
+                relative_offset: 0,
+                absolute_offset: 0,
+                n_bytes: 0,
+            }],
+        }
+    }
+
+    /// §1.3: a `DISABLE` kill-file forces the baseline path even with the gate on
+    /// and a valid cached receipt present.
+    #[test]
+    fn disable_file_forces_baseline() {
+        let _env = lock_env();
+        let dir = temp_dir("disable");
+        let gguf = sample_gguf();
+        let receipt = GaitReceipt::new(
+            ModelSig::from_gguf(&gguf),
+            MachineSig::detect(),
+            ExecutionProfile::Auto,
+        );
+        store_in(&dir, &receipt).expect("store receipt");
+
+        std::env::set_var(GAIT_GATE_ENV, "1");
+        // Sanity: gate on + receipt present => the selector adopts it.
+        assert!(
+            maybe_select_profile_in(&dir, &gguf).is_some(),
+            "precondition: a cached gait should be selected before DISABLE"
+        );
+        // Drop the kill-file: the selector must now serve baseline (None), no
+        // profile and no substrate, despite the live receipt.
+        std::fs::write(dir.join("DISABLE"), "").expect("write DISABLE");
+        assert!(
+            maybe_select_profile_in(&dir, &gguf).is_none(),
+            "DISABLE must force the baseline path"
+        );
+
+        std::env::remove_var(GAIT_GATE_ENV);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// §4 crash-injection: a stored receipt + a stale `.applying` marker (a prior
+    /// unclean exit) must be quarantined on the next launch, after which the
+    /// selector serves the proven baseline.
+    #[test]
+    fn safe_boot_quarantines_bad_gait() {
+        let _env = lock_env();
+        let dir = temp_dir("safe_boot");
+        let gguf = sample_gguf();
+        let model_sig = ModelSig::from_gguf(&gguf);
+        let machine_sig = MachineSig::detect();
+        let key = gait_key(&model_sig, &machine_sig);
+
+        // The persisted (here, suspect) gait that crashed the prior run.
+        let receipt = GaitReceipt::new(model_sig, machine_sig, ExecutionProfile::Experimental);
+        store_in(&dir, &receipt).expect("store receipt");
+        // The marker the crashed run left behind (written directly so the global
+        // armed slot is untouched — this stands in for a previous process).
+        let marker = sentinel::ApplyingMarker {
+            gait_key: key.clone(),
+            layers: vec!["gait".to_string(), "substrate".to_string()],
+            pid: 999_999,
+            utc_epoch_secs: 0,
+        };
+        std::fs::write(
+            dir.join(".applying"),
+            serde_json::to_string(&marker).unwrap(),
+        )
+        .expect("write marker");
+
+        std::env::set_var(GAIT_GATE_ENV, "1");
+        // Sanity: before reconciliation the suspect gait is loadable.
+        assert!(
+            maybe_select_profile_in(&dir, &gguf).is_some(),
+            "precondition: the suspect gait should load before reconciliation"
+        );
+
+        // Next launch reconciles the stale marker.
+        match sentinel::reconcile_on_startup(&dir) {
+            sentinel::StartupReconcile::UncleanExit {
+                gait_key,
+                quarantined,
+            } => {
+                assert_eq!(gait_key.as_deref(), Some(key.as_str()));
+                assert!(quarantined, "first unclean exit must quarantine (threshold 1)");
+            }
+            other => panic!("expected UncleanExit, got {other:?}"),
+        }
+
+        // The receipt is quarantined, the marker cleared, so the selector now
+        // boots the baseline.
+        assert!(
+            maybe_select_profile_in(&dir, &gguf).is_none(),
+            "after quarantine the selector must serve baseline"
+        );
+        assert!(
+            dir.join(".quarantine").join(key_filename(&key)).exists(),
+            "the suspect receipt must be preserved under .quarantine/ for diagnosis"
+        );
+        assert!(!dir.join(".applying").exists(), "the marker must be cleared");
+
+        std::env::remove_var(GAIT_GATE_ENV);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -789,6 +789,43 @@ pub fn compute_thread_budget(physical_cores: usize) -> ComputeThreadBudget {
     ComputeThreadBudget { threads, reserved }
 }
 
+/// §1.1 free-RAM floor: GAIT keeps at least `max(20% of total, 4 GiB)` of physical
+/// RAM free, so an allocation campaign (e.g. calibration loading candidate
+/// weights) can never drive the host into swap / OOM. Pure, so it is testable.
+pub fn ram_headroom_floor(total_bytes: u64) -> u64 {
+    const FOUR_GIB: u64 = 4 * 1024 * 1024 * 1024;
+    (total_bytes / 5).max(FOUR_GIB)
+}
+
+/// True when `available_bytes` of free physical RAM respects the §1.1 floor for a
+/// host with `total_bytes` of physical RAM.
+pub fn ram_headroom_ok(total_bytes: u64, available_bytes: u64) -> bool {
+    available_bytes >= ram_headroom_floor(total_bytes)
+}
+
+/// Physical RAM `(total, available)` in bytes via `GlobalMemoryStatusEx`. `None`
+/// off Windows or on query failure (the caller then proceeds without the gate
+/// rather than blocking).
+#[cfg(windows)]
+pub fn host_ram_status() -> Option<(u64, u64)> {
+    use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+    // SAFETY: a zeroed MEMORYSTATUSEX with dwLength set to its own size, exactly
+    // as GlobalMemoryStatusEx requires; the call only reads/writes that struct.
+    unsafe {
+        let mut status: MEMORYSTATUSEX = std::mem::zeroed();
+        status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+        if GlobalMemoryStatusEx(&mut status) == 0 {
+            return None;
+        }
+        Some((status.ullTotalPhys, status.ullAvailPhys))
+    }
+}
+
+#[cfg(not(windows))]
+pub fn host_ram_status() -> Option<(u64, u64)> {
+    None
+}
+
 /// Measured memory characteristics — the roofline denominator (sustained DRAM
 /// bandwidth) and the latency the resonance tuning must hide. Measured at
 /// calibration, not guessed, and never folded into the gait key.
@@ -1523,5 +1560,62 @@ mod gait_safety {
             substrate::set_compute_pool_eco_qos(true),
             substrate::EcoQosStatus::Unavailable
         );
+    }
+
+    #[cfg(windows)]
+    fn hanging_child() -> std::process::Child {
+        std::process::Command::new("cmd")
+            .args(["/C", "ping -n 30 127.0.0.1 >NUL"])
+            .stdout(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn hanging child")
+    }
+
+    #[cfg(not(windows))]
+    fn hanging_child() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("30")
+            .stdout(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn hanging child")
+    }
+
+    /// §1.4: a candidate that hangs is killed at the deadline and abandoned — the
+    /// supervisor returns promptly and the calling (serving) process survives.
+    #[test]
+    fn watchdog_survives_hung_candidate() {
+        use std::time::{Duration, Instant};
+        let child = hanging_child();
+        let started = Instant::now();
+        let outcome = calibrate::supervise(
+            child,
+            Duration::from_millis(400),
+            Duration::from_millis(20),
+        );
+        let elapsed = started.elapsed();
+        assert!(
+            matches!(outcome, calibrate::WatchdogOutcome::TimedOut),
+            "a hung candidate must time out, got {outcome:?}"
+        );
+        // Killed at the deadline, not waited out (the child would sleep ~30s); and
+        // reaching this line at all proves the supervisor did not wedge us.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "watchdog must kill promptly, took {elapsed:?}"
+        );
+    }
+
+    /// §1.1: the free-RAM floor is max(20% of total, 4 GiB), and the headroom
+    /// check honors it.
+    #[test]
+    fn ram_headroom() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        // 20% dominates on a big box; the 4 GiB floor dominates on a small one.
+        assert_eq!(ram_headroom_floor(100 * GIB), 20 * GIB);
+        assert_eq!(ram_headroom_floor(8 * GIB), 4 * GIB);
+        assert!(ram_headroom_ok(100 * GIB, 30 * GIB));
+        assert!(!ram_headroom_ok(100 * GIB, 10 * GIB));
+        assert!(ram_headroom_ok(8 * GIB, 5 * GIB));
+        assert!(!ram_headroom_ok(8 * GIB, 2 * GIB));
     }
 }

--- a/src/gait/mod.rs
+++ b/src/gait/mod.rs
@@ -753,14 +753,40 @@ pub fn apply_selected_gait(gait: &SelectedGait) {
         sentinel::begin_apply(&dir, &gait.gait_key, &layers);
     }
     if gait.eco_qos_opt_out {
-        let status = substrate::set_eco_qos_opt_out(true);
+        // §1.2: scope the EcoQoS opt-out to the compute worker threads only (the
+        // Rayon decode pool + this thread), NOT the whole process — UI and
+        // background threads keep their eco-friendly OS-managed default.
+        let status = substrate::set_compute_pool_eco_qos(true);
         eprintln!(
-            "[gait] applied profile={:?} + eco_qos opt-out -> {status:?}",
+            "[gait] applied profile={:?} + eco_qos opt-out (compute pool) -> {status:?}",
             gait.profile
         );
     } else {
         eprintln!("[gait] applied profile={:?}", gait.profile);
     }
+}
+
+/// §1.2 host-safety compute-thread budget. The compute pool must always leave the
+/// OS headroom: reserve at least one core, and at least two on small machines
+/// (`<= 8` physical cores), so the UI/OS keep a performance core no matter what.
+/// Pure arithmetic on the physical-core count, so it is platform-independent and
+/// directly testable; never returns zero.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComputeThreadBudget {
+    /// Compute worker threads permitted (`>= 1`).
+    pub threads: usize,
+    /// Cores actually left for the OS (`physical_cores - threads`).
+    pub reserved: usize,
+}
+
+/// Resolve the [`ComputeThreadBudget`] for a machine with `physical_cores`.
+pub fn compute_thread_budget(physical_cores: usize) -> ComputeThreadBudget {
+    // Reserve two cores on small boxes, one on larger ones.
+    let want_reserve = if physical_cores <= 8 { 2 } else { 1 };
+    // Never drop below a single worker, even on a 1-2 core host.
+    let threads = physical_cores.saturating_sub(want_reserve).max(1);
+    let reserved = physical_cores.saturating_sub(threads);
+    ComputeThreadBudget { threads, reserved }
 }
 
 /// Measured memory characteristics — the roofline denominator (sustained DRAM
@@ -1421,5 +1447,81 @@ mod gait_safety {
 
         std::env::remove_var(GAIT_GATE_ENV);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// §1.2: the compute-thread budget always leaves the OS a core reserve, never
+    /// returns zero, and never exceeds the physical-core count.
+    #[test]
+    fn core_headroom() {
+        for &phys in &[1usize, 2, 4, 6, 8, 12, 16, 32, 64] {
+            let b = compute_thread_budget(phys);
+            assert!(b.threads >= 1, "phys={phys}: must keep >=1 worker");
+            assert!(b.threads <= phys, "phys={phys}: cannot exceed physical cores");
+            assert_eq!(
+                b.reserved,
+                phys - b.threads,
+                "phys={phys}: reserved bookkeeping"
+            );
+            if phys >= 2 {
+                assert!(b.reserved >= 1, "phys={phys}: OS must keep >=1 core");
+            }
+            if (3..=8).contains(&phys) {
+                assert!(b.reserved >= 2, "phys={phys}: small boxes reserve >=2 cores");
+                assert!(b.threads <= phys - 2, "phys={phys}: threads <= phys-2");
+            }
+            if phys > 8 {
+                assert!(b.threads <= phys - 1, "phys={phys}: threads <= phys-1");
+            }
+        }
+    }
+
+    /// §1.1: the weight/KV arena is never page-locked. Audit the load/mmap path
+    /// source for the forbidden APIs — locking pages makes them non-reclaimable
+    /// and can OOM/wedge the host (the v1 crash mechanism, REMOVED in v2).
+    #[test]
+    fn no_weight_locking() {
+        let root = env!("CARGO_MANIFEST_DIR");
+        // The weight-arena load + mmap path. (Deliberately not this file — it
+        // contains the forbidden token strings below as the search needles.)
+        let arena_files = ["src/wire_mmap.rs", "src/platform_fs.rs"];
+        let forbidden = [
+            "VirtualLock",
+            "MEM_LARGE_PAGES",
+            "GetLargePageMinimum",
+            "SetProcessWorkingSetSize",
+            "mlockall",
+            "MAP_LOCKED",
+        ];
+        for rel in arena_files {
+            let path = std::path::Path::new(root).join(rel);
+            let Ok(src) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            for token in forbidden {
+                assert!(
+                    !src.contains(token),
+                    "{rel} must not page-lock the weight arena (found `{token}`)"
+                );
+            }
+        }
+    }
+
+    /// §6C: off Windows the scheduling substrate is fully inert — every lever
+    /// returns Unavailable, so a non-Windows run is byte-identical to baseline.
+    #[cfg(not(windows))]
+    #[test]
+    fn non_windows_byte_identical() {
+        assert_eq!(
+            substrate::set_eco_qos_opt_out(true),
+            substrate::EcoQosStatus::Unavailable
+        );
+        assert_eq!(
+            substrate::set_thread_eco_qos_opt_out(true),
+            substrate::EcoQosStatus::Unavailable
+        );
+        assert_eq!(
+            substrate::set_compute_pool_eco_qos(true),
+            substrate::EcoQosStatus::Unavailable
+        );
     }
 }

--- a/src/gait/sentinel.rs
+++ b/src/gait/sentinel.rs
@@ -1,0 +1,333 @@
+//! Safe-boot sentinel (§4) + kill-switches (§1.3) for GAIT.
+//!
+//! Persisted, auto-applied execution state is the most dangerous property of any
+//! perf system: a configuration that crashes, freezes, or wedges the host will
+//! reload and crash again on the next launch — a crash *loop* the customer cannot
+//! escape without clearing the cache by hand. This module makes that structurally
+//! impossible.
+//!
+//! The protocol (all state under the gait dir, `%LOCALAPPDATA%\Camelid\gait\`):
+//!
+//! - **`.applying`** — a marker written *before* a gait/substrate is applied,
+//!   recording `{ gait_key, layers, pid, utc }`. It is cleared once the gait has
+//!   proven healthy (a real decode completed via [`mark_healthy`]) or on an
+//!   orderly exit ([`clean_shutdown`]). If it is still present at the *next*
+//!   launch, the previous run applied a gait and never cleared it → an unclean
+//!   exit → that gait is the suspect.
+//! - **`.quarantine/`** — receipts disabled by the sentinel, kept for diagnosis
+//!   and never loaded again.
+//! - **`DISABLE`** — an unconditional kill-file: while it exists the selector
+//!   serves the baseline path and calibration is suppressed.
+//!
+//! [`reconcile_on_startup`] runs once at process start: if it finds a stale
+//! `.applying`, it strikes (and, past the threshold, quarantines) the offending
+//! `gait_key`, deletes the marker, and lets the engine boot the proven baseline.
+//! A crash *loop* therefore degrades to a single crash followed by automatic
+//! self-heal.
+//!
+//! Everything here is best-effort and fail-safe: any I/O error biases toward
+//! quarantine / baseline (the safe direction), never toward re-applying a suspect
+//! gait. The module is inert unless the `CAMELID_GAIT` bring-up gate is on and a
+//! gait was actually applied, so the default path is byte-identical to today.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+/// In-progress apply marker.
+const APPLYING: &str = ".applying";
+/// Subdirectory holding quarantined (permanently disabled) receipts.
+const QUARANTINE_DIR: &str = ".quarantine";
+/// Unconditional kill-file: while present, baseline serves and calibration is off.
+const DISABLE_FILE: &str = "DISABLE";
+/// Per-key strike-count sidecar suffix (`<sanitized_key>.strikes`).
+const STRIKES_SUFFIX: &str = ".strikes";
+
+/// Quarantine a `gait_key` after this many unclean exits. The spec sets the
+/// default to **1** (quarantine on the first unclean exit) and forbids a value
+/// above 2 — a higher tolerance would let a genuinely host-wedging gait keep
+/// getting re-applied. Enforced at compile time.
+const QUARANTINE_STRIKE_THRESHOLD: u32 = 1;
+const _: () =
+    assert!(QUARANTINE_STRIKE_THRESHOLD >= 1 && QUARANTINE_STRIKE_THRESHOLD <= 2);
+
+/// The marker written before a gait/substrate is applied. Its presence at the
+/// next launch is the unclean-exit signal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApplyingMarker {
+    /// The gait being applied (so a suspect can be quarantined by key).
+    pub gait_key: String,
+    /// Which layers were in flight (`"gait"` and/or `"substrate"`), so the
+    /// offending layer is identifiable for diagnosis.
+    pub layers: Vec<String>,
+    /// PID of the applying process — distinguishes our own marker from a stale
+    /// one when clearing.
+    pub pid: u32,
+    /// Wall-clock seconds since the Unix epoch at apply time (diagnosis only).
+    pub utc_epoch_secs: u64,
+}
+
+/// The location + PID of this process's in-progress marker, set by
+/// [`begin_apply`] and consumed by [`mark_healthy`] / [`clean_shutdown`]. A
+/// process applies at most one gait, so a single slot suffices.
+static ARMED: Mutex<Option<(PathBuf, u32)>> = Mutex::new(None);
+
+/// Outcome of the startup reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartupReconcile {
+    /// No in-progress marker — the previous run (if any) exited cleanly.
+    Clean,
+    /// A stale marker was found: the previous run applied a gait and never
+    /// cleared it. `gait_key` is the suspect (None if the marker was
+    /// unparseable); `quarantined` is true if its receipt was moved to
+    /// `.quarantine/` this launch (false if it merely took a strike).
+    UncleanExit {
+        gait_key: Option<String>,
+        quarantined: bool,
+    },
+}
+
+/// §1.3 kill-file: true when `DISABLE` exists under `dir`. While true the caller
+/// must serve the baseline path unconditionally — no cached profile, no
+/// substrate, no calibration.
+pub fn disable_present(dir: &Path) -> bool {
+    dir.join(DISABLE_FILE).exists()
+}
+
+/// §4 startup reconciliation. Detects a stale `.applying` marker left by a prior
+/// unclean exit, strikes/quarantines the suspect `gait_key`, removes the marker,
+/// and returns what happened. Pure with respect to `dir` (no globals), so it is
+/// directly testable. Best-effort: I/O failures bias toward quarantine.
+///
+/// Call this **once**, early at process start, before any gait is applied — at
+/// that point any `.applying` present is necessarily from a previous process.
+pub fn reconcile_on_startup(dir: &Path) -> StartupReconcile {
+    let marker_path = dir.join(APPLYING);
+    let raw = match std::fs::read_to_string(&marker_path) {
+        Ok(raw) => raw,
+        // No marker (or it cannot be read) → nothing to reconcile.
+        Err(_) => return StartupReconcile::Clean,
+    };
+
+    // A marker exists at startup → the previous run applied a gait/substrate and
+    // never cleared it → treat it as the cause of an unclean exit.
+    let gait_key = serde_json::from_str::<ApplyingMarker>(&raw)
+        .ok()
+        .map(|m| m.gait_key);
+
+    let mut quarantined = false;
+    if let Some(ref key) = gait_key {
+        let strikes = bump_strikes(dir, key);
+        if strikes >= QUARANTINE_STRIKE_THRESHOLD {
+            quarantined = quarantine_receipt(dir, key);
+            // The suspect is gone; reset its strike count.
+            let _ = std::fs::remove_file(strikes_path(dir, key));
+        }
+    }
+    let _ = std::fs::remove_file(&marker_path);
+
+    eprintln!(
+        "[gait] safe-boot: unclean exit detected (prior run left {APPLYING}); \
+         key={gait_key:?} quarantined={quarantined} -> booting baseline"
+    );
+    StartupReconcile::UncleanExit {
+        gait_key,
+        quarantined,
+    }
+}
+
+/// Write the in-progress marker and arm it for clearing. Call immediately
+/// **before** applying a gait's profile/substrate, so a crash during apply or
+/// early use is caught on the next launch. Best-effort.
+pub fn begin_apply(dir: &Path, gait_key: &str, layers: &[&str]) {
+    let _ = std::fs::create_dir_all(dir);
+    let marker = ApplyingMarker {
+        gait_key: gait_key.to_string(),
+        layers: layers.iter().map(|s| s.to_string()).collect(),
+        pid: std::process::id(),
+        utc_epoch_secs: now_epoch_secs(),
+    };
+    let path = dir.join(APPLYING);
+    if let Ok(json) = serde_json::to_string_pretty(&marker) {
+        let _ = std::fs::write(&path, json);
+    }
+    if let Ok(mut armed) = ARMED.lock() {
+        *armed = Some((path, marker.pid));
+    }
+}
+
+/// Clear the in-progress marker because the applied gait has proven healthy — a
+/// real decode completed without wedging the host. Idempotent and cheap after
+/// the first call (the armed slot is taken), so it is safe to call on every
+/// generation. A no-op if no gait was applied this process.
+pub fn mark_healthy() {
+    let armed = ARMED.lock().ok().and_then(|mut slot| slot.take());
+    if let Some((path, pid)) = armed {
+        clear_if_ours(&path, pid);
+    }
+}
+
+/// Clear the in-progress marker on an orderly process exit. Belt-and-suspenders
+/// alongside [`mark_healthy`]: covers short-lived commands that exit before any
+/// decode, and defensively removes a residual marker this process owns.
+pub fn clean_shutdown(dir: &Path) {
+    mark_healthy();
+    clear_if_ours(&dir.join(APPLYING), std::process::id());
+}
+
+/// Move a `gait_key`'s receipt into `.quarantine/` so it is never loaded again.
+/// Returns true if a receipt was disabled. If the quarantine move cannot be
+/// completed, the receipt is removed outright — the safety goal is "never
+/// re-apply this suspect", and diagnosis is secondary to that.
+pub fn quarantine_receipt(dir: &Path, gait_key: &str) -> bool {
+    let src = dir.join(super::key_filename(gait_key));
+    if !src.exists() {
+        return false;
+    }
+    let qdir = dir.join(QUARANTINE_DIR);
+    if std::fs::create_dir_all(&qdir).is_err() {
+        let _ = std::fs::remove_file(&src);
+        return true;
+    }
+    let dst = qdir.join(super::key_filename(gait_key));
+    match std::fs::rename(&src, &dst) {
+        Ok(()) => true,
+        // Could not move (e.g. cross-volume) → remove so it cannot be reloaded.
+        Err(_) => {
+            let _ = std::fs::remove_file(&src);
+            true
+        }
+    }
+}
+
+/// Increment and persist the unclean-exit strike count for `gait_key`, returning
+/// the new count. An unreadable/garbled sidecar counts as zero prior strikes; a
+/// write failure still returns the incremented value (so a cache we cannot write
+/// biases toward quarantine on the first strike, the safe direction).
+fn bump_strikes(dir: &Path, gait_key: &str) -> u32 {
+    let path = strikes_path(dir, gait_key);
+    let prev = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .unwrap_or(0);
+    let next = prev.saturating_add(1);
+    let _ = std::fs::write(&path, next.to_string());
+    next
+}
+
+/// Remove `path` only if it is this process's marker (PID matches). A marker we
+/// cannot parse is left in place for the next launch's reconciliation rather than
+/// risk clearing another process's marker.
+fn clear_if_ours(path: &Path, our_pid: u32) {
+    if let Ok(raw) = std::fs::read_to_string(path) {
+        let ours = serde_json::from_str::<ApplyingMarker>(&raw)
+            .map(|m| m.pid == our_pid)
+            .unwrap_or(false);
+        if ours {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+fn strikes_path(dir: &Path, gait_key: &str) -> PathBuf {
+    dir.join(format!(
+        "{}{STRIKES_SUFFIX}",
+        gait_key.replace(':', "_")
+    ))
+}
+
+fn now_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "camelid_sentinel_{tag}_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn reconcile_is_clean_with_no_marker() {
+        let dir = temp_dir("clean");
+        assert_eq!(reconcile_on_startup(&dir), StartupReconcile::Clean);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn begin_apply_writes_a_parseable_marker() {
+        let dir = temp_dir("begin");
+        begin_apply(&dir, "modelhash:machinehash", &["gait", "substrate"]);
+        let raw = std::fs::read_to_string(dir.join(APPLYING)).unwrap();
+        let marker: ApplyingMarker = serde_json::from_str(&raw).unwrap();
+        assert_eq!(marker.gait_key, "modelhash:machinehash");
+        assert_eq!(marker.layers, vec!["gait", "substrate"]);
+        assert_eq!(marker.pid, std::process::id());
+        // Our own marker clears on a healthy/clean exit.
+        clean_shutdown(&dir);
+        assert!(!dir.join(APPLYING).exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn strike_threshold_default_quarantines_on_first_unclean_exit() {
+        // The compile-time default is 1, so a single stale marker quarantines.
+        let dir = temp_dir("strike");
+        let key = "k1:k2";
+        std::fs::write(dir.join(super::super::key_filename(key)), "{}").unwrap();
+        std::fs::write(
+            dir.join(APPLYING),
+            serde_json::to_string(&ApplyingMarker {
+                gait_key: key.to_string(),
+                layers: vec!["gait".to_string()],
+                pid: 4242,
+                utc_epoch_secs: 0,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        match reconcile_on_startup(&dir) {
+            StartupReconcile::UncleanExit {
+                gait_key,
+                quarantined,
+            } => {
+                assert_eq!(gait_key.as_deref(), Some(key));
+                assert!(quarantined, "default threshold 1 must quarantine immediately");
+            }
+            other => panic!("expected UncleanExit, got {other:?}"),
+        }
+        assert!(!dir.join(APPLYING).exists(), "marker must be cleared");
+        assert!(
+            dir.join(QUARANTINE_DIR)
+                .join(super::super::key_filename(key))
+                .exists(),
+            "receipt must be moved into .quarantine/"
+        );
+        assert!(
+            !dir.join(super::super::key_filename(key)).exists(),
+            "receipt must no longer be loadable from the live store"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn disable_present_tracks_the_kill_file() {
+        let dir = temp_dir("disable");
+        assert!(!disable_present(&dir));
+        std::fs::write(dir.join(DISABLE_FILE), "").unwrap();
+        assert!(disable_present(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/gait/substrate.rs
+++ b/src/gait/substrate.rs
@@ -79,6 +79,74 @@ pub fn set_eco_qos_opt_out(_opt_out: bool) -> EcoQosStatus {
     EcoQosStatus::Unavailable
 }
 
+/// Per-thread EcoQoS control for the **current** thread, via
+/// `SetThreadInformation(ThreadPowerThrottling, …)`. This is the §1.2-correct
+/// granularity: applied across the compute pool it disables execution-speed
+/// throttling for inference workers only, leaving UI/background threads on the
+/// eco-friendly OS-managed default (unlike the process-wide
+/// [`set_eco_qos_opt_out`], whose blast radius is every thread).
+///
+/// Best-effort and idempotent: returns [`EcoQosStatus::Unavailable`] rather than
+/// erroring.
+#[cfg(windows)]
+pub fn set_thread_eco_qos_opt_out(opt_out: bool) -> EcoQosStatus {
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentThread, SetThreadInformation, ThreadPowerThrottling,
+        THREAD_POWER_THROTTLING_CURRENT_VERSION, THREAD_POWER_THROTTLING_EXECUTION_SPEED,
+        THREAD_POWER_THROTTLING_STATE,
+    };
+
+    let control_mask = if opt_out {
+        THREAD_POWER_THROTTLING_EXECUTION_SPEED
+    } else {
+        0
+    };
+    let state = THREAD_POWER_THROTTLING_STATE {
+        Version: THREAD_POWER_THROTTLING_CURRENT_VERSION,
+        ControlMask: control_mask,
+        StateMask: 0,
+    };
+
+    // SAFETY: `state` outlives the call; size is the struct's own size.
+    let ok = unsafe {
+        SetThreadInformation(
+            GetCurrentThread(),
+            ThreadPowerThrottling,
+            &state as *const THREAD_POWER_THROTTLING_STATE as *const core::ffi::c_void,
+            std::mem::size_of::<THREAD_POWER_THROTTLING_STATE>() as u32,
+        )
+    };
+    if ok != 0 {
+        if opt_out {
+            EcoQosStatus::OptedOut
+        } else {
+            EcoQosStatus::OsManaged
+        }
+    } else {
+        EcoQosStatus::Unavailable
+    }
+}
+
+#[cfg(not(windows))]
+pub fn set_thread_eco_qos_opt_out(_opt_out: bool) -> EcoQosStatus {
+    EcoQosStatus::Unavailable
+}
+
+/// Apply the per-thread EcoQoS opt-out across the Rayon **compute pool** (every
+/// global-pool worker) plus the calling thread — the §1.2-scoped replacement for
+/// the process-wide opt-out. Decode parallelism runs on these threads (and the
+/// caller participates via work-stealing), so this covers the inference workers
+/// without touching the process's UI/background threads. Returns the calling
+/// thread's status as a representative outcome. Inert (`Unavailable`) off Windows.
+pub fn set_compute_pool_eco_qos(opt_out: bool) -> EcoQosStatus {
+    // `broadcast` runs the closure once on every global-pool worker thread.
+    rayon::broadcast(|_| {
+        let _ = set_thread_eco_qos_opt_out(opt_out);
+    });
+    // The calling thread also participates in Rayon work-stealing.
+    set_thread_eco_qos_opt_out(opt_out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -99,5 +167,29 @@ mod tests {
             assert_eq!(on, EcoQosStatus::Unavailable);
             assert_eq!(off, EcoQosStatus::Unavailable);
         }
+    }
+
+    #[test]
+    fn thread_eco_qos_round_trip_does_not_panic() {
+        let on = set_thread_eco_qos_opt_out(true);
+        let off = set_thread_eco_qos_opt_out(false);
+        #[cfg(windows)]
+        {
+            assert_eq!(on, EcoQosStatus::OptedOut);
+            assert_eq!(off, EcoQosStatus::OsManaged);
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(on, EcoQosStatus::Unavailable);
+            assert_eq!(off, EcoQosStatus::Unavailable);
+        }
+    }
+
+    #[test]
+    fn compute_pool_eco_qos_does_not_panic() {
+        // Broadcasts the per-thread opt-out across the Rayon pool; must always
+        // return a status, never panic, on any host.
+        let _ = set_compute_pool_eco_qos(true);
+        let _ = set_compute_pool_eco_qos(false);
     }
 }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -6991,6 +6991,21 @@ fn linear_with_diagnostic_layouts_with_plan(
     }
     let rows = weight.dim(0)?;
     let cols = weight.dim(1)?;
+    // K-quant (Q4_K / Q6_K) wire weights have no f32 data and no general CPU
+    // consumer; intercept them here — the single chokepoint both the diagnostic
+    // and runtime linear chains funnel through — with the original tensor, before
+    // any layout reinterpretation that would drop the wire bytes. The block-dot
+    // is layout-agnostic: it takes the contraction width from the input and the
+    // output width from the wire length, so a GGUF `[in, out]` weight (where
+    // cols != input_width, e.g. GQA k/v projections) is handled correctly too.
+    if q4_k_cpu_block_dot_enabled() && input_width % Q6_K_VALUES_PER_BLOCK == 0 {
+        if weight.source_type == Some(GgufTensorType::Q4K) && weight.q4_k_wire_bytes.is_some() {
+            return matmul_rhs_transposed_q4_k_block_dot(input, weight, name);
+        }
+        if weight.source_type == Some(GgufTensorType::Q6K) && weight.q6_k_wire_bytes.is_some() {
+            return matmul_rhs_transposed_q6_k_block_dot(input, weight, name);
+        }
+    }
     if rows == input_width && cols == input_width {
         match square_layout {
             SquareLinearLayout::Descriptor => {
@@ -7093,6 +7108,8 @@ struct BorrowedLinearWeight<'a> {
     q8_0_runtime_storage: Option<&'a Q8_0RuntimeStorage>,
     q8_0_file_backing: Option<&'a Q8_0FileBacking>,
     tq2_0_wire_bytes: Option<&'a [u8]>,
+    q4_k_wire_bytes: Option<&'a [u8]>,
+    q6_k_wire_bytes: Option<&'a [u8]>,
 }
 
 impl<'a> BorrowedLinearWeight<'a> {
@@ -7114,6 +7131,8 @@ impl<'a> BorrowedLinearWeight<'a> {
             q8_0_runtime_storage: weight.q8_0_runtime_storage.as_ref(),
             q8_0_file_backing: weight.q8_0_file_backing.as_ref(),
             tq2_0_wire_bytes: weight.tq2_0_wire_bytes.as_deref().map(|v| v.as_slice()),
+            q4_k_wire_bytes: weight.q4_k_wire_bytes.as_deref().map(|v| v.as_slice()),
+            q6_k_wire_bytes: weight.q6_k_wire_bytes.as_deref().map(|v| v.as_slice()),
         })
     }
 
@@ -7129,6 +7148,10 @@ impl<'a> BorrowedLinearWeight<'a> {
             q8_0_packed_rows4_4x4: None,
             q8_0_packed_rows4_4x8: None,
             q8_0_runtime_storage,
+            // Keep the K-quant wire across the swap: the block-dot takes its
+            // contraction width from the input and its output width from the wire
+            // length (not from these logical rows/cols), so the swap does not
+            // affect its indexing.
             ..self
         }
     }
@@ -7361,6 +7384,17 @@ fn matmul_rhs_transposed_with_precision_with_plan(
     if weight.source_type == Some(GgufTensorType::Tq2_0) && weight.tq2_0_wire_bytes.is_some() {
         return matmul_rhs_transposed_tq2_0_block_dot(input, weight, name);
     }
+    // K-quant (Q4_K / Q6_K) 2-D linears retain wire bytes with no f32 data, so
+    // without an in-place CPU dot they have no CPU consumer. Dispatch them to the
+    // bit-exact block-dot kernels (gated; a Q4_K_M model mixes both quants).
+    if q4_k_cpu_block_dot_enabled() && input_width % Q6_K_VALUES_PER_BLOCK == 0 {
+        if weight.source_type == Some(GgufTensorType::Q4K) && weight.q4_k_wire_bytes.is_some() {
+            return matmul_rhs_transposed_q4_k_block_dot(input, weight, name);
+        }
+        if weight.source_type == Some(GgufTensorType::Q6K) && weight.q6_k_wire_bytes.is_some() {
+            return matmul_rhs_transposed_q6_k_block_dot(input, weight, name);
+        }
+    }
     if should_use_q8_0_block_dot_with_plan(weight, input_width, runtime_plan) {
         return matmul_rhs_transposed_q8_0_block_dot_with_plan(input, weight, name, runtime_plan);
     }
@@ -7414,6 +7448,18 @@ fn matmul_rhs_transposed_borrowed_with_precision_with_plan(
         )));
     }
     let output_width = weight.rows;
+    if q4_k_cpu_block_dot_enabled() && input_width % Q6_K_VALUES_PER_BLOCK == 0 {
+        if weight.source_type == Some(GgufTensorType::Q4K) {
+            if let Some(wire) = weight.q4_k_wire_bytes {
+                return q4_k_block_dot_core(input, wire, output_width, input_width, name);
+            }
+        }
+        if weight.source_type == Some(GgufTensorType::Q6K) {
+            if let Some(wire) = weight.q6_k_wire_bytes {
+                return q6_k_block_dot_core(input, wire, output_width, input_width, name);
+            }
+        }
+    }
     if let Some(backing) = borrowed_q8_0_reader_backing(weight, input_width, output_width)? {
         return matmul_rhs_transposed_q8_0_block_reader_with_flags(
             input,
@@ -15267,6 +15313,30 @@ fn accumulate_transposed_linear_row_tq2_0(input_row: &[f32], wire: &[u8], output
     });
 }
 
+/// Per-input-row Q4_K accumulate: quantise the row to Q8_K, dot against each
+/// output row's Q4_K wire super-blocks via the bit-exact kernel (rayon over the
+/// output dimension). Mirrors [`accumulate_transposed_linear_row_tq2_0`].
+fn accumulate_transposed_linear_row_q4_k(input_row: &[f32], wire: &[u8], output: &mut [f32]) {
+    use rayon::prelude::*;
+    let row_bytes = (input_row.len() / Q6_K_VALUES_PER_BLOCK) * Q4_K_WIRE_BYTES_PER_BLOCK;
+    let q8 = quantize_q8_k_blocks(input_row);
+    output.par_iter_mut().enumerate().for_each(|(o, slot)| {
+        let w_row = &wire[o * row_bytes..(o + 1) * row_bytes];
+        *slot = crate::diffusion_gemma::refmath::q4_k_dot_arm(w_row, &q8);
+    });
+}
+
+/// Per-input-row Q6_K accumulate (210 B/block, `q6_k_wire_row_dot`).
+fn accumulate_transposed_linear_row_q6_k(input_row: &[f32], wire: &[u8], output: &mut [f32]) {
+    use rayon::prelude::*;
+    let row_bytes = (input_row.len() / Q6_K_VALUES_PER_BLOCK) * Q6_K_WIRE_BYTES_PER_BLOCK;
+    let q8 = quantize_q8_k_blocks(input_row);
+    output.par_iter_mut().enumerate().for_each(|(o, slot)| {
+        let w_row = &wire[o * row_bytes..(o + 1) * row_bytes];
+        *slot = q6_k_wire_row_dot(w_row, &q8);
+    });
+}
+
 /// Streaming Q6_K linear (used for the tied embed/lm_head output projection): rather than
 /// materialise the ~1.6 GB f32 embedding and run a generic f32 matmul (which dominated
 /// decode at ~88% of the per-token time), quantise each input row to Q8_K once and dot it
@@ -15309,6 +15379,139 @@ fn matmul_rhs_transposed_q6_k_block_dot(
                 .iter()
                 .map(|q8| q6_k_wire_row_dot(w_row, q8))
                 .collect()
+        })
+        .collect();
+    let mut out = vec![0f32; n_rows * out_dim];
+    for (o, col) in cols.iter().enumerate() {
+        for (r, &v) in col.iter().enumerate() {
+            out[r * out_dim + o] = v;
+        }
+    }
+    CpuTensor::from_f32(name, vec![n_rows, out_dim], out)
+}
+
+/// Whether the experimental CPU Q4_K block-dot decode path is enabled. Default
+/// off (fail-closed): without it, Q4_K 2-D linears have no CPU consumer (their
+/// wire bytes are retained for the GPU resident path), so the gate cannot
+/// regress any working CPU behavior — it only adds one.
+fn q4_k_cpu_block_dot_enabled() -> bool {
+    matches!(
+        std::env::var("CAMELID_X86_Q4K_DECODE").ok().as_deref(),
+        Some("1") | Some("on") | Some("true") | Some("yes") | Some("enabled")
+    )
+}
+
+/// Streaming Q4_K linear: quantise each input row to Q8_K once, then dot it
+/// against the retained Q4_K wire super-blocks via the bit-exact AVX2 kernel
+/// (rayon over the output dimension). Mirrors [`matmul_rhs_transposed_q6_k_block_dot`].
+/// Reads ~144 B per 256-weight block with no f32 materialisation, so it both
+/// speeds up decode on a bandwidth-bound CPU and makes runnable a large Q4_K
+/// model the f32 path would OOM on. Parity oracle is llama.cpp's Q4_K decode
+/// (which likewise quantises activations to Q8_K), not Camelid's f32 path.
+/// Core Q4_K block-dot: quantise each input row to Q8_K, dot against `wire`
+/// (row-major [out_dim, in_dim] Q4_K super-blocks) via the bit-exact kernel,
+/// rayon over `out_dim`. `wire.len()` must equal `out_dim * (in_dim/256) * 144`.
+fn q4_k_block_dot_core(
+    input: &CpuTensor,
+    wire: &[u8],
+    out_dim: usize,
+    in_dim: usize,
+    name: impl Into<String>,
+) -> Result<CpuTensor> {
+    use rayon::prelude::*;
+    if in_dim % Q6_K_VALUES_PER_BLOCK != 0 {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Q4_K block-dot requires in_dim multiple of 256, got {in_dim}"
+        )));
+    }
+    let row_bytes = (in_dim / Q6_K_VALUES_PER_BLOCK) * Q4_K_WIRE_BYTES_PER_BLOCK;
+    if row_bytes == 0 || wire.len() != out_dim * row_bytes {
+        return Err(BackendError::InvalidTensorData(format!(
+            "Q4_K wire length {} != out_dim {out_dim} * row_bytes {row_bytes}",
+            wire.len()
+        )));
+    }
+    let n_rows = input.dim(0)?;
+    let preps: Vec<Vec<Q8KBlock>> = (0..n_rows)
+        .map(|r| quantize_q8_k_blocks(&input.data[r * in_dim..(r + 1) * in_dim]))
+        .collect();
+    let cols: Vec<Vec<f32>> = (0..out_dim)
+        .into_par_iter()
+        .map(|o| {
+            let w_row = &wire[o * row_bytes..(o + 1) * row_bytes];
+            preps
+                .iter()
+                .map(|q8| crate::diffusion_gemma::refmath::q4_k_dot_arm(w_row, q8))
+                .collect()
+        })
+        .collect();
+    let mut out = vec![0f32; n_rows * out_dim];
+    for (o, col) in cols.iter().enumerate() {
+        for (r, &v) in col.iter().enumerate() {
+            out[r * out_dim + o] = v;
+        }
+    }
+    CpuTensor::from_f32(name, vec![n_rows, out_dim], out)
+}
+
+fn matmul_rhs_transposed_q4_k_block_dot(
+    input: &CpuTensor,
+    weight: &CpuTensor,
+    name: impl Into<String>,
+) -> Result<CpuTensor> {
+    let in_dim = input.dim(1)?;
+    let wire = weight.q4_k_wire_bytes.as_deref().ok_or_else(|| {
+        BackendError::RuntimeShapeMismatch("Q4_K weight missing wire bytes".to_string())
+    })?;
+    if in_dim % Q6_K_VALUES_PER_BLOCK != 0 {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Q4_K block-dot requires in_dim multiple of 256, got {in_dim}"
+        )));
+    }
+    let row_bytes = (in_dim / Q6_K_VALUES_PER_BLOCK) * Q4_K_WIRE_BYTES_PER_BLOCK;
+    if row_bytes == 0 || wire.len() % row_bytes != 0 {
+        return Err(BackendError::InvalidTensorData(format!(
+            "Q4_K weight wire length {} not a multiple of row_bytes {row_bytes}",
+            wire.len()
+        )));
+    }
+    // Tied-embed/output transpose passes [in, out]; derive out_dim from the wire.
+    let out_dim = wire.len() / row_bytes;
+    q4_k_block_dot_core(input, wire, out_dim, in_dim, name)
+}
+
+/// Q6_K analogue of [`q4_k_block_dot_core`] (210 B/block, `q6_k_wire_row_dot`),
+/// for the borrowed-weight dispatch. The owned dispatch uses the existing
+/// [`matmul_rhs_transposed_q6_k_block_dot`].
+fn q6_k_block_dot_core(
+    input: &CpuTensor,
+    wire: &[u8],
+    out_dim: usize,
+    in_dim: usize,
+    name: impl Into<String>,
+) -> Result<CpuTensor> {
+    use rayon::prelude::*;
+    if in_dim % Q6_K_VALUES_PER_BLOCK != 0 {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Q6_K block-dot requires in_dim multiple of 256, got {in_dim}"
+        )));
+    }
+    let row_bytes = (in_dim / Q6_K_VALUES_PER_BLOCK) * Q6_K_WIRE_BYTES_PER_BLOCK;
+    if row_bytes == 0 || wire.len() != out_dim * row_bytes {
+        return Err(BackendError::InvalidTensorData(format!(
+            "Q6_K wire length {} != out_dim {out_dim} * row_bytes {row_bytes}",
+            wire.len()
+        )));
+    }
+    let n_rows = input.dim(0)?;
+    let preps: Vec<Vec<Q8KBlock>> = (0..n_rows)
+        .map(|r| quantize_q8_k_blocks(&input.data[r * in_dim..(r + 1) * in_dim]))
+        .collect();
+    let cols: Vec<Vec<f32>> = (0..out_dim)
+        .into_par_iter()
+        .map(|o| {
+            let w_row = &wire[o * row_bytes..(o + 1) * row_bytes];
+            preps.iter().map(|q8| q6_k_wire_row_dot(w_row, q8)).collect()
         })
         .collect();
     let mut out = vec![0f32; n_rows * out_dim];
@@ -17153,6 +17356,23 @@ fn accumulate_transposed_linear_row_with_precision_with_plan(
         if let Some(wire) = weight.tq2_0_wire_bytes {
             accumulate_transposed_linear_row_tq2_0(input_row, wire, output);
             return;
+        }
+    }
+    // K-quant (Q4_K / Q6_K) wire weights: no f32 data to accumulate, so dot the
+    // retained wire blocks in place. This is the universal funnel for the
+    // accumulate-based (descriptor/borrowed) matmul layouts.
+    if q4_k_cpu_block_dot_enabled() && input_row.len() % Q6_K_VALUES_PER_BLOCK == 0 {
+        if weight.source_type == Some(GgufTensorType::Q4K) {
+            if let Some(wire) = weight.q4_k_wire_bytes {
+                accumulate_transposed_linear_row_q4_k(input_row, wire, output);
+                return;
+            }
+        }
+        if weight.source_type == Some(GgufTensorType::Q6K) {
+            if let Some(wire) = weight.q6_k_wire_bytes {
+                accumulate_transposed_linear_row_q6_k(input_row, wire, output);
+                return;
+            }
         }
     }
     if should_use_borrowed_q8_0_block_dot_with_plan(weight, input_row.len(), runtime_plan) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -762,6 +762,28 @@ enum Command {
         #[arg(long)]
         threads: Option<usize>,
     },
+    /// GAIT internal: run ONE calibration candidate trial in isolation and print
+    /// its TrialResult as a single JSON line. Spawned as a child process by the
+    /// calibration supervisor (§1.4 crash isolation); not for direct use.
+    #[command(hide = true)]
+    GaitTrial {
+        /// GGUF model path.
+        model: PathBuf,
+        #[arg(long)]
+        prompt_file: Option<PathBuf>,
+        #[arg(long)]
+        prompt: Option<String>,
+        #[arg(long, default_value_t = 64)]
+        max_tokens: usize,
+        /// Profile label: auto | safe | experimental | debug.
+        #[arg(long)]
+        profile: String,
+        /// Apply the compute-pool EcoQoS opt-out for this trial.
+        #[arg(long, default_value_t = false)]
+        eco_qos: bool,
+        #[arg(long)]
+        threads: Option<usize>,
+    },
     /// GAIT cache maintenance (e.g. `camelid gait reset`).
     #[command(hide = true)]
     Gait {
@@ -1505,6 +1527,17 @@ async fn main() -> anyhow::Result<()> {
         } => {
             run_gait_calibrate(model, prompt_file, prompt, max_tokens, rounds, warmup, threads)?;
         }
+        Command::GaitTrial {
+            model,
+            prompt_file,
+            prompt,
+            max_tokens,
+            profile,
+            eco_qos,
+            threads,
+        } => {
+            run_gait_trial(model, prompt_file, prompt, max_tokens, profile, eco_qos, threads)?;
+        }
         Command::Gait { action } => match action {
             GaitAction::Reset => run_gait_reset()?,
         },
@@ -2055,16 +2088,15 @@ fn run_gait_calibrate(
     configure_rayon_threads(host_safe_thread_count(threads))?;
     camelid::capability::HardwareProfile::detect().log();
 
-    let prompt_text = match (&prompt_file, &prompt) {
-        (Some(path), _) => std::fs::read_to_string(path)?,
-        (None, Some(text)) => text.clone(),
-        (None, None) => anyhow::bail!("provide --prompt-file <path> or --prompt <text>"),
-    };
+    anyhow::ensure!(
+        prompt_file.is_some() || prompt.is_some(),
+        "provide --prompt-file <path> or --prompt <text>"
+    );
 
+    // The gguf is needed for the fingerprint, memory measurement, and roofline
+    // numerator; each candidate's prompt encoding + decode happens in its own
+    // child trial (§1.4 crash isolation), so the parent does not load weights.
     let gguf = read_metadata(&model)?;
-    let tokenizer = Tokenizer::from_gguf(&gguf)?;
-    let prompt_token_ids = tokenizer.encode(&prompt_text, true, false)?;
-    anyhow::ensure!(!prompt_token_ids.is_empty(), "prompt encoded to zero tokens");
 
     // Baseline = today's behavior (Auto profile, OS-managed throttling). The
     // candidates vary the EcoQoS substrate (and profile) so the tournament
@@ -2102,22 +2134,54 @@ fn run_gait_calibrate(
         config.warmup_rounds,
         model.display()
     );
-    let trial = |candidate: &Candidate| -> Option<camelid::gait::calibrate::TrialResult> {
-        match gait_profile_trial(&model, threads, &prompt_token_ids, max_tokens, candidate) {
-            Ok(result) => {
-                eprintln!(
-                    "[gait] {:<13} {:>7.2} tok/s  parity {}",
-                    candidate.label,
-                    result.tokens_per_s,
-                    &result.parity_token[..12]
-                );
-                Some(result)
-            }
-            Err(err) => {
-                eprintln!("[gait] {:<13} trial failed: {err}", candidate.label);
-                None
-            }
+    // §1.1 host-safety: do not launch the calibration allocation campaign (each
+    // child trial loads multi-GB weights) if the box is already low on free RAM.
+    #[cfg(windows)]
+    if let Some((total, avail)) = camelid::gait::host_ram_status() {
+        if !camelid::gait::ram_headroom_ok(total, avail) {
+            let floor = camelid::gait::ram_headroom_floor(total);
+            eprintln!(
+                "[gait] insufficient free RAM (avail {:.1} GiB < floor {:.1} GiB) -> skipping calibration; baseline serves",
+                avail as f64 / 1e9,
+                floor as f64 / 1e9
+            );
+            return Ok(());
         }
+    }
+
+    // §1.4 crash isolation: each candidate runs in a supervised CHILD PROCESS, so
+    // a candidate that segfaults or hangs cannot take down this process. The
+    // per-candidate timeout is min(3x the baseline's wall time, the absolute
+    // ceiling); the baseline (timed first) gets the full ceiling.
+    let exe = std::env::current_exe()
+        .map_err(|err| anyhow::anyhow!("cannot resolve current exe for child trials: {err}"))?;
+    let baseline_label = baseline.label.clone();
+    let mut baseline_wall: Option<std::time::Duration> = None;
+    let trial = |candidate: &Candidate| -> Option<camelid::gait::calibrate::TrialResult> {
+        let timeout = match baseline_wall {
+            Some(bw) => bw.mul_f64(3.0).min(CAL_TRIAL_CEILING),
+            None => CAL_TRIAL_CEILING,
+        };
+        let started = std::time::Instant::now();
+        let result = run_trial_in_child(
+            &exe, &model, &prompt_file, &prompt, max_tokens, candidate, threads, timeout,
+        );
+        if candidate.label == baseline_label && baseline_wall.is_none() {
+            baseline_wall = Some(started.elapsed());
+        }
+        match &result {
+            Some(r) => eprintln!(
+                "[gait] {:<13} {:>7.2} tok/s  parity {}",
+                candidate.label,
+                r.tokens_per_s,
+                &r.parity_token[..12.min(r.parity_token.len())]
+            ),
+            None => eprintln!(
+                "[gait] {:<13} disqualified (timeout/crash/parse)",
+                candidate.label
+            ),
+        }
+        result
     };
 
     let (outcome, path) = calibrate_and_store(&store_dir, &gguf, &baseline, &candidates, &config, trial);
@@ -2154,6 +2218,147 @@ fn run_gait_reset() -> anyhow::Result<()> {
         None => println!("gait: no cache directory could be resolved"),
     }
     Ok(())
+}
+
+/// Per-candidate absolute timeout ceiling for a child trial (§1.4). The live
+/// per-candidate budget is `min(3x the baseline's wall time, this ceiling)`.
+const CAL_TRIAL_CEILING: std::time::Duration = std::time::Duration::from_secs(180);
+
+/// `camelid gait-trial` (internal): run ONE candidate trial in this isolated
+/// child process and print its TrialResult as a single JSON line to stdout. The
+/// crash/hang isolation lives in the PARENT supervisor ([`run_trial_in_child`]);
+/// here we just run the trial and report.
+fn run_gait_trial(
+    model: PathBuf,
+    prompt_file: Option<PathBuf>,
+    prompt: Option<String>,
+    max_tokens: usize,
+    profile: String,
+    eco_qos: bool,
+    threads: Option<usize>,
+) -> anyhow::Result<()> {
+    use camelid::execution_plan::ExecutionProfile;
+    use camelid::gait::calibrate::Candidate;
+
+    anyhow::ensure!(max_tokens >= 1, "--max-tokens must be at least 1");
+    std::env::remove_var("CAMELID_GAIT");
+    configure_rayon_threads(host_safe_thread_count(threads))?;
+
+    let profile_label = profile.clone();
+    let profile = match profile.to_ascii_lowercase().as_str() {
+        "auto" => ExecutionProfile::Auto,
+        "safe" => ExecutionProfile::Safe,
+        "experimental" => ExecutionProfile::Experimental,
+        "debug" => ExecutionProfile::Debug,
+        other => anyhow::bail!("unknown profile {other:?} (want auto|safe|experimental|debug)"),
+    };
+
+    let prompt_text = match (&prompt_file, &prompt) {
+        (Some(path), _) => std::fs::read_to_string(path)?,
+        (None, Some(text)) => text.clone(),
+        (None, None) => anyhow::bail!("provide --prompt-file <path> or --prompt <text>"),
+    };
+    let gguf = read_metadata(&model)?;
+    let tokenizer = Tokenizer::from_gguf(&gguf)?;
+    let prompt_token_ids = tokenizer.encode(&prompt_text, true, false)?;
+    anyhow::ensure!(!prompt_token_ids.is_empty(), "prompt encoded to zero tokens");
+
+    let candidate = Candidate {
+        label: profile_label,
+        profile,
+        eco_qos_opt_out: eco_qos,
+    };
+    let result = gait_profile_trial(&model, threads, &prompt_token_ids, max_tokens, &candidate)?;
+    // The ONLY stdout line — the JSON result the parent supervisor parses.
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}
+
+/// Run ONE candidate trial in a supervised child process, returning its result or
+/// `None` if it timed out, crashed, exited non-zero, or its output could not be
+/// parsed (the candidate is disqualified upstream). This is the §1.4 crash-
+/// isolation boundary: a segfaulting/hanging candidate kernel cannot take down
+/// the calibrating (or, in production, serving) process.
+fn run_trial_in_child(
+    exe: &std::path::Path,
+    model: &std::path::Path,
+    prompt_file: &Option<PathBuf>,
+    prompt: &Option<String>,
+    max_tokens: usize,
+    candidate: &camelid::gait::calibrate::Candidate,
+    threads: Option<usize>,
+    timeout: std::time::Duration,
+) -> Option<camelid::gait::calibrate::TrialResult> {
+    use camelid::gait::calibrate::{supervise, TrialResult, WatchdogOutcome};
+    use std::process::{Command, Stdio};
+
+    let mut cmd = Command::new(exe);
+    cmd.arg("gait-trial")
+        .arg(model)
+        .arg("--profile")
+        .arg(gait_profile_env_value(&candidate.profile))
+        .arg("--max-tokens")
+        .arg(max_tokens.to_string());
+    if candidate.eco_qos_opt_out {
+        cmd.arg("--eco-qos");
+    }
+    if let Some(t) = threads {
+        cmd.arg("--threads").arg(t.to_string());
+    }
+    match (prompt_file, prompt) {
+        (Some(path), _) => {
+            cmd.arg("--prompt-file").arg(path);
+        }
+        (None, Some(text)) => {
+            cmd.arg("--prompt").arg(text);
+        }
+        (None, None) => {}
+    }
+    // CPU calibration; keep the child off the GPU and out of the gait selector.
+    cmd.env("CUDA_VISIBLE_DEVICES", "-1");
+    cmd.env_remove("CAMELID_GAIT");
+    // stdout carries the JSON result; stderr is inherited so the child's logs show.
+    cmd.stdout(Stdio::piped());
+
+    let child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            eprintln!("[gait] {:<13} child spawn failed: {err}", candidate.label);
+            return None;
+        }
+    };
+
+    match supervise(child, timeout, std::time::Duration::from_millis(100)) {
+        WatchdogOutcome::Completed(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            // The result is the last parseable JSON line (robust to stray stdout).
+            stdout
+                .lines()
+                .rev()
+                .find_map(|line| serde_json::from_str::<TrialResult>(line.trim()).ok())
+        }
+        WatchdogOutcome::Completed(out) => {
+            eprintln!(
+                "[gait] {:<13} child exited {} -> disqualified",
+                candidate.label, out.status
+            );
+            None
+        }
+        WatchdogOutcome::TimedOut => {
+            eprintln!(
+                "[gait] {:<13} TIMED OUT after {timeout:?} -> disqualified",
+                candidate.label
+            );
+            None
+        }
+        WatchdogOutcome::Errored => {
+            eprintln!(
+                "[gait] {:<13} child supervision error -> disqualified",
+                candidate.label
+            );
+            None
+        }
+    }
 }
 
 struct GenerationRun {

--- a/src/main.rs
+++ b/src/main.rs
@@ -783,6 +783,13 @@ enum Command {
         eco_qos: bool,
         #[arg(long)]
         threads: Option<usize>,
+        /// §5 groups_per_chunk tiling overrides (pass all three together).
+        #[arg(long)]
+        gpc_attn: Option<usize>,
+        #[arg(long)]
+        gpc_ffn: Option<usize>,
+        #[arg(long)]
+        gpc_matmul: Option<usize>,
     },
     /// GAIT cache maintenance (e.g. `camelid gait reset`).
     #[command(hide = true)]
@@ -1535,8 +1542,14 @@ async fn main() -> anyhow::Result<()> {
             profile,
             eco_qos,
             threads,
+            gpc_attn,
+            gpc_ffn,
+            gpc_matmul,
         } => {
-            run_gait_trial(model, prompt_file, prompt, max_tokens, profile, eco_qos, threads)?;
+            run_gait_trial(
+                model, prompt_file, prompt, max_tokens, profile, eco_qos, threads, gpc_attn,
+                gpc_ffn, gpc_matmul,
+            )?;
         }
         Command::Gait { action } => match action {
             GaitAction::Reset => run_gait_reset()?,
@@ -1994,6 +2007,28 @@ struct BenchGenerateRecord {
     output_token_ids: Vec<u32>,
 }
 
+/// §5: set (or clear) the three managed x86 Q8 `groups_per_chunk` env knobs for a
+/// trial. `None` clears them so the trial measures the profile's default tiling;
+/// `Some` pins the search candidate's values. Must be called AFTER
+/// `PlannerEnv::apply` (these keys are managed) so the override is authoritative.
+fn apply_groups_per_chunk(gpc: Option<camelid::gait::calibrate::GroupsPerChunk>) {
+    const ATTN: &str = "CAMELID_X86_Q8_ATTENTION_QKV_DECODE_GROUPS_PER_CHUNK";
+    const FFN: &str = "CAMELID_X86_Q8_FFN_GATE_UP_DECODE_GROUPS_PER_CHUNK";
+    const MATMUL: &str = "CAMELID_X86_Q8_PACKED_ROWS4_MATMUL_GROUPS_PER_CHUNK";
+    match gpc {
+        Some(g) => {
+            std::env::set_var(ATTN, g.attn_qkv_decode.to_string());
+            std::env::set_var(FFN, g.ffn_gate_up_decode.to_string());
+            std::env::set_var(MATMUL, g.packed_rows4_matmul.to_string());
+        }
+        None => {
+            std::env::remove_var(ATTN);
+            std::env::remove_var(FFN);
+            std::env::remove_var(MATMUL);
+        }
+    }
+}
+
 fn gait_profile_env_value(profile: &camelid::execution_plan::ExecutionProfile) -> &'static str {
     use camelid::execution_plan::ExecutionProfile::*;
     match profile {
@@ -2034,6 +2069,10 @@ fn gait_profile_trial(
     // Apply this candidate's plan before loading weights, exactly as bench-generate does.
     let plan = camelid::execution_plan::plan_for_model(model, &gguf, threads);
     camelid::execution_plan::PlannerEnv::capture().apply(&plan.env_updates);
+    // §5: apply this candidate's groups_per_chunk tiling AFTER the planner's
+    // env_updates — the gpc knobs are MANAGED_ENV_KEYS, so PlannerEnv::apply would
+    // otherwise clear/overwrite them. Applying here lets the search override win.
+    apply_groups_per_chunk(candidate.groups_per_chunk);
 
     let config = LlamaModelConfig::from_gguf(&gguf)?;
     let binding = LlamaTensorBinding::bind(&gguf, &config)?;
@@ -2105,19 +2144,30 @@ fn run_gait_calibrate(
         label: "auto".to_string(),
         profile: ExecutionProfile::Auto,
         eco_qos_opt_out: false,
+        groups_per_chunk: None,
     };
-    let candidates = vec![
-        Candidate {
-            label: "auto+ecoqos".to_string(),
-            profile: ExecutionProfile::Auto,
-            eco_qos_opt_out: true,
-        },
-        Candidate {
-            label: "experimental+ecoqos".to_string(),
+    // §5 bounded local search: the EcoQoS substrate dimension (auto+ecoqos) plus
+    // the experimental kernel under each groups_per_chunk neighbor. Every
+    // candidate is parity-gated + crash-isolated; the tournament fails closed to
+    // baseline if none beats it by margin (the honest outcome on a
+    // memory-bandwidth-bound box, where the tiling knob is expected to be flat).
+    let mut candidates = vec![Candidate {
+        label: "auto+ecoqos".to_string(),
+        profile: ExecutionProfile::Auto,
+        eco_qos_opt_out: true,
+        groups_per_chunk: None,
+    }];
+    for gpc in camelid::gait::calibrate::groups_per_chunk_neighbors() {
+        candidates.push(Candidate {
+            label: format!(
+                "exp+gpc[{},{},{}]",
+                gpc.attn_qkv_decode, gpc.ffn_gate_up_decode, gpc.packed_rows4_matmul
+            ),
             profile: ExecutionProfile::Experimental,
-            eco_qos_opt_out: true,
-        },
-    ];
+            eco_qos_opt_out: false,
+            groups_per_chunk: Some(gpc),
+        });
+    }
 
     let store_dir = default_store_dir()
         .ok_or_else(|| anyhow::anyhow!("could not resolve the gait store directory"))?;
@@ -2228,6 +2278,7 @@ const CAL_TRIAL_CEILING: std::time::Duration = std::time::Duration::from_secs(18
 /// child process and print its TrialResult as a single JSON line to stdout. The
 /// crash/hang isolation lives in the PARENT supervisor ([`run_trial_in_child`]);
 /// here we just run the trial and report.
+#[allow(clippy::too_many_arguments)]
 fn run_gait_trial(
     model: PathBuf,
     prompt_file: Option<PathBuf>,
@@ -2236,9 +2287,12 @@ fn run_gait_trial(
     profile: String,
     eco_qos: bool,
     threads: Option<usize>,
+    gpc_attn: Option<usize>,
+    gpc_ffn: Option<usize>,
+    gpc_matmul: Option<usize>,
 ) -> anyhow::Result<()> {
     use camelid::execution_plan::ExecutionProfile;
-    use camelid::gait::calibrate::Candidate;
+    use camelid::gait::calibrate::{Candidate, GroupsPerChunk};
 
     anyhow::ensure!(max_tokens >= 1, "--max-tokens must be at least 1");
     std::env::remove_var("CAMELID_GAIT");
@@ -2263,10 +2317,23 @@ fn run_gait_trial(
     let prompt_token_ids = tokenizer.encode(&prompt_text, true, false)?;
     anyhow::ensure!(!prompt_token_ids.is_empty(), "prompt encoded to zero tokens");
 
+    // §5: the three gpc knobs travel together — all present, or none.
+    let groups_per_chunk = match (gpc_attn, gpc_ffn, gpc_matmul) {
+        (Some(a), Some(f), Some(m)) => Some(GroupsPerChunk {
+            attn_qkv_decode: a,
+            ffn_gate_up_decode: f,
+            packed_rows4_matmul: m,
+        }),
+        (None, None, None) => None,
+        _ => anyhow::bail!(
+            "groups_per_chunk override requires all three of --gpc-attn / --gpc-ffn / --gpc-matmul"
+        ),
+    };
     let candidate = Candidate {
         label: profile_label,
         profile,
         eco_qos_opt_out: eco_qos,
+        groups_per_chunk,
     };
     let result = gait_profile_trial(&model, threads, &prompt_token_ids, max_tokens, &candidate)?;
     // The ONLY stdout line — the JSON result the parent supervisor parses.
@@ -2304,6 +2371,14 @@ fn run_trial_in_child(
     }
     if let Some(t) = threads {
         cmd.arg("--threads").arg(t.to_string());
+    }
+    if let Some(g) = candidate.groups_per_chunk {
+        cmd.arg("--gpc-attn")
+            .arg(g.attn_qkv_decode.to_string())
+            .arg("--gpc-ffn")
+            .arg(g.ffn_gate_up_decode.to_string())
+            .arg("--gpc-matmul")
+            .arg(g.packed_rows4_matmul.to_string());
     }
     match (prompt_file, prompt) {
         (Some(path), _) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1985,8 +1985,9 @@ fn gait_profile_trial(
 ) -> anyhow::Result<camelid::gait::calibrate::TrialResult> {
     std::env::set_var("CAMELID_PROFILE", gait_profile_env_value(&candidate.profile));
     // Apply this candidate's Windows scheduling substrate before timing, so the
-    // measured decode reflects it. Process-level, covers the Rayon pool.
-    let eco_status = camelid::gait::substrate::set_eco_qos_opt_out(candidate.eco_qos_opt_out);
+    // measured decode reflects it. §1.2-scoped to the compute pool (the Rayon
+    // workers + this thread), matching what production applies.
+    let eco_status = camelid::gait::substrate::set_compute_pool_eco_qos(candidate.eco_qos_opt_out);
     if candidate.eco_qos_opt_out
         && eco_status != camelid::gait::substrate::EcoQosStatus::OptedOut
     {
@@ -2048,7 +2049,10 @@ fn run_gait_calibrate(
     // Calibration must measure the candidates we choose — never let a previously
     // cached gait receipt override the candidate's profile mid-trial.
     std::env::remove_var("CAMELID_GAIT");
-    configure_rayon_threads(threads)?;
+    // §1.2: calibrate under the same core-reserve cap production will run with, so
+    // the measured tok/s reflects the host-safe thread budget. The gate is off
+    // here, so configure_rayon_threads won't apply the cap itself.
+    configure_rayon_threads(host_safe_thread_count(threads))?;
     camelid::capability::HardwareProfile::detect().log();
 
     let prompt_text = match (&prompt_file, &prompt) {
@@ -4512,6 +4516,26 @@ fn windows_physical_core_count() -> Option<usize> {
     }
 }
 
+/// §1.2 core-cap: clamp a resolved compute-thread count so the OS always keeps
+/// its reserve (see [`camelid::gait::compute_thread_budget`]). Windows x86-64
+/// only — the GAIT substrate's scope; elsewhere `requested` is returned
+/// unchanged. A `None` request resolves to the full safe budget.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn host_safe_thread_count(requested: Option<usize>) -> Option<usize> {
+    let phys = windows_physical_core_count()?;
+    let budget = camelid::gait::compute_thread_budget(phys);
+    Some(
+        requested
+            .map(|r| r.min(budget.threads))
+            .unwrap_or(budget.threads),
+    )
+}
+
+#[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+fn host_safe_thread_count(requested: Option<usize>) -> Option<usize> {
+    requested
+}
+
 fn configure_rayon_threads(threads: Option<usize>) -> anyhow::Result<()> {
     if let Some(t) = threads {
         anyhow::ensure!(t > 0, "--threads must be greater than zero");
@@ -4523,6 +4547,15 @@ fn configure_rayon_threads(threads: Option<usize>) -> anyhow::Result<()> {
     let resolved = threads.or_else(windows_physical_core_count);
     #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
     let resolved = threads;
+
+    // §1.2 host-safety: when GAIT is engaged, cap the pool so the OS keeps a core
+    // reserve. Gated on the bring-up flag so the default path is byte-identical;
+    // when GAIT becomes the baseline the cap becomes unconditional.
+    let resolved = if camelid::gait::gait_enabled() {
+        host_safe_thread_count(resolved)
+    } else {
+        resolved
+    };
 
     #[cfg(target_os = "macos")]
     let should_configure = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,15 @@ fn pin_to_high_performance_gpu() {
 #[cfg(not(windows))]
 fn pin_to_high_performance_gpu() {}
 
+/// `camelid gait <action>` — GAIT cache maintenance subcommands.
+#[derive(Debug, Subcommand)]
+enum GaitAction {
+    /// Clear the GAIT cache (profiles, quarantine, in-progress markers, and the
+    /// DISABLE kill-file) under %LOCALAPPDATA%\Camelid\gait, fully reverting to
+    /// the baseline path.
+    Reset,
+}
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Start the local HTTP API server.
@@ -753,6 +762,12 @@ enum Command {
         #[arg(long)]
         threads: Option<usize>,
     },
+    /// GAIT cache maintenance (e.g. `camelid gait reset`).
+    #[command(hide = true)]
+    Gait {
+        #[command(subcommand)]
+        action: GaitAction,
+    },
     /// SPEC_RECHECK measurement harness: run lossless greedy speculative decode and a plain
     /// greedy baseline back-to-back on one prompt, and emit a single JSON record with the
     /// per-run economics (acceptance rate, draft/verify latency split, f_draft, S_sync) plus
@@ -891,6 +906,17 @@ async fn main() -> anyhow::Result<()> {
 
     // No subcommand (a bare double-click of the exe) launches the open-and-use app.
     let command = Cli::parse().command.unwrap_or_else(default_launch_command);
+
+    // §4 safe-boot: a gait/substrate that crashed or wedged the host on the
+    // previous run left an `.applying` marker; detect it now — before anything is
+    // applied — quarantine that profile, and boot the proven baseline so a crash
+    // can never loop. Inert unless the CAMELID_GAIT gate is on, so the default
+    // path is byte-identical to today.
+    if camelid::gait::gait_enabled() {
+        if let Some(dir) = camelid::gait::gait_dir() {
+            let _ = camelid::gait::sentinel::reconcile_on_startup(&dir);
+        }
+    }
     // Deterministic mode opts out of the GPU fast stack entirely; otherwise the CLI
     // defaults to the measured-fastest Metal configuration. Branch before any env is set
     // so the deterministic path never even arms the GPU defaults.
@@ -1479,6 +1505,9 @@ async fn main() -> anyhow::Result<()> {
         } => {
             run_gait_calibrate(model, prompt_file, prompt, max_tokens, rounds, warmup, threads)?;
         }
+        Command::Gait { action } => match action {
+            GaitAction::Reset => run_gait_reset()?,
+        },
         Command::BenchSpeculative {
             model,
             drafter,
@@ -1577,6 +1606,13 @@ async fn main() -> anyhow::Result<()> {
                 out_path.display()
             );
         }
+    }
+
+    // §4 safe-boot: an orderly exit — clear any in-progress gait marker so a
+    // healthy run is never mistaken for a crash on the next launch. (No-op unless
+    // a gait was applied this process.)
+    if let Some(dir) = camelid::gait::gait_dir() {
+        camelid::gait::sentinel::clean_shutdown(&dir);
     }
     Ok(())
 }
@@ -2094,6 +2130,24 @@ fn run_gait_calibrate(
             "[gait] selected {:?} :: {} :: receipt NOT stored (store write failed)",
             outcome.selected_profile, outcome.reason
         ),
+    }
+    Ok(())
+}
+
+/// `camelid gait reset` — clear the entire GAIT cache, reverting fully to the
+/// baseline path (§1.3). Best-effort and idempotent: a missing cache is not an
+/// error. Deleting the folder is the documented manual revert; this is the
+/// in-CLI equivalent.
+fn run_gait_reset() -> anyhow::Result<()> {
+    match camelid::gait::gait_dir() {
+        Some(dir) if dir.exists() => {
+            std::fs::remove_dir_all(&dir)?;
+            println!("gait: cleared cache at {}", dir.display());
+        }
+        Some(dir) => {
+            println!("gait: nothing to clear ({} does not exist)", dir.display());
+        }
+        None => println!("gait: no cache directory could be resolved"),
     }
     Ok(())
 }


### PR DESCRIPTION
GAIT v2 (WINDOWS_CPU_GAIT_CONDUCTOR) host-safety campaign. The v2 spec's prime directive — "do no harm to the host" (§0/§1/§4/§9) — is implemented, tested, and made auditable in the gait receipt. Everything is behind the `CAMELID_GAIT` bring-up gate, so the default path is byte-identical.

**Commits**
- `525903c3` feat(inference): in-place Q4_K/Q6_K CPU decode — gated `CAMELID_X86_Q4K_DECODE`, **default OFF** (the base this branch built on; default behavior unchanged).
- `21633987` Wave 1 — safe-boot sentinel (`.applying` marker → quarantine → baseline), `DISABLE` kill-file, `camelid gait reset`.
- `917847d2` Wave 2a — §1.2 core-cap-with-reserve + EcoQoS re-scoped to the compute pool (per-thread, not process-wide).
- `c67727cc` Wave 2b — §1.4 calibration watchdog + child-process crash isolation + §1.1 RAM-headroom gate.
- `d3c685e4` Wave 3a — §6F receipt `host_safety` + `scheduling` attestation.
- `fe726243` Wave 3 §5 — bounded `groups_per_chunk` search (measured **NULL** on this box; tiling is parity-neutral).
- `cdd3b39a` fix(gait) — noise-significance selection gate (settling §5 surfaced that child-process trials are noisy ±7-31%, so the 1.05 margin was persisting noise winners).
- `5caf2112` fix(serve) — warmup banner now words for the actual device (was falsely "GPU" on CPU-only runs).

**Validation**
- 586 lib tests pass, 0 failed (31 GPU-device tests ignored — need a CUDA device + `--ignored`); `cargo check` lib+bins clean.
- All 7 §9 `gait_safety` tests present (safe-boot crash-injection, DISABLE, core_headroom, ram_headroom, watchdog, no_weight_locking, non_windows).
- Release binary built + server smoke-tested serving Llama-3.2-1B on both GPU and CPU.
- §5 search + the noise-gate fix validated on real `--rounds 5` calibrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)