### PR TITLE
capability: finish 3 wip lanes (system_multiturn + context/rope) on the on-disk rows

### DIFF
--- a/CAPABILITY_MATRIX.md
+++ b/CAPABILITY_MATRIX.md
@@ -13,7 +13,9 @@ Per-cell vocabulary (conductor §5):
 
 **Phase 0 status:** 3 / 4 rows discovered + hash-anchored (TinyLlama, Llama 3.2 1B, Llama 3.2 3B). **Llama 3 8B Q8_0 is not downloaded** — its column (`*`) is PROVISIONAL (spec-derived, not GGUF-anchored, Phase 0 INCOMPLETE).
 
-**Cell tally** (4 model columns × 13 capabilities = 52 cells): `n/a` 4 · `open` 11 · `wip` 11 · `done` 26. The `done` cells are each backed by a `camelid.capability-receipt/v1` under `qa/capability/receipts/`, validated this pass on the **3 on-disk rows** (TinyLlama, Llama 3.2 1B, Llama 3.2 3B) — no cross-row inheritance (conductor §6). The 8B column stays provisional until its GGUF is downloaded.
+**Cell tally** (4 model columns × 13 capabilities = 52 cells): `n/a` 4 · `open` 11 · `wip` 5 · `done` 32. The `done` cells are each backed by a `camelid.capability-receipt/v1` under `qa/capability/receipts/`, validated on the **3 on-disk rows** (TinyLlama, Llama 3.2 1B, Llama 3.2 3B) — no cross-row inheritance (conductor §6). The 8B column stays provisional until its GGUF is downloaded.
+
+Two `wip` cells are **host-limited, not model-limited**: `context.full_length` on Llama 3.2 1B and 3B is validated bit-exact across a long context (feasible frontier 8511 / 8304 tokens), but their trained **131072** context materializes an **8.0 GiB / 28 GiB** f32 CPU KV cache that this 15.74 GiB box cannot safely hold — so those cells stay `wip` (the model supports it; this host cannot reach it). See `qa/validation-notes/2026-06-25-capability-context-host-limits.md`, which also flags that Camelid has no pre-flight KV predict-and-abort. The remaining `wip` is `load.quant_breadth` ×3 (secondary axis).
 
 ## Matrix
 
@@ -25,11 +27,11 @@ Per-cell vocabulary (conductor §5):
 | `sampling.full_set` | I | done | done | done | open | partial |
 | `sampling.seed_determinism` | I | done | done | done | open | drives |
 | `logprobs.top_logprobs` | D | done | done | done | open | drives |
-| `chat.system_multiturn` | D | wip | wip | wip | open | drives |
+| `chat.system_multiturn` | D | done | done | done | open | drives |
 | `tools.function_calling` | B | n/a | done | done | n/a | drives |
 | `structured.json_grammar` | B | done | done | done | open | drives |
-| `context.full_length` | D | wip | wip | wip | open | drives |
-| `context.rope_scaling` | D | n/a | wip | wip | n/a | drives |
+| `context.full_length` | D | done | wip | wip | open | drives |
+| `context.rope_scaling` | D | n/a | done | done | n/a | drives |
 | `observ.usage_timing` | C | done | done | done | open | drives |
 | `load.quant_breadth` | D | wip | wip | wip | open | partial |
 
@@ -50,15 +52,15 @@ Per-cell vocabulary (conductor §5):
 - **`logprobs.top_logprobs`** — logprobs/top_logprobs at temp=0 (any causal LM)
   - DONE (class D, 3 on-disk rows): per-step log_softmax capture in the decode loop (greedy-fast bypassed) -> chat logprobs.content[] + completions logprobs.{tokens,token_logprobs,top_logprobs,text_offset}. Greedy invariant + shapes validated e2e; token IDs bit-exact vs llama.cpp acd79d6 (values within the ~5e-2 f32 envelope). Non-streaming single-choice. Receipt minted.
 - **`chat.system_multiturn`** — system role + multi-turn template fidelity (per THIS template)
-  - wip — per-arch renderers drive system + multi-turn (api/mod.rs:8789+); not exercised by this pass's smoke (single user turn). Needs a system+multi-turn e2e to earn its receipt.
+  - DONE (class D, 3 on-disk rows): a system + 2-user-turn + 1-assistant-turn conversation, greedy. GENERATION PARITY bit-exact vs llama.cpp acd79d6 on all 3 rows (prompt-pinned `verify-receipt`, first_divergent_token_index=-1). TEMPLATE FIDELITY: TinyLlama byte+token-identical to llama.cpp; Llama 3.2 1B/3B differ ONLY by the live-date "Cutting Knowledge Date / Today Date" system preamble llama.cpp injects — a non-deterministic, intended cross-engine difference (src/receipt/verify.rs:662), so parity is asserted on the pinned prompt. Harness qa/capability/system_multiturn_parity.mjs. Receipts minted.
 - **`tools.function_calling`** — native tool/function calling — REQUIRES tool-call branch or tool/ipython control tokens in THIS model template
   - DONE (class B, Llama 3.2 1B/3B): input renders tools via the model template; output now parses the Llama 3.x {name,parameters} tool-call into OpenAI tool_calls (parse_tool_calls), finish_reason=tool_calls, content emptied. tool_choice:none suppresses. Battery 6/6 structurally valid. TinyLlama/8B n/a (no tool branch).
 - **`structured.json_grammar`** — JSON mode + GBNF grammar-constrained decode (decoder-side, model-agnostic)
   - DONE (class B, 3 on-disk rows): response_format json_object -> JSON-grammar-constrained decoding (src/grammar.rs PDA + per-step logit mask in the decode loop). Battery 12/12 valid JSON. Non-streaming; json_schema/GBNF + force-close-at-max_tokens are follow-ups.
 - **`context.full_length`** — full TRAINED context length, exact value from metadata
-  - wip — honored from GGUF metadata as KV cap (model.rs:141, inference.rs:2086). Trained length differs per row: TL 2048 / 1B 131072 / 3B 131072 / 8B 8192*. Needs near-limit validation (memory predict-and-abort).
-- **`context.rope_scaling`** — RoPE scaling/extension — REQUIRES a rope scaling type/factor declared in metadata
-  - Engine implements None/Linear/Llama3/YaRN (rope.rs:296-518). TinyLlama & 8B: no scaling (n/a). Llama 3.2 1B/3B: llama3 scaling baked into rope_freqs.weight (no metadata key) reaching 131072 → capable/wip; validate parity at extended positions vs llama.cpp.
+  - DONE for TinyLlama (class D): validated bit-exact at 1953 tok = 95% of the full trained 2048; KV ~88 MiB, fully reachable; receipt minted. 1B/3B: **HOST-LIMITED, stays `wip`** — validated bit-exact at the feasible frontier (8511 / 8304 tok) but the trained 131072 needs 8.0 GiB / 28 GiB f32 CPU KV, unreachable with safe headroom on this 15.74 GiB box (NOT a model limit). Cap honored from GGUF metadata (model.rs:141, kv_cache.rs:23). Camelid has **no pre-flight KV predict-and-abort** (would OOM mid-gen at kv_cache.rs:135-136) — flagged as a follow-up. Harness qa/capability/context_parity.mjs (projects KV + aborts before an unsafe ctx). See qa/validation-notes/2026-06-25-capability-context-host-limits.md.
+- **`context.rope_scaling`** — RoPE scaling/extension (llama3 baked rope_freqs) at positions beyond the original context
+  - DONE (class D, Llama 3.2 1B/3B): bit-exact parity vs llama.cpp acd79d6 at positions BEYOND the original 8192 context (1B 8511 tok, full self+reference verify; 3B 8304 tok, reference-only) — the llama3-scaled regime. CORRECTION to the manifest synthesis_correction: scaling is baked into the rope_freqs.weight tensor (no rope.scaling.* metadata key); both engines read it identically — Camelid via rope.rs:499-500 under the `RopeScalingKind::None` arm, NOT the dormant metadata-llama3 branch at rope.rs:507. TinyLlama & 8B: no scaling (n/a). Receipts minted.
 - **`observ.usage_timing`** — prompt/completion/total token accounting + optional timing fields
   - DONE (class C, 3 on-disk rows): prompt/completion/total usage present + arithmetically correct e2e. Receipt minted. (ttft timing still not populated — not claimed.)
 - **`load.quant_breadth`** — (SECONDARY) loadability across additional quants beyond Q8_0
