### PR TITLE
feat(api): JSON-grammar-constrained decoding — response_format json_object (capability conductor)

### DIFF
--- a/CAPABILITY_MATRIX.md
+++ b/CAPABILITY_MATRIX.md
@@ -13,7 +13,7 @@ Per-cell vocabulary (conductor §5):
 
 **Phase 0 status:** 3 / 4 rows discovered + hash-anchored (TinyLlama, Llama 3.2 1B, Llama 3.2 3B). **Llama 3 8B Q8_0 is not downloaded** — its column (`*`) is PROVISIONAL (spec-derived, not GGUF-anchored, Phase 0 INCOMPLETE).
 
-**Cell tally** (4 model columns × 13 capabilities = 52 cells): `n/a` 4 · `open` 14 · `wip` 11 · `done` 23. The `done` cells are each backed by a `camelid.capability-receipt/v1` under `qa/capability/receipts/`, validated this pass on the **3 on-disk rows** (TinyLlama, Llama 3.2 1B, Llama 3.2 3B) — no cross-row inheritance (conductor §6). The 8B column stays provisional until its GGUF is downloaded.
+**Cell tally** (4 model columns × 13 capabilities = 52 cells): `n/a` 4 · `open` 11 · `wip` 11 · `done` 26. The `done` cells are each backed by a `camelid.capability-receipt/v1` under `qa/capability/receipts/`, validated this pass on the **3 on-disk rows** (TinyLlama, Llama 3.2 1B, Llama 3.2 3B) — no cross-row inheritance (conductor §6). The 8B column stays provisional until its GGUF is downloaded.
 
 ## Matrix
 
@@ -27,7 +27,7 @@ Per-cell vocabulary (conductor §5):
 | `logprobs.top_logprobs` | D | done | done | done | open | drives |
 | `chat.system_multiturn` | D | wip | wip | wip | open | drives |
 | `tools.function_calling` | B | n/a | done | done | n/a | drives |
-| `structured.json_grammar` | B | open | open | open | open | typed_error_stub |
+| `structured.json_grammar` | B | done | done | done | open | drives |
 | `context.full_length` | D | wip | wip | wip | open | drives |
 | `context.rope_scaling` | D | n/a | wip | wip | n/a | drives |
 | `observ.usage_timing` | C | done | done | done | open | drives |
@@ -54,7 +54,7 @@ Per-cell vocabulary (conductor §5):
 - **`tools.function_calling`** — native tool/function calling — REQUIRES tool-call branch or tool/ipython control tokens in THIS model template
   - DONE (class B, Llama 3.2 1B/3B): input renders tools via the model template; output now parses the Llama 3.x {name,parameters} tool-call into OpenAI tool_calls (parse_tool_calls), finish_reason=tool_calls, content emptied. tool_choice:none suppresses. Battery 6/6 structurally valid. TinyLlama/8B n/a (no tool branch).
 - **`structured.json_grammar`** — JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)
-  - OPEN — rejected (HTTP 400 stub, api/mod.rs:6753); no GBNF/grammar mask in the sampler.
+  - DONE (class B, 3 on-disk rows): response_format json_object -> JSON-grammar-constrained decoding (src/grammar.rs PDA + per-step logit mask in the decode loop). Battery 12/12 valid JSON. Non-streaming; json_schema/GBNF + force-close-at-max_tokens are follow-ups.
 - **`context.full_length`** — full TRAINED context length, exact value from metadata
   - wip — honored from GGUF metadata as KV cap (model.rs:141, inference.rs:2086). Trained length differs per row: TL 2048 / 1B 131072 / 3B 131072 / 8B 8192*. Needs near-limit validation (memory predict-and-abort).
 - **`context.rope_scaling`** — RoPE scaling/extension — REQUIRES a rope scaling type/factor declared in metadata
@@ -71,7 +71,7 @@ Per-cell vocabulary (conductor §5):
 - **`context.full_length` differs sharply per row** — 2048 / 131072 / 131072 / 8192 — and must never be cross-claimed. Memory/abort projection (conductor §9) governs the 131072 rows before any near-limit validation.
 - **6 capabilities are now `done` on the 3 on-disk rows**, each with a `camelid.capability-receipt/v1`: the **sampling lane** (`sampling.full_set` — `min_p`+`repeat_penalty` added; `sampling.seed_determinism` — degenerate per-seed RNG fixed to a per-step SplitMix64 stream, **a real correctness bug**), **`gen.n_choices`** (n>1 independent reproducibly-seeded choices, converted from a 400 stub), and the contract caps `gen.stream_usage`, `gen.length_stop`, `observ.usage_timing`.
 - **`tools.function_calling` splits by row, exactly as the conductor demands.** TinyLlama → `n/a` (no tool branch). Llama 3.2 1B & 3B → **`done`** (class B): Camelid renders tools via the model template on input and parses the Llama 3.x tool-call output back into structured `tool_calls` (battery 6/6 valid; `tool_choice:"none"` suppresses). Original Llama 3 8B → `n/a`/provisional.
-- **One greenfield `open` lane remains** (HTTP-400 stub, model-agnostic): `structured.json_grammar` (GBNF/JSON-mode constrained decode). `logprobs.top_logprobs` is now **`done`** (class D — token IDs bit-exact vs llama.cpp; values within the f32 envelope).
+- **Every greenfield `open` lane is now `done`.** The last one, `structured.json_grammar` (JSON-mode constrained decode), is `done` on the 3 on-disk rows (class B — battery 12/12 valid JSON via a byte-level JSON PDA + per-step logit mask). `logprobs.top_logprobs` is `done` (class D — token IDs bit-exact vs llama.cpp; values within the f32 envelope). The only non-`done` cells left are `wip` (implemented, receipt pending a row-specific e2e) or the provisional 8B column.
 - **`context.full_length` differs sharply per row** — 2048 / 131072 / 131072 / 8192 — and must never be cross-claimed; near-limit validation (with memory predict-and-abort) keeps it `wip`. `context.rope_scaling` is `n/a` on TinyLlama/8B and `wip` on the 1B/3B (tensor-baked llama3 scaling — see below).
 
 ## Recommended sequencing (conductor §6) — progress
@@ -80,14 +80,14 @@ Per-cell vocabulary (conductor §5):
 2. ✅ **`gen.n_choices` + `logprobs.top_logprobs`** — both **DONE**: n_choices (class C) and logprobs (class D — chat + completions; token IDs bit-exact vs llama.cpp, values within the f32 envelope; non-streaming single-choice).
 3. ✅ **Receipts for the already-driving caps** — `gen.stream_usage`, `gen.length_stop`, `observ.usage_timing` minted **DONE**; `chat.system_multiturn` + `context.full_length` still `wip` (need a system/multi-turn and a near-limit e2e respectively).
 4. ✅ **`tools.function_calling`** (1B/3B) — **DONE** (class B): input rendered via the model template, output parsed into structured `tool_calls` (battery 6/6). Gated on the manifest (TinyLlama/8B `n/a`).
-5. **`structured.json_grammar`** — GBNF/JSON-mode constrained decode (class B), all rows.
+5. ✅ **`structured.json_grammar`** — **DONE** (class B): response_format json_object -> JSON-grammar-constrained decode (byte-level PDA + per-step logit mask); battery 12/12 valid JSON. (json_schema/GBNF + force-close-at-max_tokens are follow-ups.)
 6. **Download Llama 3 8B Q8_0** to complete its Phase 0 manifest, re-resolve `tools`/`full_length`/`rope_scaling`, and extend the done receipts to that row.
 7. *(secondary)* `load.quant_breadth` — only if widening the load matrix is in scope.
 
 ## Artifacts
 
 - Per-row manifests: `qa/capability/capability-manifest.<row>.json` (schema `camelid.capability-manifest/v1`).
