### PR TITLE
feat(attn): canonical blocked f32 dot/axpy kernels for Windows x86_64 decode attention (default-off)

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -22,6 +22,7 @@ use crate::execution_plan::MAC_Q8_PREFILL_I8MM_MIN_ROWS;
 use crate::metal;
 use crate::telemetry;
 
+mod attn_f32_dot;
 #[cfg(target_arch = "aarch64")]
 mod cpu_neon;
 mod diagnostic_config;
@@ -1263,6 +1264,76 @@ pub fn dump_stage_timings() {
             pct(us)
         );
     }
+}
+
+/// Hot-cache micro-benchmark for the attention f32 dot kernels: the legacy
+/// scalar chain (`tensor::dot_product`) vs the canonical blocked scalar
+/// reference vs the blocked AVX2/FMA realization. Returns
+/// `(variant, ns_per_call)` pairs; the AVX2 row is omitted when the CPU lacks
+/// AVX2+FMA. Bench-only entry point — never called on the inference path.
+pub fn attn_f32_dot_microbench(
+    len: usize,
+    repeats: usize,
+    warmup: usize,
+) -> Vec<(&'static str, f64)> {
+    let x: Vec<f32> = (0..len).map(|i| ((i % 97) as f32 - 48.0) * 0.001).collect();
+    let y: Vec<f32> = (0..len).map(|i| ((i % 89) as f32 - 44.0) * 0.002).collect();
+    fn measure(
+        results: &mut Vec<(&'static str, f64)>,
+        x: &[f32],
+        y: &[f32],
+        repeats: usize,
+        warmup: usize,
+        label: &'static str,
+        mut f: impl FnMut(&[f32], &[f32]) -> f32,
+    ) {
+        use std::hint::black_box;
+        let mut sink = 0.0f32;
+        for _ in 0..warmup {
+            sink += f(black_box(x), black_box(y));
+        }
+        let started = Instant::now();
+        for _ in 0..repeats {
+            sink += f(black_box(x), black_box(y));
+        }
+        let elapsed = started.elapsed();
+        black_box(sink);
+        results.push((label, elapsed.as_nanos() as f64 / repeats as f64));
+    }
+
+    let mut results = Vec::new();
+    measure(
+        &mut results,
+        &x,
+        &y,
+        repeats,
+        warmup,
+        "legacy_scalar_chain",
+        crate::tensor::dot_product,
+    );
+    measure(
+        &mut results,
+        &x,
+        &y,
+        repeats,
+        warmup,
+        "blocked_scalar",
+        attn_f32_dot::dot_blocked_scalar,
+    );
+    #[cfg(target_arch = "x86_64")]
+    if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma") {
+        measure(
+            &mut results,
+            &x,
+            &y,
+            repeats,
+            warmup,
+            "blocked_avx2",
+            // SAFETY: guarded by the runtime AVX2+FMA feature check above.
+            |a, b| unsafe { attn_f32_dot::dot_blocked_avx2(a, b) },
+        );
+    }
+    results
 }
 
 #[allow(dead_code)]
@@ -20776,6 +20847,30 @@ fn causal_attention_context_batch(
     CpuTensor::from_f32(name, vec![rows, expected_width], out)
 }
 
+/// Flag gate for the canonical blocked f32 attention kernels
+/// (`BACKENDINFERENCE_ATTENTION_F32_BLOCKED_DOT`, default off). Scoped to the
+/// Windows x86_64 decode attention lane; any guard failing (flag off, AVX2 or
+/// FMA missing) keeps the exact legacy scalar code path. Resolved once per
+/// process outside tests.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn attention_f32_blocked_dot_enabled() -> bool {
+    #[cfg(test)]
+    {
+        q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_ATTENTION_F32_BLOCKED_DOT")
+            && std::arch::is_x86_feature_detected!("avx2")
+            && std::arch::is_x86_feature_detected!("fma")
+    }
+    #[cfg(not(test))]
+    {
+        static ATTENTION_F32_BLOCKED_DOT_ENABLED: OnceLock<bool> = OnceLock::new();
+        *ATTENTION_F32_BLOCKED_DOT_ENABLED.get_or_init(|| {
+            q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_ATTENTION_F32_BLOCKED_DOT")
+                && std::arch::is_x86_feature_detected!("avx2")
+                && std::arch::is_x86_feature_detected!("fma")
+        })
+    }
+}
+
 struct AttentionContextHeadParams<'a> {
     kv_cache: &'a LlamaKvCache,
     layer_idx: usize,