@@ -67,27 +69,30 @@ Per-cell vocabulary (conductor §5):
 ## Notable Phase 0 findings
 
 - **`tools.function_calling` splits by row, exactly as the conductor demands.** TinyLlama → `n/a` (template has only user/system/assistant branches, no tool/ipython tokens). Llama 3.2 1B & 3B → **capable** (their embedded templates carry the Llama-3.1-style tool-call branch + `Environment: ipython`). Original Llama 3 8B → `n/a`/provisional (pre-3.1 template, no tool tokens — must be re-confirmed against the real GGUF, since a mislabeled 3.1 file would flip it).
-- **`context.rope_scaling` splits 2 / 2 after a synthesis correction.** TinyLlama (native 2048) and original Llama 3 8B (native 8192) declare no scaling → `n/a`. The Llama 3.2 1B & 3B reach 131072 via **llama3 rope scaling baked into a `rope_freqs.weight` tensor** (no `rope.scaling.*` *metadata* key, but the transform is real and Camelid applies the llama3 path, `rope.rs:507`) → reclassified **capable / class D / `wip`**. The over-strict "metadata-key-required" Phase 0 prompt had marked these `n/a`; that was an underclaim (conductor §0/§4.6) and is corrected here. Their validation overlaps `context.full_length` at the 131072 frontier — parity at extended positions vs llama.cpp.
+- **`context.rope_scaling` splits 2 / 2 after a synthesis correction.** TinyLlama (native 2048) and original Llama 3 8B (native 8192) declare no scaling → `n/a`. The Llama 3.2 1B & 3B reach 131072 via **llama3 rope scaling baked into a `rope_freqs.weight` tensor** (no `rope.scaling.*` *metadata* key, but the transform is real). Camelid reads that tensor at `rope.rs:499-500` under the `RopeScalingKind::None` arm — NOT the metadata-llama3 branch at `rope.rs:507`, which is dormant for these GGUFs (an earlier note misnamed this path). Reclassified **capable / class D**, and **now `done`** — validated bit-exact at positions > 8192 (1B 8511 tok, 3B 8304 tok) vs llama.cpp. The over-strict "metadata-key-required" Phase 0 prompt had marked these `n/a`; that was an underclaim (conductor §0/§4.6), corrected here.
 - **`context.full_length` differs sharply per row** — 2048 / 131072 / 131072 / 8192 — and must never be cross-claimed. Memory/abort projection (conductor §9) governs the 131072 rows before any near-limit validation.
 - **6 capabilities are now `done` on the 3 on-disk rows**, each with a `camelid.capability-receipt/v1`: the **sampling lane** (`sampling.full_set` — `min_p`+`repeat_penalty` added; `sampling.seed_determinism` — degenerate per-seed RNG fixed to a per-step SplitMix64 stream, **a real correctness bug**), **`gen.n_choices`** (n>1 independent reproducibly-seeded choices, converted from a 400 stub), and the contract caps `gen.stream_usage`, `gen.length_stop`, `observ.usage_timing`.
 - **`tools.function_calling` splits by row, exactly as the conductor demands.** TinyLlama → `n/a` (no tool branch). Llama 3.2 1B & 3B → **`done`** (class B): Camelid renders tools via the model template on input and parses the Llama 3.x tool-call output back into structured `tool_calls` (battery 6/6 valid; `tool_choice:"none"` suppresses). Original Llama 3 8B → `n/a`/provisional.
 - **Every greenfield `open` lane is now `done`.** The last one, `structured.json_grammar` (JSON-mode constrained decode), is `done` on the 3 on-disk rows (class B — battery 12/12 valid JSON via a byte-level JSON PDA + per-step logit mask). `logprobs.top_logprobs` is `done` (class D — token IDs bit-exact vs llama.cpp; values within the f32 envelope). The only non-`done` cells left are `wip` (implemented, receipt pending a row-specific e2e) or the provisional 8B column.
-- **`context.full_length` differs sharply per row** — 2048 / 131072 / 131072 / 8192 — and must never be cross-claimed; near-limit validation (with memory predict-and-abort) keeps it `wip`. `context.rope_scaling` is `n/a` on TinyLlama/8B and `wip` on the 1B/3B (tensor-baked llama3 scaling — see below).
+- **`context.full_length` differs sharply per row** — 2048 / 131072 / 131072 / 8192 — and must never be cross-claimed. TinyLlama is now `done` (validated to 1953/2048); 1B & 3B stay `wip` = **host-limited** (the trained 131072 needs 8/28 GiB f32 CPU KV, beyond safe RAM on this 15.74 GiB box — not a model limit; conductor §9 memory/abort projection). `context.rope_scaling` is `n/a` on TinyLlama/8B and now **`done`** on the 1B/3B (tensor-baked llama3 scaling, bit-exact > 8192).
 
 ## Recommended sequencing (conductor §6) — progress
 
 1. ✅ **Sampling lane** (`sampling.full_set` + `sampling.seed_determinism`) — `min_p`/`repeat_penalty` added, per-step RNG fixed, class-I invariants + e2e. **DONE.**
 2. ✅ **`gen.n_choices` + `logprobs.top_logprobs`** — both **DONE**: n_choices (class C) and logprobs (class D — chat + completions; token IDs bit-exact vs llama.cpp, values within the f32 envelope; non-streaming single-choice).
-3. ✅ **Receipts for the already-driving caps** — `gen.stream_usage`, `gen.length_stop`, `observ.usage_timing` minted **DONE**; `chat.system_multiturn` + `context.full_length` still `wip` (need a system/multi-turn and a near-limit e2e respectively).
+3. ✅ **Receipts for the already-driving caps** — `gen.stream_usage`, `gen.length_stop`, `observ.usage_timing` minted **DONE**.
 4. ✅ **`tools.function_calling`** (1B/3B) — **DONE** (class B): input rendered via the model template, output parsed into structured `tool_calls` (battery 6/6). Gated on the manifest (TinyLlama/8B `n/a`).
 5. ✅ **`structured.json_grammar`** — **DONE** (class B): response_format json_object -> JSON-grammar-constrained decode (byte-level PDA + per-step logit mask); battery 12/12 valid JSON. (json_schema/GBNF + force-close-at-max_tokens are follow-ups.)
-6. **Download Llama 3 8B Q8_0** to complete its Phase 0 manifest, re-resolve `tools`/`full_length`/`rope_scaling`, and extend the done receipts to that row.
-7. *(secondary)* `load.quant_breadth` — only if widening the load matrix is in scope.
+6. ✅ **`chat.system_multiturn`** (class D, 3 rows) — **DONE**: system + multi-turn parity bit-exact vs llama.cpp (prompt-pinned); TinyLlama byte+token-identical templates, 1B/3B differ only by the live-date preamble. Harness `system_multiturn_parity.mjs`.
+7. ✅ **`context.full_length` + `context.rope_scaling`** (class D) — TinyLlama full_length **DONE** (1953/2048); 1B & 3B rope_scaling **DONE** (bit-exact at 8511 / 8304 tok, positions > 8192). 1B/3B `context.full_length` stay **`wip` = host-limited** (trained 131072 KV 8/28 GiB > safe RAM here, not a model limit). Harness `context_parity.mjs`; host-limit note in `qa/validation-notes/`.
+8. **Download Llama 3 8B Q8_0** to complete its Phase 0 manifest, re-resolve `tools`/`full_length`/`rope_scaling`, and extend the done receipts to that row.
+9. *(secondary)* `load.quant_breadth` — only if widening the load matrix is in scope.
 
 ## Artifacts
 
 - Per-row manifests: `qa/capability/capability-manifest.<row>.json` (schema `camelid.capability-manifest/v1`).