-- Capability receipts: `qa/capability/receipts/capability-receipt.<cap>.<row>.json` (schema `camelid.capability-receipt/v1`) — **23 minted** this pass (6 caps × 3 on-disk rows).
+- Capability receipts: `qa/capability/receipts/capability-receipt.<cap>.<row>.json` (schema `camelid.capability-receipt/v1`) — **26 minted** this pass (6 caps × 3 on-disk rows).
 - E2E harness: `qa/capability/smoke.sh` (boots each model on Windows CPU, exercises the validated caps).
 - Checksums: `qa/capability/SHA256SUMS` (manifests + receipts).
 - Provenance: produced on branch `feat/capability-conductor` (base `12f202d0`) with the sampling + n_choices diff **uncommitted** at receipt time — re-seal against the commit once landed.

--- a/qa/capability/SHA256SUMS
+++ b/qa/capability/SHA256SUMS
@@ -1,7 +1,7 @@
-58823d41c64f18da3dcf16023bac08b44bdd9baf3dfdd54b63e12681beaebbb0  capability-manifest.llama-3-8b-instruct-q8_0.json
-f14b32ca800f04c5084dd38892214c20cdd823fae8c8e5525eea65895f94c117  capability-manifest.llama-3.2-1b-instruct-q8_0.json
-ed0095c18969589f56fee66fed354ce72de47386004ad5e19d7d89cc6320ff7a  capability-manifest.llama-3.2-3b-instruct-q8_0.json
-7b74a633e371915094ebccefb92f57d446d5a668faaa2fc4d279adbca452e274  capability-manifest.tinyllama-1.1b-chat-q8_0.json
+1d708cdc641c6ffe3707076f18ab5dcb14d45f2565b04ae5cb1db80a92659bc7  capability-manifest.llama-3-8b-instruct-q8_0.json
+224463f0ce4ef6d2c17e880cc29aea7f8f376e0187df0acd1ca8147a02cdcdeb  capability-manifest.llama-3.2-1b-instruct-q8_0.json
+b5ffdc42a941522f834616664545d373287a14be17ff7c28e24fa7197636f3b5  capability-manifest.llama-3.2-3b-instruct-q8_0.json
+75f89c509b09096cf395c97bf1884df2a0b6045180a8ddb00dac03efa287b614  capability-manifest.tinyllama-1.1b-chat-q8_0.json
 2a2a9e5149dfb91100277c5a8816d1fb05610148db11f380a0dfe8e57770a493  receipts/capability-receipt.gen.length_stop.llama-3.2-1b-instruct-q8_0.json
 97249d71f821ea221f6b073f150d6f26502e3c36a8d37c8fc78d42e5effe650a  receipts/capability-receipt.gen.length_stop.llama-3.2-3b-instruct-q8_0.json
 3a08885298290e93c47e583e082be2b9a69808f9692bf1705e8c312e7dc94051  receipts/capability-receipt.gen.length_stop.tinyllama-1.1b-chat-q8_0.json
@@ -23,5 +23,8 @@ af3a0ec7379d5f973e1f10f6c2ca24138b8076405015b638065cfa8102802134  receipts/capab
 4928c99a0e19e9134d23ebae64afa09d6704078a5b7edf26a04ab294adaf3f95  receipts/capability-receipt.sampling.seed_determinism.llama-3.2-1b-instruct-q8_0.json
 89219176b1a64b285bfe77a24b0512c956f302bc2879da0c56651967a42645d8  receipts/capability-receipt.sampling.seed_determinism.llama-3.2-3b-instruct-q8_0.json
 032d1912a5b206b16c518c5ddd5f21d05194eb0269e7d148e4d35fb8b123e9e7  receipts/capability-receipt.sampling.seed_determinism.tinyllama-1.1b-chat-q8_0.json
+f999dd53325aa90e01eb87af9b252a21beb00a6cd49bbf89f545b5703fe0e19e  receipts/capability-receipt.structured.json_grammar.llama-3.2-1b-instruct-q8_0.json
+0a094029bde9c54a4c4986cc7ca00c79ef4cc5d2821a7c2ebd750d3e06b3e94f  receipts/capability-receipt.structured.json_grammar.llama-3.2-3b-instruct-q8_0.json
+1b99336114c57aa86763e15efd88c3e97494d9819835eb2e22e237ca2fcd8cc3  receipts/capability-receipt.structured.json_grammar.tinyllama-1.1b-chat-q8_0.json
 3d7f550893f566f597cf99ebe247b2448efb3afe935972f1fe4d63ae2efb4169  receipts/capability-receipt.tools.function_calling.llama-3.2-1b-instruct-q8_0.json
 190db13ae7ac80adfa7856051d6583d5d850abd093b45c39e65417889707ef35  receipts/capability-receipt.tools.function_calling.llama-3.2-3b-instruct-q8_0.json

--- a/qa/capability/capability-manifest.llama-3-8b-instruct-q8_0.json
+++ b/qa/capability/capability-manifest.llama-3-8b-instruct-q8_0.json
@@ -137,7 +137,7 @@
       "verdict": "uncertain",
       "oracle_class": "B",
       "matrix_cell": "open",
-      "camelid_state": "typed_error_stub",
+      "camelid_state": "drives",
       "receipt_present": false,
       "receipt": null,
       "model_evidence": "PROVISIONAL — not from on-disk GGUF. RETAINED uncertain on adversarial review: the unknown here is purely ENGINE-side (whether the conductor's decode path implements JSON-mode / GBNF grammar-constrained decoding), which is model-agnostic and independent of Llama 3 weights. Unlike tools.function_calling (a definite model-template negative), there is no template/metadata signal to anchor a verdict either way, so flipping to 'incapable' would assert an unsupported negative about the engine. Not an overclaim; re-assess once the row is loadable and the decoder feature set is confirmed."

--- a/qa/capability/capability-manifest.llama-3.2-1b-instruct-q8_0.json
+++ b/qa/capability/capability-manifest.llama-3.2-1b-instruct-q8_0.json
@@ -135,10 +135,10 @@
       "capability": "JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)",
       "verdict": "capable",
       "oracle_class": "B",
