### PR TITLE
Ornith-1.0-9B: qwen35 GPU resident lane — fully GPU-resident on 6 GB, token-parity, ~12 tok/s, 8192 ctx

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1668,8 +1668,16 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         "none"
     };
     // The gemma4 runtime (Q8-resident) is ready as soon as it is loaded; the Llama
-    // f32-budget check does not apply to it.
-    let generation_ready = gemma4_available || model.is_some_and(loaded_model_generation_ready);
+    // f32-budget check does not apply to it. Likewise, a model served by the runnable
+    // lane (CAMELID_RUNNABLE_SERVE + a runnable-served arch, e.g. qwen35/Ornith) is
+    // generation-ready once loaded — the runnable serve runtime is built lazily on the
+    // first chat, so gate on "runnable-serve enabled + runnable arch + loaded" rather
+    // than the lazy runtime map (otherwise chat stays locked until you chat → deadlock).
+    let runnable_serve_ready = runnable_serve_enabled()
+        && model.is_some_and(|m| is_runnable_serve_arch(m.gguf.architecture().unwrap_or_default()));
+    let generation_ready = gemma4_available
+        || runnable_serve_ready
+        || model.is_some_and(loaded_model_generation_ready);
     let execution_plans = state.execution_plans.read().await;
     let execution_plan = active_id_lock
         .as_ref()

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -2271,6 +2271,26 @@ use cudarc::driver::{CudaSlice, LaunchConfig, PushKernelArg};
 /// (`n_blocks` f32). Quants-first keeps every block's 32 i8 16-byte aligned so
 /// the kernel can issue `int4` loads. Done once per weight at upload; the values
 /// are unchanged, only their arrangement.
