### PR TITLE
feat(api): structured tool_calls output for Llama 3.2 1B/3B (capability conductor)

### DIFF
--- a/CAPABILITY_MATRIX.md
+++ b/CAPABILITY_MATRIX.md
@@ -13,7 +13,7 @@ Per-cell vocabulary (conductor §5):
 
 **Phase 0 status:** 3 / 4 rows discovered + hash-anchored (TinyLlama, Llama 3.2 1B, Llama 3.2 3B). **Llama 3 8B Q8_0 is not downloaded** — its column (`*`) is PROVISIONAL (spec-derived, not GGUF-anchored, Phase 0 INCOMPLETE).
 
-**Cell tally** (4 model columns × 13 capabilities = 52 cells): `n/a` 4 · `open` 14 · `wip` 13 · `done` 21. The `done` cells are each backed by a `camelid.capability-receipt/v1` under `qa/capability/receipts/`, validated this pass on the **3 on-disk rows** (TinyLlama, Llama 3.2 1B, Llama 3.2 3B) — no cross-row inheritance (conductor §6). The 8B column stays provisional until its GGUF is downloaded.
+**Cell tally** (4 model columns × 13 capabilities = 52 cells): `n/a` 4 · `open` 14 · `wip` 11 · `done` 23. The `done` cells are each backed by a `camelid.capability-receipt/v1` under `qa/capability/receipts/`, validated this pass on the **3 on-disk rows** (TinyLlama, Llama 3.2 1B, Llama 3.2 3B) — no cross-row inheritance (conductor §6). The 8B column stays provisional until its GGUF is downloaded.
 
 ## Matrix
 
@@ -26,7 +26,7 @@ Per-cell vocabulary (conductor §5):
 | `sampling.seed_determinism` | I | done | done | done | open | drives |
 | `logprobs.top_logprobs` | D | done | done | done | open | drives |
 | `chat.system_multiturn` | D | wip | wip | wip | open | drives |
-| `tools.function_calling` | B | n/a | wip | wip | n/a | partial |
+| `tools.function_calling` | B | n/a | done | done | n/a | drives |
 | `structured.json_grammar` | B | open | open | open | open | typed_error_stub |
 | `context.full_length` | D | wip | wip | wip | open | drives |
 | `context.rope_scaling` | D | n/a | wip | wip | n/a | drives |
@@ -52,7 +52,7 @@ Per-cell vocabulary (conductor §5):
 - **`chat.system_multiturn`** — system role + multi-turn template fidelity (per THIS template)
   - wip — per-arch renderers drive system + multi-turn (api/mod.rs:8789+); not exercised by this pass's smoke (single user turn). Needs a system+multi-turn e2e to earn its receipt.
 - **`tools.function_calling`** — native tool/function calling — REQUIRES tool-call branch or tool/ipython control tokens in THIS model template
-  - Input renders native tool protocol (Qwen3/Mistral, api/mod.rs:8904/9295) but NO structured tool_calls output; tool_choice stubbed (6750). Output-side is the work (1B/3B only).
+  - DONE (class B, Llama 3.2 1B/3B): input renders tools via the model template; output now parses the Llama 3.x {name,parameters} tool-call into OpenAI tool_calls (parse_tool_calls), finish_reason=tool_calls, content emptied. tool_choice:none suppresses. Battery 6/6 structurally valid. TinyLlama/8B n/a (no tool branch).
 - **`structured.json_grammar`** — JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)
   - OPEN — rejected (HTTP 400 stub, api/mod.rs:6753); no GBNF/grammar mask in the sampler.
 - **`context.full_length`** — full TRAINED context length, exact value from metadata
@@ -70,7 +70,7 @@ Per-cell vocabulary (conductor §5):
 - **`context.rope_scaling` splits 2 / 2 after a synthesis correction.** TinyLlama (native 2048) and original Llama 3 8B (native 8192) declare no scaling → `n/a`. The Llama 3.2 1B & 3B reach 131072 via **llama3 rope scaling baked into a `rope_freqs.weight` tensor** (no `rope.scaling.*` *metadata* key, but the transform is real and Camelid applies the llama3 path, `rope.rs:507`) → reclassified **capable / class D / `wip`**. The over-strict "metadata-key-required" Phase 0 prompt had marked these `n/a`; that was an underclaim (conductor §0/§4.6) and is corrected here. Their validation overlaps `context.full_length` at the 131072 frontier — parity at extended positions vs llama.cpp.
 - **`context.full_length` differs sharply per row** — 2048 / 131072 / 131072 / 8192 — and must never be cross-claimed. Memory/abort projection (conductor §9) governs the 131072 rows before any near-limit validation.
 - **6 capabilities are now `done` on the 3 on-disk rows**, each with a `camelid.capability-receipt/v1`: the **sampling lane** (`sampling.full_set` — `min_p`+`repeat_penalty` added; `sampling.seed_determinism` — degenerate per-seed RNG fixed to a per-step SplitMix64 stream, **a real correctness bug**), **`gen.n_choices`** (n>1 independent reproducibly-seeded choices, converted from a 400 stub), and the contract caps `gen.stream_usage`, `gen.length_stop`, `observ.usage_timing`.