-      "matrix_cell": "open",
-      "camelid_state": "typed_error_stub",
-      "receipt_present": false,
-      "receipt": null,
+      "matrix_cell": "done",
+      "camelid_state": "drives",
+      "receipt_present": true,
+      "receipt": "receipts/capability-receipt.structured.json_grammar.llama-3.2-1b-instruct-q8_0.json",
       "model_evidence": "JSON mode + GBNF grammar-constrained decode is decoder-side and model-agnostic for any causal LM."
     },
     {

--- a/qa/capability/capability-manifest.llama-3.2-3b-instruct-q8_0.json
+++ b/qa/capability/capability-manifest.llama-3.2-3b-instruct-q8_0.json
@@ -135,10 +135,10 @@
       "capability": "JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)",
       "verdict": "capable",
       "oracle_class": "B",
-      "matrix_cell": "open",
-      "camelid_state": "typed_error_stub",
-      "receipt_present": false,
-      "receipt": null,
+      "matrix_cell": "done",
+      "camelid_state": "drives",
+      "receipt_present": true,
+      "receipt": "receipts/capability-receipt.structured.json_grammar.llama-3.2-3b-instruct-q8_0.json",
       "model_evidence": "JSON mode + GBNF grammar-constrained decode is decoder-side and model-agnostic; behavioral battery validates conformance."
     },
     {

--- a/qa/capability/capability-manifest.tinyllama-1.1b-chat-q8_0.json
+++ b/qa/capability/capability-manifest.tinyllama-1.1b-chat-q8_0.json
@@ -135,10 +135,10 @@
       "capability": "JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)",
       "verdict": "capable",
       "oracle_class": "B",
-      "matrix_cell": "open",
-      "camelid_state": "typed_error_stub",
-      "receipt_present": false,
-      "receipt": null,
+      "matrix_cell": "done",
+      "camelid_state": "drives",
+      "receipt_present": true,
+      "receipt": "receipts/capability-receipt.structured.json_grammar.tinyllama-1.1b-chat-q8_0.json",
       "model_evidence": "JSON mode + GBNF grammar-constrained decode is decoder-side (logit masking), model-agnostic; arch=llama imposes no constraint."
     },
     {

--- a/qa/capability/json_smoke.sh
+++ b/qa/capability/json_smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# E2E behavioral battery for structured.json_grammar (class B): response_format
+# json_object -> JSON-grammar-constrained decoding. Every response's content MUST
+# be valid JSON. Also: without json_object the model is free (control).
+set -u
+EXE="${CAMELID_EXE:-target/release/camelid.exe}"
+MODEL="${1:?usage: json_smoke.sh <model.gguf> [port] [out-suffix]}"
+PORT="${2:-8271}"
+BASE="http://127.0.0.1:${PORT}"
+OUT="${CAMELID_JSON_OUT:-qa/capability/json_out${3:-}}"
+mkdir -p "$OUT"
+CT='Content-Type: application/json'
+
+export CUDA_VISIBLE_DEVICES=-1
+"$EXE" serve --addr 127.0.0.1:"${PORT}" --model "$MODEL" > "$OUT/serve.log" 2>&1 &
+PID=$!; trap 'kill $PID 2>/dev/null; wait $PID 2>/dev/null' EXIT
+curl -s --fail --retry-connrefused --retry-all-errors --retry 180 --retry-delay 1 --max-time 10 "${BASE}/api/models/current" -o /dev/null || { echo "NOT READY"; tail -20 "$OUT/serve.log"; exit 1; }
+
+ jreq() { # $1 prompt, $2 out
+  curl -s --max-time 240 -H "$CT" \
+    -d "{\"messages\":[{\"role\":\"user\",\"content\":\"$1\"}],\"response_format\":{\"type\":\"json_object\"},\"temperature\":0,\"max_tokens\":300}" \
+    "${BASE}/v1/chat/completions" > "$OUT/$2"
+}
+jreq "Give me a JSON object with a person's name, age, and city." "p1.json"
+jreq "Return JSON with keys a, b, c set to the numbers 1, 2, 3." "p2.json"
+jreq "Describe a cat as JSON." "p3.json"
+jreq "List three colors as a JSON object with a colors array." "p4.json"
+# control: no response_format -> free text (not constrained).
+curl -s --max-time 120 -H "$CT" \
+  -d '{"messages":[{"role":"user","content":"Say hello in one sentence."}],"temperature":0,"max_tokens":20}' \
+  "${BASE}/v1/chat/completions" > "$OUT/free.json"
+
+echo "SMOKE_DONE"

--- a/qa/capability/receipts/capability-receipt.structured.json_grammar.llama-3.2-1b-instruct-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.structured.json_grammar.llama-3.2-1b-instruct-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "structured.json_grammar",
+  "capability": "JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)",
+  "row": "llama-3.2-1b-instruct-q8_0",
+  "model_label": "Llama 3.2 1B Instruct Q8_0",
+  "oracle_class": "B",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "Llama-3.2-1B-Instruct-Q8_0.gguf",
+    "sha256": "3f87a880027e7b9ea8e0da9e4009584336f352af444a0e6e5c20721ac4c7ffd1"
+  },
+  "harness": {
+    "repo_head": "12f202d0a2e1182f0d76ff656f632e2b9e17252e",
+    "branch": "feat/capability-conductor",
+    "working_tree": "Produced with the capability-conductor sampling + n_choices diff UNCOMMITTED on branch feat/capability-conductor (base 12f202d0). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/smoke.sh (TinyLlama/1B/3B, Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "invariant_unit + behavioral_battery",
+    "summary": "unit: 6 JsonState PDA tests (src/grammar.rs) — complete-object acceptance cross-checked vs serde_json, prefix-validity, number/string/escape edge cases, multibyte tokens spanning structure, done-only-after-top-level-close, accepts() non-mutation — plus the response_format interpreter test (json_object on, text/absent off, json_schema rejected). e2e behavioral battery on TinyLlama/1B/3B (qa/capability/json_smoke.sh, response_format json_object, temperature 0): 12/12 responses are valid JSON (every choices[0].message.content parses); the free-text control (no response_format) is unconstrained. Mechanism: per-step logit mask to tokens that keep a valid JSON-object prefix (a large finite negative logit for the rest so the sampler accepts it), EOG allowed only once the object closes, GPU greedy-fast + speculative lanes bypassed, mask applied to a clone so logprobs/diagnostics see the real distribution. Non-streaming; json_object+stream and json_schema fail closed. Caveat: a too-small max_tokens truncates mid-object (set an adequate budget; full force-close is a follow-up)."
+  }
+}

--- a/qa/capability/receipts/capability-receipt.structured.json_grammar.llama-3.2-3b-instruct-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.structured.json_grammar.llama-3.2-3b-instruct-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "structured.json_grammar",
+  "capability": "JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)",
+  "row": "llama-3.2-3b-instruct-q8_0",
+  "model_label": "Llama 3.2 3B Instruct Q8_0",
+  "oracle_class": "B",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "Llama-3.2-3B-Instruct-Q8_0.gguf",
+    "sha256": "f34112a11b7dad74ab517dedf6dcf00d624c9adac2dc0c72c719ca0478554ef2"
+  },
+  "harness": {
+    "repo_head": "12f202d0a2e1182f0d76ff656f632e2b9e17252e",
+    "branch": "feat/capability-conductor",
+    "working_tree": "Produced with the capability-conductor sampling + n_choices diff UNCOMMITTED on branch feat/capability-conductor (base 12f202d0). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/smoke.sh (TinyLlama/1B/3B, Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "invariant_unit + behavioral_battery",
+    "summary": "unit: 6 JsonState PDA tests (src/grammar.rs) — complete-object acceptance cross-checked vs serde_json, prefix-validity, number/string/escape edge cases, multibyte tokens spanning structure, done-only-after-top-level-close, accepts() non-mutation — plus the response_format interpreter test (json_object on, text/absent off, json_schema rejected). e2e behavioral battery on TinyLlama/1B/3B (qa/capability/json_smoke.sh, response_format json_object, temperature 0): 12/12 responses are valid JSON (every choices[0].message.content parses); the free-text control (no response_format) is unconstrained. Mechanism: per-step logit mask to tokens that keep a valid JSON-object prefix (a large finite negative logit for the rest so the sampler accepts it), EOG allowed only once the object closes, GPU greedy-fast + speculative lanes bypassed, mask applied to a clone so logprobs/diagnostics see the real distribution. Non-streaming; json_object+stream and json_schema fail closed. Caveat: a too-small max_tokens truncates mid-object (set an adequate budget; full force-close is a follow-up)."
+  }
+}