-- Capability receipts: `qa/capability/receipts/capability-receipt.<cap>.<row>.json` (schema `camelid.capability-receipt/v1`) — **26 minted** this pass (6 caps × 3 on-disk rows).
-- E2E harness: `qa/capability/smoke.sh` (boots each model on Windows CPU, exercises the validated caps).
+- Capability receipts: `qa/capability/receipts/capability-receipt.<cap>.<row>.json` (schema `camelid.capability-receipt/v1`) — **32 minted** (the original 26 + `chat.system_multiturn` ×3 + `context.full_length` ×1 [TinyLlama] + `context.rope_scaling` ×2 [1B/3B]).
+- E2E harnesses: `qa/capability/smoke.sh` (sampling/n_choices/stream_usage), `tools_smoke.sh`, `json_smoke.sh`, **`system_multiturn_parity.mjs`** (system+multi-turn parity + template-fidelity diff), **`context_parity.mjs`** (long-context / rope parity with a built-in KV predict-and-abort). All Windows CPU, `CUDA_VISIBLE_DEVICES=-1`.
+- Host-limit / safety note: `qa/validation-notes/2026-06-25-capability-context-host-limits.md` (1B/3B `context.full_length` host limits + the missing in-engine KV predict-and-abort).
 - Checksums: `qa/capability/SHA256SUMS` (manifests + receipts).
-- Provenance: produced on branch `feat/capability-conductor` (base `12f202d0`) with the sampling + n_choices diff **uncommitted** at receipt time — re-seal against the commit once landed.
+- Provenance: the original 26 receipts were minted on branch `feat/capability-conductor` (base `12f202d0`); the 6 new receipts on `feat/capability-context-chat` (base `bde66bc7`, main) with the lane diff **uncommitted** at receipt time — re-seal against the commit once landed.

--- a/qa/capability/SHA256SUMS
+++ b/qa/capability/SHA256SUMS
@@ -2,6 +2,12 @@
 224463f0ce4ef6d2c17e880cc29aea7f8f376e0187df0acd1ca8147a02cdcdeb  capability-manifest.llama-3.2-1b-instruct-q8_0.json
 b5ffdc42a941522f834616664545d373287a14be17ff7c28e24fa7197636f3b5  capability-manifest.llama-3.2-3b-instruct-q8_0.json
 75f89c509b09096cf395c97bf1884df2a0b6045180a8ddb00dac03efa287b614  capability-manifest.tinyllama-1.1b-chat-q8_0.json
+68fe1bdbd76b668057ace1ab2c361c2909bde508c566e3337d02990fb600492f  receipts/capability-receipt.chat.system_multiturn.llama-3.2-1b-instruct-q8_0.json
+84e3a64f081b5aa2ae4251039d8eab90f935522d9380fee9bf4d0cd2dd1b8722  receipts/capability-receipt.chat.system_multiturn.llama-3.2-3b-instruct-q8_0.json
+103fb5fab2cf7b0e4a748ca6f7e4ba00855df9b5c663d5103bbb2568bda08802  receipts/capability-receipt.chat.system_multiturn.tinyllama-1.1b-chat-q8_0.json
+72f0ca9888a1af7085ecfe0c01985d28a7b66ce54e2c8baaa6653cd260508477  receipts/capability-receipt.context.full_length.tinyllama-1.1b-chat-q8_0.json
+741b9d4c85401665507173d6469a3bffe390a2992e41a92f979b37fd7d4141c2  receipts/capability-receipt.context.rope_scaling.llama-3.2-1b-instruct-q8_0.json
+20cd3c387b22d341191c4a2d286042095a522af2ca36ef95a86b5c2b5459602b  receipts/capability-receipt.context.rope_scaling.llama-3.2-3b-instruct-q8_0.json
 2a2a9e5149dfb91100277c5a8816d1fb05610148db11f380a0dfe8e57770a493  receipts/capability-receipt.gen.length_stop.llama-3.2-1b-instruct-q8_0.json
 97249d71f821ea221f6b073f150d6f26502e3c36a8d37c8fc78d42e5effe650a  receipts/capability-receipt.gen.length_stop.llama-3.2-3b-instruct-q8_0.json
 3a08885298290e93c47e583e082be2b9a69808f9692bf1705e8c312e7dc94051  receipts/capability-receipt.gen.length_stop.tinyllama-1.1b-chat-q8_0.json

