### PR TITLE
fix(cuda): reclaim resident VRAM on model switch so the 4B stays GPU-resident

### DIFF
--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -152,14 +152,14 @@ pub fn selected_device_ordinal() -> usize {
 
 #[cfg(feature = "cuda")]
 pub use backend::{
-    detect_cuda_device, probe_capability, try_q8_0_block_linear_row, try_q8_0_encoded_linear_row,
-    try_q8_0_encoded_linear_rows,
+    detect_cuda_device, probe_capability, release_async_pool, try_q8_0_block_linear_row,
+    try_q8_0_encoded_linear_row, try_q8_0_encoded_linear_rows,
 };
 
 #[cfg(not(feature = "cuda"))]
 pub use stub::{
-    detect_cuda_device, probe_capability, try_q8_0_block_linear_row, try_q8_0_encoded_linear_row,
-    try_q8_0_encoded_linear_rows,
+    detect_cuda_device, probe_capability, release_async_pool, try_q8_0_block_linear_row,
+    try_q8_0_encoded_linear_row, try_q8_0_encoded_linear_rows,
 };
 
 #[cfg(not(feature = "cuda"))]
@@ -169,6 +169,9 @@ mod stub {
     pub fn probe_capability() -> Option<CudaCapability> {
         None
     }
+
+    /// No-op without CUDA: there is no async memory pool to trim.
+    pub fn release_async_pool() {}
 
     pub fn detect_cuda_device() -> CudaDeviceInfo {
         CudaDeviceInfo {
@@ -468,6 +471,61 @@ extern "C" __global__ void q8_0_block_linear_row(
             vram_total_bytes: vram_total as u64,
             vram_free_bytes: vram_free as u64,
         })
+    }
+
+    /// Return memory cached in the device's default stream-ordered (async) memory
+    /// pool to the driver. cudarc allocates device buffers via `cuMemAllocAsync`, so
+    /// dropping a `CudaSlice` calls `cuMemFreeAsync`, which returns the bytes to this
+    /// pool rather than to the OS — leaving `cuMemGetInfo` (the free-VRAM probe in
+    /// `probe_capability`) still counting them as used. After dropping a resident
+    /// decode engine we trim the pool to 0 so the freed VRAM becomes visible to the
+    /// probe again; otherwise switching to a larger model under-counts free VRAM and
+    /// wrongly falls back to the CPU decode path. Best-effort: any error (or a host
+    /// without CUDA) is ignored — the caller only loses the reclaim, never correctness.
+    pub fn release_async_pool() {
+        let ordinal = super::selected_device_ordinal();
+        // Retain the primary context so the driver is initialized and the device
+        // handle is valid; held until after the trim. Guard the first call against a
+        // missing driver library (cudarc panics rather than returning Err there).
+        let _ctx = match std::panic::catch_unwind(|| CudaContext::new(ordinal)) {
+            Ok(Ok(ctx)) => ctx,
+            _ => return,
+        };
+        let trace = std::env::var_os("CAMELID_RESIDENT_TRACE").is_some();
+        let free_before = result::mem_get_info().map(|(f, _)| f).unwrap_or(0);
+        // The just-dropped engine released its weight/KV buffers with `cuMemFreeAsync`
+        // (cudarc allocates via `cuMemAllocAsync`), which is STREAM-ORDERED: the pool
+        // cannot hand that memory back — to the driver via trim OR to the next
+        // allocation — until the device has actually retired the frees. Synchronize the
+        // context FIRST, then trim. Without the sync the trim runs before the frees
+        // retire and reclaims nothing (measured: free stays pinned at the old model's
+        // footprint, so the next model's fit probe under-counts and falls back to CPU —
+        // the exact bug this function exists to fix).
+        let _ = result::ctx::synchronize();
+        // SAFETY: `ordinal` indexes a device the driver just reported via the retained
+        // context; the default pool handle is valid for the device's lifetime; and
+        // `trim_to` only releases pool reservations that no live allocation is using,
+        // so it cannot invalidate any outstanding `CudaSlice`.
+        unsafe {
+            let dev = match result::device::get(ordinal as core::ffi::c_int) {
+                Ok(dev) => dev,
+                Err(_) => return,
+            };
+            let pool = match result::device::get_default_mem_pool(dev) {
+                Ok(pool) => pool,
+                Err(_) => return,
+            };
+            let _ = result::mem_pool::trim_to(pool, 0);
+        }
+        if trace {
+            let free_after = result::mem_get_info().map(|(f, _)| f).unwrap_or(0);
+            eprintln!(
+                "[resident-cuda] release_async_pool: free {} MiB -> {} MiB (reclaimed {} MiB)",
+                free_before / (1024 * 1024),
+                free_after / (1024 * 1024),
+                free_after.saturating_sub(free_before) / (1024 * 1024),
+            );
+        }
     }
 
     pub fn detect_cuda_device() -> CudaDeviceInfo {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2141,6 +2141,16 @@ impl LlamaInferenceSession {
             .as_ref()
             .is_none_or(|slot| slot.key != key || !slot.engine.weights_ready());
         if need_build {
+            // Switching/rebuilding the resident engine: free any prior engine and
+            // return its VRAM to the driver BEFORE the new engine's fit probe. cudarc's
+            // cuMemAllocAsync pool keeps a dropped engine's bytes reserved (invisible to
+            // cuMemGetInfo), so without this the new (possibly larger) model under-counts
+            // free VRAM and falls back to the CPU path. No-op on the hot path: this only
+            // runs when a build is actually needed (key change / first build).
+            if guard.is_some() {
+                *guard = None;
+                crate::cuda::release_async_pool();
+            }
             match build_resident_cuda_engine(
                 &weights,
                 0..n_layers,
@@ -2785,6 +2795,14 @@ impl LlamaInferenceSession {
         }
         let build_started = std::time::Instant::now();
         if need_build {
+            // Free any prior resident engine and return its VRAM to the driver before
+            // the new engine's fit probe (see the matching note on the prefill path):
+            // cudarc's async pool otherwise hides the freed bytes from cuMemGetInfo and a
+            // larger model wrongly falls back to CPU. Only runs when a build is needed.
+            if guard.is_some() {
+                *guard = None;
+                crate::cuda::release_async_pool();
+            }
             match build_resident_cuda_engine(
                 &weights,
                 range.clone(),
@@ -9903,6 +9921,12 @@ pub fn reset_resident_caches() {
     *resident_cuda_drafter_cache()
         .lock()
         .unwrap_or_else(|p| p.into_inner()) = None;
+    // The engines dropped above returned their VRAM to cudarc's stream-ordered async
+    // pool (cuMemFreeAsync), where the free-VRAM probe cannot see it. Trim the pool so
+    // the next model's resident fit decision measures the real free VRAM — otherwise a
+    // larger model wrongly falls back to the CPU path (the ~20x-slower symptom this
+    // unload path exists to prevent).
+    crate::cuda::release_async_pool();
 }
 #[cfg(not(feature = "cuda"))]
 pub fn reset_resident_caches() {}


### PR DESCRIPTION
## Problem

On the 6 GB RTX 3060 laptop, switching to the Qwen3-4B in the desktop app dropped it to **~1 tok/s with the GPU idle (P8)** — the resident Q8 decode was silently falling back to the CPU path. The 4B is *not* too big: loaded into clean VRAM it goes fully resident (0/36 layers offloaded, ~27 tok/s). The problem only appeared after a **model switch**.

## Root cause

cudarc 0.19 allocates device buffers via `cuMemAllocAsync` (a stream-ordered memory pool). Dropping a `CudaSlice` calls `cuMemFreeAsync`, which returns the bytes to that **pool, not to the driver** — so `cuMemGetInfo` (the resident fit-probe at `inference.rs` ~10027) still counts them as used. `unload_model` already cleared the engine cache via `reset_resident_caches()`, but nothing trimmed the pool, so a switched-in model saw almost no free VRAM and refused the resident lane → CPU fallback (and for K-quant weights, a hard error since they aren't f32-readable on CPU).

Process restart was the only thing that cleared it (process exit destroys the pool).

## Fix

Add `cuda::release_async_pool()`:
1. `cuCtxSynchronize()` — so the stream-ordered `cuMemFreeAsync`s actually retire,
2. `cuMemPoolTrimTo(default_pool, 0)` — return the freed reservations to the driver.

Call it right after dropping a resident engine — in `reset_resident_caches()` and before both `need_build` rebuilds in the resident decode/prefill seams (`if guard.is_some() { *guard = None; release_async_pool(); }`).

The synchronize is **load-bearing**: trimming before the device retires the frees reclaims nothing (measured: 0 MiB reclaimed without the sync; **4640 MiB with it — free 482 → 5122**).

## Result (6 GB RTX 3060 laptop, via the desktop app)

| | before | after |
|---|---|---|
| 4B Q8 on switch | ~1 tok/s (CPU, P8) | **~27 tok/s (resident, P0)** |

Validated by switching 1.7B ↔ 4B-Q8 ↔ 4B-Q4_K_M repeatedly — every model goes fully GPU-resident after a one-time re-upload. Single-model / non-switch path is unchanged; CPU-only builds get a no-op stub.

## Scope

- `src/cuda.rs`: new `release_async_pool()` (+ re-export + non-cuda stub), with a `CAMELID_RESIDENT_TRACE` reclaim line.
- `src/inference.rs`: call it in `reset_resident_caches()` and before the two resident rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)