--- a/qa/capability/receipts/capability-receipt.structured.json_grammar.tinyllama-1.1b-chat-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.structured.json_grammar.tinyllama-1.1b-chat-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "structured.json_grammar",
+  "capability": "JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)",
+  "row": "tinyllama-1.1b-chat-q8_0",
+  "model_label": "TinyLlama 1.1B Chat Q8_0",
+  "oracle_class": "B",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+    "sha256": "a4c9bb1dbaa372f6381a035fa5c02ef087aaa1ff1f843a56a22328114f03fc59"
+  },
+  "harness": {
+    "repo_head": "12f202d0a2e1182f0d76ff656f632e2b9e17252e",
+    "branch": "feat/capability-conductor",
+    "working_tree": "Produced with the capability-conductor sampling + n_choices diff UNCOMMITTED on branch feat/capability-conductor (base 12f202d0). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/smoke.sh (TinyLlama/1B/3B, Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "invariant_unit + behavioral_battery",
+    "summary": "unit: 6 JsonState PDA tests (src/grammar.rs) — complete-object acceptance cross-checked vs serde_json, prefix-validity, number/string/escape edge cases, multibyte tokens spanning structure, done-only-after-top-level-close, accepts() non-mutation — plus the response_format interpreter test (json_object on, text/absent off, json_schema rejected). e2e behavioral battery on TinyLlama/1B/3B (qa/capability/json_smoke.sh, response_format json_object, temperature 0): 12/12 responses are valid JSON (every choices[0].message.content parses); the free-text control (no response_format) is unconstrained. Mechanism: per-step logit mask to tokens that keep a valid JSON-object prefix (a large finite negative logit for the rest so the sampler accepts it), EOG allowed only once the object closes, GPU greedy-fast + speculative lanes bypassed, mask applied to a clone so logprobs/diagnostics see the real distribution. Non-streaming; json_object+stream and json_schema fail closed. Caveat: a too-small max_tokens truncates mid-object (set an adequate budget; full force-close is a follow-up)."
+  }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -449,6 +449,11 @@ pub struct ChatCompletionRequest {
     /// OpenAI `parallel_tool_calls`: accepted and ignored (Camelid surfaces the
     /// tool calls the model actually emits). Declared here so it is not rejected.
     pub parallel_tool_calls: Option<bool>,
+    /// OpenAI `response_format`. Only `{"type":"json_object"}` is honored — it turns
+    /// on JSON-grammar-constrained decoding so the output is guaranteed valid JSON.
+    /// `{"type":"text"}`/absent is normal decoding; other shapes (json_schema) are
+    /// rejected. Declared here so it is not in `unsupported_fields`.
+    pub response_format: Option<serde_json::Value>,
     /// OpenAI `stream_options`. The only honored subfield is `include_usage`
     /// (bool); any other shape or subfield is tolerated silently and ignored,
     /// matching the permissive llama-server oracle. Parsed as a raw value so a
@@ -912,6 +917,10 @@ pub struct GenerationSessionRequest {
     pub unsupported_fields: HashMap<String, serde_json::Value>,
     #[serde(default, skip_deserializing)]
     default_max_tokens_cap: Option<u32>,
+    /// JSON-grammar-constrained decoding (`response_format: json_object`). Set by the
+    /// chat handler; never deserialized from the wire.
+    #[serde(default, skip_deserializing)]
+    json_object_mode: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -1264,6 +1273,9 @@ struct PreparedGeneration {
     /// When set, collect per-token logprobs each step (chosen + this many top
     /// alternatives). Forces the full-host-logits decode path (no GPU greedy-fast).
     logprobs_top_n: Option<usize>,
+    /// JSON-grammar-constrained decoding: each step is masked to tokens that keep a
+    /// valid JSON-object prefix. Forces the full-logits CPU decode path.
+    json_object_mode: bool,
     stop_sequences: Vec<String>,
     logit_diagnostic_token_ids: Vec<u32>,
     collect_dense_diagnostics: bool,
@@ -2039,6 +2051,7 @@ async fn llama_server_completion(
         tools: None,
         unsupported_fields: req.unsupported_fields,
         default_max_tokens_cap: Some(DEFAULT_PUBLIC_CHAT_MAX_TOKENS),
+        json_object_mode: false,
     };
     // Serialize generation so only one decode runs against the shared
     // CUDA-resident KV state at a time (see AppState::generation_lock).
@@ -5464,6 +5477,7 @@ async fn completions(
         tools: None,
         unsupported_fields: req.unsupported_fields,
         default_max_tokens_cap: None,
+        json_object_mode: false,
     };
     let stream = req.stream.unwrap_or(false);
     // Serialize generation so only one decode runs against the shared
@@ -5749,6 +5763,20 @@ async fn chat_completions(
     // request supplied tools and tool_choice is not "none".
     let tools_active = req.tools.as_ref().is_some_and(|t| !t.is_empty())
         && tool_choice_allows_calls(req.tool_choice.as_ref());
+    // response_format: json_object -> JSON-grammar-constrained decoding (non-streaming).
+    let json_object_mode = match json_object_mode_from_response_format(req.response_format.as_ref())
+    {
+        Ok(mode) => mode,
+        Err(response) => return *response,
+    };
+    if json_object_mode && req.stream.unwrap_or(false) {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            "response_format json_object is not supported with stream:true; request it without streaming".to_string(),
+            Some("response_format"),
+        );
+    }
     if wants_logprobs && req.stream.unwrap_or(false) {
         return api_error(
             StatusCode::BAD_REQUEST,
@@ -5804,6 +5832,7 @@ async fn chat_completions(
         tools: req.tools,
         unsupported_fields: req.unsupported_fields,
         default_max_tokens_cap: Some(DEFAULT_PUBLIC_CHAT_MAX_TOKENS),
+        json_object_mode,
     };
     let stream = req.stream.unwrap_or(false);
     // Serialize generation so only one decode runs against the shared
@@ -6164,6 +6193,7 @@ pub async fn replay_receipt_request(
         tools: None,
         unsupported_fields: HashMap::new(),
         default_max_tokens_cap: None,
+        json_object_mode: false,
     };
     let prepared = match prepare_generation(&state, session_request).await {
         Ok(prepared) => prepared,
@@ -6841,6 +6871,7 @@ async fn prepare_generation(
         session,
         sampling,
         logprobs_top_n,
+        json_object_mode: req.json_object_mode,
         stop_sequences,
         logit_diagnostic_token_ids,
         collect_dense_diagnostics,
@@ -7582,6 +7613,7 @@ async fn generate_stream_step_blocking(
                 sampler,
                 &history,
                 collect_dense_diagnostics,
+                None,
             )
             .map_err(|err| {
                 Box::new(api_error(
@@ -7938,6 +7970,34 @@ fn generate_token_ids(
     let mut top_logits = Vec::new();
     let mut step_top_logits = Vec::new();
     let mut step_logprobs: Vec<StepLogprob> = Vec::new();
+    // JSON-grammar-constrained decoding setup (response_format json_object). Cache
+    // each token's output bytes once; mask the logits to valid JSON-prefix tokens
+    // each step; stop as soon as the top-level object closes.
+    let json_grammar_active = prepared.json_object_mode;
+    let grammar_vocab = prepared.tokenizer.tokens.len();
+    let grammar_token_bytes: Vec<Vec<u8>> = if json_grammar_active {
+        (0..grammar_vocab as u32)
+            .map(|id| {
+                prepared
+                    .tokenizer
+                    .decode(&[id], false)
+                    .unwrap_or_default()
+                    .into_bytes()
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let mut grammar: Option<crate::grammar::JsonState> =
+        json_grammar_active.then(crate::grammar::JsonState::new);
+    let mut grammar_mask: Vec<bool> = vec![
+        false;
+        if json_grammar_active {
+            grammar_vocab
+        } else {
+            0
+        }
+    ];
     let collect_step_top_logits = !prepared.logit_diagnostic_token_ids.is_empty();
     let mut output_projection = Vec::new();
     let mut dense = None;
@@ -8031,6 +8091,7 @@ fn generate_token_ids(
                 && !collect_dense_for_step
                 && !collect_step_top_logits
                 && prepared.logprobs_top_n.is_none()
+                && grammar.is_none()
                 && !top_logits.is_empty()
         }) {
             let remaining = (prepared.max_tokens as usize).saturating_sub(generated.len());
@@ -8145,6 +8206,28 @@ fn generate_token_ids(
                 continue;
             }
         }
+        // JSON-grammar mask for this step: a token is allowed iff its bytes keep a
+        // valid JSON-object prefix; EOG only once the object is complete.
+        let grammar_allowed: Option<&[bool]> = match grammar.as_ref() {
+            Some(state) => {
+                let done = state.is_done();
+                for (id, slot) in grammar_mask.iter_mut().enumerate() {
+                    let bytes = grammar_token_bytes
+                        .get(id)
+                        .map(|v| v.as_slice())
+                        .unwrap_or_default();
+                    *slot = if prepared.tokenizer.special.eog.contains(&(id as u32)) {
+                        done
+                    } else if bytes.is_empty() {
+                        false
+                    } else {
+                        state.accepts(bytes)
+                    };
+                }
+                Some(grammar_mask.as_slice())
+            }
+            None => None,
+        };
         // Single-token continuations with no per-step logit consumers ride the
         // resident GPU fast lane: greedy via GPU argmax, temperature-only sampling
         // via GPU Gumbel-max. Everything else takes the general step.
@@ -8152,6 +8235,7 @@ fn generate_token_ids(
             && !collect_dense_for_step
             && !collect_step_top_logits
             && prepared.logprobs_top_n.is_none()
+            && grammar.is_none()
             && !top_logits.is_empty()
         {
             match &sampler {
@@ -8199,6 +8283,7 @@ fn generate_token_ids(
                     sampler,
                     &history,
                     collect_dense_for_step,
+                    grammar_allowed,
                 )
                 .map_err(|err| {
                     Box::new(api_error(
@@ -8291,6 +8376,19 @@ fn generate_token_ids(
         }
         generated.push(step.next_token_id);
         history.push(step.next_token_id);
+        // Advance the JSON grammar by the chosen token's bytes; stop the moment the
+        // top-level object closes (the mask guaranteed the bytes are acceptable).
+        if let Some(state) = grammar.as_mut() {
+            if let Some(bytes) = grammar_token_bytes.get(step.next_token_id as usize) {
+                for &b in bytes {
+                    let _ = state.advance(b);
+                }
+            }
+            if state.is_done() {
+                finish_reason = "stop";
+                break;
+            }
+        }
         if prepared.tokenizer.special.eog.contains(&step.next_token_id) {
             finish_reason = "stop";
             break;
@@ -8496,6 +8594,29 @@ fn build_completion_logprobs(steps: &[StepLogprob]) -> CompletionLogprobs {
         token_logprobs,
         top_logprobs,
         text_offset,
+    }
+}
+
+/// Interpret OpenAI `response_format`. `Ok(true)` = json_object mode (constrain to
+/// valid JSON), `Ok(false)` = normal decoding (text / absent), `Err` = a typed 400
+/// for shapes Camelid does not support yet (json_schema, unknown types).
+fn json_object_mode_from_response_format(
+    response_format: Option<&serde_json::Value>,
+) -> std::result::Result<bool, Box<Response>> {
+    let Some(value) = response_format.filter(|v| !v.is_null()) else {
+        return Ok(false);
+    };
+    match value.get("type").and_then(serde_json::Value::as_str) {
+        Some("json_object") => Ok(true),
+        Some("text") | None => Ok(false),
+        Some(other) => Err(Box::new(api_error(
+            StatusCode::BAD_REQUEST,
+            "unsupported_parameter",
+            format!(
+                "response_format type {other:?} is not supported yet; only json_object (and text) are honored"
+            ),
+            Some("response_format"),
+        ))),
     }
 }
 
@@ -10673,6 +10794,22 @@ mod tests {
     }
 
     #[test]
+    fn response_format_interprets_json_object_mode() {
+        use serde_json::json;
+        // json_object turns constrained decoding on; text / absent leave it off.
+        assert!(
+            json_object_mode_from_response_format(Some(&json!({"type": "json_object"}))).unwrap()
+        );
+        assert!(!json_object_mode_from_response_format(Some(&json!({"type": "text"}))).unwrap());
+        assert!(!json_object_mode_from_response_format(None).unwrap());
+        assert!(!json_object_mode_from_response_format(Some(&json!(null))).unwrap());
+        // json_schema (and other types) are a typed error, not silently ignored.
+        assert!(
+            json_object_mode_from_response_format(Some(&json!({"type": "json_schema"}))).is_err()
+        );
+    }
+
+    #[test]
     fn terminal_usage_chunk_has_empty_choices_array_and_usage() {
         // The terminal include_usage frame: empty `choices` array (not omitted),
         // the three real usage integers, no camelid diagnostics. Mirrors the
@@ -11835,6 +11972,7 @@ mod tests {
                 crate::inference::LlamaSampler::Greedy,
                 &[1, 2],
                 false,
+                None,
             )
             .unwrap();
         let prepared = prepared_for_cache("tiny", "model-a.gguf", vec![1, 2], session);
@@ -11880,6 +12018,7 @@ mod tests {
                 crate::inference::LlamaSampler::Greedy,
                 &[1, 2],
                 false,
+                None,
             )
             .unwrap();
         let prepared = prepared_for_cache("tiny", "model-a.gguf", vec![1, 2], session);
@@ -13332,6 +13471,7 @@ mod tests {
             session,
             sampling: SamplingConfig::default(),
             logprobs_top_n: None,
+            json_object_mode: false,
             stop_sequences: Vec::new(),
             logit_diagnostic_token_ids: Vec::new(),
             collect_dense_diagnostics: false,
@@ -13440,6 +13580,7 @@ mod tests {
                     LlamaSampler::Greedy,
                     &history,
                     false,
+                    None,
                 )
                 .unwrap();
             generated.push(step.next_token_id);
@@ -13472,6 +13613,7 @@ mod tests {
                 LlamaSampler::Greedy,
                 &history,
                 false,
+                None,
             )
             .unwrap();
         generated.push(first.next_token_id);

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,0 +1,503 @@
+//! Minimal JSON-object grammar for constrained decoding (`response_format:
+//! {"type":"json_object"}`). A byte-level pushdown automaton that decides, at each
+//! decode step, which token continuations keep the output a valid JSON-object
+//! prefix — so the model can only emit well-formed JSON. Pure and heavily tested;
+//! this is the high-value core of the structured-output lane. Arbitrary GBNF and
+//! full JSON Schema are deliberate follow-ups.
+
+/// The container we are currently inside.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Frame {
+    Object,
+    Array,
+}
+
+/// Sub-state while scanning a JSON number. The "complete" sub-states (a number may
+/// validly end here) are `Zero`, `Int`, `Frac`, `Exp`; the rest require more input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Num {
+    Sign,     // saw '-', need first digit
+    Zero,     // saw leading '0' (complete)
+    Int,      // saw 1-9 then digits (complete)
+    DotFirst, // saw '.', need first fraction digit
+    Frac,     // fraction digits (complete)
+    ExpSign,  // saw e/E, may take +/- or a digit
+    ExpFirst, // saw e/E and a sign, need first exponent digit
+    Exp,      // exponent digits (complete)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Mode {
+    Start,                                    // top level: whitespace then '{'
+    Value,                                    // a value is required (after ':')
+    Str { escape: bool, hex: u8, key: bool }, // inside a "string"
+    Num(Num),                                 // inside a number
+    Lit { rest: &'static [u8] },              // matching true / false / null
+    Key { allow_close: bool },                // object: a key string (or '}')
+    Colon,                                    // object: ':'
+    ArrVal { allow_close: bool },             // array: a value (or ']')
+    AfterValue,                               // ',' or the container's close
+    Done,                                     // top-level object complete
+}
+
+/// Incremental JSON-object validator. `advance` consumes one byte and returns an
+/// error if that byte cannot extend a valid JSON object. `is_done` is true once the
+/// top-level object has fully closed.
+#[derive(Clone, Debug)]
+pub struct JsonState {
+    stack: Vec<Frame>,
+    mode: Mode,
+}
+
+impl Default for JsonState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn is_ws(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+fn is_digit(b: u8) -> bool {
+    b.is_ascii_digit()
+}
+
+fn is_hex(b: u8) -> bool {
+    b.is_ascii_hexdigit()
+}
+
+/// A byte that can terminate a number (whitespace or a structural close/separator).
+fn is_num_delim(b: u8) -> bool {
+    is_ws(b) || matches!(b, b',' | b'}' | b']')
+}
+
+impl JsonState {
+    pub fn new() -> Self {
+        Self {
+            stack: Vec::new(),
+            mode: Mode::Start,
+        }
+    }
+
+    /// True when a complete top-level JSON object has been emitted (the model may
+    /// stop). The decode loop stops as soon as this becomes true.
+    pub fn is_done(&self) -> bool {
+        self.mode == Mode::Done
+    }
+
+    /// Would `bytes` keep the output a valid JSON-object prefix from the current
+    /// state? Used to mask a candidate token without mutating the live state.
+    pub fn accepts(&self, bytes: &[u8]) -> bool {
+        let mut probe = self.clone();
+        for &b in bytes {
+            if probe.advance(b).is_err() {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Begin a value on `b` (used after ':' and after array '[' / ','). Strings
+    /// started here are values (not keys).
+    fn start_value(&mut self, b: u8) -> Result<(), ()> {
+        self.mode = match b {
+            b'{' => {
+                self.stack.push(Frame::Object);
+                Mode::Key { allow_close: true }
+            }
+            b'[' => {
+                self.stack.push(Frame::Array);
+                Mode::ArrVal { allow_close: true }
+            }
+            b'"' => Mode::Str {
+                escape: false,
+                hex: 0,
+                key: false,
+            },
+            b'-' => Mode::Num(Num::Sign),
+            b'0' => Mode::Num(Num::Zero),
+            b'1'..=b'9' => Mode::Num(Num::Int),
+            b't' => Mode::Lit { rest: b"rue" },
+            b'f' => Mode::Lit { rest: b"alse" },
+            b'n' => Mode::Lit { rest: b"ull" },
+            _ => return Err(()),
+        };
+        Ok(())
+    }
+
+    /// A container (or the top-level object) just closed, completing a value.
+    fn after_close(&mut self) {
+        self.mode = if self.stack.is_empty() {
+            Mode::Done
+        } else {
+            Mode::AfterValue
+        };
+    }
+
+    /// Consume one byte; `Err(())` means the byte cannot extend a valid JSON object.
+    /// The error is intentionally information-free — a rejected byte is a rejected
+    /// byte; the caller only needs the yes/no.
+    #[allow(clippy::result_unit_err)]
+    pub fn advance(&mut self, b: u8) -> Result<(), ()> {
+        match self.mode {
+            Mode::Start => {
+                if is_ws(b) {
+                    Ok(())
+                } else if b == b'{' {
+                    self.stack.push(Frame::Object);
+                    self.mode = Mode::Key { allow_close: true };
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+            Mode::Value => {
+                if is_ws(b) {
+                    Ok(())
+                } else {
+                    self.start_value(b)
+                }
+            }
+            Mode::ArrVal { allow_close } => {
+                if is_ws(b) {
+                    Ok(())
+                } else if allow_close && b == b']' {
+                    self.stack.pop();
+                    self.after_close();
+                    Ok(())
+                } else {
+                    self.start_value(b)
+                }
+            }
+            Mode::Key { allow_close } => {
+                if is_ws(b) {
+                    Ok(())
+                } else if allow_close && b == b'}' {
+                    self.stack.pop();
+                    self.after_close();
+                    Ok(())
+                } else if b == b'"' {
+                    self.mode = Mode::Str {
+                        escape: false,
+                        hex: 0,
+                        key: true,
+                    };
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+            Mode::Colon => {
+                if is_ws(b) {
+                    Ok(())
+                } else if b == b':' {
+                    self.mode = Mode::Value;
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+            Mode::Str { escape, hex, key } => {
+                if hex > 0 {
+                    if is_hex(b) {
+                        self.mode = Mode::Str {
+                            escape: false,
+                            hex: hex - 1,
+                            key,
+                        };
+                        Ok(())
+                    } else {
+                        Err(())
+                    }
+                } else if escape {
+                    match b {
+                        b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' => {
+                            self.mode = Mode::Str {
+                                escape: false,
+                                hex: 0,
+                                key,
+                            };
+                            Ok(())
+                        }
+                        b'u' => {
+                            self.mode = Mode::Str {
+                                escape: false,
+                                hex: 4,
+                                key,
+                            };
+                            Ok(())
+                        }
+                        _ => Err(()),
+                    }
+                } else {
+                    match b {
+                        b'"' => {
+                            self.mode = if key { Mode::Colon } else { Mode::AfterValue };
+                            Ok(())
+                        }
+                        b'\\' => {
+                            self.mode = Mode::Str {
+                                escape: true,
+                                hex: 0,
+                                key,
+                            };
+                            Ok(())
+                        }
+                        // Raw control characters are not allowed in a JSON string.
+                        0x00..=0x1F => Err(()),
+                        _ => Ok(()),
+                    }
+                }
+            }
+            Mode::Lit { rest } => match rest.split_first() {
+                Some((&first, tail)) if first == b => {
+                    if tail.is_empty() {
+                        self.mode = Mode::AfterValue;
+                    } else {
+                        self.mode = Mode::Lit { rest: tail };
+                    }
+                    Ok(())
+                }
+                _ => Err(()),
+            },
+            Mode::Num(num) => self.advance_num(num, b),
+            Mode::AfterValue => {
+                if is_ws(b) {
+                    return Ok(());
+                }
+                match self.stack.last().copied() {
+                    Some(Frame::Object) => match b {
+                        b',' => {
+                            self.mode = Mode::Key { allow_close: false };
+                            Ok(())
+                        }
+                        b'}' => {
+                            self.stack.pop();
+                            self.after_close();
+                            Ok(())
+                        }
+                        _ => Err(()),
+                    },
+                    Some(Frame::Array) => match b {
+                        b',' => {
+                            self.mode = Mode::ArrVal { allow_close: false };
+                            Ok(())
+                        }
+                        b']' => {
+                            self.stack.pop();
+                            self.after_close();
+                            Ok(())
+                        }
+                        _ => Err(()),
+                    },
+                    None => Err(()),
+                }
+            }
+            Mode::Done => {
+                // After the top-level object, only trailing whitespace is valid.
+                if is_ws(b) {
+                    Ok(())
+                } else {
+                    Err(())
+                }
+            }
+        }
+    }
+
+    fn advance_num(&mut self, num: Num, b: u8) -> Result<(), ()> {
+        // Complete sub-states end the number on a delimiter, which is then
+        // re-processed in `AfterValue`.
+        let complete = matches!(num, Num::Zero | Num::Int | Num::Frac | Num::Exp);
+        if complete && is_num_delim(b) {
+            self.mode = Mode::AfterValue;
+            return self.advance(b);
+        }
+        let next = match num {
+            Num::Sign => match b {
+                b'0' => Num::Zero,
+                b'1'..=b'9' => Num::Int,
+                _ => return Err(()),
+            },
+            Num::Zero => match b {
+                b'.' => Num::DotFirst,
+                b'e' | b'E' => Num::ExpSign,
+                _ => return Err(()), // no leading-zero digits, e.g. "01"
+            },
+            Num::Int => match b {
+                _ if is_digit(b) => Num::Int,
+                b'.' => Num::DotFirst,
+                b'e' | b'E' => Num::ExpSign,
+                _ => return Err(()),
+            },
+            Num::DotFirst => {
+                if is_digit(b) {
+                    Num::Frac
+                } else {
+                    return Err(());
+                }
+            }
+            Num::Frac => match b {
+                _ if is_digit(b) => Num::Frac,
+                b'e' | b'E' => Num::ExpSign,
+                _ => return Err(()),
+            },
+            Num::ExpSign => match b {
+                b'+' | b'-' => Num::ExpFirst,
+                _ if is_digit(b) => Num::Exp,
+                _ => return Err(()),
+            },
+            Num::ExpFirst => {
+                if is_digit(b) {
+                    Num::Exp
+                } else {
+                    return Err(());
+                }
+            }
+            Num::Exp => {
+                if is_digit(b) {
+                    Num::Exp
+                } else {
+                    return Err(());
+                }
+            }
+        };
+        self.mode = Mode::Num(next);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feed a full string; returns the final state if every byte was accepted.
+    fn feed(s: &str) -> Result<JsonState, ()> {
+        let mut st = JsonState::new();
+        for &b in s.as_bytes() {
+            st.advance(b)?;
+        }
+        Ok(st)
+    }
+
+    fn valid_complete(s: &str) -> bool {
+        feed(s).map(|st| st.is_done()).unwrap_or(false)
+    }
+
+    fn valid_prefix(s: &str) -> bool {
+        feed(s).is_ok()
+    }
+
+    #[test]
+    fn accepts_complete_objects() {
+        for s in [
+            r#"{}"#,
+            r#"{"a":1}"#,
+            r#"{ "a" : 1 , "b" : 2 }"#,
+            r#"{"a":[1,2,3]}"#,
+            r#"{"a":{"b":{"c":[]}}}"#,
+            r#"{"s":"hi \"there\"\né"}"#,
+            r#"{"n":-12.5e+10,"z":0,"f":false,"t":true,"x":null}"#,
+            "{\n  \"k\": 1\n}\n",
+        ] {
+            assert!(valid_complete(s), "should be complete valid: {s}");
+            // serde agrees it is real JSON.
+            assert!(serde_json::from_str::<serde_json::Value>(s.trim()).is_ok());
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_bytes() {
+        // Each must be rejected at some byte (never a valid prefix all the way).
+        for s in [
+            "[1]",         // top level must be an object
+            "{,}",         // expected key
+            "{\"a\":}",    // value required
+            "{\"a\":1,}",  // trailing comma -> needs a key
+            "{\"a\" 1}",   // missing colon
+            "{\"a\":01}",  // leading zero
+            "{\"a\":1.}",  // dangling fraction is not complete... but as a prefix it's ok
+            "{\"a\":tru}", // bad literal
+            "{'a':1}",     // single quotes
+        ] {
+            // `1.}` is a valid *prefix* until the `}`; assert it is not *complete*.
+            assert!(!valid_complete(s), "should not be complete valid JSON: {s}");
+        }
+        assert!(!valid_prefix("[1]"));
+        assert!(!valid_prefix("{,}"));
+        assert!(!valid_prefix("{\"a\" 1}"));
+        assert!(!valid_prefix("{\"a\":01}"));
+        assert!(!valid_prefix("{'a':1}"));
+    }
+
+    #[test]
+    fn tracks_prefix_validity() {
+        // Genuine prefixes of a valid object are accepted but not complete.
+        for p in [
+            "",
+            "{",
+            "{\"",
+            "{\"a",
+            "{\"a\"",
+            "{\"a\":",
+            "{\"a\":1",
+            "{\"a\":1,",
+            "{\"a\":-",
+            "{\"a\":1.",
+            "{\"a\":1e",
+            "{\"a\":[",
+            "{\"a\":[1,",
+            "{\"a\":tru",
+        ] {
+            assert!(valid_prefix(p), "should be a valid prefix: {p:?}");
+            assert!(!valid_complete(p), "prefix should not be complete: {p:?}");
+        }
+    }
+
+    #[test]
+    fn accepts_masks_continuations_without_mutation() {
+        let mut st = JsonState::new();
+        for &b in br#"{"a":"# {
+            st.advance(b).unwrap();
+        }
+        // A value is required next: these start valid values; `}`/`,` do not.
+        assert!(st.accepts(b"1"));
+        assert!(st.accepts(b"\"x\""));
+        assert!(st.accepts(b"{"));
+        assert!(st.accepts(b"true"));
+        assert!(!st.accepts(b"}"));
+        assert!(!st.accepts(b","));
+        // accepts() must not have mutated the live state.
+        assert!(!st.is_done());
+        st.advance(b'1').unwrap();
+        // After the value: ',' or '}' continue/close; another digit does not start.
+        assert!(st.accepts(b","));
+        assert!(st.accepts(b"}"));
+        assert!(!st.accepts(b"x"));
+    }
+
+    #[test]
+    fn done_only_after_top_level_close() {
+        let mut st = JsonState::new();
+        for &b in br#"{"a":1}"# {
+            st.advance(b).unwrap();
+        }
+        assert!(st.is_done());
+        // Trailing whitespace stays done; anything else is rejected.
+        assert!(st.accepts(b"  \n"));
+        assert!(!st.accepts(b"{"));
+        assert!(!st.accepts(b"1"));
+    }
+
+    #[test]
+    fn multibyte_tokens_validated_whole() {
+        // A token whose bytes span structure ("}," or "1}") must validate as a unit.
+        let mut st = JsonState::new();
+        for &b in br#"{"a":[1"# {
+            st.advance(b).unwrap();
+        }
+        assert!(st.accepts(b"]}")); // close array then object
+        assert!(st.accepts(b",2")); // continue the array
+        assert!(!st.accepts(b"}")); // can't close the object while inside the array
+    }
+}

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -3844,15 +3844,26 @@ impl LlamaInferenceSession {
         sampler: LlamaSampler,
         token_history: &[u32],
     ) -> Result<LlamaGenerationStep> {
-        self.generate_next_token_with_history_diagnostics(token_ids, sampler, token_history, true)
+        self.generate_next_token_with_history_diagnostics(
+            token_ids,
+            sampler,
+            token_history,
+            true,
+            None,
+        )
     }
 
+    /// `allowed_tokens`, when set, is a vocab-sized mask applied to the logits
+    /// before sampling (disallowed tokens forced to `-inf`) — grammar-constrained
+    /// decoding. The unmasked logits are still returned in the step (so logprobs /
+    /// diagnostics see the real distribution).
     pub fn generate_next_token_with_history_diagnostics(
         &mut self,
         token_ids: &[u32],
         sampler: LlamaSampler,
         token_history: &[u32],
         collect_diagnostics: bool,
+        allowed_tokens: Option<&[bool]>,
     ) -> Result<LlamaGenerationStep> {
         if token_ids.is_empty() {
             return Err(BackendError::RuntimeShapeMismatch(
@@ -3960,7 +3971,14 @@ impl LlamaInferenceSession {
         let hidden_state = output.hidden_state;
         let output_norm_state = output.output_norm_state;
         let sample_started = Instant::now();
-        let next_token_id = sampler.sample_with_history(&logits, token_history)?;
+        let next_token_id = match allowed_tokens {
+            Some(allowed) => {
+                let mut masked = logits.clone();
+                apply_token_mask(&mut masked, allowed)?;
+                sampler.sample_with_history(&masked, token_history)?
+            }
+            None => sampler.sample_with_history(&logits, token_history)?,
+        };
         let sample = sample_started.elapsed().as_micros();
         if telemetry::active() {
             // Candidate probabilities are computed from the real logits of
@@ -5208,6 +5226,37 @@ fn greedy_sample_rows(logits: &CpuTensor) -> Result<Vec<u32>> {
         out.push(token_index_to_u32(best_idx)?);
     }
     Ok(out)
+}
+
+/// Force every disallowed token's logit to `-inf` (grammar-constrained decoding).
+/// Errors if the mask length does not match the vocab or masks every token.
+fn apply_token_mask(logits: &mut CpuTensor, allowed: &[bool]) -> Result<()> {
+    if allowed.len() != logits.data.len() {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "grammar mask length {} does not match vocabulary size {}",
+            allowed.len(),
+            logits.data.len()
+        )));
+    }
+    // A large *finite* negative value, not -inf: the sampler rejects non-finite
+    // logits, and this is still far below any real logit (~[-50, 50]) so greedy
+    // argmax and softmax both exclude it, while staying finite through the
+    // temperature division.
+    const MASK_LOGIT: f32 = -1e30;
+    let mut any_allowed = false;
+    for (logit, &ok) in logits.data.iter_mut().zip(allowed.iter()) {
+        if ok {
+            any_allowed = true;
+        } else {
+            *logit = MASK_LOGIT;
+        }
+    }
+    if !any_allowed {
+        return Err(BackendError::RuntimeShapeMismatch(
+            "grammar constraint masked every token".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn sample_with_config(

--- a/src/inference/speculative.rs
+++ b/src/inference/speculative.rs
@@ -248,6 +248,7 @@ impl ModelDrafter {
                                     LlamaSampler::Greedy,
                                     history,
                                     false,
+                                    None,
                                 )?
                                 .next_token_id
                         }
@@ -263,6 +264,7 @@ impl ModelDrafter {
                         LlamaSampler::Greedy,
                         history,
                         false,
+                        None,
                     )?
                     .next_token_id
             }
@@ -287,6 +289,7 @@ impl ModelDrafter {
                             LlamaSampler::Greedy,
                             history,
                             false,
+                            None,
                         )?
                         .next_token_id
                 }

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -9500,7 +9500,7 @@ fn single_token_forward_diagnostics_follow_llama_stage_order() {
     let mut session = LlamaInferenceSession::new(config, weights).unwrap();
 
     let step = session
-        .generate_next_token_with_history_diagnostics(&[0], LlamaSampler::Greedy, &[0], true)
+        .generate_next_token_with_history_diagnostics(&[0], LlamaSampler::Greedy, &[0], true, None)
         .unwrap();
 
     assert_eq!(step.prompt_token_count, 1);
@@ -9761,14 +9761,26 @@ fn chunked_prefill_matches_sequential_prefill_outputs_and_cache() {
     std::env::set_var("CAMELID_PREFILL_CHUNK_TOKENS", "1");
     let mut sequential = LlamaInferenceSession::new(config.clone(), weights.clone()).unwrap();
     let sequential_step = sequential
-        .generate_next_token_with_history_diagnostics(&prompt, LlamaSampler::Greedy, &prompt, false)
+        .generate_next_token_with_history_diagnostics(
+            &prompt,
+            LlamaSampler::Greedy,
+            &prompt,
+            false,
+            None,
+        )
         .unwrap();
 
     std::env::set_var("CAMELID_PREFILL_CHUNK_TOKENS", "2");
     std::env::set_var("CAMELID_FORWARD_RSS_TIMINGS", "1");
     let mut chunked = LlamaInferenceSession::new(config.clone(), weights.clone()).unwrap();
     let chunked_step = chunked
-        .generate_next_token_with_history_diagnostics(&prompt, LlamaSampler::Greedy, &prompt, false)
+        .generate_next_token_with_history_diagnostics(
+            &prompt,
+            LlamaSampler::Greedy,
+            &prompt,
+            false,
+            None,
+        )
         .unwrap();
 
     let prefill_memory = chunked_step
@@ -9812,7 +9824,13 @@ fn chunked_prefill_matches_sequential_prefill_outputs_and_cache() {
     std::env::set_var("CAMELID_PREFILL_LAYER_MAJOR_ATTRIBUTION", "1");
     let mut layer_major = LlamaInferenceSession::new(config, weights).unwrap();
     let layer_major_step = layer_major
-        .generate_next_token_with_history_diagnostics(&prompt, LlamaSampler::Greedy, &prompt, false)
+        .generate_next_token_with_history_diagnostics(
+            &prompt,
+            LlamaSampler::Greedy,
+            &prompt,
+            false,
+            None,
+        )
         .unwrap();
     let layer_major_memory = layer_major_step
         .prefill_timings
@@ -10201,6 +10219,7 @@ fn zero_prefill_chunk_env_falls_back_without_panicking() {
             LlamaSampler::Greedy,
             &[0, 1, 2],
             false,
+            None,
         )
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod gemma4_distributed;
 pub mod gemma4_runtime;
 pub mod gguf;
 pub mod ghost;
+pub mod grammar;
 pub mod hf_browse;
 pub mod inference;
 pub mod metal;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2507,6 +2507,7 @@ fn generate_run(
         sampler.clone(),
         &history,
         false,
+        None,
     )?;
     let ttft_ms = ttft_start.elapsed().as_secs_f64() * 1000.0;
     let prefill_ms = step.prefill_timings.total as f64 / 1000.0; // microseconds -> ms
@@ -2599,6 +2600,7 @@ fn generate_run(
                         sampler.clone(),
                         &history,
                         false,
+                        None,
                     )?;
                     if time_decode {
                         wall_us += step_started.elapsed().as_micros();
@@ -2639,6 +2641,7 @@ fn generate_run(
                         sampler.clone(),
                         &history,
                         false,
+                        None,
                     )?;
                     if time_decode {
                         wall_us += step_started.elapsed().as_micros();
@@ -2939,6 +2942,7 @@ fn generate_run_speculative(
         LlamaSampler::Greedy,
         &history,
         false,
+        None,
     )?;
     let ttft_ms = ttft_start.elapsed().as_secs_f64() * 1000.0;
     let first = step.next_token_id;
@@ -3103,6 +3107,7 @@ fn generate_run_speculative(
                                 LlamaSampler::Greedy,
                                 &history,
                                 false,
+                                None,
                             )?
                             .next_token_id
                     }
@@ -3192,6 +3197,7 @@ fn generate_run_speculative(
                             LlamaSampler::Greedy,
                             &history,
                             false,
+                            None,
                         )?
                         .next_token_id
                 }
@@ -3229,6 +3235,7 @@ fn generate_run_speculative(
                             LlamaSampler::Greedy,
                             &history,
                             false,
+                            None,
                         )?
                         .next_token_id
                 }

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -1629,7 +1629,9 @@ async fn chat_completion_accepts_tools_but_rejects_other_tool_fields() {
 }
 
 #[tokio::test]
-async fn chat_completion_rejects_response_format_before_runtime() {
+async fn chat_completion_rejects_unsupported_response_format_before_runtime() {
+    // response_format json_object is now supported (JSON-grammar-constrained
+    // decoding); json_schema and other types are still rejected before runtime.
     let app = camelid::api::router();
     let response = app
         .oneshot(
@@ -1638,7 +1640,7 @@ async fn chat_completion_rejects_response_format_before_runtime() {
                 .uri("/v1/chat/completions")
                 .header("content-type", "application/json")
                 .body(Body::from(
-                    r#"{"model":"tiny","messages":[{"role":"user","content":"hello"}],"max_tokens":1,"response_format":{"type":"json_object"}}"#,
+                    r#"{"model":"tiny","messages":[{"role":"user","content":"hello"}],"max_tokens":1,"response_format":{"type":"json_schema"}}"#,
                 ))
                 .unwrap(),
         )


### PR DESCRIPTION
Capability-conductor **structured output** lane (class B) — the last greenfield `open` lane. `response_format: {"type":"json_object"}` guarantees valid JSON output via grammar-constrained decoding. Moves `structured.json_grammar` to **`done`** on the 3 on-disk rows.

## What
- **`src/grammar.rs`** — a pure, byte-level JSON-object **pushdown automaton** (`JsonState`) that decides, per byte, whether a continuation keeps a valid JSON-object prefix, and when the top-level object is complete. Heavily unit-tested and cross-checked against `serde_json` (completion, prefix-validity, numbers/strings/escapes, multibyte tokens that span structure).
- **Decode loop:** when json_object mode is on, cache each token's output bytes once, **mask the logits each step** to tokens that keep a valid JSON prefix (EOG only once the object closes), and stop the moment it closes. The mask is a large *finite* negative logit (the sampler rejects `-inf`), applied to a clone so logprobs/diagnostics still see the real distribution. GPU greedy-fast + speculative lanes are bypassed when constrained.
- **API:** `generate_next_token_with_history_diagnostics` takes an optional token mask (`apply_token_mask`). `response_format` typed on the chat request; `json_object` honored, `text`/absent off, `json_schema`/other and `json_object + stream` fail closed.

## Validation
- **Unit:** 6 JSON-PDA tests + a response_format-interpreter test + an updated integration test.
- **e2e behavioral battery** on TinyLlama/1B/3B (`qa/capability/json_smoke.sh`, temperature 0): **12/12 responses are valid JSON**; the free-text control (no response_format) is unconstrained.
- *Caveat (honest):* a too-small `max_tokens` truncates mid-object — set an adequate budget; full force-close is a follow-up, as are `json_schema` / arbitrary GBNF.

## Artifacts
- `CAPABILITY_MATRIX.md` json_grammar row → `done done done open` (tally done 23 → 26); 3 new `capability-receipt/v1`. **All greenfield open lanes are now done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)