--- a/qa/capability/context_parity.mjs
+++ b/qa/capability/context_parity.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Capability harness for `context.full_length` / `context.rope_scaling` (oracle class D)
+// on Windows CPU. Drives a LONG prompt through Camelid, emits a server-sealed
+// camelid.parity-receipt/v1, and asserts bit-exact generation parity vs llama.cpp with
+// the prompt PINNED (verify-receipt) — so a match proves Camelid's KV cache AND rope
+// (incl. the llama3 baked rope_freqs scaling, for prompts whose positions exceed the
+// original 8192 context) are correct across the whole context, token-for-token.
+//
+// SAFETY (conductor §9 predict-and-abort): the f32 CPU KV cache is the dominant,
+// UNCAPPED memory term and Camelid does NOT pre-flight it (it would OOM mid-generation
+// at src/inference/kv_cache.rs:135-136). So THIS harness projects KV bytes =
+// target_tokens * kv_bytes_per_token and ABORTS before requesting an unsafe context —
+// the host is never discovered by crashing it.
+//
+// Usage (repo root; release camelid + Windows llama.cpp build):
+//   node qa/capability/context_parity.mjs --gguf models/Llama-3.2-1B-Instruct-Q8_0.gguf \
+//     --row llama-3.2-1b-instruct-q8_0 --label "Llama 3.2 1B Instruct Q8_0" \
+//     --target-tokens 16000 --kv-bytes-per-token 65536 --llama-ctx 16384 \
+//     --camelid-exe target/release/camelid.exe --llama-server <path>/llama-server.exe \
+//     --camelid-port 8231 --llama-port 8233 --out qa/capability/ctx_out/<row>
+import { execFile, spawn } from 'node:child_process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const args = new Map()
+for (let i = 2; i < process.argv.length; i += 1) {
+  const a = process.argv[i]
+  if (!a.startsWith('--')) continue
+  const [k, inline] = a.slice(2).split('=', 2)
+  const v = inline ?? (process.argv[i + 1]?.startsWith('--') ? 'true' : process.argv[++i] ?? 'true')
+  args.set(k, v)
+}
+const need = k => args.get(k) ?? (() => { throw new Error(`--${k} required`) })()
+const gguf = resolve(need('gguf'))
+const row = need('row')
+const label = args.get('label') || row
+const targetTokens = Number.parseInt(need('target-tokens'), 10)
+const kvBytesPerToken = Number.parseInt(need('kv-bytes-per-token'), 10)
+const llamaCtx = Number.parseInt(args.get('llama-ctx') || String(targetTokens + 64), 10)
+const maxGen = Number.parseInt(args.get('max-gen') || '8', 10)
+const camelidExe = args.get('camelid-exe') || 'target/release/camelid.exe'
+const llamaServer = args.get('llama-server') || 'llama-server'
+const camelidPort = args.get('camelid-port') || '8231'
+const llamaPort = args.get('llama-port') || '8233'
+const out = resolve(args.get('out') || `qa/capability/ctx_out/${row}`)
+// 'full' = camelid self-replay + llama.cpp reference (both); 'reference-only' skips the
+// in-process self-replay (a 2nd slow CPU prefill) — the class-D parity vs llama.cpp is
+// still fully asserted from the receipt's pinned prompt. Use reference-only on big rows.
+const verifyMode = args.get('verify-mode') || 'full'
+const safeBudget = Number.parseInt(args.get('safe-kv-budget-bytes') || String(3.5 * 1024 ** 3), 10)
+const camelidBase = `http://127.0.0.1:${camelidPort}`
+const env = { ...process.env, CUDA_VISIBLE_DEVICES: '-1' }
+
+// ---- predict-and-abort: refuse a context whose projected KV exceeds the safe budget ----
+const projectedKv = targetTokens * kvBytesPerToken
+const gib = n => (n / 1024 ** 3).toFixed(2) + ' GiB'
+console.log(`row=${row} target_tokens=${targetTokens} kv/token=${kvBytesPerToken}B projected_KV=${gib(projectedKv)} safe_budget=${gib(safeBudget)}`)
+if (projectedKv > safeBudget) {
+  console.log(`ABORT (predict-and-abort): projected KV ${gib(projectedKv)} exceeds safe budget ${gib(safeBudget)} on this host — not requested.`)
+  process.exitCode = 2
+  process.exit()
+}
+
+import { writeFile as wf, mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+// Heavy long-prompt POST goes through curl: a multi-thousand-token CPU prefill is
+// O(n^2) in attention and routinely outruns node/undici's 5-min headers timeout.
+async function curlJson(url, body) {
+  const dir = await mkdtemp(join(tmpdir(), 'ctxreq-'))
+  const reqPath = join(dir, 'req.json')
+  await wf(reqPath, JSON.stringify(body))
+  const { stdout } = await execFileAsync('curl', ['-s', '--max-time', '1800', '-H', 'content-type: application/json', '-d', `@${reqPath}`, url], { maxBuffer: 64 * 1024 * 1024 })
+  return stdout ? JSON.parse(stdout) : null
+}
+async function waitUrl(url, ms = 120000) {
+  const deadline = Date.now() + ms
+  let last
+  while (Date.now() < deadline) {
+    try { const r = await fetch(url); if (r.ok || r.status === 404) return } catch (e) { last = e }
+    await new Promise(r => setTimeout(r, 500))
+  }
+  throw new Error(`not reachable at ${url}: ${last?.message}`)
+}
+
+// Build a long, non-degenerate prompt by repeating a varied paragraph to ~target tokens
+// (~3.6 chars/token heuristic; actual length is read back from the receipt).
+const para = 'The river wound past the old stone mill, where farmers once ground wheat into flour for the village bakeries. ' +
+  'Each autumn the orchards filled with ripe apples, and children carried baskets along the dusty lane toward the market square. ' +
+  'A blacksmith hammered iron near the well while merchants argued over the price of wool and salt. '
+const reps = Math.ceil((targetTokens * 3.6) / para.length)
+const prompt = (para.repeat(reps)).slice(0, Math.floor(targetTokens * 3.6))
+
+await mkdir(out, { recursive: true })
+let camelid = spawn(camelidExe, ['serve', '--addr', `127.0.0.1:${camelidPort}`, '--model', gguf], { stdio: 'ignore', env })
+let parityReceipt, promptTokens, genText
+try {
+  await waitUrl(`${camelidBase}/api/models/current`)
+  const resp = await curlJson(`${camelidBase}/v1/completions`, {
+    prompt, max_tokens: maxGen, temperature: 0, stream: false, camelid_receipt: true,
+  })
+  parityReceipt = resp.camelid_receipt
+  if (!parityReceipt) throw new Error(`no camelid_receipt: ${JSON.stringify(resp.error || resp).slice(0, 300)}`)
+  promptTokens = (resp.camelid?.prompt_token_ids || parityReceipt.result?.prompt_token_ids || []).length
+  genText = resp.choices?.[0]?.text ?? ''
+} finally {
+  camelid.kill('SIGTERM')
+  await new Promise(r => setTimeout(r, 800))
+}
+const receiptPath = resolve(out, 'parity-receipt.json')
+await writeFile(receiptPath, JSON.stringify(parityReceipt, null, 2) + '\n')
+const ctx = Math.max(llamaCtx, promptTokens + maxGen + 8)
+console.log(`actual_prompt_tokens=${promptTokens} positions_exceed_8192=${promptTokens > 8192} llama_ctx=${ctx}`)
+
+let verifyOut = ''
+const verifyArgs = [
+  'verify-receipt', receiptPath, '--gguf', gguf, '--llama-server', llamaServer,
+  '--llama-ctx', String(ctx), '--llama-port', String(Number(llamaPort) + 10),
+]
+if (verifyMode === 'reference-only') verifyArgs.push('--reference-only')
+try {
+  const { stdout } = await execFileAsync(camelidExe, verifyArgs, { env, maxBuffer: 32 * 1024 * 1024 })
+  verifyOut = stdout
+} catch (e) { verifyOut = (e.stdout || '') + (e.stderr || '') + String(e) }
+const pass = verifyMode === 'reference-only'
+  ? /PASS reference-rerun/.test(verifyOut)
+  : (/RECEIPT VERIFIED/.test(verifyOut) && /PASS reference-rerun/.test(verifyOut))
+await writeFile(resolve(out, 'verify.log'), verifyOut)
+const summary = { row, label, gguf, target_tokens: targetTokens, actual_prompt_tokens: promptTokens, positions_exceed_8192: promptTokens > 8192, projected_kv_bytes: projectedKv, generation_parity_pass: pass, evidence: (verifyOut.match(/PASS reference-rerun:.*/)?.[0] || '').trim(), generated_text: genText }
+await writeFile(resolve(out, 'summary.json'), JSON.stringify(summary, null, 2) + '\n')
+console.log(`generation_parity_pass=${pass}  (${summary.evidence})`)
+console.log(`receipt=${receiptPath}`)
+if (!pass) { console.log('FAIL: generation parity did not verify'); process.exitCode = 1 } else console.log('OK')

--- a/qa/capability/receipts/capability-receipt.chat.system_multiturn.llama-3.2-1b-instruct-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.chat.system_multiturn.llama-3.2-1b-instruct-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "chat.system_multiturn",
+  "capability": "system role + multi-turn template fidelity (per THIS template)",
+  "row": "llama-3.2-1b-instruct-q8_0",
+  "model_label": "Llama 3.2 1B Instruct Q8_0",
+  "oracle_class": "D",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "Llama-3.2-1B-Instruct-Q8_0.gguf",
+    "sha256": "3f87a880027e7b9ea8e0da9e4009584336f352af444a0e6e5c20721ac4c7ffd1"
+  },
+  "harness": {
+    "repo_head": "bde66bc7d5d6867124631487c6ebb4e674ba177a",
+    "branch": "feat/capability-context-chat",
+    "working_tree": "Produced with the chat.system_multiturn lane diff UNCOMMITTED on a branch based on bde66bc7 (main). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/system_multiturn_parity.mjs (Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "oracle_token_parity + template_fidelity",
+    "summary": "e2e (qa/capability/system_multiturn_parity.mjs, Windows CPU): a system role + multi-turn conversation (system instruction + 2 user turns + 1 prior assistant turn) is rendered through the Llama 3.2 chat template and decoded greedily (temperature=0). GENERATION PARITY (class-D core): Camelid emits a server-sealed camelid.parity-receipt/v1 (camelid_receipt:true); `camelid verify-receipt` replays it in-process AND feeds Camelid's exact prompt token ids to llama.cpp acd79d6 /completion — the continuation matches BIT-EXACT (generated tokens (4) and text identical, first_divergent_token_index=-1; RECEIPT VERIFIED across both isolated passes). The model answered the final user turn ('And the capital of Japan?') with 'Tokyo.' under the terse system instruction. TEMPLATE FIDELITY: Camelid renders a structurally-correct Llama-3 system+multi-turn prompt (per-turn <|start_header_id|>role<|end_header_id|> ... <|eot_id|> framing + final assistant generation header). The ONLY divergence from llama.cpp's rendering is the optional Llama-3.x 'Cutting Knowledge Date: December 2023 / Today Date: <today>' system preamble that llama.cpp injects with a LIVE date (camelid 53 prompt tokens vs llama.cpp 73, first diff at index 5 — the preamble insertion point). That preamble is non-deterministic by construction (live date) and is classified a legitimate cross-engine template difference by Camelid's own verifier (src/receipt/verify.rs:662), which is exactly why class-D parity is asserted on the pinned prompt rather than on template expansion. Camelid's deterministic design omits the live date (the forced-jinja path CAMELID_METADATA_CHAT_TEMPLATE=1 emits the preamble with a frozen date, still != llama.cpp's live date). Non-streaming, single-choice, greedy."
+  }
+}

