### PR TITLE
fix(cuda): make GPU spec-verify weighted-V bit-identical to plain decode

### DIFF
--- a/qa/speed/spec-verify-parity.ps1
+++ b/qa/speed/spec-verify-parity.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+  GPU speculative-verify losslessness gate: spec output must be token-identical to plain greedy.
+
+.DESCRIPTION
+  Verifies that the GPU speculative-verify kernels (attention_batched for the linear
+  verify_drafts_gpu lane, attention_tree_batched for the CAMELID_SPEC_TREE tree lane) produce
+  output bit-identical to single-token attention_decode, so every emitted token is the target's
+  own greedy argmax.
+
+  Before the weighted-V G-group fix, the verify kernels reduced the weighted-V with a single
+  sequential sum (G=1) while attention_decode splits it into G=ceil(pc/head_dim) reassociated
+  groups. Once context exceeded ~head_dim tokens those low bits disagreed and a near-tie token
+  could flip (observed: creative_writing diverged from plain greedy at generated token 113 on
+  the tree lane). This harness runs the full prompt pack on BOTH verify lanes and asserts the
+  intra-Camelid lossless gate (spec stream == this run's own plain greedy stream) on EVERY
+  column, including the spec-hostile mandatory-report columns.
+
+  No llama.cpp comparison; the denominator is always this build's own plain greedy decode.
+#>
+[CmdletBinding()]
+param(
+  [string]$Bin = '',
+  [string]$Model = 'C:\Users\timto\models\Llama-3.2-3B-Instruct-Q8_0.gguf',
+  [string]$PromptsJson = ''
+)
+$ErrorActionPreference = 'Stop'
+$ScriptDir = if ($PSScriptRoot) { $PSScriptRoot } elseif ($PSCommandPath) { Split-Path -Parent $PSCommandPath } else { (Get-Location).Path }
+if (-not $Bin)         { $Bin = Join-Path $ScriptDir '..\..\target\release\camelid.exe' }
+if (-not $PromptsJson) { $PromptsJson = Join-Path $ScriptDir 'prompts.json' }
+$Bin = (Resolve-Path $Bin).Path
+if (-not (Test-Path $Model)) { throw "model not found: $Model" }
+$utf8 = New-Object System.Text.UTF8Encoding($false)
+$pack = Get-Content $PromptsJson -Raw | ConvertFrom-Json
+$tmpDir = Join-Path $env:TEMP 'spec_verify_parity'
+New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+
+# Run one bench on a given verify lane. No native stderr redirect (PS5.1 NativeCommandError trap);
+# $out captures stdout (the JSON record) only.
+function RunLane($promptFile, $id, $nGen, $lane) {
+  if ($lane -eq 'tree') { $env:CAMELID_SPEC_TREE = '1' } else { Remove-Item Env:CAMELID_SPEC_TREE -ErrorAction SilentlyContinue }
+  $out = & $Bin bench-speculative $Model --drafter ngram --workload $id --prompt-file $promptFile --max-tokens $nGen --warmup
+  Remove-Item Env:CAMELID_SPEC_TREE -ErrorAction SilentlyContinue
+  ($out | Where-Object { $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)
+}
+
+Write-Host ("[spec-verify-parity] bin={0}" -f $Bin)
+Write-Host ("[spec-verify-parity] model={0}  columns={1}" -f (Split-Path $Model -Leaf), $pack.columns.Count)
+
+$rows = @()
+foreach ($col in $pack.columns) {
+  $id = $col.id; $nGen = [int]$col.n_gen
+  $pf = Join-Path $tmpDir ("{0}.txt" -f $id)
+  [System.IO.File]::WriteAllText($pf, [string]$col.prompt, $utf8)
+  foreach ($lane in @('linear', 'tree')) {
+    $line = RunLane $pf $id $nGen $lane
+    if (-not $line) { Write-Host ("  {0,-22} {1,-6}: NO JSON" -f $id, $lane) -ForegroundColor Red; continue }
+    $r = $line | ConvertFrom-Json
+    $div = [int]$r.first_divergent_generated_token_index
+    $ok = $r.lossless -and ($div -lt 0)
+    Write-Host ("  {0,-22} {1,-6}: {2}  (div_idx={3}, accept={4:P0})" -f $id, $lane, $(if ($ok) { 'LOSSLESS' } else { 'DIVERGE' }), $div, $r.accept_rate) `
+      -ForegroundColor $(if ($ok) { 'Green' } else { 'Red' })
+    $rows += [pscustomobject]@{ workload = $id; lane = $lane; lossless = [bool]$ok; div_idx = $div }
+  }
+}
+
+Write-Host ""
+$bad = $rows | Where-Object { -not $_.lossless }
+if ($bad) {
+  Write-Host ("FAIL: {0} (workload, lane) pair(s) diverged from plain greedy:" -f $bad.Count) -ForegroundColor Red
+  $bad | ForEach-Object { Write-Host ("  {0} / {1}  @ token {2}" -f $_.workload, $_.lane, $_.div_idx) -ForegroundColor Red }
+  exit 1
+} else {
+  Write-Host ("PASS: GPU spec-verify is token-identical to plain greedy on all {0} (workload x lane) pairs." -f $rows.Count) -ForegroundColor Green
+}

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -1335,11 +1335,29 @@ extern "C" __global__ void attention_batched(
     }
     __syncthreads();
     float inv = 1.0f / s_sum;
-    for (int d = tid; d < head_dim; d += blockDim.x) {
+    // Weighted V - IDENTICAL G-group FP-reassociation to attention_decode so spec-verify logits
+    // are bit-identical to single-token decode (greedy spec losslessness; fixes the decode==batched
+    // reduction-order gap the old sequential sum left). G is the SAME function of the key count and
+    // head_dim the decode launch uses (launch_attention: G = clamp(ceil(pc/head_dim), 1,
+    // 1024/head_dim)); the contiguous p-split and g-order combine match exactly.
+    int max_groups = 1024 / head_dim; if (max_groups < 1) max_groups = 1;
+    int G = (position_count + head_dim - 1) / head_dim;
+    if (G < 1) G = 1; if (G > max_groups) G = max_groups;
+    float* vpart = shared + head_dim + base_position + k_tokens; // [max_groups * head_dim]
+    for (int idx = tid; idx < G * head_dim; idx += blockDim.x) {
+        int gid = idx / head_dim, did = idx % head_dim;
+        int p_lo = (int)((long)gid * position_count / G);
+        int p_hi = (int)((long)(gid + 1) * position_count / G);
         float acc = 0.0f;
-        for (int p = 0; p < position_count; p++)
-            acc += (scores[p] * inv) * f16_bits_to_f32(vbase[(long)p * head_dim + d]);
-        out[(long)t * q_per_token + (long)head * head_dim + d] = acc;
+        for (int p = p_lo; p < p_hi; p++)
+            acc += (scores[p] * inv) * f16_bits_to_f32(vbase[(long)p * head_dim + did]);
+        vpart[(long)did * G + gid] = acc;
+    }
+    __syncthreads();
+    for (int did = tid; did < head_dim; did += blockDim.x) {
+        float sum = 0.0f;
+        for (int g = 0; g < G; g++) sum += vpart[(long)did * G + g];
+        out[(long)t * q_per_token + (long)head * head_dim + did] = sum;
     }
 }
 
@@ -1444,11 +1462,28 @@ extern "C" __global__ void attention_tree_batched(
     }
     __syncthreads();
     float inv = 1.0f / s_sum;
-    for (int d = tid; d < head_dim; d += blockDim.x) {
+    // Weighted V - IDENTICAL G-group FP-reassociation to attention_decode (G from the attended key
+    // count `count`; contiguous split + g-order combine match exactly). On a LINEAR tree
+    // count==position_count and slots[i]==i, so this is bit-identical to attention_batched and to
+    // single-token decode - the spec-verify losslessness anchor.
+    int max_groups = 1024 / head_dim; if (max_groups < 1) max_groups = 1;
+    int G = (count + head_dim - 1) / head_dim;
+    if (G < 1) G = 1; if (G > max_groups) G = max_groups;
+    float* vpart = (float*)(slots + base_position + k_tokens); // [max_groups * head_dim]
+    for (int idx = tid; idx < G * head_dim; idx += blockDim.x) {
+        int gid = idx / head_dim, did = idx % head_dim;
+        int i_lo = (int)((long)gid * count / G);
+        int i_hi = (int)((long)(gid + 1) * count / G);
         float acc = 0.0f;
-        for (int i = 0; i < count; i++)
-            acc += (scores[i] * inv) * f16_bits_to_f32(vbase[(long)slots[i] * head_dim + d]);
-        out[(long)t * q_per_token + (long)head * head_dim + d] = acc;
+        for (int i = i_lo; i < i_hi; i++)
+            acc += (scores[i] * inv) * f16_bits_to_f32(vbase[(long)slots[i] * head_dim + did]);
+        vpart[(long)did * G + gid] = acc;
+    }
+    __syncthreads();
+    for (int did = tid; did < head_dim; did += blockDim.x) {
+        float sum = 0.0f;
+        for (int g = 0; g < G; g++) sum += vpart[(long)did * G + g];
+        out[(long)t * q_per_token + (long)head * head_dim + did] = sum;
     }
 }
 
@@ -2435,8 +2470,10 @@ pub(crate) fn launch_attention_batched(
     q_per_token: usize,
     k: usize,
 ) -> Result<(), cudarc::driver::DriverError> {
-    // Shared = query (head_dim) + scores (longest prefix = base + k).
-    let shared = ((head_dim + base_position + k) as u32) * 4;
+    // Shared = query (head_dim) + scores (longest prefix = base + k) + weighted-V partials
+    // (max_groups * head_dim, the decode-parity G-group reduction scratch).
+    let max_groups = (1024 / head_dim).max(1);
+    let shared = ((head_dim + base_position + k + max_groups * head_dim) as u32) * 4;
     let cfg = LaunchConfig {
         grid_dim: ((k * n_heads) as u32, 1, 1),
         block_dim: (128, 1, 1),
@@ -2524,9 +2561,11 @@ pub(crate) fn launch_attention_tree_batched(
     q_per_token: usize,
     k: usize,
 ) -> Result<(), cudarc::driver::DriverError> {
-    // Shared = query (head_dim) + scores (<= base + k) + slot indices (<= base + k).
+    // Shared = query (head_dim) + scores (<= base + k) + slot indices (<= base + k) + weighted-V
+    // partials (max_groups * head_dim, the decode-parity G-group reduction scratch).
     // scores are f32 and slots are i32, both 4 bytes ⇒ 2*(base+k) words past head_dim.
-    let shared = ((head_dim + 2 * (base_position + k)) as u32) * 4;
+    let max_groups = (1024 / head_dim).max(1);
+    let shared = ((head_dim + 2 * (base_position + k) + max_groups * head_dim) as u32) * 4;
     let cfg = LaunchConfig {
         grid_dim: ((k * n_heads) as u32, 1, 1),
         block_dim: (128, 1, 1),


### PR DESCRIPTION
## What

The GPU speculative-verify kernels were not producing output bit-identical to plain greedy decode, so the lossless-speculation invariant (spec output == non-spec output, token for token) could break on a near-tie once context exceeded ~`head_dim`.

`attention_decode` reduces the per-position weighted-V with `G = clamp(ceil(pc/head_dim), 1, 1024/head_dim)` FP-reassociated groups (the token-parity-blessed reduction). The two verify kernels — `attention_batched` (the linear `verify_drafts_gpu` lane) and `attention_tree_batched` (the `CAMELID_SPEC_TREE` tree lane) — used a single sequential sum (effective `G=1`). Once context >= ~`head_dim` (so decode's `G >= 2`), the low bits disagree and a near-tie token can flip.

This ports decode's exact G-group reduction into both verify kernels (same G derived from the key count, same contiguous split, same g-order combine), so verify is bit-identical to decode **in the common decode regime** (see scope below). On a linear tree it is also bit-identical to `attention_batched` — the losslessness anchor the tree path is checked against.

## Scope — where this restores bit-identity (and where it does NOT)

The fix matches the reduction `attention_decode` uses on its **common path only: context <= 512 tokens AND CUDA graphs off** (the default). It does **not** yet cover:

- **Context > 512 tokens**: plain decode switches to the split-K attention path (`SPLITK_THRESHOLD`), a genuinely different reduction the verify kernels still do not match — so the lossless-spec invariant remains broken above 512. Real chats routinely exceed this; treat "bit-identical to plain decode" as scoped to <=512, not "always". (Follow-up.)
- **CUDA graphs on** (`cuda_graphs_enabled()`, default-off): decode launches with `shared_positions = max_pos` => `G = max_groups`; the verify path derives G from the key count, so they can disagree. (Follow-up.)

The observed bug (token 113) sits inside the fixed regime, so the actual reported failure is addressed.

## Why it matters

Camelid's speculative decoding is meant to be token-identical to non-speculative decoding. That guarantee was quietly false on the GPU spec path even at modest context (>= ~`head_dim`). This makes it true on the common path and clearly scopes what remains.

## Observed vs latent (please read)

- **Tree lane** (`attention_tree_batched`, `CAMELID_SPEC_TREE`, default-off): where the flip was **observed** — `creative_writing` diverged from plain greedy at generated token 113.
- **Linear lane** (`attention_batched`, the shipped n-gram GPU verify, default-on when spec is engaged): had the **same** `G=1`-vs-decode mismatch but was **not** observed flipping in testing. This is **defensive hardening** of the shipped lane against the same class of near-tie flip, not a fix for an observed failure.

## Not a speedup

Correctness/parity only. The new reduction is the same cost class; no throughput change is claimed or measured.

## Shared memory

Adds `max_groups * head_dim` f32 (~4 KB at head_dim 128) of `vpart` scratch per batched-kernel launch. Note the dynamic shared is already dominated by `scores` at `(base+k)*4` bytes, which independently approaches the 48 KB limit around ~11K context; this patch lowers that pre-existing ceiling only marginally and does not introduce it.

## Test

`qa/speed/spec-verify-parity.ps1` runs the full prompt pack on both verify lanes and asserts the intra-Camelid lossless gate (spec stream == this run's own plain greedy stream) on every column, including the spec-hostile mandatory-report columns. Before: `creative_writing` tree lane `DIVERGE@113`. After: all 12 (workload x lane) pairs LOSSLESS.

Coverage note: the gate's prompt columns stay under 512 context, so it validates exactly the regime this fix covers; it does **not** regression-guard the disclosed >512 (split-K) gap — that needs a separate long-context fixture once that regime is matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
