### PR TITLE
fix(parity-harness): stop trimming prompt-pack message content

### DIFF
--- a/scripts/lib/chat-parity-harness.mjs
+++ b/scripts/lib/chat-parity-harness.mjs
@@ -96,7 +96,12 @@ function normalizePrompt(prompt, { packPath, index, defaultMaxTokens, defaultRen
   return {
     id: typeof prompt.id === 'string' && prompt.id.trim() ? prompt.id.trim() : `p${index + 1}`,
     note: typeof prompt.note === 'string' ? prompt.note : null,
-    message: hasMessages ? null : requireString(prompt.message, `${packPath}.prompts[${index}].message`),
+    // requireContentString, not requireString: the message is prompt CONTENT,
+    // and trimming here silently rewrote whitespace-sensitive prompts (the
+    // trailing-spaces pack entry never actually tested trailing spaces).
+    message: hasMessages
+      ? null
+      : requireContentString(prompt.message, `${packPath}.prompts[${index}].message`),
     messages: hasMessages ? normalizeMessages(prompt.messages, `${packPath}.prompts[${index}].messages`) : null,
     max_tokens: parsePositiveInt(prompt.max_tokens ?? defaultMaxTokens, `${packPath}.prompts[${index}].max_tokens`),
     render_mode: renderMode,


### PR DESCRIPTION
﻿## What

normalizePromptPack routed prompt.message through requireString, whose validation-by-trim also RETURNED the trimmed string, silently rewriting whitespace-sensitive prompts before they reached either engine. Switched to the existing content-preserving requireContentString (still rejects empty messages).

## Consequence for existing evidence

The tinyllama-broader-5prompt trailing-spaces entry has therefore never actually tested trailing spaces: the 2026-05-05 certified bundle (tinyllama-broader-template-context-perf-rss-20260505T044519Z-head-864e07b51f36) already recorded the trimmed message on both engines. **That row's reference expectations are void and will be regenerated at gate re-certification** (after the SPM merge-order decision lands). This PR deliberately does NOT regenerate them.

Comparator note, per pin policy: llama.cpp stays pinned at acd79d6 for the Windows gate; the 'longer' prompt's generated-text drift is upstream generation drift between the May-era Ubuntu pin and acd79d6 (Camelid's output is byte-stable May->today) and its reference will be regenerated from the pinned build at re-cert.

## Verification

- normalizePromptPack now returns the trailing-spaces message byte-identical to the pack file (trailing "   " preserved).
- A Windows spawn round-trip preserves the arg through the runner -> chat-parity script chain.
- Scripts-only change; no Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