--- a/qa/capability/receipts/capability-receipt.chat.system_multiturn.llama-3.2-3b-instruct-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.chat.system_multiturn.llama-3.2-3b-instruct-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "chat.system_multiturn",
+  "capability": "system role + multi-turn template fidelity (per THIS template)",
+  "row": "llama-3.2-3b-instruct-q8_0",
+  "model_label": "Llama 3.2 3B Instruct Q8_0",
+  "oracle_class": "D",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "Llama-3.2-3B-Instruct-Q8_0.gguf",
+    "sha256": "f34112a11b7dad74ab517dedf6dcf00d624c9adac2dc0c72c719ca0478554ef2"
+  },
+  "harness": {
+    "repo_head": "bde66bc7d5d6867124631487c6ebb4e674ba177a",
+    "branch": "feat/capability-context-chat",
+    "working_tree": "Produced with the chat.system_multiturn lane diff UNCOMMITTED on a branch based on bde66bc7 (main). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/system_multiturn_parity.mjs (Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "oracle_token_parity + template_fidelity",
+    "summary": "e2e (qa/capability/system_multiturn_parity.mjs, Windows CPU): a system role + multi-turn conversation (system instruction + 2 user turns + 1 prior assistant turn) is rendered through the Llama 3.2 chat template and decoded greedily (temperature=0). GENERATION PARITY (class-D core): Camelid emits a server-sealed camelid.parity-receipt/v1 (camelid_receipt:true); `camelid verify-receipt` replays it in-process AND feeds Camelid's exact prompt token ids to llama.cpp acd79d6 /completion — the continuation matches BIT-EXACT (generated tokens (4) and text identical, first_divergent_token_index=-1; RECEIPT VERIFIED across both isolated passes). The model answered the final user turn ('And the capital of Japan?') with 'Tokyo.' under the terse system instruction. TEMPLATE FIDELITY: Camelid renders a structurally-correct Llama-3 system+multi-turn prompt (per-turn <|start_header_id|>role<|end_header_id|> ... <|eot_id|> framing + final assistant generation header). The ONLY divergence from llama.cpp's rendering is the optional Llama-3.x 'Cutting Knowledge Date: December 2023 / Today Date: <today>' system preamble that llama.cpp injects with a LIVE date (camelid 53 prompt tokens vs llama.cpp 73, first diff at index 5 — the preamble insertion point). That preamble is non-deterministic by construction (live date) and is classified a legitimate cross-engine template difference by Camelid's own verifier (src/receipt/verify.rs:662), which is exactly why class-D parity is asserted on the pinned prompt rather than on template expansion. Camelid's deterministic design omits the live date (the forced-jinja path CAMELID_METADATA_CHAT_TEMPLATE=1 emits the preamble with a frozen date, still != llama.cpp's live date). Non-streaming, single-choice, greedy."
+  }
+}

--- a/qa/capability/receipts/capability-receipt.chat.system_multiturn.tinyllama-1.1b-chat-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.chat.system_multiturn.tinyllama-1.1b-chat-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "chat.system_multiturn",
+  "capability": "system role + multi-turn template fidelity (per THIS template)",
+  "row": "tinyllama-1.1b-chat-q8_0",
+  "model_label": "TinyLlama 1.1B Chat Q8_0",
+  "oracle_class": "D",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+    "sha256": "a4c9bb1dbaa372f6381a035fa5c02ef087aaa1ff1f843a56a22328114f03fc59"
+  },
+  "harness": {
+    "repo_head": "bde66bc7d5d6867124631487c6ebb4e674ba177a",
+    "branch": "feat/capability-context-chat",
+    "working_tree": "Produced with the chat.system_multiturn lane diff UNCOMMITTED on a branch based on bde66bc7 (main). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/system_multiturn_parity.mjs (Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "oracle_token_parity + template_fidelity",
+    "summary": "e2e (qa/capability/system_multiturn_parity.mjs, Windows CPU): a system role + multi-turn conversation (system instruction + 2 user turns + 1 prior assistant turn) is rendered through TinyLlama's chat template and decoded greedily (temperature=0). GENERATION PARITY (class-D core): Camelid emits a server-sealed camelid.parity-receipt/v1 (camelid_receipt:true); `camelid verify-receipt` replays it in-process AND feeds Camelid's exact prompt token ids to llama.cpp acd79d6 /completion — the continuation matches BIT-EXACT (generated tokens (5) and text identical, first_divergent_token_index=-1; RECEIPT VERIFIED across both isolated passes). TEMPLATE FIDELITY: Camelid's /apply-template rendering and prompt token ids for the same messages match llama.cpp's BYTE-FOR-BYTE and TOKEN-FOR-TOKEN (prompt_string_match=true, prompt_tokens_match=true, divergence=none) — TinyLlama's template carries no date/knowledge-cutoff preamble, so full template parity holds. Non-streaming, single-choice, greedy. Model answered the final user turn ('And the capital of Japan?') with 'Tokyo.' under the terse system instruction."
+  }
+}

--- a/qa/capability/receipts/capability-receipt.context.full_length.tinyllama-1.1b-chat-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.context.full_length.tinyllama-1.1b-chat-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "context.full_length",
+  "capability": "full TRAINED context length, exact value from metadata",
+  "row": "tinyllama-1.1b-chat-q8_0",
+  "model_label": "TinyLlama 1.1B Chat Q8_0",
+  "oracle_class": "D",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+    "sha256": "a4c9bb1dbaa372f6381a035fa5c02ef087aaa1ff1f843a56a22328114f03fc59"
+  },
+  "harness": {
+    "repo_head": "bde66bc7d5d6867124631487c6ebb4e674ba177a",
+    "branch": "feat/capability-context-chat",
+    "working_tree": "Produced with the context lane diff UNCOMMITTED on a branch based on bde66bc7 (main). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/context_parity.mjs (Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "oracle_token_parity",
+    "summary": "e2e (qa/capability/context_parity.mjs, Windows CPU): a 1953-token prompt — 95% of TinyLlama's trained context_length of 2048 — is decoded greedily (temperature=0). Camelid emits a server-sealed camelid.parity-receipt/v1 (camelid_receipt:true); `camelid verify-receipt` replays it in-process AND feeds Camelid's exact 1953 prompt token ids to llama.cpp acd79d6 /completion — the continuation matches BIT-EXACT (generated tokens (8) and text identical, first_divergent_token_index=-1; RECEIPT VERIFIED across both isolated passes). This exercises KV-cache correctness across nearly the entire trained context. TinyLlama's trained context_length=2048 is the model's hard KV cap (read at model.rs:141, enforced at inference/kv_cache.rs:23); the full-length f32 CPU KV cache is only ~88 MiB, so the FULL trained length is reachable within host RAM on this box (no host limit for this row). Non-streaming, single-choice, greedy."
+  }
+}