+/// Widen Q8_0 GGUF wire blocks (34 bytes: f16 scale + 32 i8) to the 36-byte layout
+/// (f32 scale + 32 i8) that [`repack_q8_soa`] expects. The runnable lane holds Q8_0
+/// weights as raw 34-byte GGUF blocks; the resident GEMV reads 36-byte (f32-scale)
+/// blocks, so the qwen35 builder widens before repacking.
+// Used by build_qwen35_resident (model.rs) — dead in a lib-only build until the M4
+// generate_qwen35_cuda driver calls the builder from lib code (next).
+#[allow(dead_code)]
+pub(crate) fn widen_q8(bytes: &[u8]) -> Vec<u8> {
+    let nb = bytes.len() / 34;
+    let mut out = Vec::with_capacity(nb * 36);
+    for b in 0..nb {
+        let base = b * 34;
+        let scale =
+            crate::tensor::f16_bits_to_f32(u16::from_le_bytes([bytes[base], bytes[base + 1]]));
+        out.extend_from_slice(&scale.to_le_bytes());
+        out.extend_from_slice(&bytes[base + 2..base + 34]);
+    }
+    out
+}
+
 pub(crate) fn repack_q8_soa(bytes: &[u8]) -> Vec<u8> {
     let n = bytes.len() / 36;
     let mut out = vec![0u8; n * 32 + n * 4];
@@ -3221,6 +3241,174 @@ pub(crate) fn launch_rms_norm_per_head(
     unsafe { b.launch(cfg) }.map(|_| ())
 }
 
+// ---- qwen35 (Ornith) SSM + full-attn launch helpers ------------------------
+// Single source of truth for the qwen35-specific kernel launches; the parity tests
+// in runnable/model.rs proved these exact configs (bit-identical SSM layer, 6e-3
+// full-attn layer), and forward_pass calls the SAME helpers.
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn launch_ssm_gates(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    beta_raw: &CudaSlice<f32>,
+    alpha_raw: &CudaSlice<f32>,
+    dt_bias: &CudaSlice<f32>,
+    a: &CudaSlice<f32>,
+    beta_out: &mut CudaSlice<f32>,
+    glog_out: &mut CudaSlice<f32>,
+    nv: usize,
+) -> Result<(), cudarc::driver::DriverError> {
+    let cfg = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (nv as u32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let nvi = nv as i32;
+    let mut b = s.launch_builder(f);
+    b.arg(beta_raw)
+        .arg(alpha_raw)
+        .arg(dt_bias)
+        .arg(a)
+        .arg(beta_out)
+        .arg(glog_out)
+        .arg(&nvi);
+    unsafe { b.launch(cfg) }.map(|_| ())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn launch_ssm_conv1d(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    conv_w: &CudaSlice<f32>,
+    x: &CudaSlice<f32>,
+    conv_state: &mut CudaSlice<f32>,
+    conv_out: &mut CudaSlice<f32>,
+    conv_dim: usize,
+    d_conv: usize,
+) -> Result<(), cudarc::driver::DriverError> {
+    let cfg = LaunchConfig {
+        grid_dim: ((conv_dim as u32).div_ceil(256), 1, 1),
+        block_dim: (256, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let (cdi, dci) = (conv_dim as i32, d_conv as i32);
+    let mut b = s.launch_builder(f);
+    b.arg(conv_w)
+        .arg(x)
+        .arg(conv_state)
+        .arg(conv_out)
+        .arg(&cdi)
+        .arg(&dci);
+    unsafe { b.launch(cfg) }.map(|_| ())
+}
+
+/// Per-head L2 norm in place over `buf[offset .. offset + head_count*head_dim]`.
+pub(crate) fn launch_ssm_l2_norm_per_head(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    buf: &mut CudaSlice<f32>,
+    offset: usize,
+    head_count: usize,
+    head_dim: usize,
+    eps: f32,
+) -> Result<(), cudarc::driver::DriverError> {
+    let cfg = LaunchConfig {
+        grid_dim: (head_count as u32, 1, 1),
+        block_dim: (head_dim as u32, 1, 1),
+        shared_mem_bytes: (head_dim as u32) * 4,
+    };
+    let dsi = head_dim as i32;
+    let mut view = buf.slice_mut(offset..offset + head_count * head_dim);
+    let mut b = s.launch_builder(f);
+    b.arg(&mut view).arg(&dsi).arg(&eps);
+    unsafe { b.launch(cfg) }.map(|_| ())
+}
+
+/// Gated delta-rule + gated RMSNorm. `conv_out` holds [q(key_dim)|k(key_dim)|v(value_dim)]
+/// (q/k already L2-normed); the kernel arg order is `state, k_conv, q_conv, v_conv`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn launch_ssm_delta_rule(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    state: &mut CudaSlice<f32>,
+    conv_out: &CudaSlice<f32>,
+    key_dim: usize,
+    value_dim: usize,
+    z: &CudaSlice<f32>,
+    beta: &CudaSlice<f32>,
+    glog: &CudaSlice<f32>,
+    ssm_norm: &CudaSlice<f32>,
+    out: &mut CudaSlice<f32>,
+    d_state: usize,
+    nk: usize,
+    nv: usize,
+    eps: f32,
+) -> Result<(), cudarc::driver::DriverError> {
+    let cfg = LaunchConfig {
+        grid_dim: (nv as u32, 1, 1),
+        block_dim: (d_state as u32, 1, 1),
+        shared_mem_bytes: (3 * d_state as u32) * 4,
+    };
+    let (dsi, nki) = (d_state as i32, nk as i32);
+    let qv = conv_out.slice(0..key_dim);
+    let kv = conv_out.slice(key_dim..2 * key_dim);
+    let vv = conv_out.slice(2 * key_dim..2 * key_dim + value_dim);
+    let mut b = s.launch_builder(f);
+    b.arg(state)
+        .arg(&kv)
+        .arg(&qv)
+        .arg(&vv)
+        .arg(z)
+        .arg(beta)
+        .arg(glog)
+        .arg(ssm_norm)
+        .arg(out)
+        .arg(&dsi)
+        .arg(&nki)
+        .arg(&eps);
+    unsafe { b.launch(cfg) }.map(|_| ())
+}
+
+/// Split the fused per-head [query(head_dim)|gate(head_dim)] x n_heads into q / gate.
+pub(crate) fn launch_deinterleave_qgate(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    qg: &CudaSlice<f32>,
+    q_out: &mut CudaSlice<f32>,
+    gate_out: &mut CudaSlice<f32>,
+    n_heads: usize,
+    head_dim: usize,
+) -> Result<(), cudarc::driver::DriverError> {
+    let cfg = LaunchConfig {
+        grid_dim: (((n_heads * head_dim) as u32).div_ceil(256), 1, 1),
+        block_dim: (256, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let (nh, hdi) = (n_heads as i32, head_dim as i32);
+    let mut b = s.launch_builder(f);
+    b.arg(qg).arg(q_out).arg(gate_out).arg(&nh).arg(&hdi);
+    unsafe { b.launch(cfg) }.map(|_| ())
+}
+
+/// `out[i] *= sigmoid(gate[i])` (qwen35 full-attention output gate).
+pub(crate) fn launch_sigmoid_mul(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    out: &mut CudaSlice<f32>,
+    gate: &CudaSlice<f32>,
+    n: usize,
+) -> Result<(), cudarc::driver::DriverError> {
+    let cfg = LaunchConfig {
+        grid_dim: ((n as u32).div_ceil(256), 1, 1),
+        block_dim: (256, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let ni = n as i32;
+    let mut b = s.launch_builder(f);
+    b.arg(out).arg(gate).arg(&ni);
+    unsafe { b.launch(cfg) }.map(|_| ())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn launch_kv_scatter(
     s: &Arc<CudaStream>,
@@ -3719,10 +3907,10 @@ struct SsmResident {
     dt_bias: CudaSlice<f32>, // [num_v_heads]
     a: CudaSlice<f32>,      // [num_v_heads]
     ssm_norm: CudaSlice<f32>, // [d_state]
-    /// Causal-conv ring buffer [conv_dim * (d_conv-1)] — persists across tokens.
-    conv_state: CudaSlice<f32>,
-    /// Recurrent per-head state [num_v_heads * d_state * d_state] — persists across tokens.
-    state: CudaSlice<f32>,
+                            // NOTE: the persistent conv ring buffer + recurrent state live in engine-level
+                            // `ssm_conv_state` / `ssm_state` Vecs (indexed by layer), NOT here — so the SSM
+                            // forward can borrow the state mutably while borrowing this layer's `ssm_norm`
+                            // immutably (disjoint engine fields). See `CudaResidentDecode`.
 }
 
 /// qwen35 gated-delta-net dimensions + the per-token SSM/full scratch, allocated by the
@@ -3844,8 +4032,15 @@ pub struct CudaResidentDecode {
     /// qwen35 (Ornith) gated-delta-net dims + SSM/full per-token scratch. `None` for
     /// every other architecture (no extra VRAM, no path change). Set by the qwen35
     /// resident builder.
-    #[allow(dead_code)] // read by the SSM forward branch + builder (wired next).
     qwen35: Option<Qwen35Gpu>,
+    /// qwen35 SSM causal-conv ring buffers, per layer (`[conv_dim*(d_conv-1)]`); a
+    /// 1-element placeholder for Full layers. Empty for non-qwen35 models. Persists
+    /// across tokens — zeroed by `reset_qwen35_state` at the start of each generation.
+    ssm_conv_state: Vec<CudaSlice<f32>>,
+    /// qwen35 SSM recurrent per-head state, per layer (`[num_v_heads*d_state*d_state]`);
+    /// 1-element placeholder for Full layers. Empty for non-qwen35. Persists across
+    /// tokens — zeroed by `reset_qwen35_state`.
+    ssm_state: Vec<CudaSlice<f32>>,
 }
 
 /// Max tokens verified per speculative round. The batched GEMM keeps the ordered
@@ -4001,6 +4196,8 @@ impl CudaResidentDecode {
             tree_scratch: None,
             offload: None,
             qwen35: None,
+            ssm_conv_state: Vec::new(),
+            ssm_state: Vec::new(),
             k,
         })
     }
@@ -4251,6 +4448,171 @@ impl CudaResidentDecode {
         if output_quant.needs_q8k() {
             self.uses_kquant = true;
         }
+        Ok(())
+    }
+
+    /// qwen35 (Ornith): attach the gated-delta-net dims and allocate the per-token
+    /// SSM/full scratch. `head_v_dim` == `d_state` for Ornith.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_qwen35(
+        &mut self,
+        d_state: usize,
+        d_conv: usize,
+        num_k_heads: usize,
+        num_v_heads: usize,
+        head_v_dim: usize,
+        key_dim: usize,
+        value_dim: usize,
+        conv_dim: usize,
+    ) -> Result<(), String> {
+        let s = self.k.stream.clone();
+        let af = |n: usize| -> Result<CudaSlice<f32>, String> {
+            s.alloc_zeros::<f32>(n).map_err(|e| format!("alloc: {e}"))
+        };
+        self.qwen35 = Some(Qwen35Gpu {
+            d_state,
+            d_conv,
+            num_k_heads,
+            num_v_heads,
+            head_v_dim,
+            key_dim,
+            value_dim,
+            conv_dim,
+            d_qkv: af(conv_dim)?,
+            d_conv_out: af(conv_dim)?,
+            d_z: af(value_dim)?,
+            d_beta: af(num_v_heads)?,
+            d_glog: af(num_v_heads)?,
+            d_ssm_mix: af(value_dim)?,
+            d_qgate: af(2 * self.q_width)?,
+            d_gate_attn: af(self.q_width)?,
+        });
+        Ok(())
+    }
+
+    /// Keep the per-layer `ssm_conv_state`/`ssm_state` Vecs length-synced with `layers`
+    /// for a Full (non-SSM) qwen35 layer: a never-read 1-element placeholder.
+    pub fn push_ssm_placeholders(&mut self) -> Result<(), String> {
+        let s = self.k.stream.clone();
+        self.ssm_conv_state
+            .push(s.alloc_zeros::<f32>(1).map_err(|e| format!("alloc: {e}"))?);
+        self.ssm_state
+            .push(s.alloc_zeros::<f32>(1).map_err(|e| format!("alloc: {e}"))?);
+        Ok(())
+    }
+
+    /// Zero every qwen35 SSM recurrent state + conv ring buffer and reset `filled`.
+    /// MUST be called at the start of each generation — the SSM state persists across
+    /// tokens AND across generate calls, so skipping this decodes turn 2 on stale state.
+    pub fn reset_qwen35_state(&mut self) -> Result<(), String> {
+        let s = self.k.stream.clone();
+        for buf in self
+            .ssm_conv_state
+            .iter_mut()
+            .chain(self.ssm_state.iter_mut())
+        {
+            if buf.len() > 1 {
+                let zeros = vec![0.0f32; buf.len()];
+                s.memcpy_htod(&zeros, buf)
+                    .map_err(|e| format!("reset htod: {e}"))?;
+            }
+        }
+        self.filled = 0;
+        Ok(())
+    }
+
+    /// Upload one qwen35 gated-delta-net (SSM) layer plus its persistent conv ring and
+    /// recurrent state. Q8_0 weight bytes must already be the 36-byte (f32-scale)
+    /// layout (`widen_q8`); K-quant bytes are raw GGUF super-blocks. `quants` order is
+    /// wqkv, wqkv_gate, beta, alpha, ssm_out; `ffn_quants` is gate, up, down.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_layer_ssm_qwen35(
+        &mut self,
+        gate: &[u8],
+        up: &[u8],
+        down: &[u8],
+        attn_norm: &[f32],
+        ffn_norm: &[f32],
+        wqkv: &[u8],
+        wqkv_gate: &[u8],
+        beta: &[u8],
+        alpha: &[u8],
+        ssm_out: &[u8],
+        conv1d: &[f32],
+        dt_bias: &[f32],
+        a: &[f32],
+        ssm_norm: &[f32],
+        ssm_quants: [ProjQuant; 5],
+        ffn_quants: [ProjQuant; 3],
+        conv_dim: usize,
+        d_conv: usize,
+        nv: usize,
+        d_state: usize,
+    ) -> Result<(), String> {
+        let s = self.k.stream.clone();
+        let up_u8 = |b: &[u8], q: ProjQuant| -> Result<CudaSlice<u8>, String> {
+            s.clone_htod(&repack_for_lane(b, q))
+                .map_err(|e| format!("htod: {e}"))
+        };
+        let up_f = |b: &[f32]| -> Result<CudaSlice<f32>, String> {
+            s.clone_htod(b).map_err(|e| format!("htod: {e}"))
+        };
+        let ph = || s.clone_htod(&[0u8]).map_err(|e| format!("htod: {e}"));
+        let ssm = SsmResident {
+            wqkv: up_u8(wqkv, ssm_quants[0])?,
+            wqkv_gate: up_u8(wqkv_gate, ssm_quants[1])?,
+            beta: up_u8(beta, ssm_quants[2])?,
+            alpha: up_u8(alpha, ssm_quants[3])?,
+            ssm_out: up_u8(ssm_out, ssm_quants[4])?,
+            quants: ssm_quants,
+            conv1d: up_f(conv1d)?,
+            dt_bias: up_f(dt_bias)?,
+            a: up_f(a)?,
+            ssm_norm: up_f(ssm_norm)?,
+        };
+        let gate_g = up_u8(gate, ffn_quants[0])?;
+        let up_g = up_u8(up, ffn_quants[1])?;
+        let down_g = up_u8(down, ffn_quants[2])?;
+        let attn_norm_g = up_f(attn_norm)?;
+        let ffn_norm_g = up_f(ffn_norm)?;
+        // layer.quants drives the shared attn-norm+quantize (cols 0..3 = the SSM
+        // activation consumers) and the FFN (cols 4..6 = gate/up/down).
+        let quants = [
+            ssm_quants[0],
+            ssm_quants[1],
+            ssm_quants[2],
+            ssm_quants[3],
+            ffn_quants[0],
+            ffn_quants[1],
+            ffn_quants[2],
+        ];
+        if quants.iter().any(|q| q.needs_q8k()) {
+            self.uses_kquant = true;
+        }
+        self.layers.push(ResidentLayer {
+            q: ph()?,
+            k: ph()?,
+            v: ph()?,
+            o: ph()?,
+            gate: gate_g,
+            up: up_g,
+            down: down_g,
+            attn_norm: attn_norm_g,
+            ffn_norm: ffn_norm_g,
+            q_norm: None,
+            k_norm: None,
+            offloaded: None,
+            quants,
+            kind: LayerKind::Ssm(Box::new(ssm)),
+        });
+        self.ssm_conv_state.push(
+            s.alloc_zeros::<f32>(conv_dim * (d_conv - 1))
+                .map_err(|e| format!("alloc: {e}"))?,
+        );
+        self.ssm_state.push(
+            s.alloc_zeros::<f32>(nv * d_state * d_state)
+                .map_err(|e| format!("alloc: {e}"))?,
+        );
         Ok(())
     }
 
@@ -4588,240 +4950,454 @@ impl CudaResidentDecode {
                 )
                 .map_err(map)?;
             }
-            // Q,K,V
-            dispatch_gemv(
-                &s,
-                &self.k,
-                lq[0],
-                &self.d_in_scales,
-                &self.d_in_quants,
-                &self.d_q8k_scales,
-                &self.d_q8k_quants,
-                &wq,
-                self.q_width,
-                self.hidden,
-                &mut self.d_q,
-                0,
-            )
-            .map_err(map)?;
-            dispatch_gemv(
-                &s,
-                &self.k,
-                lq[1],
-                &self.d_in_scales,
-                &self.d_in_quants,
-                &self.d_q8k_scales,
-                &self.d_q8k_quants,
-                &wk,
-                self.kv_width,
-                self.hidden,
-                &mut self.d_k,
-                0,
-            )
-            .map_err(map)?;
-            dispatch_gemv(
-                &s,
-                &self.k,
-                lq[2],
-                &self.d_in_scales,
-                &self.d_in_quants,
-                &self.d_q8k_scales,
-                &self.d_q8k_quants,
-                &wv,
-                self.kv_width,
-                self.hidden,
-                &mut self.d_v,
-                0,
-            )
-            .map_err(map)?;
-            // Qwen3 QK-norm: per-head RMSNorm on Q and K after projection, before RoPE
-            if let (Some(ref qn), Some(ref kn)) = (&self.layers[li].q_norm, &self.layers[li].k_norm)
-            {
-                launch_rms_norm_per_head(
-                    &s,
-                    &self.k.rms_norm_per_head,
-                    &mut self.d_q,
-                    qn,
-                    self.n_heads,
-                    self.head_dim,
-                    self.eps,
-                )
-                .map_err(map)?;
-                launch_rms_norm_per_head(
-                    &s,
-                    &self.k.rms_norm_per_head,
-                    &mut self.d_k,
-                    kn,
-                    self.n_kv_heads,
-                    self.head_dim,
-                    self.eps,
-                )
-                .map_err(map)?;
-            }
-            // RoPE on Q and K
-            let pairing = if self.split_half_pairing { 1i32 } else { 0i32 };
-            launch_rope(
-                &s,
-                &self.k.rope,
-                &mut self.d_q,
-                &self.d_cos,
-                &self.d_sin,
-                self.n_heads,
-                self.head_dim,
-                self.rope_dim,
-                pairing,
-            )
-            .map_err(map)?;
-            launch_rope(
-                &s,
-                &self.k.rope,
-                &mut self.d_k,
-                &self.d_cos,
-                &self.d_sin,
-                self.n_kv_heads,
-                self.head_dim,
-                self.rope_dim,
-                pairing,
-            )
-            .map_err(map)?;
-            // KV write
-            launch_kv_scatter(
-                &s,
-                &self.k.kv_scatter,
-                &self.d_k,
-                &mut self.cache_k[li],
-                &self.d_position,
-                self.n_kv_heads,
-                self.head_dim,
-                self.max_pos,
-            )
-            .map_err(map)?;
-            launch_kv_scatter(
-                &s,
-                &self.k.kv_scatter,
-                &self.d_v,
-                &mut self.cache_v[li],
-                &self.d_position,
-                self.n_kv_heads,
-                self.head_dim,
-                self.max_pos,
-            )
-            .map_err(map)?;
-            // attention. At depth, split-K (grid n_heads x n_splits) fills the SMs that
-            // the one-block-per-head launch leaves idle; below SPLITK_THRESHOLD the single
-            // kernel is cheaper (one launch, no scratch). Both are token-parity to the same
-            // reference. Split-K is skipped during graph capture (split count is ctx-dependent).
-            if !graph_capture && attn_shared > SPLITK_THRESHOLD {
-                launch_attention_splitk(
-                    &s,
-                    &self.k,
-                    &self.d_q,
-                    &self.cache_k[li],
-                    &self.cache_v[li],
-                    &mut self.d_attn,
-                    &mut self.d_sk_scores,
-                    &mut self.d_sk_chunkmax,
-                    &mut self.d_sk_lsum,
-                    &mut self.d_sk_acc,
-                    self.n_heads,
-                    self.n_kv_heads,
-                    self.head_dim,
-                    &self.d_position,
-                    attn_shared,
-                    self.max_pos,
-                    scale,
-                )
-                .map_err(map)?;
-            } else {
-                launch_attention(
-                    &s,
-                    &self.k.attention,
-                    &self.d_q,
-                    &self.cache_k[li],
-                    &self.cache_v[li],
-                    &mut self.d_attn,
-                    self.n_heads,
-                    self.n_kv_heads,
-                    self.head_dim,
-                    &self.d_position,
-                    attn_shared,
-                    self.max_pos,
-                    scale,
-                )
-                .map_err(map)?;
-            }
-            // O projection + residual. Input is the attention output (q_width wide):
-            // quantize it to the format the O lane reads, then project + add residual.
-            if lq[3] == ProjQuant::Q8_0 {
-                launch_quantize(
-                    &s,
-                    &self.k.quantize,
-                    &self.d_attn,
-                    &mut self.d_in_quants,
-                    &mut self.d_in_scales,
-                    qb,
-                )
-                .map_err(map)?;
-                if fused {
-                    launch_gemv_residual(
+            // qwen35 hybrid: SSM layers replace the whole attention mixer; full-attn
+            // layers run the existing path plus a fused query+gate split and a sigmoid
+            // output gate. Both kinds share the attn-norm+quantize above and the FFN below.
+            match &self.layers[li].kind {
+                LayerKind::Full => {
+                    // Q,K,V  (qwen35 full-attn: wq is the fused [query|gate] projection -> 2*q_width)
+                    if let Some(q) = self.qwen35.as_mut() {
+                        dispatch_gemv(
+                            &s,
+                            &self.k,
+                            lq[0],
+                            &self.d_in_scales,
+                            &self.d_in_quants,
+                            &self.d_q8k_scales,
+                            &self.d_q8k_quants,
+                            &wq,
+                            2 * self.q_width,
+                            self.hidden,
+                            &mut q.d_qgate,
+                            0,
+                        )
+                        .map_err(map)?;
+                        launch_deinterleave_qgate(
+                            &s,
+                            &self.k.deinterleave_qgate,
+                            &q.d_qgate,
+                            &mut self.d_q,
+                            &mut q.d_gate_attn,
+                            self.n_heads,
+                            self.head_dim,
+                        )
+                        .map_err(map)?;
+                    } else {
+                        dispatch_gemv(
+                            &s,
+                            &self.k,
+                            lq[0],
+                            &self.d_in_scales,
+                            &self.d_in_quants,
+                            &self.d_q8k_scales,
+                            &self.d_q8k_quants,
+                            &wq,
+                            self.q_width,
+                            self.hidden,
+                            &mut self.d_q,
+                            0,
+                        )
+                        .map_err(map)?;
+                    }
+                    dispatch_gemv(
                         &s,
-                        &self.k.gemv,
+                        &self.k,
+                        lq[1],
                         &self.d_in_scales,
                         &self.d_in_quants,
-                        &wo,
+                        &self.d_q8k_scales,
+                        &self.d_q8k_quants,
+                        &wk,
+                        self.kv_width,
                         self.hidden,
-                        qb,
-                        &mut self.d_hidden,
+                        &mut self.d_k,
+                        0,
                     )
                     .map_err(map)?;
-                } else {
-                    launch_gemv(
+                    dispatch_gemv(
                         &s,
-                        &self.k.gemv,
+                        &self.k,
+                        lq[2],
                         &self.d_in_scales,
                         &self.d_in_quants,
-                        &wo,
+                        &self.d_q8k_scales,
+                        &self.d_q8k_quants,
+                        &wv,
+                        self.kv_width,
                         self.hidden,
-                        qb,
-                        &mut self.d_proj,
+                        &mut self.d_v,
+                        0,
                     )
                     .map_err(map)?;
-                    launch_residual(
+                    // Qwen3 QK-norm: per-head RMSNorm on Q and K after projection, before RoPE
+                    if let (Some(ref qn), Some(ref kn)) =
+                        (&self.layers[li].q_norm, &self.layers[li].k_norm)
+                    {
+                        launch_rms_norm_per_head(
+                            &s,
+                            &self.k.rms_norm_per_head,
+                            &mut self.d_q,
+                            qn,
+                            self.n_heads,
+                            self.head_dim,
+                            self.eps,
+                        )
+                        .map_err(map)?;
+                        launch_rms_norm_per_head(
+                            &s,
+                            &self.k.rms_norm_per_head,
+                            &mut self.d_k,
+                            kn,
+                            self.n_kv_heads,
+                            self.head_dim,
+                            self.eps,
+                        )
+                        .map_err(map)?;
+                    }
+                    // RoPE on Q and K
+                    let pairing = if self.split_half_pairing { 1i32 } else { 0i32 };
+                    launch_rope(
                         &s,
-                        &self.k.residual_add,
-                        &mut self.d_hidden,
-                        &self.d_proj,
+                        &self.k.rope,
+                        &mut self.d_q,
+                        &self.d_cos,
+                        &self.d_sin,
+                        self.n_heads,
+                        self.head_dim,
+                        self.rope_dim,
+                        pairing,
+                    )
+                    .map_err(map)?;
+                    launch_rope(
+                        &s,
+                        &self.k.rope,
+                        &mut self.d_k,
+                        &self.d_cos,
+                        &self.d_sin,
+                        self.n_kv_heads,
+                        self.head_dim,
+                        self.rope_dim,
+                        pairing,
+                    )
+                    .map_err(map)?;
+                    // KV write
+                    launch_kv_scatter(
+                        &s,
+                        &self.k.kv_scatter,
+                        &self.d_k,
+                        &mut self.cache_k[li],
+                        &self.d_position,
+                        self.n_kv_heads,
+                        self.head_dim,
+                        self.max_pos,
+                    )
+                    .map_err(map)?;
+                    launch_kv_scatter(
+                        &s,
+                        &self.k.kv_scatter,
+                        &self.d_v,
+                        &mut self.cache_v[li],
+                        &self.d_position,
+                        self.n_kv_heads,
+                        self.head_dim,
+                        self.max_pos,
+                    )
+                    .map_err(map)?;
+                    // attention. At depth, split-K (grid n_heads x n_splits) fills the SMs that
+                    // the one-block-per-head launch leaves idle; below SPLITK_THRESHOLD the single
+                    // kernel is cheaper (one launch, no scratch). Both are token-parity to the same
+                    // reference. Split-K is skipped during graph capture (split count is ctx-dependent).
+                    if !graph_capture && attn_shared > SPLITK_THRESHOLD {
+                        launch_attention_splitk(
+                            &s,
+                            &self.k,
+                            &self.d_q,
+                            &self.cache_k[li],
+                            &self.cache_v[li],
+                            &mut self.d_attn,
+                            &mut self.d_sk_scores,
+                            &mut self.d_sk_chunkmax,
+                            &mut self.d_sk_lsum,
+                            &mut self.d_sk_acc,
+                            self.n_heads,
+                            self.n_kv_heads,
+                            self.head_dim,
+                            &self.d_position,
+                            attn_shared,
+                            self.max_pos,
+                            scale,
+                        )
+                        .map_err(map)?;
+                    } else {
+                        launch_attention(
+                            &s,
+                            &self.k.attention,
+                            &self.d_q,
+                            &self.cache_k[li],
+                            &self.cache_v[li],
+                            &mut self.d_attn,
+                            self.n_heads,
+                            self.n_kv_heads,
+                            self.head_dim,
+                            &self.d_position,
+                            attn_shared,
+                            self.max_pos,
+                            scale,
+                        )
+                        .map_err(map)?;
+                    }
+                    // qwen35 full-attention sigmoid output gate: attn[i] *= sigmoid(gate[i]).
+                    if let Some(q) = self.qwen35.as_ref() {
+                        launch_sigmoid_mul(
+                            &s,
+                            &self.k.sigmoid_mul,
+                            &mut self.d_attn,
+                            &q.d_gate_attn,
+                            self.q_width,
+                        )
+                        .map_err(map)?;
+                    }
+                    // O projection + residual. Input is the attention output (q_width wide):
+                    // quantize it to the format the O lane reads, then project + add residual.
+                    if lq[3] == ProjQuant::Q8_0 {
+                        launch_quantize(
+                            &s,
+                            &self.k.quantize,
+                            &self.d_attn,
+                            &mut self.d_in_quants,
+                            &mut self.d_in_scales,
+                            qb,
+                        )
+                        .map_err(map)?;
+                        if fused {
+                            launch_gemv_residual(
+                                &s,
+                                &self.k.gemv,
+                                &self.d_in_scales,
+                                &self.d_in_quants,
+                                &wo,
+                                self.hidden,
+                                qb,
+                                &mut self.d_hidden,
+                            )
+                            .map_err(map)?;
+                        } else {
+                            launch_gemv(
+                                &s,
+                                &self.k.gemv,
+                                &self.d_in_scales,
+                                &self.d_in_quants,
+                                &wo,
+                                self.hidden,
+                                qb,
+                                &mut self.d_proj,
+                            )
+                            .map_err(map)?;
+                            launch_residual(
+                                &s,
+                                &self.k.residual_add,
+                                &mut self.d_hidden,
+                                &self.d_proj,
+                                self.hidden,
+                            )
+                            .map_err(map)?;
+                        }
+                    } else {
+                        // K-quant O lane: Q8_K activation, fused-residual GEMV (bit-identical
+                        // to gemv + residual_add — the kernel's residual arg adds onto d_hidden).
+                        launch_quantize_q8k(
+                            &s,
+                            &self.k.quantize_q8k,
+                            &self.d_attn,
+                            &mut self.d_q8k_quants,
+                            &mut self.d_q8k_scales,
+                            self.q_width / 256,
+                        )
+                        .map_err(map)?;
+                        dispatch_gemv(
+                            &s,
+                            &self.k,
+                            lq[3],
+                            &self.d_in_scales,
+                            &self.d_in_quants,
+                            &self.d_q8k_scales,
+                            &self.d_q8k_quants,
+                            &wo,
+                            self.hidden,
+                            self.q_width,
+                            &mut self.d_hidden,
+                            1,
+                        )
+                        .map_err(map)?;
+                    }
+                }
+                LayerKind::Ssm(ssm) => {
+                    // The shared attn-norm+quantize above produced the Q8 activation in
+                    // d_in_*. Run the proven SSM mixer (== runnable qwen35_ssm_compute):
+                    // wqkv/wqkv_gate/beta/alpha gemv -> gates -> conv1d -> l2norm q/k ->
+                    // delta-rule -> ssm_out gemv (+= residual). beta_raw/alpha_raw reuse the
+                    // idle attention scratch d_k/d_v (kv_width >= num_v_heads).
+                    let (ds, nk, nv, key_dim, value_dim, conv_dim, d_conv) = {
+                        let g = self.qwen35.as_ref().unwrap();
+                        (
+                            g.d_state,
+                            g.num_k_heads,
+                            g.num_v_heads,
+                            g.key_dim,
+                            g.value_dim,
+                            g.conv_dim,
+                            g.d_conv,
+                        )
+                    };
+                    let sq = ssm.quants;
+                    let q = self.qwen35.as_mut().unwrap();
+                    dispatch_gemv(
+                        &s,
+                        &self.k,
+                        sq[0],
+                        &self.d_in_scales,
+                        &self.d_in_quants,
+                        &self.d_q8k_scales,
+                        &self.d_q8k_quants,
+                        &ssm.wqkv.as_view(),
+                        conv_dim,
                         self.hidden,
+                        &mut q.d_qkv,
+                        0,
+                    )
+                    .map_err(map)?;
+                    dispatch_gemv(
+                        &s,
+                        &self.k,
+                        sq[1],
+                        &self.d_in_scales,
+                        &self.d_in_quants,
+                        &self.d_q8k_scales,
+                        &self.d_q8k_quants,
+                        &ssm.wqkv_gate.as_view(),
+                        value_dim,
+                        self.hidden,
+                        &mut q.d_z,
+                        0,
+                    )
+                    .map_err(map)?;
+                    dispatch_gemv(
+                        &s,
+                        &self.k,
+                        sq[2],
+                        &self.d_in_scales,
+                        &self.d_in_quants,
+                        &self.d_q8k_scales,
+                        &self.d_q8k_quants,
+                        &ssm.beta.as_view(),
+                        nv,
+                        self.hidden,
+                        &mut self.d_k,
+                        0,
+                    )
+                    .map_err(map)?;
+                    dispatch_gemv(
+                        &s,
+                        &self.k,
+                        sq[3],
+                        &self.d_in_scales,
+                        &self.d_in_quants,
+                        &self.d_q8k_scales,
+                        &self.d_q8k_quants,
+                        &ssm.alpha.as_view(),
+                        nv,
+                        self.hidden,
+                        &mut self.d_v,
+                        0,
+                    )
+                    .map_err(map)?;
+                    launch_ssm_gates(
+                        &s,
+                        &self.k.ssm_gates,
+                        &self.d_k,
+                        &self.d_v,
+                        &ssm.dt_bias,
+                        &ssm.a,
+                        &mut q.d_beta,
+                        &mut q.d_glog,
+                        nv,
+                    )
+                    .map_err(map)?;
+                    launch_ssm_conv1d(
+                        &s,
+                        &self.k.ssm_conv1d,
+                        &ssm.conv1d,
+                        &q.d_qkv,
+                        &mut self.ssm_conv_state[li],
+                        &mut q.d_conv_out,
+                        conv_dim,
+                        d_conv,
+                    )
+                    .map_err(map)?;
+                    launch_ssm_l2_norm_per_head(
+                        &s,
+                        &self.k.ssm_l2_norm_per_head,
+                        &mut q.d_conv_out,
+                        0,
+                        nk,
+                        ds,
+                        self.eps,
+                    )
+                    .map_err(map)?;
+                    launch_ssm_l2_norm_per_head(
+                        &s,
+                        &self.k.ssm_l2_norm_per_head,
+                        &mut q.d_conv_out,
+                        key_dim,
+                        nk,
+                        ds,
+                        self.eps,
+                    )
+                    .map_err(map)?;
+                    launch_ssm_delta_rule(
+                        &s,
+                        &self.k.ssm_delta_rule,
+                        &mut self.ssm_state[li],
+                        &q.d_conv_out,
+                        key_dim,
+                        value_dim,
+                        &q.d_z,
+                        &q.d_beta,
+                        &q.d_glog,
+                        &ssm.ssm_norm,
+                        &mut q.d_ssm_mix,
+                        ds,
+                        nk,
+                        nv,
+                        self.eps,
+                    )
+                    .map_err(map)?;
+                    // ssm_out projection + residual into d_hidden.
+                    launch_quantize(
+                        &s,
+                        &self.k.quantize,
+                        &q.d_ssm_mix,
+                        &mut self.d_in_quants,
+                        &mut self.d_in_scales,
+                        value_dim / 32,
+                    )
+                    .map_err(map)?;
+                    dispatch_gemv(
+                        &s,
+                        &self.k,
+                        sq[4],
+                        &self.d_in_scales,
+                        &self.d_in_quants,
+                        &self.d_q8k_scales,
+                        &self.d_q8k_quants,
+                        &ssm.ssm_out.as_view(),
+                        self.hidden,
+                        value_dim,
+                        &mut self.d_hidden,
+                        1,
                     )
                     .map_err(map)?;
                 }
-            } else {
-                // K-quant O lane: Q8_K activation, fused-residual GEMV (bit-identical
-                // to gemv + residual_add — the kernel's residual arg adds onto d_hidden).
-                launch_quantize_q8k(
-                    &s,
-                    &self.k.quantize_q8k,
-                    &self.d_attn,
-                    &mut self.d_q8k_quants,
-                    &mut self.d_q8k_scales,
-                    self.q_width / 256,
-                )
-                .map_err(map)?;
-                dispatch_gemv(
-                    &s,
-                    &self.k,
-                    lq[3],
-                    &self.d_in_scales,
-                    &self.d_in_quants,
-                    &self.d_q8k_scales,
-                    &self.d_q8k_quants,
-                    &wo,
-                    self.hidden,
-                    self.q_width,
-                    &mut self.d_hidden,
-                    1,
-                )
-                .map_err(map)?;
             }
             // ffn norm + gate/up + silu + down + residual. gate/up consume the ffn-norm
             // activation; down consumes the silu(gate)*up activation. Each is produced in
@@ -5111,7 +5687,10 @@ impl CudaResidentDecode {
         // Greedy decode: replay the captured CUDA graph when enabled (one launch for
         // the whole ~600-kernel token), else the per-launch path. Both are byte-exact:
         // the graph records the identical kernels reading the same device buffers.
-        if cuda_graphs_enabled() {
+        // qwen35 (Ornith) hybrid SSM is force-serial: the captured graph freezes
+        // attention launch config and does not model the per-token recurrent SSM state
+        // mutation, so qwen35 always runs the per-launch forward_pass.
+        if cuda_graphs_enabled() && self.qwen35.is_none() {
             return self
                 .forward_token_greedy_graphed(embedding, cos, sin, position, scale)
                 .map(Some);

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -4900,8 +4900,17 @@ impl CudaResidentDecode {
             // unfused path, byte-identical) when any consumer is Q8_0, and the Q8_K
             // activation when any consumer is a K-quant lane. For an all-Q8_0 layer only
             // the Q8_0 branch runs, so the legacy path is unchanged.
-            let attn_need_q8_0 = [lq[0], lq[1], lq[2]].contains(&ProjQuant::Q8_0);
-            let attn_need_q8k = [lq[0], lq[1], lq[2]].iter().any(|q| q.needs_q8k());
+            // The attn-norm activation feeds 3 consumers for a Full layer (q/k/v) but 4
+            // for a qwen35 SSM layer (wqkv/wqkv_gate/beta/alpha — all read d_in_*/d_q8k_*),
+            // so widen the consumer span to lq[0..4] for SSM. (O-proj lq[3] of a Full
+            // layer consumes the attention output, quantized separately — not here.)
+            let n_attn_consumers = if matches!(&self.layers[li].kind, LayerKind::Ssm(_)) {
+                4
+            } else {
+                3
+            };
+            let attn_need_q8_0 = lq[..n_attn_consumers].contains(&ProjQuant::Q8_0);
+            let attn_need_q8k = lq[..n_attn_consumers].iter().any(|q| q.needs_q8k());
             if attn_need_q8_0 {
                 if fused {
                     launch_rmsnorm_quantize(
@@ -5372,16 +5381,30 @@ impl CudaResidentDecode {
                         self.eps,
                     )
                     .map_err(map)?;
-                    // ssm_out projection + residual into d_hidden.
-                    launch_quantize(
-                        &s,
-                        &self.k.quantize,
-                        &q.d_ssm_mix,
-                        &mut self.d_in_quants,
-                        &mut self.d_in_scales,
-                        value_dim / 32,
-                    )
-                    .map_err(map)?;
+                    // ssm_out projection + residual into d_hidden. Quantize the SSM mix to
+                    // the activation format ssm_out's lane reads: Q8_K for a K-quant
+                    // (Q4_K/Q6_K) ssm_out, Q8_0 otherwise.
+                    if sq[4].needs_q8k() {
+                        launch_quantize_q8k(
+                            &s,
+                            &self.k.quantize_q8k,
+                            &q.d_ssm_mix,
+                            &mut self.d_q8k_quants,
+                            &mut self.d_q8k_scales,
+                            value_dim / 256,
+                        )
+                        .map_err(map)?;
+                    } else {
+                        launch_quantize(
+                            &s,
+                            &self.k.quantize,
+                            &q.d_ssm_mix,
+                            &mut self.d_in_quants,
+                            &mut self.d_in_scales,
+                            value_dim / 32,
+                        )
+                        .map_err(map)?;
+                    }
                     dispatch_gemv(
                         &s,
                         &self.k,

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -4501,6 +4501,32 @@ impl CudaResidentDecode {
         Ok(())
     }
 
+    /// qwen35 SPARSE KV: free the KV cache buffer of every NON-attending (SSM) layer,
+    /// replacing it with a 1-element placeholder. Only the full-attention layers
+    /// (`keep_full[li] == true`) keep a real `kv_width*max_pos` buffer. `new()` allocated
+    /// dense KV for all `n_layers` (shared with every arch); this is called by the qwen35
+    /// builder AFTER `new()` but BEFORE the weight uploads — while no weights are resident
+    /// yet — so the freed dense KV (the caller then `release_async_pool()`s it back to the
+    /// device) is reused by the 5+ GB of weights. With only 8/32 layers attending, KV
+    /// shrinks ~4x, letting `max_pos` go ~4x higher in the same VRAM. The SSM placeholders
+    /// are never read: the SSM forward arm skips kv_scatter/attention, and the qwen35
+    /// driver only uses `forward_token` (never seed_layer/read_kv_layer). Absolute `li`
+    /// indexing is preserved (the Vecs stay length `n_layers`).
+    pub fn sparsify_kv(&mut self, keep_full: &[bool]) -> Result<(), String> {
+        let s = self.k.stream.clone();
+        for li in 0..self.n_layers {
+            if !keep_full.get(li).copied().unwrap_or(false) {
+                self.cache_k[li] = s
+                    .alloc_zeros::<u16>(1)
+                    .map_err(|e| format!("kv placeholder: {e}"))?;
+                self.cache_v[li] = s
+                    .alloc_zeros::<u16>(1)
+                    .map_err(|e| format!("kv placeholder: {e}"))?;
+            }
+        }
+        Ok(())
+    }
+
     /// Zero every qwen35 SSM recurrent state + conv ring buffer and reset `filled`.
     /// MUST be called at the start of each generation — the SSM state persists across
     /// tokens AND across generate calls, so skipping this decodes turn 2 on stale state.

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -2089,6 +2089,38 @@ extern "C" __global__ void sigmoid_mul(
     float gv = gate[i];
     out[i] *= 1.0f / (1.0f + expf(-gv));
 }
+
+// ---- SSM gates: beta = sigmoid(beta_raw); glog = softplus(alpha_raw+dt_bias)*a -
+// One thread per value-head (nv). Feeds ssm_delta_rule (beta post-sigmoid, glog
+// pre-exp). softplus matches the CPU's (1+exp(x)).ln() with the x>20 passthrough.
+extern "C" __global__ void ssm_gates(
+    const float* __restrict__ beta_raw, const float* __restrict__ alpha_raw,
+    const float* __restrict__ dt_bias, const float* __restrict__ a,
+    float* __restrict__ beta_out, float* __restrict__ glog_out, int nv
+) {
+    int h = blockIdx.x * blockDim.x + threadIdx.x;
+    if (h >= nv) return;
+    beta_out[h] = 1.0f / (1.0f + expf(-beta_raw[h]));
+    float x = alpha_raw[h] + dt_bias[h];
+    float sp = (x > 20.0f) ? x : logf(1.0f + expf(x));
+    glog_out[h] = sp * a[h];
+}
+
+// ---- Deinterleave fused per-head [query(hd) | gate(hd)] x n_heads ----------
+// qg is [n_heads * 2 * head_dim]; split into contiguous q_out / gate_out
+// [n_heads*head_dim] (qwen35 full-attention fused query+output-gate projection).
+extern "C" __global__ void deinterleave_qgate(
+    const float* __restrict__ qg, float* __restrict__ q_out,
+    float* __restrict__ gate_out, int n_heads, int head_dim
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n_heads * head_dim) return;
+    int head = idx / head_dim;
+    int d = idx % head_dim;
+    long src = (long)head * 2 * head_dim;
+    q_out[idx] = qg[src + d];
+    gate_out[idx] = qg[src + head_dim + d];
+}
 "#;
 
 /// Compiled kernel set + a CUDA context/stream, used to run resident-decode
@@ -2144,6 +2176,8 @@ pub struct CudaResidentKernels {
     pub(crate) ssm_conv1d: CudaFunction,
     pub(crate) ssm_delta_rule: CudaFunction,
     pub(crate) sigmoid_mul: CudaFunction,
+    pub(crate) ssm_gates: CudaFunction,
+    pub(crate) deinterleave_qgate: CudaFunction,
     /// Env-gated (CAMELID_ATTN_COALESCED) dispatch of the coalesced K-dot in
     /// split-K pass 1. Read ONCE at construction; default OFF so the shipped
     /// path stays byte-identical.
@@ -2214,6 +2248,8 @@ impl CudaResidentKernels {
             ssm_conv1d: f("ssm_conv1d")?,
             ssm_delta_rule: f("ssm_delta_rule")?,
             sigmoid_mul: f("sigmoid_mul")?,
+            ssm_gates: f("ssm_gates")?,
+            deinterleave_qgate: f("deinterleave_qgate")?,
             attn_coalesced: std::env::var("CAMELID_ATTN_COALESCED")
                 .map(|v| v != "0" && !v.is_empty())
                 .unwrap_or(false),

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -3686,6 +3686,67 @@ struct ResidentLayer {
     /// right GEMV kernel + activation quantizer per tensor. All `Q8_0` for a plain
     /// Q8_0 model (path stays byte-identical).
     quants: LayerQuants,
+    /// Which qwen35 (Ornith) mixer this layer runs. `Full` for every non-qwen35 model
+    /// (the existing attention path, byte-identical) and for qwen35's sparse
+    /// full-attention layers; `Ssm` for qwen35's gated-delta-net layers, whose mixer
+    /// replaces attention with the recurrent SSM compute. See [`forward_pass`].
+    #[allow(dead_code)] // read by the SSM forward branch (wired next).
+    kind: LayerKind,
+}
+
+/// qwen35 layer mixer discriminant on [`ResidentLayer`]. Default `Full` keeps every
+/// existing architecture on the unchanged attention path.
+#[allow(dead_code)] // `Ssm` is constructed by the qwen35 builder + read by `forward_pass` (wired next).
+enum LayerKind {
+    Full,
+    Ssm(Box<SsmResident>),
+}
+
+/// Resident VRAM weights + persistent runtime state for one qwen35 gated-delta-net
+/// (SSM) layer. Mirrors `Qwen35Kind::Ssm` / `Qwen35Cache` (src/runnable/model.rs): the
+/// 5 projections are repacked per their quant lane like the dense path, the 4 small
+/// tensors stay f32, and `conv_state` + `state` persist across tokens (never reset).
+#[allow(dead_code)] // fields read by the SSM forward branch (wired next).
+struct SsmResident {
+    wqkv: CudaSlice<u8>,      // hidden -> conv_dim
+    wqkv_gate: CudaSlice<u8>, // hidden -> value_dim (z gate)
+    beta: CudaSlice<u8>,      // hidden -> num_v_heads
+    alpha: CudaSlice<u8>,     // hidden -> num_v_heads
+    ssm_out: CudaSlice<u8>,   // value_dim -> hidden
+    /// Per-projection quant lane (wqkv, wqkv_gate, beta, alpha, ssm_out).
+    quants: [ProjQuant; 5],
+    conv1d: CudaSlice<f32>, // [conv_dim * d_conv], channel-major [c*d_conv + tap]
+    dt_bias: CudaSlice<f32>, // [num_v_heads]
+    a: CudaSlice<f32>,      // [num_v_heads]
+    ssm_norm: CudaSlice<f32>, // [d_state]
+    /// Causal-conv ring buffer [conv_dim * (d_conv-1)] — persists across tokens.
+    conv_state: CudaSlice<f32>,
+    /// Recurrent per-head state [num_v_heads * d_state * d_state] — persists across tokens.
+    state: CudaSlice<f32>,
+}
+
+/// qwen35 gated-delta-net dimensions + the per-token SSM/full scratch, allocated by the
+/// qwen35 builder. `None` on `CudaResidentDecode` for every other architecture, so no
+/// extra VRAM and no path change for non-qwen35 models.
+#[allow(dead_code)] // read by the SSM forward branch + builder (wired next).
+struct Qwen35Gpu {
+    d_state: usize,
+    d_conv: usize,
+    num_k_heads: usize,
+    num_v_heads: usize,
+    head_v_dim: usize,
+    key_dim: usize,
+    value_dim: usize,
+    conv_dim: usize,
+    // per-token scratch (reused across layers)
+    d_qkv: CudaSlice<f32>,       // conv_dim  (wqkv output / conv input)
+    d_conv_out: CudaSlice<f32>,  // conv_dim  (post-conv, sliced into q|k|v)
+    d_z: CudaSlice<f32>,         // value_dim (wqkv_gate output)
+    d_beta: CudaSlice<f32>,      // num_v_heads (post-sigmoid)
+    d_glog: CudaSlice<f32>,      // num_v_heads (pre-exp)
+    d_ssm_mix: CudaSlice<f32>,   // value_dim (delta-rule output, before ssm_out)
+    d_qgate: CudaSlice<f32>,     // 2*q_width (full-attn fused query+gate projection)
+    d_gate_attn: CudaSlice<f32>, // q_width (deinterleaved attention gate)
 }
 
 /// A captured CUDA graph, wrapped to be `Send`. cudarc does not mark `CudaGraph`
@@ -3780,6 +3841,11 @@ pub struct CudaResidentDecode {
     /// Shared GPU scratch for offloaded layers (None when every layer is resident).
     /// Allocated by `enable_offload_scratch` when the build decides to offload.
     offload: Option<OffloadState>,
+    /// qwen35 (Ornith) gated-delta-net dims + SSM/full per-token scratch. `None` for
+    /// every other architecture (no extra VRAM, no path change). Set by the qwen35
+    /// resident builder.
+    #[allow(dead_code)] // read by the SSM forward branch + builder (wired next).
+    qwen35: Option<Qwen35Gpu>,
 }
 
 /// Max tokens verified per speculative round. The batched GEMM keeps the ordered
@@ -3934,6 +4000,7 @@ impl CudaResidentDecode {
             verify_scratch: None,
             tree_scratch: None,
             offload: None,
+            qwen35: None,
             k,
         })
     }
@@ -4023,6 +4090,7 @@ impl CudaResidentDecode {
                 k_norm: k_norm_gpu,
                 offloaded: None,
                 quants,
+                kind: LayerKind::Full,
             });
             return Ok(());
         }
@@ -4070,6 +4138,7 @@ impl CudaResidentDecode {
             k_norm: k_norm_gpu,
             offloaded: Some(OffloadedLayer { host: pinned, off }),
             quants,
+            kind: LayerKind::Full,
         });
         Ok(())
     }

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -2271,7 +2271,7 @@ use cudarc::driver::{CudaSlice, LaunchConfig, PushKernelArg};
 /// (`n_blocks` f32). Quants-first keeps every block's 32 i8 16-byte aligned so
 /// the kernel can issue `int4` loads. Done once per weight at upload; the values
 /// are unchanged, only their arrangement.
-fn repack_q8_soa(bytes: &[u8]) -> Vec<u8> {
+pub(crate) fn repack_q8_soa(bytes: &[u8]) -> Vec<u8> {
     let n = bytes.len() / 36;
     let mut out = vec![0u8; n * 32 + n * 4];
     let (quants, scales) = out.split_at_mut(n * 32);

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -1957,6 +1957,138 @@ extern "C" __global__ void attn_sk_combine(
         out[(long)head * head_dim + d] = a * s_inv;
     }
 }
+
+// =====================================================================
+// qwen35 (Ornith) hybrid gated-delta-net (SSM) kernels.
+// Mirror the CPU reference in src/runnable/model.rs::qwen35_ssm_compute,
+// preserving its arithmetic AND summation order so greedy-token parity holds.
+// =====================================================================
+
+// ---- Per-head L2 normalize (q/k in SSM layers) -----------------------------
+// In-place: buf[head*head_dim + i] /= max(sqrt(sum x^2), eps). One block per head.
+// Matches CPU l2_norm_inplace: DOUBLE-precision sum of squares, cast to f32, sqrt,
+// then fmax(eps). The per-element apply is parallel.
+extern "C" __global__ void ssm_l2_norm_per_head(
+    float* __restrict__ buf, int head_dim, float eps
+) {
+    extern __shared__ float xs[];
+    __shared__ float s_scale;
+    int head = blockIdx.x;
+    int tid = threadIdx.x;
+    long base = (long)head * head_dim;
+    for (int i = tid; i < head_dim; i += blockDim.x) xs[i] = buf[base + i];
+    __syncthreads();
+    if (tid == 0) {
+        double ss = 0.0;
+        for (int i = 0; i < head_dim; i++) { double v = (double)xs[i]; ss += v * v; }
+        float denom = sqrtf((float)ss);
+        if (denom < eps) denom = eps;
+        s_scale = 1.0f / denom;
+    }
+    __syncthreads();
+    float scale = s_scale;
+    for (int i = tid; i < head_dim; i += blockDim.x) buf[base + i] = xs[i] * scale;
+}
+
+// ---- Causal depthwise conv1d (kernel d_conv) + SiLU ------------------------
+// One thread per channel c. window = [ring_state(oldest..newest), current x[c]];
+// acc = sum_t w[c,t]*state[c,t] + w[c,d_conv-1]*x[c]; out = silu(acc); then the
+// ring buffer shifts left and appends x[c]. Bit-identical to the CPU conv loop.
+extern "C" __global__ void ssm_conv1d(
+    const float* __restrict__ conv_w,    // [conv_dim * d_conv]
+    const float* __restrict__ x,         // [conv_dim] current input
+    float* __restrict__ conv_state,      // [conv_dim * (d_conv-1)] ring, updated
+    float* __restrict__ conv_out,        // [conv_dim] output (post-SiLU)
+    int conv_dim, int d_conv
+) {
+    int c = blockIdx.x * blockDim.x + threadIdx.x;
+    if (c >= conv_dim) return;
+    int cm1 = d_conv - 1;
+    const float* w = conv_w + (long)c * d_conv;
+    float* st = conv_state + (long)c * cm1;
+    float xc = x[c];
+    float acc = 0.0f;
+    for (int t = 0; t < cm1; t++) acc += w[t] * st[t];
+    acc += w[cm1] * xc;
+    conv_out[c] = acc / (1.0f + expf(-acc));   // SiLU
+    for (int t = 0; t < cm1 - 1; t++) st[t] = st[t + 1];
+    st[cm1 - 1] = xc;
+}
+
+// ---- Gated delta-rule recurrence (one decode step) + gated RMSNorm ---------
+// One block per value-head (gridDim.x = nv), blockDim.x = d_state (== head_v_dim).
+// Thread j owns column j of the [d_state x d_state] state S (row-major [i*d_state+j]).
+//   decay:  S[i,j] *= exp(glog[h])
+//   sk[j]   = sum_i S[i,j]*k[i]                 (fused with decay, i-order)
+//   d[j]    = (v[j] - sk[j]) * beta[h]
+//   S[i,j] += k[i]*d[j];  o[j] = sum_i S[i,j]*(q[i]*qscale)   (fused, i-order)
+//   gated RMSNorm: out = RMSNorm(o, ssm_norm) * SiLU(z)       (j-order serial sum)
+// k_conv/q_conv are L2-normed; GQA tile-repeat key head = h % nk. beta is already
+// sigmoid'd; glog is pre-exp. Bit-identical order to the CPU reference.
+extern "C" __global__ void ssm_delta_rule(
+    float* __restrict__ state,           // [nv*d_state*d_state], updated in place
+    const float* __restrict__ k_conv,    // [nk*d_state]
+    const float* __restrict__ q_conv,    // [nk*d_state]
+    const float* __restrict__ v_conv,    // [nv*d_state]
+    const float* __restrict__ z,         // [nv*d_state]
+    const float* __restrict__ beta,      // [nv] (post-sigmoid)
+    const float* __restrict__ glog,      // [nv] (pre-exp)
+    const float* __restrict__ ssm_norm,  // [d_state]
+    float* __restrict__ out,             // [nv*d_state]
+    int d_state, int nk, float eps
+) {
+    int h = blockIdx.x;
+    int j = threadIdx.x;                 // 0..d_state-1
+    int hk = h % nk;
+    extern __shared__ float sh[];
+    float* sk_ = sh;                     // [d_state] k head
+    float* sq_ = sh + d_state;           // [d_state] q head
+    float* so_ = sh + 2 * d_state;       // [d_state] o scratch
+    sk_[j] = k_conv[(long)hk * d_state + j];
+    sq_[j] = q_conv[(long)hk * d_state + j];
+    __syncthreads();
+    float* St = state + (long)h * d_state * d_state;
+    float g = expf(glog[h]);
+    float bh = beta[h];
+    float qscale = 1.0f / sqrtf((float)d_state);
+    float skj = 0.0f;
+    for (int i = 0; i < d_state; i++) {
+        float s = St[(long)i * d_state + j] * g;
+        St[(long)i * d_state + j] = s;
+        skj += s * sk_[i];
+    }
+    float dj = (v_conv[(long)h * d_state + j] - skj) * bh;
+    float oj = 0.0f;
+    for (int i = 0; i < d_state; i++) {
+        float s = St[(long)i * d_state + j] + sk_[i] * dj;
+        St[(long)i * d_state + j] = s;
+        oj += s * (sq_[i] * qscale);
+    }
+    so_[j] = oj;
+    __syncthreads();
+    __shared__ float s_scale;
+    if (j == 0) {
+        float sum = 0.0f;
+        for (int t = 0; t < d_state; t++) sum += so_[t] * so_[t];
+        s_scale = 1.0f / sqrtf(sum / (float)d_state + eps);
+    }
+    __syncthreads();
+    float normed = so_[j] * s_scale * ssm_norm[j];
+    float zj = z[(long)h * d_state + j];
+    float silu_z = zj / (1.0f + expf(-zj));
+    out[(long)h * d_state + j] = normed * silu_z;
+}
+
+// ---- Sigmoid output gate (qwen35 full-attention) ---------------------------
+// out[i] *= sigmoid(gate[i]). One thread per element.
+extern "C" __global__ void sigmoid_mul(
+    float* __restrict__ out, const float* __restrict__ gate, int n
+) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    float gv = gate[i];
+    out[i] *= 1.0f / (1.0f + expf(-gv));
+}
 "#;
 
 /// Compiled kernel set + a CUDA context/stream, used to run resident-decode
@@ -2007,6 +2139,11 @@ pub struct CudaResidentKernels {
     pub(crate) attn_sk_scores_coalesced: CudaFunction,
     pub(crate) attn_sk_partial: CudaFunction,
     pub(crate) attn_sk_combine: CudaFunction,
+    // qwen35 (Ornith) gated-delta-net SSM kernels.
+    pub(crate) ssm_l2_norm_per_head: CudaFunction,
+    pub(crate) ssm_conv1d: CudaFunction,
+    pub(crate) ssm_delta_rule: CudaFunction,
+    pub(crate) sigmoid_mul: CudaFunction,
     /// Env-gated (CAMELID_ATTN_COALESCED) dispatch of the coalesced K-dot in
     /// split-K pass 1. Read ONCE at construction; default OFF so the shipped
     /// path stays byte-identical.
@@ -2073,6 +2210,10 @@ impl CudaResidentKernels {
             attn_sk_scores_coalesced: f("attn_sk_scores_coalesced")?,
             attn_sk_partial: f("attn_sk_partial")?,
             attn_sk_combine: f("attn_sk_combine")?,
+            ssm_l2_norm_per_head: f("ssm_l2_norm_per_head")?,
+            ssm_conv1d: f("ssm_conv1d")?,
+            ssm_delta_rule: f("ssm_delta_rule")?,
+            sigmoid_mul: f("sigmoid_mul")?,
             attn_coalesced: std::env::var("CAMELID_ATTN_COALESCED")
                 .map(|v| v != "0" && !v.is_empty())
                 .unwrap_or(false),

--- a/src/cuda_resident/tests.rs
+++ b/src/cuda_resident/tests.rs
@@ -3015,3 +3015,228 @@ fn deinterleave_qgate_matches_cpu() {
         "deinterleave_qgate gate diverged"
     );
 }
+
+// Composition test: the 4 SSM kernels (gates -> conv1d -> l2norm q/k -> delta_rule)
+// chained into one SSM-layer `mix`, vs the CPU qwen35_ssm_compute core (fed the same
+// post-projection qkv/z/beta_raw/alpha_raw). Proves the GPU orchestration — conv_out
+// sub-range views, in-place per-head L2 norm, launch sequencing — matches the
+// reference. This is the SSM half of the qwen35 forward branch, validated before the
+// engine wiring.
+#[test]
+#[ignore = "requires a CUDA device"]
+fn ssm_layer_chain_matches_cpu() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    let ds = 128usize;
+    let nk = 16usize;
+    let nv = 32usize;
+    let d_conv = 4usize;
+    let cm1 = d_conv - 1;
+    let key_dim = nk * ds; // 2048
+    let value_dim = nv * ds; // 4096
+    let conv_dim = 2 * key_dim + value_dim; // 8192
+    let eps = 1e-6f32;
+    let mut rng = Lcg(0xC0FFEE);
+    let qkv: Vec<f32> = (0..conv_dim).map(|_| rng.next_f32()).collect();
+    let z: Vec<f32> = (0..value_dim).map(|_| rng.next_f32()).collect();
+    let beta_raw: Vec<f32> = (0..nv).map(|_| rng.next_f32() * 3.0).collect();
+    let alpha_raw: Vec<f32> = (0..nv).map(|_| rng.next_f32() * 3.0).collect();
+    let dt_bias: Vec<f32> = (0..nv).map(|_| rng.next_f32()).collect();
+    let a_vec: Vec<f32> = (0..nv).map(|_| -(rng.next_f32() * 0.5 + 0.5)).collect();
+    let conv_w: Vec<f32> = (0..conv_dim * d_conv).map(|_| rng.next_f32()).collect();
+    let ssm_norm: Vec<f32> = (0..ds).map(|_| rng.next_f32() * 0.5 + 1.0).collect();
+    let conv_state0: Vec<f32> = (0..conv_dim * cm1).map(|_| rng.next_f32()).collect();
+    let state0: Vec<f32> = (0..nv * ds * ds).map(|_| rng.next_f32() * 0.1).collect();
+    let silu = |v: f32| v / (1.0 + (-v).exp());
+    let sigmoid = |v: f32| 1.0 / (1.0 + (-v).exp());
+    let softplus = |x: f32| if x > 20.0 { x } else { (1.0 + x.exp()).ln() };
+
+    // ---- CPU reference (qwen35_ssm_compute core, post-projection) ----
+    let mut beta = vec![0f32; nv];
+    let mut glog = vec![0f32; nv];
+    for h in 0..nv {
+        beta[h] = sigmoid(beta_raw[h]);
+        glog[h] = softplus(alpha_raw[h] + dt_bias[h]) * a_vec[h];
+    }
+    let mut exp_cs = conv_state0.clone();
+    let mut conv_out = vec![0f32; conv_dim];
+    for c in 0..conv_dim {
+        let mut acc = 0f32;
+        for t in 0..cm1 {
+            acc += conv_w[c * d_conv + t] * exp_cs[c * cm1 + t];
+        }
+        acc += conv_w[c * d_conv + cm1] * qkv[c];
+        conv_out[c] = silu(acc);
+        for t in 0..cm1 - 1 {
+            exp_cs[c * cm1 + t] = exp_cs[c * cm1 + t + 1];
+        }
+        exp_cs[c * cm1 + (cm1 - 1)] = qkv[c];
+    }
+    let mut q_conv = conv_out[0..key_dim].to_vec();
+    let mut k_conv = conv_out[key_dim..2 * key_dim].to_vec();
+    let v_conv = conv_out[2 * key_dim..].to_vec();
+    for hk in 0..nk {
+        for buf in [&mut q_conv, &mut k_conv] {
+            let s = &mut buf[hk * ds..(hk + 1) * ds];
+            let ss: f64 = s.iter().map(|v| (*v as f64) * (*v as f64)).sum();
+            let sc = 1.0f32 / (ss as f32).sqrt().max(eps);
+            for v in s.iter_mut() {
+                *v *= sc;
+            }
+        }
+    }
+    let qscale = 1.0f32 / (ds as f32).sqrt();
+    let mut exp_state = state0.clone();
+    let mut exp_final = vec![0f32; value_dim];
+    for h in 0..nv {
+        let hk = h % nk;
+        let qh = &q_conv[hk * ds..(hk + 1) * ds];
+        let kh = &k_conv[hk * ds..(hk + 1) * ds];
+        let vh = &v_conv[h * ds..(h + 1) * ds];
+        let st = &mut exp_state[h * ds * ds..(h + 1) * ds * ds];
+        let g = glog[h].exp();
+        for s in st.iter_mut() {
+            *s *= g;
+        }
+        let mut sk = vec![0f32; ds];
+        for i in 0..ds {
+            let ki = kh[i];
+            for j in 0..ds {
+                sk[j] += st[i * ds + j] * ki;
+            }
+        }
+        let mut dvec = vec![0f32; ds];
+        for j in 0..ds {
+            dvec[j] = (vh[j] - sk[j]) * beta[h];
+        }
+        for i in 0..ds {
+            let ki = kh[i];
+            for j in 0..ds {
+                st[i * ds + j] += ki * dvec[j];
+            }
+        }
+        let mut o = vec![0f32; ds];
+        for i in 0..ds {
+            let qi = qh[i] * qscale;
+            for j in 0..ds {
+                o[j] += st[i * ds + j] * qi;
+            }
+        }
+        let ssn: f32 = o.iter().map(|v| v * v).sum();
+        let inv = 1.0 / (ssn / ds as f32 + eps).sqrt();
+        for j in 0..ds {
+            exp_final[h * ds + j] = (o[j] * inv * ssm_norm[j]) * silu(z[h * ds + j]);
+        }
+    }
+
+    // ---- GPU chain ----
+    let dqkv = k.stream.clone_htod(&qkv).unwrap();
+    let dz = k.stream.clone_htod(&z).unwrap();
+    let dbr = k.stream.clone_htod(&beta_raw).unwrap();
+    let dar = k.stream.clone_htod(&alpha_raw).unwrap();
+    let ddt = k.stream.clone_htod(&dt_bias).unwrap();
+    let da = k.stream.clone_htod(&a_vec).unwrap();
+    let dcw = k.stream.clone_htod(&conv_w).unwrap();
+    let dnorm = k.stream.clone_htod(&ssm_norm).unwrap();
+    let mut dcs = k.stream.clone_htod(&conv_state0).unwrap();
+    let mut dstate = k.stream.clone_htod(&state0).unwrap();
+    let mut dbeta = k.stream.alloc_zeros::<f32>(nv).unwrap();
+    let mut dglog = k.stream.alloc_zeros::<f32>(nv).unwrap();
+    let mut dconv_out = k.stream.alloc_zeros::<f32>(conv_dim).unwrap();
+    let mut dfinal = k.stream.alloc_zeros::<f32>(value_dim).unwrap();
+    let nvi = nv as i32;
+    let dsi = ds as i32;
+    let nki = nk as i32;
+    // gates
+    {
+        let cfg = LaunchConfig {
+            grid_dim: (1, 1, 1),
+            block_dim: (nv as u32, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        let mut b = k.stream.launch_builder(&k.ssm_gates);
+        b.arg(&dbr)
+            .arg(&dar)
+            .arg(&ddt)
+            .arg(&da)
+            .arg(&mut dbeta)
+            .arg(&mut dglog)
+            .arg(&nvi);
+        unsafe { b.launch(cfg).unwrap() };
+    }
+    // conv1d
+    {
+        let cfg = LaunchConfig {
+            grid_dim: (conv_dim.div_ceil(256) as u32, 1, 1),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        let cdi = conv_dim as i32;
+        let dci = d_conv as i32;
+        let mut b = k.stream.launch_builder(&k.ssm_conv1d);
+        b.arg(&dcw)
+            .arg(&dqkv)
+            .arg(&mut dcs)
+            .arg(&mut dconv_out)
+            .arg(&cdi)
+            .arg(&dci);
+        unsafe { b.launch(cfg).unwrap() };
+    }
+    // l2-norm q (conv_out[0..key_dim]) and k (conv_out[key_dim..2*key_dim]), in place
+    for lo in [0usize, key_dim] {
+        let cfg = LaunchConfig {
+            grid_dim: (nk as u32, 1, 1),
+            block_dim: (ds as u32, 1, 1),
+            shared_mem_bytes: (ds as u32) * 4,
+        };
+        let mut view = dconv_out.slice_mut(lo..lo + key_dim);
+        let mut b = k.stream.launch_builder(&k.ssm_l2_norm_per_head);
+        b.arg(&mut view).arg(&dsi).arg(&eps);
+        unsafe { b.launch(cfg).unwrap() };
+    }
+    // delta rule + gated RMSNorm (reads q/k/v sub-ranges of conv_out)
+    {
+        let cfg = LaunchConfig {
+            grid_dim: (nv as u32, 1, 1),
+            block_dim: (ds as u32, 1, 1),
+            shared_mem_bytes: (3 * ds as u32) * 4,
+        };
+        let qv = dconv_out.slice(0..key_dim);
+        let kv = dconv_out.slice(key_dim..2 * key_dim);
+        let vv = dconv_out.slice(2 * key_dim..2 * key_dim + value_dim);
+        let mut b = k.stream.launch_builder(&k.ssm_delta_rule);
+        b.arg(&mut dstate)
+            .arg(&kv)
+            .arg(&qv)
+            .arg(&vv)
+            .arg(&dz)
+            .arg(&dbeta)
+            .arg(&dglog)
+            .arg(&dnorm)
+            .arg(&mut dfinal)
+            .arg(&dsi)
+            .arg(&nki)
+            .arg(&eps);
+        unsafe { b.launch(cfg).unwrap() };
+    }
+    let mut got_final = vec![0f32; value_dim];
+    let mut got_state = vec![0f32; nv * ds * ds];
+    let mut got_cs = vec![0f32; conv_dim * cm1];
+    k.stream.memcpy_dtoh(&dfinal, &mut got_final).unwrap();
+    k.stream.memcpy_dtoh(&dstate, &mut got_state).unwrap();
+    k.stream.memcpy_dtoh(&dcs, &mut got_cs).unwrap();
+    k.ctx.synchronize().unwrap();
+    assert!(
+        close(&got_final, &exp_final, 3e-3),
+        "ssm chain final_out diverged"
+    );
+    assert!(
+        close(&got_state, &exp_state, 3e-3),
+        "ssm chain state diverged"
+    );
+    assert!(
+        close(&got_cs, &exp_cs, 3e-3),
+        "ssm chain conv_state diverged"
+    );
+}

--- a/src/cuda_resident/tests.rs
+++ b/src/cuda_resident/tests.rs
@@ -2682,3 +2682,246 @@ fn q6k_gemv_matches_oracle() {
         "q6k_gemv diverged from q6_k_wire_row_dot oracle (worst rel {worst:.3e})"
     );
 }
+
+// ---- qwen35 (Ornith) gated-delta-net SSM kernels ---------------------------
+
+#[test]
+#[ignore = "requires a CUDA device"]
+fn ssm_l2_norm_per_head_matches_cpu() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    let nk = 4usize;
+    let hd = 128usize;
+    let eps = 1e-6f32;
+    let mut rng = Lcg(11);
+    let buf: Vec<f32> = (0..nk * hd).map(|_| rng.next_f32()).collect();
+    // CPU: double-precision sum, fmax(eps) — matches l2_norm_inplace.
+    let mut expected = buf.clone();
+    for h in 0..nk {
+        let s = &mut expected[h * hd..(h + 1) * hd];
+        let ss: f64 = s.iter().map(|v| (*v as f64) * (*v as f64)).sum();
+        let scale = 1.0f32 / (ss as f32).sqrt().max(eps);
+        for v in s.iter_mut() {
+            *v *= scale;
+        }
+    }
+    let mut dbuf = k.stream.clone_htod(&buf).unwrap();
+    let cfg = LaunchConfig {
+        grid_dim: (nk as u32, 1, 1),
+        block_dim: (hd as u32, 1, 1),
+        shared_mem_bytes: (hd as u32) * 4,
+    };
+    let hdi = hd as i32;
+    let mut b = k.stream.launch_builder(&k.ssm_l2_norm_per_head);
+    b.arg(&mut dbuf).arg(&hdi).arg(&eps);
+    unsafe { b.launch(cfg).unwrap() };
+    let mut got = vec![0f32; nk * hd];
+    k.stream.memcpy_dtoh(&dbuf, &mut got).unwrap();
+    k.ctx.synchronize().unwrap();
+    assert!(
+        close(&got, &expected, 2e-3),
+        "ssm_l2_norm_per_head diverged"
+    );
+}
+
+#[test]
+#[ignore = "requires a CUDA device"]
+fn ssm_conv1d_matches_cpu() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    let conv_dim = 256usize;
+    let d_conv = 4usize;
+    let cm1 = d_conv - 1;
+    let mut rng = Lcg(23);
+    let w: Vec<f32> = (0..conv_dim * d_conv).map(|_| rng.next_f32()).collect();
+    let x: Vec<f32> = (0..conv_dim).map(|_| rng.next_f32()).collect();
+    let st0: Vec<f32> = (0..conv_dim * cm1).map(|_| rng.next_f32()).collect();
+    let silu = |v: f32| v / (1.0 + (-v).exp());
+    // CPU reference (matches qwen35_ssm_compute conv loop).
+    let mut exp_out = vec![0f32; conv_dim];
+    let mut exp_st = st0.clone();
+    for c in 0..conv_dim {
+        let mut acc = 0.0f32;
+        for t in 0..cm1 {
+            acc += w[c * d_conv + t] * exp_st[c * cm1 + t];
+        }
+        acc += w[c * d_conv + cm1] * x[c];
+        exp_out[c] = silu(acc);
+        for t in 0..cm1 - 1 {
+            exp_st[c * cm1 + t] = exp_st[c * cm1 + t + 1];
+        }
+        exp_st[c * cm1 + (cm1 - 1)] = x[c];
+    }
+    let dw = k.stream.clone_htod(&w).unwrap();
+    let dx = k.stream.clone_htod(&x).unwrap();
+    let mut dst = k.stream.clone_htod(&st0).unwrap();
+    let mut dout = k.stream.alloc_zeros::<f32>(conv_dim).unwrap();
+    let cfg = LaunchConfig {
+        grid_dim: (conv_dim.div_ceil(128) as u32, 1, 1),
+        block_dim: (128, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let cdi = conv_dim as i32;
+    let dci = d_conv as i32;
+    let mut b = k.stream.launch_builder(&k.ssm_conv1d);
+    b.arg(&dw)
+        .arg(&dx)
+        .arg(&mut dst)
+        .arg(&mut dout)
+        .arg(&cdi)
+        .arg(&dci);
+    unsafe { b.launch(cfg).unwrap() };
+    let mut got_out = vec![0f32; conv_dim];
+    let mut got_st = vec![0f32; conv_dim * cm1];
+    k.stream.memcpy_dtoh(&dout, &mut got_out).unwrap();
+    k.stream.memcpy_dtoh(&dst, &mut got_st).unwrap();
+    k.ctx.synchronize().unwrap();
+    assert!(close(&got_out, &exp_out, 2e-3), "ssm_conv1d out diverged");
+    assert!(
+        close(&got_st, &exp_st, 2e-3),
+        "ssm_conv1d ring-state diverged"
+    );
+}
+
+#[test]
+#[ignore = "requires a CUDA device"]
+fn ssm_delta_rule_matches_cpu() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    let ds = 128usize;
+    let nk = 16usize;
+    let nv = 32usize;
+    let eps = 1e-6f32;
+    let mut rng = Lcg(0x5511);
+    let state0: Vec<f32> = (0..nv * ds * ds).map(|_| rng.next_f32()).collect();
+    let kc: Vec<f32> = (0..nk * ds).map(|_| rng.next_f32()).collect();
+    let qc: Vec<f32> = (0..nk * ds).map(|_| rng.next_f32()).collect();
+    let vc: Vec<f32> = (0..nv * ds).map(|_| rng.next_f32()).collect();
+    let z: Vec<f32> = (0..nv * ds).map(|_| rng.next_f32()).collect();
+    let beta: Vec<f32> = (0..nv).map(|_| rng.next_f32() * 0.5 + 0.5).collect(); // (0,1)
+    let glog: Vec<f32> = (0..nv)
+        .map(|_| -(rng.next_f32() * 0.5 + 0.5) * 0.1)
+        .collect(); // <= 0
+    let norm: Vec<f32> = (0..ds).map(|_| rng.next_f32() * 0.5 + 1.0).collect();
+    let silu = |v: f32| v / (1.0 + (-v).exp());
+    // CPU reference (matches qwen35_ssm_compute recurrence + gated RMSNorm).
+    let mut exp_state = state0.clone();
+    let mut exp_out = vec![0f32; nv * ds];
+    let qscale = 1.0f32 / (ds as f32).sqrt();
+    for h in 0..nv {
+        let hk = h % nk;
+        let g = glog[h].exp();
+        let bh = beta[h];
+        let st = &mut exp_state[h * ds * ds..(h + 1) * ds * ds];
+        for s in st.iter_mut() {
+            *s *= g;
+        }
+        let mut sk = vec![0f32; ds];
+        for i in 0..ds {
+            let ki = kc[hk * ds + i];
+            for j in 0..ds {
+                sk[j] += st[i * ds + j] * ki;
+            }
+        }
+        let mut dvec = vec![0f32; ds];
+        for j in 0..ds {
+            dvec[j] = (vc[h * ds + j] - sk[j]) * bh;
+        }
+        for i in 0..ds {
+            let ki = kc[hk * ds + i];
+            for j in 0..ds {
+                st[i * ds + j] += ki * dvec[j];
+            }
+        }
+        let mut o = vec![0f32; ds];
+        for i in 0..ds {
+            let qi = qc[hk * ds + i] * qscale;
+            for j in 0..ds {
+                o[j] += st[i * ds + j] * qi;
+            }
+        }
+        let ss: f32 = o.iter().map(|v| v * v).sum();
+        let inv = 1.0 / (ss / ds as f32 + eps).sqrt();
+        for j in 0..ds {
+            exp_out[h * ds + j] = (o[j] * inv * norm[j]) * silu(z[h * ds + j]);
+        }
+    }
+    let mut dstate = k.stream.clone_htod(&state0).unwrap();
+    let dk = k.stream.clone_htod(&kc).unwrap();
+    let dq = k.stream.clone_htod(&qc).unwrap();
+    let dv = k.stream.clone_htod(&vc).unwrap();
+    let dz = k.stream.clone_htod(&z).unwrap();
+    let dbeta = k.stream.clone_htod(&beta).unwrap();
+    let dglog = k.stream.clone_htod(&glog).unwrap();
+    let dnorm = k.stream.clone_htod(&norm).unwrap();
+    let mut dout = k.stream.alloc_zeros::<f32>(nv * ds).unwrap();
+    let cfg = LaunchConfig {
+        grid_dim: (nv as u32, 1, 1),
+        block_dim: (ds as u32, 1, 1),
+        shared_mem_bytes: (3 * ds as u32) * 4,
+    };
+    let dsi = ds as i32;
+    let nki = nk as i32;
+    let mut b = k.stream.launch_builder(&k.ssm_delta_rule);
+    b.arg(&mut dstate)
+        .arg(&dk)
+        .arg(&dq)
+        .arg(&dv)
+        .arg(&dz)
+        .arg(&dbeta)
+        .arg(&dglog)
+        .arg(&dnorm)
+        .arg(&mut dout)
+        .arg(&dsi)
+        .arg(&nki)
+        .arg(&eps);
+    unsafe { b.launch(cfg).unwrap() };
+    let mut got_out = vec![0f32; nv * ds];
+    let mut got_state = vec![0f32; nv * ds * ds];
+    k.stream.memcpy_dtoh(&dout, &mut got_out).unwrap();
+    k.stream.memcpy_dtoh(&dstate, &mut got_state).unwrap();
+    k.ctx.synchronize().unwrap();
+    assert!(
+        close(&got_out, &exp_out, 3e-3),
+        "ssm_delta_rule output diverged"
+    );
+    assert!(
+        close(&got_state, &exp_state, 3e-3),
+        "ssm_delta_rule carried state diverged"
+    );
+}
+
+#[test]
+#[ignore = "requires a CUDA device"]
+fn sigmoid_mul_matches_cpu() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    let n = 512usize;
+    let mut rng = Lcg(77);
+    let out0: Vec<f32> = (0..n).map(|_| rng.next_f32()).collect();
+    let gate: Vec<f32> = (0..n).map(|_| rng.next_f32() * 4.0).collect();
+    let expected: Vec<f32> = out0
+        .iter()
+        .zip(&gate)
+        .map(|(o, g)| o * (1.0 / (1.0 + (-g).exp())))
+        .collect();
+    let mut dout = k.stream.clone_htod(&out0).unwrap();
+    let dgate = k.stream.clone_htod(&gate).unwrap();
+    let cfg = LaunchConfig {
+        grid_dim: (n.div_ceil(256) as u32, 1, 1),
+        block_dim: (256, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let ni = n as i32;
+    let mut b = k.stream.launch_builder(&k.sigmoid_mul);
+    b.arg(&mut dout).arg(&dgate).arg(&ni);
+    unsafe { b.launch(cfg).unwrap() };
+    let mut got = vec![0f32; n];
+    k.stream.memcpy_dtoh(&dout, &mut got).unwrap();
+    k.ctx.synchronize().unwrap();
+    assert!(close(&got, &expected, 2e-3), "sigmoid_mul diverged");
+}

--- a/src/cuda_resident/tests.rs
+++ b/src/cuda_resident/tests.rs
@@ -2925,3 +2925,93 @@ fn sigmoid_mul_matches_cpu() {
     k.ctx.synchronize().unwrap();
     assert!(close(&got, &expected, 2e-3), "sigmoid_mul diverged");
 }
+
+#[test]
+#[ignore = "requires a CUDA device"]
+fn ssm_gates_matches_cpu() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    let nv = 32usize;
+    let mut rng = Lcg(31);
+    let beta_raw: Vec<f32> = (0..nv).map(|_| rng.next_f32() * 3.0).collect();
+    let alpha_raw: Vec<f32> = (0..nv).map(|_| rng.next_f32() * 3.0).collect();
+    let dt_bias: Vec<f32> = (0..nv).map(|_| rng.next_f32()).collect();
+    let a: Vec<f32> = (0..nv).map(|_| -(rng.next_f32() * 0.5 + 0.5)).collect(); // a = -exp(.) <= 0
+    let softplus = |x: f32| if x > 20.0 { x } else { (1.0 + x.exp()).ln() };
+    let sigmoid = |x: f32| 1.0 / (1.0 + (-x).exp());
+    let exp_beta: Vec<f32> = beta_raw.iter().map(|&v| sigmoid(v)).collect();
+    let exp_glog: Vec<f32> = (0..nv)
+        .map(|h| softplus(alpha_raw[h] + dt_bias[h]) * a[h])
+        .collect();
+    let dbr = k.stream.clone_htod(&beta_raw).unwrap();
+    let dar = k.stream.clone_htod(&alpha_raw).unwrap();
+    let ddt = k.stream.clone_htod(&dt_bias).unwrap();
+    let da = k.stream.clone_htod(&a).unwrap();
+    let mut dbeta = k.stream.alloc_zeros::<f32>(nv).unwrap();
+    let mut dglog = k.stream.alloc_zeros::<f32>(nv).unwrap();
+    let cfg = LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (nv as u32, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let nvi = nv as i32;
+    let mut b = k.stream.launch_builder(&k.ssm_gates);
+    b.arg(&dbr)
+        .arg(&dar)
+        .arg(&ddt)
+        .arg(&da)
+        .arg(&mut dbeta)
+        .arg(&mut dglog)
+        .arg(&nvi);
+    unsafe { b.launch(cfg).unwrap() };
+    let mut got_beta = vec![0f32; nv];
+    let mut got_glog = vec![0f32; nv];
+    k.stream.memcpy_dtoh(&dbeta, &mut got_beta).unwrap();
+    k.stream.memcpy_dtoh(&dglog, &mut got_glog).unwrap();
+    k.ctx.synchronize().unwrap();
+    assert!(close(&got_beta, &exp_beta, 2e-3), "ssm_gates beta diverged");
+    assert!(close(&got_glog, &exp_glog, 2e-3), "ssm_gates glog diverged");
+}
+
+#[test]
+#[ignore = "requires a CUDA device"]
+fn deinterleave_qgate_matches_cpu() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    let n_heads = 16usize;
+    let hd = 256usize;
+    let mut rng = Lcg(91);
+    let qg: Vec<f32> = (0..n_heads * 2 * hd).map(|_| rng.next_f32()).collect();
+    let mut exp_q = vec![0f32; n_heads * hd];
+    let mut exp_gate = vec![0f32; n_heads * hd];
+    for h in 0..n_heads {
+        let b = h * hd * 2;
+        exp_q[h * hd..(h + 1) * hd].copy_from_slice(&qg[b..b + hd]);
+        exp_gate[h * hd..(h + 1) * hd].copy_from_slice(&qg[b + hd..b + 2 * hd]);
+    }
+    let dqg = k.stream.clone_htod(&qg).unwrap();
+    let mut dq = k.stream.alloc_zeros::<f32>(n_heads * hd).unwrap();
+    let mut dgate = k.stream.alloc_zeros::<f32>(n_heads * hd).unwrap();
+    let cfg = LaunchConfig {
+        grid_dim: ((n_heads * hd).div_ceil(256) as u32, 1, 1),
+        block_dim: (256, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let nh = n_heads as i32;
+    let hdi = hd as i32;
+    let mut b = k.stream.launch_builder(&k.deinterleave_qgate);
+    b.arg(&dqg).arg(&mut dq).arg(&mut dgate).arg(&nh).arg(&hdi);
+    unsafe { b.launch(cfg).unwrap() };
+    let mut got_q = vec![0f32; n_heads * hd];
+    let mut got_gate = vec![0f32; n_heads * hd];
+    k.stream.memcpy_dtoh(&dq, &mut got_q).unwrap();
+    k.stream.memcpy_dtoh(&dgate, &mut got_gate).unwrap();
+    k.ctx.synchronize().unwrap();
+    assert!(close(&got_q, &exp_q, 1e-6), "deinterleave_qgate q diverged");
+    assert!(
+        close(&got_gate, &exp_gate, 1e-6),
+        "deinterleave_qgate gate diverged"
+    );
+}

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -2130,6 +2130,9 @@ mod gpu_ssm_layer_tests {
         let mut cache = Qwen35Cache::new(rt, rt.layers.len());
 
         let mut worst_all = 0.0f32;
+        // `p` is the absolute position (used in RoPE tables, kv_scatter, d_pos) as well
+        // as the index into `hiddens`, so a plain range loop is clearest here.
+        #[allow(clippy::needless_range_loop)]
         for p in 0..n_steps {
             let hidden = &hiddens[p];
 

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -2024,4 +2024,305 @@ mod gpu_ssm_layer_tests {
         );
         eprintln!("qwen35_ssm_layer_gpu: PASS (worst rel {worst:.3e})");
     }
+    #[test]
+    #[ignore = "needs CAMELID_ORNITH_GGUF (Q8) + a CUDA device"]
+    fn qwen35_full_attn_layer_gpu_matches_cpu() {
+        use crate::cuda_resident::{
+            launch_attention, launch_kv_scatter, launch_rms_norm_per_head, launch_rope,
+        };
+        let path = match std::env::var("CAMELID_ORNITH_GGUF") {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let Ok(k) = CudaResidentKernels::new() else {
+            return;
+        };
+        let model = RunnableModel::load(&path).expect("load qwen35");
+        let rt = model.qwen35.as_ref().expect("qwen35 runtime");
+        let li = 3usize; // layer 3 is full-attention ((3+1) % 4 == 0)
+        let layer = &rt.layers[li];
+        let (wq, wk, wv, wo, q_norm, k_norm) = match &layer.kind {
+            Qwen35Kind::Full {
+                wq,
+                wk,
+                wv,
+                wo,
+                q_norm,
+                k_norm,
+            } => (wq, wk, wv, wo, q_norm, k_norm),
+            _ => panic!("layer {li} is not full-attention"),
+        };
+        for m in [wq, wk, wv, wo] {
+            assert_eq!(
+                m.tt,
+                GgufTensorType::Q8_0,
+                "test assumes a Q8_0 Ornith GGUF"
+            );
+        }
+
+        let hidden_dim = model.d_model; // 4096
+        let eps = model.eps; // 1e-6
+        let n_head = model.n_heads; // 16
+        let n_kv = model.n_kv_heads; // 4
+        let hd = model.head_dim; // 256
+        let rope_dim = model.rope_dim; // 64
+        let rope_base = model.rope_base; // 1e7
+        let pairing = if model.rope_neox { 1i32 } else { 0i32 };
+        let q_width = n_head * hd; // 4096
+        let kv_width = n_kv * hd; // 1024
+        let half = rope_dim / 2; // 32 rope pairs
+        let hb = hidden_dim / 32; // 128 input blocks per projection row
+        let qb = q_width / 32; // 128 blocks for the wo input (attn-out)
+        let scale = 1.0f32 / (hd as f32).sqrt(); // 1/sqrt(256) = 0.0625
+        let n_steps = 6usize;
+        let max_pos = 8usize;
+        assert!(n_steps <= max_pos);
+
+        // Deterministic pseudo-random hidden activations, one DISTINCT vector per
+        // position (distinct K/V per step => a genuinely non-uniform softmax at pos>0,
+        // which is what exercises GQA / q-k-norm / RoPE / scale; pos=0 alone is
+        // degenerate: a single key makes softmax==1 and the output == V regardless).
+        let mut seed = 0x1234_5678u64;
+        let mut nextf = || {
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((seed >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+        };
+        let hiddens: Vec<Vec<f32>> = (0..n_steps)
+            .map(|_| (0..hidden_dim).map(|_| nextf()).collect())
+            .collect();
+
+        // ---- GPU: upload Q8_0 weights once (SoA-repacked, 34->36 widened) ----
+        let s = &k.stream;
+        let up = |m: &RawMat| s.clone_htod(&repack_q8_soa(&widen_q8(&m.bytes))).unwrap();
+        let d_wq = up(wq);
+        let d_wk = up(wk);
+        let d_wv = up(wv);
+        let d_wo = up(wo);
+        let d_qn = s.clone_htod(q_norm).unwrap();
+        let d_kn = s.clone_htod(k_norm).unwrap();
+        let d_attn_norm = s.clone_htod(&layer.attn_norm).unwrap();
+
+        // device scratch (reused across positions)
+        let mut d_hidden = s.alloc_zeros::<f32>(hidden_dim).unwrap();
+        let mut in_q = s.alloc_zeros::<i8>(hidden_dim).unwrap();
+        let mut in_s = s.alloc_zeros::<f32>(hb).unwrap();
+        let mut d_qgate = s.alloc_zeros::<f32>(2 * q_width).unwrap(); // fused [q|gate]
+        let mut d_q = s.alloc_zeros::<f32>(q_width).unwrap();
+        let mut d_gate = s.alloc_zeros::<f32>(q_width).unwrap();
+        let mut d_k = s.alloc_zeros::<f32>(kv_width).unwrap();
+        let mut d_v = s.alloc_zeros::<f32>(kv_width).unwrap();
+        let mut d_attn = s.alloc_zeros::<f32>(q_width).unwrap();
+        let mut mix_q = s.alloc_zeros::<i8>(q_width).unwrap();
+        let mut mix_s = s.alloc_zeros::<f32>(qb).unwrap();
+        let mut d_mix = s.alloc_zeros::<f32>(hidden_dim).unwrap();
+
+        // persistent KV cache (f16 bits, layout [kv_head][position][head_dim]) +
+        // device position + per-pair RoPE tables.
+        let mut cache_k = s.alloc_zeros::<u16>(kv_width * max_pos).unwrap();
+        let mut cache_v = s.alloc_zeros::<u16>(kv_width * max_pos).unwrap();
+        let mut d_pos = s.alloc_zeros::<i32>(1).unwrap();
+        let mut d_cos = s.alloc_zeros::<f32>(half).unwrap();
+        let mut d_sin = s.alloc_zeros::<f32>(half).unwrap();
+
+        // CPU reference cache (grows per position; only the full-attn layer li used).
+        let mut cache = Qwen35Cache::new(rt, rt.layers.len());
+
+        let mut worst_all = 0.0f32;
+        for p in 0..n_steps {
+            let hidden = &hiddens[p];
+
+            // ---- CPU reference: the FULL layer attention mix (incl. wo); also grows
+            // cache.k/v[li] exactly as the GPU scatter does. qwen35_full_attn internally
+            // calls qwen35_attn_compute then wo.par_matvec — so we compare the post-wo
+            // mix on both sides (the GPU pipeline below also ends in wo). ----
+            let xn = rms_norm(hidden, &layer.attn_norm, eps);
+            let cpu_mix = model
+                .qwen35_full_attn(li, wq, wk, wv, wo, q_norm, k_norm, &xn, p, &mut cache)
+                .expect("cpu full attn");
+
+            // ---- GPU forward for this position ----
+            // RoPE cos/sin for absolute position p (computed in f32 on the host, exactly
+            // like apply_rope's per-pair freqs, then uploaded -> GPU RoPE is bit-identical).
+            let mut cosv = vec![0f32; half];
+            let mut sinv = vec![0f32; half];
+            for i in 0..half {
+                let freq = 1.0f32 / rope_base.powf(2.0 * i as f32 / rope_dim as f32);
+                let (si, ci) = (p as f32 * freq).sin_cos();
+                cosv[i] = ci;
+                sinv[i] = si;
+            }
+            s.memcpy_htod(&cosv, &mut d_cos).unwrap();
+            s.memcpy_htod(&sinv, &mut d_sin).unwrap();
+            s.memcpy_htod(&[p as i32], &mut d_pos).unwrap();
+            s.memcpy_htod(hidden.as_slice(), &mut d_hidden).unwrap();
+
+            // attn-norm + quantize the hidden -> in_q / in_s
+            launch_rmsnorm_quantize(
+                s,
+                &k.rms_norm_quantize,
+                &d_hidden,
+                &d_attn_norm,
+                &mut in_q,
+                &mut in_s,
+                hidden_dim,
+                eps,
+            )
+            .unwrap();
+
+            // fused query+gate projection: wq rows = 2*q_width = 8192
+            launch_gemv(
+                s,
+                &k.gemv,
+                &in_s,
+                &in_q,
+                &d_wq.slice(0..d_wq.len()),
+                2 * q_width,
+                hb,
+                &mut d_qgate,
+            )
+            .unwrap();
+            // K / V projections (kv_width = 1024 rows each)
+            launch_gemv(
+                s,
+                &k.gemv,
+                &in_s,
+                &in_q,
+                &d_wk.slice(0..d_wk.len()),
+                kv_width,
+                hb,
+                &mut d_k,
+            )
+            .unwrap();
+            launch_gemv(
+                s,
+                &k.gemv,
+                &in_s,
+                &in_q,
+                &d_wv.slice(0..d_wv.len()),
+                kv_width,
+                hb,
+                &mut d_v,
+            )
+            .unwrap();
+
+            // deinterleave fused [query(hd)|gate(hd)] x n_head -> contiguous d_q / d_gate
+            {
+                let cfg = LaunchConfig {
+                    grid_dim: ((q_width as u32).div_ceil(256), 1, 1),
+                    block_dim: (256, 1, 1),
+                    shared_mem_bytes: 0,
+                };
+                let (nh, hdi) = (n_head as i32, hd as i32);
+                let mut b = s.launch_builder(&k.deinterleave_qgate);
+                b.arg(&d_qgate)
+                    .arg(&mut d_q)
+                    .arg(&mut d_gate)
+                    .arg(&nh)
+                    .arg(&hdi);
+                unsafe { b.launch(cfg).unwrap() };
+            }
+
+            // QK per-head RMSNorm (BEFORE RoPE), shared weight across heads
+            launch_rms_norm_per_head(s, &k.rms_norm_per_head, &mut d_q, &d_qn, n_head, hd, eps)
+                .unwrap();
+            launch_rms_norm_per_head(s, &k.rms_norm_per_head, &mut d_k, &d_kn, n_kv, hd, eps)
+                .unwrap();
+
+            // partial NEOX RoPE on Q (n_head heads) and K (n_kv heads)
+            launch_rope(
+                s, &k.rope, &mut d_q, &d_cos, &d_sin, n_head, hd, rope_dim, pairing,
+            )
+            .unwrap();
+            launch_rope(
+                s, &k.rope, &mut d_k, &d_cos, &d_sin, n_kv, hd, rope_dim, pairing,
+            )
+            .unwrap();
+
+            // scatter K (post-norm, post-rope) and V (RAW) into the cache at position p
+            launch_kv_scatter(
+                s,
+                &k.kv_scatter,
+                &d_k,
+                &mut cache_k,
+                &d_pos,
+                n_kv,
+                hd,
+                max_pos,
+            )
+            .unwrap();
+            launch_kv_scatter(
+                s,
+                &k.kv_scatter,
+                &d_v,
+                &mut cache_v,
+                &d_pos,
+                n_kv,
+                hd,
+                max_pos,
+            )
+            .unwrap();
+
+            // GQA causal attention over positions 0..=p
+            let n_pos = p + 1;
+            launch_attention(
+                s,
+                &k.attention,
+                &d_q,
+                &cache_k,
+                &cache_v,
+                &mut d_attn,
+                n_head,
+                n_kv,
+                hd,
+                &d_pos,
+                n_pos,
+                max_pos,
+                scale,
+            )
+            .unwrap();
+
+            // sigmoid output gate: attn[i] *= sigmoid(gate[i])
+            {
+                let cfg = LaunchConfig {
+                    grid_dim: ((q_width as u32).div_ceil(256), 1, 1),
+                    block_dim: (256, 1, 1),
+                    shared_mem_bytes: 0,
+                };
+                let n_i = q_width as i32;
+                let mut b = s.launch_builder(&k.sigmoid_mul);
+                b.arg(&mut d_attn).arg(&d_gate).arg(&n_i);
+                unsafe { b.launch(cfg).unwrap() };
+            }
+
+            // quantize the gated attn-out, then the O projection -> d_mix
+            launch_quantize(s, &k.quantize, &d_attn, &mut mix_q, &mut mix_s, qb).unwrap();
+            launch_gemv(
+                s,
+                &k.gemv,
+                &mix_s,
+                &mix_q,
+                &d_wo.slice(0..d_wo.len()),
+                hidden_dim,
+                qb,
+                &mut d_mix,
+            )
+            .unwrap();
+
+            let mut got = vec![0f32; hidden_dim];
+            s.memcpy_dtoh(&d_mix, &mut got).unwrap();
+            k.ctx.synchronize().unwrap();
+            let (_ok, worst) = rel_close(&got, &cpu_mix, 1e-2);
+            if worst > worst_all {
+                worst_all = worst;
+            }
+            eprintln!("qwen35_full_attn pos {p}: worst rel {worst:.3e}");
+        }
+        assert!(
+            worst_all < 1e-2,
+            "qwen35 full-attn layer GPU vs CPU diverged (worst rel {worst_all:.3e})"
+        );
+        eprintln!("qwen35_full_attn_layer_gpu: PASS (worst rel {worst_all:.3e})");
+    }
 }

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -1313,13 +1313,14 @@ impl RunnableModel {
         max_new: usize,
         stop: &[u32],
     ) -> Result<Vec<u32>> {
-        // KV cache is dense over all 32 layers (131072 bytes/pos) on top of the 5.24 GB
-        // Q4_K_M, so the context window is VRAM-bound on a 6 GB card (sparse KV for the 8
-        // full-attn layers is the P7 lift). Default 2048 fits; override for bigger cards.
+        // Sparse KV: only the 8 full-attention layers keep a real KV buffer (the 24 SSM
+        // layers don't attend — see build_qwen35_resident::sparsify_kv), so KV is ~4x
+        // smaller than dense and 8192 positions fit alongside the 5.24 GB Q4_K_M on a 6 GB
+        // card (~5.8 GB resident). Default 8192; override (e.g. higher on bigger cards).
         let max_pos: usize = std::env::var("CAMELID_QWEN35_CUDA_MAXPOS")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(2048);
+            .unwrap_or(8192);
         let mut guard = self
             .cuda
             .lock()
@@ -1911,6 +1912,18 @@ impl RunnableModel {
             rt.value_dim,
             rt.conv_dim,
         )?;
+        // Sparse KV: only the 8 full-attention layers attend; the 24 SSM layers never
+        // touch KV (the SSM forward arm skips kv_scatter/attention). new() over-allocated
+        // dense KV for all 32 layers, so free the SSM layers' buffers NOW — before any
+        // weights are resident — and trim the async pool so the freed VRAM is reused by
+        // the weights. With ~4x less KV, max_pos fits ~4x higher in the 6 GB card.
+        let keep_full: Vec<bool> = rt
+            .layers
+            .iter()
+            .map(|l| matches!(l.kind, Qwen35Kind::Full { .. }))
+            .collect();
+        e.sparsify_kv(&keep_full)?;
+        crate::cuda::release_async_pool();
         for layer in &rt.layers {
             match &layer.kind {
                 Qwen35Kind::Full {
@@ -2732,6 +2745,81 @@ mod gpu_ssm_layer_tests {
              speedup={:.2}x  [GPU {g_lo:.1}s@{n_lo} -> {g_hi:.1}s@{n_hi}; \
              CPU {c_lo:.1}s@{n_lo} -> {c_hi:.1}s@{n_hi}]",
             gpu_tokps / cpu_tokps
+        );
+    }
+
+    /// Sparse-KV long-context proof: build the resident engine at max_pos=8192 (which
+    /// ONLY fits the 6 GB card because sparsify_kv frees the 24 SSM layers' KV — dense KV
+    /// at 8192 is ~1 GB on top of the 5.24 GB Q4_K_M = OOM), prefill a >2048-token prompt
+    /// (beyond the old dense cap, so the full-attn layers' KV is actually addressed past
+    /// 2048), and decode a few tokens. Succeeding (no OOM, in-range tokens) proves sparse
+    /// KV both fits and works. Point CAMELID_ORNITH_GGUF at the Q4_K_M.
+    #[test]
+    #[ignore = "needs CAMELID_ORNITH_GGUF (point at Q4_K_M) + a CUDA device"]
+    fn qwen35_gpu_long_context_fits() {
+        let Ok(path) = std::env::var("CAMELID_ORNITH_GGUF") else {
+            return;
+        };
+        let model = RunnableModel::load(&path).expect("load qwen35");
+        if model.qwen35.is_none() {
+            return;
+        }
+        let max_pos = 8192usize; // only fits with sparse KV
+        let mut e = match model.build_qwen35_resident(max_pos) {
+            Ok(e) => e,
+            Err(err) => {
+                eprintln!("build_qwen35_resident({max_pos}) failed (OOM => sparse KV not applied?): {err}");
+                panic!("long-context build failed: {err}");
+            }
+        };
+        e.reset_qwen35_state().unwrap();
+        let scale = 1.0f32 / (model.head_dim as f32).sqrt();
+        // A >2048-token prompt: repeat a short base until past the old dense cap.
+        let base: Vec<u32> = vec![3710, 369, 279, 6511, 314, 9338, 30];
+        let mut prompt: Vec<u32> = Vec::new();
+        while prompt.len() < 2100 {
+            prompt.extend_from_slice(&base);
+        }
+        let plen = prompt.len();
+        assert!(
+            plen > 2048,
+            "prompt must exceed the old 2048 cap (got {plen})"
+        );
+        let mut next = 0u32;
+        for (i, &tok) in prompt.iter().enumerate() {
+            let emb = model
+                .token_embd
+                .dequant_row(tok as usize, "token_embd")
+                .expect("embd");
+            let (cos, sin) = super::qwen35_rope_tables(i, model.rope_base, model.rope_dim);
+            let last = i == plen - 1;
+            let out = e
+                .forward_token(&emb, &cos, &sin, i, scale, last)
+                .expect("gpu forward_token (long-ctx prefill)");
+            if last {
+                next = out.expect("logits on final prompt token");
+            }
+        }
+        let mut decoded = vec![next];
+        for step in 0..4 {
+            let pos = plen + step;
+            let emb = model
+                .token_embd
+                .dequant_row(next as usize, "token_embd")
+                .expect("embd");
+            let (cos, sin) = super::qwen35_rope_tables(pos, model.rope_base, model.rope_dim);
+            next = e
+                .forward_token(&emb, &cos, &sin, pos, scale, true)
+                .expect("gpu forward_token (long-ctx decode)")
+                .expect("logits");
+            decoded.push(next);
+        }
+        eprintln!(
+            "qwen35_gpu_long_context: prefilled {plen} tokens at max_pos={max_pos}, decoded {decoded:?}"
+        );
+        assert!(
+            decoded.iter().all(|&t| (t as usize) < model.vocab),
+            "decoded token out of range"
         );
     }
 }

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -1735,13 +1735,143 @@ fn read_tensor_bytes(f: &mut File, d: &GgufTensorDescriptor, name: &str) -> Resu
     Ok(bytes)
 }
 
+/// qwen35 (Ornith) partial-NEOX RoPE cos/sin tables for absolute `pos`, length
+/// `rope_dim/2`. VERBATIM `apply_rope`: `1.0/base.powf(2.0*i/rope_dim)` then
+/// `(pos*freq).sin_cos()` (sin first) — do NOT use the negated-exponent form the
+/// Llama lane uses (last-ULP drift can flip a near-tie greedy token).
+#[cfg(feature = "cuda")]
+#[allow(dead_code)] // used by the GPU test + the M4 generate_qwen35_cuda driver (next).
+fn qwen35_rope_tables(pos: usize, rope_base: f32, rope_dim: usize) -> (Vec<f32>, Vec<f32>) {
+    let half = rope_dim / 2;
+    let mut cos_t = vec![0.0f32; half];
+    let mut sin_t = vec![0.0f32; half];
+    for i in 0..half {
+        let freq = 1.0f32 / rope_base.powf(2.0 * i as f32 / rope_dim as f32);
+        let (s, c) = (pos as f32 * freq).sin_cos();
+        cos_t[i] = c;
+        sin_t[i] = s;
+    }
+    (cos_t, sin_t)
+}
+
+#[cfg(feature = "cuda")]
+impl RunnableModel {
+    /// Build a GPU resident decode engine for this qwen35 (Ornith) model: upload every
+    /// layer (SSM or full-attn) + the LM head, mirroring the proven per-layer GPU
+    /// sequences. Q8_0 only (the certified Ornith Q8 row); widens 34->36 byte blocks.
+    #[allow(dead_code)] // called by the GPU test + the M4 generate_qwen35_cuda driver (next).
+    pub(crate) fn build_qwen35_resident(
+        &self,
+        max_pos: usize,
+    ) -> std::result::Result<crate::cuda_resident::CudaResidentDecode, String> {
+        use crate::cuda_resident::{widen_q8, CudaResidentDecode, ProjQuant};
+        let rt = self.qwen35.as_ref().ok_or("not a qwen35 model")?;
+        let q8 = ProjQuant::Q8_0;
+        let ffn_dim = rt.layers[0].ffn_gate.out_features;
+        let w = |m: &RawMat| -> std::result::Result<Vec<u8>, String> {
+            if m.tt != GgufTensorType::Q8_0 {
+                return Err(format!("qwen35 CUDA lane needs Q8_0, got {:?}", m.tt));
+            }
+            Ok(widen_q8(&m.bytes))
+        };
+        let mut e = CudaResidentDecode::new(
+            self.n_layers,
+            self.n_heads,
+            self.n_kv_heads,
+            self.head_dim,
+            self.d_model,
+            ffn_dim,
+            self.rope_dim,
+            max_pos,
+            self.vocab,
+            self.eps,
+            self.rope_neox,
+        )?;
+        e.set_qwen35(
+            rt.d_state,
+            rt.d_conv,
+            rt.num_k_heads,
+            rt.num_v_heads,
+            rt.head_v_dim,
+            rt.key_dim,
+            rt.value_dim,
+            rt.conv_dim,
+        )?;
+        for layer in &rt.layers {
+            match &layer.kind {
+                Qwen35Kind::Full {
+                    wq,
+                    wk,
+                    wv,
+                    wo,
+                    q_norm,
+                    k_norm,
+                } => {
+                    e.set_layer_located(
+                        &w(wq)?,
+                        &w(wk)?,
+                        &w(wv)?,
+                        &w(wo)?,
+                        &w(&layer.ffn_gate)?,
+                        &w(&layer.ffn_up)?,
+                        &w(&layer.ffn_down)?,
+                        &layer.attn_norm,
+                        &layer.post_attn_norm,
+                        Some(q_norm.as_slice()),
+                        Some(k_norm.as_slice()),
+                        true,
+                        [q8; 7],
+                    )?;
+                    e.push_ssm_placeholders()?;
+                }
+                Qwen35Kind::Ssm {
+                    wqkv,
+                    wqkv_gate,
+                    conv1d,
+                    dt_bias,
+                    a,
+                    beta,
+                    alpha,
+                    ssm_norm,
+                    ssm_out,
+                } => {
+                    e.set_layer_ssm_qwen35(
+                        &w(&layer.ffn_gate)?,
+                        &w(&layer.ffn_up)?,
+                        &w(&layer.ffn_down)?,
+                        &layer.attn_norm,
+                        &layer.post_attn_norm,
+                        &w(wqkv)?,
+                        &w(wqkv_gate)?,
+                        &w(beta)?,
+                        &w(alpha)?,
+                        &w(ssm_out)?,
+                        conv1d,
+                        dt_bias,
+                        a,
+                        ssm_norm,
+                        [q8; 5],
+                        [q8; 3],
+                        rt.conv_dim,
+                        rt.d_conv,
+                        rt.num_v_heads,
+                        rt.d_state,
+                    )?;
+                }
+            }
+        }
+        e.set_output(&self.output_norm, &w(&self.output)?, q8)?;
+        Ok(e)
+    }
+}
+
 /// GPU single-SSM-layer parity: upload layer 0's REAL Ornith SSM weights and run the
 /// whole GPU forward (rmsnorm+quantize -> q8 gemv x4 -> SSM kernel chain -> ssm_out
 /// gemv), comparing the layer `mix` to the CPU `qwen35_ssm`. Proves the gemv-from-real-
 /// weights path composes with the proven SSM chain — the mechanism the resident
 /// forward_pass SSM branch will use. Q8_0 weights (34-byte GGUF blocks widened to the
 /// 36-byte f32-scale layout repack_q8_soa expects).
-#[cfg(test)]
+#[cfg(all(test, feature = "cuda"))]
 mod gpu_ssm_layer_tests {
     use super::*;
     use crate::cuda_resident::{
@@ -2327,5 +2457,62 @@ mod gpu_ssm_layer_tests {
             "qwen35 full-attn layer GPU vs CPU diverged (worst rel {worst_all:.3e})"
         );
         eprintln!("qwen35_full_attn_layer_gpu: PASS (worst rel {worst_all:.3e})");
+    }
+
+    fn argmax_u32(v: &[f32]) -> u32 {
+        v.iter()
+            .enumerate()
+            .fold((0usize, f32::NEG_INFINITY), |(bi, bv), (i, &x)| {
+                if x > bv {
+                    (i, x)
+                } else {
+                    (bi, bv)
+                }
+            })
+            .0 as u32
+    }
+
+    /// Full 32-layer GPU stack: build the resident engine from real weights, run a
+    /// prompt token-by-token through forward_pass (SSM + full-attn branches), and assert
+    /// the GPU next-token argmax equals the CPU runnable lane's (greedy-token parity).
+    #[test]
+    #[ignore = "needs CAMELID_ORNITH_GGUF (Q8) + a CUDA device"]
+    fn qwen35_gpu_single_token_matches_cpu() {
+        let Ok(path) = std::env::var("CAMELID_ORNITH_GGUF") else {
+            return;
+        };
+        let model = RunnableModel::load(&path).expect("load qwen35");
+        if model.qwen35.is_none() {
+            return;
+        }
+        let prompt: Vec<u32> = vec![3710, 369, 279, 6511, 314, 9338, 30];
+        let cpu_logits = model.forward_logits_qwen35(&prompt).expect("cpu forward");
+        let cpu_tok = argmax_u32(&cpu_logits);
+        let mut e = match model.build_qwen35_resident(prompt.len() + 4) {
+            Ok(e) => e,
+            Err(err) => {
+                eprintln!("build_qwen35_resident failed: {err}");
+                return;
+            }
+        };
+        e.reset_qwen35_state().unwrap();
+        let scale = 1.0f32 / (model.head_dim as f32).sqrt();
+        let mut gpu_tok = 0u32;
+        for (i, &tok) in prompt.iter().enumerate() {
+            let emb = model
+                .token_embd
+                .dequant_row(tok as usize, "token_embd")
+                .expect("embd");
+            let (cos, sin) = super::qwen35_rope_tables(i, model.rope_base, model.rope_dim);
+            let last = i == prompt.len() - 1;
+            let out = e
+                .forward_token(&emb, &cos, &sin, i, scale, last)
+                .expect("gpu forward_token");
+            if last {
+                gpu_tok = out.expect("logits on final token");
+            }
+        }
+        eprintln!("qwen35_gpu_single_token: cpu={cpu_tok} gpu={gpu_tok}");
+        assert_eq!(gpu_tok, cpu_tok, "GPU next-token argmax != CPU runnable");
     }
 }

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -2691,4 +2691,47 @@ mod gpu_ssm_layer_tests {
         }
         eprintln!("qwen35_gpu_greedy: PASS (8-tok GPU==CPU, run-twice stable)");
     }
+
+    /// Decode tok/s benchmark, GPU resident lane vs CPU runnable lane, same Q4_K_M
+    /// model. Two-point timing ((t_hi - t_lo) over (n_hi - n_lo) generated tokens)
+    /// cancels the per-call prompt prefill + model-load + GPU build, leaving the
+    /// steady-state per-token decode rate. Needs CAMELID_ORNITH_GGUF = the Q4_K_M.
+    #[test]
+    #[ignore = "tok/s benchmark — needs CAMELID_ORNITH_GGUF (Q4_K_M) + a CUDA device"]
+    fn qwen35_gpu_vs_cpu_tokps() {
+        let Ok(path) = std::env::var("CAMELID_ORNITH_GGUF") else {
+            return;
+        };
+        let model = RunnableModel::load(&path).expect("load qwen35");
+        if model.qwen35.is_none() {
+            return;
+        }
+        let prompt: Vec<u32> = vec![3710, 369, 279, 6511, 314, 9338, 30];
+        let (n_lo, n_hi) = (16usize, 64usize);
+        let secs = |gpu: bool, n: usize| -> f64 {
+            let t = std::time::Instant::now();
+            let r = if gpu {
+                model.generate_qwen35_cuda(&prompt, n, &[])
+            } else {
+                model.generate_qwen35_cpu(&prompt, n, &[])
+            };
+            r.expect("generate");
+            t.elapsed().as_secs_f64()
+        };
+        // GPU: warm (lazy-build + 5.24 GB upload), then two timed runs.
+        let _ = model.generate_qwen35_cuda(&prompt, 4, &[]);
+        let g_lo = secs(true, n_lo);
+        let g_hi = secs(true, n_hi);
+        let gpu_tokps = (n_hi - n_lo) as f64 / (g_hi - g_lo);
+        // CPU: two timed runs.
+        let c_lo = secs(false, n_lo);
+        let c_hi = secs(false, n_hi);
+        let cpu_tokps = (n_hi - n_lo) as f64 / (c_hi - c_lo);
+        eprintln!(
+            "qwen35 DECODE tok/s (Q4_K_M): GPU={gpu_tokps:.2}  CPU={cpu_tokps:.2}  \
+             speedup={:.2}x  [GPU {g_lo:.1}s@{n_lo} -> {g_hi:.1}s@{n_hi}; \
+             CPU {c_lo:.1}s@{n_lo} -> {c_hi:.1}s@{n_hi}]",
+            gpu_tokps / cpu_tokps
+        );
+    }
 }

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -357,6 +357,12 @@ pub struct RunnableModel {
     /// layers have no K/V attention). When set, the forward path is routed to the
     /// dedicated `*_qwen35` methods and `layers` is empty. See [`Qwen35Runtime`].
     qwen35: Option<Qwen35Runtime>,
+    /// Lazily-built GPU resident decode engine for the qwen35 lane, gated by
+    /// `CAMELID_QWEN35_CUDA=1`. `Mutex` gives the `&mut` the per-token forward needs
+    /// while `generate_*` take `&self`; built on first use and reused, with the SSM/conv
+    /// recurrent state reset at the start of every generate. `None` until first use.
+    #[cfg(feature = "cuda")]
+    cuda: std::sync::Mutex<Option<crate::cuda_resident::CudaResidentDecode>>,
 }
 
 impl RunnableModel {
@@ -534,6 +540,8 @@ impl RunnableModel {
                     value_dim,
                     conv_dim,
                 }),
+                #[cfg(feature = "cuda")]
+                cuda: std::sync::Mutex::new(None),
             });
         }
 
@@ -642,6 +650,8 @@ impl RunnableModel {
             output_norm,
             layers,
             qwen35: None,
+            #[cfg(feature = "cuda")]
+            cuda: std::sync::Mutex::new(None),
         })
     }
 
@@ -1243,7 +1253,33 @@ impl RunnableModel {
     /// for the shared prefix (same per-token math, same accumulation order).
     ///
     /// [`forward_logits_qwen35`]: RunnableModel::forward_logits_qwen35
+    /// qwen35 greedy decode. Routes to the GPU resident lane when `CAMELID_QWEN35_CUDA=1`
+    /// (lazy-built, reused, recurrent state reset per call), and falls back to the CPU
+    /// runnable lane on any CUDA error. The CPU lane is the certified oracle and default.
     fn generate_qwen35(&self, prompt: &[u32], max_new: usize, stop: &[u32]) -> Result<Vec<u32>> {
+        #[cfg(feature = "cuda")]
+        {
+            if std::env::var("CAMELID_QWEN35_CUDA")
+                .map(|v| v == "1")
+                .unwrap_or(false)
+            {
+                match self.generate_qwen35_cuda(prompt, max_new, stop) {
+                    Ok(v) => return Ok(v),
+                    Err(e) => {
+                        eprintln!("[qwen35] CUDA lane failed ({e}); falling back to CPU");
+                    }
+                }
+            }
+        }
+        self.generate_qwen35_cpu(prompt, max_new, stop)
+    }
+
+    fn generate_qwen35_cpu(
+        &self,
+        prompt: &[u32],
+        max_new: usize,
+        stop: &[u32],
+    ) -> Result<Vec<u32>> {
         // Batched prefill of the whole prompt (weights read once per layer), then
         // per-token greedy decode from the resulting cache.
         let (mut cache, last) = self.prefill_qwen35(prompt)?;
@@ -1261,6 +1297,78 @@ impl RunnableModel {
                 let logits = self.decode_token_qwen35(next, pos, &mut cache, true)?;
                 pos += 1;
                 next = argmax(&logits);
+            }
+        }
+        Ok(out)
+    }
+
+    /// GPU resident greedy decode for qwen35. Builds the engine on first use (cached in
+    /// `self.cuda`), resets the recurrent SSM/conv state, then prefills the prompt and
+    /// greedily decodes via `forward_token`. Token-parity with the CPU lane (not
+    /// bit-identical: int8 activation quant + FP-reassociated attention).
+    #[cfg(feature = "cuda")]
+    fn generate_qwen35_cuda(
+        &self,
+        prompt: &[u32],
+        max_new: usize,
+        stop: &[u32],
+    ) -> Result<Vec<u32>> {
+        // KV cache is dense over all 32 layers (131072 bytes/pos) on top of the 5.24 GB
+        // Q4_K_M, so the context window is VRAM-bound on a 6 GB card (sparse KV for the 8
+        // full-attn layers is the P7 lift). Default 2048 fits; override for bigger cards.
+        let max_pos: usize = std::env::var("CAMELID_QWEN35_CUDA_MAXPOS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(2048);
+        let mut guard = self
+            .cuda
+            .lock()
+            .map_err(|_| BackendError::InvalidTensorData("qwen35 cuda mutex poisoned".into()))?;
+        if guard.is_none() {
+            let e = self
+                .build_qwen35_resident(max_pos)
+                .map_err(BackendError::InvalidTensorData)?;
+            *guard = Some(e);
+        }
+        let engine = guard.as_mut().unwrap();
+        // CRITICAL: the SSM/conv recurrent state persists across generate calls; reset it
+        // at the start of every call or the 2nd+ prompt decodes on stale state.
+        engine
+            .reset_qwen35_state()
+            .map_err(BackendError::InvalidTensorData)?;
+        let scale = 1.0f32 / (self.head_dim as f32).sqrt();
+        // Prefill: only the final prompt token needs logits.
+        let mut next = 0u32;
+        for (i, &tok) in prompt.iter().enumerate() {
+            let emb = self.token_embd.dequant_row(tok as usize, "token_embd")?;
+            let (cos, sin) = qwen35_rope_tables(i, self.rope_base, self.rope_dim);
+            let last = i == prompt.len() - 1;
+            let out = engine
+                .forward_token(&emb, &cos, &sin, i, scale, last)
+                .map_err(BackendError::InvalidTensorData)?;
+            if last {
+                next = out.ok_or_else(|| {
+                    BackendError::InvalidTensorData("no logits on final prompt token".into())
+                })?;
+            }
+        }
+        let mut out = Vec::with_capacity(max_new);
+        let mut pos = prompt.len();
+        for i in 0..max_new {
+            if stop.contains(&next) {
+                break;
+            }
+            out.push(next);
+            if i + 1 < max_new {
+                let emb = self.token_embd.dequant_row(next as usize, "token_embd")?;
+                let (cos, sin) = qwen35_rope_tables(pos, self.rope_base, self.rope_dim);
+                next = engine
+                    .forward_token(&emb, &cos, &sin, pos, scale, true)
+                    .map_err(BackendError::InvalidTensorData)?
+                    .ok_or_else(|| {
+                        BackendError::InvalidTensorData("no logits on decode step".into())
+                    })?;
+                pos += 1;
             }
         }
         Ok(out)
@@ -1758,8 +1866,8 @@ fn qwen35_rope_tables(pos: usize, rope_base: f32, rope_dim: usize) -> (Vec<f32>,
 impl RunnableModel {
     /// Build a GPU resident decode engine for this qwen35 (Ornith) model: upload every
     /// layer (SSM or full-attn) + the LM head, mirroring the proven per-layer GPU
-    /// sequences. Q8_0 only (the certified Ornith Q8 row); widens 34->36 byte blocks.
-    #[allow(dead_code)] // called by the GPU test + the M4 generate_qwen35_cuda driver (next).
+    /// sequences. Maps each tensor's quant per-tensor (Q8_0 widened 34->36; Q4_K/Q6_K
+    /// raw passthrough), so both the Q8_0 and the 6 GB-fitting Q4_K_M rows build.
     pub(crate) fn build_qwen35_resident(
         &self,
         max_pos: usize,
@@ -2536,5 +2644,51 @@ mod gpu_ssm_layer_tests {
         }
         eprintln!("qwen35_gpu_single_token: cpu={cpu_tok} gpu={gpu_tok}");
         assert_eq!(gpu_tok, cpu_tok, "GPU next-token argmax != CPU runnable");
+    }
+
+    /// End-to-end qwen35 GPU greedy decode vs the CPU runnable lane (point
+    /// CAMELID_ORNITH_GGUF at the 5.24 GB Q4_K_M so it fits 6 GB VRAM). Also a run-twice
+    /// check: the second GPU call reuses the cached engine, so identical streams prove
+    /// reset_qwen35_state() actually clears the recurrent SSM/conv state.
+    #[test]
+    #[ignore = "needs CAMELID_ORNITH_GGUF (point at Q4_K_M) + a CUDA device"]
+    fn qwen35_gpu_greedy_matches_cpu() {
+        let Ok(path) = std::env::var("CAMELID_ORNITH_GGUF") else {
+            return;
+        };
+        let model = RunnableModel::load(&path).expect("load qwen35");
+        if model.qwen35.is_none() {
+            return;
+        }
+        // "What is the capital of France?" prompt tokens.
+        let prompt: Vec<u32> = vec![3710, 369, 279, 6511, 314, 9338, 30];
+        let n = 8usize;
+        let cpu = model.generate_qwen35_cpu(&prompt, n, &[]).expect("cpu gen");
+        let gpu = model
+            .generate_qwen35_cuda(&prompt, n, &[])
+            .expect("gpu gen");
+        // run-twice reuses the cached engine -> validates reset_qwen35_state.
+        let gpu2 = model
+            .generate_qwen35_cuda(&prompt, n, &[])
+            .expect("gpu gen 2");
+        eprintln!("cpu ={cpu:?}");
+        eprintln!("gpu ={gpu:?}");
+        eprintln!("gpu2={gpu2:?}");
+        assert_eq!(
+            gpu, gpu2,
+            "qwen35 CUDA run-twice differs — SSM state not reset"
+        );
+        assert_eq!(gpu, cpu, "qwen35 CUDA greedy != CPU runnable");
+        // Coherence sanity: decode a 16-token GPU continuation.
+        if let Ok(gguf) = read_metadata(&path) {
+            if let Ok(tok) = crate::tokenizer::Tokenizer::from_gguf(&gguf) {
+                let ids16 = model
+                    .generate_qwen35_cuda(&prompt, 16, &[])
+                    .expect("gpu 16-tok");
+                let text = tok.decode(&ids16, true).unwrap_or_default();
+                eprintln!("qwen35 GPU 16-tok decode: {text}");
+            }
+        }
+        eprintln!("qwen35_gpu_greedy: PASS (8-tok GPU==CPU, run-twice stable)");
     }
 }

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -1734,3 +1734,294 @@ fn read_tensor_bytes(f: &mut File, d: &GgufTensorDescriptor, name: &str) -> Resu
     })?;
     Ok(bytes)
 }
+
+/// GPU single-SSM-layer parity: upload layer 0's REAL Ornith SSM weights and run the
+/// whole GPU forward (rmsnorm+quantize -> q8 gemv x4 -> SSM kernel chain -> ssm_out
+/// gemv), comparing the layer `mix` to the CPU `qwen35_ssm`. Proves the gemv-from-real-
+/// weights path composes with the proven SSM chain — the mechanism the resident
+/// forward_pass SSM branch will use. Q8_0 weights (34-byte GGUF blocks widened to the
+/// 36-byte f32-scale layout repack_q8_soa expects).
+#[cfg(test)]
+mod gpu_ssm_layer_tests {
+    use super::*;
+    use crate::cuda_resident::{
+        launch_gemv, launch_quantize, launch_rmsnorm_quantize, repack_q8_soa, CudaResidentKernels,
+    };
+    use cudarc::driver::{LaunchConfig, PushKernelArg};
+
+    fn widen_q8(bytes: &[u8]) -> Vec<u8> {
+        let nb = bytes.len() / 34;
+        let mut out = Vec::with_capacity(nb * 36);
+        for b in 0..nb {
+            let base = b * 34;
+            let scale =
+                crate::tensor::f16_bits_to_f32(u16::from_le_bytes([bytes[base], bytes[base + 1]]));
+            out.extend_from_slice(&scale.to_le_bytes());
+            out.extend_from_slice(&bytes[base + 2..base + 34]);
+        }
+        out
+    }
+
+    fn rel_close(a: &[f32], b: &[f32], tol: f32) -> (bool, f32) {
+        let mut worst = 0.0f32;
+        for (x, y) in a.iter().zip(b) {
+            let d = (x - y).abs() / y.abs().max(1.0);
+            if d > worst {
+                worst = d;
+            }
+        }
+        (worst < tol, worst)
+    }
+
+    #[test]
+    #[ignore = "needs CAMELID_ORNITH_GGUF (Q8) + a CUDA device"]
+    fn qwen35_ssm_layer_gpu_matches_cpu() {
+        let path = match std::env::var("CAMELID_ORNITH_GGUF") {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let Ok(k) = CudaResidentKernels::new() else {
+            return;
+        };
+        let model = RunnableModel::load(&path).expect("load qwen35");
+        let rt = model.qwen35.as_ref().expect("qwen35 runtime");
+        let li = 0usize; // layer 0 is SSM ((0+1)%4 != 0)
+        let layer = &rt.layers[li];
+        let (wqkv, wqkv_gate, conv1d, dt_bias, a_vec, beta_m, alpha_m, ssm_norm, ssm_out) =
+            match &layer.kind {
+                Qwen35Kind::Ssm {
+                    wqkv,
+                    wqkv_gate,
+                    conv1d,
+                    dt_bias,
+                    a,
+                    beta,
+                    alpha,
+                    ssm_norm,
+                    ssm_out,
+                } => (
+                    wqkv, wqkv_gate, conv1d, dt_bias, a, beta, alpha, ssm_norm, ssm_out,
+                ),
+                _ => panic!("layer 0 is not SSM"),
+            };
+        for m in [wqkv, wqkv_gate, beta_m, alpha_m, ssm_out] {
+            assert_eq!(
+                m.tt,
+                GgufTensorType::Q8_0,
+                "test assumes a Q8_0 Ornith GGUF"
+            );
+        }
+        let hidden_dim = model.d_model;
+        let eps = model.eps;
+        let (ds, nk, nv) = (rt.d_state, rt.num_k_heads, rt.num_v_heads);
+        let (key_dim, value_dim, conv_dim, d_conv) =
+            (rt.key_dim, rt.value_dim, rt.conv_dim, rt.d_conv);
+
+        // Deterministic pseudo-random hidden activation.
+        let mut seed = 0x1234_5678u64;
+        let mut nextf = || {
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((seed >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+        };
+        let hidden: Vec<f32> = (0..hidden_dim).map(|_| nextf()).collect();
+
+        // ---- CPU reference: the layer mix from qwen35_ssm ----
+        let mut cache = Qwen35Cache::new(rt, rt.layers.len());
+        let xn = rms_norm(&hidden, &layer.attn_norm, eps);
+        let cpu_mix = model
+            .qwen35_ssm(rt, layer, li, &xn, &mut cache)
+            .expect("cpu ssm");
+
+        // ---- GPU forward ----
+        let s = &k.stream;
+        let up = |m: &RawMat| s.clone_htod(&repack_q8_soa(&widen_q8(&m.bytes))).unwrap();
+        let d_wqkv = up(wqkv);
+        let d_wqkv_gate = up(wqkv_gate);
+        let d_beta_w = up(beta_m);
+        let d_alpha_w = up(alpha_m);
+        let d_ssm_out = up(ssm_out);
+        let d_conv1d = s.clone_htod(conv1d).unwrap();
+        let d_dt = s.clone_htod(dt_bias).unwrap();
+        let d_a = s.clone_htod(a_vec).unwrap();
+        let d_norm = s.clone_htod(ssm_norm).unwrap();
+        let d_attn_norm = s.clone_htod(&layer.attn_norm).unwrap();
+        let d_hidden = s.clone_htod(&hidden).unwrap();
+
+        let hb = hidden_dim / 32;
+        let vb = value_dim / 32;
+        let mut in_q = s.alloc_zeros::<i8>(hidden_dim).unwrap();
+        let mut in_s = s.alloc_zeros::<f32>(hb).unwrap();
+        let mut d_qkv = s.alloc_zeros::<f32>(conv_dim).unwrap();
+        let mut d_z = s.alloc_zeros::<f32>(value_dim).unwrap();
+        let mut d_br = s.alloc_zeros::<f32>(nv).unwrap();
+        let mut d_ar = s.alloc_zeros::<f32>(nv).unwrap();
+        let mut d_beta = s.alloc_zeros::<f32>(nv).unwrap();
+        let mut d_glog = s.alloc_zeros::<f32>(nv).unwrap();
+        let mut d_conv_out = s.alloc_zeros::<f32>(conv_dim).unwrap();
+        let mut d_ssm_mix = s.alloc_zeros::<f32>(value_dim).unwrap();
+        let mut d_conv_state = s.alloc_zeros::<f32>(conv_dim * (d_conv - 1)).unwrap();
+        let mut d_state = s.alloc_zeros::<f32>(nv * ds * ds).unwrap();
+        let mut mix_q = s.alloc_zeros::<i8>(value_dim).unwrap();
+        let mut mix_s = s.alloc_zeros::<f32>(vb).unwrap();
+        let mut d_mix = s.alloc_zeros::<f32>(hidden_dim).unwrap();
+
+        // attn rmsnorm + quantize the hidden
+        launch_rmsnorm_quantize(
+            s,
+            &k.rms_norm_quantize,
+            &d_hidden,
+            &d_attn_norm,
+            &mut in_q,
+            &mut in_s,
+            hidden_dim,
+            eps,
+        )
+        .unwrap();
+        // projections (Q8_0 q8_gemv): wqkv -> qkv, wqkv_gate -> z, beta -> br, alpha -> ar
+        launch_gemv(
+            s,
+            &k.gemv,
+            &in_s,
+            &in_q,
+            &d_wqkv.slice(0..d_wqkv.len()),
+            conv_dim,
+            hb,
+            &mut d_qkv,
+        )
+        .unwrap();
+        launch_gemv(
+            s,
+            &k.gemv,
+            &in_s,
+            &in_q,
+            &d_wqkv_gate.slice(0..d_wqkv_gate.len()),
+            value_dim,
+            hb,
+            &mut d_z,
+        )
+        .unwrap();
+        launch_gemv(
+            s,
+            &k.gemv,
+            &in_s,
+            &in_q,
+            &d_beta_w.slice(0..d_beta_w.len()),
+            nv,
+            hb,
+            &mut d_br,
+        )
+        .unwrap();
+        launch_gemv(
+            s,
+            &k.gemv,
+            &in_s,
+            &in_q,
+            &d_alpha_w.slice(0..d_alpha_w.len()),
+            nv,
+            hb,
+            &mut d_ar,
+        )
+        .unwrap();
+
+        let nvi = nv as i32;
+        let dsi = ds as i32;
+        let nki = nk as i32;
+        // gates
+        {
+            let cfg = LaunchConfig {
+                grid_dim: (1, 1, 1),
+                block_dim: (nv as u32, 1, 1),
+                shared_mem_bytes: 0,
+            };
+            let mut b = s.launch_builder(&k.ssm_gates);
+            b.arg(&d_br)
+                .arg(&d_ar)
+                .arg(&d_dt)
+                .arg(&d_a)
+                .arg(&mut d_beta)
+                .arg(&mut d_glog)
+                .arg(&nvi);
+            unsafe { b.launch(cfg).unwrap() };
+        }
+        // conv1d
+        {
+            let cfg = LaunchConfig {
+                grid_dim: (conv_dim.div_ceil(256) as u32, 1, 1),
+                block_dim: (256, 1, 1),
+                shared_mem_bytes: 0,
+            };
+            let cdi = conv_dim as i32;
+            let dci = d_conv as i32;
+            let mut b = s.launch_builder(&k.ssm_conv1d);
+            b.arg(&d_conv1d)
+                .arg(&d_qkv)
+                .arg(&mut d_conv_state)
+                .arg(&mut d_conv_out)
+                .arg(&cdi)
+                .arg(&dci);
+            unsafe { b.launch(cfg).unwrap() };
+        }
+        // l2norm q (0..key_dim) and k (key_dim..2*key_dim)
+        for lo in [0usize, key_dim] {
+            let cfg = LaunchConfig {
+                grid_dim: (nk as u32, 1, 1),
+                block_dim: (ds as u32, 1, 1),
+                shared_mem_bytes: (ds as u32) * 4,
+            };
+            let mut view = d_conv_out.slice_mut(lo..lo + key_dim);
+            let mut b = s.launch_builder(&k.ssm_l2_norm_per_head);
+            b.arg(&mut view).arg(&dsi).arg(&eps);
+            unsafe { b.launch(cfg).unwrap() };
+        }
+        // delta rule
+        {
+            let cfg = LaunchConfig {
+                grid_dim: (nv as u32, 1, 1),
+                block_dim: (ds as u32, 1, 1),
+                shared_mem_bytes: (3 * ds as u32) * 4,
+            };
+            let qv = d_conv_out.slice(0..key_dim);
+            let kv = d_conv_out.slice(key_dim..2 * key_dim);
+            let vv = d_conv_out.slice(2 * key_dim..2 * key_dim + value_dim);
+            let mut b = s.launch_builder(&k.ssm_delta_rule);
+            b.arg(&mut d_state)
+                .arg(&kv)
+                .arg(&qv)
+                .arg(&vv)
+                .arg(&d_z)
+                .arg(&d_beta)
+                .arg(&d_glog)
+                .arg(&d_norm)
+                .arg(&mut d_ssm_mix)
+                .arg(&dsi)
+                .arg(&nki)
+                .arg(&eps);
+            unsafe { b.launch(cfg).unwrap() };
+        }
+        // quantize the SSM mix, then ssm_out projection (Q8_0 gemv) -> d_mix
+        launch_quantize(s, &k.quantize, &d_ssm_mix, &mut mix_q, &mut mix_s, vb).unwrap();
+        launch_gemv(
+            s,
+            &k.gemv,
+            &mix_s,
+            &mix_q,
+            &d_ssm_out.slice(0..d_ssm_out.len()),
+            hidden_dim,
+            vb,
+            &mut d_mix,
+        )
+        .unwrap();
+
+        let mut got = vec![0f32; hidden_dim];
+        s.memcpy_dtoh(&d_mix, &mut got).unwrap();
+        k.ctx.synchronize().unwrap();
+        let (ok, worst) = rel_close(&got, &cpu_mix, 1e-2);
+        assert!(
+            ok,
+            "qwen35 SSM layer GPU vs CPU diverged (worst rel {worst:.3e})"
+        );
+        eprintln!("qwen35_ssm_layer_gpu: PASS (worst rel {worst:.3e})");
+    }
+}

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -1766,13 +1766,19 @@ impl RunnableModel {
     ) -> std::result::Result<crate::cuda_resident::CudaResidentDecode, String> {
         use crate::cuda_resident::{widen_q8, CudaResidentDecode, ProjQuant};
         let rt = self.qwen35.as_ref().ok_or("not a qwen35 model")?;
-        let q8 = ProjQuant::Q8_0;
         let ffn_dim = rt.layers[0].ffn_gate.out_features;
-        let w = |m: &RawMat| -> std::result::Result<Vec<u8>, String> {
-            if m.tt != GgufTensorType::Q8_0 {
-                return Err(format!("qwen35 CUDA lane needs Q8_0, got {:?}", m.tt));
+        // Per-tensor quant: Q8_0 weights are widened 34->36 (set_*'s repack_for_lane
+        // then runs repack_q8_soa); K-quant (Q4_K/Q6_K) bytes pass through raw (the
+        // q4k/q6k GEMV kernels expand them on the fly). Returns (repack-ready bytes, lane).
+        let prep = |m: &RawMat| -> std::result::Result<(Vec<u8>, ProjQuant), String> {
+            match m.tt {
+                GgufTensorType::Q8_0 => Ok((widen_q8(&m.bytes), ProjQuant::Q8_0)),
+                GgufTensorType::Q4K => Ok((m.bytes.clone(), ProjQuant::Q4K)),
+                GgufTensorType::Q6K => Ok((m.bytes.clone(), ProjQuant::Q6K)),
+                other => Err(format!(
+                    "qwen35 CUDA lane: unsupported projection quant {other:?}"
+                )),
             }
-            Ok(widen_q8(&m.bytes))
         };
         let mut e = CudaResidentDecode::new(
             self.n_layers,
@@ -1807,20 +1813,27 @@ impl RunnableModel {
                     q_norm,
                     k_norm,
                 } => {
+                    let (bq, qq) = prep(wq)?;
+                    let (bk, qk) = prep(wk)?;
+                    let (bv, qv) = prep(wv)?;
+                    let (bo, qo) = prep(wo)?;
+                    let (bg, qg) = prep(&layer.ffn_gate)?;
+                    let (bu, qu) = prep(&layer.ffn_up)?;
+                    let (bd, qd) = prep(&layer.ffn_down)?;
                     e.set_layer_located(
-                        &w(wq)?,
-                        &w(wk)?,
-                        &w(wv)?,
-                        &w(wo)?,
-                        &w(&layer.ffn_gate)?,
-                        &w(&layer.ffn_up)?,
-                        &w(&layer.ffn_down)?,
+                        &bq,
+                        &bk,
+                        &bv,
+                        &bo,
+                        &bg,
+                        &bu,
+                        &bd,
                         &layer.attn_norm,
                         &layer.post_attn_norm,
                         Some(q_norm.as_slice()),
                         Some(k_norm.as_slice()),
                         true,
-                        [q8; 7],
+                        [qq, qk, qv, qo, qg, qu, qd],
                     )?;
                     e.push_ssm_placeholders()?;
                 }
@@ -1835,23 +1848,31 @@ impl RunnableModel {
                     ssm_norm,
                     ssm_out,
                 } => {
+                    let (bg, qg) = prep(&layer.ffn_gate)?;
+                    let (bu, qu) = prep(&layer.ffn_up)?;
+                    let (bd, qd) = prep(&layer.ffn_down)?;
+                    let (bqkv, qqkv) = prep(wqkv)?;
+                    let (bgate, qgate) = prep(wqkv_gate)?;
+                    let (bbeta, qbeta) = prep(beta)?;
+                    let (balpha, qalpha) = prep(alpha)?;
+                    let (bout, qout) = prep(ssm_out)?;
                     e.set_layer_ssm_qwen35(
-                        &w(&layer.ffn_gate)?,
-                        &w(&layer.ffn_up)?,
-                        &w(&layer.ffn_down)?,
+                        &bg,
+                        &bu,
+                        &bd,
                         &layer.attn_norm,
                         &layer.post_attn_norm,
-                        &w(wqkv)?,
-                        &w(wqkv_gate)?,
-                        &w(beta)?,
-                        &w(alpha)?,
-                        &w(ssm_out)?,
+                        &bqkv,
+                        &bgate,
+                        &bbeta,
+                        &balpha,
+                        &bout,
                         conv1d,
                         dt_bias,
                         a,
                         ssm_norm,
-                        [q8; 5],
-                        [q8; 3],
+                        [qqkv, qgate, qbeta, qalpha, qout],
+                        [qg, qu, qd],
                         rt.conv_dim,
                         rt.d_conv,
                         rt.num_v_heads,
@@ -1860,7 +1881,8 @@ impl RunnableModel {
                 }
             }
         }
-        e.set_output(&self.output_norm, &w(&self.output)?, q8)?;
+        let (bout, qout) = prep(&self.output)?;
+        e.set_output(&self.output_norm, &bout, qout)?;
         Ok(e)
     }
 }


### PR DESCRIPTION
## qwen35 (Ornith-1.0-9B) GPU resident decode lane

Adds a CUDA GPU-resident decode lane for the **qwen35 hybrid gated-delta-net (SSM) + sparse full-attention** architecture, running **fully GPU-resident on a 6 GB RTX 3060** via a Q4_K_M requant. Stacked on #350 (the CPU bringup); base will retarget to `main` when #350 merges.

### Result
- **Fully GPU-resident** on 6 GB (the 9.5 GB Q8 OOMs; a 5.24 GB Q4_K_M fits — `output→q6_K`, most SSM tensors Q4_K).
- **Greedy token-identical to the CPU oracle** — single-token argmax `cpu=gpu=271`; 8-token `[271,760,6511,314,9338,369,11751,13]` GPU == CPU == run-twice == the certified parity receipt.
- **~12 tok/s decode** (~3.6× the fast CPU Q8 lane; near the realistic batch-1 ceiling — measured at ~17% of VRAM bandwidth, so gemv-latency-bound, not launch-bound).
- **8192-token context** via sparse KV (real KV buffers only for the 8 attention layers; placeholders for the 24 SSM layers → ~4× less KV; peak 5.26 GB at 8192 + 2100-tok prefill).
- **Serve-usable**: `CAMELID_RUNNABLE_SERVE=1` + `CAMELID_QWEN35_CUDA=1` routes the OpenAI chat API + web UI through the GPU lane (lazy-built, CPU fallback on error).

### How
- **6 new CUDA kernels** (no qwen35 op existed for any arch): `ssm_delta_rule` (gated delta-rule recurrence + gated RMSNorm), `ssm_conv1d`, `ssm_l2_norm_per_head`, `ssm_gates`, `deinterleave_qgate`, `sigmoid_mul`. Each parity-proven vs the CPU reference, and validated **from real weights** (SSM layer bit-identical; full-attn layer worst-rel 6e-3 = the f16-KV floor). RoPE/attention/gemv/QK-norm reuse the existing kernels.
- **Engine integration**: `forward_pass` branches on `LayerKind { Full, Ssm }`; `build_qwen35_resident` uploads all 32 layers with per-tensor `Q4_K`/`Q6_K`/`Q8_0` quant mapping; `generate_qwen35_cuda` driver + per-call SSM-state reset; force-serial (the SSM recurrence is not graph/batch-safe).
- **`fix(serve)`**: `/v1/health` now reports `generation_ready` for runnable-served archs (the UI gates Send on it; previously the qwen35 model showed "Loading" forever).

### Safety / scope
- **Every non-qwen35 architecture is byte-identical** — all additions are gated behind `self.qwen35.is_some()`; the shared `CudaResidentDecode::new()` is unchanged.
- Validation tests in `src/runnable/model.rs` (`gpu_ssm_layer_tests`) + `src/cuda_resident/tests.rs` (per-kernel); all `#[ignore]` (need a CUDA device + the GGUF). Gate green: `clippy --all-targets --all-features -D warnings` + `fmt`.

Commits `6f0d10ab` → `82caaaa6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
