### PR TITLE
fix(evidence-gate): normalize path separators so the claims gate passes on Windows

### DIFF
--- a/scripts/check-public-evidence-claims.mjs
+++ b/scripts/check-public-evidence-claims.mjs
@@ -207,7 +207,12 @@ function validateBackendLocalCurrentHeadExactRowGuardrail(bundleRel, manifest) {
 }
 
 function evidenceBundlePath(path) {
-  const rel = relative(process.cwd(), path)
+  // Normalize to forward slashes so comparisons match the `/`-style paths stored
+  // in evidence manifests on every platform. Node's `relative` emits the OS
+  // separator (backslashes on Windows), which otherwise both breaks the
+  // `/manifest.json` trim below and mismatches the manifests' stored refs —
+  // producing false failures on Windows while Ubuntu CI stays green.
+  const rel = relative(process.cwd(), path).replace(/\\/g, '/')
   const marker = '/manifest.json'
   if (rel.endsWith(marker)) return rel.slice(0, -marker.length)
   const summaryMarker = '/summary.json'


### PR DESCRIPTION
`scripts/check-public-evidence-claims.mjs` was reporting **13 false failures** on Windows ("Mixtral blocker reconciliation supersedes / blocker_evidence must include …"). Root cause: `evidenceBundlePath()` built comparison paths with Node's `relative` (OS separator → backslashes on Windows) but trims/compares against `/`-style markers and the forward-slash refs stored in evidence manifests. On Windows it emitted `qa\evidence-bundles\…\manifest.json` (backslashes + the `/manifest.json` trim never firing), mismatching the manifests' `/`-style paths.

This is a **Windows-only false positive** — Ubuntu CI (the lane this gate runs on) uses `/` and was always green, and the Mixtral reconciliation manifest is correct and complete (it already lists all 6 `supersedes` + 2 `blocker_evidence` bundles the gate requires).

**Fix:** normalize `evidenceBundlePath()` output to forward slashes. One line; **no evidence artifact changed**. The gate now passes on Windows too: `passed: 132 manifest(s), 49 summary file(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)