@@ -20800,10 +20895,21 @@ fn attention_context_for_head_into(
         .head_base_offset(params.layer_idx, params.kv_head);
     let position_stride = params.kv_cache.position_stride();
 
+    // Canonical blocked f32 kernels (Windows x86_64, flag-gated, default off).
+    // `false` on every other target keeps the legacy path literally unchanged.
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    let use_blocked_kernels = attention_f32_blocked_dot_enabled();
+    #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+    let use_blocked_kernels = false;
+
     let mut key_start = head_base;
     for position in 0..params.position_count {
         let key_slice = &params.kv_cache.keys[key_start..key_start + head_dim];
-        let score = dot_product(params.query_slice, key_slice) * params.scale;
+        let score = if use_blocked_kernels {
+            attn_f32_dot::dot_blocked(params.query_slice, key_slice) * params.scale
+        } else {
+            dot_product(params.query_slice, key_slice) * params.scale
+        };
         scores.push(score);
         if position + 1 < params.position_count {
             key_start += position_stride;
@@ -20827,8 +20933,12 @@ fn attention_context_for_head_into(
     for (position, score) in scores.iter().copied().enumerate() {
         let probability = score * inv_score_sum;
         let value_slice = &params.kv_cache.values[value_start..value_start + head_dim];
-        for (out_value, value) in out_slice.iter_mut().zip(value_slice) {
-            *out_value += probability * *value;
+        if use_blocked_kernels {
+            attn_f32_dot::axpy_blocked(out_slice, probability, value_slice);
+        } else {
+            for (out_value, value) in out_slice.iter_mut().zip(value_slice) {
+                *out_value += probability * *value;
+            }
         }
         if position + 1 < params.position_count {
             value_start += position_stride;

--- a/src/inference/attn_f32_dot.rs
+++ b/src/inference/attn_f32_dot.rs
@@ -1,0 +1,432 @@
+//! Canonical blocked f32 reduction kernels for decode attention.
+//!
+//! Camelid's determinism guarantee for the attention QK dot product and the
+//! V-weighted accumulation is a *fixed, documented reduction order* — not the
+//! legacy scalar left-to-right order. This module defines that canonical
+//! blocked order and implements it twice: a portable scalar form (the
+//! reference on every platform) and an AVX2/FMA form that realizes the same
+//! order with intrinsics and is therefore bitwise identical to the reference
+//! by construction. Bitwise equality is enforced by property tests below; any
+//! divergence is a bug in the kernel, never an accepted tolerance.
+//!
+//! Normative reduction order for `dot(x, y)` with `len = x.len()`:
+//!
+//! - 32 partial accumulators, conceptually four 8-lane f32 vectors
+//!   `acc0..acc3` (`p[k*8 + l]` = lane `l` of `acc_k`), all starting at 0.0.
+//! - Main loop over `i` in steps of 32 while `i + 32 <= len`:
+//!   `acc_k.lane[l] = fma(x[i + k*8 + l], y[i + k*8 + l], acc_k.lane[l])`.
+//!   FMA is canonical: a single rounding per multiply-add.
+//! - Combine, lane-wise, in this exact order: `s01 = acc0 + acc1`,
+//!   `s23 = acc2 + acc3`, `s = s01 + s23`.
+//! - Horizontal sum of `s`, fixed tree: `t0 = s[0]+s[4]`, `t1 = s[1]+s[5]`,
+//!   `t2 = s[2]+s[6]`, `t3 = s[3]+s[7]`, then `u0 = t0+t2`, `u1 = t1+t3`,
+//!   result `h = u0 + u1`.
+//! - Tail (`len % 32` elements): scalar, ascending index, each element folded
+//!   as `h = fma(x[i], y[i], h)`.
+//!
+//! Normative form for the V accumulation (`axpy`): per element, ascending,
+//! `out[d] = fma(prob, v[d], out[d])`. This is elementwise (no cross-lane
+//! reduction), so the scalar and SIMD forms agree bitwise as long as both use
+//! a single-rounding fused multiply-add.
+//!
+//! `f32::mul_add` lowers to a hardware FMA on every target this lane can be
+//! enabled on (the workspace pins `target-cpu=x86-64-v3`, which includes FMA)
+//! and to a correctly-rounded libm `fmaf` elsewhere, so the scalar reference
+//! is single-rounding everywhere.
+
+#[cfg(target_arch = "x86_64")]
+use std::sync::OnceLock;
+
+const BLOCK: usize = 32;
+const LANES: usize = 8;
+
+/// Canonical blocked dot product — portable scalar realization of the
+/// normative reduction order documented at module level. This is the
+/// reference implementation on all platforms.
+pub(super) fn dot_blocked_scalar(x: &[f32], y: &[f32]) -> f32 {
+    debug_assert_eq!(x.len(), y.len());
+    let len = x.len();
+    let mut acc = [[0.0f32; LANES]; 4];
+    let mut i = 0;
+    while i + BLOCK <= len {
+        for (k, acc_k) in acc.iter_mut().enumerate() {
+            let base = i + k * LANES;
+            for (l, lane) in acc_k.iter_mut().enumerate() {
+                *lane = x[base + l].mul_add(y[base + l], *lane);
+            }
+        }
+        i += BLOCK;
+    }
+    let mut s = [0.0f32; LANES];
+    for (l, s_lane) in s.iter_mut().enumerate() {
+        let s01 = acc[0][l] + acc[1][l];
+        let s23 = acc[2][l] + acc[3][l];
+        *s_lane = s01 + s23;
+    }
+    let t0 = s[0] + s[4];
+    let t1 = s[1] + s[5];
+    let t2 = s[2] + s[6];
+    let t3 = s[3] + s[7];
+    let u0 = t0 + t2;
+    let u1 = t1 + t3;
+    let mut h = u0 + u1;
+    while i < len {
+        h = x[i].mul_add(y[i], h);
+        i += 1;
+    }
+    h
+}
+
+/// Canonical V accumulation — `out[d] = fma(prob, v[d], out[d])`, ascending.
+pub(super) fn axpy_blocked_scalar(out: &mut [f32], prob: f32, v: &[f32]) {
+    debug_assert_eq!(out.len(), v.len());
+    for (out_value, value) in out.iter_mut().zip(v) {
+        *out_value = prob.mul_add(*value, *out_value);
+    }
+}
+
+/// AVX2/FMA realization of the canonical blocked dot product. Bitwise
+/// identical to [`dot_blocked_scalar`] by construction: four independent
+/// `__m256` accumulators updated with `_mm256_fmadd_ps` (one rounding per
+/// lane, same as `mul_add`), the two specified lane-wise combine adds, then
+/// the fixed horizontal tree performed on extracted lanes (no `hadd`).
+///
+/// # Safety
+/// Caller must ensure AVX2 and FMA are available on the running CPU.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+pub(super) unsafe fn dot_blocked_avx2(x: &[f32], y: &[f32]) -> f32 {
+    use std::arch::x86_64::{
+        _mm256_add_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_setzero_ps, _mm256_storeu_ps,
+    };
+    debug_assert_eq!(x.len(), y.len());
+    let len = x.len();
+    let xp = x.as_ptr();
+    let yp = y.as_ptr();
+    let mut acc0 = _mm256_setzero_ps();
+    let mut acc1 = _mm256_setzero_ps();
+    let mut acc2 = _mm256_setzero_ps();
+    let mut acc3 = _mm256_setzero_ps();
+    let mut i = 0;
+    while i + BLOCK <= len {
+        // SAFETY: the loop guard ensures `i + 32 <= len`, so every 8-lane
+        // load below stays inside both slices.
+        unsafe {
+            acc0 = _mm256_fmadd_ps(_mm256_loadu_ps(xp.add(i)), _mm256_loadu_ps(yp.add(i)), acc0);
+            acc1 = _mm256_fmadd_ps(
+                _mm256_loadu_ps(xp.add(i + 8)),
+                _mm256_loadu_ps(yp.add(i + 8)),
+                acc1,
+            );
+            acc2 = _mm256_fmadd_ps(
+                _mm256_loadu_ps(xp.add(i + 16)),
+                _mm256_loadu_ps(yp.add(i + 16)),
+                acc2,
+            );
+            acc3 = _mm256_fmadd_ps(
+                _mm256_loadu_ps(xp.add(i + 24)),
+                _mm256_loadu_ps(yp.add(i + 24)),
+                acc3,
+            );
+        }
+        i += BLOCK;
+    }
+    let s01 = _mm256_add_ps(acc0, acc1);
+    let s23 = _mm256_add_ps(acc2, acc3);
+    let s = _mm256_add_ps(s01, s23);
+    let mut lanes = [0.0f32; LANES];
+    // SAFETY: `lanes` is exactly 8 f32s, the width of one __m256 store.
+    unsafe { _mm256_storeu_ps(lanes.as_mut_ptr(), s) };
+    let t0 = lanes[0] + lanes[4];
+    let t1 = lanes[1] + lanes[5];
+    let t2 = lanes[2] + lanes[6];
+    let t3 = lanes[3] + lanes[7];
+    let u0 = t0 + t2;
+    let u1 = t1 + t3;
+    let mut h = u0 + u1;
+    while i < len {
+        h = x[i].mul_add(y[i], h);
+        i += 1;
+    }
+    h
+}
+
+/// AVX2/FMA realization of the canonical V accumulation. Elementwise fused
+/// multiply-add, so it agrees bitwise with [`axpy_blocked_scalar`] on every
+/// element by construction.
+///
+/// # Safety
+/// Caller must ensure AVX2 and FMA are available on the running CPU.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+pub(super) unsafe fn axpy_blocked_avx2(out: &mut [f32], prob: f32, v: &[f32]) {
+    use std::arch::x86_64::{_mm256_fmadd_ps, _mm256_loadu_ps, _mm256_set1_ps, _mm256_storeu_ps};
+    debug_assert_eq!(out.len(), v.len());
+    let len = out.len();
+    let prob_v = _mm256_set1_ps(prob);
+    let mut i = 0;
+    while i + LANES <= len {
+        // SAFETY: the loop guard ensures `i + 8 <= len` for both slices.
+        unsafe {
+            let value = _mm256_loadu_ps(v.as_ptr().add(i));
+            let current = _mm256_loadu_ps(out.as_ptr().add(i));
+            _mm256_storeu_ps(
+                out.as_mut_ptr().add(i),
+                _mm256_fmadd_ps(prob_v, value, current),
+            );
+        }
+        i += LANES;
+    }
+    while i < len {
+        out[i] = prob.mul_add(v[i], out[i]);
+        i += 1;
+    }
+}
+
+/// Runtime dispatch guard for the AVX2/FMA realizations, resolved once.
+#[cfg(target_arch = "x86_64")]
+fn attn_f32_avx2_fma_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma")
+    })
+}
+
+/// Canonical blocked dot product with safe dispatch: AVX2/FMA when the CPU
+/// has it, otherwise the scalar reference. Both paths produce identical bits.
+pub(super) fn dot_blocked(x: &[f32], y: &[f32]) -> f32 {
+    #[cfg(target_arch = "x86_64")]
+    if attn_f32_avx2_fma_available() {
+        // SAFETY: guarded by the runtime AVX2+FMA feature check above.
+        return unsafe { dot_blocked_avx2(x, y) };
+    }
+    dot_blocked_scalar(x, y)
+}
+
+/// Canonical V accumulation with safe dispatch, mirroring [`dot_blocked`].
+pub(super) fn axpy_blocked(out: &mut [f32], prob: f32, v: &[f32]) {
+    #[cfg(target_arch = "x86_64")]
+    if attn_f32_avx2_fma_available() {
+        // SAFETY: guarded by the runtime AVX2+FMA feature check above.
+        unsafe { axpy_blocked_avx2(out, prob, v) };
+        return;
+    }
+    axpy_blocked_scalar(out, prob, v);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic xorshift64* generator so the property tests are
+    /// reproducible without pulling in a rand dependency.
+    struct XorShift64Star(u64);
+
+    impl XorShift64Star {
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x >> 12;
+            x ^= x << 25;
+            x ^= x >> 27;
+            self.0 = x;
+            x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        }
+
+        fn next_usize(&mut self, bound: usize) -> usize {
+            (self.next_u64() % bound as u64) as usize
+        }
+
+        /// Finite f32 spanning subnormals through large magnitudes, both
+        /// signs. Magnitudes cap at 1e15 so pairwise products (≤ ~2.5e29) and
+        /// any partial sum stay finite in f32 — the canonical-order contract
+        /// is about reduction order on finite reals, not overflow behavior.
+        fn next_f32(&mut self) -> f32 {
+            let magnitude_class = self.next_u64() % 8;
+            let unit = ((self.next_u64() >> 40) as f32) / (1u64 << 24) as f32 - 0.5;
+            match magnitude_class {
+                0 => unit * f32::MIN_POSITIVE * 0.5, // subnormal territory
+                1 => unit * 1e-20,
+                2 => unit * 1e-6,
+                3 | 4 => unit * 2.0,
+                5 => unit * 1e4,
+                6 => unit * 1e12,
+                _ => unit * 1e15,
+            }
+        }
+    }
+
+    fn fill(rng: &mut XorShift64Star, len: usize) -> Vec<f32> {
+        (0..len).map(|_| rng.next_f32()).collect()
+    }
+
+    #[test]
+    fn dot_blocked_scalar_known_answers() {
+        // All-ones: exact integer sums, main loop only (64, 128) and with a
+        // tail (103 = 3*32 + 7).
+        for len in [64usize, 128, 103] {
+            let x = vec![1.0f32; len];
+            let y = vec![1.0f32; len];
+            assert_eq!(dot_blocked_scalar(&x, &y), len as f32, "len {len}");
+        }
+        // Alternating signs cancel exactly regardless of reduction order.
+        let x: Vec<f32> = (0..128)
+            .map(|i| if i % 2 == 0 { 3.0 } else { -3.0 })
+            .collect();
+        let y = vec![2.5f32; 128];
+        assert_eq!(dot_blocked_scalar(&x, &y), 0.0);
+        // Exactly representable dyadic values, len not a multiple of 32:
+        // dot = sum of i * 0.25 for i in 0..103 = 5253 * 0.25 = 1313.25.
+        let x: Vec<f32> = (0..103).map(|i| i as f32).collect();
+        let y = vec![0.25f32; 103];
+        assert_eq!(dot_blocked_scalar(&x, &y), 1313.25);
+        // Subnormals survive: 32 * (MIN_POSITIVE/2) * 1.0, folded through the
+        // blocked tree, is still 16 * MIN_POSITIVE.
+        let x = vec![f32::MIN_POSITIVE * 0.5; 32];
+        let y = vec![1.0f32; 32];
+        assert_eq!(dot_blocked_scalar(&x, &y), f32::MIN_POSITIVE * 16.0);
+        // Magnitude spread with negatives, checked against an f64 oracle with
+        // the standard condition-aware forward-error bound: for any reduction
+        // order, |dot_f32 - dot_f64| <= len * eps_f32 * sum(|x*y|). A naive
+        // relative tolerance would be flaky under catastrophic cancellation.
+        let mut rng = XorShift64Star(0x5EED_0001);
+        let len = 96 + 7;
+        let x = fill(&mut rng, len);
+        let y = fill(&mut rng, len);
+        let oracle: f64 = x
+            .iter()
+            .zip(&y)
+            .map(|(a, b)| f64::from(*a) * f64::from(*b))
+            .sum();
+        let magnitude: f64 = x
+            .iter()
+            .zip(&y)
+            .map(|(a, b)| (f64::from(*a) * f64::from(*b)).abs())
+            .sum();
+        let got = f64::from(dot_blocked_scalar(&x, &y));
+        let bound = len as f64 * f64::from(f32::EPSILON) * magnitude + f64::from(f32::MIN_POSITIVE);
+        assert!(
+            (got - oracle).abs() <= bound,
+            "blocked dot strayed from f64 oracle: got {got}, oracle {oracle}, bound {bound}"
+        );
+    }
+
+    #[test]
+    fn axpy_blocked_scalar_known_answers() {
+        let mut out = vec![1.0f32; 103];
+        let v: Vec<f32> = (0..103).map(|i| i as f32).collect();
+        axpy_blocked_scalar(&mut out, 0.5, &v);
+        for (i, value) in out.iter().enumerate() {
+            assert_eq!(*value, 1.0 + 0.5 * i as f32, "index {i}");
+        }
+    }
+
+    /// The canonical blocked order intentionally differs from the legacy
+    /// scalar chain in `crate::tensor::dot_product`. This test locks that in
+    /// so nobody "fixes" the blocked kernels back to the legacy order: the
+    /// two are DIFFERENT reductions and must be allowed to disagree in the
+    /// last bits. (Constructed input, not a fluke: mixed magnitudes make the
+    /// serial chain and the blocked FMA tree round differently.)
+    #[test]
+    fn dot_blocked_scalar_differs_from_legacy_dot_product() {
+        let mut rng = XorShift64Star(0xD1FF_0001);
+        let mut found_difference = false;
+        for _ in 0..64 {
+            let x = fill(&mut rng, 128);
+            let y = fill(&mut rng, 128);
+            let blocked = dot_blocked_scalar(&x, &y);
+            let legacy = crate::tensor::dot_product(&x, &y);
+            if blocked.to_bits() != legacy.to_bits() {
+                found_difference = true;
+                break;
+            }
+        }
+        assert!(
+            found_difference,
+            "blocked order unexpectedly matched the legacy scalar chain on \
+             64 mixed-magnitude inputs — the canonical order should differ"
+        );
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn dot_blocked_avx2_matches_scalar_bitwise() {
+        if !attn_f32_avx2_fma_available() {
+            eprintln!("skipping: AVX2+FMA not available on this host");
+            return;
+        }
+        let mut rng = XorShift64Star(0xB10C_0001);
+        for case in 0..10_000 {
+            // Bias lengths toward the real head dims (64/128); otherwise
+            // exercise the whole [1, 512] range including tails.
+            let len = match case % 4 {
+                0 => 64,
+                1 => 128,
+                _ => 1 + rng.next_usize(512),
+            };
+            let x = fill(&mut rng, len);
+            let y = fill(&mut rng, len);
+            let scalar = dot_blocked_scalar(&x, &y);
+            // SAFETY: guarded by the runtime AVX2+FMA feature check above.
+            let avx2 = unsafe { dot_blocked_avx2(&x, &y) };
+            assert_eq!(
+                scalar.to_bits(),
+                avx2.to_bits(),
+                "case {case}: len {len}, scalar {scalar}, avx2 {avx2}"
+            );
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn axpy_blocked_avx2_matches_scalar_bitwise() {
+        if !attn_f32_avx2_fma_available() {
+            eprintln!("skipping: AVX2+FMA not available on this host");
+            return;
+        }
+        let mut rng = XorShift64Star(0xA4B9_0001);
+        for case in 0..10_000 {
+            let len = match case % 4 {
+                0 => 64,
+                1 => 128,
+                _ => 1 + rng.next_usize(512),
+            };
+            let prob = rng.next_f32();
+            let base = fill(&mut rng, len);
+            let v = fill(&mut rng, len);
+            let mut out_scalar = base.clone();
+            let mut out_avx2 = base;
+            axpy_blocked_scalar(&mut out_scalar, prob, &v);
+            // SAFETY: guarded by the runtime AVX2+FMA feature check above.
+            unsafe { axpy_blocked_avx2(&mut out_avx2, prob, &v) };
+            for (d, (s, a)) in out_scalar.iter().zip(&out_avx2).enumerate() {
+                assert_eq!(
+                    s.to_bits(),
+                    a.to_bits(),
+                    "case {case}: len {len}, element {d}, scalar {s}, avx2 {a}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dispatch_matches_scalar_bitwise() {
+        let mut rng = XorShift64Star(0xD15B_0001);
+        for _ in 0..256 {
+            let len = 1 + rng.next_usize(512);
+            let prob = rng.next_f32();
+            let x = fill(&mut rng, len);
+            let y = fill(&mut rng, len);
+            assert_eq!(
+                dot_blocked(&x, &y).to_bits(),
+                dot_blocked_scalar(&x, &y).to_bits()
+            );
+            let mut out_dispatch = x.clone();
+            let mut out_scalar = x.clone();
+            axpy_blocked(&mut out_dispatch, prob, &y);
+            axpy_blocked_scalar(&mut out_scalar, prob, &y);
+            for (a, b) in out_dispatch.iter().zip(&out_scalar) {
+                assert_eq!(a.to_bits(), b.to_bits());
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -677,6 +677,20 @@ enum Command {
         #[arg(long)]
         threads: Option<usize>,
     },
+    /// Hidden: hot-cache micro-benchmark of the attention f32 dot kernels
+    /// (legacy scalar chain vs canonical blocked scalar vs blocked AVX2/FMA).
+    #[command(hide = true)]
+    BenchAttnDot {
+        /// Vector lengths to measure (defaults cover the real head dims).
+        #[arg(long = "len", default_values_t = [64usize, 128])]
+        lens: Vec<usize>,
+        /// Measured iterations per variant.
+        #[arg(long, default_value_t = 2_000_000)]
+        repeats: usize,
+        /// Unreported warmup iterations per variant.
+        #[arg(long, default_value_t = 100_000)]
+        warmup: usize,
+    },
     /// Load one GGUF Q8_0 tensor as retained blocks and benchmark bounded row dequantization/dot rows.
     #[command(hide = true)]
     BenchQ8Blocks {
@@ -1633,6 +1647,25 @@ async fn main() -> anyhow::Result<()> {
             configure_rayon_threads(threads)?;
             let report = bench_dense_hotloops(hidden, ffn, repeats, warmup)?;
             println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        Command::BenchAttnDot {
+            lens,
+            repeats,
+            warmup,
+        } => {
+            for len in lens {
+                for (variant, ns_per_call) in
+                    camelid::inference::attn_f32_dot_microbench(len, repeats, warmup)
+                {
+                    let record = serde_json::json!({
+                        "schema": "camelid.bench-attn-dot/v1",
+                        "len": len,
+                        "variant": variant,
+                        "ns_per_call": ns_per_call,
+                    });
+                    println!("{}", serde_json::to_string(&record)?);
+                }
+            }
         }
         Command::BenchQ8Blocks {
             path,


### PR DESCRIPTION
﻿## What

Canonical blocked f32 reduction order for Windows x86_64 decode attention, implemented twice (portable scalar reference + AVX2/FMA realization, bitwise-locked), wired into `attention_context_for_head_into` behind `BACKENDINFERENCE_ATTENTION_F32_BLOCKED_DOT` - **default OFF**.

**Promotion pending gate re-certification.** The Windows default stays unflipped: flag-on divergence is judged against the TinyLlama five-prompt gate, which currently stands on drifted SPM tokenization (post-2026-05-08, see the SPM recon mission) plus a harness that trimmed its own trailing-spaces prompt (separate PR). No README/COMPATIBILITY/STATUS/ledger changes here.

## Why

Phase-0 receipts (Llama-3.2-3B Q8_0, CPU decode, i7-11800H): attention QK+softmax+V is 35.4% of decode at 519 ctx and **69.9% at 2047 ctx** (407 of 585 ms/tok), scaling linearly with depth while projections stay flat (~166 ms/tok). The legacy scalar dot chain is latency-bound; IEEE order preservation forbids LLVM from vectorizing it.

## Correctness posture

- Deterministic != scalar-serial: the canonical order is now the documented blocked order (4x8 FMA accumulators, fixed combine tree, fixed horizontal tree, ascending FMA tail; normative spec in src/inference/attn_f32_dot.rs).
- AVX2 kernel is bitwise-identical to the scalar reference by construction, enforced by 10,000-case to_bits() property tests per kernel (dot + axpy), plus a documented test locking in that the canonical order intentionally differs from the legacy chain.
- Flag off => byte-identical to main, proven end-to-end: 3B bench-generate token IDs at 519/2047 ctx, TinyLlama five-prompt pack, and 3B compact hello at 1/5/50 tokens all byte-identical against a pristine-main binary.

## Micro-bench (hot cache, bench-attn-dot, i7-11800H)

| len | legacy scalar chain | blocked scalar | blocked AVX2 | speedup vs legacy |
|---|---|---|---|---|
| 64  | 39.9 ns | 35.1 ns | 4.50 ns | 8.9x |
| 128 | 92.3 ns | 67.0 ns | 7.42 ns | 12.4x |

## A/B (flag off vs on, interleaved x3 same session, 3B Q8_0, 64 greedy tokens)

| depth | off tok/s | on tok/s | speedup | per-pair | attn ms/tok off->on |
|---|---|---|---|---|---|
| 512  | 3.608 | 4.774 | 1.32x | 1.25 / 1.32 / 1.41 | 102.8 -> 36.2 |
| 2048 | 1.729 | 2.899 | 1.68x | 1.73 / 1.70 / 1.62 | 408.9 -> 171.5 |

8192 is host-limited on the 15.7 GiB dev box (3B f32 KV alone ~1.79 GiB; run memory-starved, killed) - motivating evidence for the KV-dtype item.

## Flag-on divergences (verbatim; expected near-tie argmax flips from the canonical-order change)

1. 3B compact hello: **zero divergence** - token-identical to flag-off AND llama.cpp acd79d6 at 1/5/bounded-50 tokens.
2. TinyLlama five-prompt: 4/5 byte-identical to flag-off. trailing-spaces flips at generated index 0: on [14353,295,333,2] ("Camelid"+EOS) vs off 31-token repetition [13504,7143,445,9508,29915,29879,25053,8162,29901,13,13,14353,295,333,13,13,13504,7143,445,9508,29915,29879,25053,8162,29901,13,13,14353,295,333,2]; llama.cpp acd79d6 emits a third output [29907,420,492,333,2] ("Cameliid") - the prompt is already off-contract vs this comparator on pristine main.
3. 3B free generation at 2047 ctx: single flip at generated index 22, off [...,527,17057,304,264,44448,32348] ("...are organized in a cyclical...") vs on [...,527,28902,304,264,23490,4288] ("...are arranged in a seemingly random..."). Both arms deterministic 3/3 runs. At 512 ctx the arms are token-identical.

Receipts: target/attn-blocked-dot-baseline-20260701T142635/ and target/attn-blocked-dot-ab-20260701T152819/ (SHA256-sealed, local to the dev box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