-- **`tools.function_calling` splits by row, exactly as the conductor demands.** TinyLlama → `n/a` (template has only user/system/assistant branches, no tool/ipython tokens). Llama 3.2 1B & 3B → **`wip`** (templates carry the Llama-3.1-style tool-call branch + `Environment: ipython`; Camelid renders the input protocol but emits no structured `tool_calls` yet). Original Llama 3 8B → `n/a`/provisional.
+- **`tools.function_calling` splits by row, exactly as the conductor demands.** TinyLlama → `n/a` (no tool branch). Llama 3.2 1B & 3B → **`done`** (class B): Camelid renders tools via the model template on input and parses the Llama 3.x tool-call output back into structured `tool_calls` (battery 6/6 valid; `tool_choice:"none"` suppresses). Original Llama 3 8B → `n/a`/provisional.
 - **One greenfield `open` lane remains** (HTTP-400 stub, model-agnostic): `structured.json_grammar` (GBNF/JSON-mode constrained decode). `logprobs.top_logprobs` is now **`done`** (class D — token IDs bit-exact vs llama.cpp; values within the f32 envelope).
 - **`context.full_length` differs sharply per row** — 2048 / 131072 / 131072 / 8192 — and must never be cross-claimed; near-limit validation (with memory predict-and-abort) keeps it `wip`. `context.rope_scaling` is `n/a` on TinyLlama/8B and `wip` on the 1B/3B (tensor-baked llama3 scaling — see below).
 
@@ -79,7 +79,7 @@ Per-cell vocabulary (conductor §5):
 1. ✅ **Sampling lane** (`sampling.full_set` + `sampling.seed_determinism`) — `min_p`/`repeat_penalty` added, per-step RNG fixed, class-I invariants + e2e. **DONE.**
 2. ✅ **`gen.n_choices` + `logprobs.top_logprobs`** — both **DONE**: n_choices (class C) and logprobs (class D — chat + completions; token IDs bit-exact vs llama.cpp, values within the f32 envelope; non-streaming single-choice).
 3. ✅ **Receipts for the already-driving caps** — `gen.stream_usage`, `gen.length_stop`, `observ.usage_timing` minted **DONE**; `chat.system_multiturn` + `context.full_length` still `wip` (need a system/multi-turn and a near-limit e2e respectively).
-4. **`tools.function_calling`** (1B/3B only) — build the structured `tool_calls` output side; validate over a behavioral battery (class B). Gate strictly on the manifest (TinyLlama/8B stay `n/a`).
+4. ✅ **`tools.function_calling`** (1B/3B) — **DONE** (class B): input rendered via the model template, output parsed into structured `tool_calls` (battery 6/6). Gated on the manifest (TinyLlama/8B `n/a`).
 5. **`structured.json_grammar`** — GBNF/JSON-mode constrained decode (class B), all rows.
 6. **Download Llama 3 8B Q8_0** to complete its Phase 0 manifest, re-resolve `tools`/`full_length`/`rope_scaling`, and extend the done receipts to that row.
 7. *(secondary)* `load.quant_breadth` — only if widening the load matrix is in scope.
@@ -87,7 +87,7 @@ Per-cell vocabulary (conductor §5):
 ## Artifacts
 
 - Per-row manifests: `qa/capability/capability-manifest.<row>.json` (schema `camelid.capability-manifest/v1`).
