### PR TITLE
feat(attn): head-parallel decode attention lane for Windows x86_64 (default-off, bitwise-neutral)

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -20699,26 +20699,20 @@ fn causal_attention_context(
                 .copy_from_slice(&kv_cache.values[value_start..value_start + head_dim]);
         }
     } else {
-        let mut scores = Vec::with_capacity(position_count);
-        for attention_head in 0..attention_heads {
-            let kv_head =
-                map_attention_head_to_kv_head(attention_head, repeats, kv_heads, head_mapping);
-            let query_start = attention_head * head_dim;
-            let query_slice = &query.data[query_start..query_start + head_dim];
-            let out_start = attention_head * head_dim;
-            attention_context_for_head_into(
-                AttentionContextHeadParams {
-                    kv_cache,
-                    layer_idx,
-                    kv_head,
-                    query_slice,
-                    position_count,
-                    scale,
-                },
-                &mut out[out_start..out_start + head_dim],
-                &mut scores,
-            )?;
-        }
+        decode_attention_all_heads_into(
+            &DecodeAttentionHeadsParams {
+                kv_cache,
+                layer_idx,
+                query_data: &query.data,
+                attention_heads,
+                repeats,
+                kv_heads,
+                head_mapping,
+                position_count,
+                scale,
+            },
+            &mut out,
+        )?;
     }
 
     let tensor = CpuTensor::from_f32(name, vec![1, expected_width], out)?;
@@ -20871,6 +20865,57 @@ fn attention_f32_blocked_dot_enabled() -> bool {
     }
 }
 
+/// Flag gate for the decode attention head-parallel lane
+/// (`BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL`, default off). Scoped to
+/// Windows x86_64 per the standing Windows-first directive — the mechanism
+/// itself is arch-agnostic (scheduling only, no arithmetic), so lifting the
+/// gate is a one-line follow-up decision, not a code change. Resolved once
+/// per process outside tests.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn attention_decode_parallel_enabled() -> bool {
+    #[cfg(test)]
+    {
+        q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL")
+    }
+    #[cfg(not(test))]
+    {
+        static ATTENTION_DECODE_PARALLEL_ENABLED: OnceLock<bool> = OnceLock::new();
+        *ATTENTION_DECODE_PARALLEL_ENABLED.get_or_init(|| {
+            q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL")
+        })
+    }
+}
+
+/// Provisional dispatch-overhead floor for the head-parallel lane; below this
+/// many cached positions the serial loop runs even with the lane on. The
+/// shipped default comes from the Phase-4 crossover sweep.
+const ATTENTION_DECODE_PARALLEL_DEFAULT_MIN_POSITIONS: usize = 64;
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn attention_decode_parallel_min_positions_uncached() -> usize {
+    env::var("BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL_MIN_POSITIONS")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .unwrap_or(ATTENTION_DECODE_PARALLEL_DEFAULT_MIN_POSITIONS)
+}
+
+/// Position threshold for the head-parallel lane
+/// (`BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL_MIN_POSITIONS`). Resolved once
+/// per process outside tests.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn attention_decode_parallel_min_positions() -> usize {
+    #[cfg(test)]
+    {
+        attention_decode_parallel_min_positions_uncached()
+    }
+    #[cfg(not(test))]
+    {
+        static ATTENTION_DECODE_PARALLEL_MIN_POSITIONS: OnceLock<usize> = OnceLock::new();
+        *ATTENTION_DECODE_PARALLEL_MIN_POSITIONS
+            .get_or_init(attention_decode_parallel_min_positions_uncached)
+    }
+}
+
 struct AttentionContextHeadParams<'a> {
     kv_cache: &'a LlamaKvCache,
     layer_idx: usize,
@@ -20880,10 +20925,127 @@ struct AttentionContextHeadParams<'a> {
     scale: f32,
 }
 