--- a/qa/capability/receipts/capability-receipt.context.rope_scaling.llama-3.2-1b-instruct-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.context.rope_scaling.llama-3.2-1b-instruct-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "context.rope_scaling",
+  "capability": "RoPE scaling/extension at positions beyond the original context (llama3 baked rope_freqs)",
+  "row": "llama-3.2-1b-instruct-q8_0",
+  "model_label": "Llama 3.2 1B Instruct Q8_0",
+  "oracle_class": "D",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "Llama-3.2-1B-Instruct-Q8_0.gguf",
+    "sha256": "3f87a880027e7b9ea8e0da9e4009584336f352af444a0e6e5c20721ac4c7ffd1"
+  },
+  "harness": {
+    "repo_head": "bde66bc7d5d6867124631487c6ebb4e674ba177a",
+    "branch": "feat/capability-context-chat",
+    "working_tree": "Produced with the context lane diff UNCOMMITTED on a branch based on bde66bc7 (main). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/context_parity.mjs (Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "oracle_token_parity",
+    "summary": "e2e (qa/capability/context_parity.mjs, Windows CPU): an 8511-token prompt — positions 0..8510, EXCEEDING the model's original 8192-token context — is decoded greedily (temperature=0), exercising the llama3 RoPE extension at extended positions. Camelid emits a server-sealed camelid.parity-receipt/v1; `camelid verify-receipt` replays it in-process AND feeds Camelid's exact 8511 prompt token ids to llama.cpp acd79d6 /completion — the continuation matches BIT-EXACT (generated tokens (8) and text identical, first_divergent_token_index=-1; RECEIPT VERIFIED across both isolated passes). Because positions exceed 8192, a bit-exact match confirms Camelid applies the model's rope extension identically to llama.cpp in the scaled regime (and KV-cache correctness across all 8511 positions). MECHANISM (this corrects the manifest's synthesis_correction, which named rope.rs:507): the Llama 3.2 1B GGUF declares NO llama.rope.scaling.* metadata key; the llama3 NTK-by-parts scaling is BAKED into a rope_freqs.weight tensor (32 f32 factors). BOTH engines read that tensor identically — Camelid via effective_base = rope_freq_base / rope_freqs[pair] (src/inference/rope.rs:499-500, taken under the RopeScalingKind::None arm, NOT the dormant metadata-llama3 branch at rope.rs:507) — so the comparison is apples-to-apples with no formula re-derivation drift. Non-streaming, single-choice, greedy. (The full trained 131072 context is host-limited on this box; see qa/validation-notes/2026-06-25-capability-context-host-limits.md.)"
+  }
+}

--- a/qa/capability/receipts/capability-receipt.context.rope_scaling.llama-3.2-3b-instruct-q8_0.json
+++ b/qa/capability/receipts/capability-receipt.context.rope_scaling.llama-3.2-3b-instruct-q8_0.json
@@ -1,0 +1,31 @@
+{
+  "schema": "camelid.capability-receipt/v1",
+  "capability_id": "context.rope_scaling",
+  "capability": "RoPE scaling/extension at positions beyond the original context (llama3 baked rope_freqs)",
+  "row": "llama-3.2-3b-instruct-q8_0",
+  "model_label": "Llama 3.2 3B Instruct Q8_0",
+  "oracle_class": "D",
+  "verdict": "validated",
+  "generated": "2026-06-25",
+  "platform": {
+    "os": "windows",
+    "target": "x86_64-pc-windows-msvc",
+    "backend": "cpu",
+    "oracle": "llama.cpp acd79d6 (MSVC, Windows AMD64)"
+  },
+  "gguf": {
+    "filename": "Llama-3.2-3B-Instruct-Q8_0.gguf",
+    "sha256": "f34112a11b7dad74ab517dedf6dcf00d624c9adac2dc0c72c719ca0478554ef2"
+  },
+  "harness": {
+    "repo_head": "bde66bc7d5d6867124631487c6ebb4e674ba177a",
+    "branch": "feat/capability-context-chat",
+    "working_tree": "Produced with the context lane diff UNCOMMITTED on a branch based on bde66bc7 (main). Re-seal against the commit once landed.",
+    "binary": "target/release/camelid.exe",
+    "e2e_harness": "qa/capability/context_parity.mjs (Windows CPU, CUDA_VISIBLE_DEVICES=-1)"
+  },
+  "evidence": {
+    "kind": "oracle_token_parity",
+    "summary": "e2e (qa/capability/context_parity.mjs, Windows CPU): an 8304-token prompt — positions 0..8303, EXCEEDING the model's original 8192-token context — is decoded greedily (temperature=0), exercising the llama3 RoPE extension at extended positions. Camelid emits a server-sealed camelid.parity-receipt/v1 recording its actual generated tokens; `camelid verify-receipt --reference-only` feeds Camelid's exact 8304 prompt token ids to llama.cpp acd79d6 /completion — the continuation matches BIT-EXACT (generated tokens (8) and text identical, first_divergent_token_index=-1; digest + lane-identity + llama.cpp reference-rerun all PASS). reference-only (the in-process Camelid self-replay was skipped to bound the cost of a ~8.3k-token 3B CPU prefill; Camelid greedy determinism is independently established on the companion full self+reference runs — TinyLlama/1B system_multiturn and the 1B rope run). Because positions exceed 8192, a bit-exact match confirms Camelid applies the model's rope extension identically to llama.cpp in the scaled regime (and KV-cache correctness across all 8304 positions). MECHANISM: same as the 1B row — the Llama 3.2 3B GGUF declares no llama.rope.scaling.* metadata; the llama3 scaling is baked into a rope_freqs.weight tensor that both engines read identically (Camelid: effective_base = rope_freq_base / rope_freqs[pair], src/inference/rope.rs:499-500, under the RopeScalingKind::None arm, not the dormant rope.rs:507 metadata branch). KV projection: 8304 tokens x 229376 B/token = 1.9 GiB f32 CPU KV (within the harness's predict-and-abort budget). Non-streaming, single-choice, greedy. (The full trained 131072 context is host-limited on this box — 28 GiB KV; see qa/validation-notes/2026-06-25-capability-context-host-limits.md.)"
+  }
+}