-- Capability receipts: `qa/capability/receipts/capability-receipt.<cap>.<row>.json` (schema `camelid.capability-receipt/v1`) — **21 minted** this pass (6 caps × 3 on-disk rows).
+- Capability receipts: `qa/capability/receipts/capability-receipt.<cap>.<row>.json` (schema `camelid.capability-receipt/v1`) — **23 minted** this pass (6 caps × 3 on-disk rows).
 - E2E harness: `qa/capability/smoke.sh` (boots each model on Windows CPU, exercises the validated caps).
 - Checksums: `qa/capability/SHA256SUMS` (manifests + receipts).
 - Provenance: produced on branch `feat/capability-conductor` (base `12f202d0`) with the sampling + n_choices diff **uncommitted** at receipt time — re-seal against the commit once landed.

--- a/qa/capability/SHA256SUMS
+++ b/qa/capability/SHA256SUMS
@@ -1,7 +1,7 @@
-95f23bfb671e95fc1a6463217ea780e194b921b268a32482dbccfd682373d9a4  capability-manifest.llama-3-8b-instruct-q8_0.json
-fdc9b4bfe7f3946d82c5383cdeda5f883517f3e66793c86cb48b44d161f4be3d  capability-manifest.llama-3.2-1b-instruct-q8_0.json
-86a865bfc9235d746d93253a2d044189031801008c9d36f5302c41208e3dc40b  capability-manifest.llama-3.2-3b-instruct-q8_0.json
-38aa88760f1227e073005a7d35cc6bb6ee58c41d84817b29c19755202b3ac3cf  capability-manifest.tinyllama-1.1b-chat-q8_0.json
+58823d41c64f18da3dcf16023bac08b44bdd9baf3dfdd54b63e12681beaebbb0  capability-manifest.llama-3-8b-instruct-q8_0.json
+f14b32ca800f04c5084dd38892214c20cdd823fae8c8e5525eea65895f94c117  capability-manifest.llama-3.2-1b-instruct-q8_0.json
+ed0095c18969589f56fee66fed354ce72de47386004ad5e19d7d89cc6320ff7a  capability-manifest.llama-3.2-3b-instruct-q8_0.json
+7b74a633e371915094ebccefb92f57d446d5a668faaa2fc4d279adbca452e274  capability-manifest.tinyllama-1.1b-chat-q8_0.json
 2a2a9e5149dfb91100277c5a8816d1fb05610148db11f380a0dfe8e57770a493  receipts/capability-receipt.gen.length_stop.llama-3.2-1b-instruct-q8_0.json
 97249d71f821ea221f6b073f150d6f26502e3c36a8d37c8fc78d42e5effe650a  receipts/capability-receipt.gen.length_stop.llama-3.2-3b-instruct-q8_0.json
 3a08885298290e93c47e583e082be2b9a69808f9692bf1705e8c312e7dc94051  receipts/capability-receipt.gen.length_stop.tinyllama-1.1b-chat-q8_0.json
@@ -23,3 +23,5 @@ af3a0ec7379d5f973e1f10f6c2ca24138b8076405015b638065cfa8102802134  receipts/capab
 4928c99a0e19e9134d23ebae64afa09d6704078a5b7edf26a04ab294adaf3f95  receipts/capability-receipt.sampling.seed_determinism.llama-3.2-1b-instruct-q8_0.json
 89219176b1a64b285bfe77a24b0512c956f302bc2879da0c56651967a42645d8  receipts/capability-receipt.sampling.seed_determinism.llama-3.2-3b-instruct-q8_0.json
 032d1912a5b206b16c518c5ddd5f21d05194eb0269e7d148e4d35fb8b123e9e7  receipts/capability-receipt.sampling.seed_determinism.tinyllama-1.1b-chat-q8_0.json
+3d7f550893f566f597cf99ebe247b2448efb3afe935972f1fe4d63ae2efb4169  receipts/capability-receipt.tools.function_calling.llama-3.2-1b-instruct-q8_0.json
+190db13ae7ac80adfa7856051d6583d5d850abd093b45c39e65417889707ef35  receipts/capability-receipt.tools.function_calling.llama-3.2-3b-instruct-q8_0.json

--- a/qa/capability/capability-manifest.llama-3-8b-instruct-q8_0.json
+++ b/qa/capability/capability-manifest.llama-3-8b-instruct-q8_0.json
@@ -126,7 +126,7 @@
       "verdict": "incapable",
       "oracle_class": "none",
       "matrix_cell": "n/a",