+/// Everything the multi-position decode attention driver needs to run every
+/// Q head, serially or across the rayon pool.
+struct DecodeAttentionHeadsParams<'a> {
+    kv_cache: &'a LlamaKvCache,
+    layer_idx: usize,
+    query_data: &'a [f32],
+    attention_heads: usize,
+    repeats: usize,
+    kv_heads: usize,
+    head_mapping: GqaHeadMapping,
+    position_count: usize,
+    scale: f32,
+}
+
+/// Multi-position decode attention over all Q heads. Picks the head-parallel
+/// lane when the Windows flag gate and the position threshold both pass;
+/// otherwise runs the historical serial loop.
+fn decode_attention_all_heads_into(
+    params: &DecodeAttentionHeadsParams<'_>,
+    out: &mut [f32],
+) -> Result<()> {
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    let parallel = attention_decode_parallel_enabled()
+        && params.position_count >= attention_decode_parallel_min_positions();
+    #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+    let parallel = false;
+    decode_attention_all_heads_into_with_mode(params, out, parallel)
+}
+
+/// Explicit-mode variant of [`decode_attention_all_heads_into`] so the
+/// bitwise-identity tests can pin the scheduling mode without touching
+/// process env.
+///
+/// The parallel arm is a SCHEDULING-ONLY change: each Q head runs the exact
+/// per-head body the serial loop runs (`attention_context_for_head_into`) on
+/// its own disjoint `head_dim` output chunk, with one scratch Vec per rayon
+/// worker instead of one total. No cross-task reduction exists, so serial
+/// and parallel outputs are bitwise identical by construction.
+fn decode_attention_all_heads_into_with_mode(
+    params: &DecodeAttentionHeadsParams<'_>,
+    out: &mut [f32],
+    parallel: bool,
+) -> Result<()> {
+    let head_dim = params.kv_cache.plan.head_dim;
+    debug_assert_eq!(out.len(), params.attention_heads * head_dim);
+    if parallel {
+        return out
+            .par_chunks_exact_mut(head_dim)
+            .enumerate()
+            .try_for_each_init(Vec::new, |scores, (attention_head, out_slice)| {
+                let kv_head = map_attention_head_to_kv_head(
+                    attention_head,
+                    params.repeats,
+                    params.kv_heads,
+                    params.head_mapping,
+                );
+                let query_start = attention_head * head_dim;
+                attention_context_for_head_into(
+                    AttentionContextHeadParams {
+                        kv_cache: params.kv_cache,
+                        layer_idx: params.layer_idx,
+                        kv_head,
+                        query_slice: &params.query_data[query_start..query_start + head_dim],
+                        position_count: params.position_count,
+                        scale: params.scale,
+                    },
+                    out_slice,
+                    scores,
+                )
+            });
+    }
+
+    let mut scores = Vec::with_capacity(params.position_count);
+    for attention_head in 0..params.attention_heads {
+        let kv_head = map_attention_head_to_kv_head(
+            attention_head,
+            params.repeats,
+            params.kv_heads,
+            params.head_mapping,
+        );
+        let query_start = attention_head * head_dim;
+        let out_start = attention_head * head_dim;
+        attention_context_for_head_into(
+            AttentionContextHeadParams {
+                kv_cache: params.kv_cache,
+                layer_idx: params.layer_idx,
+                kv_head,
+                query_slice: &params.query_data[query_start..query_start + head_dim],
+                position_count: params.position_count,
+                scale: params.scale,
+            },
+            &mut out[out_start..out_start + head_dim],
+            &mut scores,
+        )?;
+    }
+    Ok(())
+}
+
 fn attention_context_for_head_into(
     params: AttentionContextHeadParams<'_>,
     out_slice: &mut [f32],
     scores: &mut Vec<f32>,
+) -> Result<()> {
+    // Canonical blocked f32 kernels (Windows x86_64, flag-gated, default off).
+    // `false` on every other target keeps the legacy path literally unchanged.
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    let use_blocked_kernels = attention_f32_blocked_dot_enabled();
+    #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+    let use_blocked_kernels = false;
+    attention_context_for_head_into_with_kernels(params, out_slice, scores, use_blocked_kernels)
+}
+
+/// Explicit-dot-lane variant of [`attention_context_for_head_into`] so the
+/// bitwise-identity tests can pin the kernel lane without touching process
+/// env. Production callers go through the flag-resolving wrapper above; the
+/// arithmetic below is byte-for-byte the pre-split body.
+fn attention_context_for_head_into_with_kernels(
+    params: AttentionContextHeadParams<'_>,
+    out_slice: &mut [f32],
+    scores: &mut Vec<f32>,
+    use_blocked_kernels: bool,
 ) -> Result<()> {
     let head_dim = params.kv_cache.plan.head_dim;
     debug_assert_eq!(params.query_slice.len(), head_dim);
@@ -20894,13 +21056,6 @@ fn attention_context_for_head_into(
         .kv_cache
         .head_base_offset(params.layer_idx, params.kv_head);
     let position_stride = params.kv_cache.position_stride();
-
-    // Canonical blocked f32 kernels (Windows x86_64, flag-gated, default off).
-    // `false` on every other target keeps the legacy path literally unchanged.
-    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-    let use_blocked_kernels = attention_f32_blocked_dot_enabled();
-    #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
-    let use_blocked_kernels = false;
 
     let mut key_start = head_base;
     for position in 0..params.position_count {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -20889,6 +20889,7 @@ fn attention_decode_parallel_enabled() -> bool {
 /// Provisional dispatch-overhead floor for the head-parallel lane; below this
 /// many cached positions the serial loop runs even with the lane on. The
 /// shipped default comes from the Phase-4 crossover sweep.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 const ATTENTION_DECODE_PARALLEL_DEFAULT_MIN_POSITIONS: usize = 64;
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -11487,3 +11487,196 @@ fn cuda_resident_accepts_qwen3_qk_norm() {
         "test fixture should have QK-norm weights"
     );
 }
+
+/// Item 2 bitwise lock: the decode attention head-parallel lane is a
+/// scheduling-only change, so its full attention output must be bit-identical
+/// to the serial loop for every GQA shape, head_dim, position count, dot
+/// lane, and random content — and identical across repeated parallel runs.
+#[test]
+fn decode_attention_parallel_lane_is_bitwise_identical_to_serial() {
+    struct XorShift64Star(u64);
+    impl XorShift64Star {
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x >> 12;
+            x ^= x << 25;
+            x ^= x >> 27;
+            self.0 = x;
+            x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        }
+        /// Finite f32 spanning subnormals through +-1e12, both signs.
+        fn next_f32(&mut self) -> f32 {
+            let unit = ((self.next_u64() >> 40) as f32) / (1u64 << 24) as f32 - 0.5;
+            match self.next_u64() % 8 {
+                0 => unit * f32::MIN_POSITIVE * 0.5,
+                1 => unit * 1e-12,
+                2..=4 => unit * 2.0,
+                5 => unit * 1e4,
+                _ => unit * 1e12,
+            }
+        }
+        fn fill(&mut self, len: usize) -> Vec<f32> {
+            (0..len).map(|_| self.next_f32()).collect()
+        }
+    }
+
+    let gqa_shapes = [(32usize, 4usize), (24, 8), (32, 8)];
+    let head_dims = [64usize, 128];
+    let position_counts = [2usize, 63, 64, 65, 511, 2048];
+    let cases_per_point = 100u64;
+    let dot_lanes: &[bool] = if cfg!(target_arch = "x86_64")
+        && std::arch::is_x86_feature_detected!("avx2")
+        && std::arch::is_x86_feature_detected!("fma")
+    {
+        &[false, true]
+    } else {
+        &[false]
+    };
+
+    let mut points = Vec::new();
+    for &(attention_heads, kv_heads) in &gqa_shapes {
+        for &head_dim in &head_dims {
+            for &position_count in &position_counts {
+                for case in 0..cases_per_point {
+                    points.push((attention_heads, kv_heads, head_dim, position_count, case));
+                }
+            }
+        }
+    }
+
+    // The case grid is large (36 shape points x 100 cases x up to 2048
+    // positions); spread cases across the pool so the suite stays fast. Any
+    // scheduling sensitivity this introduces is exactly what the assertion
+    // must be immune to.
+    let mismatches: usize = points
+        .par_iter()
+        .map(
+            |&(attention_heads, kv_heads, head_dim, position_count, case)| {
+                let mut rng = XorShift64Star(
+                    0x1770_0001
+                        ^ ((attention_heads as u64) << 48)
+                        ^ ((kv_heads as u64) << 40)
+                        ^ ((head_dim as u64) << 24)
+                        ^ ((position_count as u64) << 8)
+                        ^ case,
+                );
+                let plan = LlamaKvCachePlan {
+                    max_sequence_length: position_count,
+                    layer_count: 1,
+                    kv_head_count: kv_heads,
+                    head_dim,
+                    key_shape: vec![1, position_count, kv_heads, head_dim],
+                    value_shape: vec![1, position_count, kv_heads, head_dim],
+                };
+                let mut kv_cache = LlamaKvCache::new(plan).expect("kv cache");
+                let kv_len = position_count * kv_heads * head_dim;
+                kv_cache.keys = rng.fill(kv_len);
+                kv_cache.values = rng.fill(kv_len);
+                kv_cache.allocated_sequence_length = position_count;
+                kv_cache.position = position_count - 1;
+                let query = rng.fill(attention_heads * head_dim);
+                let params = DecodeAttentionHeadsParams {
+                    kv_cache: &kv_cache,
+                    layer_idx: 0,
+                    query_data: &query,
+                    attention_heads,
+                    repeats: attention_heads / kv_heads,
+                    kv_heads,
+                    head_mapping: GqaHeadMapping::Grouped,
+                    position_count,
+                    scale: 1.0 / (head_dim as f32).sqrt(),
+                };
+
+                let width = attention_heads * head_dim;
+                let repeats = attention_heads / kv_heads;
+                let mut mismatch = 0usize;
+
+                // Production driver, serial vs parallel, parallel run twice to
+                // expose scheduling nondeterminism. The per-head body resolves the
+                // dot lane from env (untouched in tests => the legacy lane).
+                let mut serial = vec![0.0f32; width];
+                decode_attention_all_heads_into_with_mode(&params, &mut serial, false)
+                    .expect("serial");
+                let mut parallel_a = vec![0.0f32; width];
+                decode_attention_all_heads_into_with_mode(&params, &mut parallel_a, true)
+                    .expect("parallel run 1");
+                let mut parallel_b = vec![0.0f32; width];
+                decode_attention_all_heads_into_with_mode(&params, &mut parallel_b, true)
+                    .expect("parallel run 2");
+                for ((s, a), b) in serial.iter().zip(&parallel_a).zip(&parallel_b) {
+                    if s.to_bits() != a.to_bits() || a.to_bits() != b.to_bits() {
+                        mismatch += 1;
+                    }
+                }
+
+                // Dot-lane lock: run every head through the explicit-kernel body
+                // with the lane pinned (no process-env writes), serial vs a rayon
+                // scope mirroring the production parallel arm, compared bitwise.
+                // Covers composition with the Item-1 blocked lane on AVX2 hosts.
+                for &use_blocked in dot_lanes {
+                    let mut serial_pinned = vec![0.0f32; width];
+                    let mut scores = Vec::new();
+                    for head in 0..attention_heads {
+                        let kv_head = map_attention_head_to_kv_head(
+                            head,
+                            repeats,
+                            kv_heads,
+                            params.head_mapping,
+                        );
+                        attention_context_for_head_into_with_kernels(
+                            AttentionContextHeadParams {
+                                kv_cache: &kv_cache,
+                                layer_idx: 0,
+                                kv_head,
+                                query_slice: &query[head * head_dim..(head + 1) * head_dim],
+                                position_count,
+                                scale: params.scale,
+                            },
+                            &mut serial_pinned[head * head_dim..(head + 1) * head_dim],
+                            &mut scores,
+                            use_blocked,
+                        )
+                        .expect("serial pinned");
+                    }
+                    let mut parallel_pinned = vec![0.0f32; width];
+                    parallel_pinned
+                        .par_chunks_exact_mut(head_dim)
+                        .enumerate()
+                        .try_for_each_init(Vec::new, |scratch, (head, out_slice)| {
+                            let kv_head = map_attention_head_to_kv_head(
+                                head,
+                                repeats,
+                                kv_heads,
+                                params.head_mapping,
+                            );
+                            attention_context_for_head_into_with_kernels(
+                                AttentionContextHeadParams {
+                                    kv_cache: &kv_cache,
+                                    layer_idx: 0,
+                                    kv_head,
+                                    query_slice: &query[head * head_dim..(head + 1) * head_dim],
+                                    position_count,
+                                    scale: params.scale,
+                                },
+                                out_slice,
+                                scratch,
+                                use_blocked,
+                            )
+                        })
+                        .expect("parallel pinned");
+                    for (s, p) in serial_pinned.iter().zip(&parallel_pinned) {
+                        if s.to_bits() != p.to_bits() {
+                            mismatch += 1;
+                        }
+                    }
+                }
+                mismatch
+            },
+        )
+        .sum();
+
+    assert_eq!(
+        mismatches, 0,
+        "decode attention parallel lane diverged from serial in {mismatches} element(s)"
+    );
+}

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -11524,14 +11524,16 @@ fn decode_attention_parallel_lane_is_bitwise_identical_to_serial() {
     let head_dims = [64usize, 128];
     let position_counts = [2usize, 63, 64, 65, 511, 2048];
     let cases_per_point = 100u64;
-    let dot_lanes: &[bool] = if cfg!(target_arch = "x86_64")
-        && std::arch::is_x86_feature_detected!("avx2")
+    #[cfg(target_arch = "x86_64")]
+    let dot_lanes: &[bool] = if std::arch::is_x86_feature_detected!("avx2")
         && std::arch::is_x86_feature_detected!("fma")
     {
         &[false, true]
     } else {
         &[false]
     };
+    #[cfg(not(target_arch = "x86_64"))]
+    let dot_lanes: &[bool] = &[false];
 
     let mut points = Vec::new();
     for &(attention_heads, kv_heads) in &gqa_shapes {


### PR DESCRIPTION
﻿## What

Head-parallel decode attention for Windows x86_64: causal_attention_context fans its Q-head loop across the rayon pool behind BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL - **default OFF** - with BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL_MIN_POSITIONS (default 64) as the dispatch floor. Scheduling-only: each head runs the identical per-head body on a disjoint output chunk (par_chunks_exact_mut + one scratch Vec per worker); no arithmetic or reduction order changes anywhere. Composes with and is orthogonal to the Item-1 blocked-dot lane. position_count==1, batch/prefill attention, and should_parallelize_attention_context_batch untouched.

**Bitwise identity is the contract, and it held**: zero divergent bits anywhere in this mission. Promotion pending review - and explicitly INDEPENDENT of the SPM re-certification, since this lane is parity-neutral by construction (byte-identical output in every configuration; nothing here can shift any parity gate).

## Bitwise lock (tests)

36 shape points - GQA 32q/4kv, 24q/8kv, 32q/8kv x head_dim 64/128 x positions 2/63/64/65/511/2048 - x 100 randomized cases (subnormals through 1e12): production driver serial vs parallel run twice, plus both Item-1 dot lanes pinned per head through a mirrored rayon scope. **Zero mismatching elements** (element-wise to_bits equality). Note: the matrix test adds ~108 s to the lib suite on a 16-core host.

## Flag-off identity (end to end)

bench-generate 3B token IDs equal pre-change receipts at 519/2047 ctx in BOTH dot lanes; TinyLlama five-prompt pack and 3B compact hello (1/5/50) camelid-side byte-identical to pristine main on equal inputs.

## Phase 0 baseline (blocked-dot ON, pre-change, i7-11800H 16 threads)

| ctx | decode tok/s | attn ms/tok | attention share | cores busy (decode) |
|---|---|---|---|---|
| 519 | 4.76 | 33.4 | 16.3% | 5.2 / 16 |
| 2047 | 2.36 | 221.1 | 53.4% | 2.8 / 16 |

## A/B (interleaved x3 same session, blocked-dot ON, 3B Q8_0, 64 greedy tokens)

| depth | off tok/s | on tok/s | speedup | per-pair | attn ms/tok off->on | attn speedup | token IDs identical |
|---|---|---|---|---|---|---|---|
| 512 | 5.764 | 6.590 | 1.14x | 1.10 / 1.14 / 1.19 | 30.5 -> 11.4 | 2.67x | **yes** |
| 2048 | 3.148 | 5.188 | 1.65x | 1.58 / 1.71 / 1.67 | 164.0 -> 42.5 | 3.86x | **yes** |

Secondary (blocked-dot OFF, x1, 2048): 1.915 -> 4.216 tok/s, attn 362.6 -> 79.8 ms/tok, IDs identical - the lane helps the legacy dot chain even more, and the two flags compose to 2.36 -> 5.19 tok/s at 2048 vs the pre-Item-1 serial-scalar path.

Thread sweep (2048, lane on): attn 80.6 / 59.5 / 41.5 ms/tok at 4 / 8 / 16 threads - still scaling at 16, so the DRAM knee was NOT reached; the limit is the 24-task head count, not bandwidth. Achieved attention speedup 3.86x vs the predicted 2.5-3.5x band (above-band for the same reason).

MIN_POSITIONS crossover at prompt depths 18/41/82/166: on/off ratios 1.015/1.012/0.993/1.037 (all noise) -> default stays 64; below it the lane only risks dispatch pathologies for no measured gain.

## Item 3 hand-off

Attention reads ~477 MB of f32 KV per decoded token at ~2080 ctx, sustaining ~11.2-11.5 GB/s with the lane on. f16 KV halves the bytes (projected ~21 ms/tok attention at unchanged throughput) and halves the footprint that made 8192 ctx host-limited on the 15.7 GiB box.

Receipts: target/attn-decode-parallel-baseline-20260701T164854/ and target/attn-decode-parallel-ab-20260701T172315/ (SHA256-sealed, dev box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