--- a/qa/capability/system_multiturn_parity.mjs
+++ b/qa/capability/system_multiturn_parity.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Capability harness for `chat.system_multiturn` (oracle class D) on Windows CPU.
+//
+// Validates two complementary things for a system + multi-turn conversation:
+//   1. GENERATION PARITY (the class-D core): Camelid emits a server-sealed
+//      camelid.parity-receipt/v1 (camelid_receipt:true); `camelid verify-receipt`
+//      then feeds Camelid's EXACT prompt token ids to llama.cpp /completion and
+//      asserts the continuation matches bit-exact. Pinning the prompt isolates
+//      decode parity from chat-template rendering.
+//   2. TEMPLATE FIDELITY: compares Camelid's own /apply-template rendering + prompt
+//      token ids against llama.cpp's for the same messages, and characterizes any
+//      divergence (notably the Llama-3.x "Cutting Knowledge Date / Today Date"
+//      system preamble, which carries a LIVE date and is therefore not byte-parity-able
+//      across engines — see src/receipt/verify.rs:662).
+//
+// Exit 0 iff generation parity verifies. Template divergence is REPORTED, not failed,
+// because the live-date preamble is an intended, deterministic-design difference.
+//
+// Usage (run from the repo root, release camelid + a Windows llama.cpp build):
+//   node qa/capability/system_multiturn_parity.mjs \
+//     --gguf models/Llama-3.2-3B-Instruct-Q8_0.gguf \
+//     --row llama-3.2-3b-instruct-q8_0 --label "Llama 3.2 3B Instruct Q8_0" \
+//     --camelid-exe target/release/camelid.exe \
+//     --llama-server <path-to>/llama-server.exe \
+//     --camelid-port 8231 --llama-port 8233 --out qa/capability/sm_out/<row>
+// --gguf / --llama-server accept any path; defaults assume llama-server is on PATH.
+import { execFile, spawn } from 'node:child_process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const args = new Map()
+for (let i = 2; i < process.argv.length; i += 1) {
+  const a = process.argv[i]
+  if (!a.startsWith('--')) continue
+  const [k, inline] = a.slice(2).split('=', 2)
+  const v = inline ?? (process.argv[i + 1]?.startsWith('--') ? 'true' : process.argv[++i] ?? 'true')
+  args.set(k, v)
+}
+const gguf = resolve(args.get('gguf') || (() => { throw new Error('--gguf required') })())
+const row = args.get('row') || (() => { throw new Error('--row required') })()
+const label = args.get('label') || row
+const camelidExe = args.get('camelid-exe') || 'target/release/camelid.exe'
+const llamaServer = args.get('llama-server') || 'llama-server'
+const camelidPort = args.get('camelid-port') || '8231'
+const llamaPort = args.get('llama-port') || '8233'
+const maxTokens = Number.parseInt(args.get('max-tokens') || '24', 10)
+const out = resolve(args.get('out') || `qa/capability/sm_out/${row}`)
+const camelidBase = `http://127.0.0.1:${camelidPort}`
+const llamaBase = `http://127.0.0.1:${llamaPort}`
+const env = { ...process.env, CUDA_VISIBLE_DEVICES: '-1' }
+
+// A system role + multi-turn (2 user turns, 1 prior assistant turn) conversation.
+const messages = [
+  { role: 'system', content: 'You are a terse assistant. Reply with a single short sentence.' },
+  { role: 'user', content: 'What is the capital of France?' },
+  { role: 'assistant', content: 'Paris.' },
+  { role: 'user', content: 'And the capital of Japan?' },
+]
+
+async function fetchJson(url, body) {
+  const res = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+  const t = await res.text()
+  if (!res.ok) throw new Error(`${url}: ${res.status}: ${t}`)
+  return t ? JSON.parse(t) : null
+}
+async function waitUrl(url, label, ms = 90000) {
+  const deadline = Date.now() + ms
+  let last
+  while (Date.now() < deadline) {
+    try { const r = await fetch(url); if (r.ok || r.status === 404) return } catch (e) { last = e }
+    await new Promise(r => setTimeout(r, 500))
+  }
+  throw new Error(`${label} not reachable at ${url}: ${last?.message}`)
+}
+function eqArr(a, b) { return a.length === b.length && a.every((x, i) => x === b[i]) }
+function firstDiff(a, b) { const n = Math.max(a.length, b.length); for (let i = 0; i < n; i++) if (a[i] !== b[i]) return i; return -1 }
+
+await mkdir(out, { recursive: true })
+const summary = { row, label, gguf, checks: {} }
+
+// ---- Phase 1: Camelid emits the sealed parity receipt + its own rendering ----
+let camelid = spawn(camelidExe, ['serve', '--addr', `127.0.0.1:${camelidPort}`, '--model', gguf], { stdio: 'ignore', env })
+let parityReceipt, camelidPrompt, camelidPromptTokens, camelidText
+try {
+  await waitUrl(`${camelidBase}/api/models/current`, 'camelid serve')
+  const resp = await fetchJson(`${camelidBase}/v1/chat/completions`, {
+    messages, temperature: 0, max_tokens: maxTokens, stream: false, camelid_receipt: true,
+  })
+  parityReceipt = resp.camelid_receipt
+  if (!parityReceipt) throw new Error(`no camelid_receipt in response: ${JSON.stringify(resp.error || resp).slice(0, 300)}`)
+  camelidPromptTokens = resp.camelid?.prompt_token_ids || []
+  camelidText = resp.choices?.[0]?.message?.content ?? ''
+  const tmpl = await fetchJson(`${camelidBase}/apply-template`, { messages })
+  camelidPrompt = tmpl.prompt
+} finally {
+  camelid.kill('SIGTERM')
+  await new Promise(r => setTimeout(r, 800))
+}
+const receiptPath = resolve(out, 'parity-receipt.json')
+await writeFile(receiptPath, JSON.stringify(parityReceipt, null, 2) + '\n')
+summary.checks.camelid_emit = { generated_text: camelidText, prompt_tokens: camelidPromptTokens.length, receipt_id: parityReceipt.receipt_id }
+
+// ---- Phase 2: class-D generation parity via verify-receipt (spawns its own llama-server) ----
+let verifyOut = ''
+let verifyPass = false
+try {
+  const { stdout } = await execFileAsync(camelidExe, [
+    'verify-receipt', receiptPath,
+    '--gguf', gguf,
+    '--llama-server', llamaServer,
+    '--llama-ctx', '2048',
+    '--llama-port', String(Number(llamaPort) + 10),
+  ], { env, maxBuffer: 16 * 1024 * 1024 })
+  verifyOut = stdout
+} catch (e) { verifyOut = (e.stdout || '') + (e.stderr || '') + String(e) }
+verifyPass = /RECEIPT VERIFIED/.test(verifyOut) && /PASS reference-rerun/.test(verifyOut)
+await writeFile(resolve(out, 'verify.log'), verifyOut)
+summary.checks.generation_parity = { pass: verifyPass, evidence: (verifyOut.match(/PASS reference-rerun:.*/)?.[0] || '').trim() }
+
+// ---- Phase 3: template fidelity vs llama.cpp ----
+let llama = spawn(llamaServer, ['--host', '127.0.0.1', '--port', llamaPort, '-m', gguf, '-ngl', '0', '-c', '2048', '--no-warmup'], { stdio: 'ignore', env })
+try {
+  await waitUrl(`${llamaBase}/health`, 'llama-server')
+  const llamaTmpl = await fetchJson(`${llamaBase}/apply-template`, { messages })
+  const llamaPrompt = llamaTmpl.prompt
+  const llamaTok = await fetchJson(`${llamaBase}/tokenize`, { content: llamaPrompt, add_special: true })
+  const llamaTokens = llamaTok.tokens || []
+  const stringMatch = camelidPrompt === llamaPrompt
+  const tokenMatch = eqArr(camelidPromptTokens, llamaTokens)
+  // Characterize the divergence: does llama's rendering carry the live-date preamble?
+  const preamble = /Cutting Knowledge Date|Today Date/.test(llamaPrompt) && !/Cutting Knowledge Date|Today Date/.test(camelidPrompt)
+  summary.checks.template_fidelity = {
+    prompt_string_match: stringMatch,
+    prompt_tokens_match: tokenMatch,
+    first_token_diff_index: firstDiff(camelidPromptTokens, llamaTokens),
+    camelid_prompt_tokens: camelidPromptTokens.length,
+    llama_prompt_tokens: llamaTokens.length,
+    divergence: stringMatch ? 'none' : (preamble ? 'llama_injects_live_date_system_preamble' : 'other'),
+    camelid_prompt: camelidPrompt,
+    llama_prompt: llamaPrompt,
+  }
+} finally {
+  llama.kill('SIGTERM')
+}
+
+await writeFile(resolve(out, 'summary.json'), JSON.stringify(summary, null, 2) + '\n')
+console.log(`row=${row}`)
+console.log(`generated_text=${JSON.stringify(camelidText)}`)
+console.log(`generation_parity_pass=${summary.checks.generation_parity.pass}  (${summary.checks.generation_parity.evidence})`)
+console.log(`template_string_match=${summary.checks.template_fidelity.prompt_string_match}  tokens_match=${summary.checks.template_fidelity.prompt_tokens_match}  divergence=${summary.checks.template_fidelity.divergence}`)
+console.log(`receipt=${receiptPath}`)
+console.log(`SUMMARY=${resolve(out, 'summary.json')}`)
+if (!verifyPass) { console.log('FAIL: generation parity did not verify'); process.exitCode = 1 }
+else console.log('OK')