-      "camelid_state": "partial",
+      "camelid_state": "drives",
       "receipt_present": false,
       "receipt": null,
       "model_evidence": "PROVISIONAL — not from on-disk GGUF. CORRECTED uncertain→INCAPABLE on adversarial review. The ORIGINAL Llama 3 (pre-3.1) chat template predates the 3.1 tool-calling format: it has NO tool-call/tool-response branch, no 'tool'/'ipython' role handling, and special_tokens contains NONE of <|python_tag|>, <|eom_id|>, <|eot_id| as a tool terminator>, or any tool-call control token (only the 5 header/text tokens are present). Because there is NO specific template branch or control token expressing native function calling, and per the 'choose the stricter verdict' rule, this is a definitive model-anchored NEGATIVE, not genuine uncertainty. Must still be re-confirmed against the actual GGUF chat_template + added_tokens once downloaded (and a file mislabeled as 3.1 would change this)."

--- a/qa/capability/capability-manifest.llama-3.2-1b-instruct-q8_0.json
+++ b/qa/capability/capability-manifest.llama-3.2-1b-instruct-q8_0.json
@@ -124,10 +124,10 @@
       "capability": "native tool/function calling — REQUIRES tool-call branch or tool/ipython control tokens in THIS model template",
       "verdict": "capable",
       "oracle_class": "B",
-      "matrix_cell": "wip",
-      "camelid_state": "partial",
-      "receipt_present": false,
-      "receipt": null,
+      "matrix_cell": "done",
+      "camelid_state": "drives",
+      "receipt_present": true,
+      "receipt": "receipts/capability-receipt.tools.function_calling.llama-3.2-1b-instruct-q8_0.json",
       "model_evidence": "VERIFIED specific template branch \"{%- elif 'tool_calls' in message %}\" emitting {\"name\": tool_call.name, \"parameters\": tool_call.arguments|tojson} under assistant header; plus tools-gated \"Environment: ipython\" line, tools_in_user_message JSON-function guidance block, and tool-response role header \"<|start_header_id|>ipython<|end_header_id|>\" (role==tool/ipython branch). Template-expressed -> capable."
     },
     {

--- a/qa/capability/capability-manifest.llama-3.2-3b-instruct-q8_0.json
+++ b/qa/capability/capability-manifest.llama-3.2-3b-instruct-q8_0.json
@@ -124,10 +124,10 @@
       "capability": "native tool/function calling — REQUIRES tool-call branch or tool/ipython control tokens in THIS model template",
       "verdict": "capable",
       "oracle_class": "B",
-      "matrix_cell": "wip",
-      "camelid_state": "partial",
-      "receipt_present": false,
-      "receipt": null,
+      "matrix_cell": "done",
+      "camelid_state": "drives",
+      "receipt_present": true,
+      "receipt": "receipts/capability-receipt.tools.function_calling.llama-3.2-3b-instruct-q8_0.json",
       "model_evidence": "VERIFIED in template: \"{%- elif 'tool_calls' in message %}\" branch emits assistant JSON {\"name\":..,\"parameters\":..}; \"Environment: ipython\" preamble when tools!=none; tool/ipython result role -> <|start_header_id|>ipython<|end_header_id|>. Single-tool-call only (raise_exception if tool_calls|length != 1)."
     },
     {

--- a/qa/capability/capability-manifest.tinyllama-1.1b-chat-q8_0.json
+++ b/qa/capability/capability-manifest.tinyllama-1.1b-chat-q8_0.json
@@ -125,7 +125,7 @@
       "verdict": "incapable",
       "oracle_class": "none",
       "matrix_cell": "n/a",
-      "camelid_state": "partial",
+      "camelid_state": "drives",
       "receipt_present": false,
       "receipt": null,
       "model_evidence": "VERIFIED: chat_template has ONLY user/system/assistant role branches; no tool/tool_calls branch, and tokenizer has no tool/ipython/function control tokens. True n/a, not a gap."

--- a/qa/capability/receipts/capability-receipt.tools.function_calling.llama-3.2-1b-instruct-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.tools.function_calling.llama-3.2-1b-instruct-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "tools.function_calling",
+  "capability": "native tool/function calling — REQUIRES tool-call branch or tool/ipython control tokens in THIS model template",
+  "row": "llama-3.2-1b-instruct-q8_0",
+  "model_label": "Llama 3.2 1B Instruct Q8_0",
+  "oracle_class": "B",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "Llama-3.2-1B-Instruct-Q8_0.gguf",
+    "sha256": "3f87a880027e7b9ea8e0da9e4009584336f352af444a0e6e5c20721ac4c7ffd1"
+  },
+  "harness": {
+    "repo_head": "12f202d0a2e1182f0d76ff656f632e2b9e17252e",
+    "branch": "feat/capability-conductor",
+    "working_tree": "Produced with the capability-conductor sampling + n_choices diff UNCOMMITTED on branch feat/capability-conductor (base 12f202d0). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/smoke.sh (TinyLlama/1B/3B, Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "invariant_unit + behavioral_battery",
+    "summary": "unit: parse_tool_calls extracts the Llama 3.x {name, parameters|arguments} form (tolerates <|python_tag|> prefix + trailing junk; prose / no-name -> None); tool_choice:none suppresses. e2e behavioral battery on Llama 3.2 1B/3B (qa/capability/tools_smoke.sh): tools rendered into the model template on input, output parsed back to OpenAI tool_calls — 6/6 prompts produced structurally-valid tool calls (function name + JSON-string arguments), finish_reason=\"tool_calls\", content emptied; tool_choice:\"none\" suppresses parsing. 3B arguments are semantically correct; 1B is structurally valid but semantically imperfect (model limitation, not the parser). Non-streaming single-choice. TinyLlama / Llama 3 8B stay n/a (template has no tool branch)."
+  }
+}

