### PR TITLE
feat(kv): head-major layout + f16 storage lanes for Windows x86_64 (default-off, bitwise-neutral)

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1735,8 +1735,11 @@ impl LlamaInferenceSession {
     pub fn take_for_step(&mut self) -> LlamaInferenceSession {
         let plan = self.kv_cache.plan.clone();
         // Carry the resolved KV budget onto the hollow placeholder so the predict-and-abort
-        // guard stays in force without re-querying host RAM on every step.
+        // guard stays in force without re-querying host RAM on every step. Same for the
+        // layout: it is fixed at construction, and the placeholder must match the real
+        // cache so a later re-assign round-trips identically.
         let kv_budget_bytes = self.kv_cache.kv_budget_bytes;
+        let layout = self.kv_cache.layout;
         LlamaInferenceSession {
             config: self.config.clone(),
             weights: Arc::clone(&self.weights),
@@ -1744,6 +1747,7 @@ impl LlamaInferenceSession {
                 &mut self.kv_cache,
                 LlamaKvCache {
                     plan,
+                    layout,
                     keys: Vec::new(),
                     values: Vec::new(),
                     allocated_sequence_length: 0,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -58,7 +58,7 @@ pub use diagnostic_config::{
     SquareLinearLayout,
 };
 pub use kv_cache::{
-    KvLayout, LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, LlamaKvCacheTrace,
+    KvDtype, KvLayout, LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, LlamaKvCacheTrace,
 };
 pub use q8_block_reader::Q8BlockReader;
 use q8_runtime::{
@@ -1740,6 +1740,7 @@ impl LlamaInferenceSession {
         // cache so a later re-assign round-trips identically.
         let kv_budget_bytes = self.kv_cache.kv_budget_bytes;
         let layout = self.kv_cache.layout;
+        let dtype = self.kv_cache.dtype;
         LlamaInferenceSession {
             config: self.config.clone(),
             weights: Arc::clone(&self.weights),
@@ -1748,8 +1749,11 @@ impl LlamaInferenceSession {
                 LlamaKvCache {
                     plan,
                     layout,
+                    dtype,
                     keys: Vec::new(),
                     values: Vec::new(),
+                    keys_f16: Vec::new(),
+                    values_f16: Vec::new(),
                     allocated_sequence_length: 0,
                     position: 0,
                     kv_budget_bytes,
@@ -2358,11 +2362,17 @@ impl LlamaInferenceSession {
             for p in 0..n {
                 for h in 0..n_kv {
                     let src = (h * n + p) * head_dim;
-                    let dst = self.kv_cache.offset(layer, p, h);
-                    self.kv_cache.keys[dst..dst + head_dim]
-                        .copy_from_slice(&k[src..src + head_dim]);
-                    self.kv_cache.values[dst..dst + head_dim]
-                        .copy_from_slice(&v[src..src + head_dim]);
+                    // Canonical store, not a raw copy: the GPU KV is f16, so
+                    // this data is f16-exact and the rounding inside is
+                    // idempotent — the routing enforces the invariant
+                    // structurally instead of relying on the GPU dtype.
+                    self.kv_cache.store_kv_head_row(
+                        layer,
+                        p,
+                        h,
+                        &k[src..src + head_dim],
+                        &v[src..src + head_dim],
+                    );
                 }
             }
         }
@@ -2971,12 +2981,19 @@ impl LlamaInferenceSession {
                     let mut cv = vec![0.0f32; kv_dim * position];
                     for p in 0..position {
                         for h in 0..n_kv {
-                            let src = self.kv_cache.offset(range.start + layer, p, h);
                             let dst = (h * position + p) * head_dim;
-                            ck[dst..dst + head_dim]
-                                .copy_from_slice(&self.kv_cache.keys[src..src + head_dim]);
-                            cv[dst..dst + head_dim]
-                                .copy_from_slice(&self.kv_cache.values[src..src + head_dim]);
+                            self.kv_cache.copy_key_row_into(
+                                range.start + layer,
+                                p,
+                                h,
+                                &mut ck[dst..dst + head_dim],
+                            );
+                            self.kv_cache.copy_value_row_into(
+                                range.start + layer,
+                                p,
+                                h,
+                                &mut cv[dst..dst + head_dim],
+                            );
                         }
                     }
                     if slot.engine.seed_layer(layer, &ck, &cv, position).is_err() {
@@ -20428,20 +20445,19 @@ fn write_kv_cache(
         )));
     }
     kv_cache.ensure_position_capacity(kv_cache.position + 1)?;
-    // Per-head copies: identical element order and per-element math as the
+    // Per-head stores: identical element order and per-element math as the
     // historical whole-row copy in position-major (heads are contiguous
     // there), and the only correct shape in head-major, where one token's
-    // heads live in separate streams.
+    // heads live in separate streams. `store_kv_head_row` is the canonical
+    // f16-rounding store for both dtypes.
     let head_dim = kv_cache.plan.head_dim;
     for kv_head in 0..kv_cache.plan.kv_head_count {
-        let dst = kv_cache.offset(layer_idx, kv_cache.position, kv_head);
         let src = kv_head * head_dim;
-        copy_to_f16_kv_cache_storage(
-            &mut kv_cache.keys[dst..dst + head_dim],
+        kv_cache.store_kv_head_row(
+            layer_idx,
+            kv_cache.position,
+            kv_head,
             &key.data[src..src + head_dim],
-        );
-        copy_to_f16_kv_cache_storage(
-            &mut kv_cache.values[dst..dst + head_dim],
             &value.data[src..src + head_dim],
         );
     }
@@ -20475,20 +20491,18 @@ fn write_kv_cache_batch(
     }
     let rows = key.dim(0)?;
     kv_cache.ensure_position_capacity(base_position + rows)?;
-    // Per-head copies; see `write_kv_cache` for the order argument.
+    // Per-head stores; see `write_kv_cache` for the order argument.
     let head_dim = kv_cache.plan.head_dim;
     for row in 0..rows {
         let position = base_position + row;
         let row_start = row * expected_width;
         for kv_head in 0..kv_cache.plan.kv_head_count {
-            let dst = kv_cache.offset(layer_idx, position, kv_head);
             let src = row_start + kv_head * head_dim;
-            copy_to_f16_kv_cache_storage(
-                &mut kv_cache.keys[dst..dst + head_dim],
+            kv_cache.store_kv_head_row(
+                layer_idx,
+                position,
+                kv_head,
                 &key.data[src..src + head_dim],
-            );
-            copy_to_f16_kv_cache_storage(
-                &mut kv_cache.values[dst..dst + head_dim],
                 &value.data[src..src + head_dim],
             );
         }
@@ -20537,19 +20551,17 @@ fn kv_cache_trace(
     let mut value_max_abs_index = 0;
 
     // Walk per (position, kv_head) with the LOGICAL in-token index so the
-    // checksum/ordinal stream is identical in both KV layouts (in
-    // position-major this touches the exact same addresses in the exact same
-    // order as the historical whole-row walk).
+    // checksum/ordinal stream is identical in both KV layouts and dtypes (in
+    // position-major/f32 this reads the exact same values in the exact same
+    // order as the historical whole-row walk; f16 expansion is exact).
     let head_dim = kv_cache.plan.head_dim;
+    let mut key_row = vec![0.0f32; head_dim];
+    let mut value_row = vec![0.0f32; head_dim];
     for position in 0..position_count {
         for kv_head in 0..kv_cache.plan.kv_head_count {
-            let start = kv_cache.offset(layer_idx, position, kv_head);
-            let end = start + head_dim;
-            for (dim, (&key, &value)) in kv_cache.keys[start..end]
-                .iter()
-                .zip(kv_cache.values[start..end].iter())
-                .enumerate()
-            {
+            kv_cache.copy_key_row_into(layer_idx, position, kv_head, &mut key_row);
+            kv_cache.copy_value_row_into(layer_idx, position, kv_head, &mut value_row);
+            for (dim, (&key, &value)) in key_row.iter().zip(value_row.iter()).enumerate() {
                 let idx = kv_head * head_dim + dim;
                 if !key.is_finite() || !value.is_finite() {
                     return Err(BackendError::RuntimeShapeMismatch(format!(
@@ -20613,15 +20625,25 @@ fn kv_cache_position_trace(
 ) -> Result<LlamaKvCachePositionTrace> {
     // Materialize the token's logical row (kv_head-major element order, the
     // historical contiguous order) so checksums, ordinals, and sampled
-    // values are identical in both KV layouts. Diagnostics-only path; the
-    // copy is TENSOR-trace sized, not hot.
+    // values are identical in both KV layouts and dtypes. Diagnostics-only
+    // path; the copy is TENSOR-trace sized, not hot.
     let head_dim = kv_cache.plan.head_dim;
-    let mut key_row = Vec::with_capacity(key_value_width);
-    let mut value_row = Vec::with_capacity(key_value_width);
+    let mut key_row = vec![0.0f32; key_value_width];
+    let mut value_row = vec![0.0f32; key_value_width];
     for kv_head in 0..kv_cache.plan.kv_head_count {
-        let start = kv_cache.offset(layer_idx, position, kv_head);
-        key_row.extend_from_slice(&kv_cache.keys[start..start + head_dim]);
-        value_row.extend_from_slice(&kv_cache.values[start..start + head_dim]);
+        let out_start = kv_head * head_dim;
+        kv_cache.copy_key_row_into(
+            layer_idx,
+            position,
+            kv_head,
+            &mut key_row[out_start..out_start + head_dim],
+        );
+        kv_cache.copy_value_row_into(
+            layer_idx,
+            position,
+            kv_head,
+            &mut value_row[out_start..out_start + head_dim],
+        );
     }
     let key_slice = key_row.as_slice();
     let value_slice = value_row.as_slice();
@@ -20667,13 +20689,6 @@ fn kv_cache_position_trace(
             .copied()
             .collect(),
     })
-}
-
-fn copy_to_f16_kv_cache_storage(dest: &mut [f32], source: &[f32]) {
-    debug_assert_eq!(dest.len(), source.len());
-    for (dest_value, source_value) in dest.iter_mut().zip(source.iter().copied()) {
-        *dest_value = f16_bits_to_f32(f32_to_f16_bits(source_value));
-    }
 }
 
 const ATTENTION_TRACE_HEAD_LIMIT: usize = 8;
@@ -20735,9 +20750,12 @@ fn causal_attention_context(
             let kv_head =
                 map_attention_head_to_kv_head(attention_head, repeats, kv_heads, head_mapping);
             let out_start = attention_head * head_dim;
-            let value_start = kv_cache.offset(layer_idx, 0, kv_head);
-            out[out_start..out_start + head_dim]
-                .copy_from_slice(&kv_cache.values[value_start..value_start + head_dim]);
+            kv_cache.copy_value_row_into(
+                layer_idx,
+                0,
+                kv_head,
+                &mut out[out_start..out_start + head_dim],
+            );
         }
     } else {
         decode_attention_all_heads_into(
@@ -20837,9 +20855,12 @@ fn causal_attention_context_batch(
                 let kv_head =
                     map_attention_head_to_kv_head(attention_head, repeats, kv_heads, head_mapping);
                 let out_start = attention_head * head_dim;
-                let value_start = kv_cache.offset(layer_idx, 0, kv_head);
-                out_row[out_start..out_start + head_dim]
-                    .copy_from_slice(&kv_cache.values[value_start..value_start + head_dim]);
+                kv_cache.copy_value_row_into(
+                    layer_idx,
+                    0,
+                    kv_head,
+                    &mut out_row[out_start..out_start + head_dim],
+                );
             }
         } else {
             for attention_head in 0..attention_heads {
@@ -21101,11 +21122,23 @@ fn attention_context_for_head_into_with_kernels(
 
     let mut key_start = head_base;
     for position in 0..params.position_count {
-        let key_slice = &params.kv_cache.keys[key_start..key_start + head_dim];
-        let score = if use_blocked_kernels {
-            attn_f32_dot::dot_blocked(params.query_slice, key_slice) * params.scale
-        } else {
-            dot_product(params.query_slice, key_slice) * params.scale
+        let score = match params.kv_cache.dtype {
+            KvDtype::F32 => {
+                let key_slice = &params.kv_cache.keys[key_start..key_start + head_dim];
+                if use_blocked_kernels {
+                    attn_f32_dot::dot_blocked(params.query_slice, key_slice) * params.scale
+                } else {
+                    dot_product(params.query_slice, key_slice) * params.scale
+                }
+            }
+            KvDtype::F16 => {
+                // f16 storage requires the blocked lane (enforced at cache
+                // construction; fail-closed to F32 otherwise). The fused
+                // kernel expands each element exactly and then runs the
+                // identical canonical blocked order.
+                let key_slice = &params.kv_cache.keys_f16[key_start..key_start + head_dim];
+                attn_f32_dot::dot_blocked_f16(params.query_slice, key_slice) * params.scale
+            }
         };
         scores.push(score);
         if position + 1 < params.position_count {
@@ -21129,12 +21162,20 @@ fn attention_context_for_head_into_with_kernels(
     let mut value_start = head_base;
     for (position, score) in scores.iter().copied().enumerate() {
         let probability = score * inv_score_sum;
-        let value_slice = &params.kv_cache.values[value_start..value_start + head_dim];
-        if use_blocked_kernels {
-            attn_f32_dot::axpy_blocked(out_slice, probability, value_slice);
-        } else {
-            for (out_value, value) in out_slice.iter_mut().zip(value_slice) {
-                *out_value += probability * *value;
+        match params.kv_cache.dtype {
+            KvDtype::F32 => {
+                let value_slice = &params.kv_cache.values[value_start..value_start + head_dim];
+                if use_blocked_kernels {
+                    attn_f32_dot::axpy_blocked(out_slice, probability, value_slice);
+                } else {
+                    for (out_value, value) in out_slice.iter_mut().zip(value_slice) {
+                        *out_value += probability * *value;
+                    }
+                }
+            }
+            KvDtype::F16 => {
+                let value_slice = &params.kv_cache.values_f16[value_start..value_start + head_dim];
+                attn_f32_dot::axpy_blocked_f16(out_slice, probability, value_slice);
             }
         }
         if position + 1 < params.position_count {
@@ -21246,9 +21287,19 @@ fn attention_trace_with_params(params: AttentionTraceParams<'_>) -> Result<Llama
         let sampled_positions = sampled_attention_trace_positions(params.position_count);
         let mut positions = Vec::with_capacity(sampled_positions.len());
         for position in sampled_positions {
-            let key_start = params.kv_cache.offset(params.layer_idx, position, kv_head);
-            let key_slice = &params.kv_cache.keys[key_start..key_start + head_dim];
-            let value_slice = &params.kv_cache.values[key_start..key_start + head_dim];
+            let mut key_row = vec![0.0f32; head_dim];
+            let mut value_row = vec![0.0f32; head_dim];
+            params
+                .kv_cache
+                .copy_key_row_into(params.layer_idx, position, kv_head, &mut key_row);
+            params.kv_cache.copy_value_row_into(
+                params.layer_idx,
+                position,
+                kv_head,
+                &mut value_row,
+            );
+            let key_slice = key_row.as_slice();
+            let value_slice = value_row.as_slice();
             let qk_products = query_slice
                 .iter()
                 .zip(key_slice.iter())
@@ -21311,15 +21362,14 @@ fn attention_scores_for_head(
 ) -> Vec<f32> {
     let head_dim = kv_cache.plan.head_dim;
     let mut scores = Vec::with_capacity(position_count);
-    let mut key_start = kv_cache.head_base_offset(layer_idx, kv_head);
-    let position_stride = kv_cache.head_position_stride();
+    // Diagnostics-only reconstruction: materialize each key row (exact for
+    // both dtypes; a plain copy for f32) and keep the historical legacy-dot
+    // scoring this trace has always used.
+    let mut key_row = vec![0.0f32; head_dim];
     for position in 0..position_count {
-        let key_slice = &kv_cache.keys[key_start..key_start + head_dim];
-        let score = dot_product(query_slice, key_slice) * scale;
+        kv_cache.copy_key_row_into(layer_idx, position, kv_head, &mut key_row);
+        let score = dot_product(query_slice, &key_row) * scale;
         scores.push(score);
-        if position + 1 < position_count {
-            key_start += position_stride;
-        }
     }
     scores
 }
@@ -21360,11 +21410,11 @@ fn reconstruct_attention_context_for_head(
     probabilities: &[f32],
 ) -> Vec<f32> {
     let mut context = vec![0.0; head_dim];
+    let mut value_row = vec![0.0f32; head_dim];
     for (position, probability) in probabilities.iter().copied().enumerate() {
-        let value_start = kv_cache.offset(layer_idx, position, kv_head);
-        let value_slice = &kv_cache.values[value_start..value_start + head_dim];
+        kv_cache.copy_value_row_into(layer_idx, position, kv_head, &mut value_row);
         for dim in 0..head_dim {
-            context[dim] += probability * value_slice[dim];
+            context[dim] += probability * value_row[dim];
         }
     }
     context
@@ -21396,15 +21446,16 @@ fn top_attention_probability_positions(
         .into_iter()
         .take(ATTENTION_TRACE_TOP_PROBABILITY_LIMIT)
         .map(|(position, probability)| {
-            let key_start = kv_cache.offset(layer_idx, position, kv_head);
-            let key_slice = &kv_cache.keys[key_start..key_start + head_dim];
-            let value_slice = &kv_cache.values[key_start..key_start + head_dim];
+            let mut key_row = vec![0.0f32; head_dim];
+            let mut value_row = vec![0.0f32; head_dim];
+            kv_cache.copy_key_row_into(layer_idx, position, kv_head, &mut key_row);
+            kv_cache.copy_value_row_into(layer_idx, position, kv_head, &mut value_row);
             LlamaAttentionTopProbabilityTrace {
                 position,
                 score: scores[position],
                 probability,
-                key_first_values: sample_first_values(key_slice),
-                value_first_values: sample_first_values(value_slice),
+                key_first_values: sample_first_values(&key_row),
+                value_first_values: sample_first_values(&value_row),
             }
         })
         .collect()

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -29,6 +29,7 @@ mod diagnostic_config;
 pub mod draft_merge;
 pub(crate) mod gemma4;
 mod kv_cache;
+mod kv_f16;
 mod metal_resident;
 mod metal_seam;
 mod q8_block_reader;
@@ -56,7 +57,9 @@ pub use diagnostic_config::{
     GqaHeadMapping, LinearAccumulationPrecision, OutputProjectionLayout, RectangularLinearLayout,
     SquareLinearLayout,
 };
-pub use kv_cache::{LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, LlamaKvCacheTrace};
+pub use kv_cache::{
+    KvLayout, LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, LlamaKvCacheTrace,
+};
 pub use q8_block_reader::Q8BlockReader;
 use q8_runtime::{
     q8_0_env_flag_enabled_default_off, q8_0_env_flag_enabled_default_on_fail_closed,
@@ -20421,10 +20424,23 @@ fn write_kv_cache(
         )));
     }
     kv_cache.ensure_position_capacity(kv_cache.position + 1)?;
-    let offset = kv_cache.offset(layer_idx, kv_cache.position, 0);
-    let end = offset + expected_width;
-    copy_to_f16_kv_cache_storage(&mut kv_cache.keys[offset..end], &key.data);
-    copy_to_f16_kv_cache_storage(&mut kv_cache.values[offset..end], &value.data);
+    // Per-head copies: identical element order and per-element math as the
+    // historical whole-row copy in position-major (heads are contiguous
+    // there), and the only correct shape in head-major, where one token's
+    // heads live in separate streams.
+    let head_dim = kv_cache.plan.head_dim;
+    for kv_head in 0..kv_cache.plan.kv_head_count {
+        let dst = kv_cache.offset(layer_idx, kv_cache.position, kv_head);
+        let src = kv_head * head_dim;
+        copy_to_f16_kv_cache_storage(
+            &mut kv_cache.keys[dst..dst + head_dim],
+            &key.data[src..src + head_dim],
+        );
+        copy_to_f16_kv_cache_storage(
+            &mut kv_cache.values[dst..dst + head_dim],
+            &value.data[src..src + head_dim],
+        );
+    }
     Ok(())
 }
 
@@ -20455,20 +20471,23 @@ fn write_kv_cache_batch(
     }
     let rows = key.dim(0)?;
     kv_cache.ensure_position_capacity(base_position + rows)?;
+    // Per-head copies; see `write_kv_cache` for the order argument.
+    let head_dim = kv_cache.plan.head_dim;
     for row in 0..rows {
         let position = base_position + row;
-        let offset = kv_cache.offset(layer_idx, position, 0);
-        let end = offset + expected_width;
         let row_start = row * expected_width;
-        let row_end = row_start + expected_width;
-        copy_to_f16_kv_cache_storage(
-            &mut kv_cache.keys[offset..end],
-            &key.data[row_start..row_end],
-        );
-        copy_to_f16_kv_cache_storage(
-            &mut kv_cache.values[offset..end],
-            &value.data[row_start..row_end],
-        );
+        for kv_head in 0..kv_cache.plan.kv_head_count {
+            let dst = kv_cache.offset(layer_idx, position, kv_head);
+            let src = row_start + kv_head * head_dim;
+            copy_to_f16_kv_cache_storage(
+                &mut kv_cache.keys[dst..dst + head_dim],
+                &key.data[src..src + head_dim],
+            );
+            copy_to_f16_kv_cache_storage(
+                &mut kv_cache.values[dst..dst + head_dim],
+                &value.data[src..src + head_dim],
+            );
+        }
     }
     Ok(())
 }
@@ -20513,37 +20532,45 @@ fn kv_cache_trace(
     let mut value_max_abs_position = 0;
     let mut value_max_abs_index = 0;
 
+    // Walk per (position, kv_head) with the LOGICAL in-token index so the
+    // checksum/ordinal stream is identical in both KV layouts (in
+    // position-major this touches the exact same addresses in the exact same
+    // order as the historical whole-row walk).
+    let head_dim = kv_cache.plan.head_dim;
     for position in 0..position_count {
-        let start = kv_cache.offset(layer_idx, position, 0);
-        let end = start + key_value_width;
-        for (idx, (&key, &value)) in kv_cache.keys[start..end]
-            .iter()
-            .zip(kv_cache.values[start..end].iter())
-            .enumerate()
-        {
-            if !key.is_finite() || !value.is_finite() {
-                return Err(BackendError::RuntimeShapeMismatch(format!(
-                    "KV trace found non-finite value at layer {layer_idx} position {position} index {idx}"
-                )));
-            }
-            let ordinal = ((position * key_value_width) + idx + 1) as f64;
-            let key64 = key as f64;
-            let value64 = value as f64;
-            key_sum_square += key64 * key64;
-            value_sum_square += value64 * value64;
-            key_checksum += ordinal * key64;
-            value_checksum += ordinal * value64;
-            let key_abs = key.abs();
-            if key_abs > key_max_abs {
-                key_max_abs = key_abs;
-                key_max_abs_position = position;
-                key_max_abs_index = idx;
-            }
-            let value_abs = value.abs();
-            if value_abs > value_max_abs {
-                value_max_abs = value_abs;
-                value_max_abs_position = position;
-                value_max_abs_index = idx;
+        for kv_head in 0..kv_cache.plan.kv_head_count {
+            let start = kv_cache.offset(layer_idx, position, kv_head);
+            let end = start + head_dim;
+            for (dim, (&key, &value)) in kv_cache.keys[start..end]
+                .iter()
+                .zip(kv_cache.values[start..end].iter())
+                .enumerate()
+            {
+                let idx = kv_head * head_dim + dim;
+                if !key.is_finite() || !value.is_finite() {
+                    return Err(BackendError::RuntimeShapeMismatch(format!(
+                        "KV trace found non-finite value at layer {layer_idx} position {position} index {idx}"
+                    )));
+                }
+                let ordinal = ((position * key_value_width) + idx + 1) as f64;
+                let key64 = key as f64;
+                let value64 = value as f64;
+                key_sum_square += key64 * key64;
+                value_sum_square += value64 * value64;
+                key_checksum += ordinal * key64;
+                value_checksum += ordinal * value64;
+                let key_abs = key.abs();
+                if key_abs > key_max_abs {
+                    key_max_abs = key_abs;
+                    key_max_abs_position = position;
+                    key_max_abs_index = idx;
+                }
+                let value_abs = value.abs();
+                if value_abs > value_max_abs {
+                    value_max_abs = value_abs;
+                    value_max_abs_position = position;
+                    value_max_abs_index = idx;
+                }
             }
         }
     }
@@ -20580,10 +20607,20 @@ fn kv_cache_position_trace(
     position: usize,
     key_value_width: usize,
 ) -> Result<LlamaKvCachePositionTrace> {
-    let start = kv_cache.offset(layer_idx, position, 0);
-    let end = start + key_value_width;
-    let key_slice = &kv_cache.keys[start..end];
-    let value_slice = &kv_cache.values[start..end];
+    // Materialize the token's logical row (kv_head-major element order, the
+    // historical contiguous order) so checksums, ordinals, and sampled
+    // values are identical in both KV layouts. Diagnostics-only path; the
+    // copy is TENSOR-trace sized, not hot.
+    let head_dim = kv_cache.plan.head_dim;
+    let mut key_row = Vec::with_capacity(key_value_width);
+    let mut value_row = Vec::with_capacity(key_value_width);
+    for kv_head in 0..kv_cache.plan.kv_head_count {
+        let start = kv_cache.offset(layer_idx, position, kv_head);
+        key_row.extend_from_slice(&kv_cache.keys[start..start + head_dim]);
+        value_row.extend_from_slice(&kv_cache.values[start..start + head_dim]);
+    }
+    let key_slice = key_row.as_slice();
+    let value_slice = value_row.as_slice();
     let mut key_sum_square = 0.0_f64;
     let mut value_sum_square = 0.0_f64;
     let mut key_checksum = 0.0_f64;
@@ -21055,7 +21092,7 @@ fn attention_context_for_head_into_with_kernels(
     let head_base = params
         .kv_cache
         .head_base_offset(params.layer_idx, params.kv_head);
-    let position_stride = params.kv_cache.position_stride();
+    let position_stride = params.kv_cache.head_position_stride();
 
     let mut key_start = head_base;
     for position in 0..params.position_count {
@@ -21270,7 +21307,7 @@ fn attention_scores_for_head(
     let head_dim = kv_cache.plan.head_dim;
     let mut scores = Vec::with_capacity(position_count);
     let mut key_start = kv_cache.head_base_offset(layer_idx, kv_head);
-    let position_stride = kv_cache.position_stride();
+    let position_stride = kv_cache.head_position_stride();
     for position in 0..position_count {
         let key_slice = &kv_cache.keys[key_start..key_start + head_dim];
         let score = dot_product(query_slice, key_slice) * scale;

--- a/src/inference/attn_f32_dot.rs
+++ b/src/inference/attn_f32_dot.rs
@@ -214,6 +214,193 @@ pub(super) fn axpy_blocked(out: &mut [f32], prob: f32, v: &[f32]) {
     axpy_blocked_scalar(out, prob, v);
 }
 
+// ---------------------------------------------------------------------------
+// f16-operand variants (KV f16 storage lane, `BACKENDINFERENCE_KV_F16`).
+//
+// Canonical order: convert each f16 element to f32 (exact expansion, pinned
+// to the existing-helper semantics — see `kv_f16`), THEN the identical
+// blocked order above. The conversion is fused into the loads (`vcvtph2ps`
+// on the fast path) so no f32 staging buffer re-adds the traffic the lane
+// removes. Bitwise-locked to their scalar references by the same >=10k-case
+// to_bits() property tests as the f32 kernels.
+// ---------------------------------------------------------------------------
+
+use super::kv_f16::f16_to_f32_kv;
+
+/// Canonical blocked dot with an f16 K operand — scalar reference.
+// Consumed by the flag-gated KV f16 storage integration; until that wiring
+// lands only the tests exercise it.
+#[allow(dead_code)]
+pub(super) fn dot_blocked_f16_scalar(x: &[f32], y16: &[u16]) -> f32 {
+    debug_assert_eq!(x.len(), y16.len());
+    let len = x.len();
+    let mut acc = [[0.0f32; LANES]; 4];
+    let mut i = 0;
+    while i + BLOCK <= len {
+        for (k, acc_k) in acc.iter_mut().enumerate() {
+            let base = i + k * LANES;
+            for (l, lane) in acc_k.iter_mut().enumerate() {
+                *lane = x[base + l].mul_add(f16_to_f32_kv(y16[base + l]), *lane);
+            }
+        }
+        i += BLOCK;
+    }
+    let mut s = [0.0f32; LANES];
+    for (l, s_lane) in s.iter_mut().enumerate() {
+        let s01 = acc[0][l] + acc[1][l];
+        let s23 = acc[2][l] + acc[3][l];
+        *s_lane = s01 + s23;
+    }
+    let t0 = s[0] + s[4];
+    let t1 = s[1] + s[5];
+    let t2 = s[2] + s[6];
+    let t3 = s[3] + s[7];
+    let u0 = t0 + t2;
+    let u1 = t1 + t3;
+    let mut h = u0 + u1;
+    while i < len {
+        h = x[i].mul_add(f16_to_f32_kv(y16[i]), h);
+        i += 1;
+    }
+    h
+}
+
+/// Canonical V accumulation with an f16 V operand — scalar reference.
+#[allow(dead_code)]
+pub(super) fn axpy_blocked_f16_scalar(out: &mut [f32], prob: f32, v16: &[u16]) {
+    debug_assert_eq!(out.len(), v16.len());
+    for (out_value, value) in out.iter_mut().zip(v16) {
+        *out_value = prob.mul_add(f16_to_f32_kv(*value), *out_value);
+    }
+}
+
+/// AVX2/FMA/F16C realization of [`dot_blocked_f16_scalar`]: 8 halves per
+/// load expanded with `vcvtph2ps` (exact, matches the scalar expansion
+/// bitwise on all 2^16 inputs), then the identical accumulator/combine/tail
+/// structure as [`dot_blocked_avx2`].
+///
+/// # Safety
+/// Caller must ensure AVX2, FMA, and F16C are available on the running CPU.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma,f16c")]
+pub(super) unsafe fn dot_blocked_f16_avx2(x: &[f32], y16: &[u16]) -> f32 {
+    use std::arch::x86_64::{
+        _mm256_add_ps, _mm256_cvtph_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_setzero_ps,
+        _mm256_storeu_ps, _mm_loadu_si128, __m128i,
+    };
+    debug_assert_eq!(x.len(), y16.len());
+    let len = x.len();
+    let xp = x.as_ptr();
+    let yp = y16.as_ptr();
+    let mut acc0 = _mm256_setzero_ps();
+    let mut acc1 = _mm256_setzero_ps();
+    let mut acc2 = _mm256_setzero_ps();
+    let mut acc3 = _mm256_setzero_ps();
+    let mut i = 0;
+    while i + BLOCK <= len {
+        // SAFETY: the loop guard ensures `i + 32 <= len`, so every 8-lane
+        // load below stays inside both slices.
+        unsafe {
+            let y0 = _mm256_cvtph_ps(_mm_loadu_si128(yp.add(i) as *const __m128i));
+            acc0 = _mm256_fmadd_ps(_mm256_loadu_ps(xp.add(i)), y0, acc0);
+            let y1 = _mm256_cvtph_ps(_mm_loadu_si128(yp.add(i + 8) as *const __m128i));
+            acc1 = _mm256_fmadd_ps(_mm256_loadu_ps(xp.add(i + 8)), y1, acc1);
+            let y2 = _mm256_cvtph_ps(_mm_loadu_si128(yp.add(i + 16) as *const __m128i));
+            acc2 = _mm256_fmadd_ps(_mm256_loadu_ps(xp.add(i + 16)), y2, acc2);
+            let y3 = _mm256_cvtph_ps(_mm_loadu_si128(yp.add(i + 24) as *const __m128i));
+            acc3 = _mm256_fmadd_ps(_mm256_loadu_ps(xp.add(i + 24)), y3, acc3);
+        }
+        i += BLOCK;
+    }
+    let s01 = _mm256_add_ps(acc0, acc1);
+    let s23 = _mm256_add_ps(acc2, acc3);
+    let s = _mm256_add_ps(s01, s23);
+    let mut lanes = [0.0f32; LANES];
+    // SAFETY: `lanes` is exactly 8 f32s, the width of one __m256 store.
+    unsafe { _mm256_storeu_ps(lanes.as_mut_ptr(), s) };
+    let t0 = lanes[0] + lanes[4];
+    let t1 = lanes[1] + lanes[5];
+    let t2 = lanes[2] + lanes[6];
+    let t3 = lanes[3] + lanes[7];
+    let u0 = t0 + t2;
+    let u1 = t1 + t3;
+    let mut h = u0 + u1;
+    while i < len {
+        h = x[i].mul_add(f16_to_f32_kv(y16[i]), h);
+        i += 1;
+    }
+    h
+}
+
+/// AVX2/FMA/F16C realization of [`axpy_blocked_f16_scalar`].
+///
+/// # Safety
+/// Caller must ensure AVX2, FMA, and F16C are available on the running CPU.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma,f16c")]
+pub(super) unsafe fn axpy_blocked_f16_avx2(out: &mut [f32], prob: f32, v16: &[u16]) {
+    use std::arch::x86_64::{
+        _mm256_cvtph_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_set1_ps, _mm256_storeu_ps,
+        _mm_loadu_si128, __m128i,
+    };
+    debug_assert_eq!(out.len(), v16.len());
+    let len = out.len();
+    let prob_v = _mm256_set1_ps(prob);
+    let mut i = 0;
+    while i + LANES <= len {
+        // SAFETY: the loop guard ensures `i + 8 <= len` for both slices.
+        unsafe {
+            let value = _mm256_cvtph_ps(_mm_loadu_si128(v16.as_ptr().add(i) as *const __m128i));
+            let current = _mm256_loadu_ps(out.as_ptr().add(i));
+            _mm256_storeu_ps(
+                out.as_mut_ptr().add(i),
+                _mm256_fmadd_ps(prob_v, value, current),
+            );
+        }
+        i += LANES;
+    }
+    while i < len {
+        out[i] = prob.mul_add(f16_to_f32_kv(v16[i]), out[i]);
+        i += 1;
+    }
+}
+
+/// Runtime dispatch guard for the f16 kernel fast paths, resolved once.
+#[cfg(target_arch = "x86_64")]
+fn attn_f16_kernels_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        std::arch::is_x86_feature_detected!("avx2")
+            && std::arch::is_x86_feature_detected!("fma")
+            && std::arch::is_x86_feature_detected!("f16c")
+    })
+}
+
+/// f16-K blocked dot with safe dispatch. Both paths produce identical bits.
+// Consumed by the flag-gated KV f16 storage integration; until that wiring
+// lands only the tests exercise it.
+#[allow(dead_code)]
+pub(super) fn dot_blocked_f16(x: &[f32], y16: &[u16]) -> f32 {
+    #[cfg(target_arch = "x86_64")]
+    if attn_f16_kernels_available() {
+        // SAFETY: guarded by the runtime AVX2+FMA+F16C feature check above.
+        return unsafe { dot_blocked_f16_avx2(x, y16) };
+    }
+    dot_blocked_f16_scalar(x, y16)
+}
+
+/// f16-V blocked axpy with safe dispatch, mirroring [`dot_blocked_f16`].
+#[allow(dead_code)]
+pub(super) fn axpy_blocked_f16(out: &mut [f32], prob: f32, v16: &[u16]) {
+    #[cfg(target_arch = "x86_64")]
+    if attn_f16_kernels_available() {
+        // SAFETY: guarded by the runtime AVX2+FMA+F16C feature check above.
+        unsafe { axpy_blocked_f16_avx2(out, prob, v16) };
+        return;
+    }
+    axpy_blocked_f16_scalar(out, prob, v16);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -257,6 +444,111 @@ mod tests {
 
     fn fill(rng: &mut XorShift64Star, len: usize) -> Vec<f32> {
         (0..len).map(|_| rng.next_f32()).collect()
+    }
+
+    /// Random u16 across the FULL binary16 domain — finite values,
+    /// subnormals, ±inf, and NaN payloads all occur; the f16 kernels must be
+    /// bitwise-locked on all of them.
+    fn fill_u16(rng: &mut XorShift64Star, len: usize) -> Vec<u16> {
+        (0..len).map(|_| rng.next_u64() as u16).collect()
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn f16_kernels_testable() -> bool {
+        std::arch::is_x86_feature_detected!("avx2")
+            && std::arch::is_x86_feature_detected!("fma")
+            && std::arch::is_x86_feature_detected!("f16c")
+    }
+
+    /// Fusion oracle: the f16 scalar kernel must equal "expand every element
+    /// through the pinned conversion, then the existing f32 blocked order".
+    #[test]
+    fn dot_blocked_f16_scalar_equals_expand_then_blocked() {
+        let mut rng = XorShift64Star(0xf16d_0001);
+        for case in 0..2_000 {
+            let len = match case % 4 {
+                0 => 64,
+                1 => 128,
+                _ => 1 + rng.next_usize(512),
+            };
+            let x = fill(&mut rng, len);
+            let y16 = fill_u16(&mut rng, len);
+            let expanded: Vec<f32> = y16.iter().map(|&b| super::f16_to_f32_kv(b)).collect();
+            let fused = dot_blocked_f16_scalar(&x, &y16);
+            let staged = dot_blocked_scalar(&x, &expanded);
+            assert_eq!(
+                fused.to_bits(),
+                staged.to_bits(),
+                "case {case}: len {len}, fused {fused}, staged {staged}"
+            );
+            let prob = rng.next_f32();
+            let mut out_fused = x.clone();
+            let mut out_staged = x.clone();
+            axpy_blocked_f16_scalar(&mut out_fused, prob, &y16);
+            axpy_blocked_scalar(&mut out_staged, prob, &expanded);
+            for (a, b) in out_fused.iter().zip(&out_staged) {
+                assert_eq!(a.to_bits(), b.to_bits(), "axpy case {case}");
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn dot_blocked_f16_avx2_matches_scalar_bitwise() {
+        if !f16_kernels_testable() {
+            eprintln!("skipping: AVX2+FMA+F16C not available on this host");
+            return;
+        }
+        let mut rng = XorShift64Star(0xf16b_0001);
+        for case in 0..10_000 {
+            let len = match case % 4 {
+                0 => 64,
+                1 => 128,
+                _ => 1 + rng.next_usize(512),
+            };
+            let x = fill(&mut rng, len);
+            let y16 = fill_u16(&mut rng, len);
+            let scalar = dot_blocked_f16_scalar(&x, &y16);
+            // SAFETY: guarded by the runtime feature check above.
+            let avx2 = unsafe { dot_blocked_f16_avx2(&x, &y16) };
+            assert_eq!(
+                scalar.to_bits(),
+                avx2.to_bits(),
+                "case {case}: len {len}, scalar {scalar}, avx2 {avx2}"
+            );
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn axpy_blocked_f16_avx2_matches_scalar_bitwise() {
+        if !f16_kernels_testable() {
+            eprintln!("skipping: AVX2+FMA+F16C not available on this host");
+            return;
+        }
+        let mut rng = XorShift64Star(0xf16a_0001);
+        for case in 0..10_000 {
+            let len = match case % 4 {
+                0 => 64,
+                1 => 128,
+                _ => 1 + rng.next_usize(512),
+            };
+            let prob = rng.next_f32();
+            let base = fill(&mut rng, len);
+            let v16 = fill_u16(&mut rng, len);
+            let mut out_scalar = base.clone();
+            let mut out_avx2 = base;
+            axpy_blocked_f16_scalar(&mut out_scalar, prob, &v16);
+            // SAFETY: guarded by the runtime feature check above.
+            unsafe { axpy_blocked_f16_avx2(&mut out_avx2, prob, &v16) };
+            for (d, (s, a)) in out_scalar.iter().zip(&out_avx2).enumerate() {
+                assert_eq!(
+                    s.to_bits(),
+                    a.to_bits(),
+                    "case {case}: len {len}, element {d}, scalar {s}, avx2 {a}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/inference/attn_f32_dot.rs
+++ b/src/inference/attn_f32_dot.rs
@@ -285,8 +285,8 @@ pub(super) fn axpy_blocked_f16_scalar(out: &mut [f32], prob: f32, v16: &[u16]) {
 #[target_feature(enable = "avx2,fma,f16c")]
 pub(super) unsafe fn dot_blocked_f16_avx2(x: &[f32], y16: &[u16]) -> f32 {
     use std::arch::x86_64::{
-        _mm256_add_ps, _mm256_cvtph_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_setzero_ps,
-        _mm256_storeu_ps, _mm_loadu_si128, __m128i,
+        __m128i, _mm256_add_ps, _mm256_cvtph_ps, _mm256_fmadd_ps, _mm256_loadu_ps,
+        _mm256_setzero_ps, _mm256_storeu_ps, _mm_loadu_si128,
     };
     debug_assert_eq!(x.len(), y16.len());
     let len = x.len();
@@ -340,8 +340,8 @@ pub(super) unsafe fn dot_blocked_f16_avx2(x: &[f32], y16: &[u16]) -> f32 {
 #[target_feature(enable = "avx2,fma,f16c")]
 pub(super) unsafe fn axpy_blocked_f16_avx2(out: &mut [f32], prob: f32, v16: &[u16]) {
     use std::arch::x86_64::{
-        _mm256_cvtph_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_set1_ps, _mm256_storeu_ps,
-        _mm_loadu_si128, __m128i,
+        __m128i, _mm256_cvtph_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_set1_ps,
+        _mm256_storeu_ps, _mm_loadu_si128,
     };
     debug_assert_eq!(out.len(), v16.len());
     let len = out.len();

--- a/src/inference/attn_f32_dot.rs
+++ b/src/inference/attn_f32_dot.rs
@@ -228,9 +228,6 @@ pub(super) fn axpy_blocked(out: &mut [f32], prob: f32, v: &[f32]) {
 use super::kv_f16::f16_to_f32_kv;
 
 /// Canonical blocked dot with an f16 K operand — scalar reference.
-// Consumed by the flag-gated KV f16 storage integration; until that wiring
-// lands only the tests exercise it.
-#[allow(dead_code)]
 pub(super) fn dot_blocked_f16_scalar(x: &[f32], y16: &[u16]) -> f32 {
     debug_assert_eq!(x.len(), y16.len());
     let len = x.len();
@@ -266,7 +263,6 @@ pub(super) fn dot_blocked_f16_scalar(x: &[f32], y16: &[u16]) -> f32 {
 }
 
 /// Canonical V accumulation with an f16 V operand — scalar reference.
-#[allow(dead_code)]
 pub(super) fn axpy_blocked_f16_scalar(out: &mut [f32], prob: f32, v16: &[u16]) {
     debug_assert_eq!(out.len(), v16.len());
     for (out_value, value) in out.iter_mut().zip(v16) {
@@ -377,9 +373,6 @@ fn attn_f16_kernels_available() -> bool {
 }
 
 /// f16-K blocked dot with safe dispatch. Both paths produce identical bits.
-// Consumed by the flag-gated KV f16 storage integration; until that wiring
-// lands only the tests exercise it.
-#[allow(dead_code)]
 pub(super) fn dot_blocked_f16(x: &[f32], y16: &[u16]) -> f32 {
     #[cfg(target_arch = "x86_64")]
     if attn_f16_kernels_available() {
@@ -390,7 +383,6 @@ pub(super) fn dot_blocked_f16(x: &[f32], y16: &[u16]) -> f32 {
 }
 
 /// f16-V blocked axpy with safe dispatch, mirroring [`dot_blocked_f16`].
-#[allow(dead_code)]
 pub(super) fn axpy_blocked_f16(out: &mut [f32], prob: f32, v16: &[u16]) {
     #[cfg(target_arch = "x86_64")]
     if attn_f16_kernels_available() {

--- a/src/inference/kv_cache.rs
+++ b/src/inference/kv_cache.rs
@@ -76,8 +76,17 @@ pub struct LlamaKvCache {
     pub plan: LlamaKvCachePlan,
     /// Physical K/V arrangement; see [`KvLayout`]. Fixed at construction.
     pub layout: KvLayout,
+    /// Element storage type; see [`KvDtype`]. Fixed at construction. In
+    /// `F32` mode `keys`/`values` are live and the `_f16` buffers stay
+    /// empty; in `F16` mode the reverse. The stored VALUES are identical
+    /// either way — the write path has always rounded through f16 — so the
+    /// dtype choice is bytes, not bits.
+    pub dtype: KvDtype,
     pub keys: Vec<f32>,
     pub values: Vec<f32>,
+    /// f16 storage (bit patterns), live only when `dtype == KvDtype::F16`.
+    pub keys_f16: Vec<u16>,
+    pub values_f16: Vec<u16>,
     pub allocated_sequence_length: usize,
     pub position: usize,
     /// Max f32 K+V bytes this session may materialize before the predict-and-abort
@@ -94,8 +103,11 @@ impl PartialEq for LlamaKvCache {
         // must not affect equality (the session PartialEq compares caches across runs).
         self.plan == other.plan
             && self.layout == other.layout
+            && self.dtype == other.dtype
             && self.keys == other.keys
             && self.values == other.values
+            && self.keys_f16 == other.keys_f16
+            && self.values_f16 == other.values_f16
             && self.allocated_sequence_length == other.allocated_sequence_length
             && self.position == other.position
     }
@@ -128,27 +140,78 @@ fn kv_layout_head_major_enabled() -> bool {
     super::q8_runtime::q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR")
 }
 
+/// Element storage for the K/V buffers. Chosen ONCE at cache construction
+/// (`BACKENDINFERENCE_KV_F16`, default off). f16 storage holds exactly the
+/// values the write path has always produced (it rounds through f16
+/// unconditionally), so both dtypes carry the bitwise-identity contract —
+/// f16 just stops paying 2x the bytes for them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KvDtype {
+    F32,
+    F16,
+}
+
+/// Env gate for f16 storage, read once per cache construction. Requires the
+/// Item-1 blocked-dot lane (the fused f16 kernels realize its canonical
+/// order; the legacy serial dot has no f16 variant by design) — requested
+/// without it, the flag is inert and logged once.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn kv_f16_enabled() -> bool {
+    let requested = super::q8_runtime::q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_KV_F16");
+    if requested && !super::attention_f32_blocked_dot_enabled() {
+        static LOGGED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        LOGGED.get_or_init(|| {
+            eprintln!(
+                "[kv-f16] BACKENDINFERENCE_KV_F16 requested without \
+                 BACKENDINFERENCE_ATTENTION_F32_BLOCKED_DOT; the f16 lane is inert \
+                 (the fused f16 kernels require the blocked-dot lane)"
+            );
+        });
+        return false;
+    }
+    requested
+}
+
 impl LlamaKvCache {
     pub fn new(plan: LlamaKvCachePlan) -> Result<Self> {
         #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-        let layout = if kv_layout_head_major_enabled() {
-            KvLayout::HeadMajor
-        } else {
-            KvLayout::PositionMajor
-        };
+        let (layout, dtype) = (
+            if kv_layout_head_major_enabled() {
+                KvLayout::HeadMajor
+            } else {
+                KvLayout::PositionMajor
+            },
+            if kv_f16_enabled() {
+                KvDtype::F16
+            } else {
+                KvDtype::F32
+            },
+        );
         #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
-        let layout = KvLayout::PositionMajor;
-        Self::new_with_layout(plan, layout)
+        let (layout, dtype) = (KvLayout::PositionMajor, KvDtype::F32);
+        Self::new_with_layout_and_dtype(plan, layout, dtype)
     }
 
     /// Explicit-layout constructor so the bitwise-identity tests can build
     /// both layouts without touching process env.
     pub fn new_with_layout(plan: LlamaKvCachePlan, layout: KvLayout) -> Result<Self> {
+        Self::new_with_layout_and_dtype(plan, layout, KvDtype::F32)
+    }
+
+    /// Explicit-everything constructor for the bitwise-identity tests.
+    pub fn new_with_layout_and_dtype(
+        plan: LlamaKvCachePlan,
+        layout: KvLayout,
+        dtype: KvDtype,
+    ) -> Result<Self> {
         Ok(Self {
             plan,
             layout,
+            dtype,
             keys: Vec::new(),
             values: Vec::new(),
+            keys_f16: Vec::new(),
+            values_f16: Vec::new(),
             allocated_sequence_length: 0,
             position: 0,
             kv_budget_bytes: resolve_kv_cache_budget_bytes(),
@@ -212,36 +275,70 @@ impl LlamaKvCache {
             .ok_or_else(|| {
                 BackendError::RuntimeShapeMismatch("KV cache element count overflow".to_string())
             })?;
-        match self.layout {
-            KvLayout::PositionMajor => {
-                // Positions are outermost, so growth is a pure append.
-                self.keys.resize(values, 0.0);
-                self.values.resize(values, 0.0);
-            }
-            KvLayout::HeadMajor => {
-                // Each head's stream stride is the allocated capacity, so
-                // growth re-lays the buffer: copy every (layer, head) block
-                // to its new base. Pure permutation of identical bits —
-                // bitwise-neutral — amortized over the growth chunking.
-                let head_dim = self.plan.head_dim;
-                let old_len = self.allocated_sequence_length * head_dim;
-                let streams = self.plan.layer_count * self.plan.kv_head_count;
-                let new_len = target_sequence_length * head_dim;
-                let mut new_keys = vec![0.0f32; values];
-                let mut new_values = vec![0.0f32; values];
-                if old_len > 0 {
-                    for stream in 0..streams {
-                        let old_base = stream * old_len;
-                        let new_base = stream * new_len;
-                        new_keys[new_base..new_base + old_len]
-                            .copy_from_slice(&self.keys[old_base..old_base + old_len]);
-                        new_values[new_base..new_base + old_len]
-                            .copy_from_slice(&self.values[old_base..old_base + old_len]);
-                    }
+        #[allow(clippy::too_many_arguments)]
+        fn grow_buffers<T: Copy + Default>(
+            keys: &mut Vec<T>,
+            vals: &mut Vec<T>,
+            layout: KvLayout,
+            elements: usize,
+            old_alloc: usize,
+            new_alloc: usize,
+            head_dim: usize,
+            streams: usize,
+        ) {
+            match layout {
+                KvLayout::PositionMajor => {
+                    // Positions are outermost, so growth is a pure append.
+                    keys.resize(elements, T::default());
+                    vals.resize(elements, T::default());
                 }
-                self.keys = new_keys;
-                self.values = new_values;
+                KvLayout::HeadMajor => {
+                    // Each head's stream stride is the allocated capacity, so
+                    // growth re-lays the buffer: copy every (layer, head)
+                    // block to its new base. Pure permutation of identical
+                    // bits — bitwise-neutral — amortized over the chunking.
+                    let old_len = old_alloc * head_dim;
+                    let new_len = new_alloc * head_dim;
+                    let mut new_keys = vec![T::default(); elements];
+                    let mut new_vals = vec![T::default(); elements];
+                    if old_len > 0 {
+                        for stream in 0..streams {
+                            let old_base = stream * old_len;
+                            let new_base = stream * new_len;
+                            new_keys[new_base..new_base + old_len]
+                                .copy_from_slice(&keys[old_base..old_base + old_len]);
+                            new_vals[new_base..new_base + old_len]
+                                .copy_from_slice(&vals[old_base..old_base + old_len]);
+                        }
+                    }
+                    *keys = new_keys;
+                    *vals = new_vals;
+                }
             }
+        }
+        let head_dim = self.plan.head_dim;
+        let streams = self.plan.layer_count * self.plan.kv_head_count;
+        match self.dtype {
+            KvDtype::F32 => grow_buffers(
+                &mut self.keys,
+                &mut self.values,
+                self.layout,
+                values,
+                self.allocated_sequence_length,
+                target_sequence_length,
+                head_dim,
+                streams,
+            ),
+            KvDtype::F16 => grow_buffers(
+                &mut self.keys_f16,
+                &mut self.values_f16,
+                self.layout,
+                values,
+                self.allocated_sequence_length,
+                target_sequence_length,
+                head_dim,
+                streams,
+            ),
         }
         self.allocated_sequence_length = target_sequence_length;
         Ok(())
@@ -259,11 +356,18 @@ impl LlamaKvCache {
     }
 
     pub fn allocated_elements(&self) -> usize {
-        self.keys.len() + self.values.len()
+        self.keys.len() + self.values.len() + self.keys_f16.len() + self.values_f16.len()
     }
 
     pub fn allocated_bytes(&self) -> u64 {
-        (self.allocated_elements() as u64) * (std::mem::size_of::<f32>() as u64)
+        (self.allocated_elements() as u64) * self.element_bytes()
+    }
+
+    fn element_bytes(&self) -> u64 {
+        match self.dtype {
+            KvDtype::F32 => std::mem::size_of::<f32>() as u64,
+            KvDtype::F16 => std::mem::size_of::<u16>() as u64,
+        }
     }
 
     pub(super) fn offset(&self, layer_idx: usize, position: usize, kv_head: usize) -> usize {
@@ -302,12 +406,97 @@ impl LlamaKvCache {
         self.plan.layer_count * self.plan.kv_head_count * self.plan.head_dim
     }
 
-    /// f32 bytes one token's KV occupies across all layers/heads, counting both the
-    /// K and V buffers — the per-token cost the predict-and-abort guard projects.
+    /// Bytes one token's KV occupies across all layers/heads at the active
+    /// dtype, counting both the K and V buffers — the per-token cost the
+    /// predict-and-abort guard projects.
     fn kv_bytes_per_token(&self) -> u64 {
         (self.position_stride() as u64)
             .saturating_mul(2) // K + V
-            .saturating_mul(std::mem::size_of::<f32>() as u64)
+            .saturating_mul(self.element_bytes())
+    }
+
+    /// THE canonical KV store: one (layer, position, kv_head) row of K and V,
+    /// rounded through f16 exactly as the write path always has, into
+    /// whichever dtype backs this cache. Every writer routes through here —
+    /// including the CUDA prefill mirror-back, whose data is f16-exact
+    /// already (re-rounding is idempotent), so the routing is bit-neutral
+    /// and enforces the f16-exactness invariant structurally.
+    pub(super) fn store_kv_head_row(
+        &mut self,
+        layer_idx: usize,
+        position: usize,
+        kv_head: usize,
+        key_row: &[f32],
+        value_row: &[f32],
+    ) {
+        let head_dim = self.plan.head_dim;
+        debug_assert_eq!(key_row.len(), head_dim);
+        debug_assert_eq!(value_row.len(), head_dim);
+        let dst = self.offset(layer_idx, position, kv_head);
+        match self.dtype {
+            KvDtype::F32 => {
+                for (slot, &value) in self.keys[dst..dst + head_dim].iter_mut().zip(key_row) {
+                    *slot = super::kv_f16::f16_to_f32_kv(super::kv_f16::f32_to_f16_kv(value));
+                }
+                for (slot, &value) in self.values[dst..dst + head_dim].iter_mut().zip(value_row) {
+                    *slot = super::kv_f16::f16_to_f32_kv(super::kv_f16::f32_to_f16_kv(value));
+                }
+            }
+            KvDtype::F16 => {
+                super::kv_f16::convert_f32_slice_to_f16(
+                    key_row,
+                    &mut self.keys_f16[dst..dst + head_dim],
+                );
+                super::kv_f16::convert_f32_slice_to_f16(
+                    value_row,
+                    &mut self.values_f16[dst..dst + head_dim],
+                );
+            }
+        }
+    }
+
+    /// Copy one key row out as f32, whichever dtype backs it. Cold paths
+    /// only (diagnostics, GPU seeding) — the decode hot path reads the
+    /// buffers directly through the layout accessors.
+    pub(super) fn copy_key_row_into(
+        &self,
+        layer_idx: usize,
+        position: usize,
+        kv_head: usize,
+        out: &mut [f32],
+    ) {
+        let head_dim = self.plan.head_dim;
+        debug_assert_eq!(out.len(), head_dim);
+        let src = self.offset(layer_idx, position, kv_head);
+        match self.dtype {
+            KvDtype::F32 => out.copy_from_slice(&self.keys[src..src + head_dim]),
+            KvDtype::F16 => {
+                for (slot, &bits) in out.iter_mut().zip(&self.keys_f16[src..src + head_dim]) {
+                    *slot = super::kv_f16::f16_to_f32_kv(bits);
+                }
+            }
+        }
+    }
+
+    /// Copy one value row out as f32; see [`Self::copy_key_row_into`].
+    pub(super) fn copy_value_row_into(
+        &self,
+        layer_idx: usize,
+        position: usize,
+        kv_head: usize,
+        out: &mut [f32],
+    ) {
+        let head_dim = self.plan.head_dim;
+        debug_assert_eq!(out.len(), head_dim);
+        let src = self.offset(layer_idx, position, kv_head);
+        match self.dtype {
+            KvDtype::F32 => out.copy_from_slice(&self.values[src..src + head_dim]),
+            KvDtype::F16 => {
+                for (slot, &bits) in out.iter_mut().zip(&self.values_f16[src..src + head_dim]) {
+                    *slot = super::kv_f16::f16_to_f32_kv(bits);
+                }
+            }
+        }
     }
 }
 

--- a/src/inference/kv_cache.rs
+++ b/src/inference/kv_cache.rs
@@ -74,6 +74,8 @@ pub struct LlamaKvCachePositionTrace {
 #[derive(Debug, Clone)]
 pub struct LlamaKvCache {
     pub plan: LlamaKvCachePlan,
+    /// Physical K/V arrangement; see [`KvLayout`]. Fixed at construction.
+    pub layout: KvLayout,
     pub keys: Vec<f32>,
     pub values: Vec<f32>,
     pub allocated_sequence_length: usize,
@@ -91,6 +93,7 @@ impl PartialEq for LlamaKvCache {
         // Cache STATE only. `kv_budget_bytes` is host-derived operational config and
         // must not affect equality (the session PartialEq compares caches across runs).
         self.plan == other.plan
+            && self.layout == other.layout
             && self.keys == other.keys
             && self.values == other.values
             && self.allocated_sequence_length == other.allocated_sequence_length
@@ -98,10 +101,52 @@ impl PartialEq for LlamaKvCache {
     }
 }
 
+/// Physical arrangement of the K/V buffers. Chosen ONCE at cache
+/// construction (`BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR`, default off) and
+/// carried on the cache; every element address goes through the layout-aware
+/// accessors below, so the choice never appears in hot loops as more than a
+/// resolved stride. Values and arithmetic are identical in both layouts —
+/// only addresses differ — so the head-major lane carries a bitwise-identity
+/// contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KvLayout {
+    /// `[position, layer, kv_head, head_dim]` — the historical layout; one
+    /// token's row is contiguous, one head's positions sit a full token
+    /// stride apart.
+    PositionMajor,
+    /// `[layer, kv_head, position, head_dim]` — each head's K/V is one
+    /// contiguous stream over positions (stride = `allocated_sequence_length
+    /// * head_dim`, re-laid-out on growth); decode reads become sequential.
+    HeadMajor,
+}
+
+/// Env gate for the head-major layout, read once per cache construction.
+/// Windows-first per the standing directive; the mechanism is arch-agnostic
+/// and lifting the gate is a one-line decision.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+fn kv_layout_head_major_enabled() -> bool {
+    super::q8_runtime::q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR")
+}
+
 impl LlamaKvCache {
     pub fn new(plan: LlamaKvCachePlan) -> Result<Self> {
+        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        let layout = if kv_layout_head_major_enabled() {
+            KvLayout::HeadMajor
+        } else {
+            KvLayout::PositionMajor
+        };
+        #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+        let layout = KvLayout::PositionMajor;
+        Self::new_with_layout(plan, layout)
+    }
+
+    /// Explicit-layout constructor so the bitwise-identity tests can build
+    /// both layouts without touching process env.
+    pub fn new_with_layout(plan: LlamaKvCachePlan, layout: KvLayout) -> Result<Self> {
         Ok(Self {
             plan,
+            layout,
             keys: Vec::new(),
             values: Vec::new(),
             allocated_sequence_length: 0,
@@ -115,10 +160,10 @@ impl LlamaKvCache {
     }
 
     /// Roll the cache back to an earlier `position`, discarding newer
-    /// entries. Storage is position-major and `position` alone bounds what
-    /// attention reads, so entries past the rollback point are dead until
-    /// overwritten by later appends — no buffer work is needed. Used by
-    /// speculative decoding to drop rejected draft tokens.
+    /// entries. In both layouts `position` alone bounds what attention
+    /// reads, so entries past the rollback point are dead until overwritten
+    /// by later appends — no buffer work is needed. Used by speculative
+    /// decoding to drop rejected draft tokens.
     pub fn rollback_to_position(&mut self, position: usize) -> Result<()> {
         if position > self.position {
             return Err(BackendError::RuntimeShapeMismatch(format!(
@@ -167,8 +212,37 @@ impl LlamaKvCache {
             .ok_or_else(|| {
                 BackendError::RuntimeShapeMismatch("KV cache element count overflow".to_string())
             })?;
-        self.keys.resize(values, 0.0);
-        self.values.resize(values, 0.0);
+        match self.layout {
+            KvLayout::PositionMajor => {
+                // Positions are outermost, so growth is a pure append.
+                self.keys.resize(values, 0.0);
+                self.values.resize(values, 0.0);
+            }
+            KvLayout::HeadMajor => {
+                // Each head's stream stride is the allocated capacity, so
+                // growth re-lays the buffer: copy every (layer, head) block
+                // to its new base. Pure permutation of identical bits —
+                // bitwise-neutral — amortized over the growth chunking.
+                let head_dim = self.plan.head_dim;
+                let old_len = self.allocated_sequence_length * head_dim;
+                let streams = self.plan.layer_count * self.plan.kv_head_count;
+                let new_len = target_sequence_length * head_dim;
+                let mut new_keys = vec![0.0f32; values];
+                let mut new_values = vec![0.0f32; values];
+                if old_len > 0 {
+                    for stream in 0..streams {
+                        let old_base = stream * old_len;
+                        let new_base = stream * new_len;
+                        new_keys[new_base..new_base + old_len]
+                            .copy_from_slice(&self.keys[old_base..old_base + old_len]);
+                        new_values[new_base..new_base + old_len]
+                            .copy_from_slice(&self.values[old_base..old_base + old_len]);
+                    }
+                }
+                self.keys = new_keys;
+                self.values = new_values;
+            }
+        }
         self.allocated_sequence_length = target_sequence_length;
         Ok(())
     }
@@ -193,14 +267,38 @@ impl LlamaKvCache {
     }
 
     pub(super) fn offset(&self, layer_idx: usize, position: usize, kv_head: usize) -> usize {
-        (((position * self.plan.layer_count) + layer_idx) * self.plan.kv_head_count + kv_head)
-            * self.plan.head_dim
+        match self.layout {
+            KvLayout::PositionMajor => {
+                (((position * self.plan.layer_count) + layer_idx) * self.plan.kv_head_count
+                    + kv_head)
+                    * self.plan.head_dim
+            }
+            KvLayout::HeadMajor => {
+                (((layer_idx * self.plan.kv_head_count) + kv_head)
+                    * self.allocated_sequence_length
+                    + position)
+                    * self.plan.head_dim
+            }
+        }
     }
 
     pub(super) fn head_base_offset(&self, layer_idx: usize, kv_head: usize) -> usize {
-        ((layer_idx * self.plan.kv_head_count) + kv_head) * self.plan.head_dim
+        self.offset(layer_idx, 0, kv_head)
     }
 
+    /// Element step between one head's consecutive positions — the stride the
+    /// per-head attention walks take. A full token stride in position-major,
+    /// `head_dim` (contiguous) in head-major.
+    pub(super) fn head_position_stride(&self) -> usize {
+        match self.layout {
+            KvLayout::PositionMajor => self.position_stride(),
+            KvLayout::HeadMajor => self.plan.head_dim,
+        }
+    }
+
+    /// Elements ONE TOKEN occupies per buffer across all layers/heads —
+    /// layout-independent count used for capacity and budget math, NOT an
+    /// address stride (use [`Self::head_position_stride`] for walks).
     pub(super) fn position_stride(&self) -> usize {
         self.plan.layer_count * self.plan.kv_head_count * self.plan.head_dim
     }

--- a/src/inference/kv_cache.rs
+++ b/src/inference/kv_cache.rs
@@ -274,8 +274,7 @@ impl LlamaKvCache {
                     * self.plan.head_dim
             }
             KvLayout::HeadMajor => {
-                (((layer_idx * self.plan.kv_head_count) + kv_head)
-                    * self.allocated_sequence_length
+                (((layer_idx * self.plan.kv_head_count) + kv_head) * self.allocated_sequence_length
                     + position)
                     * self.plan.head_dim
             }

--- a/src/inference/kv_f16.rs
+++ b/src/inference/kv_f16.rs
@@ -1,0 +1,343 @@
+//! Canonical f32<->f16 (IEEE binary16) conversions for the KV f16 storage
+//! lane (`BACKENDINFERENCE_KV_F16`).
+//!
+//! Load-bearing discovery (2026-07-01): the CPU KV write path ALREADY rounds
+//! every stored key/value through f16 unconditionally
+//! (`copy_to_f16_kv_cache_storage` = `f16_bits_to_f32(f32_to_f16_bits(x))`
+//! in both `write_kv_cache` and `write_kv_cache_batch`), so main's f32
+//! buffers hold exactly-f16-representable values at 2x the bytes. The f16
+//! storage lane therefore introduces ZERO new rounding: storing
+//! `f32_to_f16_bits(x)` as u16 and expanding with `f16_bits_to_f32` on read
+//! reproduces today's buffer values bit-for-bit, upgrading this lane to the
+//! bitwise-identity contract.
+//!
+//! Canonical semantics are consequently pinned to the EXISTING helpers
+//! (round-to-nearest-even; overflow to ±inf incl. the 65520 tie; RNE
+//! subnormals; every NaN canonicalized to sign|0x7E00), NOT to raw F16C: the
+//! F16C fast paths below must match the existing scalar semantics bitwise on
+//! every input, which requires a NaN fixup after `vcvtps2ph` (hardware
+//! preserves truncated NaN payloads; the canonical form does not). The
+//! f16->f32 direction is exact and `vcvtph2ps` already matches the scalar
+//! helper on all 2^16 inputs, NaN payloads included. All enforced by the
+//! exhaustive + randomized property tests below.
+//!
+//! All arithmetic in the attention kernels stays f32; these conversions are
+//! the only place the dtype changes, applied at KV store and fused into the
+//! blocked kernels at read (see `attn_f32_dot`).
+
+/// Reference f32 -> f16: RNE, NaN -> sign|0x7E00. Semantically identical to
+/// `crate::inference::f32_to_f16_bits` (locked by test) — duplicated here so
+/// the KV lane's canonical conversion is self-contained and cannot drift if
+/// the Metal/GPU helper ever changes.
+pub(super) fn f32_to_f16_kv(value: f32) -> u16 {
+    let bits = value.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let exp = ((bits >> 23) & 0xff) as i32;
+    let mant = bits & 0x007f_ffff;
+
+    if exp == 0xff {
+        return sign | if mant == 0 { 0x7c00 } else { 0x7e00 };
+    }
+    let half_exp = exp - 127 + 15;
+    if half_exp >= 0x1f {
+        return sign | 0x7c00;
+    }
+    if half_exp <= 0 {
+        if half_exp < -10 {
+            return sign;
+        }
+        let mantissa = mant | 0x0080_0000;
+        let shift = 14 - half_exp;
+        let mut half_mant = (mantissa >> shift) as u16;
+        let round_bit = 1_u32 << (shift - 1);
+        if (mantissa & round_bit) != 0
+            && ((mantissa & (round_bit - 1)) != 0 || (half_mant & 1) != 0)
+        {
+            half_mant = half_mant.wrapping_add(1);
+        }
+        return sign | half_mant;
+    }
+
+    let mut half = sign | ((half_exp as u16) << 10) | ((mant >> 13) as u16);
+    if (mant & 0x0000_1000) != 0 && ((mant & 0x0000_0fff) != 0 || (half & 1) != 0) {
+        half = half.wrapping_add(1);
+    }
+    half
+}
+
+/// Reference f16 -> f32 (exact), bitwise-equal to `vcvtph2ps`.
+pub(super) fn f16_to_f32_kv(bits: u16) -> f32 {
+    let sign = (u32::from(bits & 0x8000)) << 16;
+    let exp = (bits & 0x7c00) >> 10;
+    let frac = u32::from(bits & 0x03ff);
+    let out = match exp {
+        0 => {
+            if frac == 0 {
+                sign
+            } else {
+                let mut mant = frac;
+                let mut e = -14_i32;
+                while (mant & 0x0400) == 0 {
+                    mant <<= 1;
+                    e -= 1;
+                }
+                mant &= 0x03ff;
+                let exp32 = (e + 127) as u32;
+                sign | (exp32 << 23) | (mant << 13)
+            }
+        }
+        0x1f => sign | 0x7f80_0000 | (frac << 13),
+        _ => {
+            let exp32 = u32::from(exp) + (127 - 15);
+            sign | (exp32 << 23) | (frac << 13)
+        }
+    };
+    f32::from_bits(out)
+}
+
+/// Convert a full f32 slice into f16 storage, F16C-accelerated where the CPU
+/// has it. Both paths produce identical bits (property-tested).
+// Consumed by the flag-gated KV f16 storage integration; until that wiring
+// lands only the tests exercise it.
+#[allow(dead_code)]
+pub(super) fn convert_f32_slice_to_f16(source: &[f32], dest: &mut [u16]) {
+    debug_assert_eq!(source.len(), dest.len());
+    #[cfg(target_arch = "x86_64")]
+    if f16c_available() {
+        // SAFETY: guarded by the runtime F16C/AVX feature check.
+        unsafe { convert_f32_slice_to_f16_f16c(source, dest) };
+        return;
+    }
+    for (d, s) in dest.iter_mut().zip(source) {
+        *d = f32_to_f16_kv(*s);
+    }
+}
+
+/// Runtime gate for the F16C fast paths, resolved once.
+#[cfg(target_arch = "x86_64")]
+pub(super) fn f16c_available() -> bool {
+    static AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        std::arch::is_x86_feature_detected!("f16c") && std::arch::is_x86_feature_detected!("avx")
+    })
+}
+
+/// F16C bulk f32 -> f16 (RNE). Bitwise-equal to the scalar reference,
+/// including the canonical-NaN semantics: hardware `vcvtps2ph` preserves
+/// truncated NaN payloads, so NaN lanes (detected via unordered compare,
+/// branch taken only when present) are re-converted through the reference.
+///
+/// # Safety
+/// Caller must ensure F16C and AVX are available on the running CPU.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx,f16c")]
+unsafe fn convert_f32_slice_to_f16_f16c(source: &[f32], dest: &mut [u16]) {
+    use std::arch::x86_64::{
+        _mm256_cmp_ps, _mm256_loadu_ps, _mm256_movemask_ps, _mm_storeu_si128,
+        _CMP_UNORD_Q, _MM_FROUND_TO_NEAREST_INT, __m128i, _mm256_cvtps_ph,
+    };
+    let len = source.len();
+    let mut i = 0;
+    while i + 8 <= len {
+        // SAFETY: the loop guard keeps every 8-lane load/store in bounds.
+        unsafe {
+            let wide = _mm256_loadu_ps(source.as_ptr().add(i));
+            let half = _mm256_cvtps_ph::<_MM_FROUND_TO_NEAREST_INT>(wide);
+            _mm_storeu_si128(dest.as_mut_ptr().add(i) as *mut __m128i, half);
+            let nan_lanes = _mm256_movemask_ps(_mm256_cmp_ps::<_CMP_UNORD_Q>(wide, wide));
+            if nan_lanes != 0 {
+                for lane in 0..8 {
+                    if nan_lanes & (1 << lane) != 0 {
+                        dest[i + lane] = f32_to_f16_kv(source[i + lane]);
+                    }
+                }
+            }
+        }
+        i += 8;
+    }
+    while i < len {
+        dest[i] = f32_to_f16_kv(source[i]);
+        i += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_arch = "x86_64")]
+    fn hardware_f16_to_f32(bits: u16) -> f32 {
+        use std::arch::x86_64::{_mm256_cvtph_ps, _mm256_storeu_ps, _mm_set1_epi16};
+        assert!(f16c_available(), "test requires F16C");
+        let mut out = [0.0f32; 8];
+        // SAFETY: guarded by the f16c_available assertion above.
+        unsafe {
+            let half = _mm_set1_epi16(bits as i16);
+            let wide = _mm256_cvtph_ps(half);
+            _mm256_storeu_ps(out.as_mut_ptr(), wide);
+        }
+        out[0]
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn hardware_f32_to_f16(value: f32) -> u16 {
+        use std::arch::x86_64::{
+            _mm256_set1_ps, _mm_storeu_si128, _MM_FROUND_TO_NEAREST_INT, __m128i, _mm256_cvtps_ph,
+        };
+        assert!(f16c_available(), "test requires F16C");
+        let mut out = [0u16; 8];
+        // SAFETY: guarded by the f16c_available assertion above.
+        unsafe {
+            let wide = _mm256_set1_ps(value);
+            let half = _mm256_cvtps_ph::<_MM_FROUND_TO_NEAREST_INT>(wide);
+            _mm_storeu_si128(out.as_mut_ptr() as *mut __m128i, half);
+        }
+        out[0]
+    }
+
+    /// Exhaustive: every one of the 2^16 f16 bit patterns converts to f32
+    /// bitwise-equal to hardware AND to the repo's existing helper, and
+    /// round-trips back to itself (non-NaN) or to the canonical NaN.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn f16_to_f32_matches_hardware_exhaustively_and_round_trips() {
+        if !f16c_available() {
+            eprintln!("skipping: F16C not available on this host");
+            return;
+        }
+        for bits in 0..=u16::MAX {
+            let reference = f16_to_f32_kv(bits);
+            let hardware = hardware_f16_to_f32(bits);
+            assert_eq!(
+                reference.to_bits(),
+                hardware.to_bits(),
+                "f16->f32 mismatch at bits {bits:#06x}: ref {reference}, hw {hardware}"
+            );
+            assert_eq!(
+                reference.to_bits(),
+                crate::inference::f16_bits_to_f32(bits).to_bits(),
+                "f16->f32 drifted from the existing helper at bits {bits:#06x}"
+            );
+            let round_trip = f32_to_f16_kv(reference);
+            let is_nan = (bits & 0x7c00) == 0x7c00 && (bits & 0x03ff) != 0;
+            if is_nan {
+                assert_eq!(
+                    round_trip,
+                    (bits & 0x8000) | 0x7e00,
+                    "NaN canonicalization failed at bits {bits:#06x}"
+                );
+            } else {
+                assert_eq!(
+                    round_trip, bits,
+                    "round-trip failed at bits {bits:#06x} (got {round_trip:#06x})"
+                );
+            }
+        }
+    }
+
+    /// >=1M randomized f32 inputs across all magnitude classes, plus targeted
+    /// edge sets (subnormal f32/f16 territory, overflow boundary, rounding
+    /// ties, ±inf, NaN payloads): f32->f16 bitwise-equal to hardware RNE.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn f32_to_f16_matches_hardware_randomized_and_edges() {
+        if !f16c_available() {
+            eprintln!("skipping: F16C not available on this host");
+            return;
+        }
+        let mut check = |value: f32| {
+            let reference = f32_to_f16_kv(value);
+            // Semantic lock to main: the KV canonical conversion must equal
+            // the existing helper (whose output today's f32 buffers hold) on
+            // EVERY input, NaN included.
+            assert_eq!(
+                reference,
+                crate::inference::f32_to_f16_bits(value),
+                "f32->f16 drifted from the existing helper at {:#010x}",
+                value.to_bits()
+            );
+            if value.is_nan() {
+                // Canonical NaN by definition; hardware preserves payloads
+                // instead, so the fast path carries a NaN fixup (covered by
+                // bulk_conversion_matches_reference).
+                assert_eq!(reference, ((value.to_bits() >> 16) as u16 & 0x8000) | 0x7e00);
+                return;
+            }
+            let hardware = hardware_f32_to_f16(value);
+            assert_eq!(
+                reference, hardware,
+                "f32->f16 mismatch at {value} ({:#010x}): ref {reference:#06x}, hw {hardware:#06x}",
+                value.to_bits()
+            );
+        };
+
+        // Targeted edges.
+        for value in [
+            0.0f32,
+            -0.0,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::NAN,
+            f32::from_bits(0x7f80_0001), // signalling NaN, minimal payload
+            f32::from_bits(0xffc0_1234), // negative quiet NaN with payload
+            f32::from_bits(0x7fbf_ffff), // max-payload signalling NaN
+            65504.0,                     // f16 max finite
+            65519.999,
+            65520.0, // tie: rounds to inf
+            65536.0,
+            6.1035156e-5,  // f16 min normal
+            6.0975552e-5,  // largest f16 subnormal
+            5.9604645e-8,  // f16 min subnormal
+            2.9802322e-8,  // half the min subnormal (tie to zero)
+            2.9802326e-8,  // just above the tie
+            f32::MIN_POSITIVE,
+            f32::from_bits(1), // min f32 subnormal
+        ] {
+            check(value);
+        }
+        // Every exponent x a few mantissa patterns, both signs.
+        for exp in 0..=0xffu32 {
+            for mant in [0u32, 1, 0x1000, 0x0fff, 0x1fff, 0x2000, 0x7f_ffff] {
+                for sign in [0u32, 0x8000_0000] {
+                    check(f32::from_bits(sign | (exp << 23) | mant));
+                }
+            }
+        }
+        // Randomized sweep.
+        let mut state = 0x5eed_f16c_0001u64;
+        let mut next = move || {
+            state ^= state >> 12;
+            state ^= state << 25;
+            state ^= state >> 27;
+            state.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        };
+        for _ in 0..1_200_000 {
+            check(f32::from_bits(next() as u32));
+        }
+    }
+
+    /// Bulk conversion (F16C path incl. the scalar tail) matches the scalar
+    /// reference element-wise.
+    #[test]
+    fn bulk_conversion_matches_reference() {
+        let mut state = 0xb01d_f16c_0002u64;
+        let mut next = move || {
+            state ^= state >> 12;
+            state ^= state << 25;
+            state ^= state >> 27;
+            state.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        };
+        for len in [1usize, 7, 8, 9, 64, 127, 128, 1000] {
+            let source: Vec<f32> = (0..len).map(|_| f32::from_bits(next() as u32)).collect();
+            let mut dest = vec![0u16; len];
+            convert_f32_slice_to_f16(&source, &mut dest);
+            for (i, (s, d)) in source.iter().zip(&dest).enumerate() {
+                assert_eq!(
+                    *d,
+                    f32_to_f16_kv(*s),
+                    "bulk mismatch at len {len} index {i}"
+                );
+            }
+        }
+    }
+}

--- a/src/inference/kv_f16.rs
+++ b/src/inference/kv_f16.rs
@@ -112,9 +112,6 @@ pub(super) fn f16_to_f32_kv(bits: u16) -> f32 {
 
 /// Convert a full f32 slice into f16 storage, F16C-accelerated where the CPU
 /// has it. Both paths produce identical bits (property-tested).
-// Consumed by the flag-gated KV f16 storage integration; until that wiring
-// lands only the tests exercise it.
-#[allow(dead_code)]
 pub(super) fn convert_f32_slice_to_f16(source: &[f32], dest: &mut [u16]) {
     debug_assert_eq!(source.len(), dest.len());
     #[cfg(target_arch = "x86_64")]

--- a/src/inference/kv_f16.rs
+++ b/src/inference/kv_f16.rs
@@ -11,14 +11,15 @@
 //! reproduces today's buffer values bit-for-bit, upgrading this lane to the
 //! bitwise-identity contract.
 //!
-//! Canonical semantics are consequently pinned to the EXISTING helpers
+//! Canonical STORE semantics are consequently pinned to the EXISTING helper
 //! (round-to-nearest-even; overflow to ±inf incl. the 65520 tie; RNE
 //! subnormals; every NaN canonicalized to sign|0x7E00), NOT to raw F16C: the
-//! F16C fast paths below must match the existing scalar semantics bitwise on
-//! every input, which requires a NaN fixup after `vcvtps2ph` (hardware
-//! preserves truncated NaN payloads; the canonical form does not). The
-//! f16->f32 direction is exact and `vcvtph2ps` already matches the scalar
-//! helper on all 2^16 inputs, NaN payloads included. All enforced by the
+//! F16C write fast path must match that bitwise on every input, which
+//! requires a NaN fixup after `vcvtps2ph` (hardware preserves truncated NaN
+//! payloads; the canonical form does not). The READ direction is exact and
+//! pinned to `vcvtph2ps` on the full 2^16 domain; it differs from the repo's
+//! `f16_bits_to_f32` only on signalling-NaN inputs (hardware quiets them),
+//! which the canonical store makes unreachable. All enforced by the
 //! exhaustive + randomized property tests below.
 //!
 //! All arithmetic in the attention kernels stays f32; these conversions are
@@ -65,7 +66,14 @@ pub(super) fn f32_to_f16_kv(value: f32) -> u16 {
     half
 }
 
-/// Reference f16 -> f32 (exact), bitwise-equal to `vcvtph2ps`.
+/// Reference f16 -> f32 (exact), bitwise-equal to `vcvtph2ps` on the FULL
+/// 2^16 domain — including quieting signalling NaNs (hardware sets the f32
+/// quiet bit; payload otherwise preserved). This is the one place the read
+/// direction differs from the repo's `f16_bits_to_f32`, which passes sNaN
+/// through un-quieted: the delta is UNREACHABLE from the KV lane, because
+/// the pinned store conversion canonicalizes every NaN to sign|0x7E00 (a
+/// quiet NaN) before anything lands in the cache — locked by the tests
+/// below.
 pub(super) fn f16_to_f32_kv(bits: u16) -> f32 {
     let sign = (u32::from(bits & 0x8000)) << 16;
     let exp = (bits & 0x7c00) >> 10;
@@ -86,7 +94,14 @@ pub(super) fn f16_to_f32_kv(bits: u16) -> f32 {
                 sign | (exp32 << 23) | (mant << 13)
             }
         }
-        0x1f => sign | 0x7f80_0000 | (frac << 13),
+        0x1f => {
+            if frac == 0 {
+                sign | 0x7f80_0000
+            } else {
+                // NaN: quiet bit forced, payload preserved — vcvtph2ps.
+                sign | 0x7f80_0000 | 0x0040_0000 | (frac << 13)
+            }
+        }
         _ => {
             let exp32 = u32::from(exp) + (127 - 15);
             sign | (exp32 << 23) | (frac << 13)
@@ -133,8 +148,8 @@ pub(super) fn f16c_available() -> bool {
 #[target_feature(enable = "avx,f16c")]
 unsafe fn convert_f32_slice_to_f16_f16c(source: &[f32], dest: &mut [u16]) {
     use std::arch::x86_64::{
-        _mm256_cmp_ps, _mm256_loadu_ps, _mm256_movemask_ps, _mm_storeu_si128,
-        _CMP_UNORD_Q, _MM_FROUND_TO_NEAREST_INT, __m128i, _mm256_cvtps_ph,
+        __m128i, _mm256_cmp_ps, _mm256_cvtps_ph, _mm256_loadu_ps, _mm256_movemask_ps,
+        _mm_storeu_si128, _CMP_UNORD_Q, _MM_FROUND_TO_NEAREST_INT,
     };
     let len = source.len();
     let mut i = 0;
@@ -182,7 +197,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     fn hardware_f32_to_f16(value: f32) -> u16 {
         use std::arch::x86_64::{
-            _mm256_set1_ps, _mm_storeu_si128, _MM_FROUND_TO_NEAREST_INT, __m128i, _mm256_cvtps_ph,
+            __m128i, _mm256_cvtps_ph, _mm256_set1_ps, _mm_storeu_si128, _MM_FROUND_TO_NEAREST_INT,
         };
         assert!(f16c_available(), "test requires F16C");
         let mut out = [0u16; 8];
@@ -213,11 +228,24 @@ mod tests {
                 hardware.to_bits(),
                 "f16->f32 mismatch at bits {bits:#06x}: ref {reference}, hw {hardware}"
             );
-            assert_eq!(
-                reference.to_bits(),
-                crate::inference::f16_bits_to_f32(bits).to_bits(),
-                "f16->f32 drifted from the existing helper at bits {bits:#06x}"
-            );
+            let is_snan = (bits & 0x7c00) == 0x7c00 && (bits & 0x03ff) != 0 && (bits & 0x0200) == 0;
+            if is_snan {
+                // Documented delta: the existing helper passes sNaN through
+                // un-quieted; hardware (and this reference) quiets it. sNaN
+                // cannot reach the cache — the store conversion below
+                // canonicalizes every NaN to a quiet 0x7E00.
+                assert_eq!(
+                    reference.to_bits(),
+                    crate::inference::f16_bits_to_f32(bits).to_bits() | 0x0040_0000,
+                    "sNaN quieting delta changed shape at bits {bits:#06x}"
+                );
+            } else {
+                assert_eq!(
+                    reference.to_bits(),
+                    crate::inference::f16_bits_to_f32(bits).to_bits(),
+                    "f16->f32 drifted from the existing helper at bits {bits:#06x}"
+                );
+            }
             let round_trip = f32_to_f16_kv(reference);
             let is_nan = (bits & 0x7c00) == 0x7c00 && (bits & 0x03ff) != 0;
             if is_nan {
@@ -235,9 +263,10 @@ mod tests {
         }
     }
 
-    /// >=1M randomized f32 inputs across all magnitude classes, plus targeted
-    /// edge sets (subnormal f32/f16 territory, overflow boundary, rounding
-    /// ties, ±inf, NaN payloads): f32->f16 bitwise-equal to hardware RNE.
+    /// At least 1.2M randomized f32 inputs across all magnitude classes,
+    /// plus targeted edge sets (subnormal f32/f16 territory, overflow
+    /// boundary, rounding ties, ±inf, NaN payloads): f32->f16 bitwise-equal
+    /// to hardware RNE (non-NaN) and to the canonical-NaN form (NaN).
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn f32_to_f16_matches_hardware_randomized_and_edges() {
@@ -245,7 +274,7 @@ mod tests {
             eprintln!("skipping: F16C not available on this host");
             return;
         }
-        let mut check = |value: f32| {
+        let check = |value: f32| {
             let reference = f32_to_f16_kv(value);
             // Semantic lock to main: the KV canonical conversion must equal
             // the existing helper (whose output today's f32 buffers hold) on
@@ -260,12 +289,16 @@ mod tests {
                 // Canonical NaN by definition; hardware preserves payloads
                 // instead, so the fast path carries a NaN fixup (covered by
                 // bulk_conversion_matches_reference).
-                assert_eq!(reference, ((value.to_bits() >> 16) as u16 & 0x8000) | 0x7e00);
+                assert_eq!(
+                    reference,
+                    ((value.to_bits() >> 16) as u16 & 0x8000) | 0x7e00
+                );
                 return;
             }
             let hardware = hardware_f32_to_f16(value);
             assert_eq!(
-                reference, hardware,
+                reference,
+                hardware,
                 "f32->f16 mismatch at {value} ({:#010x}): ref {reference:#06x}, hw {hardware:#06x}",
                 value.to_bits()
             );
@@ -285,11 +318,11 @@ mod tests {
             65519.999,
             65520.0, // tie: rounds to inf
             65536.0,
-            6.1035156e-5,  // f16 min normal
-            6.0975552e-5,  // largest f16 subnormal
-            5.9604645e-8,  // f16 min subnormal
-            2.9802322e-8,  // half the min subnormal (tie to zero)
-            2.9802326e-8,  // just above the tie
+            6.1035156e-5, // f16 min normal
+            6.097555e-5,  // largest f16 subnormal
+            5.9604645e-8, // f16 min subnormal
+            2.9802322e-8, // half the min subnormal (tie to zero)
+            2.9802326e-8, // just above the tie
             f32::MIN_POSITIVE,
             f32::from_bits(1), // min f32 subnormal
         ] {

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -11684,6 +11684,8 @@ fn decode_attention_parallel_lane_is_bitwise_identical_to_serial() {
 }
 
 /// Item 3 Lane A bitwise lock: the head-major KV layout is address math only.
+/// (KV content magnitudes cap below the f16 finite max — the real write path
+/// f16-rounds every stored element, on main too, and inf KV rejects softmax.)
 /// For every GQA shape, head_dim, and position count: build one cache per
 /// layout, drive them through the REAL write paths (write_kv_cache /
 /// write_kv_cache_batch) including growth re-layout (positions > the 256
@@ -11711,7 +11713,11 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
                 1 => unit * 1e-12,
                 2..=4 => unit * 2.0,
                 5 => unit * 1e4,
-                _ => unit * 1e12,
+                // Cap below the f16 finite max (65504): the REAL write path
+                // rounds every stored element through f16, so bigger inputs
+                // become ±inf in the cache (true on main too) and inf KV
+                // makes softmax reject the row.
+                _ => unit * 6e4,
             }
         }
         fn fill(&mut self, len: usize) -> Vec<f32> {
@@ -11737,186 +11743,192 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
 
     let mismatches: usize = points
         .par_iter()
-        .map(|&(attention_heads, kv_heads, head_dim, position_count, case)| {
-            let mut rng = XorShift64Star(
-                0x1a1e_0001
-                    ^ ((attention_heads as u64) << 48)
-                    ^ ((kv_heads as u64) << 40)
-                    ^ ((head_dim as u64) << 24)
-                    ^ ((position_count as u64) << 8)
-                    ^ case,
-            );
-            let width = kv_heads * head_dim;
-            let plan = || LlamaKvCachePlan {
-                // max_sequence_length >= 512 engages the 256-position grow
-                // chunking, so deep points exercise the head-major
-                // re-layout-on-growth path.
-                max_sequence_length: position_count.max(512),
-                layer_count: 2,
-                kv_head_count: kv_heads,
-                head_dim,
-                key_shape: vec![2, position_count.max(512), kv_heads, head_dim],
-                value_shape: vec![2, position_count.max(512), kv_heads, head_dim],
-            };
-            let mut pm =
-                LlamaKvCache::new_with_layout(plan(), KvLayout::PositionMajor).expect("pm cache");
-            let mut hm =
-                LlamaKvCache::new_with_layout(plan(), KvLayout::HeadMajor).expect("hm cache");
+        .map(
+            |&(attention_heads, kv_heads, head_dim, position_count, case)| {
+                let mut rng = XorShift64Star(
+                    0x1a1e_0001
+                        ^ ((attention_heads as u64) << 48)
+                        ^ ((kv_heads as u64) << 40)
+                        ^ ((head_dim as u64) << 24)
+                        ^ ((position_count as u64) << 8)
+                        ^ case,
+                );
+                let width = kv_heads * head_dim;
+                let plan = || LlamaKvCachePlan {
+                    // max_sequence_length >= 512 engages the 256-position grow
+                    // chunking, so deep points exercise the head-major
+                    // re-layout-on-growth path.
+                    max_sequence_length: position_count.max(512),
+                    layer_count: 2,
+                    kv_head_count: kv_heads,
+                    head_dim,
+                    key_shape: vec![2, position_count.max(512), kv_heads, head_dim],
+                    value_shape: vec![2, position_count.max(512), kv_heads, head_dim],
+                };
+                let mut pm = LlamaKvCache::new_with_layout(plan(), KvLayout::PositionMajor)
+                    .expect("pm cache");
+                let mut hm =
+                    LlamaKvCache::new_with_layout(plan(), KvLayout::HeadMajor).expect("hm cache");
 
-            // Phase A: append `position_count` tokens through the real
-            // single-token write path on layer 0 and the batch path on
-            // layer 1 (same data), on BOTH caches.
-            let mut token_rows = Vec::with_capacity(position_count);
-            for _ in 0..position_count {
-                token_rows.push((rng.fill(width), rng.fill(width)));
-            }
-            for (p, (k_row, v_row)) in token_rows.iter().enumerate() {
-                let k = CpuTensor::from_f32("k", vec![1, width], k_row.clone()).unwrap();
-                let v = CpuTensor::from_f32("v", vec![1, width], v_row.clone()).unwrap();
-                for cache in [&mut pm, &mut hm] {
-                    cache.position = p;
-                    write_kv_cache(cache, 0, &k, &v).expect("write layer0");
+                // Phase A: append `position_count` tokens through the real
+                // single-token write path on layer 0 and the batch path on
+                // layer 1 (same data), on BOTH caches.
+                let mut token_rows = Vec::with_capacity(position_count);
+                for _ in 0..position_count {
+                    token_rows.push((rng.fill(width), rng.fill(width)));
                 }
-            }
-            let flat_k: Vec<f32> = token_rows.iter().flat_map(|(k, _)| k.clone()).collect();
-            let flat_v: Vec<f32> = token_rows.iter().flat_map(|(_, v)| v.clone()).collect();
-            let bk = CpuTensor::from_f32("bk", vec![position_count, width], flat_k).unwrap();
-            let bv = CpuTensor::from_f32("bv", vec![position_count, width], flat_v).unwrap();
-            write_kv_cache_batch(&mut pm, 1, 0, &bk, &bv).expect("batch pm");
-            write_kv_cache_batch(&mut hm, 1, 0, &bk, &bv).expect("batch hm");
-            pm.position = position_count - 1;
-            hm.position = position_count - 1;
-
-            // Phase B: rollback to half depth and overwrite the tail with
-            // DIFFERENT data (spec-decode shape), through the real path.
-            if position_count >= 4 {
-                let half = position_count / 2;
-                pm.rollback_to_position(half).unwrap();
-                hm.rollback_to_position(half).unwrap();
-                for p in half..position_count {
-                    let k = CpuTensor::from_f32("k2", vec![1, width], rng.fill(width)).unwrap();
-                    let v = CpuTensor::from_f32("v2", vec![1, width], rng.fill(width)).unwrap();
+                for (p, (k_row, v_row)) in token_rows.iter().enumerate() {
+                    let k = CpuTensor::from_f32("k", vec![1, width], k_row.clone()).unwrap();
+                    let v = CpuTensor::from_f32("v", vec![1, width], v_row.clone()).unwrap();
                     for cache in [&mut pm, &mut hm] {
                         cache.position = p;
-                        write_kv_cache(cache, 0, &k, &v).expect("overwrite layer0");
+                        write_kv_cache(cache, 0, &k, &v).expect("write layer0");
                     }
                 }
+                let flat_k: Vec<f32> = token_rows.iter().flat_map(|(k, _)| k.clone()).collect();
+                let flat_v: Vec<f32> = token_rows.iter().flat_map(|(_, v)| v.clone()).collect();
+                let bk = CpuTensor::from_f32("bk", vec![position_count, width], flat_k).unwrap();
+                let bv = CpuTensor::from_f32("bv", vec![position_count, width], flat_v).unwrap();
+                write_kv_cache_batch(&mut pm, 1, 0, &bk, &bv).expect("batch pm");
+                write_kv_cache_batch(&mut hm, 1, 0, &bk, &bv).expect("batch hm");
                 pm.position = position_count - 1;
                 hm.position = position_count - 1;
-            }
 
-            // Phase C: CUDA mirror-back pattern (copy_resident_cuda_kv_to_host):
-            // raw offset-addressed per-(position, head) writes of f16-exact
-            // rows into layer 1 of both caches.
-            for p in 0..position_count.min(8) {
-                for h in 0..kv_heads {
-                    let row: Vec<f32> = (0..head_dim)
-                        .map(|_| f16_bits_to_f32(f32_to_f16_bits(rng.next_f32())))
-                        .collect();
-                    for cache in [&mut pm, &mut hm] {
-                        let dst = cache.offset(1, p, h);
-                        cache.keys[dst..dst + head_dim].copy_from_slice(&row);
-                        cache.values[dst..dst + head_dim].copy_from_slice(&row);
+                // Phase B: rollback to half depth and overwrite the tail with
+                // DIFFERENT data (spec-decode shape), through the real path.
+                if position_count >= 4 {
+                    let half = position_count / 2;
+                    pm.rollback_to_position(half).unwrap();
+                    hm.rollback_to_position(half).unwrap();
+                    for p in half..position_count {
+                        let k = CpuTensor::from_f32("k2", vec![1, width], rng.fill(width)).unwrap();
+                        let v = CpuTensor::from_f32("v2", vec![1, width], rng.fill(width)).unwrap();
+                        for cache in [&mut pm, &mut hm] {
+                            cache.position = p;
+                            write_kv_cache(cache, 0, &k, &v).expect("overwrite layer0");
+                        }
+                    }
+                    pm.position = position_count - 1;
+                    hm.position = position_count - 1;
+                }
+
+                // Phase C: CUDA mirror-back pattern (copy_resident_cuda_kv_to_host):
+                // raw offset-addressed per-(position, head) writes of f16-exact
+                // rows into layer 1 of both caches.
+                for p in 0..position_count.min(8) {
+                    for h in 0..kv_heads {
+                        let row: Vec<f32> = (0..head_dim)
+                            .map(|_| f16_bits_to_f32(f32_to_f16_bits(rng.next_f32())))
+                            .collect();
+                        for cache in [&mut pm, &mut hm] {
+                            let dst = cache.offset(1, p, h);
+                            cache.keys[dst..dst + head_dim].copy_from_slice(&row);
+                            cache.values[dst..dst + head_dim].copy_from_slice(&row);
+                        }
                     }
                 }
-            }
 
-            let mut mismatch = 0usize;
+                let mut mismatch = 0usize;
 
-            // (a) Logical buffer equality across layouts, every element.
-            for layer in 0..2 {
-                for p in 0..position_count {
-                    for h in 0..kv_heads {
-                        let po = pm.offset(layer, p, h);
-                        let ho = hm.offset(layer, p, h);
-                        for d in 0..head_dim {
-                            if pm.keys[po + d].to_bits() != hm.keys[ho + d].to_bits()
-                                || pm.values[po + d].to_bits() != hm.values[ho + d].to_bits()
-                            {
-                                mismatch += 1;
+                // (a) Logical buffer equality across layouts, every element.
+                for layer in 0..2 {
+                    for p in 0..position_count {
+                        for h in 0..kv_heads {
+                            let po = pm.offset(layer, p, h);
+                            let ho = hm.offset(layer, p, h);
+                            for d in 0..head_dim {
+                                if pm.keys[po + d].to_bits() != hm.keys[ho + d].to_bits()
+                                    || pm.values[po + d].to_bits() != hm.values[ho + d].to_bits()
+                                {
+                                    mismatch += 1;
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            // (b) Attention outputs bitwise-equal across layouts, both
-            // scheduling modes, both dot lanes (pinned per head, env-free).
-            let query = rng.fill(attention_heads * head_dim);
-            let scale = 1.0 / (head_dim as f32).sqrt();
-            let repeats = attention_heads / kv_heads;
-            // is_x86_feature_detected! cannot COMPILE on non-x86 targets
-            // (aarch64 macOS CI), so this needs a cfg split, not cfg!().
-            #[cfg(target_arch = "x86_64")]
-            let dot_lanes: &[bool] = if std::arch::is_x86_feature_detected!("avx2")
-                && std::arch::is_x86_feature_detected!("fma")
-            {
-                &[false, true]
-            } else {
-                &[false]
-            };
-            #[cfg(not(target_arch = "x86_64"))]
-            let dot_lanes: &[bool] = &[false];
-            for layer in 0..2 {
-                for &parallel in &[false, true] {
-                    let run = |cache: &LlamaKvCache| {
-                        let params = DecodeAttentionHeadsParams {
-                            kv_cache: cache,
-                            layer_idx: layer,
-                            query_data: &query,
-                            attention_heads,
-                            repeats,
-                            kv_heads,
-                            head_mapping: GqaHeadMapping::Grouped,
-                            position_count,
-                            scale,
+                // (b) Attention outputs bitwise-equal across layouts, both
+                // scheduling modes, both dot lanes (pinned per head, env-free).
+                let query = rng.fill(attention_heads * head_dim);
+                let scale = 1.0 / (head_dim as f32).sqrt();
+                let repeats = attention_heads / kv_heads;
+                // is_x86_feature_detected! cannot COMPILE on non-x86 targets
+                // (aarch64 macOS CI), so this needs a cfg split, not cfg!().
+                #[cfg(target_arch = "x86_64")]
+                let dot_lanes: &[bool] = if std::arch::is_x86_feature_detected!("avx2")
+                    && std::arch::is_x86_feature_detected!("fma")
+                {
+                    &[false, true]
+                } else {
+                    &[false]
+                };
+                #[cfg(not(target_arch = "x86_64"))]
+                let dot_lanes: &[bool] = &[false];
+                for layer in 0..2 {
+                    for &parallel in &[false, true] {
+                        let run = |cache: &LlamaKvCache| {
+                            let params = DecodeAttentionHeadsParams {
+                                kv_cache: cache,
+                                layer_idx: layer,
+                                query_data: &query,
+                                attention_heads,
+                                repeats,
+                                kv_heads,
+                                head_mapping: GqaHeadMapping::Grouped,
+                                position_count,
+                                scale,
+                            };
+                            let mut out = vec![0.0f32; attention_heads * head_dim];
+                            decode_attention_all_heads_into_with_mode(&params, &mut out, parallel)
+                                .expect("attention");
+                            out
                         };
-                        let mut out = vec![0.0f32; attention_heads * head_dim];
-                        decode_attention_all_heads_into_with_mode(&params, &mut out, parallel)
-                            .expect("attention");
-                        out
-                    };
-                    let a = run(&pm);
-                    let b = run(&hm);
-                    for (x, y) in a.iter().zip(&b) {
-                        if x.to_bits() != y.to_bits() {
-                            mismatch += 1;
-                        }
-                    }
-                }
-                for &use_blocked in dot_lanes {
-                    let mut scores = Vec::new();
-                    for head in 0..attention_heads {
-                        let kv_head =
-                            map_attention_head_to_kv_head(head, repeats, kv_heads, GqaHeadMapping::Grouped);
-                        let mut out_pm = vec![0.0f32; head_dim];
-                        let mut out_hm = vec![0.0f32; head_dim];
-                        for (cache, out) in [(&pm, &mut out_pm), (&hm, &mut out_hm)] {
-                            attention_context_for_head_into_with_kernels(
-                                AttentionContextHeadParams {
-                                    kv_cache: cache,
-                                    layer_idx: layer,
-                                    kv_head,
-                                    query_slice: &query[head * head_dim..(head + 1) * head_dim],
-                                    position_count,
-                                    scale,
-                                },
-                                out,
-                                &mut scores,
-                                use_blocked,
-                            )
-                            .expect("pinned attention");
-                        }
-                        for (x, y) in out_pm.iter().zip(&out_hm) {
+                        let a = run(&pm);
+                        let b = run(&hm);
+                        for (x, y) in a.iter().zip(&b) {
                             if x.to_bits() != y.to_bits() {
                                 mismatch += 1;
                             }
                         }
                     }
+                    for &use_blocked in dot_lanes {
+                        let mut scores = Vec::new();
+                        for head in 0..attention_heads {
+                            let kv_head = map_attention_head_to_kv_head(
+                                head,
+                                repeats,
+                                kv_heads,
+                                GqaHeadMapping::Grouped,
+                            );
+                            let mut out_pm = vec![0.0f32; head_dim];
+                            let mut out_hm = vec![0.0f32; head_dim];
+                            for (cache, out) in [(&pm, &mut out_pm), (&hm, &mut out_hm)] {
+                                attention_context_for_head_into_with_kernels(
+                                    AttentionContextHeadParams {
+                                        kv_cache: cache,
+                                        layer_idx: layer,
+                                        kv_head,
+                                        query_slice: &query[head * head_dim..(head + 1) * head_dim],
+                                        position_count,
+                                        scale,
+                                    },
+                                    out,
+                                    &mut scores,
+                                    use_blocked,
+                                )
+                                .expect("pinned attention");
+                            }
+                            for (x, y) in out_pm.iter().zip(&out_hm) {
+                                if x.to_bits() != y.to_bits() {
+                                    mismatch += 1;
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-            mismatch
-        })
+                mismatch
+            },
+        )
         .sum();
 
     assert_eq!(

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -11680,3 +11680,245 @@ fn decode_attention_parallel_lane_is_bitwise_identical_to_serial() {
         "decode attention parallel lane diverged from serial in {mismatches} element(s)"
     );
 }
+
+/// Item 3 Lane A bitwise lock: the head-major KV layout is address math only.
+/// For every GQA shape, head_dim, and position count: build one cache per
+/// layout, drive them through the REAL write paths (write_kv_cache /
+/// write_kv_cache_batch) including growth re-layout (positions > the 256
+/// grow chunk), a rollback + divergent overwrite sequence, and the CUDA
+/// mirror-back accessor pattern (offset-addressed per (position, head)
+/// writes, covering copy_resident_cuda_kv_to_host); then assert (a) logical
+/// buffer equality element-by-element via offset(), and (b) bitwise-equal
+/// attention outputs in both scheduling modes and both dot lanes.
+#[test]
+fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
+    struct XorShift64Star(u64);
+    impl XorShift64Star {
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x >> 12;
+            x ^= x << 25;
+            x ^= x >> 27;
+            self.0 = x;
+            x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        }
+        fn next_f32(&mut self) -> f32 {
+            let unit = ((self.next_u64() >> 40) as f32) / (1u64 << 24) as f32 - 0.5;
+            match self.next_u64() % 8 {
+                0 => unit * f32::MIN_POSITIVE * 0.5,
+                1 => unit * 1e-12,
+                2..=4 => unit * 2.0,
+                5 => unit * 1e4,
+                _ => unit * 1e12,
+            }
+        }
+        fn fill(&mut self, len: usize) -> Vec<f32> {
+            (0..len).map(|_| self.next_f32()).collect()
+        }
+    }
+
+    let gqa_shapes = [(32usize, 4usize), (24, 8), (32, 8)];
+    let head_dims = [64usize, 128];
+    let position_counts = [2usize, 63, 64, 65, 511, 2048];
+    let cases_per_point = 8u64;
+
+    let mut points = Vec::new();
+    for &(attention_heads, kv_heads) in &gqa_shapes {
+        for &head_dim in &head_dims {
+            for &position_count in &position_counts {
+                for case in 0..cases_per_point {
+                    points.push((attention_heads, kv_heads, head_dim, position_count, case));
+                }
+            }
+        }
+    }
+
+    let mismatches: usize = points
+        .par_iter()
+        .map(|&(attention_heads, kv_heads, head_dim, position_count, case)| {
+            let mut rng = XorShift64Star(
+                0x1a1e_0001
+                    ^ ((attention_heads as u64) << 48)
+                    ^ ((kv_heads as u64) << 40)
+                    ^ ((head_dim as u64) << 24)
+                    ^ ((position_count as u64) << 8)
+                    ^ case,
+            );
+            let width = kv_heads * head_dim;
+            let plan = || LlamaKvCachePlan {
+                // max_sequence_length >= 512 engages the 256-position grow
+                // chunking, so deep points exercise the head-major
+                // re-layout-on-growth path.
+                max_sequence_length: position_count.max(512),
+                layer_count: 2,
+                kv_head_count: kv_heads,
+                head_dim,
+                key_shape: vec![2, position_count.max(512), kv_heads, head_dim],
+                value_shape: vec![2, position_count.max(512), kv_heads, head_dim],
+            };
+            let mut pm =
+                LlamaKvCache::new_with_layout(plan(), KvLayout::PositionMajor).expect("pm cache");
+            let mut hm =
+                LlamaKvCache::new_with_layout(plan(), KvLayout::HeadMajor).expect("hm cache");
+
+            // Phase A: append `position_count` tokens through the real
+            // single-token write path on layer 0 and the batch path on
+            // layer 1 (same data), on BOTH caches.
+            let mut token_rows = Vec::with_capacity(position_count);
+            for _ in 0..position_count {
+                token_rows.push((rng.fill(width), rng.fill(width)));
+            }
+            for (p, (k_row, v_row)) in token_rows.iter().enumerate() {
+                let k = CpuTensor::from_f32("k", vec![1, width], k_row.clone()).unwrap();
+                let v = CpuTensor::from_f32("v", vec![1, width], v_row.clone()).unwrap();
+                for cache in [&mut pm, &mut hm] {
+                    cache.position = p;
+                    write_kv_cache(cache, 0, &k, &v).expect("write layer0");
+                }
+            }
+            let flat_k: Vec<f32> = token_rows.iter().flat_map(|(k, _)| k.clone()).collect();
+            let flat_v: Vec<f32> = token_rows.iter().flat_map(|(_, v)| v.clone()).collect();
+            let bk = CpuTensor::from_f32("bk", vec![position_count, width], flat_k).unwrap();
+            let bv = CpuTensor::from_f32("bv", vec![position_count, width], flat_v).unwrap();
+            write_kv_cache_batch(&mut pm, 1, 0, &bk, &bv).expect("batch pm");
+            write_kv_cache_batch(&mut hm, 1, 0, &bk, &bv).expect("batch hm");
+            pm.position = position_count - 1;
+            hm.position = position_count - 1;
+
+            // Phase B: rollback to half depth and overwrite the tail with
+            // DIFFERENT data (spec-decode shape), through the real path.
+            if position_count >= 4 {
+                let half = position_count / 2;
+                pm.rollback_to_position(half).unwrap();
+                hm.rollback_to_position(half).unwrap();
+                for p in half..position_count {
+                    let k = CpuTensor::from_f32("k2", vec![1, width], rng.fill(width)).unwrap();
+                    let v = CpuTensor::from_f32("v2", vec![1, width], rng.fill(width)).unwrap();
+                    for cache in [&mut pm, &mut hm] {
+                        cache.position = p;
+                        write_kv_cache(cache, 0, &k, &v).expect("overwrite layer0");
+                    }
+                }
+                pm.position = position_count - 1;
+                hm.position = position_count - 1;
+            }
+
+            // Phase C: CUDA mirror-back pattern (copy_resident_cuda_kv_to_host):
+            // raw offset-addressed per-(position, head) writes of f16-exact
+            // rows into layer 1 of both caches.
+            for p in 0..position_count.min(8) {
+                for h in 0..kv_heads {
+                    let row: Vec<f32> = (0..head_dim)
+                        .map(|_| f16_bits_to_f32(f32_to_f16_bits(rng.next_f32())))
+                        .collect();
+                    for cache in [&mut pm, &mut hm] {
+                        let dst = cache.offset(1, p, h);
+                        cache.keys[dst..dst + head_dim].copy_from_slice(&row);
+                        cache.values[dst..dst + head_dim].copy_from_slice(&row);
+                    }
+                }
+            }
+
+            let mut mismatch = 0usize;
+
+            // (a) Logical buffer equality across layouts, every element.
+            for layer in 0..2 {
+                for p in 0..position_count {
+                    for h in 0..kv_heads {
+                        let po = pm.offset(layer, p, h);
+                        let ho = hm.offset(layer, p, h);
+                        for d in 0..head_dim {
+                            if pm.keys[po + d].to_bits() != hm.keys[ho + d].to_bits()
+                                || pm.values[po + d].to_bits() != hm.values[ho + d].to_bits()
+                            {
+                                mismatch += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // (b) Attention outputs bitwise-equal across layouts, both
+            // scheduling modes, both dot lanes (pinned per head, env-free).
+            let query = rng.fill(attention_heads * head_dim);
+            let scale = 1.0 / (head_dim as f32).sqrt();
+            let repeats = attention_heads / kv_heads;
+            // is_x86_feature_detected! cannot COMPILE on non-x86 targets
+            // (aarch64 macOS CI), so this needs a cfg split, not cfg!().
+            #[cfg(target_arch = "x86_64")]
+            let dot_lanes: &[bool] = if std::arch::is_x86_feature_detected!("avx2")
+                && std::arch::is_x86_feature_detected!("fma")
+            {
+                &[false, true]
+            } else {
+                &[false]
+            };
+            #[cfg(not(target_arch = "x86_64"))]
+            let dot_lanes: &[bool] = &[false];
+            for layer in 0..2 {
+                for &parallel in &[false, true] {
+                    let run = |cache: &LlamaKvCache| {
+                        let params = DecodeAttentionHeadsParams {
+                            kv_cache: cache,
+                            layer_idx: layer,
+                            query_data: &query,
+                            attention_heads,
+                            repeats,
+                            kv_heads,
+                            head_mapping: GqaHeadMapping::Grouped,
+                            position_count,
+                            scale,
+                        };
+                        let mut out = vec![0.0f32; attention_heads * head_dim];
+                        decode_attention_all_heads_into_with_mode(&params, &mut out, parallel)
+                            .expect("attention");
+                        out
+                    };
+                    let a = run(&pm);
+                    let b = run(&hm);
+                    for (x, y) in a.iter().zip(&b) {
+                        if x.to_bits() != y.to_bits() {
+                            mismatch += 1;
+                        }
+                    }
+                }
+                for &use_blocked in dot_lanes {
+                    let mut scores = Vec::new();
+                    for head in 0..attention_heads {
+                        let kv_head =
+                            map_attention_head_to_kv_head(head, repeats, kv_heads, GqaHeadMapping::Grouped);
+                        let mut out_pm = vec![0.0f32; head_dim];
+                        let mut out_hm = vec![0.0f32; head_dim];
+                        for (cache, out) in [(&pm, &mut out_pm), (&hm, &mut out_hm)] {
+                            attention_context_for_head_into_with_kernels(
+                                AttentionContextHeadParams {
+                                    kv_cache: cache,
+                                    layer_idx: layer,
+                                    kv_head,
+                                    query_slice: &query[head * head_dim..(head + 1) * head_dim],
+                                    position_count,
+                                    scale,
+                                },
+                                out,
+                                &mut scores,
+                                use_blocked,
+                            )
+                            .expect("pinned attention");
+                        }
+                        for (x, y) in out_pm.iter().zip(&out_hm) {
+                            if x.to_bits() != y.to_bits() {
+                                mismatch += 1;
+                            }
+                        }
+                    }
+                }
+            }
+            mismatch
+        })
+        .sum();
+
+    assert_eq!(
+        mismatches, 0,
+        "head-major KV layout diverged from position-major in {mismatches} element(s)"
+    );
+}

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -11769,6 +11769,18 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
                     .expect("pm cache");
                 let mut hm =
                     LlamaKvCache::new_with_layout(plan(), KvLayout::HeadMajor).expect("hm cache");
+                let mut pm16 = LlamaKvCache::new_with_layout_and_dtype(
+                    plan(),
+                    KvLayout::PositionMajor,
+                    KvDtype::F16,
+                )
+                .expect("pm16 cache");
+                let mut hm16 = LlamaKvCache::new_with_layout_and_dtype(
+                    plan(),
+                    KvLayout::HeadMajor,
+                    KvDtype::F16,
+                )
+                .expect("hm16 cache");
 
                 // Phase A: append `position_count` tokens through the real
                 // single-token write path on layer 0 and the batch path on
@@ -11780,7 +11792,7 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
                 for (p, (k_row, v_row)) in token_rows.iter().enumerate() {
                     let k = CpuTensor::from_f32("k", vec![1, width], k_row.clone()).unwrap();
                     let v = CpuTensor::from_f32("v", vec![1, width], v_row.clone()).unwrap();
-                    for cache in [&mut pm, &mut hm] {
+                    for cache in [&mut pm, &mut hm, &mut pm16, &mut hm16] {
                         cache.position = p;
                         write_kv_cache(cache, 0, &k, &v).expect("write layer0");
                     }
@@ -11789,41 +11801,41 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
                 let flat_v: Vec<f32> = token_rows.iter().flat_map(|(_, v)| v.clone()).collect();
                 let bk = CpuTensor::from_f32("bk", vec![position_count, width], flat_k).unwrap();
                 let bv = CpuTensor::from_f32("bv", vec![position_count, width], flat_v).unwrap();
-                write_kv_cache_batch(&mut pm, 1, 0, &bk, &bv).expect("batch pm");
-                write_kv_cache_batch(&mut hm, 1, 0, &bk, &bv).expect("batch hm");
-                pm.position = position_count - 1;
-                hm.position = position_count - 1;
+                for cache in [&mut pm, &mut hm, &mut pm16, &mut hm16] {
+                    write_kv_cache_batch(cache, 1, 0, &bk, &bv).expect("batch write");
+                    cache.position = position_count - 1;
+                }
 
                 // Phase B: rollback to half depth and overwrite the tail with
                 // DIFFERENT data (spec-decode shape), through the real path.
                 if position_count >= 4 {
                     let half = position_count / 2;
-                    pm.rollback_to_position(half).unwrap();
-                    hm.rollback_to_position(half).unwrap();
+                    for cache in [&mut pm, &mut hm, &mut pm16, &mut hm16] {
+                        cache.rollback_to_position(half).unwrap();
+                    }
                     for p in half..position_count {
                         let k = CpuTensor::from_f32("k2", vec![1, width], rng.fill(width)).unwrap();
                         let v = CpuTensor::from_f32("v2", vec![1, width], rng.fill(width)).unwrap();
-                        for cache in [&mut pm, &mut hm] {
+                        for cache in [&mut pm, &mut hm, &mut pm16, &mut hm16] {
                             cache.position = p;
                             write_kv_cache(cache, 0, &k, &v).expect("overwrite layer0");
                         }
                     }
-                    pm.position = position_count - 1;
-                    hm.position = position_count - 1;
+                    for cache in [&mut pm, &mut hm, &mut pm16, &mut hm16] {
+                        cache.position = position_count - 1;
+                    }
                 }
 
                 // Phase C: CUDA mirror-back pattern (copy_resident_cuda_kv_to_host):
-                // raw offset-addressed per-(position, head) writes of f16-exact
-                // rows into layer 1 of both caches.
+                // per-(position, head) stores of f16-exact rows into layer 1
+                // through the canonical store, exactly like the fixed site.
                 for p in 0..position_count.min(8) {
                     for h in 0..kv_heads {
                         let row: Vec<f32> = (0..head_dim)
                             .map(|_| f16_bits_to_f32(f32_to_f16_bits(rng.next_f32())))
                             .collect();
-                        for cache in [&mut pm, &mut hm] {
-                            let dst = cache.offset(1, p, h);
-                            cache.keys[dst..dst + head_dim].copy_from_slice(&row);
-                            cache.values[dst..dst + head_dim].copy_from_slice(&row);
+                        for cache in [&mut pm, &mut hm, &mut pm16, &mut hm16] {
+                            cache.store_kv_head_row(1, p, h, &row, &row);
                         }
                     }
                 }
@@ -11923,6 +11935,68 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
                                     mismatch += 1;
                                 }
                             }
+
+                            // Lane B: f16 storage under the blocked lane must
+                            // be bitwise-equal to f32 storage under the
+                            // blocked lane, in both layouts (the values are
+                            // identical — the write path always rounded — and
+                            // the fused kernel is expand-then-blocked).
+                            if use_blocked {
+                                let mut out_pm16 = vec![0.0f32; head_dim];
+                                let mut out_hm16 = vec![0.0f32; head_dim];
+                                for (cache, out) in [(&pm16, &mut out_pm16), (&hm16, &mut out_hm16)]
+                                {
+                                    attention_context_for_head_into_with_kernels(
+                                        AttentionContextHeadParams {
+                                            kv_cache: cache,
+                                            layer_idx: layer,
+                                            kv_head,
+                                            query_slice: &query
+                                                [head * head_dim..(head + 1) * head_dim],
+                                            position_count,
+                                            scale,
+                                        },
+                                        out,
+                                        &mut scores,
+                                        true,
+                                    )
+                                    .expect("pinned f16 attention");
+                                }
+                                for ((x, y), z) in out_pm.iter().zip(&out_pm16).zip(&out_hm16) {
+                                    if x.to_bits() != y.to_bits() || y.to_bits() != z.to_bits() {
+                                        mismatch += 1;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // (c) Logical content equality across dtypes: the f16 caches
+                // expand to exactly the values the f32 caches hold.
+                let mut row_ref = vec![0.0f32; head_dim];
+                let mut row_alt = vec![0.0f32; head_dim];
+                for layer in 0..2 {
+                    for p in 0..position_count {
+                        for h in 0..kv_heads {
+                            pm.copy_key_row_into(layer, p, h, &mut row_ref);
+                            for cache in [&pm16, &hm16] {
+                                cache.copy_key_row_into(layer, p, h, &mut row_alt);
+                                for (x, y) in row_ref.iter().zip(&row_alt) {
+                                    if x.to_bits() != y.to_bits() {
+                                        mismatch += 1;
+                                    }
+                                }
+                            }
+                            pm.copy_value_row_into(layer, p, h, &mut row_ref);
+                            for cache in [&pm16, &hm16] {
+                                cache.copy_value_row_into(layer, p, h, &mut row_alt);
+                                for (x, y) in row_ref.iter().zip(&row_alt) {
+                                    if x.to_bits() != y.to_bits() {
+                                        mismatch += 1;
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -11933,6 +12007,7 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
 
     assert_eq!(
         mismatches, 0,
-        "head-major KV layout diverged from position-major in {mismatches} element(s)"
+        "KV layout/dtype lanes diverged from the position-major f32 reference in \
+         {mismatches} element(s)"
     );
 }


### PR DESCRIPTION
﻿## What

Two independent, separately flag-gated KV lanes for Windows x86_64 decode attention, both **default OFF**, both carrying the **bitwise-identity contract**:

- **Lane A - layout**: BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR reorders the cache [layer, seq, kv_head, head_dim] -> [layer, kv_head, seq, head_dim] so each head's K/V is one contiguous stream. Chosen once at construction, carried on the cache, growth re-lays per-stream (pure permutation). Address math only.
- **Lane B - dtype**: BACKENDINFERENCE_KV_F16 stores K/V as u16 f16 bits. **Zero new rounding**: the write path has ALWAYS rounded every stored element through f16 (copy_to_f16_kv_cache_storage - unconditional on main) and then kept f32 buffers, 2x the bytes for zero precision. Storing the u16 and expanding on read reproduces main's values bit-for-bit. Requires the Item-1 blocked-dot lane (fused vcvtph2ps kernels realize its canonical order); inert + one-time log without it. All Item-1/2 parity evidence was earned on f16-rounded KV values.

Per the 2026-07-01 gate ruling: mission reframed with deep-context enablement primary; Lane B upgraded to bitwise contract with the canonical conversion pinned to the existing helper semantics; NO llama.cpp runs (identity vs flag-off is the whole parity story); no default flips.

## Conversion pins (property-tested)

Canonical STORE = existing f32_to_f16_bits semantics (RNE; overflow to inf incl. the 65520 tie; NaN -> sign|0x7E00). F16C write path carries a NaN-lane fixup because vcvtps2ph preserves truncated NaN payloads. READ = vcvtph2ps exactly on all 2^16 inputs; it differs from the repo helper ONLY on signalling NaNs (hardware quiets them - found by the exhaustive sweep at 0x7C01), unreachable because the canonical store quiets every NaN first. Locks: exhaustive 2^16 sweep vs hardware + round-trip, 1.2M randomized f32s + tie/subnormal/inf/NaN edge sets vs hardware and vs the existing helper, bulk-path equality on all inputs.

## Write-bypass sweep (ruling amendment b)

One bypass existed: copy_resident_cuda_kv_to_host (CUDA prefill mirror-back) wrote raw f32 without the rounding helper. Its data is f16-exact by construction (the GPU KV is f16), and it now routes through the new canonical store_kv_head_row like every other writer - bit-neutral today (re-rounding f16-exact values is idempotent, proven by the flag-off identity matrix) and structurally closed. All other writers already went through the helpers; full inventory in the mission report.

## Bitwise locks (tests)

- Four-cache matrix: {position-major, head-major} x {f32, f16}, 36 GQA shape points x 8 cases, driven through the REAL write / rollback+overwrite / growth-re-layout / mirror-back paths; attention outputs (both scheduling modes, both dot lanes, f16 pinned to blocked) and expanded logical content all bit-equal to the position-major f32 reference. Zero mismatches.
- f16 kernel property tests: 10k-case to_bits() locks (dot + axpy, AVX2/FMA/F16C vs scalar reference) over the FULL u16 domain incl. NaN/inf, plus a 2k-case fusion oracle (fused == expand-then-blocked).

## End-to-end identity: PASS 17/17 + serve stack

Token IDs byte-identical to stored references: storage flags off in all four {blocked, parallel} combos (proving the refactor is bit-neutral); f16 and f16+head-major under both scheduling arms; the inert guard; and the composed combo through the serve stack (TinyLlama five-prompt pack + 3B hello 1/5/50 camelid-side identical to flag-off records). 3/3 within-arm determinism everywhere.

## Performance (3B Q8_0, blocked+parallel ON, interleaved x3)

| depth | storage off tok/s | on tok/s | speedup | attn ms/tok | attn speedup | ids |
|---|---|---|---|---|---|---|
| 512  | 6.115 | 6.425 | 1.05x | 11.2 -> 6.4 | 1.75x | identical |
| 2047 | 5.130 | 5.665 | **1.10x** | 40.9 -> **17.2** | **2.38x** | identical |

Lane A alone: +10.2% @2048 (attn 45.6 -> 26.7 ms, KV GB/s 10.5 -> 17.9). Composed beats the 21 ms/tok projection. Secondary criterion (>=8% @2048) met.

**8192 ctx (primary deliverable): completes on this box** - prompt 8137 tok, prefill 428 s, decode 4.037 tok/s, attention 75.2 ms/tok (31.2% of decode), peak working set 5.72 GB. The f32 attempt was memory-starved (~6 GiB WS, 1.9 GiB free) and never finished prefill.

Thread sweep (all lanes on, 2048): attention flat at 17-19 ms across 4/8/16 threads - the DRAM knee has arrived at ~12-14 GB/s of f16 bytes (Item 2 was still scaling at 16T). Q8_0-KV hand-off: at 2048 attention is now ~10% of decode (2x more bytes saved caps at ~+5%, not mission-worthy); at 8192 it is 31% (projects ~+18%) - a deep-context-only play.

Receipts (SHA256-sealed, dev box): target/kv-lanes-baseline-20260701T180113/, target/kv-lanes-ab-20260701T185422/ (Lane A), target/kv-lanes-ab2-20260701T195346/ (identity matrix, composed A/B, sweep, 8192).

Promotion: both lanes are parity-neutral by construction (bitwise-identical output in every configuration), so promotion is INDEPENDENT of the SPM re-certification - pending review either way. No README/COMPATIBILITY/STATUS/ledger changes here (the f16-in-f32 discovery's ledger entry is queued behind this landing per the ruling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