--- a/qa/validation-notes/2026-06-25-capability-context-host-limits.md
+++ b/qa/validation-notes/2026-06-25-capability-context-host-limits.md
@@ -1,0 +1,41 @@
+# Capability conductor — `context.full_length` host limits + a KV predict-and-abort gap (Windows CPU)
+
+Date: 2026-06-25 · Platform: Windows x86_64 (MSVC), CPU backend · Oracle: llama.cpp `acd79d6`
+Scope: the `context.full_length` and `context.rope_scaling` lanes of `MODEL_CAPABILITY_COVERAGE_CONDUCTOR.md`, validated on this development host.
+
+This note records why two `context.full_length` cells (Llama 3.2 1B and 3B) are **NOT** promoted to `done` on this box, and surfaces a real safety gap. It is the honest counterpart to the receipts that *did* land. Per conductor §9 (predict-and-abort) and the runnable-lane memory policy, a length the model genuinely supports but that this host cannot materialize is a **host limit**, not a model limit or a refusal — and it must be documented, never discovered by crashing.
+
+## Host facts
+
+- Total RAM: **15.74 GiB** (16,905,969,664 bytes); ~7 GiB free at measurement.
+- Resident Q8_0 weights (default lazy file-backed): TinyLlama ~1.17 GB, Llama 3.2 1B ~1.32 GB, Llama 3.2 3B ~3.42 GB.
+- CPU KV cache is **f32** (`src/inference/kv_cache.rs`), shape `[layers, seq, kv_heads, head_dim]` for each of K and V. Per-token bytes = `2 · n_layers · n_kv_heads · head_dim · 4`.
+
+| Row | n_layers | n_kv_heads | head_dim | KV bytes/token | trained ctx | KV at trained ctx |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| TinyLlama 1.1B | 22 | 4 | 64 | 45,056 (44 KiB) | 2048 | **88 MiB** ✅ |
+| Llama 3.2 1B | 16 | 8 | 64 | 65,536 (64 KiB) | 131072 | **8.0 GiB** ⚠ no headroom |
+| Llama 3.2 3B | 28 | 8 | 128 | 229,376 (224 KiB) | 131072 | **28.0 GiB** ❌ infeasible |
+
+(The 3B figure corrects an in-flight reader error that had claimed 1.75 MiB/token; the `inspect`-measured head counts give 224 KiB/token, confirmed by recompute. This is load-bearing: it is why 3B rope-scaling at >8192 positions IS feasible here, while 3B *full* 131072 is not.)
+
+## What was validated (class D, bit-exact vs llama.cpp `acd79d6`)
+
+Harness `qa/capability/context_parity.mjs`: a long prompt is decoded greedily; Camelid emits a server-sealed `camelid.parity-receipt/v1`; `camelid verify-receipt` feeds Camelid's exact prompt token ids to llama.cpp `/completion` and asserts the continuation matches bit-exact (prompt PINNED → proves KV + rope correctness across the whole context, token-for-token). The harness itself projects KV bytes and **aborts before requesting an unsafe context** — the host is never discovered by crashing it.
+
+- **TinyLlama `context.full_length` → done.** Bit-exact at **1953 tokens (95% of the trained 2048)**; full-length KV ≈ 88 MiB, fully reachable. Receipt: `capability-receipt.context.full_length.tinyllama-1.1b-chat-q8_0.json`.
+- **Llama 3.2 1B `context.rope_scaling` → done.** Bit-exact at **8511 tokens (> 8192, the llama3-scaled regime; full self+reference verify)**. Receipt: `capability-receipt.context.rope_scaling.llama-3.2-1b-instruct-q8_0.json`.
+- **Llama 3.2 3B `context.rope_scaling` → done.** Bit-exact at **8304 tokens (> 8192; reference-only verify — 1.9 GiB KV)**. Receipt: `capability-receipt.context.rope_scaling.llama-3.2-3b-instruct-q8_0.json`.
+
+## What stays `wip` (host-limited, NOT a model limit)
+
+- **Llama 3.2 1B `context.full_length`** — validated bit-exact across a long context (feasible frontier, **8511 tokens**; also an earlier 7958-token run), but the **trained 131072** materializes an 8.0 GiB f32 KV cache, which fits total RAM only with no safe headroom (and exceeds free memory). Not validated at the trained length on this box. Needs a larger-RAM host.
+- **Llama 3.2 3B `context.full_length`** — validated bit-exact across a long context (feasible frontier, **8304 tokens**), but the **trained 131072** needs a **28 GiB** f32 KV cache — ~12 GiB beyond this box's entire RAM. Decisively infeasible here.
+
+These two cells remain `wip` with this host-limit annotation. They are NOT `n/a` (the models genuinely support 131072) and NOT `done` (unvalidated at the trained length here).
+
+## Safety gap surfaced (conductor §9)
+
+Camelid has **no pre-flight KV predict-and-abort**. The context cap is the GGUF trained length (`model.rs:141` → `kv_cache.rs:23`), but the KV cache grows **lazily/incrementally** (`kv_cache.rs:135-136`, `keys.resize`/`values.resize`, chunks of `CAMELID_KV_CACHE_GROW_TOKENS`=256). A request approaching 131072 on a host that cannot hold the projected KV would **OOM mid-generation**, not fail closed. The existing weight-materialization guard (`CAMELID_MAX_CPU_WEIGHT_MATERIALIZATION_BYTES`, default 6 GiB, `api/mod.rs:6533`) covers **weights only** and estimates ≈0 for lazy-Q8 file-backed linears, so it never fires for KV.
+
+This is exactly the rail conductor §9 calls load-bearing on Windows ("never discover the ceiling by crashing the host"). The `context_parity.mjs` harness models the missing guard externally (projects KV, aborts before request). A clean in-engine fix would project `requested_positions · kv_bytes_per_token` against an available-memory budget at request admission / KV-plan time and return a typed error before the first oversized `resize`. **Proposed as a follow-up; not implemented in this lane** (it touches the core request/KV path and warrants its own validation + gate run).


### PR DESCRIPTION
Finishes the Model Capability Coverage Conductor's three remaining `wip` lanes on the 3 on-disk rows (TinyLlama 1.1B, Llama 3.2 1B, Llama 3.2 3B), all **class-D vs Windows llama.cpp `acd79d6`**, each backed by a `camelid.capability-receipt/v1`. **No Rust changed** — harnesses (.mjs) + receipts (JSON) + docs only.

## Results

| Lane | TinyLlama | Llama 3.2 1B | Llama 3.2 3B |
| --- | :---: | :---: | :---: |
| `chat.system_multiturn` | ✅ done | ✅ done | ✅ done |
| `context.full_length` | ✅ done (2048) | ⏳ wip — host-limited | ⏳ wip — host-limited |
| `context.rope_scaling` | n/a | ✅ done (8511 tok) | ✅ done (8304 tok) |

Matrix tally: `n/a 4 · open 11 · wip 5 · done 32` (+6).

## chat.system_multiturn → done (3 rows)
New harness `qa/capability/system_multiturn_parity.mjs`: a system + 2-user-turn + 1-assistant-turn conversation, greedy; `camelid_receipt:true` emits a sealed parity-receipt and `verify-receipt` asserts **bit-exact generation parity with the prompt pinned** (`first_divergent_token_index=-1` on all 3 rows), plus a template-fidelity diff.

**Finding (surfaced, not papered over):** TinyLlama renders **byte+token-identical** to llama.cpp; Llama 3.2 1B/3B differ **only** by the live-date `Cutting Knowledge Date / Today Date` system preamble llama.cpp injects — a non-deterministic, intended cross-engine difference (Camelid's own verifier classifies it so at `src/receipt/verify.rs:662`), which is exactly why class-D parity is asserted on the pinned prompt.

## context.full_length / context.rope_scaling
New harness `qa/capability/context_parity.mjs`: long-prompt greedy parity-receipt + prompt-pinned `verify-receipt`. The harness **projects KV bytes and aborts before an unsafe context** (conductor §9 — never crash the host).

- TinyLlama `context.full_length` → done (1953/2048, the full trained length; ~88 MiB KV).
- 1B & 3B `context.rope_scaling` → done: bit-exact at **8511 / 8304 tokens, positions > 8192** (the llama3-scaled regime).
- **Correction:** the llama3 rope extension is read from the baked `rope_freqs.weight` tensor at `rope.rs:499-500` (`RopeScalingKind::None` arm), **not** the dormant metadata branch at `rope.rs:507` the manifest had named. Also corrected the 3B KV figure (224 KiB/token, not 1.75 MiB/token) — which is *why* 3B's scaled regime was reachable here.

## Host limit (this 15.74 GiB box) — 2 cells stay `wip`
1B/3B `context.full_length` are validated bit-exact at a feasible frontier (8511 / 8304 tok) but the **trained 131072** context needs **8.0 GiB / 28 GiB** f32 CPU KV — unreachable with safe headroom (a host limit, **not** a model limit). Documented in `qa/validation-notes/2026-06-25-capability-context-host-limits.md`, which also flags a real gap: **Camelid has no in-engine pre-flight KV predict-and-abort** (a 131072 request would OOM mid-generation at `kv_cache.rs:135-136`) — proposed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)