--- a/qa/capability/receipts/capability-receipt.tools.function_calling.llama-3.2-3b-instruct-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.tools.function_calling.llama-3.2-3b-instruct-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "tools.function_calling",
+  "capability": "native tool/function calling — REQUIRES tool-call branch or tool/ipython control tokens in THIS model template",
+  "row": "llama-3.2-3b-instruct-q8_0",
+  "model_label": "Llama 3.2 3B Instruct Q8_0",
+  "oracle_class": "B",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "Llama-3.2-3B-Instruct-Q8_0.gguf",
+    "sha256": "f34112a11b7dad74ab517dedf6dcf00d624c9adac2dc0c72c719ca0478554ef2"
+  },
+  "harness": {
+    "repo_head": "12f202d0a2e1182f0d76ff656f632e2b9e17252e",
+    "branch": "feat/capability-conductor",
+    "working_tree": "Produced with the capability-conductor sampling + n_choices diff UNCOMMITTED on branch feat/capability-conductor (base 12f202d0). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/smoke.sh (TinyLlama/1B/3B, Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "invariant_unit + behavioral_battery",
+    "summary": "unit: parse_tool_calls extracts the Llama 3.x {name, parameters|arguments} form (tolerates <|python_tag|> prefix + trailing junk; prose / no-name -> None); tool_choice:none suppresses. e2e behavioral battery on Llama 3.2 1B/3B (qa/capability/tools_smoke.sh): tools rendered into the model template on input, output parsed back to OpenAI tool_calls — 6/6 prompts produced structurally-valid tool calls (function name + JSON-string arguments), finish_reason=\"tool_calls\", content emptied; tool_choice:\"none\" suppresses parsing. 3B arguments are semantically correct; 1B is structurally valid but semantically imperfect (model limitation, not the parser). Non-streaming single-choice. TinyLlama / Llama 3 8B stay n/a (template has no tool branch)."
+  }
+}

--- a/qa/capability/tools_smoke.sh
+++ b/qa/capability/tools_smoke.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# E2E behavioral battery for tools.function_calling (class B): supply tools +
+# triggering prompts; verify structured tool_calls are surfaced (name + valid
+# JSON arguments) with finish_reason "tool_calls". Also: tool_choice:"none"
+# suppresses parsing.
+set -u
+EXE="${CAMELID_EXE:-target/release/camelid.exe}"
+MODEL="${1:?usage: tools_smoke.sh <model.gguf> [port] [out-suffix]}"
+PORT="${2:-8261}"
+BASE="http://127.0.0.1:${PORT}"
+OUT="${CAMELID_TOOLS_OUT:-qa/capability/tools_out${3:-}}"
+mkdir -p "$OUT"
+CT='Content-Type: application/json'
+TOOLS='[{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}},{"type":"function","function":{"name":"add","description":"Add two numbers","parameters":{"type":"object","properties":{"a":{"type":"number"},"b":{"type":"number"}},"required":["a","b"]}}}]'
+
+export CUDA_VISIBLE_DEVICES=-1
+"$EXE" serve --addr 127.0.0.1:"${PORT}" --model "$MODEL" > "$OUT/serve.log" 2>&1 &
+PID=$!; trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null' EXIT
+curl -s --fail --retry-connrefused --retry-all-errors --retry 180 --retry-delay 1 --max-time 10 "${BASE}/api/models/current" -o /dev/null || { echo "NOT READY"; tail -20 "$OUT/serve.log"; exit 1; }
+
+req() { # $1 = prompt, $2 = out, $3 = extra-json
+  curl -s --max-time 180 -H "$CT" \
+    -d "{\"messages\":[{\"role\":\"user\",\"content\":\"$1\"}],\"tools\":${TOOLS},\"temperature\":0,\"max_tokens\":60${3:-}}" \
+    "${BASE}/v1/chat/completions" > "$OUT/$2"
+}
+req "What is the weather in Paris? Use a tool." "p1.json"
+req "Add 17 and 25 using the tool." "p2.json"
+req "What is the weather in Tokyo? Use a tool." "p3.json"
+# tool_choice:none must suppress tool parsing (content stays).
+req "What is the weather in Paris? Use a tool." "none.json" ',"tool_choice":"none"'
+
+echo "SMOKE_DONE"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -438,9 +438,17 @@ pub struct ChatCompletionRequest {
     pub camelid_enable_thinking: Option<bool>,
     /// OpenAI-style tool/function definitions. When present, they are rendered
     /// into the prompt through the loaded model's own chat template (Hybrid agent
-    /// mode); the model's tool-call output is parsed by the client. Models whose
-    /// template does not render tools simply ignore them.
+    /// mode); the model's tool-call output is parsed back into `tool_calls` (for
+    /// templates that render tools — Llama 3.x etc.). Models whose template does
+    /// not render tools simply ignore them.
     pub tools: Option<Vec<serde_json::Value>>,
+    /// OpenAI `tool_choice`: `"auto"` (default), `"none"` (suppress parsing), or
+    /// `"required"`/a specific function (treated as `auto`). Parsed permissively
+    /// as a raw value. Declaring it here removes it from `unsupported_fields`.
+    pub tool_choice: Option<serde_json::Value>,
+    /// OpenAI `parallel_tool_calls`: accepted and ignored (Camelid surfaces the
+    /// tool calls the model actually emits). Declared here so it is not rejected.
+    pub parallel_tool_calls: Option<bool>,
     /// OpenAI `stream_options`. The only honored subfield is `include_usage`
     /// (bool); any other shape or subfield is tolerated silently and ignored,
     /// matching the permissive llama-server oracle. Parsed as a raw value so a
@@ -1128,6 +1136,27 @@ pub struct ChatTopLogprob {
 pub struct ChatCompletionMessage {
     pub role: &'static str,
     pub content: String,
+    /// Parsed structured tool calls (OpenAI shape); present only when the model
+    /// emitted a tool call and the request supplied `tools`. `content` is empty
+    /// when this is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+}
+
+/// OpenAI tool-call object surfaced in an assistant message.
+#[derive(Debug, Serialize)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    pub function: ToolCallFunction,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolCallFunction {
+    pub name: String,
+    /// JSON-encoded arguments string (OpenAI shape).
+    pub arguments: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -5598,6 +5627,8 @@ async fn chat_completions_multi_choice(
             message: ChatCompletionMessage {
                 role: "assistant",
                 content,
+                // Tool-call parsing is single-choice only (the non-streaming path).
+                tool_calls: None,
             },
             finish_reason,
             // Logprobs are rejected upstream for n>1.
@@ -5714,6 +5745,10 @@ async fn chat_completions(
     // Logprobs are non-streaming, single-choice only (per-chunk / per-choice logprobs
     // are a follow-up). Reject the unsupported combinations before runtime.
     let wants_logprobs = matches!(req.logprobs, Some(true)) || req.top_logprobs.is_some();
+    // Tool calls are surfaced on the non-streaming single-choice path when the
+    // request supplied tools and tool_choice is not "none".
+    let tools_active = req.tools.as_ref().is_some_and(|t| !t.is_empty())
+        && tool_choice_allows_calls(req.tool_choice.as_ref());
     if wants_logprobs && req.stream.unwrap_or(false) {
         return api_error(
             StatusCode::BAD_REQUEST,
@@ -5820,6 +5855,24 @@ async fn chat_completions(
             } else {
                 generated.text
             };
+            // Parse the model's tool-call output into structured tool_calls when the
+            // request supplied tools and tool_choice permits it. On a tool call,
+            // content is emptied and finish_reason flips to "tool_calls".
+            let tool_calls = if tools_active {
+                parse_tool_calls(&content)
+            } else {
+                None
+            };
+            let (content, finish_reason) = if tool_calls.is_some() {
+                (String::new(), "tool_calls")
+            } else {
+                (content, generated.finish_reason)
+            };
+            let logprobs = if generated.step_logprobs.is_empty() {
+                None
+            } else {
+                Some(build_chat_logprobs(&generated.step_logprobs))
+            };
             (
                 StatusCode::OK,
                 Json(ChatCompletionResponse {
@@ -5832,13 +5885,10 @@ async fn chat_completions(
                         message: ChatCompletionMessage {
                             role: "assistant",
                             content,
+                            tool_calls,
                         },
-                        finish_reason: generated.finish_reason,
-                        logprobs: if generated.step_logprobs.is_empty() {
-                            None
-                        } else {
-                            Some(build_chat_logprobs(&generated.step_logprobs))
-                        },
+                        finish_reason,
+                        logprobs,
                     }],
                     usage: CompletionUsage {
                         prompt_tokens: prompt_token_count,
@@ -7169,8 +7219,8 @@ fn validate_unsupported_generation_fields(
         return Ok(());
     };
     let message = match param {
-        "tools" | "tool_choice" | "parallel_tool_calls" | "parse_tool_calls" => {
-            "tool/function calling is not supported by Camelid generation routes yet"
+        "parse_tool_calls" => {
+            "the camelid parse_tool_calls control is not supported on this route yet"
         }
         "response_format" | "json_schema" | "schema" | "grammar" => {
             "JSON/schema/grammar constrained generation is not supported yet"
@@ -8447,6 +8497,45 @@ fn build_completion_logprobs(steps: &[StepLogprob]) -> CompletionLogprobs {
         top_logprobs,
         text_offset,
     }
+}
+
+/// Whether `tool_choice` permits surfacing tool calls. `"none"` suppresses them;
+/// everything else (auto / required / a specific function / absent) allows.
+fn tool_choice_allows_calls(tool_choice: Option<&serde_json::Value>) -> bool {
+    !matches!(tool_choice.and_then(|value| value.as_str()), Some("none"))
+}
+
+/// Parse a model's tool-call output into OpenAI `tool_calls`. Handles the Llama
+/// 3.x form `{"name": <fn>, "parameters": {...}}` (also `"arguments"`), optionally
+/// `<|python_tag|>`-prefixed, and tolerates trailing junk small models emit.
+/// Returns `None` when the text is prose, not a tool call.
+fn parse_tool_calls(text: &str) -> Option<Vec<ToolCall>> {
+    let trimmed = text.trim();
+    let trimmed = trimmed
+        .strip_prefix("<|python_tag|>")
+        .unwrap_or(trimmed)
+        .trim_start();
+    // Read the first complete JSON value; ignore any trailing junk.
+    let value = serde_json::Deserializer::from_str(trimmed)
+        .into_iter::<serde_json::Value>()
+        .next()?
+        .ok()?;
+    let obj = value.as_object()?;
+    let name = obj.get("name")?.as_str()?.to_string();
+    if name.is_empty() {
+        return None;
+    }
+    let args = obj
+        .get("parameters")
+        .or_else(|| obj.get("arguments"))
+        .cloned()
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    let arguments = serde_json::to_string(&args).ok()?;
+    Some(vec![ToolCall {
+        id: format!("call_{}", uuid::Uuid::new_v4().simple()),
+        kind: "function",
+        function: ToolCallFunction { name, arguments },
+    }])
 }
 
 fn top_logit_diagnostics(
@@ -10545,6 +10634,42 @@ mod tests {
         }))
         .expect("deserialize");
         assert!(validate_choice_and_logprob_fields(&oob).is_err());
+    }
+
+    #[test]
+    fn parse_tool_calls_extracts_llama_format() {
+        // Llama 3.x: {"name", "parameters"}; arguments becomes a JSON string.
+        let tc = parse_tool_calls(r#"{"name": "get_weather", "parameters": {"city": "Paris"}}"#)
+            .unwrap();
+        assert_eq!(tc.len(), 1);
+        assert_eq!(tc[0].function.name, "get_weather");
+        assert_eq!(tc[0].kind, "function");
+        assert!(tc[0].id.starts_with("call_"));
+        let args: serde_json::Value = serde_json::from_str(&tc[0].function.arguments).unwrap();
+        assert_eq!(args["city"], "Paris");
+    }
+
+    #[test]
+    fn parse_tool_calls_tolerates_python_tag_and_junk() {
+        // python_tag prefix + trailing junk small models emit; "arguments" variant.
+        let tc = parse_tool_calls(r#"<|python_tag|>{"name": "f", "arguments": {"x": 1}} trailing"#)
+            .unwrap();
+        assert_eq!(tc[0].function.name, "f");
+        let args: serde_json::Value = serde_json::from_str(&tc[0].function.arguments).unwrap();
+        assert_eq!(args["x"], 1);
+        // prose is not a tool call; a JSON object without "name" is not either.
+        assert!(parse_tool_calls("The weather in Paris is sunny.").is_none());
+        assert!(parse_tool_calls(r#"{"parameters": {"x": 1}}"#).is_none());
+    }
+
+    #[test]
+    fn tool_choice_none_suppresses_calls() {
+        assert!(!tool_choice_allows_calls(Some(&serde_json::json!("none"))));
+        assert!(tool_choice_allows_calls(Some(&serde_json::json!("auto"))));
+        assert!(tool_choice_allows_calls(Some(&serde_json::json!(
+            "required"
+        ))));
+        assert!(tool_choice_allows_calls(None));
     }
 
     #[test]

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -1605,8 +1605,8 @@ async fn chat_completion_accepts_tools_but_rejects_other_tool_fields() {
         serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
     assert_ne!(body["error"]["code"], "unsupported_parameter");
 
-    // The other tool/function-calling fields remain unsupported and are still
-    // rejected before runtime.
+    // tool_choice and parallel_tool_calls are now accepted too; only the
+    // camelid-specific parse_tool_calls control remains unsupported.
     let response = camelid::api::router()
         .oneshot(
             Request::builder()
@@ -1614,7 +1614,7 @@ async fn chat_completion_accepts_tools_but_rejects_other_tool_fields() {
                 .uri("/v1/chat/completions")
                 .header("content-type", "application/json")
                 .body(Body::from(
-                    r#"{"model":"tiny","messages":[{"role":"user","content":"hello"}],"max_tokens":1,"tool_choice":"auto"}"#,
+                    r#"{"model":"tiny","messages":[{"role":"user","content":"hello"}],"max_tokens":1,"parse_tool_calls":true}"#,
                 ))
                 .unwrap(),
         )
@@ -1625,7 +1625,7 @@ async fn chat_completion_accepts_tools_but_rejects_other_tool_fields() {
     let body: Value =
         serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
     assert_eq!(body["error"]["code"], "unsupported_parameter");
-    assert_eq!(body["error"]["param"], "tool_choice");
+    assert_eq!(body["error"]["param"], "parse_tool_calls");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Capability-conductor **tools** lane (class B) — the output side. Moves `tools.function_calling` from `wip` to **`done`** on Llama 3.2 1B/3B. (TinyLlama / Llama 3 8B stay `n/a` — their templates have no tool branch.)

## What
Camelid already renders `tools` into the model's own chat template on input (Llama 3.x etc.); this PR surfaces the result as structured `tool_calls`.
- `tool_calls` on `ChatCompletionMessage` + `ToolCall`/`ToolCallFunction`; typed `tool_choice` + `parallel_tool_calls` request fields (un-stubbed — removed from the unsupported-field reject; only the camelid-specific `parse_tool_calls` stays unsupported).
- `parse_tool_calls`: Llama 3.x `{"name", "parameters"|"arguments"}` (optional `<|python_tag|>` prefix, tolerates trailing junk) → `tool_calls`; `content` emptied, `finish_reason` → `"tool_calls"`. `tool_choice:"none"` suppresses parsing. Non-streaming single-choice.

## Validation
- **Unit (3):** parse (Llama format → JSON-string arguments), python_tag/junk tolerance + prose/no-name → None, `tool_choice:none`. Plus an updated integration test.
- **e2e behavioral battery** on Llama 3.2 1B/3B (`qa/capability/tools_smoke.sh`): **6/6 structurally-valid tool calls** (function name + JSON arguments), `finish_reason: tool_calls`, content emptied; `tool_choice:"none"` suppresses. 3B arguments are semantically correct; 1B is structurally valid but semantically imperfect (model limitation, not the parser).

## Artifacts
- `CAPABILITY_MATRIX.md` tools row → `n/a done done n/a` (tally done 21 → 23); 2 new `capability-receipt/v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)