### PR TITLE
perf(decode): hot-loop strip + decode scheduling lane (Items 4+5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,10 @@ cudarc = { version = "0.19", default-features = false, features = [
 # The CPU path remains the parity reference everywhere.
 default = []
 cuda = ["dep:cudarc"]
+# Decode zero-alloc gate (Lane B step 6): installs a counting global allocator
+# and enables the hidden `bench-alloc-gate` subcommand. Measurement-only build;
+# never enabled in shipped binaries (the default allocator stays untouched).
+alloc-gate = []
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/src/alloc_gate.rs
+++ b/src/alloc_gate.rs
@@ -1,0 +1,170 @@
+//! Decode zero-alloc gate (Lane B step 6).
+//!
+//! A counting global allocator plus a driver that decodes real tokens through
+//! a loaded model and reports steady-state heap-allocation counts per token.
+//! This is the evidence that the scratch-pool strip actually removed the
+//! per-token heap churn (main allocated ~3 heap objects per op output, layer-
+//! proportional; the stripped loop's steady state is a small constant set:
+//! the per-token tensors that escape to the caller — embedding, final norm,
+//! logits — plus the timings vec).
+//!
+//! Why a feature-gated binary and not a `#[cfg(test)]` unit test: test builds
+//! deliberately leave the env-flag accessors and `ResolvedRuntimePlan::from_env`
+//! UNCACHED (tests mutate env vars), so a unit test would count hundreds of
+//! env-parsing allocations per token that do not exist in a real binary. The
+//! gate must measure the shipped configuration, so it runs in a normal build
+//! with `--features alloc-gate` (see the hidden `bench-alloc-gate` subcommand).
+//!
+//! Run CPU-pinned like every decode receipt: `CUDA_VISIBLE_DEVICES=-1`.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+/// System allocator wrapper that counts allocation events and requested bytes.
+/// Deallocations are not counted (the gate is about allocation churn).
+pub struct CountingAllocator;
+
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+/// Attribution mode: when armed, allocations of at least
+/// `TRACE_MIN_BYTES` print a backtrace (bounded count, reentrancy-guarded —
+/// capturing a backtrace allocates).
+static TRACE_BIG: AtomicBool = AtomicBool::new(false);
+static TRACES_REMAINING: AtomicU64 = AtomicU64::new(0);
+/// Matching allocations to skip before tracing (`CAMELID_ALLOC_GATE_TRACE_SKIP`),
+/// so the sample can land mid-token instead of on token-start sites.
+static TRACES_TO_SKIP: AtomicU64 = AtomicU64::new(0);
+/// Trace threshold; defaults to 1 MiB, overridable at gate start via
+/// `CAMELID_ALLOC_GATE_TRACE_MIN` (bytes) to attribute small-alloc churn.
+static TRACE_MIN_BYTES: AtomicU64 = AtomicU64::new(1 << 20);
+
+thread_local! {
+    static IN_TRACE: Cell<bool> = const { Cell::new(false) };
+}
+
+fn maybe_trace(size: usize) {
+    if !TRACE_BIG.load(Ordering::Relaxed) || (size as u64) < TRACE_MIN_BYTES.load(Ordering::Relaxed)
+    {
+        return;
+    }
+    IN_TRACE.with(|guard| {
+        if guard.get() {
+            return;
+        }
+        if TRACES_TO_SKIP
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_sub(1))
+            .is_ok()
+        {
+            return;
+        }
+        if TRACES_REMAINING
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_sub(1))
+            .is_err()
+        {
+            return;
+        }
+        guard.set(true);
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        eprintln!("=== alloc {size} bytes ===\n{backtrace}");
+        guard.set(false);
+    });
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        maybe_trace(layout.size());
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        maybe_trace(layout.size());
+        System.alloc_zeroed(layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        maybe_trace(new_size);
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn allocation_snapshot() -> (u64, u64) {
+    (
+        ALLOCATIONS.load(Ordering::Relaxed),
+        ALLOCATED_BYTES.load(Ordering::Relaxed),
+    )
+}
+
+/// Load `model`, decode `warmup` tokens to warm the scratch pools, decode
+/// binding cells, and KV growth chunk, then decode `tokens` more and report
+/// the allocation delta of that steady-state window.
+pub fn run_decode_alloc_gate(
+    model: &std::path::Path,
+    warmup: usize,
+    tokens: usize,
+    compute_logits: bool,
+    trace_big: bool,
+) -> crate::Result<serde_json::Value> {
+    let gguf = crate::gguf::read_metadata(model)?;
+    let config = crate::model::LlamaModelConfig::from_gguf(&gguf)?;
+    let binding = crate::model::LlamaTensorBinding::bind(&gguf, &config)?;
+    let store = crate::tensor::TensorStore::open(model, &gguf);
+    let weights = crate::inference::LlamaLoadedWeights::load(&store, &binding, None)?;
+    let mut session = crate::inference::LlamaInferenceSession::new(config, weights)?;
+
+    // Token identity does not change the decode allocation path; a fixed
+    // in-vocab id keeps the run deterministic.
+    let token_id = 100u32;
+    for _ in 0..warmup {
+        session.forward_single_token_alloc_probe(token_id, compute_logits)?;
+    }
+
+    if trace_big {
+        if let Ok(min) = std::env::var("CAMELID_ALLOC_GATE_TRACE_MIN") {
+            if let Ok(min) = min.parse::<u64>() {
+                TRACE_MIN_BYTES.store(min, Ordering::Relaxed);
+            }
+        }
+        if let Ok(skip) = std::env::var("CAMELID_ALLOC_GATE_TRACE_SKIP") {
+            if let Ok(skip) = skip.parse::<u64>() {
+                TRACES_TO_SKIP.store(skip, Ordering::Relaxed);
+            }
+        }
+        TRACES_REMAINING.store(12, Ordering::Relaxed);
+        TRACE_BIG.store(true, Ordering::Relaxed);
+    }
+    let (allocs_before, bytes_before) = allocation_snapshot();
+    for _ in 0..tokens {
+        session.forward_single_token_alloc_probe(token_id, compute_logits)?;
+    }
+    let (allocs_after, bytes_after) = allocation_snapshot();
+    TRACE_BIG.store(false, Ordering::Relaxed);
+
+    let allocs = allocs_after - allocs_before;
+    let bytes = bytes_after - bytes_before;
+    Ok(serde_json::json!({
+        "schema": "camelid.bench-alloc-gate/v1",
+        "model": model.display().to_string(),
+        "warmup_tokens": warmup,
+        "measured_tokens": tokens,
+        "compute_logits": compute_logits,
+        "allocations": allocs,
+        "allocated_bytes": bytes,
+        "allocations_per_token": allocs as f64 / tokens as f64,
+        "allocated_bytes_per_token": bytes as f64 / tokens as f64,
+    }))
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-use std::{
+﻿use std::{
     collections::HashMap,
     convert::Infallible,
     env, mem,
@@ -87,7 +87,7 @@ pub struct AppState {
     gemma4_runtimes: Arc<RwLock<HashMap<String, Arc<Gemma4ServeRuntime>>>>,
     /// Runnable-lane serve runtimes (qwen35/Ornith), keyed by model id. Populated
     /// only when `CAMELID_RUNNABLE_SERVE` is set and a runnable-served arch is
-    /// loaded. Additive, parallel to the optimized engine — see the runnable serve
+    /// loaded. Additive, parallel to the optimized engine â€” see the runnable serve
     /// bridge near `runnable_chat_nonstreaming`.
     runnable_runtimes: Arc<RwLock<HashMap<String, Arc<RunnableServeRuntime>>>>,
     execution_plans: Arc<RwLock<HashMap<String, ExecutionPlan>>>,
@@ -99,7 +99,7 @@ pub struct AppState {
     /// Serializes token generation across requests. The CUDA-resident Q8 runtime
     /// keeps KV / decode state in GPU-resident buffers that are reached through
     /// shared `Arc`s under read locks, so two decodes running at once clobber each
-    /// other's state — producing garbled "word-salad" output, non-deterministic
+    /// other's state â€” producing garbled "word-salad" output, non-deterministic
     /// greedy decoding, and an intermittent out-of-bounds slice panic in the
     /// worker. This lock is held for the full duration of every generation,
     /// including the entire SSE stream, so only one decode is ever in flight.
@@ -434,7 +434,7 @@ pub struct ChatCompletionRequest {
     pub camelid_dense_diagnostics: Option<bool>,
     pub camelid_dense_diagnostic_generated_index: Option<u32>,
     /// Opt-in: attach a parity receipt to the (non-streaming) response. The
-    /// receipt is a claim of output for the verifier to check — no reference
+    /// receipt is a claim of output for the verifier to check â€” no reference
     /// runs here, so its parity block is emitted as not-compared.
     pub camelid_receipt: Option<bool>,
     /// Opt-in gemma4 thinking mode: renders the reference's enable_thinking
@@ -445,7 +445,7 @@ pub struct ChatCompletionRequest {
     /// OpenAI-style tool/function definitions. When present, they are rendered
     /// into the prompt through the loaded model's own chat template (Hybrid agent
     /// mode); the model's tool-call output is parsed back into `tool_calls` (for
-    /// templates that render tools — Llama 3.x etc.). Models whose template does
+    /// templates that render tools â€” Llama 3.x etc.). Models whose template does
     /// not render tools simply ignore them.
     pub tools: Option<Vec<serde_json::Value>>,
     /// OpenAI `tool_choice`: `"auto"` (default), `"none"` (suppress parsing), or
@@ -455,7 +455,7 @@ pub struct ChatCompletionRequest {
     /// OpenAI `parallel_tool_calls`: accepted and ignored (Camelid surfaces the
     /// tool calls the model actually emits). Declared here so it is not rejected.
     pub parallel_tool_calls: Option<bool>,
-    /// OpenAI `response_format`. Only `{"type":"json_object"}` is honored — it turns
+    /// OpenAI `response_format`. Only `{"type":"json_object"}` is honored â€” it turns
     /// on JSON-grammar-constrained decoding so the output is guaranteed valid JSON.
     /// `{"type":"text"}`/absent is normal decoding; other shapes (json_schema) are
     /// rejected. Declared here so it is not in `unsupported_fields`.
@@ -514,8 +514,8 @@ pub struct ChatMessage {
     pub role: String,
     pub content: String,
     /// Content-part types from the OpenAI parts form that Camelid cannot honor
-    /// (`image_url`, `input_audio`, `video_url`, …). Camelid generates text
-    /// tokens only — vision/audio towers are never loaded — so the chat
+    /// (`image_url`, `input_audio`, `video_url`, â€¦). Camelid generates text
+    /// tokens only â€” vision/audio towers are never loaded â€” so the chat
     /// handlers fail closed with a typed `unsupported_multimodal_content`
     /// error whenever this is non-empty. Plain-string content and `text` parts
     /// never populate it.
@@ -912,7 +912,7 @@ pub struct GenerationSessionRequest {
     pub camelid_dense_diagnostic_generated_index: Option<u32>,
     /// Opt-in Qwen3/gemma4 thinking mode: when true the chat renderer emits the
     /// template's thinking generation prompt (the model produces its own
-    /// `<think>…</think>` block) instead of the deterministic thinking-disabled
+    /// `<think>â€¦</think>` block) instead of the deterministic thinking-disabled
     /// shape. `None`/false preserves the parity-locked thinking-disabled default.
     pub camelid_enable_thinking: Option<bool>,
     /// Tool/function definitions, rendered into the prompt via the model's chat
@@ -960,7 +960,7 @@ pub struct ChatCompletionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub camelid_receipt: Option<ParityReceipt>,
     /// Serve-lane disclosure. Present and `"experimental"` only when the active
-    /// model is an implemented decoder that is NOT a supported exact row — the
+    /// model is an implemented decoder that is NOT a supported exact row â€” the
     /// output is unverified and carries no parity claim. Omitted for supported rows
     /// (whose support is asserted by `/api/capabilities`, never by this field) and
     /// is NEVER a parity receipt: the live token stream is not evidence of support.
@@ -1528,22 +1528,22 @@ pub async fn serve(
 
     // Warm the generation path BEFORE telling the user we're ready. The GPU resident
     // engine (NVRTC kernel compile + multi-GB weight upload + first prefill) is built
-    // lazily on the first generation — a one-time cost of several seconds. If it lands
+    // lazily on the first generation â€” a one-time cost of several seconds. If it lands
     // on the user's first prompt the model looks "dog slow" (it's really the cold
     // build, on the GPU the whole time). So: start serving in the background, fire one
     // tiny self-request through the exact same code path to build the engine, BLOCK on
     // it, and only then print "ready". After this the first real request is warm
-    // (~0.5s) instead of ~10s. The warm-up is best-effort — any failure just falls back
+    // (~0.5s) instead of ~10s. The warm-up is best-effort â€” any failure just falls back
     // to the old lazy build and is not fatal.
     let warm_model_id = state.active_model_id.read().await.clone();
     let server = tokio::spawn(async move { axum::serve(listener, router_with_state(state)).await });
     if let Some(model_id) = warm_model_id {
-        // Word the banner for the device that will actually serve — saying "GPU"
+        // Word the banner for the device that will actually serve â€” saying "GPU"
         // on a CPU-only run (e.g. CUDA_VISIBLE_DEVICES=-1) was misleading.
         let warming_msg = if crate::cuda::gpu_accel_enabled() {
-            "🐪 Warming up the GPU (building the resident engine, one-time)…"
+            "ðŸª Warming up the GPU (building the resident engine, one-time)â€¦"
         } else {
-            "🐪 Warming up the model (building the engine, one-time)…"
+            "ðŸª Warming up the model (building the engine, one-time)â€¦"
         };
         eprintln!("\n  {warming_msg}");
         warmup_generation_blocking(addr, model_id).await;
@@ -1566,7 +1566,7 @@ async fn warmup_generation_blocking(addr: SocketAddr, model_id: String) {
 
 /// Send the warm-up chat request and read the full response (blocking). Returns once
 /// the forward has completed so the resident engine is built before the caller
-/// proceeds. Errors are swallowed by the caller — this only shaves the cold start.
+/// proceeds. Errors are swallowed by the caller â€” this only shaves the cold start.
 fn warmup_request(addr: SocketAddr, model_id: &str) {
     use std::io::{Read, Write};
     // Give the just-spawned listener a moment to start accepting; retry briefly.
@@ -1609,7 +1609,7 @@ fn warmup_request(addr: SocketAddr, model_id: &str) {
 /// `tracing` output is for operators; this banner is for the person who just
 /// ran `camelid serve` and wants to know where to click.
 fn print_ready_banner(url: &str) {
-    eprintln!("\n  🐪 Camelid is ready");
+    eprintln!("\n  ðŸª Camelid is ready");
     eprintln!("  Open the chat UI:  {url}");
     eprintln!("  OpenAI-style API:  {url}/v1/chat/completions\n");
 }
@@ -1670,9 +1670,9 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     // The gemma4 runtime (Q8-resident) is ready as soon as it is loaded; the Llama
     // f32-budget check does not apply to it. Likewise, a model served by the runnable
     // lane (CAMELID_RUNNABLE_SERVE + a runnable-served arch, e.g. qwen35/Ornith) is
-    // generation-ready once loaded — the runnable serve runtime is built lazily on the
+    // generation-ready once loaded â€” the runnable serve runtime is built lazily on the
     // first chat, so gate on "runnable-serve enabled + runnable arch + loaded" rather
-    // than the lazy runtime map (otherwise chat stays locked until you chat → deadlock).
+    // than the lazy runtime map (otherwise chat stays locked until you chat â†’ deadlock).
     let runnable_serve_ready = runnable_serve_enabled()
         && model.is_some_and(|m| is_runnable_serve_arch(m.gguf.architecture().unwrap_or_default()));
     let generation_ready = gemma4_available
@@ -2238,7 +2238,7 @@ fn current_gpu_runtime() -> GpuRuntimeState {
     GpuRuntimeState {
         available: crate::cuda::is_available(),
         // Report the MASTER GPU-acceleration switch (resident decode), which is what
-        // actually runs the model on the GPU — not the legacy hybrid-matmul flag, which
+        // actually runs the model on the GPU â€” not the legacy hybrid-matmul flag, which
         // defaults off and made the UI read "GPU off" while the GPU did all the work.
         enabled: crate::cuda::gpu_accel_enabled(),
         device: crate::cuda::device_name(),
@@ -2247,12 +2247,12 @@ fn current_gpu_runtime() -> GpuRuntimeState {
     }
 }
 
-/// GET `/api/runtime/gpu` — current GPU-acceleration availability + on/off state.
+/// GET `/api/runtime/gpu` â€” current GPU-acceleration availability + on/off state.
 async fn gpu_runtime() -> Json<GpuRuntimeState> {
     Json(current_gpu_runtime())
 }
 
-/// POST `/api/runtime/gpu` `{ "enabled": bool }` — flip GPU acceleration at
+/// POST `/api/runtime/gpu` `{ "enabled": bool }` â€” flip GPU acceleration at
 /// runtime (no restart). A no-op effect when no CUDA device is present, since
 /// the inference dispatch falls back to the CPU reference either way.
 async fn set_gpu_runtime(Json(req): Json<GpuRuntimeRequest>) -> Json<GpuRuntimeState> {
@@ -2394,7 +2394,7 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
             // receipts (read_file / list_dir / write_file). The id matches the
             // side-loaded server id (general.name) so the live `--agent` gate
             // (`active_tool_capable`) resolves; `family: "ornith"` routes tool-call
-            // parsing to the custom `<function=…>` XML parser.
+            // parsing to the custom `<function=â€¦>` XML parser.
             ModelCompatibilityTarget {
                 id: "Ornith 1.0 9B",
                 tool_capable: true,
@@ -3349,14 +3349,14 @@ struct InspectModelResponse {
     quant: Option<String>,
     /// Predicted lane (`supported` / `experimental_implemented` / `unsupported`).
     lane_class: ModelLaneClass,
-    /// The exact typed blocker the load would hit — predicted WITHOUT binding
+    /// The exact typed blocker the load would hit â€” predicted WITHOUT binding
     /// tensors or loading weights. `None` when the architecture is implemented
     /// (it would load and run, supported or experimental).
     #[serde(skip_serializing_if = "Option::is_none")]
     blocker: Option<InspectBlocker>,
 }
 
-/// `POST /api/models/inspect` — header-only prediction of a GGUF's lane and the
+/// `POST /api/models/inspect` â€” header-only prediction of a GGUF's lane and the
 /// exact reason it would fail closed, WITHOUT loading weights, so the UI can warn
 /// before a multi-GB load attempt. Reads only the GGUF metadata header.
 async fn inspect_model(Json(req): Json<InspectModelRequest>) -> Response {
@@ -3391,8 +3391,8 @@ async fn inspect_model(Json(req): Json<InspectModelRequest>) -> Response {
         .to_string();
     let quant = Some(crate::runnable::headline_quant_of(&gguf)).filter(|q| !q.is_empty());
 
-    // Parse the config header (no tensor bind, no weight load). Ok ⇒ it would load;
-    // Err ⇒ it would fail closed with this exact typed reason.
+    // Parse the config header (no tensor bind, no weight load). Ok â‡’ it would load;
+    // Err â‡’ it would fail closed with this exact typed reason.
     let (lane_class, blocker) = match LlamaModelConfig::from_gguf(&gguf) {
         Ok(_) => (
             classify_model_lane(architecture.as_deref(), &filename),
@@ -3452,21 +3452,21 @@ fn model_family(gguf: &GgufFile) -> &'static str {
 }
 
 /// Gemma 4 chat template constants + renderer. Turns are
-/// `<|turn>{system|user|model}\n…<turn|>\n` and generation follows a trailing
+/// `<|turn>{system|user|model}\nâ€¦<turn|>\n` and generation follows a trailing
 /// `<|turn>model\n`; a leading system message gets its own system turn, and
 /// thinking mode injects `<|think|>` (see `gemma4_chat_prompt`). The renderer
 /// is locked byte-for-byte to the reference rendering by
 /// `qa/gemma4/template_shapes_v1.json`.
 /// Gemma 4 turn markers. Gemma 4 RENAMED them from Gemma 3's
 /// `<start_of_turn>`/`<end_of_turn>` to `<|turn>` (id 105) / `<turn|>` (id 106)
-/// — verified against the E2B/E4B/12B GGUF vocab and the GGUF-embedded Jinja
-/// chat template (`'<|turn>' + role + '\n'` … `'<turn|>\n'`). Using the old
+/// â€” verified against the E2B/E4B/12B GGUF vocab and the GGUF-embedded Jinja
+/// chat template (`'<|turn>' + role + '\n'` â€¦ `'<turn|>\n'`). Using the old
 /// spellings tokenizes as PLAIN TEXT: the model mimics them back and the stop
 /// token never matches.
 pub(crate) const GEMMA4_TURN_START: &str = "<|turn>";
 pub(crate) const GEMMA4_TURN_END: &str = "<turn|>";
 /// Thinking-channel markers (ids 100/101): the model may wrap hidden reasoning
-/// in `<|channel>…<channel|>`. The GGUF template strips these spans from chat
+/// in `<|channel>â€¦<channel|>`. The GGUF template strips these spans from chat
 /// history; Camelid strips them from chat OUTPUT so hidden reasoning never
 /// leaks to the client.
 pub(crate) const GEMMA4_CHANNEL_START: &str = "<|channel>";
@@ -3544,7 +3544,7 @@ mod gemma4_template_tests {
         }];
         let prompt = render_qwen3_chatml_prompt(&messages, true);
         // Thinking enabled: bare assistant turn, no pre-filled <think></think>
-        // block — the model emits its own reasoning (the template default branch).
+        // block â€” the model emits its own reasoning (the template default branch).
         assert_eq!(
             prompt,
             "<|im_start|>user\nWhat is the capital of France?<|im_end|>\n\
@@ -3620,7 +3620,7 @@ mod gemma4_template_tests {
         assert_eq!(pack.pack_id, "qwen3-chatml-thinking-template-pack-v1");
         assert_eq!(pack.support_scope, "thinking_opt_in_leading_trace_only");
         assert!(!pack.shapes.is_empty(), "pack must carry shapes");
-        // At least one enable_thinking=true shape — the lane's whole reason to exist.
+        // At least one enable_thinking=true shape â€” the lane's whole reason to exist.
         assert!(
             pack.shapes.iter().any(|s| s.enable_thinking),
             "pack must lock at least one enable_thinking=true shape"
@@ -3793,9 +3793,9 @@ fn gemma4_chat_prompt(messages: &[ChatMessage], thinking: bool) -> String {
     out
 }
 
-/// Strip `<|channel>…<channel|>` thinking spans from a complete gemma4 chat
+/// Strip `<|channel>â€¦<channel|>` thinking spans from a complete gemma4 chat
 /// response. An unterminated span (generation hit the token budget inside the
-/// channel) is stripped to its start — hidden reasoning must never leak.
+/// channel) is stripped to its start â€” hidden reasoning must never leak.
 fn gemma4_strip_channels(text: &str) -> String {
     let mut out = String::new();
     let mut rest = text;
@@ -3906,7 +3906,7 @@ impl Gemma4ServeRuntime {
 }
 
 /// Distributed gemma4 serve config from the environment: both vars must be
-/// present and well-formed, or the pair is rejected loudly — a half-configured
+/// present and well-formed, or the pair is rejected loudly â€” a half-configured
 /// distributed lane must never silently fall back to a partial local load.
 fn gemma4_distributed_serve_config() -> std::result::Result<Option<(String, usize)>, String> {
     let worker = std::env::var("CAMELID_GEMMA4_WORKER").ok();
@@ -3985,7 +3985,7 @@ fn unix_secs() -> u64 {
 /// Non-streaming Gemma 4 chat. Builds the gemma prompt, generates greedily on a
 /// blocking thread, and returns a minimal OpenAI-compatible response.
 /// Gemma 4 raw completion (non-streaming): BOS + plain prompt text through the
-/// greedy runtime — the same envelope the committed basic_v1 oracle pack checks.
+/// greedy runtime â€” the same envelope the committed basic_v1 oracle pack checks.
 async fn gemma4_completion_nonstreaming(
     id: String,
     runtime: Arc<Gemma4ServeRuntime>,
@@ -4228,8 +4228,8 @@ fn gemma4_telemetry_error(message: String) -> telemetry::RequestFinish {
 // ===================================================================================
 // Runnable-lane serve bridge (additive, gated by CAMELID_RUNNABLE_SERVE).
 //
-// Architectures implemented only in the runnable (pure-f32 oracle) lane — currently
-// `qwen35` (Ornith) — are not in the optimized inference engine, so the Llama serve
+// Architectures implemented only in the runnable (pure-f32 oracle) lane â€” currently
+// `qwen35` (Ornith) â€” are not in the optimized inference engine, so the Llama serve
 // path fails closed on them. This bridge mirrors the gemma4 serve pattern: a parallel
 // per-model-id runtime map, a short-circuit at the top of `chat_completions`, and a
 // dedicated chat handler. The optimized lane is untouched. Generation is greedy
@@ -4238,7 +4238,7 @@ fn gemma4_telemetry_error(message: String) -> telemetry::RequestFinish {
 // ===================================================================================
 
 /// The Ornith / qwen35 tool-call instruction literal, byte-for-byte from the GGUF
-/// chat template (the custom `<tool_call><function=…><parameter=…>` format the model
+/// chat template (the custom `<tool_call><function=â€¦><parameter=â€¦>` format the model
 /// was trained on). Rendering anything else makes the model emit the wrong format.
 const ORNITH_TOOL_INSTRUCTIONS: &str = "\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>";
 
@@ -4318,7 +4318,7 @@ fn render_ornith_chatml_prompt(messages: &[ChatMessage], enable_thinking: bool) 
 }
 
 /// Render an Ornith/qwen35 ChatML prompt with tool definitions, faithful to the GGUF
-/// template's tools system block + custom `<function=…>` instructions. `tools` are the
+/// template's tools system block + custom `<function=â€¦>` instructions. `tools` are the
 /// flat function objects (`{name,description,parameters}`). Tool results (`role:"tool"`)
 /// are wrapped in `<tool_response>` user turns as the template expects.
 fn render_ornith_chatml_prompt_with_tools(
@@ -4395,7 +4395,7 @@ fn split_ornith_think(text: &str) -> (Option<String>, String) {
     }
 }
 
-/// Lift Ornith/qwen35 `<tool_call><function=NAME><parameter=ARG>VALUE</parameter>…
+/// Lift Ornith/qwen35 `<tool_call><function=NAME><parameter=ARG>VALUE</parameter>â€¦
 /// </function></tool_call>` XML into OpenAI `tool_calls` JSON
 /// (`{id,type:"function",function:{name,arguments:<json-string>}}`). Mirrors the
 /// chat-lane `parse_ornith`; `arguments` is a JSON object string. Scalars stay
@@ -4469,7 +4469,7 @@ async fn resolve_runnable_runtime(
     if let Some(runtime) = state.runnable_runtimes.read().await.get(&id).cloned() {
         return Ok(Some((id, runtime)));
     }
-    // Loaded as a runnable-served arch but no runtime → fail clearly rather than
+    // Loaded as a runnable-served arch but no runtime â†’ fail clearly rather than
     // letting the Llama path produce garbage / an unsupported error.
     let needs_runnable = state
         .loaded_models
@@ -4516,7 +4516,7 @@ async fn load_runnable_serve_runtime(
 
 /// Non-streaming chat for a runnable-served model (qwen35/Ornith): render the Ornith
 /// ChatML prompt (with tools when present), greedy-generate to EOG, split the
-/// `<think>` reasoning, and lift `<function=…>` tool calls into structured `tool_calls`
+/// `<think>` reasoning, and lift `<function=â€¦>` tool calls into structured `tool_calls`
 /// (the content keeps the tool-call text so the agent's client-side parser also lifts).
 async fn runnable_chat_nonstreaming(
     id: String,
@@ -4573,7 +4573,7 @@ async fn runnable_chat_nonstreaming(
     };
 
     let (reasoning, content) = split_ornith_think(&text);
-    // Structured tool_calls (OpenAI shape) lifted from the Ornith `<function=…>` XML.
+    // Structured tool_calls (OpenAI shape) lifted from the Ornith `<function=â€¦>` XML.
     // The agent loop ALSO re-parses the content text client-side (chat-lane
     // `parse_ornith`), so the content keeps the tool-call text below.
     let tool_calls = parse_ornith_tool_calls_json(&content);
@@ -4770,7 +4770,7 @@ async fn load_model_from_path_with_activation(
     }
     // Capture the exact typed blocker so a loaded-but-non-runnable model surfaces
     // WHY it fails closed (architecture not implemented, missing/invalid metadata,
-    // DiffusionGemma redirect, …) instead of silently sitting non-generative.
+    // DiffusionGemma redirect, â€¦) instead of silently sitting non-generative.
     let unsupported_runtime = match &llama_config_result {
         Err(
             err @ (BackendError::UnsupportedModelArchitecture(_)
@@ -4832,7 +4832,7 @@ async fn load_model_from_path_with_activation(
     }
 
     // Gemma 4 serve path (additive, gated by CAMELID_GEMMA4_SERVE): load a
-    // serve runtime so /v1/chat can route to it. Fail clearly on error — never
+    // serve runtime so /v1/chat can route to it. Fail clearly on error â€” never
     // silently fall back to the Llama path (which would produce garbage here).
     if gemma4_serve_enabled() && model_family(&loaded.gguf) == "gemma4" {
         load_gemma4_serve_runtime(state, &id, &loaded.path).await?;
@@ -6023,7 +6023,7 @@ async fn completions(
 /// Non-streaming multi-choice (`n` > 1) chat generation: runs `n_choices`
 /// independent generations, each with its own derived seed so the choices are
 /// distinct yet reproducible, and assembles them into one OpenAI response. Each
-/// choice is a full generation (its own prefill + decode) — a capability, not a
+/// choice is a full generation (its own prefill + decode) â€” a capability, not a
 /// throughput claim. `camelid` diagnostics mirror the first choice; usage counts
 /// the prompt once and sums completion tokens across choices. Streaming and
 /// receipts are rejected upstream for this path. The caller holds the generation
@@ -6254,7 +6254,7 @@ async fn chat_completions(
             Some("logprobs"),
         );
     }
-    // OpenAI stream_options.include_usage: resolved here (permissive — see
+    // OpenAI stream_options.include_usage: resolved here (permissive â€” see
     // stream_options_include_usage) before `req` is consumed into the generation
     // request. Threaded into stream_completion; ignored on the non-streaming
     // branch, which already returns `usage`.
@@ -6809,7 +6809,7 @@ fn estimate_cpu_weight_materialization_bytes(binding: &LlamaTensorBinding) -> cr
             && matches!(desc.dimensions.len(), 2 | 3);
         // K-quant 2-D/3-D linears (Q4_K/Q6_K/Q2_K/Q3_K) load via the wire path
         // (`load_kquant_wire_linear`), retaining only the compact super-block wire
-        // bytes — they never materialize an f32 copy, so they must not be counted
+        // bytes â€” they never materialize an f32 copy, so they must not be counted
         // against the f32 budget (otherwise a 4B Q2_K/Q4_K model's ~16 GB f32 estimate
         // wrongly trips the safety limit even though the resident GPU path uses wire).
         let wire_resident_kquant = matches!(
@@ -6952,12 +6952,12 @@ fn estimate_cpu_weight_materialization_bytes(binding: &LlamaTensorBinding) -> cr
 /// Q6_K) in a dense (non-MoE) layout. Such a model is loaded WIRE-ONLY: K-quant 2-D
 /// linears keep only their packed super-block wire bytes (see `load_kquant_wire_linear`
 /// in `LlamaLoadedWeights::load_with_ownership`) and Q8_0 linears keep their 36-byte
-/// blocks/pages — neither materializes the f32 the CPU-budget guard estimates. The CUDA
+/// blocks/pages â€” neither materializes the f32 the CPU-budget guard estimates. The CUDA
 /// resident decode engine reads those packed bytes in place (q8_gemv / q4k_gemv /
 /// q6k_gemv), so the f32 quantity the guard sizes is never produced for this model.
 ///
 /// This is the binding-level mirror of `LlamaInferenceSession::resident_decode_eligible`
-/// (which needs a built session); it intentionally checks only what the guard needs —
+/// (which needs a built session); it intentionally checks only what the guard needs â€”
 /// the per-tensor quant types and the dense layout. Anything else (an f16/f32 linear, a
 /// MoE router/expert stack) keeps the eager-f32 CPU path and stays under the guard.
 fn binding_all_resident_quant_linears(binding: &LlamaTensorBinding) -> bool {
@@ -6990,7 +6990,7 @@ fn binding_all_resident_quant_linears(binding: &LlamaTensorBinding) -> bool {
     })
 }
 
-/// Whether the GPU-resident decode engine will run this model — and therefore the
+/// Whether the GPU-resident decode engine will run this model â€” and therefore the
 /// CPU f32 weight materialization the budget guard estimates is never produced. True
 /// only when CUDA resident decode is active for this process AND every linear is a
 /// resident-eligible quant (`binding_all_resident_quant_linears`). On non-CUDA builds
@@ -6999,7 +6999,7 @@ fn binding_runs_on_resident_gpu(binding: &LlamaTensorBinding) -> bool {
     crate::inference::resident_decode_cuda_active() && binding_all_resident_quant_linears(binding)
 }
 
-/// Whether the CPU decode path consumes every linear WIRE-ONLY — and so, like the
+/// Whether the CPU decode path consumes every linear WIRE-ONLY â€” and so, like the
 /// resident-GPU case, never materializes the f32 weights the budget guard sizes. True
 /// when the K-quant CPU block-dot is enabled (Q4_K/Q6_K linears stream their wire bytes
 /// via `q4_k`/`q6_k_block_dot`, Q8_0 linears stream their packed blocks) AND every linear
@@ -7015,13 +7015,13 @@ fn binding_runs_on_cpu_wire_only(binding: &LlamaTensorBinding) -> bool {
 fn guard_cpu_weight_materialization_budget(binding: &LlamaTensorBinding) -> crate::Result<u64> {
     // Resident-GPU models load wire-only (packed Q8_0/Q4_K/Q6_K bytes the CUDA engine
     // reads in place) and never materialize the f32 weights this guard sizes. Bypass the
-    // CPU budget for them — but ONLY them; genuinely CPU-bound large models (or any
+    // CPU budget for them â€” but ONLY them; genuinely CPU-bound large models (or any
     // build/host without the resident GPU path) still hit the guard below.
     if binding_runs_on_resident_gpu(binding) {
         return Ok(0);
     }
     // CPU K-quant block-dot decode is also wire-only (no f32 materialization), so the
-    // same bypass applies on the CPU lane — otherwise a K-quant model that runs fine via
+    // same bypass applies on the CPU lane â€” otherwise a K-quant model that runs fine via
     // the block-dot is wrongly rejected here. (K-quant conductor Phase 2 follow-up.)
     if binding_runs_on_cpu_wire_only(binding) {
         return Ok(0);
@@ -7343,7 +7343,7 @@ async fn prepare_generation(
         stream: req.stream.unwrap_or(false),
     };
 
-    // Logprobs request → collect chosen + top-N each step. Chat uses logprobs:true
+    // Logprobs request â†’ collect chosen + top-N each step. Chat uses logprobs:true
     // plus top_logprobs:N; legacy completions uses logprobs:N directly.
     let logprobs_top_n = if matches!(req.chat_logprobs, Some(true)) {
         Some(req.top_logprobs.unwrap_or(0) as usize)
@@ -7377,7 +7377,7 @@ async fn prepare_generation(
 /// Build the draft-model drafter for `CAMELID_SPEC_DECODE=draft`: load the
 /// configured draft GGUF under the reserved `spec-draft` id (without making
 /// it the active model) and fail closed unless its token mapping is
-/// identical to the target's — drafted token ids must mean the same text in
+/// identical to the target's â€” drafted token ids must mean the same text in
 /// the target vocabulary.
 async fn build_model_drafter(
     state: &AppState,
@@ -7802,7 +7802,7 @@ fn static_param_name(param: &str) -> &'static str {
 /// `include_usage` is absent or not a boolean; and ignores any unknown subfields.
 /// Only an explicit `include_usage: true` turns the terminal usage chunk on, so
 /// it is the sole honored subfield (exact-row support); nothing else is claimed.
-/// `stream: false` needs no handling here — the non-streaming response already
+/// `stream: false` needs no handling here â€” the non-streaming response already
 /// carries `usage`, so a non-streaming request with `stream_options` "just works"
 /// untouched.
 fn stream_options_include_usage(stream_options: Option<&serde_json::Value>) -> bool {
@@ -7941,7 +7941,7 @@ async fn generate_decoded_tokens_blocking(
     });
     match tokio::time::timeout(timeout, handle).await {
         Ok(Ok(result)) => {
-            // §4 safe-boot: a decode ran to completion under the applied gait
+            // Â§4 safe-boot: a decode ran to completion under the applied gait
             // without wedging the host, so clear the in-progress marker. Cheap
             // and idempotent (a no-op after the first call, or when no gait was
             // applied), so it is safe on the hot path.
@@ -8313,7 +8313,7 @@ fn lookup_prompt_prefix_cache(prepared: &PreparedGeneration) -> Option<CachedPro
 
 fn store_prompt_prefix_cache(prepared: &PreparedGeneration, step: &LlamaGenerationStep) {
     // A resident-GPU-prefilled session keeps its K/V history on the GPU only; the cached
-    // clone would drop it and resume from empty CPU buffers. Skip caching those sessions —
+    // clone would drop it and resume from empty CPU buffers. Skip caching those sessions â€”
     // a cache miss just re-runs the (fast, resident) prefill.
     if !prepared.session.cpu_kv_authoritative() {
         return;
@@ -8600,7 +8600,7 @@ fn generate_token_ids(
             } else {
                 Vec::new()
             };
-            // No drafts (e.g. no n-gram match) → fall through to the plain
+            // No drafts (e.g. no n-gram match) â†’ fall through to the plain
             // single-token step below; a one-token verify chunk would only
             // add chunk-path overhead over the tuned decode step.
             if !drafts.is_empty() {
@@ -8608,7 +8608,7 @@ fn generate_token_ids(
                 // batched forward on the target's resident engine, which manages the KV
                 // itself (accept the longest matching prefix, advance position). Falls
                 // back to the CPU chunk verify when the engine isn't resident-ready.
-                // Lossless either way — the emitted tokens are the target's own greedy
+                // Lossless either way â€” the emitted tokens are the target's own greedy
                 // argmax given the accepted prefix.
                 let gpu_accepted = if spec_gpu_enabled() {
                     prepared
@@ -9479,7 +9479,7 @@ fn stream_completion(
     };
     let events = async_stream::stream! {
         // Hold the generation lock for the entire stream so no other decode
-        // starts until this one finishes — or the client disconnects and the
+        // starts until this one finishes â€” or the client disconnects and the
         // stream is dropped, releasing the guard. See AppState::generation_lock.
         let _gen_guard = gen_guard;
         let stream_started = Instant::now();
@@ -9551,7 +9551,7 @@ fn stream_completion(
         // Bypass the prompt-prefix cache when the CUDA-resident engine drives
         // decode: reusing a cached session reseeds the GPU KV from f16-rounded
         // host history (a different reduction order than a clean GPU prefill),
-        // which corrupts the resumed decode — mild for greedy (a few near-tie
+        // which corrupts the resumed decode â€” mild for greedy (a few near-tie
         // flips) but catastrophic under temperature sampling, where it produces
         // garbled, off-topic output. The non-streaming path already gates the
         // cache this way (see resident_decode_cuda_active); the streaming path
@@ -9943,7 +9943,7 @@ fn normalize_mistral_instruct_bos_prefix_tokens(
     let Some(bos_text) = tokenizer.token_text(Some(bos_id)) else {
         return;
     };
-    let Some(space_id) = tokenizer.token_id("▁") else {
+    let Some(space_id) = tokenizer.token_id("â–") else {
         return;
     };
     if rendered_prompt.parse_special
@@ -10010,11 +10010,11 @@ fn render_chat_prompt_for_tokenization_with_tools(
     tokenizer: &Tokenizer,
     tools: &[serde_json::Value],
 ) -> std::result::Result<RenderedPrompt, MiniJinjaError> {
-    // Normalize OpenAI-style `{ "type":"function", "function":{…} }` tools to the
+    // Normalize OpenAI-style `{ "type":"function", "function":{â€¦} }` tools to the
     // flat function objects (`{ "name", "description", "parameters" }`) the chat
-    // templates (Llama 3.x etc.) actually render — matching llama.cpp / vLLM. This
+    // templates (Llama 3.x etc.) actually render â€” matching llama.cpp / vLLM. This
     // keeps the wire format OpenAI-standard while the prompt the model sees aligns
-    // with the `{"name":…, "parameters":…}` response format the template requests
+    // with the `{"name":â€¦, "parameters":â€¦}` response format the template requests
     // (the nested envelope otherwise leaks into the prompt and small models echo
     // the schema). See `TOOLCALL_DIAG.md`.
     let normalized: Vec<serde_json::Value> = tools
@@ -10027,7 +10027,7 @@ fn render_chat_prompt_for_tokenization_with_tools(
         .collect();
     if let Some(template) = tokenizer.chat_template.as_deref() {
         // Mistral Instruct templates (v0.3 GGUF) don't reference the `tools`
-        // Jinja variable — the generic Jinja render silently drops them. Use
+        // Jinja variable â€” the generic Jinja render silently drops them. Use
         // the dedicated renderer that produces [AVAILABLE_TOOLS] natively.
         if is_mistral_instruct_template(template) {
             return Ok(RenderedPrompt {
@@ -10079,7 +10079,7 @@ fn render_chat_prompt_for_tokenization_fallback(
         // The marker strings themselves (<|user|>, <|assistant|>, <|system|>)
         // are not vocab entries and stay plain SPM text either way; the
         // template's `</s>` IS a control token, and llama-server encodes it
-        // as EOS when tokenizing the rendered template — so chat prompts
+        // as EOS when tokenizing the rendered template â€” so chat prompts
         // parse specials (chat_prompt_parse_special), with dummy-prefix
         // handling after control tokens preserved by encode_piece.
         // Checked BEFORE tinyllama: Phi-3 reuses the same <|user|>/<|assistant|>
@@ -10092,7 +10092,7 @@ fn render_chat_prompt_for_tokenization_fallback(
                 // Phi-3 sets add_bos_token=true; the tokenizer prepends <s>.
                 add_special: true,
                 // Parse specials so <|user|>/<|assistant|>/<|end|> become the control
-                // token ids — in particular <|end|> as the end-of-turn stop token.
+                // token ids â€” in particular <|end|> as the end-of-turn stop token.
                 parse_special: true,
             };
         }
@@ -10147,9 +10147,9 @@ fn render_chat_prompt_for_tokenization_fallback(
 /// the generation prompt for the requested thinking mode:
 /// - `enable_thinking = false` (the deterministic, parity-locked default):
 ///   `<|im_start|>assistant\n<think>\n\n</think>\n\n` (the template's
-///   `enable_thinking is false` branch — a direct answer, no reasoning).
+///   `enable_thinking is false` branch â€” a direct answer, no reasoning).
 /// - `enable_thinking = true`: `<|im_start|>assistant\n` (the template's default
-///   branch — the model emits its own `<think>…</think>` reasoning block first).
+///   branch â€” the model emits its own `<think>â€¦</think>` reasoning block first).
 ///
 /// Verified token-identical to the reference for single-turn user prompts.
 fn render_qwen3_chatml_prompt(messages: &[ChatMessage], enable_thinking: bool) -> String {
@@ -10169,7 +10169,7 @@ fn render_qwen3_chatml_prompt(messages: &[ChatMessage], enable_thinking: bool) -
     if append_generation_prompt {
         if enable_thinking {
             // Thinking enabled: the bare assistant turn matches the GGUF template's
-            // default branch; the model generates its own <think>…</think> block.
+            // default branch; the model generates its own <think>â€¦</think> block.
             prompt.push_str("<|im_start|>assistant\n");
         } else {
             // Thinking disabled: the empty <think></think> block matches the GGUF
@@ -10184,7 +10184,7 @@ fn render_qwen3_chatml_prompt(messages: &[ChatMessage], enable_thinking: bool) -
 /// Renders a Qwen3 ChatML prompt with tool definitions injected into the system
 /// message and thinking suppressed. The format matches Qwen3's expected tool-call
 /// protocol: tools as flat JSON objects in the system turn, model responds with
-/// `<tool_call>{"name":…,"arguments":{…}}</tool_call>`.
+/// `<tool_call>{"name":â€¦,"arguments":{â€¦}}</tool_call>`.
 fn render_qwen3_chatml_prompt_with_tools(
     messages: &[ChatMessage],
     tools: &[serde_json::Value],
@@ -10220,7 +10220,7 @@ fn render_qwen3_chatml_prompt_with_tools(
         }
     }
     if !has_system {
-        // No system message from caller — tool block IS the system message.
+        // No system message from caller â€” tool block IS the system message.
     }
     prompt.push_str(&tool_block);
     prompt.push_str("<|im_end|>\n");
@@ -10885,7 +10885,10 @@ mod tests {
 
     use crate::{
         execution_plan::{ExecutionPlan, ExecutionProfile},
-        inference::{LlamaInferenceSession, LlamaLayerWeights, LlamaLoadedWeights, SamplingConfig},
+        inference::{
+            DecodeBindingCell, DecodeLinearBindings, LlamaInferenceSession, LlamaLayerWeights,
+            LlamaLoadedWeights, SamplingConfig,
+        },
         model::LlamaModelConfig,
         tensor::CpuTensor,
         tokenizer::{
@@ -10901,7 +10904,7 @@ mod tests {
     /// generation handlers (`completions`, `chat_completions`,
     /// `llama_server_completion`) and `stream_completion` must hold
     /// `AppState::generation_lock` for the whole decode. This verifies the lock
-    /// actually serializes — with many tasks acquiring it the way the handlers
+    /// actually serializes â€” with many tasks acquiring it the way the handlers
     /// do, never more than one is inside the critical section at a time.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn generation_lock_serializes_decoding() {
@@ -11055,7 +11058,7 @@ mod tests {
             &json!({"include_usage": false})
         )));
         // Wrong-typed include_usage -> off (matches the permissive oracle; the
-        // request is never rejected — see ref_err_bad_type capture, HTTP 200).
+        // request is never rejected â€” see ref_err_bad_type capture, HTTP 200).
         assert!(!stream_options_include_usage(Some(
             &json!({"include_usage": "yes"})
         )));
@@ -11631,7 +11634,7 @@ mod tests {
                 target.evidence.contains("windows-x86-chatml-parity"),
                 "{id} evidence should cite the Windows bundle"
             );
-            // ChatML short-chat smoke only — no bounded context pack is promoted.
+            // ChatML short-chat smoke only â€” no bounded context pack is promoted.
             assert_eq!(
                 target.bounded_context_512_pack, "not_promoted",
                 "{id} ctx512"
@@ -11641,7 +11644,7 @@ mod tests {
 
     #[test]
     fn classify_model_lane_separates_supported_experimental_and_unsupported() {
-        // Exact supported curated artifact → Supported.
+        // Exact supported curated artifact â†’ Supported.
         assert_eq!(
             classify_model_lane(Some("llama"), "tinyllama-1.1b-chat-v1.0.Q8_0.gguf"),
             ModelLaneClass::Supported,
@@ -11651,7 +11654,7 @@ mod tests {
             ModelLaneClass::Supported,
         );
         // Implemented architecture but NOT a supported exact artifact (different
-        // quant/filename) → experimental, never falsely supported.
+        // quant/filename) â†’ experimental, never falsely supported.
         assert_eq!(
             classify_model_lane(Some("qwen3"), "Qwen3-0.6B-Q4_K_M.gguf"),
             ModelLaneClass::ExperimentalImplemented,
@@ -11660,7 +11663,7 @@ mod tests {
             classify_model_lane(Some("mistral"), "some-random-mistral-finetune-Q8_0.gguf"),
             ModelLaneClass::ExperimentalImplemented,
         );
-        // Architecture not in the implemented set → Unsupported (fails closed at load).
+        // Architecture not in the implemented set â†’ Unsupported (fails closed at load).
         assert_eq!(
             classify_model_lane(Some("falcon"), "falcon-7b-Q8_0.gguf"),
             ModelLaneClass::Unsupported,
@@ -12424,7 +12427,7 @@ mod tests {
 
     #[test]
     fn binding_all_resident_quant_linears_rejects_non_quant_linears() {
-        // An f32/f16 linear is NOT resident-eligible — it takes the eager-f32 CPU path,
+        // An f32/f16 linear is NOT resident-eligible â€” it takes the eager-f32 CPU path,
         // which the guard must keep protecting.
         for ty in [GgufTensorType::F32, GgufTensorType::F16] {
             let binding = materialization_binding(false, ty, vec![256, 256]);
@@ -12453,7 +12456,7 @@ mod tests {
     #[test]
     fn cpu_weight_materialization_budget_bypassed_for_kquant_block_dot() {
         // The budget guard must treat a K-quant block-dot model as wire-only (no f32
-        // materialization) on the CPU lane — otherwise serve CPU mode false-positives
+        // materialization) on the CPU lane â€” otherwise serve CPU mode false-positives
         // on the f32 size it never produces (Phase 2 follow-up). Tested directly on
         // `binding_runs_on_cpu_wire_only` to avoid the `resident_decode_cuda_active`
         // GPU-bypass confound on CUDA builds.
@@ -14163,7 +14166,7 @@ mod tests {
 
         assert_eq!(generated, vanilla);
         // The tiny model settles into a cycle, so the drafters must have
-        // actually accepted drafted tokens — otherwise this test would pass
+        // actually accepted drafted tokens â€” otherwise this test would pass
         // without exercising multi-token acceptance and rollback.
         assert!(
             accepted_total > 0,
@@ -14272,8 +14275,10 @@ mod tests {
                 attention_q_norm: None,
                 attention_k_norm: None,
                 moe_router: None,
+                decode_bindings: DecodeLinearBindings::default(),
             }],
             layer_range: None,
+            output_projection_binding: DecodeBindingCell::default(),
         }
     }
 
@@ -14318,7 +14323,7 @@ pub struct CatalogItem {
     pub downloads: u64,
     pub likes: u64,
     pub quant: &'static str,
-    /// `general.architecture` the GGUF will report (authoritative — curated, not
+    /// `general.architecture` the GGUF will report (authoritative â€” curated, not
     /// inferred from the filename). Drives the catalog's predicted lane.
     pub architecture: &'static str,
     pub license: &'static str,
@@ -14326,7 +14331,7 @@ pub struct CatalogItem {
 
 /// A catalog item plus its predicted runnable lane, so the Models tab can show which
 /// lane each entry would land in without downloading it. `oracle_qualified` means the
-/// `(architecture, quant)` combo is anchored → it would be Compatible after download
+/// `(architecture, quant)` combo is anchored â†’ it would be Compatible after download
 /// (unless it also matches a supported contract row, which the frontend resolves).
 ///
 /// Owns its strings so it can carry both **curated** rows (authoritative metadata,
@@ -14334,7 +14339,7 @@ pub struct CatalogItem {
 /// (`arch_detected: false`, where `architecture`/`quant` are filename guesses). The
 /// JSON field names are unchanged from the previous flattened `CatalogItem` shape;
 /// `group`/`arch_detected` are additive. Experimental rows always report
-/// `oracle_qualified: false` — a filename guess can never anchor a lane, so the
+/// `oracle_qualified: false` â€” a filename guess can never anchor a lane, so the
 /// frontend resolves them to "not yet in a lane" regardless of name coincidence.
 #[derive(Debug, serde::Serialize)]
 pub struct CatalogItemView {
@@ -14620,19 +14625,19 @@ pub struct LocalModelEntry {
     pub admission_reason: Option<String>,
     /// The (architecture, quant) combo is oracle-qualified, so smoke-admission is
     /// allowed. A model that is admitted but NOT oracle_qualified is "combo not yet
-    /// anchored" — never presented as compatible.
+    /// anchored" â€” never presented as compatible.
     pub oracle_qualified: bool,
     /// A cached runnable smoke receipt already exists for this file (it passed
-    /// smoke-admission before) — i.e. it belongs in the Compatible section.
+    /// smoke-admission before) â€” i.e. it belongs in the Compatible section.
     pub runnable_receipt_present: bool,
-    /// The GGUF ships a chat template — i.e. it is an instruction-tuned chat model
+    /// The GGUF ships a chat template â€” i.e. it is an instruction-tuned chat model
     /// (vs a base text-completion model). A model capability, not a system fact.
     pub chat_capable: bool,
-    /// Trained context window (tokens) from the GGUF — a model capability.
+    /// Trained context window (tokens) from the GGUF â€” a model capability.
     pub context_length: Option<u32>,
     /// Server-computed lane class from real header metadata (architecture) + the
     /// exact-artifact supported-row check. `experimental_implemented` means the
-    /// architecture is implemented but this is NOT a supported row — attemptable,
+    /// architecture is implemented but this is NOT a supported row â€” attemptable,
     /// unverified, no parity claim. Corroborates the frontend contract gate; it
     /// never promotes a row.
     pub lane_class: ModelLaneClass,
@@ -14647,7 +14652,7 @@ pub struct LocalModelsResponse {
 
 /// Cached metadata-derived facts for one local model, keyed by (mtime, size) so a
 /// re-download invalidates it. Parsing a GGUF's tensor index is slow for big models
-/// (the 16 GB MoE alone is seconds), and this endpoint is polled — so we re-parse
+/// (the 16 GB MoE alone is seconds), and this endpoint is polled â€” so we re-parse
 /// only files that are new or changed.
 #[derive(Clone)]
 struct CachedLocalMeta {
@@ -14680,7 +14685,7 @@ fn runnable_smoke_receipt_path(filename: &str) -> PathBuf {
         .join(format!("{stem}.json"))
 }
 
-/// `GET /api/models/local` — enumerate `models/*.gguf` with per-model lane facts.
+/// `GET /api/models/local` â€” enumerate `models/*.gguf` with per-model lane facts.
 /// Membership is derived downstream from these facts; nothing here is hand-authored.
 async fn local_models() -> Json<LocalModelsResponse> {
     let dir = PathBuf::from("models");
@@ -14797,7 +14802,7 @@ struct RunnableReceiptQuery {
     filename: String,
 }
 
-/// `GET /api/models/runnable-receipt?filename=<gguf>` — return the cached runnable
+/// `GET /api/models/runnable-receipt?filename=<gguf>` â€” return the cached runnable
 /// smoke receipt for a model (lane=runnable; attests deterministic execution, not
 /// parity). 404 when the model has not been smoke-admitted yet.
 async fn runnable_receipt(
@@ -14835,7 +14840,7 @@ struct RunnableSmokeRequest {
     filename: String,
 }
 
-/// `POST /api/models/runnable-smoke {filename}` — run smoke-admission on a local
+/// `POST /api/models/runnable-smoke {filename}` â€” run smoke-admission on a local
 /// model (admit -> load -> forward sanity -> coherence), cache + return the runnable
 /// receipt on pass. User-initiated; the model joins the Compatible section after.
 /// CPU-heavy (~minute) so it runs on a blocking thread.
@@ -14907,23 +14912,23 @@ async fn run_runnable_smoke(Json(req): Json<RunnableSmokeRequest>) -> Response {
 const HF_SEARCH_LIMIT: usize = 15;
 
 /// Lane classification for a downloaded/loaded model, driven only by real GGUF
-/// metadata (`general.architecture`) and the exact-artifact supported-row check —
+/// metadata (`general.architecture`) and the exact-artifact supported-row check â€”
 /// never a filename guess of the architecture. Drives experimental UI copy only; it
 /// never promotes a row or widens what `LlamaModelConfig::from_gguf` accepts.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelLaneClass {
-    /// Exact supported row (asserted by `/api/capabilities`) — the full supported lane.
+    /// Exact supported row (asserted by `/api/capabilities`) â€” the full supported lane.
     Supported,
     /// Architecture is implemented but this is NOT a supported row: attemptable,
     /// unverified, no parity claim.
     ExperimentalImplemented,
-    /// Architecture is not in the implemented set — fails closed at load.
+    /// Architecture is not in the implemented set â€” fails closed at load.
     Unsupported,
 }
 
 /// The `id`s of `/api/capabilities` compatibility rows whose status is `supported*`.
-/// Memoized — these are static contract literals. Reads the SAME rows the contract
+/// Memoized â€” these are static contract literals. Reads the SAME rows the contract
 /// publishes, so this introduces no second ledger.
 fn supported_compatibility_row_ids() -> &'static std::collections::HashSet<&'static str> {
     static IDS: OnceLock<std::collections::HashSet<&'static str>> = OnceLock::new();
@@ -14996,9 +15001,9 @@ fn backend_error_code(err: &BackendError) -> &'static str {
 
 /// The Models-tab catalog: a **curated** group (pinned, known-good rows, always
 /// first) followed, when the user is searching, by an **experimental** group of
-/// live Hugging Face results. Experimental rows are advisory-only — `oracle_qualified`
-/// is forced false and the frontend marks them unverified — so live browse can never
-/// widen what Camelid claims. A non-trivial `query` (≥2 chars) triggers the HF search;
+/// live Hugging Face results. Experimental rows are advisory-only â€” `oracle_qualified`
+/// is forced false and the frontend marks them unverified â€” so live browse can never
+/// widen what Camelid claims. A non-trivial `query` (â‰¥2 chars) triggers the HF search;
 /// a network failure degrades silently to curated-only.
 async fn get_catalog(
     axum::extract::Query(q): axum::extract::Query<CatalogQuery>,
@@ -15094,8 +15099,8 @@ async fn install_catalog_model(Json(req): Json<InstallCatalogRequest>) -> Respon
         req.repo_id, req.filename
     );
 
-    // `-f` makes curl FAIL on an HTTP error (404/403/…) instead of writing the
-    // error page to the output file and exiting 0 — which previously looked like an
+    // `-f` makes curl FAIL on an HTTP error (404/403/â€¦) instead of writing the
+    // error page to the output file and exiting 0 â€” which previously looked like an
     // instant successful download.
     match std::process::Command::new("curl")
         .args(["-f", "-L", "-C", "-", "-o", &part_path, &url])
@@ -15121,7 +15126,7 @@ async fn install_catalog_model(Json(req): Json<InstallCatalogRequest>) -> Respon
                 let mut child = child;
                 let succeeded = matches!(child.wait(), Ok(status) if status.success());
                 // Completion is the curl exit code AND a successful promote of the
-                // .part file to the final path — never a size heuristic.
+                // .part file to the final path â€” never a size heuristic.
                 let promoted =
                     succeeded && std::fs::rename(&part_path_clone, &dest_path_clone).is_ok();
                 if !promoted {

--- a/src/ghost.rs
+++ b/src/ghost.rs
@@ -1,9 +1,9 @@
-//! Ghost (layer-streaming) mode: the `.cghost` container format and its reader/writer.
+﻿//! Ghost (layer-streaming) mode: the `.cghost` container format and its reader/writer.
 //!
 //! Standard GGUF files scatter a transformer block's tensors across the file, which turns a
 //! layer-by-layer streaming pass into random reads. A `.cghost` file is a pure re-layout of
 //! a GGUF at **source quantization**: every tensor a block needs is contiguous on disk, so
-//! streaming one layer is ONE sequential read. v1 deliberately does not requantize —
+//! streaming one layer is ONE sequential read. v1 deliberately does not requantize â€”
 //! identical bytes mean the ghost path can be parity-gated against the resident path.
 //!
 //! Layout:
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{BackendError, Result};
 use crate::gguf::GgufTensorType;
-use crate::inference::LlamaLayerWeights;
+use crate::inference::{DecodeLinearBindings, LlamaLayerWeights};
 use crate::model::{LlamaFfnTensors, LlamaTensorBinding};
 use crate::tensor::{cpu_tensor_from_gguf_bytes, CpuTensor, TensorStore};
 
@@ -98,12 +98,12 @@ fn io_err(path: &Path, source: std::io::Error) -> BackendError {
     }
 }
 
-/// Write a `.cghost` re-layout of `store`'s GGUF. Dense models only — ghost v1 refuses MoE
+/// Write a `.cghost` re-layout of `store`'s GGUF. Dense models only â€” ghost v1 refuses MoE
 /// (the streaming window assumes one fixed-size group per block).
 ///
 /// `layer_range` selects a pipeline shard: only those "blk.N" groups are written, the "pre"
 /// group (embedding) only when the range starts at layer 0, and the "post" group
-/// (output norm/projection) only when it ends at the last layer — so each mesh node hosts
+/// (output norm/projection) only when it ends at the last layer â€” so each mesh node hosts
 /// just its own half of the payload on local disk. `None` writes the whole model.
 pub fn write_cghost(
     store: &TensorStore,
@@ -234,7 +234,7 @@ impl GhostFile {
     /// handle (macOS) so streamed reads bypass the page cache entirely. For models that fit
     /// in RAM the cache is a free win (leave this off); for the over-RAM models ghost mode
     /// targets, the cache can only thrash and the OS must not accumulate the file's pages.
-    /// (`posix_madvise(DONTNEED)` does not apply here — that is for mmap'd ranges, and the
+    /// (`posix_madvise(DONTNEED)` does not apply here â€” that is for mmap'd ranges, and the
     /// streamer uses positioned reads.)
     pub fn open_with_options(path: &Path, evict_page_cache: bool) -> Result<Self> {
         let this = Self::open(path)?;
@@ -345,12 +345,13 @@ impl GhostFile {
                 ffn_up: take("ffn_up")?,
                 ffn_down: take("ffn_down")?,
                 moe_router: None,
+                decode_bindings: DecodeLinearBindings::default(),
             },
             span_len,
         ))
     }
 
-    /// Largest "blk.N" group payload in bytes — the size of the streaming read buffer.
+    /// Largest "blk.N" group payload in bytes â€” the size of the streaming read buffer.
     pub fn max_layer_span(&self) -> u64 {
         self.index
             .groups
@@ -375,7 +376,7 @@ pub struct PrefetchedLayer {
 
 /// Double-buffered streaming: a background worker reads + decodes layer N+1 from the
 /// `.cghost` file while the main thread runs layer N's forward. The result channel is a
-/// rendezvous (capacity 0), so at most TWO layer windows exist at any instant — one in the
+/// rendezvous (capacity 0), so at most TWO layer windows exist at any instant â€” one in the
 /// session being computed, one finished in the worker's hand awaiting handoff. The worker
 /// fulfills requests strictly in order; the main thread queues each chunk's layer indices
 /// ahead of consuming them (and primes the next chunk before the current one finishes, so
@@ -429,7 +430,7 @@ impl GhostPrefetcher {
     }
 
     /// Block until the next requested layer is ready (instant when the worker finished
-    /// while the previous layer was computing — the double-buffered steady state).
+    /// while the previous layer was computing â€” the double-buffered steady state).
     pub fn next(&self) -> Result<PrefetchedLayer> {
         self.result_rx
             .as_ref()

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -3317,6 +3317,20 @@ impl LlamaInferenceSession {
         Ok(self.forward_single_token_timed_fast(token_id)?.output)
     }
 
+    /// Alloc-gate probe (Lane B step 6): the plain decode forward with the
+    /// logits stage optionally skipped, so the gate can attribute allocation
+    /// churn to the layer loop vs the final norm + output projection.
+    #[cfg(feature = "alloc-gate")]
+    pub fn forward_single_token_alloc_probe(
+        &mut self,
+        token_id: u32,
+        compute_logits: bool,
+    ) -> Result<LlamaForwardOutput> {
+        Ok(self
+            .forward_single_token_timed_internal(token_id, false, compute_logits)?
+            .output)
+    }
+
     pub fn forward_single_token_timed(&mut self, token_id: u32) -> Result<LlamaTimedForwardOutput> {
         let timed = self.forward_single_token_timed_internal(token_id, true, true)?;
         Ok(LlamaTimedForwardOutput {
@@ -3486,6 +3500,9 @@ impl LlamaInferenceSession {
             .embedding_lookup(token_ids, "token_embedding_prefill_chunk")?;
         let mut timings = LlamaForwardTimings {
             embedding: embedding_started.elapsed().as_micros(),
+            // One allocation instead of a per-push growth chain (one layer
+            // entry pushed per layer per forward).
+            layers: Vec::with_capacity(self.weights.layers.len()),
             ..LlamaForwardTimings::default()
         };
         if let Some(memory) = &mut memory {
@@ -3587,6 +3604,9 @@ impl LlamaInferenceSession {
             .embedding_lookup(token_ids, "token_embedding_verify_chunk")?;
         let mut timings = LlamaForwardTimings {
             embedding: embedding_started.elapsed().as_micros(),
+            // One allocation instead of a per-push growth chain (one layer
+            // entry pushed per layer per forward).
+            layers: Vec::with_capacity(self.weights.layers.len()),
             ..LlamaForwardTimings::default()
         };
         let layers_started = Instant::now();
@@ -3695,6 +3715,9 @@ impl LlamaInferenceSession {
             .embedding_lookup(token_ids, "token_embedding_prefill_layer_major")?;
         let mut timings = LlamaForwardTimings {
             embedding: embedding_started.elapsed().as_micros(),
+            // One allocation instead of a per-push growth chain (one layer
+            // entry pushed per layer per forward).
+            layers: Vec::with_capacity(self.weights.layers.len()),
             ..LlamaForwardTimings::default()
         };
         if let Some(memory) = &mut memory {
@@ -3885,6 +3908,9 @@ impl LlamaInferenceSession {
             .transpose()?;
         let mut timings = LlamaForwardTimings {
             embedding: embedding_started.elapsed().as_micros(),
+            // One allocation instead of a per-push growth chain (one layer
+            // entry pushed per layer per forward).
+            layers: Vec::with_capacity(self.weights.layers.len()),
             ..LlamaForwardTimings::default()
         };
         let mut layer_diagnostics =
@@ -7683,6 +7709,23 @@ fn linear_with_diagnostic_layouts_with_plan(
         let descriptor_weight = linear_weight_reinterpreted_as_descriptor(weight, input_width)?;
         matmul_descriptor_with_precision_with_plan(input, &descriptor_weight, name, runtime_plan)
     } else if rectangular_layout == RectangularLinearLayout::Transposed || rows == input_width {
+        // Zero-clone fast path for the dominant decode case: a Q8_0 weight
+        // whose (shape-reinterpreted) view routes to the block-dot kernel.
+        // Materializing the reinterpreted tensor below clones the weight's
+        // full Vec<Q8_0Block> per call; the borrowed view runs the SAME
+        // kernel on the SAME blocks/packed storage without the copy. The
+        // tq2_0/q4_k/q6_k routes checked ahead of block-dot in the tensor
+        // chain cannot fire for a Q8_0-sourced weight, so gating on the
+        // block-dot predicate alone preserves route selection exactly.
+        let borrowed = borrowed_linear_weight_as_transposed(weight, input_width)?;
+        if should_use_borrowed_q8_0_block_dot_with_plan(borrowed, input_width, runtime_plan) {
+            return matmul_rhs_transposed_q8_0_block_dot_borrowed_with_plan(
+                input,
+                borrowed,
+                name,
+                runtime_plan,
+            );
+        }
         let transposed_weight = linear_weight_reinterpreted_as_transposed(weight, input_width)?;
         matmul_rhs_transposed_with_precision_with_plan(
             input,
@@ -8949,9 +8992,9 @@ fn try_attention_qkv_shared_q8_0_block_dot(
     };
 
     let quantized_input = quantize_q8_0_row(input_row);
-    let mut q = vec![0.0; q_width];
-    let mut k = vec![0.0; k_width];
-    let mut v = vec![0.0; v_width];
+    let mut q = decode_scratch::take(q_width);
+    let mut k = decode_scratch::take(k_width);
+    let mut v = decode_scratch::take(v_width);
     accumulate_transposed_linear_row_q8_0_block_dot_quantized(
         &quantized_input.blocks,
         q_transposed,
@@ -8969,9 +9012,9 @@ fn try_attention_qkv_shared_q8_0_block_dot(
     );
 
     Ok(Some((
-        CpuTensor::from_f32("attention_q_shared_q8", vec![1, q_width], q)?,
-        CpuTensor::from_f32("attention_k_shared_q8", vec![1, k_width], k)?,
-        CpuTensor::from_f32("attention_v_shared_q8", vec![1, v_width], v)?,
+        decode_scratch::tensor_from_pooled("attention_q_shared_q8", &[1, q_width], q)?,
+        decode_scratch::tensor_from_pooled("attention_k_shared_q8", &[1, k_width], k)?,
+        decode_scratch::tensor_from_pooled("attention_v_shared_q8", &[1, v_width], v)?,
     )))
 }
 
@@ -9040,8 +9083,8 @@ fn gated_ffn_activation_with_plan(
     }
 
     let input_row = &input.data[..input_width];
-    let mut gate = vec![0.0; gate_width];
-    let mut up = vec![0.0; up_width];
+    let mut gate = decode_scratch::take(gate_width);
+    let mut up = decode_scratch::take(up_width);
 
     let ffn_gate_up_decode_consumer = if collect_diagnostics {
         if runtime_plan.q8.ffn_gate_up_decode_consumer {
@@ -9176,12 +9219,13 @@ fn gated_ffn_activation_with_plan(
     metal_seam::synchronize_active_session();
     let order = diagnostic_ffn_gate_up_order()?;
     let started = Instant::now();
-    for (gate_value, up_value) in gate.iter_mut().zip(up) {
+    for (gate_value, up_value) in gate.iter_mut().zip(up.iter().copied()) {
         *gate_value = match order {
             FfnGateUpOrder::GateUp => (*gate_value / (1.0 + (-*gate_value).exp())) * up_value,
             FfnGateUpOrder::UpGate => (up_value / (1.0 + (-up_value).exp())) * *gate_value,
         };
     }
+    decode_scratch::recycle(up);
     let activation_elapsed = started.elapsed().as_micros();
     if used_ffn_gate_up_decode_consumer {
         add_q8_schedule_counter(
@@ -9190,7 +9234,7 @@ fn gated_ffn_activation_with_plan(
         );
     }
     let tensor_started = q8_schedule_telemetry_enabled().then(Instant::now);
-    let tensor = CpuTensor::from_f32(name, vec![1, gate_width], gate)?;
+    let tensor = decode_scratch::tensor_from_pooled(&name, &[1, gate_width], gate)?;
     if used_ffn_gate_up_decode_consumer {
         if let Some(started) = tensor_started {
             add_q8_schedule_counter(
@@ -9234,7 +9278,8 @@ fn try_x86_q8_ffn_gate_up_decode_fused_activation_path(
     name: impl Into<String>,
     runtime_plan: &ResolvedRuntimePlan,
 ) -> Result<Option<GatedFfnActivation>> {
-    let name = name.into();
+    // Bail before materializing the name String: on plans without the fused
+    // route this runs (and returns None) once per layer per decode token.
     if !runtime_plan.q8.ffn_gate_up_decode_consumer
         || !runtime_plan.q8.ffn_gate_up_decode_fused_activation
         || input.rank() != 2
@@ -9242,6 +9287,7 @@ fn try_x86_q8_ffn_gate_up_decode_fused_activation_path(
     {
         return Ok(None);
     }
+    let name = name.into();
     let input_width = input.dim(1)?;
     if !input_width.is_multiple_of(Q8_0_BLOCK_VALUES) {
         record_q8_schedule_projection_route_denial(
@@ -10340,8 +10386,18 @@ fn q8_0_block_dot_enabled() -> bool {
 fn q8_0_file_reader_block_dot_enabled() -> bool {
     // Lazy/file-backed Q8 rows should also use block-dot by default. Preserving this
     // default is required because Q8 runtime/packed tensors may not have row-major
-    // f32 backing for a safe generic fallback.
-    q8_0_env_flag_enabled_default_on_fail_closed("CAMELID_Q8_0_FILE_READER_BLOCK_DOT")
+    // f32 backing for a safe generic fallback. Read once per process (non-test).
+    #[cfg(test)]
+    {
+        q8_0_env_flag_enabled_default_on_fail_closed("CAMELID_Q8_0_FILE_READER_BLOCK_DOT")
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            q8_0_env_flag_enabled_default_on_fail_closed("CAMELID_Q8_0_FILE_READER_BLOCK_DOT")
+        })
+    }
 }
 
 #[allow(dead_code)]
@@ -15711,7 +15767,7 @@ fn matmul_rhs_transposed_q8_0_block_dot_with_plan(
         }
     }
 
-    let mut output = vec![0.0_f32; rows * output_width];
+    let mut output = decode_scratch::take(rows * output_width);
     use rayon::prelude::*;
     if should_parallelize_linear_output(rows * output_width) {
         output
@@ -15806,7 +15862,165 @@ fn matmul_rhs_transposed_q8_0_block_dot_with_plan(
             }
         }
     }
-    CpuTensor::from_f32(name, vec![rows, output_width], output)
+    decode_scratch::tensor_from_pooled(&name, &[rows, output_width], output)
+}
+
+/// [`matmul_rhs_transposed_q8_0_block_dot_with_plan`] over a borrowed weight
+/// view — the SAME kernel body reading the same blocks/packed storage, minus
+/// the materialized weight tensor. This is the zero-clone path for shape-
+/// reinterpreted linears: `weight_with_swapped_matrix_shape` cloned the full
+/// `Vec<Q8_0Block>` per call (28 MB per layer per token for the 3B ffn_down
+/// decode projection), and the clone's only purpose was carrying swapped dims.
+fn matmul_rhs_transposed_q8_0_block_dot_borrowed_with_plan(
+    input: &CpuTensor,
+    weight: BorrowedLinearWeight<'_>,
+    name: impl Into<String>,
+    runtime_plan: &ResolvedRuntimePlan,
+) -> Result<CpuTensor> {
+    let name = name.into();
+    let rows = input.dim(0)?;
+    let input_width = input.dim(1)?;
+    let output_width = weight.rows;
+    let rhs_k = weight.cols;
+    if input_width != rhs_k {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "q8_0 block-dot shape mismatch: lhs {:?}, rhs [{}, {}]",
+            input.shape.dims, weight.rows, weight.cols
+        )));
+    }
+    let blocks_per_row = input_width / Q8_0_BLOCK_VALUES;
+    let expected_blocks = output_width * blocks_per_row;
+    if let Some(weight_blocks) = weight.q8_0_blocks {
+        if weight_blocks.len() != expected_blocks {
+            return Err(BackendError::RuntimeShapeMismatch(format!(
+                "q8_0 block-dot expected {expected_blocks} blocks for weight [{}, {}] feeding {name}, got {}",
+                weight.rows,
+                weight.cols,
+                weight_blocks.len()
+            )));
+        }
+    } else if q8_0_selected_borrowed_packed_rows4(weight)
+        .filter(|(packed, _)| {
+            packed.rows == output_width && packed.blocks_per_row == blocks_per_row
+        })
+        .is_none()
+    {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "q8_0 block-dot requested for {name} without q8_0 blocks or matching packed rows4"
+        )));
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    if mac_q8_prefill_i8mm_enabled() && mac_q8_prefill_i8mm_row_threshold_met(rows) {
+        if let Some((packed, Q8_0PackedRows4Interleave::I8)) =
+            q8_0_selected_borrowed_packed_rows4(weight)
+        {
+            if packed.rows == output_width && packed.blocks_per_row == blocks_per_row {
+                return matmul_rhs_transposed_q8_0_packed_rows4_prefill_i8mm(
+                    input,
+                    packed,
+                    output_width,
+                    q8_schedule_role_for_output_name(&name),
+                    name,
+                );
+            }
+        }
+    }
+
+    let mut output = decode_scratch::take(rows * output_width);
+    use rayon::prelude::*;
+    if should_parallelize_linear_output(rows * output_width) {
+        output
+            .par_chunks_mut(output_width)
+            .enumerate()
+            .for_each(|(row, output_row)| {
+                let input_start = row * input_width;
+                let quantized_input =
+                    quantize_q8_0_row(&input.data[input_start..input_start + input_width]);
+                if let Some((packed, interleave)) = q8_0_selected_borrowed_packed_rows4(weight) {
+                    if packed.rows == output_width && packed.blocks_per_row == blocks_per_row {
+                        accumulate_q8_0_packed_rows4_dot_quantized_cpu(
+                            &quantized_input.blocks,
+                            packed,
+                            interleave,
+                            output_row,
+                        );
+                        return;
+                    }
+                }
+                let weight_blocks = weight
+                    .q8_0_blocks
+                    .expect("q8_0 block-dot precondition checked");
+                for (output_idx, out_value) in output_row.iter_mut().enumerate() {
+                    let weight_start = output_idx * blocks_per_row;
+                    *out_value = q8_0_dot_rows(
+                        &weight_blocks[weight_start..weight_start + blocks_per_row],
+                        &quantized_input.blocks,
+                    );
+                }
+            });
+    } else {
+        for row in 0..rows {
+            let input_start = row * input_width;
+            let quantized_input =
+                quantize_q8_0_row(&input.data[input_start..input_start + input_width]);
+            let out_start = row * output_width;
+            let output_row = &mut output[out_start..out_start + output_width];
+            if let Some((packed, interleave)) = q8_0_selected_borrowed_packed_rows4(weight) {
+                if packed.rows == output_width && packed.blocks_per_row == blocks_per_row {
+                    accumulate_q8_0_packed_rows4_dot_quantized_cpu(
+                        &quantized_input.blocks,
+                        packed,
+                        interleave,
+                        output_row,
+                    );
+                    continue;
+                }
+            }
+            let weight_blocks = weight
+                .q8_0_blocks
+                .expect("q8_0 block-dot precondition checked");
+            if runtime_plan.q8.metal_retained {
+                let weight_bytes = q8_0_blocks_as_bytes(weight_blocks);
+                if with_q8_0_block_scales_and_quants(
+                    &quantized_input.blocks,
+                    |input_scales, input_quants| {
+                        metal_seam::try_block_linear_row(
+                            input_scales,
+                            input_quants,
+                            weight_bytes,
+                            output_width,
+                            blocks_per_row,
+                            output_row,
+                        )
+                    },
+                ) {
+                    continue;
+                }
+            }
+            if should_parallelize_q8_0_file_reader_output(output_width) {
+                output_row
+                    .par_iter_mut()
+                    .enumerate()
+                    .for_each(|(output_idx, out_value)| {
+                        let weight_start = output_idx * blocks_per_row;
+                        *out_value = q8_0_dot_rows(
+                            &weight_blocks[weight_start..weight_start + blocks_per_row],
+                            &quantized_input.blocks,
+                        );
+                    });
+            } else {
+                for (output_idx, out_value) in output_row.iter_mut().enumerate() {
+                    let weight_start = output_idx * blocks_per_row;
+                    *out_value = q8_0_dot_rows(
+                        &weight_blocks[weight_start..weight_start + blocks_per_row],
+                        &quantized_input.blocks,
+                    );
+                }
+            }
+        }
+    }
+    decode_scratch::tensor_from_pooled(&name, &[rows, output_width], output)
 }
 
 fn quantize_q8_0_row(input: &[f32]) -> QuantizedQ8_0Row {
@@ -16889,7 +17103,18 @@ fn matmul_rhs_transposed_q6_k_block_dot(
 /// (K-quant conductor Phase 2); Linux/macOS f32-near-tie parity confirmation is a
 /// documented follow-up.
 pub(crate) fn q4_k_cpu_block_dot_enabled() -> bool {
-    q8_0_env_flag_enabled_default_on_fail_closed("CAMELID_X86_Q4K_DECODE")
+    // Read once per process (non-test): this predicate runs per projection
+    // call on the decode hot loop, and env reads allocate on Windows.
+    #[cfg(test)]
+    {
+        q8_0_env_flag_enabled_default_on_fail_closed("CAMELID_X86_Q4K_DECODE")
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED
+            .get_or_init(|| q8_0_env_flag_enabled_default_on_fail_closed("CAMELID_X86_Q4K_DECODE"))
+    }
 }
 
 /// Streaming Q4_K linear: quantise each input row to Q8_K once, then dot it
@@ -18001,7 +18226,7 @@ fn matmul_rhs_transposed_q8_0_packed_rows4_f32_input(
             packed.rows, packed.blocks_per_row
         )));
     }
-    let mut output = vec![0.0_f32; rows * output_width];
+    let mut output = decode_scratch::take(rows * output_width);
     use rayon::prelude::*;
     if should_parallelize_linear_output(rows * output_width) {
         output
@@ -18028,7 +18253,8 @@ fn matmul_rhs_transposed_q8_0_packed_rows4_f32_input(
             );
         }
     }
-    CpuTensor::from_f32(name, vec![rows, output_width], output)
+    let name = name.into();
+    decode_scratch::tensor_from_pooled(&name, &[rows, output_width], output)
 }
 
 #[cfg(test)]
@@ -18963,17 +19189,30 @@ fn q8_0_file_reader_scratch_capacities() -> (usize, usize, usize, usize) {
 
 fn should_parallelize_q8_0_file_reader_output(output_width: usize) -> bool {
     const DEFAULT_Q8_0_FILE_READER_PARALLEL_MIN_OUTPUTS: usize = 1024;
+    // (defer_to_linear, min_outputs), resolved once per process outside tests:
+    // this predicate runs inside per-row kernels on the decode hot loop.
+    fn config_uncached() -> (bool, usize) {
+        let defer_to_linear = env::var("CAMELID_PARALLEL_LINEAR").is_ok();
+        let min_outputs = env::var("CAMELID_PARALLEL_LINEAR_MIN_OUTPUTS")
+            .ok()
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_Q8_0_FILE_READER_PARALLEL_MIN_OUTPUTS);
+        (defer_to_linear, min_outputs)
+    }
+    #[cfg(test)]
+    let (defer_to_linear, min_outputs) = config_uncached();
+    #[cfg(not(test))]
+    let (defer_to_linear, min_outputs) = {
+        static CONFIG: OnceLock<(bool, usize)> = OnceLock::new();
+        *CONFIG.get_or_init(config_uncached)
+    };
     if rayon::current_num_threads() <= 1 {
         return false;
     }
-    if env::var("CAMELID_PARALLEL_LINEAR").is_ok() {
+    if defer_to_linear {
         return should_parallelize_linear_output(output_width);
     }
-    let min_outputs = env::var("CAMELID_PARALLEL_LINEAR_MIN_OUTPUTS")
-        .ok()
-        .and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_Q8_0_FILE_READER_PARALLEL_MIN_OUTPUTS);
     output_width >= min_outputs
 }
 
@@ -19258,11 +19497,29 @@ fn accumulate_transposed_linear_row_q8_0_block_dot_quantized_with_flags(
 }
 
 fn q8_0_packed_4x4_dot_enabled() -> bool {
-    env_flag_enabled("CAMELID_Q8_0_PACKED_4X4_DOT")
+    // Read once per process (non-test): consulted by packed-rows selection on
+    // every projection call in the decode hot loop.
+    #[cfg(test)]
+    {
+        env_flag_enabled("CAMELID_Q8_0_PACKED_4X4_DOT")
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| env_flag_enabled("CAMELID_Q8_0_PACKED_4X4_DOT"))
+    }
 }
 
 fn q8_0_packed_4x8_dot_enabled() -> bool {
-    env_flag_enabled("CAMELID_Q8_0_PACKED_4X8_DOT")
+    #[cfg(test)]
+    {
+        env_flag_enabled("CAMELID_Q8_0_PACKED_4X8_DOT")
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| env_flag_enabled("CAMELID_Q8_0_PACKED_4X8_DOT"))
+    }
 }
 
 fn q8_0_selected_packed_rows4(

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -192,6 +192,28 @@ impl InferenceWorkspace {
     }
 }
 
+/// Cached per-layer op label (Lane B step 2): each call site owns a lazily
+/// built table of `layer_{i}_{suffix}` strings, so steady-state decode never
+/// runs the integer formatter. The returned Cow still clones into the
+/// consumer's owned String name until the scratch arena (step 5) removes
+/// per-op tensor construction; layer indices beyond the table fall back to
+/// formatting (correctness first, no model-size assumption).
+macro_rules! cached_layer_label {
+    ($layer_idx:expr, $suffix:literal) => {{
+        const CACHED_LAYER_LABELS: usize = 160;
+        static LABELS: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
+        let labels = LABELS.get_or_init(|| {
+            (0..CACHED_LAYER_LABELS)
+                .map(|i| format!(concat!("layer_{}_", $suffix), i))
+                .collect::<Vec<_>>()
+        });
+        match labels.get($layer_idx) {
+            Some(label) => std::borrow::Cow::Borrowed(label.as_str()),
+            None => std::borrow::Cow::Owned(format!(concat!("layer_{}_", $suffix), $layer_idx)),
+        }
+    }};
+}
+
 /// One steady-state decode kernel binding: which `try_x86_q8_*` cascade arm
 /// the first rows==1 call selected for a projection slot. The cascade remains
 /// the BUILDER of this choice (it runs once and records the winner); the
@@ -434,13 +456,13 @@ impl LlamaLoadedWeights {
         load_output: bool,
     ) -> Result<Self> {
         // Q8_0 linears are ALWAYS retained as plain RAM-resident blocks. The old policy
-        // estimated a retention budget over the WHOLE binding â€” even on a pipeline-sharded
-        // node that loads only its layer range â€” and silently fell back to per-token file
+        // estimated a retention budget over the WHOLE binding Ã¢â‚¬â€ even on a pipeline-sharded
+        // node that loads only its layer range Ã¢â‚¬â€ and silently fell back to per-token file
         // streaming when the estimate crossed a cap: ~100x slower decode, and it disqualified
         // the GPU-resident path (which requires q8_0_blocks). The only way off the resident
         // path now is the explicit CAMELID_LAZY_Q8_0_LINEAR opt-out, and it is loud.
         // Fast-load (CAMELID_METAL_NOCOPY): Q8_0 linears read their wire bytes once
-        // into page-aligned allocations the GPU wraps in place â€” no 36-byte decode, no
+        // into page-aligned allocations the GPU wraps in place Ã¢â‚¬â€ no 36-byte decode, no
         // upload copy, and the page cache stays warm so reloading a model is fast.
         let nocopy_fast_load = metal_nocopy_fast_load_enabled();
         if nocopy_fast_load {
@@ -458,7 +480,7 @@ impl LlamaLoadedWeights {
         }
         let load_linear = |name: &str| {
             // K-quant (Q4_K / Q6_K) 2-D linears: retain only the raw super-block wire
-            // bytes (no f32 materialization â€” an 8B model fully decoded to f32 is ~32 GB
+            // bytes (no f32 materialization Ã¢â‚¬â€ an 8B model fully decoded to f32 is ~32 GB
             // and OOMs). The GPU-resident decode reads these via q4k_gemv / q6k_gemv.
             if let Ok(desc) = store.descriptor(name) {
                 // Ternary TQ2_0 2-D linears: stream the wire bytes (the CPU ternary
@@ -576,7 +598,7 @@ impl LlamaLoadedWeights {
                     ),
                 };
                 // DEBUG ONLY: CAMELID_DEBUG_DISABLE_QK_NORM=1 skips loading the
-                // QK-norm weights so a Qwen3 forward runs as if it had none â€” used
+                // QK-norm weights so a Qwen3 forward runs as if it had none Ã¢â‚¬â€ used
                 // to bisect whether QK-norm is the source of a parity gap. Never
                 // set in production.
                 let debug_disable_qk_norm =
@@ -1331,7 +1353,7 @@ pub fn dump_stage_timings() {
 /// scalar chain (`tensor::dot_product`) vs the canonical blocked scalar
 /// reference vs the blocked AVX2/FMA realization. Returns
 /// `(variant, ns_per_call)` pairs; the AVX2 row is omitted when the CPU lacks
-/// AVX2+FMA. Bench-only entry point â€” never called on the inference path.
+/// AVX2+FMA. Bench-only entry point Ã¢â‚¬â€ never called on the inference path.
 pub fn attn_f32_dot_microbench(
     len: usize,
     repeats: usize,
@@ -1769,7 +1791,7 @@ pub struct LlamaInferenceSession {
     resident_paths_disabled: bool,
     /// When set, the deterministic forward pass folds each layer's output hidden state and the
     /// final logits into a streaming SHA-256 rollup (an execution-trace digest). Transient
-    /// proof-carrying state, not part of the session's logical identity â€” skipped by
+    /// proof-carrying state, not part of the session's logical identity Ã¢â‚¬â€ skipped by
     /// Clone/PartialEq/Debug like `resident_decode`. Only enabled in deterministic mode
     /// (`enable_execution_trace`); the default path never allocates it.
     execution_trace: Option<ExecutionTraceHasher>,
@@ -1778,7 +1800,7 @@ pub struct LlamaInferenceSession {
     /// without this the key would be the `weights` Arc pointer, which is not stable
     /// across separately-loaded `Arc<LlamaLoadedWeights>` for the same model (e.g. a
     /// prompt-prefix-cache-restored session vs a freshly loaded one). When two such
-    /// Arcs alternate, the single-slot engine cache thrashes â€” a multi-second 3.4 GB
+    /// Arcs alternate, the single-slot engine cache thrashes Ã¢â‚¬â€ a multi-second 3.4 GB
     /// re-upload on every request. The API sets this from the model id; when unset
     /// (tests, CLI), the wrappers fall back to the Arc pointer. Transient identity,
     /// copied by Clone/take_for_step so restored sessions keep the same key.
@@ -1814,7 +1836,7 @@ impl LlamaInferenceSession {
 
     /// Move the session out for a blocking generation step, leaving a hollow placeholder
     /// behind (same identity, empty KV, no resident state). Unlike `clone`, this PRESERVES
-    /// the resident GPU session â€” the on-GPU KV cache and encode-ahead pipeline â€” which is
+    /// the resident GPU session Ã¢â‚¬â€ the on-GPU KV cache and encode-ahead pipeline Ã¢â‚¬â€ which is
     /// single-owner and dropped by `clone`. The caller must re-assign the returned session
     /// when the step finishes or the sequence loses its KV state entirely.
     pub fn take_for_step(&mut self) -> LlamaInferenceSession {
@@ -1863,7 +1885,7 @@ impl LlamaInferenceSession {
     }
 
     /// Approximate resident-weight footprint of this session in bytes: the raw Q8_0 block
-    /// bytes of every layer's attention + FFN tensors plus the output projection â€” the same
+    /// bytes of every layer's attention + FFN tensors plus the output projection Ã¢â‚¬â€ the same
     /// unit `build_resident_cuda_engine` sizes VRAM against. Used to compute the
     /// speculative-coexistence reserve (how much VRAM a draft model needs to stay resident).
     #[cfg(feature = "cuda")]
@@ -1999,7 +2021,7 @@ impl LlamaInferenceSession {
 
     /// Arm the execution-trace rollup: subsequent forward passes fold every layer's output
     /// hidden state and the final logits into a streaming SHA-256 (see [`ExecutionTraceHasher`]).
-    /// Fails closed unless deterministic mode is active â€” the rollup is only meaningful on the
+    /// Fails closed unless deterministic mode is active Ã¢â‚¬â€ the rollup is only meaningful on the
     /// order-stable CPU lane (RECEIPTS.md rule 2), and arming it would otherwise advertise a
     /// digest over a non-reproducible run. Returns whether the trace was armed.
     pub fn enable_execution_trace(&mut self) -> bool {
@@ -2031,7 +2053,7 @@ impl LlamaInferenceSession {
     }
 
     /// Roll the sequence back to `position`, discarding newer KV entries.
-    /// Requires CPU-authoritative KV state â€” the GPU-resident cache has no
+    /// Requires CPU-authoritative KV state Ã¢â‚¬â€ the GPU-resident cache has no
     /// rollback, so any resident session is dropped and reseeds from CPU on
     /// next use.
     pub fn rollback_to_position(&mut self, position: usize) -> Result<()> {
@@ -2103,7 +2125,7 @@ impl LlamaInferenceSession {
             return Ok(false);
         }
         // Wire-page (fast-load) weights satisfy residency too, but only when the wire
-        // kernels are active â€” their bytes exist solely in the 34-byte wire layout.
+        // kernels are active Ã¢â‚¬â€ their bytes exist solely in the 34-byte wire layout.
         let wire_ok = metal_seam::wire_mode_active();
         let is_q8 = |t: &CpuTensor| {
             t.source_type == Some(GgufTensorType::Q8_0)
@@ -2116,7 +2138,7 @@ impl LlamaInferenceSession {
         // source_type, so a model may be all-Q8_0, all-Q4_K, or mixed.
         // The contraction dimension (in_features) is gguf dim(0) in the runtime shape:
         // a `[in, out]` gguf linear is stored out-major (out rows of `in` contiguous
-        // values), so each output row spans `in/256` super-blocks â€” the kernel's `n_sb`.
+        // values), so each output row spans `in/256` super-blocks Ã¢â‚¬â€ the kernel's `n_sb`.
         // (The output/lm_head, with a non-256-aligned vocab in dim(1), is the case that
         // makes checking the wrong dim wrongly reject it.)
         let is_q4k = |t: &CpuTensor| {
@@ -2235,7 +2257,7 @@ impl LlamaInferenceSession {
     /// GPU prefill (CAMELID_METAL_RESIDENT_PREFILL=1): run the prompt's first N tokens
     /// through the resident session in ONE command buffer (weights stream once, attention
     /// per position). On success the GPU KV cache holds positions 0..N, the CPU KV cache is
-    /// advanced (positions left empty â€” only the resident path continues this sequence),
+    /// advanced (positions left empty Ã¢â‚¬â€ only the resident path continues this sequence),
     /// and the caller skips its CPU prefill loop entirely; the last prompt token then runs
     /// through the resident decode for logits.
     fn try_resident_prefill(&mut self, token_ids: &[u32]) -> Result<bool> {
@@ -2256,7 +2278,7 @@ impl LlamaInferenceSession {
     /// NVIDIA device (one forward per token, KV built incrementally, a single sync
     /// at the end), then leave the global engine ready at `position = n` so the
     /// last prompt token decodes straight into the first generated token. Replaces
-    /// the CPU prefill â€” the main time-to-first-token cost. Returns `false` to fall
+    /// the CPU prefill Ã¢â‚¬â€ the main time-to-first-token cost. Returns `false` to fall
     /// back to the CPU prefill for any unsupported config.
     #[cfg(feature = "cuda")]
     fn try_resident_prefill_cuda(&mut self, token_ids: &[u32]) -> Result<bool> {
@@ -2371,7 +2393,7 @@ impl LlamaInferenceSession {
         }
         // Default to the batched prefill (each weight read once per MAX_VERIFY_K-token
         // chunk instead of once per token). `CAMELID_CUDA_RESIDENT_PREFILL_BATCHED=0`
-        // forces the serial per-token loop â€” an A/B switch for parity bisection. Both
+        // forces the serial per-token loop Ã¢â‚¬â€ an A/B switch for parity bisection. Both
         // write bit-identical KV (the batched stack reuses the same per-block dot and
         // block-ordered sum), so decode after either is token-identical.
         let serial_prefill = std::env::var_os("CAMELID_CUDA_RESIDENT_PREFILL_BATCHED")
@@ -2404,7 +2426,7 @@ impl LlamaInferenceSession {
         // KV cache is authoritative too: otherwise any later forward that takes the
         // CPU path (dense diagnostics, a GPU-decode fallback, or a KV rollback) reads
         // an all-zero history and generation degenerates. The copy is a few MB of
-        // device->host transfer â€” negligible next to the prefill compute it follows,
+        // device->host transfer Ã¢â‚¬â€ negligible next to the prefill compute it follows,
         // and it keeps both backends in lockstep.
         if let Err(e) =
             self.copy_resident_cuda_kv_to_host(&slot.engine, n_layers, n, n_kv, head_dim)
@@ -2449,7 +2471,7 @@ impl LlamaInferenceSession {
                     let src = (h * n + p) * head_dim;
                     // Canonical store, not a raw copy: the GPU KV is f16, so
                     // this data is f16-exact and the rounding inside is
-                    // idempotent â€” the routing enforces the invariant
+                    // idempotent Ã¢â‚¬â€ the routing enforces the invariant
                     // structurally instead of relying on the GPU dtype.
                     self.kv_cache.store_kv_head_row(
                         layer,
@@ -2471,7 +2493,7 @@ impl LlamaInferenceSession {
     /// id sampled ON the GPU. The token graph's tail runs the argmax (exactly
     /// `LlamaSampler::Greedy`: strict greater-than, lowest-index tie-break) and gathers the
     /// sampled token's embedding row into the next pre-encoded graph's input, and that next
-    /// graph is event-released before this one finishes â€” so consecutive tokens run
+    /// graph is event-released before this one finishes Ã¢â‚¬â€ so consecutive tokens run
     /// back-to-back on the GPU with no logits readback or CPU sampling on the critical
     /// path. Returns Ok(None) when the resident fast path is unavailable (the caller falls
     /// back to the general path, which this call then leaves untouched).
@@ -2512,7 +2534,7 @@ impl LlamaInferenceSession {
 
     /// Temperature-sampling analog of the greedy resident fast lane: when the
     /// sampler is plain temperature (no top-k / top-p / penalties / logit-bias),
-    /// draw the next token on the GPU via Gumbel-max â€” no 128K-logit host copy and
+    /// draw the next token on the GPU via Gumbel-max Ã¢â‚¬â€ no 128K-logit host copy and
     /// no CPU sort, which the profiler showed cost ~7 ms/token (more than the whole
     /// forward). Returns `Ok(None)` when the config isn't GPU-eligible or CUDA
     /// resident decode is off, so the caller uses the CPU logits path unchanged.
@@ -2573,7 +2595,7 @@ impl LlamaInferenceSession {
     /// proposes up to `max_draft` tokens from `history`; the model verifies them in
     /// ONE batched forward (`verify_batch`), and the longest correct prefix plus
     /// one bonus token are accepted. Output is exactly what greedy decode would
-    /// have produced (the model's argmax verifies every token) â€” lossless â€” but a
+    /// have produced (the model's argmax verifies every token) Ã¢â‚¬â€ lossless Ã¢â‚¬â€ but a
     /// single memory-bound forward can emit several tokens. Returns the accepted
     /// tokens (1..=max_draft+1) and advances the KV position, or `Ok(None)` when no
     /// draft is available or the GPU engine isn't ready (caller does a normal step).
@@ -2648,7 +2670,7 @@ impl LlamaInferenceSession {
         }
 
         // Same key the build/decode wrappers use (stable model identity when set,
-        // else the weights Arc pointer) â€” otherwise the readiness check never matches.
+        // else the weights Arc pointer) Ã¢â‚¬â€ otherwise the readiness check never matches.
         let key = self
             .resident_cache_key
             .map(|k| k as usize)
@@ -2813,7 +2835,7 @@ impl LlamaInferenceSession {
     /// Non-CUDA build: route the GPU resident tree speculative-verify to the Metal seam
     /// (`verify_tree_metal`), which runs the batched bit-identical `verify_batch_tree` when the
     /// resident engine is live and ready, else returns `Ok(None)` so the caller takes a normal
-    /// step. Lossless either way (the target verify is authoritative â€” every emitted token is the
+    /// step. Lossless either way (the target verify is authoritative Ã¢â‚¬â€ every emitted token is the
     /// model's own greedy argmax along the accepted path).
     #[cfg(not(feature = "cuda"))]
     pub fn verify_tree_gpu(
@@ -3526,7 +3548,7 @@ impl LlamaInferenceSession {
     /// accepted token followed by drafted tokens) in ONE batched pass through
     /// the chunked-prefill layer path, then compute logits for EVERY position
     /// and return the greedy argmax per position. One weight read serves all
-    /// M tokens â€” the same amortization the prefill path gets.
+    /// M tokens Ã¢â‚¬â€ the same amortization the prefill path gets.
     ///
     /// KV entries are appended for all `token_ids` (position advances by M);
     /// the caller drops rejected suffixes with `rollback_to_position`.
@@ -3781,7 +3803,7 @@ impl LlamaInferenceSession {
             }
             timings.layers.push(layer_timings);
             std::mem::swap(&mut hidden.data, &mut next_hidden);
-            hidden.name = format!("layer_{layer_idx}_prefill_layer_major_output");
+            hidden.name = cached_layer_label!(layer_idx, "prefill_layer_major_output").into_owned();
             hidden.shape = TensorShape {
                 dims: hidden_dims.clone(),
             };
@@ -3911,7 +3933,7 @@ impl LlamaInferenceSession {
                         }
                     }
                 }
-                trace_forward_memory(&format!("layer_{layer_idx}_start"));
+                trace_forward_memory(&cached_layer_label!(layer_idx, "start"));
                 telemetry::emit(telemetry::Event::LayerStarted {
                     layer: layer_idx,
                     layers_total: self.weights.layers.len(),
@@ -3938,7 +3960,7 @@ impl LlamaInferenceSession {
                     layers_total: self.weights.layers.len(),
                     duration_us: timed.timings.total as u64,
                 });
-                trace_forward_memory(&format!("layer_{layer_idx}_done"));
+                trace_forward_memory(&cached_layer_label!(layer_idx, "done"));
                 if let (Some(memory), Some(layer_memory)) = (&mut memory, &timed.timings.memory) {
                     memory.record_layer(layer_memory.clone());
                 }
@@ -4084,7 +4106,7 @@ impl LlamaInferenceSession {
     }
 
     /// `allowed_tokens`, when set, is a vocab-sized mask applied to the logits
-    /// before sampling (disallowed tokens forced to `-inf`) â€” grammar-constrained
+    /// before sampling (disallowed tokens forced to `-inf`) Ã¢â‚¬â€ grammar-constrained
     /// decoding. The unmasked logits are still returned in the step (so logprobs /
     /// diagnostics see the real distribution).
     pub fn generate_next_token_with_history_diagnostics(
@@ -4386,9 +4408,9 @@ fn env_flag_enabled(key: &str) -> bool {
 /// forward pass: every Metal/GPU dispatch gate fails closed to its CPU equivalent,
 /// regardless of any `CAMELID_METAL_*` override. This makes the supported TinyLlama
 /// 1.1B Q8_0 forward pass bit-exact and reduction-order-stable across runs, thread
-/// counts, and processes (the CPU reduction order is already fixed â€” each output owns
+/// counts, and processes (the CPU reduction order is already fixed Ã¢â‚¬â€ each output owns
 /// its full serial K-dimension reduction; see `qa/determinism/determinism-baseline-*.md` and
-/// DECISIONS.md Â§D9). The library default is OFF, so the default (GPU fast) path and
+/// DECISIONS.md Ã‚Â§D9). The library default is OFF, so the default (GPU fast) path and
 /// every embedder are byte-for-byte unchanged. The pinned reduction order mirrors the
 /// llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated against.
 pub fn deterministic_mode_enabled() -> bool {
@@ -4409,7 +4431,7 @@ pub const EXECUTION_TRACE_ALGORITHM_ROLLUP_V1: &str = "sha256-rollup-v1";
 /// This is a single *rollup*: a mismatch proves the run differs but does not localize which
 /// token or layer. It is only meaningful on the order-stable CPU lane (deterministic mode):
 /// the underlying values are reduction-order-stable there (see [`deterministic_mode_enabled`]
-/// and DECISIONS.md Â§D9), and byte-for-byte reproducibility requires greedy decoding
+/// and DECISIONS.md Ã‚Â§D9), and byte-for-byte reproducibility requires greedy decoding
 /// (RECEIPTS.md rule 2). The digest is ISA-specific (i8mm vs scalar round differently), so it
 /// is re-derivable on the same deterministic lane/host, not portable across ISAs.
 #[derive(Clone)]
@@ -4536,12 +4558,12 @@ fn prefill_layer_major_enabled(weights: &LlamaLoadedWeights) -> bool {
 
 /// Dedicated, wider Rayon pool for the compute-bound prompt-prefill GEMM.
 ///
-/// Prompt prefill is a matrixâ€“matrix multiply (high arithmetic intensity): it
+/// Prompt prefill is a matrixÃ¢â‚¬â€œmatrix multiply (high arithmetic intensity): it
 /// scales with *logical* cores, gaining throughput from SMT siblings. Single-token
-/// decode is the opposite â€” a matrixâ€“vector stream that is memory-bandwidth-bound,
+/// decode is the opposite Ã¢â‚¬â€ a matrixÃ¢â‚¬â€œvector stream that is memory-bandwidth-bound,
 /// where SMT siblings only add memory-controller contention and *cost* throughput.
-/// Measured on an i7-11800H (8C/16T): prefill 19.5â†’23.6 tok/s going 8â†’16 threads
-/// (+21%), while decode peaks near 6 threads and falls 5.7â†’5.2 over the same range
+/// Measured on an i7-11800H (8C/16T): prefill 19.5Ã¢â€ â€™23.6 tok/s going 8Ã¢â€ â€™16 threads
+/// (+21%), while decode peaks near 6 threads and falls 5.7Ã¢â€ â€™5.2 over the same range
 /// (see `docs/perf-deep-dive/PERF_RECEIPTS/.../p1-cpu-thread-sweep`). The global
 /// pool stays sized for decode (physical cores on Windows, see
 /// `configure_rayon_threads`); only the prefill forward pass installs onto this
@@ -4549,7 +4571,7 @@ fn prefill_layer_major_enabled(weights: &LlamaLoadedWeights) -> bool {
 ///
 /// Bit-exact: the prefill matmul parallelizes over *independent* output rows, and
 /// each row's block accumulation is serial, so the thread count never changes the
-/// numeric result (verified byte-identical across 4â€“16 threads in the sweep above).
+/// numeric result (verified byte-identical across 4Ã¢â‚¬â€œ16 threads in the sweep above).
 ///
 /// Returns `None` (prefill stays on the global pool) on non-Windows/x86_64 targets,
 /// under an explicit `CAMELID_PREFILL_THREADS=0|off|global`, when the operator has
@@ -4597,10 +4619,10 @@ fn build_prefill_thread_pool() -> Option<rayon::ThreadPool> {
 
 /// Pure resolution of the prefill pool width, factored out for testing.
 ///
-/// * `spec` â€” the raw `CAMELID_PREFILL_THREADS` value, if set.
-/// * `global_pinned` â€” whether `CAMELID_THREADS` explicitly pinned the global pool.
-/// * `logical` â€” logical core count (the default widen target).
-/// * `widen_by_default` â€” whether this target auto-widens prefill (Windows/x86_64).
+/// * `spec` Ã¢â‚¬â€ the raw `CAMELID_PREFILL_THREADS` value, if set.
+/// * `global_pinned` Ã¢â‚¬â€ whether `CAMELID_THREADS` explicitly pinned the global pool.
+/// * `logical` Ã¢â‚¬â€ logical core count (the default widen target).
+/// * `widen_by_default` Ã¢â‚¬â€ whether this target auto-widens prefill (Windows/x86_64).
 fn resolve_prefill_thread_count_from(
     spec: Option<&str>,
     global_pinned: bool,
@@ -5573,7 +5595,7 @@ fn sample_with_config(
     // Advance the RNG per decode step: `token_history.len()` is the deterministic
     // stream position, so each step draws a fresh uniform while a fixed seed still
     // reproduces the whole sequence token-for-token. (Previously the draw depended
-    // only on the seed, so every step reused one identical value â€” a degenerate
+    // only on the seed, so every step reused one identical value Ã¢â‚¬â€ a degenerate
     // sampler.)
     let draw = seeded_unit_interval_at(config.seed.unwrap_or(0), token_history.len() as u64);
     let mut cumulative = 0.0;
@@ -5729,7 +5751,7 @@ fn forward_layer_timed(
     let attn_norm = hidden.rms_norm(
         &layer.attention_norm,
         rms_norm_epsilon,
-        format!("layer_{layer_idx}_attention_norm"),
+        cached_layer_label!(layer_idx, "attention_norm"),
     )?;
     let attention_norm_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&attn_norm))
@@ -5779,7 +5801,7 @@ fn forward_layer_timed(
         let q = linear_for_role_bound(
             &attn_norm,
             &layer.attention_q,
-            format!("layer_{layer_idx}_attention_q"),
+            cached_layer_label!(layer_idx, "attention_q"),
             "linear",
             runtime_plan,
             collect_diagnostics,
@@ -5791,7 +5813,7 @@ fn forward_layer_timed(
         let k = linear_for_role_bound(
             &attn_norm,
             &layer.attention_k,
-            format!("layer_{layer_idx}_attention_k"),
+            cached_layer_label!(layer_idx, "attention_k"),
             "attention_k",
             runtime_plan,
             collect_diagnostics,
@@ -5803,7 +5825,7 @@ fn forward_layer_timed(
         let v = linear_for_role_bound(
             &attn_norm,
             &layer.attention_v,
-            format!("layer_{layer_idx}_attention_v"),
+            cached_layer_label!(layer_idx, "attention_v"),
             "attention_v",
             runtime_plan,
             collect_diagnostics,
@@ -5849,7 +5871,7 @@ fn forward_layer_timed(
             weight,
             config.attention_head_count as usize,
             rms_norm_epsilon,
-            format!("layer_{layer_idx}_attention_q_norm"),
+            cached_layer_label!(layer_idx, "attention_q_norm"),
         )?,
         None => q,
     };
@@ -5858,7 +5880,7 @@ fn forward_layer_timed(
             weight,
             config.attention_head_count_kv as usize,
             rms_norm_epsilon,
-            format!("layer_{layer_idx}_attention_k_norm"),
+            cached_layer_label!(layer_idx, "attention_k_norm"),
         )?,
         None => k,
     };
@@ -5870,7 +5892,7 @@ fn forward_layer_timed(
         config.attention_head_count as usize,
         config,
         rope_freqs,
-        format!("layer_{layer_idx}_attention_q_rope"),
+        cached_layer_label!(layer_idx, "attention_q_rope"),
     )?;
     let k = apply_rope(
         &k_before_rope,
@@ -5878,7 +5900,7 @@ fn forward_layer_timed(
         config.attention_head_count_kv as usize,
         config,
         rope_freqs,
-        format!("layer_{layer_idx}_attention_k_rope"),
+        cached_layer_label!(layer_idx, "attention_k_rope"),
     )?;
     let attention_q_rope_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&q))
@@ -5947,7 +5969,7 @@ fn forward_layer_timed(
         &q,
         config.attention_head_count as usize,
         config.attention_head_count_kv as usize,
-        format!("layer_{layer_idx}_attention_context"),
+        cached_layer_label!(layer_idx, "attention_context"),
         collect_diagnostics,
     )?;
     let attention_trace = attention_context.trace;
@@ -5965,7 +5987,7 @@ fn forward_layer_timed(
     let mut attn_out = linear_for_role_bound(
         &context,
         &layer.attention_output,
-        format!("layer_{layer_idx}_attention_output"),
+        cached_layer_label!(layer_idx, "attention_output"),
         "linear",
         runtime_plan,
         collect_diagnostics,
@@ -5974,7 +5996,7 @@ fn forward_layer_timed(
     if collect_diagnostics && diagnostic_zero_delta(DeltaZeroTarget::Attention, layer_idx)? {
         attn_out = zero_like(
             &attn_out,
-            format!("layer_{layer_idx}_attention_output_zeroed"),
+            cached_layer_label!(layer_idx, "attention_output_zeroed"),
         )?;
     }
     let attention_output_stats = collect_diagnostics
@@ -5993,7 +6015,10 @@ fn forward_layer_timed(
 
     let started = Instant::now();
     metal_seam::synchronize_active_session();
-    let residual = hidden.add(&attn_out, format!("layer_{layer_idx}_attention_residual"))?;
+    let residual = hidden.add(
+        &attn_out,
+        cached_layer_label!(layer_idx, "attention_residual"),
+    )?;
     let attention_residual_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&residual))
         .transpose()?;
@@ -6013,7 +6038,7 @@ fn forward_layer_timed(
     let ffn_norm = residual.rms_norm(
         &layer.ffn_norm,
         rms_norm_epsilon,
-        format!("layer_{layer_idx}_ffn_norm"),
+        cached_layer_label!(layer_idx, "ffn_norm"),
     )?;
     let ffn_norm_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&ffn_norm))
@@ -6048,7 +6073,7 @@ fn forward_layer_timed(
             &layer.ffn_down,
             moe.expert_used_count as usize,
             MixtralMoeFfnOptions::new(
-                format!("layer_{layer_idx}_mixtral_moe_ffn"),
+                cached_layer_label!(layer_idx, "mixtral_moe_ffn"),
                 collect_diagnostics,
             ),
         )?;
@@ -6060,8 +6085,8 @@ fn forward_layer_timed(
             ffn_out, None, None, None, None, None, None, None, None, trace, false,
         )
     } else {
-        let activated_name = format!("layer_{layer_idx}_ffn_activated");
-        let down_name = format!("layer_{layer_idx}_ffn_down");
+        let activated_name = cached_layer_label!(layer_idx, "ffn_activated");
+        let down_name = cached_layer_label!(layer_idx, "ffn_down");
         if let Some(fused) = (!collect_diagnostics)
             .then(|| {
                 try_x86_q8_ffn_decode_chain_path(
@@ -6159,7 +6184,7 @@ fn forward_layer_timed(
         }
     };
     if collect_diagnostics && diagnostic_zero_delta(DeltaZeroTarget::Ffn, layer_idx)? {
-        ffn_out = zero_like(&ffn_out, format!("layer_{layer_idx}_ffn_down_zeroed"))?;
+        ffn_out = zero_like(&ffn_out, cached_layer_label!(layer_idx, "ffn_down_zeroed"))?;
     }
     if let Some(memory) = &mut memory {
         memory.record_after_ffn_down(capture_memory_sample(kv_cache));
@@ -6171,7 +6196,7 @@ fn forward_layer_timed(
     let output = if ffn_out_already_residual {
         ffn_out.clone()
     } else {
-        residual.add(&ffn_out, format!("layer_{layer_idx}_ffn_residual"))?
+        residual.add(&ffn_out, cached_layer_label!(layer_idx, "ffn_residual"))?
     };
     let ffn_residual_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&output))
@@ -6299,7 +6324,7 @@ fn forward_prefill_layer_chunk_timed(
     let attn_norm = hidden.rms_norm(
         &layer.attention_norm,
         params.rms_norm_epsilon,
-        format!("layer_{layer_idx}_prefill_attention_norm"),
+        cached_layer_label!(layer_idx, "prefill_attention_norm"),
     )?;
     timings.attention_norm = started.elapsed().as_micros();
     if let Some(memory) = &mut memory {
@@ -6329,7 +6354,7 @@ fn forward_prefill_layer_chunk_timed(
         let q = linear_runtime(
             &attn_norm,
             &layer.attention_q,
-            format!("layer_{layer_idx}_prefill_attention_q"),
+            cached_layer_label!(layer_idx, "prefill_attention_q"),
             false,
         )?;
         timings.attention_q = started.elapsed().as_micros();
@@ -6338,7 +6363,7 @@ fn forward_prefill_layer_chunk_timed(
         let k = linear_for_role_runtime(
             &attn_norm,
             &layer.attention_k,
-            format!("layer_{layer_idx}_prefill_attention_k"),
+            cached_layer_label!(layer_idx, "prefill_attention_k"),
             "attention_k",
             false,
         )?;
@@ -6348,7 +6373,7 @@ fn forward_prefill_layer_chunk_timed(
         let v = linear_for_role_runtime(
             &attn_norm,
             &layer.attention_v,
-            format!("layer_{layer_idx}_prefill_attention_v"),
+            cached_layer_label!(layer_idx, "prefill_attention_v"),
             "attention_v",
             false,
         )?;
@@ -6378,7 +6403,7 @@ fn forward_prefill_layer_chunk_timed(
             weight,
             config.attention_head_count as usize,
             params.rms_norm_epsilon,
-            format!("layer_{layer_idx}_prefill_attention_q_norm"),
+            cached_layer_label!(layer_idx, "prefill_attention_q_norm"),
         )?,
         None => q,
     };
@@ -6387,7 +6412,7 @@ fn forward_prefill_layer_chunk_timed(
             weight,
             config.attention_head_count_kv as usize,
             params.rms_norm_epsilon,
-            format!("layer_{layer_idx}_prefill_attention_k_norm"),
+            cached_layer_label!(layer_idx, "prefill_attention_k_norm"),
         )?,
         None => k,
     };
@@ -6397,7 +6422,7 @@ fn forward_prefill_layer_chunk_timed(
         config.attention_head_count as usize,
         config,
         params.rope_freqs,
-        format!("layer_{layer_idx}_prefill_attention_q_rope"),
+        cached_layer_label!(layer_idx, "prefill_attention_q_rope"),
     )?;
     let k = apply_rope_batch(
         &k,
@@ -6405,7 +6430,7 @@ fn forward_prefill_layer_chunk_timed(
         config.attention_head_count_kv as usize,
         config,
         params.rope_freqs,
-        format!("layer_{layer_idx}_prefill_attention_k_rope"),
+        cached_layer_label!(layer_idx, "prefill_attention_k_rope"),
     )?;
     timings.attention_rope = started.elapsed().as_micros();
     if let Some(memory) = &mut memory {
@@ -6434,7 +6459,7 @@ fn forward_prefill_layer_chunk_timed(
         &q,
         config.attention_head_count as usize,
         config.attention_head_count_kv as usize,
-        format!("layer_{layer_idx}_prefill_attention_context"),
+        cached_layer_label!(layer_idx, "prefill_attention_context"),
     )?;
     timings.attention_context = started.elapsed().as_micros();
     if let Some(memory) = &mut memory {
@@ -6446,7 +6471,7 @@ fn forward_prefill_layer_chunk_timed(
     let attn_out = linear_runtime(
         &context,
         &layer.attention_output,
-        format!("layer_{layer_idx}_prefill_attention_output"),
+        cached_layer_label!(layer_idx, "prefill_attention_output"),
         false,
     )?;
     timings.attention_output = started.elapsed().as_micros();
@@ -6460,7 +6485,7 @@ fn forward_prefill_layer_chunk_timed(
     add_tensor_in_place(
         &mut residual,
         hidden,
-        format!("layer_{layer_idx}_prefill_attention_residual"),
+        cached_layer_label!(layer_idx, "prefill_attention_residual"),
     )?;
     timings.attention_residual = started.elapsed().as_micros();
     if let Some(memory) = &mut memory {
@@ -6472,7 +6497,7 @@ fn forward_prefill_layer_chunk_timed(
     let ffn_norm = residual.rms_norm(
         &layer.ffn_norm,
         params.rms_norm_epsilon,
-        format!("layer_{layer_idx}_prefill_ffn_norm"),
+        cached_layer_label!(layer_idx, "prefill_ffn_norm"),
     )?;
     timings.ffn_norm = started.elapsed().as_micros();
     if let Some(memory) = &mut memory {
@@ -6488,7 +6513,10 @@ fn forward_prefill_layer_chunk_timed(
             &layer.ffn_up,
             &layer.ffn_down,
             moe.expert_used_count as usize,
-            MixtralMoeFfnOptions::new(format!("layer_{layer_idx}_prefill_mixtral_moe_ffn"), false),
+            MixtralMoeFfnOptions::new(
+                cached_layer_label!(layer_idx, "prefill_mixtral_moe_ffn"),
+                false,
+            ),
         )?;
         timings.ffn_gate = gate;
         timings.ffn_up = up;
@@ -6500,7 +6528,7 @@ fn forward_prefill_layer_chunk_timed(
             &ffn_norm,
             &layer.ffn_gate,
             &layer.ffn_up,
-            format!("layer_{layer_idx}_prefill_ffn_activated"),
+            cached_layer_label!(layer_idx, "prefill_ffn_activated"),
         )?;
         timings.ffn_gate = activated.gate;
         timings.ffn_up = activated.up;
@@ -6514,7 +6542,7 @@ fn forward_prefill_layer_chunk_timed(
         let ffn_out = linear_for_role_runtime(
             &activated,
             &layer.ffn_down,
-            format!("layer_{layer_idx}_prefill_ffn_down"),
+            cached_layer_label!(layer_idx, "prefill_ffn_down"),
             "ffn_down",
             false,
         )?;
@@ -6531,7 +6559,7 @@ fn forward_prefill_layer_chunk_timed(
     add_tensor_in_place(
         &mut output,
         &residual,
-        format!("layer_{layer_idx}_prefill_ffn_residual"),
+        cached_layer_label!(layer_idx, "prefill_ffn_residual"),
     )?;
     timings.ffn_residual = started.elapsed().as_micros();
     if let Some(memory) = &mut memory {
@@ -7063,7 +7091,7 @@ const DECODE_ARM_FALLBACK: u8 = 7;
 /// Decode-bound variant of [`linear_for_role_runtime_with_plan`]: the first
 /// rows==1 call per binding cell runs the historical cascade and records the
 /// winning arm; steady-state calls jump straight to that arm. The arm's own
-/// guards remain in force — if they ever miss (they cannot for a fixed plan
+/// guards remain in force â€” if they ever miss (they cannot for a fixed plan
 /// and shape), the call falls back to the full cascade and rebinds, so the
 /// fail-closed ordering is preserved by construction. Prefill (rows > 1) and
 /// diagnostics calls always take the historical paths untouched.
@@ -7175,7 +7203,7 @@ fn linear_for_role_bound(
 /// The historical role-dispatch cascade, unchanged in ORDER and guards; when
 /// `record` is provided (rows==1 bound calls), the winning decode-capable arm
 /// is written into the binding cell. This function remains the single
-/// authority on kernel selection — the bound fast path above only replays its
+/// authority on kernel selection â€” the bound fast path above only replays its
 /// recorded verdict.
 fn decode_linear_cascade(
     input: &CpuTensor,
@@ -7185,7 +7213,7 @@ fn decode_linear_cascade(
     runtime_plan: &ResolvedRuntimePlan,
     record: Option<&DecodeBindingCell>,
 ) -> Result<CpuTensor> {
-    // Lane 1: unified tiled Q8_0 prefill GEMM owner (default-off). Role-agnostic — covers
+    // Lane 1: unified tiled Q8_0 prefill GEMM owner (default-off). Role-agnostic â€” covers
     // every Q8_0 projection (q/k/v/o, gate/up, ffn_down) in ONE place. Returns None for
     // decode, non-Q8, or non-PackedRows4 weights, so the default path is unchanged when off.
     if let Some(output) =
@@ -7524,8 +7552,8 @@ fn linear_with_diagnostic_layouts_with_plan(
     let rows = weight.dim(0)?;
     let cols = weight.dim(1)?;
     // K-quant (Q4_K / Q6_K) wire weights have no f32 data and no general CPU
-    // consumer; intercept them here â€” the single chokepoint both the diagnostic
-    // and runtime linear chains funnel through â€” with the original tensor, before
+    // consumer; intercept them here Ã¢â‚¬â€ the single chokepoint both the diagnostic
+    // and runtime linear chains funnel through Ã¢â‚¬â€ with the original tensor, before
     // any layout reinterpretation that would drop the wire bytes. The block-dot
     // is layout-agnostic: it takes the contraction width from the input and the
     // output width from the wire length, so a GGUF `[in, out]` weight (where
@@ -10246,7 +10274,7 @@ fn resident_cuda_cache() -> &'static std::sync::Mutex<Option<ResidentCudaSlot>> 
 
 /// Second resident-engine cache, dedicated to the speculative draft model. Draft
 /// and target are different models (different weight identities), so giving them
-/// separate single-slot caches lets BOTH stay GPU-resident at once â€” sharing one
+/// separate single-slot caches lets BOTH stay GPU-resident at once Ã¢â‚¬â€ sharing one
 /// slot would thrash (rebuild + 3.4 GB re-upload) every time control passed between
 /// drafter and target. Routed by `LlamaInferenceSession::is_drafter`.
 #[cfg(feature = "cuda")]
@@ -10267,7 +10295,7 @@ static SPEC_COEXIST_RESERVE_BYTES: std::sync::atomic::AtomicU64 =
 
 /// Record the draft model's resident footprint so the target leaves room for it. Pass 0 to
 /// disable (single-model path). Does NOT evict already-built engines: a resident target built
-/// before the reserve was set keeps running (reused, not rebuilt) â€” rebuilding it would free
+/// before the reserve was set keeps running (reused, not rebuilt) Ã¢â‚¬â€ rebuilding it would free
 /// its VRAM only to the cudarc pool (which the free-VRAM probe does not see), so the rebuild
 /// would wrongly fall to CPU. The reserve therefore only shapes engines built AFTER it is set
 /// (e.g. when the drafter is configured before the target's first decode).
@@ -10285,7 +10313,7 @@ fn spec_coexist_reserve_bytes() -> u64 {
 
 /// KV-cache positions a speculative draft engine is sized for (env-tunable). The draft only
 /// needs to span the prompt + generated tokens it drafts over; capping it keeps the draft's
-/// VRAM small so it fits beside the resident target. Lossless either way â€” the target verify is
+/// VRAM small so it fits beside the resident target. Lossless either way Ã¢â‚¬â€ the target verify is
 /// authoritative, so a shorter draft context only affects accept rate, never correctness.
 #[cfg(feature = "cuda")]
 fn spec_draft_kv_context() -> usize {
@@ -10308,7 +10336,7 @@ pub fn reset_resident_caches() {
         .unwrap_or_else(|p| p.into_inner()) = None;
     // The engines dropped above returned their VRAM to cudarc's stream-ordered async
     // pool (cuMemFreeAsync), where the free-VRAM probe cannot see it. Trim the pool so
-    // the next model's resident fit decision measures the real free VRAM â€” otherwise a
+    // the next model's resident fit decision measures the real free VRAM Ã¢â‚¬â€ otherwise a
     // larger model wrongly falls back to the CPU path (the ~20x-slower symptom this
     // unload path exists to prevent).
     crate::cuda::release_async_pool();
@@ -10319,7 +10347,7 @@ pub fn reset_resident_caches() {}
 /// Prompt-lookup n-gram drafter: find the most recent earlier occurrence of the
 /// last `ngram` tokens and propose the up-to-`max_draft` tokens that followed it.
 /// Cheap (no model), and it hits whenever the model repeats a phrase already in
-/// the context (code, lists, quoted text) â€” exactly where greedy decode is
+/// the context (code, lists, quoted text) Ã¢â‚¬â€ exactly where greedy decode is
 /// predictable. Empty when there's no match.
 #[cfg(feature = "cuda")]
 fn draft_ngram(history: &[u32], max_draft: usize, ngram: usize) -> Vec<u32> {
@@ -10408,9 +10436,9 @@ fn build_resident_cuda_engine(
     // VRAM-driven resident-context sizing (portability, not hardcoded to any card):
     //   resident weights are uploaded once and live for the engine's lifetime; the
     //   GPU KV cache is allocated once at `cap` positions, costing
-    //   kv_bytes_per_pos = n_layers Â· n_kv Â· head_dim Â· 2(K,V) Â· 2(f16 bits) each. Size the
+    //   kv_bytes_per_pos = n_layers Ã‚Â· n_kv Ã‚Â· head_dim Ã‚Â· 2(K,V) Ã‚Â· 2(f16 bits) each. Size the
     //   cap so weights + KV + a scratch/headroom reserve fit in *detected free* VRAM:
-    //     cap = min(requested, (free_vram âˆ’ weights âˆ’ headroom) / kv_bytes_per_pos)
+    //     cap = min(requested, (free_vram Ã¢Ë†â€™ weights Ã¢Ë†â€™ headroom) / kv_bytes_per_pos)
     //   On a 6 GB card this stays conservative; on a 24 GB card it grows automatically
     //   to a long context. If even the floor (256) cannot fit, return None so the
     //   caller runs the model on the CPU path rather than oversubscribing VRAM.
@@ -10435,10 +10463,10 @@ fn build_resident_cuda_engine(
         + raw(weights.output_projection())
             .map(|b| b.len() as u64)
             .unwrap_or(0);
-    // Scratch reserve: logits row (vocabÂ·f32) + per-stage activation buffers + a flat
+    // Scratch reserve: logits row (vocabÃ‚Â·f32) + per-stage activation buffers + a flat
     // safety margin for driver/context overhead and fragmentation. The flat margin is
     // env-overridable (CAMELID_CUDA_RESIDENT_HEADROOM_MB) so a second engine can be
-    // packed onto a small card â€” e.g. drafter + target for speculative decode, where
+    // packed onto a small card Ã¢â‚¬â€ e.g. drafter + target for speculative decode, where
     // the default 512 MiB per engine would not leave room for both.
     // The flat margin defaults to 512 MiB for a sole resident engine. Under speculative
     // coexistence both engines pack onto the card, so 512 MiB each would not fit: the draft
@@ -10453,7 +10481,7 @@ fn build_resident_cuda_engine(
     // takes the remaining free VRAM). BUT only honor the reserve when the target still fits
     // FULLY resident after it, measured against the NORMAL single-engine headroom. If reserving
     // would force the target to offload trailing layers, that offload (a) slows the target
-    // forward and (b) pushes the batched verify onto the serial/CPU path â€” a different backend
+    // forward and (b) pushes the batched verify onto the serial/CPU path Ã¢â‚¬â€ a different backend
     // than the resident plain decode, which diverges at near-ties. Not worth it: drop the
     // reserve, build the target full-resident (NORMAL headroom), and let the draft fall back to
     // CPU (the prior, lossless behavior). So the resident-draft win is taken only on a GPU big
@@ -10474,7 +10502,7 @@ fn build_resident_cuda_engine(
     let coexist_fit_headroom = (vocab as u64 * 4) + (coexist_headroom_mb * 1024 * 1024);
     // Bounded over-allocation the WDDM driver pages to shared host memory (how llama.cpp fits both
     // models on a 6 GB card): treat free VRAM as larger by this much for the coexistence sizing.
-    // Default 0 (strict â€” no spill). Opt in via CAMELID_SPEC_COEXIST_SPILL_MB on a tight card.
+    // Default 0 (strict Ã¢â‚¬â€ no spill). Opt in via CAMELID_SPEC_COEXIST_SPILL_MB on a tight card.
     let coexist_spill = std::env::var("CAMELID_SPEC_COEXIST_SPILL_MB")
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
@@ -10492,7 +10520,7 @@ fn build_resident_cuda_engine(
     };
     // Honor the reserve only if the target still fits fully resident after it (measured with the
     // small coexist headroom; the reserve already accounts for the draft's footprint). If not,
-    // drop the reserve and build the target full-resident â€” offloading it to make room is a net
+    // drop the reserve and build the target full-resident Ã¢â‚¬â€ offloading it to make room is a net
     // loss (slow target + serial/CPU verify that diverges at near-ties from the resident plain
     // decode), so the draft falls back to CPU (the prior lossless behavior).
     let honor_reserve = raw_reserve > 0
@@ -10561,7 +10589,7 @@ fn build_resident_cuda_engine(
     // host RAM (test/override hook, fires even on a model that fits). Otherwise the
     // split is AUTOMATIC: when all weights + a minimum KV cache + headroom cannot fit
     // in free VRAM, offload the fewest TRAILING layers needed so the rest fit. Each
-    // offloaded layer streams its weights to a GPU scratch buffer every forward â€” a
+    // offloaded layer streams its weights to a GPU scratch buffer every forward Ã¢â‚¬â€ a
     // capacity tradeoff, token-identical to the all-resident path.
     let force_offload = std::env::var("CAMELID_OFFLOAD_FORCE_LAYERS")
         .ok()
@@ -10593,7 +10621,7 @@ fn build_resident_cuda_engine(
     let n_resident_layers = n_layers - offload_count;
 
     // VRAM left for the KV cache after the RESIDENT weights and (if offloading) the
-    // streaming scratch â€” so freed weight VRAM grows the resident context.
+    // streaming scratch Ã¢â‚¬â€ so freed weight VRAM grows the resident context.
     let offloaded_bytes: u64 = per_layer_bytes[n_resident_layers..].iter().sum();
     let resident_weights_bytes = weights_bytes.saturating_sub(offloaded_bytes);
     let scratch_reserve = if offload_count > 0 {
@@ -10638,7 +10666,7 @@ fn build_resident_cuda_engine(
         }
         return None;
     }
-    // Task 4 â€” explicit VRAM headroom policy. Project the actual device
+    // Task 4 Ã¢â‚¬â€ explicit VRAM headroom policy. Project the actual device
     // allocation (resident weights + streaming scratch + the sized KV cache) and
     // run it past the headroom policy *before* allocating. If it would OOM or
     // leave less than the minimum post-load headroom, refuse the resident load
@@ -10649,7 +10677,7 @@ fn build_resident_cuda_engine(
         let projected_alloc =
             resident_weights_bytes + scratch_reserve + (cap as u64) * kv_bytes_per_pos;
         // Evaluate against ACTUAL free VRAM. Under coexistence the budget already excludes the
-        // draft's reserve, so the target's sizing leaves that reserve free by construction â€”
+        // draft's reserve, so the target's sizing leaves that reserve free by construction Ã¢â‚¬â€
         // here we only require a small absolute safety margin (NOT reserve+margin, which would
         // double-count and falsely refuse). The draft, allocating last, likewise needs only the
         // small margin. Outside coexistence this is the normal 512 MiB post-load floor.
@@ -10693,7 +10721,7 @@ fn build_resident_cuda_engine(
             }
             _ => return None,
         };
-        // Per-projection quant lanes (q,k,v,o,gate,up,down) â€” drives the per-tensor
+        // Per-projection quant lanes (q,k,v,o,gate,up,down) Ã¢â‚¬â€ drives the per-tensor
         // repack + GEMV kernel + activation quantizer. Q4_K_M is mixed: most
         // projections Q4_K, with attn_v/ffn_down promoted to Q6_K in ~half the layers.
         let quants = [
@@ -10786,7 +10814,7 @@ fn resident_gpu_temperature_sampling_enabled() -> bool {
 }
 
 /// CUDA GPU-resident decode gate (the NVIDIA analog of the Metal one). On
-/// automatically whenever a usable CUDA device is present â€” the end-user app
+/// automatically whenever a usable CUDA device is present Ã¢â‚¬â€ the end-user app
 /// "just works" fast on the GPU with no flag or toggle. Deterministic mode
 /// (opt-in) forces the CPU reference; `CAMELID_CUDA_RESIDENT_DECODE=0` is an
 /// explicit escape hatch for debugging. Falls back to CPU per token for any
@@ -10824,7 +10852,7 @@ fn resident_decode_cuda_enabled() -> bool {
 /// is NOT bit-identical to a fresh GPU prefill: a cache hit reseeds the GPU KV from the
 /// f16-rounded host history and resumes, a different reduction order than a clean GPU
 /// prefill, which flips borderline (near-tie) tokens. The CPU lane is reduction-order
-/// stable, so it keeps the cache; the GPU lane must bypass it â€” exactly as deterministic
+/// stable, so it keeps the cache; the GPU lane must bypass it Ã¢â‚¬â€ exactly as deterministic
 /// mode already bypasses the cache on the CPU lane.
 pub fn resident_decode_cuda_active() -> bool {
     resident_decode_cuda_enabled()
@@ -10832,9 +10860,9 @@ pub fn resident_decode_cuda_active() -> bool {
 
 /// Maximum sequence length the CUDA resident engine keeps on the GPU. The GPU KV
 /// cache is allocated once at this many positions, so it directly sets the engine's
-/// VRAM footprint (â‰ˆ n_layersÂ·n_kvÂ·head_dimÂ·2Â·4 bytes per position) on top of the
+/// VRAM footprint (Ã¢â€°Ë† n_layersÃ‚Â·n_kvÃ‚Â·head_dimÃ‚Â·2Ã‚Â·4 bytes per position) on top of the
 /// resident weights. On a 6 GB laptop card a 3B Q8_0 model's weights already take
-/// ~3.4 GB, so an 8192-position KV (~1.8 GB for 3B) leaves almost no headroom â€” any
+/// ~3.4 GB, so an 8192-position KV (~1.8 GB for 3B) leaves almost no headroom Ã¢â‚¬â€ any
 /// other GPU app then pushes the engine past VRAM, it can no longer stay resident,
 /// and it is rebuilt (a multi-second 3.4 GB re-upload) on every request. A 4096 cap
 /// halves the KV footprint and keeps the engine resident with room to spare; beyond
@@ -10842,7 +10870,7 @@ pub fn resident_decode_cuda_active() -> bool {
 /// Optional hard ceiling on the resident KV context the wrappers *request*. The
 /// real limit is VRAM-driven inside `build_resident_cuda_engine` (which sizes the
 /// cap to detected free VRAM and reports it), so by default this imposes no extra
-/// cap â€” a big card gets a long resident context automatically. Set
+/// cap Ã¢â‚¬â€ a big card gets a long resident context automatically. Set
 /// `CAMELID_CUDA_RESIDENT_MAX_CONTEXT` to force a lower ceiling (e.g. to leave more
 /// VRAM for other apps).
 #[cfg(feature = "cuda")]
@@ -10914,8 +10942,8 @@ fn q8_0_hybrid_retained_gpu_rows(output_rows: usize) -> usize {
 }
 
 /// Explicit (and loud) opt-out from RAM-resident Q8_0 blocks: only an affirmatively set
-/// `CAMELID_LAZY_Q8_0_LINEAR` forces the per-token file-streaming path. Absence â€” and any
-/// disabled spelling â€” means weights are retained in RAM. There is no auto/budget fallback.
+/// `CAMELID_LAZY_Q8_0_LINEAR` forces the per-token file-streaming path. Absence Ã¢â‚¬â€ and any
+/// disabled spelling Ã¢â‚¬â€ means weights are retained in RAM. There is no auto/budget fallback.
 fn lazy_q8_0_linear_forced() -> bool {
     matches!(
         env::var("CAMELID_LAZY_Q8_0_LINEAR"),
@@ -10928,7 +10956,7 @@ fn lazy_q8_0_linear_forced() -> bool {
 }
 
 /// Fast-load gate: CAMELID_METAL_NOCOPY loads Q8_0 linears as page-aligned wire
-/// pages for in-place GPU consumption. macOS only â€” the storage is consumed by
+/// pages for in-place GPU consumption. macOS only Ã¢â‚¬â€ the storage is consumed by
 /// the Metal wire kernels.
 fn metal_nocopy_fast_load_enabled() -> bool {
     cfg!(target_os = "macos") && env_flag_enabled("CAMELID_METAL_NOCOPY")
@@ -13631,7 +13659,7 @@ fn q8_0_packed_rows4_gemm4_accumulate_block(
 
 /// Phase 3 (K-quant conductor): opt-in software prefetch of the weight stream ahead
 /// of the x86 packed decode dot. Default-off (`CAMELID_X86_PREFETCH`). Memory hint
-/// only â€” byte-identical output by construction. The macOS/aarch64 dot already issues
+/// only Ã¢â‚¬â€ byte-identical output by construction. The macOS/aarch64 dot already issues
 /// a NEON `prfm` two blocks ahead; this gives the x86 decode dot the same option so it
 /// can be measured on a bandwidth-bound host (the Q8 gated-SIMD history says prove the
 /// win on the box before promoting to default).
@@ -13790,16 +13818,16 @@ fn run_q8_0_packed_rows4_prefill_gemm4_kernel(
 // A role-agnostic, BIT-EXACT drop-in for the per-projection prefill block-dot. It reuses the
 // proven 4x4 register microkernel `q8_0_packed_rows4_gemm4_accumulate_block` VERBATIM, so every
 // output cell still accumulates `((int as f32) * weight_scale) * input_scale` over ascending
-// blocks with no FMA â€” byte-identical to the scalar oracle. The ONLY difference vs the (default-
+// blocks with no FMA Ã¢â‚¬â€ byte-identical to the scalar oracle. The ONLY difference vs the (default-
 // off, regressing) ffn_down GEMM4 lane is the loop nest: it parallelizes over OUTPUT-row bands
 // and streams every input group against an L1/L2-resident weight band, so each weight block is
-// read from DRAM ~once instead of once per 4-row input group â€” the arithmetic-intensity fix for
+// read from DRAM ~once instead of once per 4-row input group Ã¢â‚¬â€ the arithmetic-intensity fix for
 // the bandwidth-bound host. Tiling reorders only which cells co-compute, never the per-cell
 // arithmetic sequence, so the result is byte-identical to row-at-a-time for any band size.
 
 /// Raw output pointer shared across rayon tasks. SAFETY: each task writes a DISJOINT set of
-/// (output_row, output_channel) cells â€” output-group bands are partitioned across tasks and each
-/// task owns its channel range [og*4, og*4+4) exclusively â€” so no two tasks ever touch the same
+/// (output_row, output_channel) cells Ã¢â‚¬â€ output-group bands are partitioned across tasks and each
+/// task owns its channel range [og*4, og*4+4) exclusively Ã¢â‚¬â€ so no two tasks ever touch the same
 /// cell despite the shared base pointer.
 #[derive(Clone, Copy)]
 struct Q8UnifiedOutPtr(*mut f32);
@@ -13834,7 +13862,7 @@ fn run_q8_0_unified_prefill_tiled(
     // Parallelize over chunks of output-row groups. Each chunk keeps its weight band resident
     // (read once) and sweeps ALL input groups against it.
     (0..num_chunks).into_par_iter().for_each(|chunk_idx| {
-        // Capture the whole wrapper (Copy + Send + Sync), not the bare `*mut f32` field â€” Rust
+        // Capture the whole wrapper (Copy + Send + Sync), not the bare `*mut f32` field Ã¢â‚¬â€ Rust
         // 2021 disjoint closure capture would otherwise grab `out.0` and reject the raw pointer.
         #[allow(clippy::redundant_locals)]
         let out = out;
@@ -14011,7 +14039,7 @@ unsafe fn q8_0_packed_rows4_gemm4_accumulate_block_avx512vnni(
 }
 
 /// 4x8 dispatcher (v3): accumulate ONE input group against TWO weight groups, sharing the input
-/// load (VNNI only â€” wider AVX-512 register tile). Byte-identical to two independent 4x4 groups.
+/// load (VNNI only Ã¢â‚¬â€ wider AVX-512 register tile). Byte-identical to two independent 4x4 groups.
 /// On non-x86 this is never reached at runtime (use_vnni is always false) but must still compile.
 #[inline(always)]
 fn q8_0_unified_accumulate_pair(
@@ -15994,7 +16022,7 @@ unsafe fn q8_0_two_dot_rows_avx2(
     (first_sum, second_sum)
 }
 
-/// Q8Ã—Q8 dot of one weight row read straight from the GGUF **wire** bytes (34-byte
+/// Q8Ãƒâ€”Q8 dot of one weight row read straight from the GGUF **wire** bytes (34-byte
 /// blocks: a little-endian f16 scale + 32 i8 quants) against a pre-quantized
 /// activation row, dispatching to the same NEON `sdot` path as
 /// `cpu_neon::q8_0_dot_rows_neon_dotprod`. This lets the gemma4 wire-mmap runtime share
@@ -16034,7 +16062,7 @@ pub(crate) fn q8_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
 }
 
 // ---------------------------------------------------------------------------
-// Gemma 4 QAT (Q4_0 / Q6_K) wire kernels â€” groundwork for the QAT exact rows
+// Gemma 4 QAT (Q4_0 / Q6_K) wire kernels Ã¢â‚¬â€ groundwork for the QAT exact rows
 // (gemma-4-E4B_q4_0-it.gguf de-risk row, then 26B A4B). Marked allow(dead_code)
 // until the gemma4 loader's quant-aware wiring lands; unit-tested below.
 // ---------------------------------------------------------------------------
@@ -16044,10 +16072,10 @@ pub(crate) fn q8_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
 /// j+16 in its high nibble; both nibbles are unsigned with a -8 bias).
 pub(crate) const Q4_0_WIRE_BYTES_PER_BLOCK: usize = 18;
 
-/// Q4_0Ã—Q8_0 dot of one weight row read straight from the GGUF wire bytes
+/// Q4_0Ãƒâ€”Q8_0 dot of one weight row read straight from the GGUF wire bytes
 /// against a pre-quantized activation row. Same accumulation contract as
 /// [`q8_0_wire_row_dot`]: one exact integer dot per 32-weight block, then a
-/// sequential `int_sum * w_scale * x_scale` f32 accumulate â€” the gemma4 QAT
+/// sequential `int_sum * w_scale * x_scale` f32 accumulate Ã¢â‚¬â€ the gemma4 QAT
 /// (Q4_0) lane shares the comparator-pinning doctrine of the Q8 lane rather
 /// than mimicking any particular reference SIMD reduction shape.
 pub(crate) fn q4_0_wire_row_dot(weight_wire: &[u8], input: &[Q8_0Block]) -> f32 {
@@ -16086,7 +16114,7 @@ pub(crate) fn q4_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
     total
 }
 
-/// Scalar reference for the interleaved 8-row Q4_0Ã—Q8_0 GEMV. Consumes one
+/// Scalar reference for the interleaved 8-row Q4_0Ãƒâ€”Q8_0 GEMV. Consumes one
 /// [`crate::tensor::Q4_0PackedRows8`] row-group (`blocks_per_row` interleaved
 /// blocks starting at `group_block_start`) and one Q8 activation row, writing
 /// eight dot products (one per interleaved row) into `out`.
@@ -16132,7 +16160,7 @@ pub(crate) fn q4_0_packed_gemv8_scalar(
     let _ = bpr;
 }
 
-/// Runtime-dispatched interleaved 8-row Q4_0Ã—Q8_0 GEMV: AVX2 when available,
+/// Runtime-dispatched interleaved 8-row Q4_0Ãƒâ€”Q8_0 GEMV: AVX2 when available,
 /// else the scalar reference above. Both paths are bit-identical to
 /// [`q4_0_wire_row_dot_scalar`] run over the same eight rows.
 #[inline]
@@ -16154,17 +16182,17 @@ pub(crate) fn q4_0_packed_gemv8(
     q4_0_packed_gemv8_scalar(packed, group_block_start, input, out);
 }
 
-/// AVX2 interleaved 8-row Q4_0Ã—Q8_0 GEMV. Ported from llama.cpp's
+/// AVX2 interleaved 8-row Q4_0Ãƒâ€”Q8_0 GEMV. Ported from llama.cpp's
 /// `gemv_q4_b32_8x8_q8_0_lut_avx` (arch/x86/repack.cpp), tied to the Camelid
 /// scalar contract (nibbles carry a `-8` bias). All 8 output rows accumulate in
 /// parallel in the eight 32-bit lanes of one `__m256i`; nibbles are sign-biased
-/// via a `_mm256_shuffle_epi8` LUT and dotted with `maddubs`+`madd` â€” no
+/// via a `_mm256_shuffle_epi8` LUT and dotted with `maddubs`+`madd` Ã¢â‚¬â€ no
 /// AVX-512-VNNI dependency (the 11800H has none).
 ///
 /// Bit-exact vs [`q4_0_packed_gemv8_scalar`] / [`q4_0_wire_row_dot_scalar`]:
-/// the int32 per-block dot is exact (nibbleÃ—i8 pair-sums cannot overflow i16),
+/// the int32 per-block dot is exact (nibbleÃƒâ€”i8 pair-sums cannot overflow i16),
 /// integer accumulation is order-independent, and the per-block f32
-/// `isumÂ·w_scaleÂ·x_scale` accumulate runs in the same block order.
+/// `isumÃ‚Â·w_scaleÃ‚Â·x_scale` accumulate runs in the same block order.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn q4_0_packed_gemv8_avx2(
@@ -16317,15 +16345,15 @@ unsafe fn q4_0_packed_gemv8_avx2(
     _mm256_storeu_ps(out.as_mut_ptr(), ordered);
 }
 
-/// int8Ã—int8 pairwise-dot of two `__m256i` where each 32-bit lane holds 4
+/// int8Ãƒâ€”int8 pairwise-dot of two `__m256i` where each 32-bit lane holds 4
 /// signed bytes of `x` (weights, [-8,7]) and 4 of `y` (activations, [-128,127]),
 /// producing 8 int32 lane-dots added to `acc`. Uses the `maddubs` sign-trick
-/// (no AVX-512-VNNI): `abs(x)` is the unsigned operand, `yÂ·sign(x)` the signed
-/// operand. Bit-exact vs the scalar dot: `|x|` âˆˆ [0,8] is unsigned-safe, and
+/// (no AVX-512-VNNI): `abs(x)` is the unsigned operand, `yÃ‚Â·sign(x)` the signed
+/// operand. Bit-exact vs the scalar dot: `|x|` Ã¢Ë†Ë† [0,8] is unsigned-safe, and
 /// because weights are never `i8::MIN`, `sign_epi8` never hits the `-(-128)`
 /// overflow; the only value that could is a `-128` activation, but that lands in
 /// the *signed* operand `y` (`sign_epi8(y,x)` negates `y` only where `x<0`), and
-/// `-128` negated stays `-128` â€” which is exactly what the scalar path computes
+/// `-128` negated stays `-128` Ã¢â‚¬â€ which is exactly what the scalar path computes
 /// too, since `(-8)*(-128) = 1024` would need the *weight* to be the one negated.
 /// The weight is `x`; its abs is taken, so no activation value is ever negated
 /// into a wrong magnitude. Verified bit-exact by
@@ -16387,14 +16415,14 @@ pub(crate) const Q6_K_VALUES_PER_BLOCK: usize = 256;
 pub(crate) const Q6_K_WIRE_BYTES_PER_BLOCK: usize = 210;
 
 /// A 256-value Q8_K activation superblock (the reference's activation format
-/// for K-quant dots). `bsums` are omitted â€” the q6_K dot does not read them.
+/// for K-quant dots). `bsums` are omitted Ã¢â‚¬â€ the q6_K dot does not read them.
 pub(crate) struct Q8KBlock {
     pub d: f32,
     pub qs: [i8; Q6_K_VALUES_PER_BLOCK],
 }
 
 /// The reference's magic-number round-to-nearest-even (`nearest_int`): adding
-/// 1.5Â·2^23 forces the value into the mantissa with round-to-nearest applied,
+/// 1.5Ã‚Â·2^23 forces the value into the mantissa with round-to-nearest applied,
 /// matching its quantizer bit-for-bit (plain `round()` half-away-from-zero
 /// would differ on exact .5 ties).
 #[inline]
@@ -16464,8 +16492,8 @@ fn quantize_q8_k_with_bsums(input: &[f32]) -> (Vec<Q8KBlock>, Vec<[i16; 16]>) {
 }
 
 /// Scalar reference dot (parity floor): one TQ2_0 weight row against a Q8_K activation
-/// row. Port of ggml `ggml_vec_dot_tq2_0_q8_K_generic`: per block, sumi = Î£ (code-1)Â·q8,
-/// scaled by d_xÂ·d_y; the 2-bit codes {0,1,2} recenter to {-1,0,+1} via the `-1`.
+/// row. Port of ggml `ggml_vec_dot_tq2_0_q8_K_generic`: per block, sumi = ÃŽÂ£ (code-1)Ã‚Â·q8,
+/// scaled by d_xÃ‚Â·d_y; the 2-bit codes {0,1,2} recenter to {-1,0,+1} via the `-1`.
 fn tq2_0_row_dot(w_row: &[u8], q8: &[Q8KBlock], blocks_per_row: usize) -> f32 {
     let mut sumf = 0f32;
     for b in 0..blocks_per_row {
@@ -16492,7 +16520,7 @@ fn tq2_0_row_dot(w_row: &[u8], q8: &[Q8KBlock], blocks_per_row: usize) -> f32 {
 
 /// AVX2 ternary dot, mirroring ggml `ggml_vec_dot_tq2_0_q8_K`: unpack the 2-bit codes,
 /// `maddubs` against the int8 activations (16-bit accumulate, safe within a 256-block),
-/// subtract the per-group activation sums (`bsums`) to recenter, then scale by d_xÂ·d_y.
+/// subtract the per-group activation sums (`bsums`) to recenter, then scale by d_xÃ‚Â·d_y.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn tq2_0_row_dot_avx2(
@@ -16570,10 +16598,10 @@ fn tq2_0_dot(w_row: &[u8], q8: &[Q8KBlock], bsums: &[[i16; 16]], blocks_per_row:
     tq2_0_row_dot(w_row, q8, blocks_per_row)
 }
 
-/// Streaming TQ2_0 (ternary) linear: `output[n_rows, out_dim] = input @ weightáµ€`, with
+/// Streaming TQ2_0 (ternary) linear: `output[n_rows, out_dim] = input @ weightÃ¡Âµâ‚¬`, with
 /// the weight held as raw TQ2_0 wire bytes (never materialised to f32). PREFILL TILING:
 /// all `n_rows` activation rows are quantised once, then each weight row is streamed once
-/// (rayon-parallel over the output dimension) and dotted against every token â€” so the
+/// (rayon-parallel over the output dimension) and dotted against every token Ã¢â‚¬â€ so the
 /// weight is read once instead of once-per-token. This is the win llama.cpp's un-tiled
 /// per-element TQ kernel leaves on the table.
 fn matmul_rhs_transposed_tq2_0_block_dot(
@@ -16718,13 +16746,13 @@ fn matmul_rhs_transposed_q6_k_block_dot(
 /// Whether the experimental CPU Q4_K block-dot decode path is enabled. Default
 /// off (fail-closed): without it, Q4_K 2-D linears have no CPU consumer (their
 /// wire bytes are retained for the GPU resident path), so the gate cannot
-/// regress any working CPU behavior â€” it only adds one.
+/// regress any working CPU behavior Ã¢â‚¬â€ it only adds one.
 /// CPU K-quant (Q4_K / Q6_K) decode block-dot. **DEFAULT-ON** (opt out with
 /// `CAMELID_X86_Q4K_DECODE=0`). K-quant 2-D linears load WIRE-ONLY (no f32 `data`)
 /// for the resident GPU engine; with this gate off the CPU linear path has no
 /// consumer for them and errors (`no-row-major-data`, data_len=0). The GPU-resident
 /// decode lane never reaches this chokepoint (it runs q4k_gemv/q6k_gemv on-GPU), so
-/// default-on changes ONLY CPU-mode K-quant decode â€” turning a hard error into
+/// default-on changes ONLY CPU-mode K-quant decode Ã¢â‚¬â€ turning a hard error into
 /// parity-correct output (Q4_K via the AVX2 `q4_k_dot_arm`, Q6_K via the 8-lane
 /// `q6_k_wire_row_dot`). Windows greedy parity is proven vs llama.cpp acd79d6
 /// (K-quant conductor Phase 2); Linux/macOS f32-near-tie parity confirmation is a
@@ -16894,10 +16922,10 @@ pub(crate) fn q6_k_wire_block_dequant(block_bytes: &[u8]) -> [f32; Q6_K_VALUES_P
     out
 }
 
-/// Q6_KÃ—Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q6_KÃƒâ€”Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel's numeric shape: per superblock the
-/// 6-bit weights are rebuilt exactly, the per-16-group `scale * Î£(q8Â·w)`
-/// products accumulate into 8 integer lanes, the superblock's `d_w Â· d_act`
+/// 6-bit weights are rebuilt exactly, the per-16-group `scale * ÃŽÂ£(q8Ã‚Â·w)`
+/// products accumulate into 8 integer lanes, the superblock's `d_w Ã‚Â· d_act`
 /// scales those lanes into 8 f32 accumulators, and the 8 lanes reduce
 /// sequentially at the end.
 pub(crate) fn q6_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
@@ -16950,11 +16978,11 @@ pub(crate) fn q6_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
 
 /// K-quant conductor Phase 2 follow-up: opt-in AVX2 Q6_K row dot
 /// (`CAMELID_X86_Q6K_AVX2`, default-off). BIT-IDENTICAL to [`q6_k_wire_row_dot`]
-/// by construction â€” it vectorizes ONLY the associative integer `aux32[8]` and
+/// by construction Ã¢â‚¬â€ it vectorizes ONLY the associative integer `aux32[8]` and
 /// keeps the load-bearing 8-lane f32 reduction (`sums[l] += d * aux32[l]`, then
 /// the left-fold `sums.iter().sum()`) exactly as the scalar oracle. (The refmath
 /// `q6_k_dot_avx2` is NOT a substitute: it mirrors the single-accumulator
-/// `q6_k_dot_scalar` order, a different bit pattern.) Default-off until measured â€”
+/// `q6_k_dot_scalar` order, a different bit pattern.) Default-off until measured Ã¢â‚¬â€
 /// CPU decode is bandwidth-bound on the dev box, so this is expected to be ~null.
 #[cfg(target_arch = "x86_64")]
 fn q6k_avx2_enabled() -> bool {
@@ -16991,7 +17019,7 @@ fn q6_k_wire_row_dot_simd(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     q6_k_wire_row_dot(weight_wire, input)
 }
 
-/// AVX2 sibling of [`q6_k_wire_row_dot`] â€” see `q6k_avx2_enabled` for the parity
+/// AVX2 sibling of [`q6_k_wire_row_dot`] Ã¢â‚¬â€ see `q6k_avx2_enabled` for the parity
 /// contract. Vectorizes the per-superblock integer dot into the oracle's 8
 /// position-lanes (`aux32[l]`), exact integers; the 6-bit rebuild and the f32
 /// reduction stay byte-for-byte identical to the scalar path.
@@ -17028,8 +17056,8 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
             qh += 32;
         }
 
-        // aux32[l] = Î£_j scale_j Â· (q8[16j+l]Â·a[16j+l] + q8[16j+8+l]Â·a[16j+8+l]),
-        // l in 0..8, all exact integers (associative â€” SIMD lane order is free).
+        // aux32[l] = ÃŽÂ£_j scale_j Ã‚Â· (q8[16j+l]Ã‚Â·a[16j+l] + q8[16j+8+l]Ã‚Â·a[16j+8+l]),
+        // l in 0..8, all exact integers (associative Ã¢â‚¬â€ SIMD lane order is free).
         let mut acc = _mm256_setzero_si256();
         let aptr = a.as_ptr();
         let qptr = y.qs.as_ptr();
@@ -17052,7 +17080,7 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
         let mut aux32 = [0i32; 8];
         _mm256_storeu_si256(aux32.as_mut_ptr() as *mut __m256i, acc);
 
-        // Load-bearing 8-lane f32 reduction â€” identical to the scalar oracle.
+        // Load-bearing 8-lane f32 reduction Ã¢â‚¬â€ identical to the scalar oracle.
         for l in 0..8 {
             sums[l] += d * aux32[l] as f32;
         }
@@ -17060,7 +17088,7 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
     sums.iter().sum()
 }
 
-/// Dequantize a single Q4_0 wire block (18 bytes) into 32 f32 values â€”
+/// Dequantize a single Q4_0 wire block (18 bytes) into 32 f32 values Ã¢â‚¬â€
 /// the row-gather counterpart of [`q4_0_wire_row_dot`] for embedding-style
 /// lookups into Q4_0 tables.
 pub(crate) fn q4_0_wire_block_dequant(block_bytes: &[u8]) -> [f32; 32] {
@@ -17078,14 +17106,14 @@ pub(crate) fn q4_0_wire_block_dequant(block_bytes: &[u8]) -> [f32; 32] {
 pub(crate) const Q4_K_WIRE_BYTES_PER_BLOCK: usize = 144;
 pub(crate) const Q5_0_WIRE_BYTES_PER_BLOCK: usize = 22;
 
-/// Q4_KÃ—Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q4_KÃƒâ€”Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel's numeric shape exactly
 /// (`ggml_vec_dot_q4_K_q8_K_generic`): per superblock the nibbles expand
 /// low-then-high in 64-value groups, the packed 6-bit scales/mins unpack via
-/// the kmask scheme, per-32-group `scale * Î£(q8Â·q4)` products accumulate into
-/// 8 integer lanes scaled by `d_wÂ·d_act`, and the mins side subtracts
-/// `dminÂ·d_act Â· Î£(min_g Â· bsum_g)` with per-16 activation sums (computed
-/// inline; the reference precomputes them as Q8_K `bsums` â€” identical
+/// the kmask scheme, per-32-group `scale * ÃŽÂ£(q8Ã‚Â·q4)` products accumulate into
+/// 8 integer lanes scaled by `d_wÃ‚Â·d_act`, and the mins side subtracts
+/// `dminÃ‚Â·d_act Ã‚Â· ÃŽÂ£(min_g Ã‚Â· bsum_g)` with per-16 activation sums (computed
+/// inline; the reference precomputes them as Q8_K `bsums` Ã¢â‚¬â€ identical
 /// integers). DiffusionGemma lane: correctness-first scalar, no SIMD.
 // index-based loops intentionally mirror the reference C kernel's structure
 // unit-tested ports of the reference GENERIC kernels (the DG runtime now
@@ -17113,7 +17141,7 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             }
         }
 
-        // unpack the 8 packed 6-bit (scale, min) pairs â€” kmask scheme
+        // unpack the 8 packed 6-bit (scale, min) pairs Ã¢â‚¬â€ kmask scheme
         let mut utmp = [0u32; 4];
         utmp[0] = u32::from_le_bytes([scales_raw[0], scales_raw[1], scales_raw[2], scales_raw[3]]);
         utmp[1] = u32::from_le_bytes([scales_raw[4], scales_raw[5], scales_raw[6], scales_raw[7]]);
@@ -17148,7 +17176,7 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             ((utmp[3] >> 24) & 0xff) as u8,
         ];
 
-        // mins side: Î£ over the 16 per-16 activation sums Ã— min of their group
+        // mins side: ÃŽÂ£ over the 16 per-16 activation sums Ãƒâ€” min of their group
         let mut sumi = 0i32;
         for j in 0..16 {
             let bsum: i32 = y.qs[j * 16..(j + 1) * 16].iter().map(|&q| q as i32).sum();
@@ -17176,12 +17204,12 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf + sums.iter().sum::<f32>()
 }
 
-/// Q2_K Ã— Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q2_K Ãƒâ€” Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel `ggml_vec_dot_q2_K_q8_K`. Each 84-byte
 /// super-block is scales[16] (low nibble = quant scale, high nibble = min scale,
 /// one pair per 16-value sub-block), qs[64] (2-bit quants), d(f16), dmin(f16).
 /// Unlike Q4_K/Q6_K the reference keeps a SINGLE integer `isum` per super-block, so
-/// each super-block contributes `dallÂ·isum âˆ’ dminÂ·summs` (subtraction first) to the
+/// each super-block contributes `dallÃ‚Â·isum Ã¢Ë†â€™ dminÃ‚Â·summs` (subtraction first) to the
 /// f32 sum, summed in order. The `q2k_gemv` CUDA kernel reproduces this exactly.
 /// Correctness-first scalar (the reference's "no SIMD" generic shape).
 #[allow(dead_code, clippy::needless_range_loop)]
@@ -17195,14 +17223,14 @@ pub(crate) fn q2_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
         let d = f16_bits_to_f32(u16::from_le_bytes([block[80], block[81]]));
         let dmin = f16_bits_to_f32(u16::from_le_bytes([block[82], block[83]]));
 
-        // mins side: Î£ over the 16 sub-blocks of (per-16 activation sum) Ã— min scale
+        // mins side: ÃŽÂ£ over the 16 sub-blocks of (per-16 activation sum) Ãƒâ€” min scale
         let mut summs = 0i32;
         for j in 0..16 {
             let bsum: i32 = y.qs[j * 16..(j + 1) * 16].iter().map(|&q| q as i32).sum();
             summs += bsum * (scales[j] >> 4) as i32;
         }
 
-        // main side: 2 halves Ã— 4 groups; each group reuses the same 32 qs bytes at
+        // main side: 2 halves Ãƒâ€” 4 groups; each group reuses the same 32 qs bytes at
         // shift 2*group, split into a low (l<16) and high (l>=16) sub-block, each
         // with its own low-nibble quant scale. q8 advances 32 per group.
         let mut isum = 0i32;
@@ -17237,13 +17265,13 @@ pub(crate) fn q2_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf
 }
 
-/// Q3_K Ã— Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q3_K Ãƒâ€” Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel `ggml_vec_dot_q3_K_q8_K`. Each 110-byte
 /// super-block is hmask[32] (high bit of each 3-bit quant), qs[64] (low 2 bits),
 /// scales[12] (16 signed 6-bit scales, kmask-packed), d(f16). Q3_K has NO mins: the
 /// 3-bit quant is reconstructed as `((qs>>shift)&3) - (hmask_bit ? 0 : 4)` (centered
-/// to âˆ’4..3) and dequantized as `dÂ·(scaleâˆ’32)Â·value`. So each super-block contributes
-/// a single `dÂ·isum` (isum = Î£_sb (scaleâˆ’32)Â·Î£ q8Â·value), summed in order. The
+/// to Ã¢Ë†â€™4..3) and dequantized as `dÃ‚Â·(scaleÃ¢Ë†â€™32)Ã‚Â·value`. So each super-block contributes
+/// a single `dÃ‚Â·isum` (isum = ÃŽÂ£_sb (scaleÃ¢Ë†â€™32)Ã‚Â·ÃŽÂ£ q8Ã‚Â·value), summed in order. The
 /// `q3k_gemv` CUDA kernel reproduces this exactly. Correctness-first scalar.
 #[allow(dead_code, clippy::needless_range_loop)]
 pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
@@ -17278,8 +17306,8 @@ pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             }
         }
 
-        // isum = Î£ over the 16 sub-blocks of (scaleâˆ’32) Ã— Î£ q8Â·value. 2 halves Ã— 4
-        // groups Ã— {low,high}; qs reused per group at shift 2*group; hmask bit advances
+        // isum = ÃŽÂ£ over the 16 sub-blocks of (scaleÃ¢Ë†â€™32) Ãƒâ€” ÃŽÂ£ q8Ã‚Â·value. 2 halves Ãƒâ€” 4
+        // groups Ãƒâ€” {low,high}; qs reused per group at shift 2*group; hmask bit advances
         // per group (1<<(half*4+group)); q8 in natural order.
         let mut isum = 0i32;
         let mut sb = 0usize;
@@ -17317,11 +17345,11 @@ pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf
 }
 
-/// Q5_0Ã—Q8_0 dot of one weight row read straight from the GGUF wire bytes,
+/// Q5_0Ãƒâ€”Q8_0 dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel (`ggml_vec_dot_q5_0_q8_0_generic`):
 /// per 32-value block, rebuild the signed 5-bit weights from the nibble plus
 /// its qh bit, accumulate the two half-block integer dots, then scale by
-/// `d_wÂ·d_act`. DiffusionGemma lane: correctness-first scalar, no SIMD.
+/// `d_wÃ‚Â·d_act`. DiffusionGemma lane: correctness-first scalar, no SIMD.
 // index-based loops intentionally mirror the reference C kernel's structure
 // unit-tested ports of the reference GENERIC kernels (the DG runtime now
 // uses the ARM-order variants in diffusion_gemma::refmath)
@@ -18398,7 +18426,7 @@ fn try_accumulate_descriptor_linear_row_metal(
     #[cfg(target_os = "macos")]
     {
         // Cheap existing check first so the default path (Metal linear off) short-circuits
-        // before the deterministic-mode env read â€” zero added work when the flag is unused.
+        // before the deterministic-mode env read Ã¢â‚¬â€ zero added work when the flag is unused.
         if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1")
             || deterministic_mode_enabled()
         {
@@ -19261,7 +19289,7 @@ fn matmul_rhs_transposed_q8_0_packed_rows4_prefill_i8mm(
     let mut output = vec![0.0_f32; rows * output_width];
     // The small-M weight-resident kernel absorbs the partial final row group as a
     // zero-padded lane set so the conservative per-row GEMV tail (a full weight pass
-    // per tail row â€” ruinous for 5-20 row speculative verify chunks) never runs.
+    // per tail row Ã¢â‚¬â€ ruinous for 5-20 row speculative verify chunks) never runs.
     let small_m = rows >= 4 && rows.div_ceil(4) <= mac_q8_i8mm_small_m_max_input_groups();
     let packed_rows = if small_m { rows } else { rows / 4 * 4 };
     let collect_q8_schedule = q8_schedule_telemetry_enabled();
@@ -20098,7 +20126,7 @@ fn q8_0_packed_rows4_dot(
                 }
             }
         }
-        // Phase 3: opt-in x86 weight-stream prefetch, two packed blocks ahead â€” the
+        // Phase 3: opt-in x86 weight-stream prefetch, two packed blocks ahead Ã¢â‚¬â€ the
         // x86 mirror of the macOS NEON `prfm` above. Default-off; a memory hint only,
         // so the decoded values are byte-identical regardless of the flag.
         #[cfg(all(
@@ -20471,7 +20499,7 @@ fn try_accumulate_transposed_linear_row_metal(
     #[cfg(target_os = "macos")]
     {
         // Cheap existing check first so the default path (Metal linear off) short-circuits
-        // before the deterministic-mode env read â€” zero added work when the flag is unused.
+        // before the deterministic-mode env read Ã¢â‚¬â€ zero added work when the flag is unused.
         if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1")
             || deterministic_mode_enabled()
         {
@@ -21183,7 +21211,7 @@ fn attention_f32_blocked_dot_enabled() -> bool {
 
 /// Flag gate for the decode attention head-parallel lane
 /// (`BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL`, default off). Scoped to
-/// Windows x86_64 per the standing Windows-first directive â€” the mechanism
+/// Windows x86_64 per the standing Windows-first directive Ã¢â‚¬â€ the mechanism
 /// itself is arch-agnostic (scheduling only, no arithmetic), so lifting the
 /// gate is a one-line follow-up decision, not a code change. Resolved once
 /// per process outside tests.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -25,6 +25,7 @@ use crate::telemetry;
 mod attn_f32_dot;
 #[cfg(target_arch = "aarch64")]
 mod cpu_neon;
+mod decode_scratch;
 mod diagnostic_config;
 pub mod draft_merge;
 pub(crate) mod gemma4;
@@ -6024,7 +6025,7 @@ fn forward_layer_timed(
         &q,
         config.attention_head_count as usize,
         config.attention_head_count_kv as usize,
-        cached_layer_label!(layer_idx, "attention_context"),
+        &cached_layer_label!(layer_idx, "attention_context"),
         collect_diagnostics,
     )?;
     let attention_trace = attention_context.trace;
@@ -21046,7 +21047,7 @@ fn causal_attention_context(
     query: &CpuTensor,
     attention_heads: usize,
     kv_heads: usize,
-    name: impl Into<String>,
+    name: &str,
     collect_diagnostics: bool,
 ) -> Result<LlamaAttentionContextOutput> {
     if kv_heads == 0 || !attention_heads.is_multiple_of(kv_heads) {
@@ -21080,7 +21081,9 @@ fn causal_attention_context(
     let head_mapping = diagnostic_gqa_head_mapping()?;
     let score_scale = diagnostic_attention_score_scale()?;
     let scale = attention_score_scale_value(head_dim, score_scale);
-    let mut out = vec![0.0; expected_width];
+    // Pooled buffer: bit-identical to `vec![0.0; expected_width]` (zeroed to
+    // length); recycled by the layer forward when the context tensor dies.
+    let mut out = decode_scratch::take(expected_width);
 
     if position_count == 1 {
         for attention_head in 0..attention_heads {
@@ -21111,7 +21114,7 @@ fn causal_attention_context(
         )?;
     }
 
-    let tensor = CpuTensor::from_f32(name, vec![1, expected_width], out)?;
+    let tensor = decode_scratch::tensor_from_pooled(name, vec![1, expected_width], out)?;
     let trace = collect_diagnostics
         .then(|| {
             attention_trace_with_params(AttentionTraceParams {
@@ -21371,10 +21374,16 @@ fn decode_attention_all_heads_into_with_mode(
     let head_dim = params.kv_cache.plan.head_dim;
     debug_assert_eq!(out.len(), params.attention_heads * head_dim);
     if parallel {
-        return out
-            .par_chunks_exact_mut(head_dim)
-            .enumerate()
-            .try_for_each_init(Vec::new, |scores, (attention_head, out_slice)| {
+        // Per-WORKER persistent scratch: thread-local so parallel regions
+        // never contend on the decode pool, alive across tokens so
+        // steady-state decode allocates nothing here. The callee clears the
+        // buffer per head, so reuse is content-invisible.
+        thread_local! {
+            static ATTN_WORKER_SCORES: std::cell::RefCell<Vec<f32>> =
+                const { std::cell::RefCell::new(Vec::new()) };
+        }
+        return out.par_chunks_exact_mut(head_dim).enumerate().try_for_each(
+            |(attention_head, out_slice)| {
                 let kv_head = map_attention_head_to_kv_head(
                     attention_head,
                     params.repeats,
@@ -21382,22 +21391,27 @@ fn decode_attention_all_heads_into_with_mode(
                     params.head_mapping,
                 );
                 let query_start = attention_head * head_dim;
-                attention_context_for_head_into(
-                    AttentionContextHeadParams {
-                        kv_cache: params.kv_cache,
-                        layer_idx: params.layer_idx,
-                        kv_head,
-                        query_slice: &params.query_data[query_start..query_start + head_dim],
-                        position_count: params.position_count,
-                        scale: params.scale,
-                    },
-                    out_slice,
-                    scores,
-                )
-            });
+                ATTN_WORKER_SCORES.with(|cell| {
+                    attention_context_for_head_into(
+                        AttentionContextHeadParams {
+                            kv_cache: params.kv_cache,
+                            layer_idx: params.layer_idx,
+                            kv_head,
+                            query_slice: &params.query_data[query_start..query_start + head_dim],
+                            position_count: params.position_count,
+                            scale: params.scale,
+                        },
+                        out_slice,
+                        &mut cell.borrow_mut(),
+                    )
+                })
+            },
+        );
     }
 
-    let mut scores = Vec::with_capacity(params.position_count);
+    // Pooled serial scratch, recycled on every exit path.
+    let mut scores = decode_scratch::take(0);
+    scores.reserve(params.position_count);
     for attention_head in 0..params.attention_heads {
         let kv_head = map_attention_head_to_kv_head(
             attention_head,
@@ -21407,7 +21421,7 @@ fn decode_attention_all_heads_into_with_mode(
         );
         let query_start = attention_head * head_dim;
         let out_start = attention_head * head_dim;
-        attention_context_for_head_into(
+        let head_result = attention_context_for_head_into(
             AttentionContextHeadParams {
                 kv_cache: params.kv_cache,
                 layer_idx: params.layer_idx,
@@ -21418,8 +21432,13 @@ fn decode_attention_all_heads_into_with_mode(
             },
             &mut out[out_start..out_start + head_dim],
             &mut scores,
-        )?;
+        );
+        if let Err(error) = head_result {
+            decode_scratch::recycle(scores);
+            return Err(error);
+        }
     }
+    decode_scratch::recycle(scores);
     Ok(())
 }
 

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -3860,8 +3860,33 @@ impl LlamaInferenceSession {
         Ok(timings)
     }
 
-    #[allow(unused_assignments)]
     fn forward_single_token_timed_internal(
+        &mut self,
+        token_id: u32,
+        collect_diagnostics: bool,
+        compute_logits: bool,
+    ) -> Result<LlamaFastForwardOutput> {
+        // Item 4 Lane A: hop the whole single-token decode onto the dedicated
+        // decode pool when configured. Default is None — inline on the
+        // caller's pool, byte-identical to before the lane existed.
+        if decode_thread_pool().is_some() {
+            return run_on_decode_pool(|| {
+                self.forward_single_token_timed_on_current_pool(
+                    token_id,
+                    collect_diagnostics,
+                    compute_logits,
+                )
+            });
+        }
+        self.forward_single_token_timed_on_current_pool(
+            token_id,
+            collect_diagnostics,
+            compute_logits,
+        )
+    }
+
+    #[allow(unused_assignments)]
+    fn forward_single_token_timed_on_current_pool(
         &mut self,
         token_id: u32,
         collect_diagnostics: bool,
@@ -4737,6 +4762,87 @@ fn resolve_prefill_thread_count_from(
 /// [`prefill_thread_pool`] for the rationale and bit-exactness guarantee.
 fn run_on_prefill_pool<R: Send>(op: impl FnOnce() -> R + Send) -> R {
     match prefill_thread_pool() {
+        Some(pool) => pool.install(op),
+        None => op(),
+    }
+}
+
+/// Dedicated Rayon pool for single-token decode (Item 4 Lane A). Default OFF:
+/// with neither flag set this resolves to `None` and decode runs inline on the
+/// caller's pool, byte-identical to before.
+///
+/// * `BACKENDINFERENCE_DECODE_THREADS=N` sizes a dedicated decode pool to N
+///   workers (P0 attribution: decode is a memory-bound matvec stream that is
+///   fastest well below the logical core count — SMT siblings only add
+///   memory-controller contention; see the decode-sched receipts).
+/// * `BACKENDINFERENCE_DECODE_POOL_DEDICATED=1` isolates decode onto its own
+///   pool at the current global width without resizing (the serve/tokio
+///   interference probe).
+///
+/// Bit-exact by the same argument as the prefill pool: every decode parallel
+/// region splits independent output rows/chunks with serial per-output
+/// reductions (the attention decode lane is additionally bitwise-locked by
+/// its own contract), so pool choice and width never change the numbers.
+fn decode_thread_pool() -> Option<&'static rayon::ThreadPool> {
+    static POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
+    POOL.get_or_init(build_decode_thread_pool).as_ref()
+}
+
+fn build_decode_thread_pool() -> Option<rayon::ThreadPool> {
+    let global = rayon::current_num_threads();
+    let target = resolve_decode_thread_count_from(
+        env::var("BACKENDINFERENCE_DECODE_THREADS").ok().as_deref(),
+        q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_DECODE_POOL_DEDICATED"),
+        global,
+    )?;
+    match rayon::ThreadPoolBuilder::new()
+        .num_threads(target)
+        .thread_name(|i| format!("camelid-decode-{i}"))
+        .build()
+    {
+        Ok(pool) => {
+            tracing::info!(
+                decode_threads = target,
+                global_threads = global,
+                "decode scheduling lane: single-token decode on a dedicated pool"
+            );
+            Some(pool)
+        }
+        Err(err) => {
+            tracing::warn!("failed to build decode thread pool ({err}); using global pool");
+            None
+        }
+    }
+}
+
+/// Pure resolution of the decode pool width, factored out for testing.
+///
+/// * `spec` — raw `BACKENDINFERENCE_DECODE_THREADS` value, if present.
+/// * `dedicated` — `BACKENDINFERENCE_DECODE_POOL_DEDICATED` flag.
+/// * `global` — current global pool width (the no-resize isolation width).
+///
+/// An explicit positive `spec` wins; `0`/`off`/empty/invalid fall through to
+/// the `dedicated` check (isolate at global width) and otherwise `None`.
+fn resolve_decode_thread_count_from(
+    spec: Option<&str>,
+    dedicated: bool,
+    global: usize,
+) -> Option<usize> {
+    if let Some(spec) = spec {
+        let trimmed = spec.trim();
+        if !trimmed.is_empty() && !trimmed.eq_ignore_ascii_case("off") && trimmed != "0" {
+            if let Some(count) = trimmed.parse::<usize>().ok().filter(|n| *n > 0) {
+                return Some(count);
+            }
+        }
+    }
+    dedicated.then_some(global)
+}
+
+/// Run the decode `op` on the dedicated decode pool when one is configured,
+/// otherwise inline. See [`decode_thread_pool`].
+fn run_on_decode_pool<R: Send>(op: impl FnOnce() -> R + Send) -> R {
+    match decode_thread_pool() {
         Some(pool) => pool.install(op),
         None => op(),
     }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -192,6 +192,55 @@ impl InferenceWorkspace {
     }
 }
 
+/// One steady-state decode kernel binding: which `try_x86_q8_*` cascade arm
+/// the first rows==1 call selected for a projection slot. The cascade remains
+/// the BUILDER of this choice (it runs once and records the winner); the
+/// per-call path afterwards jumps straight to the recorded arm, whose own
+/// guards stay in place as the fail-closed check (a miss rebinds through the
+/// full cascade). Scheduling cache, not weight state: `Clone` starts fresh
+/// (a cloned session rebinds on first use) and equality always holds so
+/// weight comparisons ignore it.
+#[derive(Debug)]
+pub struct DecodeBindingCell(std::sync::atomic::AtomicU8);
+
+impl Default for DecodeBindingCell {
+    fn default() -> Self {
+        Self(std::sync::atomic::AtomicU8::new(DECODE_ARM_UNBOUND))
+    }
+}
+
+impl DecodeBindingCell {
+    fn load(&self) -> u8 {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+    fn store(&self, arm: u8) {
+        self.0.store(arm, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+impl Clone for DecodeBindingCell {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl PartialEq for DecodeBindingCell {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+/// Per-layer decode kernel bindings, one cell per linear-projection slot that
+/// routes through the role cascade at decode.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct DecodeLinearBindings {
+    pub attention_q: DecodeBindingCell,
+    pub attention_k: DecodeBindingCell,
+    pub attention_v: DecodeBindingCell,
+    pub attention_output: DecodeBindingCell,
+    pub ffn_down: DecodeBindingCell,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct LlamaLayerWeights {
     pub attention_norm: CpuTensor,
@@ -211,6 +260,8 @@ pub struct LlamaLayerWeights {
     pub ffn_up: CpuTensor,
     pub ffn_down: CpuTensor,
     pub moe_router: Option<CpuTensor>,
+    /// Steady-state decode kernel bindings; see [`DecodeBindingCell`].
+    pub decode_bindings: DecodeLinearBindings,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -221,6 +272,10 @@ pub struct LlamaLoadedWeights {
     pub rope_freqs: Option<CpuTensor>,
     pub layers: Vec<LlamaLayerWeights>,
     pub layer_range: Option<std::ops::Range<usize>>,
+    /// Reserved decode binding for the logits/output projection. Its dispatch
+    /// is shape-driven (two dim reads per call, no try-cascade), so it is not
+    /// bound yet; the cell exists so a future binding needs no struct change.
+    pub output_projection_binding: DecodeBindingCell,
 }
 
 /// Result of [`LlamaLoadedWeights::q8_0_residency_report`]: how many Q8_0 linears hold plain
@@ -379,13 +434,13 @@ impl LlamaLoadedWeights {
         load_output: bool,
     ) -> Result<Self> {
         // Q8_0 linears are ALWAYS retained as plain RAM-resident blocks. The old policy
-        // estimated a retention budget over the WHOLE binding — even on a pipeline-sharded
-        // node that loads only its layer range — and silently fell back to per-token file
+        // estimated a retention budget over the WHOLE binding â€” even on a pipeline-sharded
+        // node that loads only its layer range â€” and silently fell back to per-token file
         // streaming when the estimate crossed a cap: ~100x slower decode, and it disqualified
         // the GPU-resident path (which requires q8_0_blocks). The only way off the resident
         // path now is the explicit CAMELID_LAZY_Q8_0_LINEAR opt-out, and it is loud.
         // Fast-load (CAMELID_METAL_NOCOPY): Q8_0 linears read their wire bytes once
-        // into page-aligned allocations the GPU wraps in place — no 36-byte decode, no
+        // into page-aligned allocations the GPU wraps in place â€” no 36-byte decode, no
         // upload copy, and the page cache stays warm so reloading a model is fast.
         let nocopy_fast_load = metal_nocopy_fast_load_enabled();
         if nocopy_fast_load {
@@ -403,7 +458,7 @@ impl LlamaLoadedWeights {
         }
         let load_linear = |name: &str| {
             // K-quant (Q4_K / Q6_K) 2-D linears: retain only the raw super-block wire
-            // bytes (no f32 materialization — an 8B model fully decoded to f32 is ~32 GB
+            // bytes (no f32 materialization â€” an 8B model fully decoded to f32 is ~32 GB
             // and OOMs). The GPU-resident decode reads these via q4k_gemv / q6k_gemv.
             if let Ok(desc) = store.descriptor(name) {
                 // Ternary TQ2_0 2-D linears: stream the wire bytes (the CPU ternary
@@ -521,7 +576,7 @@ impl LlamaLoadedWeights {
                     ),
                 };
                 // DEBUG ONLY: CAMELID_DEBUG_DISABLE_QK_NORM=1 skips loading the
-                // QK-norm weights so a Qwen3 forward runs as if it had none — used
+                // QK-norm weights so a Qwen3 forward runs as if it had none â€” used
                 // to bisect whether QK-norm is the source of a parity gap. Never
                 // set in production.
                 let debug_disable_qk_norm =
@@ -557,6 +612,7 @@ impl LlamaLoadedWeights {
                     ffn_up,
                     ffn_down,
                     moe_router,
+                    decode_bindings: DecodeLinearBindings::default(),
                 });
             } else {
                 layers.push(LlamaLayerWeights {
@@ -617,6 +673,7 @@ impl LlamaLoadedWeights {
                             Some(CpuTensor::from_f32(&router.name, vec![0], vec![])?)
                         }
                     },
+                    decode_bindings: DecodeLinearBindings::default(),
                 });
             }
         }
@@ -627,6 +684,7 @@ impl LlamaLoadedWeights {
             rope_freqs,
             layers,
             layer_range,
+            output_projection_binding: DecodeBindingCell::default(),
         })
     }
 
@@ -1273,7 +1331,7 @@ pub fn dump_stage_timings() {
 /// scalar chain (`tensor::dot_product`) vs the canonical blocked scalar
 /// reference vs the blocked AVX2/FMA realization. Returns
 /// `(variant, ns_per_call)` pairs; the AVX2 row is omitted when the CPU lacks
-/// AVX2+FMA. Bench-only entry point — never called on the inference path.
+/// AVX2+FMA. Bench-only entry point â€” never called on the inference path.
 pub fn attn_f32_dot_microbench(
     len: usize,
     repeats: usize,
@@ -1337,6 +1395,33 @@ pub fn attn_f32_dot_microbench(
         );
     }
     results
+}
+
+/// Micro-benchmark the fork-join overhead of one rayon parallel region on
+/// the global pool: per-item work is a single black_box add, so region
+/// dispatch dominates. `idle_us_between > 0` sleeps between regions so the
+/// workers park (cold regions); 0 measures back-to-back (hot) regions.
+/// Returns microseconds per region. Bench-only entry point.
+pub fn rayon_region_microbench(iterations: usize, idle_us_between: u64) -> f64 {
+    use std::hint::black_box;
+    let chunks = rayon::current_num_threads().max(1) * 2;
+    let mut out = vec![0.0f32; chunks * 64];
+    for _ in 0..100 {
+        out.par_chunks_exact_mut(64)
+            .for_each(|chunk| chunk[0] = black_box(chunk[0] + 1.0));
+    }
+    let mut total = std::time::Duration::ZERO;
+    for _ in 0..iterations {
+        if idle_us_between > 0 {
+            std::thread::sleep(std::time::Duration::from_micros(idle_us_between));
+        }
+        let started = Instant::now();
+        out.par_chunks_exact_mut(64)
+            .for_each(|chunk| chunk[0] = black_box(chunk[0] + 1.0));
+        total += started.elapsed();
+    }
+    black_box(&out);
+    total.as_micros() as f64 / iterations as f64
 }
 
 #[allow(dead_code)]
@@ -1684,7 +1769,7 @@ pub struct LlamaInferenceSession {
     resident_paths_disabled: bool,
     /// When set, the deterministic forward pass folds each layer's output hidden state and the
     /// final logits into a streaming SHA-256 rollup (an execution-trace digest). Transient
-    /// proof-carrying state, not part of the session's logical identity — skipped by
+    /// proof-carrying state, not part of the session's logical identity â€” skipped by
     /// Clone/PartialEq/Debug like `resident_decode`. Only enabled in deterministic mode
     /// (`enable_execution_trace`); the default path never allocates it.
     execution_trace: Option<ExecutionTraceHasher>,
@@ -1693,7 +1778,7 @@ pub struct LlamaInferenceSession {
     /// without this the key would be the `weights` Arc pointer, which is not stable
     /// across separately-loaded `Arc<LlamaLoadedWeights>` for the same model (e.g. a
     /// prompt-prefix-cache-restored session vs a freshly loaded one). When two such
-    /// Arcs alternate, the single-slot engine cache thrashes — a multi-second 3.4 GB
+    /// Arcs alternate, the single-slot engine cache thrashes â€” a multi-second 3.4 GB
     /// re-upload on every request. The API sets this from the model id; when unset
     /// (tests, CLI), the wrappers fall back to the Arc pointer. Transient identity,
     /// copied by Clone/take_for_step so restored sessions keep the same key.
@@ -1729,7 +1814,7 @@ impl LlamaInferenceSession {
 
     /// Move the session out for a blocking generation step, leaving a hollow placeholder
     /// behind (same identity, empty KV, no resident state). Unlike `clone`, this PRESERVES
-    /// the resident GPU session — the on-GPU KV cache and encode-ahead pipeline — which is
+    /// the resident GPU session â€” the on-GPU KV cache and encode-ahead pipeline â€” which is
     /// single-owner and dropped by `clone`. The caller must re-assign the returned session
     /// when the step finishes or the sequence loses its KV state entirely.
     pub fn take_for_step(&mut self) -> LlamaInferenceSession {
@@ -1778,7 +1863,7 @@ impl LlamaInferenceSession {
     }
 
     /// Approximate resident-weight footprint of this session in bytes: the raw Q8_0 block
-    /// bytes of every layer's attention + FFN tensors plus the output projection — the same
+    /// bytes of every layer's attention + FFN tensors plus the output projection â€” the same
     /// unit `build_resident_cuda_engine` sizes VRAM against. Used to compute the
     /// speculative-coexistence reserve (how much VRAM a draft model needs to stay resident).
     #[cfg(feature = "cuda")]
@@ -1914,7 +1999,7 @@ impl LlamaInferenceSession {
 
     /// Arm the execution-trace rollup: subsequent forward passes fold every layer's output
     /// hidden state and the final logits into a streaming SHA-256 (see [`ExecutionTraceHasher`]).
-    /// Fails closed unless deterministic mode is active — the rollup is only meaningful on the
+    /// Fails closed unless deterministic mode is active â€” the rollup is only meaningful on the
     /// order-stable CPU lane (RECEIPTS.md rule 2), and arming it would otherwise advertise a
     /// digest over a non-reproducible run. Returns whether the trace was armed.
     pub fn enable_execution_trace(&mut self) -> bool {
@@ -1946,7 +2031,7 @@ impl LlamaInferenceSession {
     }
 
     /// Roll the sequence back to `position`, discarding newer KV entries.
-    /// Requires CPU-authoritative KV state — the GPU-resident cache has no
+    /// Requires CPU-authoritative KV state â€” the GPU-resident cache has no
     /// rollback, so any resident session is dropped and reseeds from CPU on
     /// next use.
     pub fn rollback_to_position(&mut self, position: usize) -> Result<()> {
@@ -2018,7 +2103,7 @@ impl LlamaInferenceSession {
             return Ok(false);
         }
         // Wire-page (fast-load) weights satisfy residency too, but only when the wire
-        // kernels are active — their bytes exist solely in the 34-byte wire layout.
+        // kernels are active â€” their bytes exist solely in the 34-byte wire layout.
         let wire_ok = metal_seam::wire_mode_active();
         let is_q8 = |t: &CpuTensor| {
             t.source_type == Some(GgufTensorType::Q8_0)
@@ -2031,7 +2116,7 @@ impl LlamaInferenceSession {
         // source_type, so a model may be all-Q8_0, all-Q4_K, or mixed.
         // The contraction dimension (in_features) is gguf dim(0) in the runtime shape:
         // a `[in, out]` gguf linear is stored out-major (out rows of `in` contiguous
-        // values), so each output row spans `in/256` super-blocks — the kernel's `n_sb`.
+        // values), so each output row spans `in/256` super-blocks â€” the kernel's `n_sb`.
         // (The output/lm_head, with a non-256-aligned vocab in dim(1), is the case that
         // makes checking the wrong dim wrongly reject it.)
         let is_q4k = |t: &CpuTensor| {
@@ -2150,7 +2235,7 @@ impl LlamaInferenceSession {
     /// GPU prefill (CAMELID_METAL_RESIDENT_PREFILL=1): run the prompt's first N tokens
     /// through the resident session in ONE command buffer (weights stream once, attention
     /// per position). On success the GPU KV cache holds positions 0..N, the CPU KV cache is
-    /// advanced (positions left empty — only the resident path continues this sequence),
+    /// advanced (positions left empty â€” only the resident path continues this sequence),
     /// and the caller skips its CPU prefill loop entirely; the last prompt token then runs
     /// through the resident decode for logits.
     fn try_resident_prefill(&mut self, token_ids: &[u32]) -> Result<bool> {
@@ -2171,7 +2256,7 @@ impl LlamaInferenceSession {
     /// NVIDIA device (one forward per token, KV built incrementally, a single sync
     /// at the end), then leave the global engine ready at `position = n` so the
     /// last prompt token decodes straight into the first generated token. Replaces
-    /// the CPU prefill — the main time-to-first-token cost. Returns `false` to fall
+    /// the CPU prefill â€” the main time-to-first-token cost. Returns `false` to fall
     /// back to the CPU prefill for any unsupported config.
     #[cfg(feature = "cuda")]
     fn try_resident_prefill_cuda(&mut self, token_ids: &[u32]) -> Result<bool> {
@@ -2286,7 +2371,7 @@ impl LlamaInferenceSession {
         }
         // Default to the batched prefill (each weight read once per MAX_VERIFY_K-token
         // chunk instead of once per token). `CAMELID_CUDA_RESIDENT_PREFILL_BATCHED=0`
-        // forces the serial per-token loop — an A/B switch for parity bisection. Both
+        // forces the serial per-token loop â€” an A/B switch for parity bisection. Both
         // write bit-identical KV (the batched stack reuses the same per-block dot and
         // block-ordered sum), so decode after either is token-identical.
         let serial_prefill = std::env::var_os("CAMELID_CUDA_RESIDENT_PREFILL_BATCHED")
@@ -2319,7 +2404,7 @@ impl LlamaInferenceSession {
         // KV cache is authoritative too: otherwise any later forward that takes the
         // CPU path (dense diagnostics, a GPU-decode fallback, or a KV rollback) reads
         // an all-zero history and generation degenerates. The copy is a few MB of
-        // device->host transfer — negligible next to the prefill compute it follows,
+        // device->host transfer â€” negligible next to the prefill compute it follows,
         // and it keeps both backends in lockstep.
         if let Err(e) =
             self.copy_resident_cuda_kv_to_host(&slot.engine, n_layers, n, n_kv, head_dim)
@@ -2364,7 +2449,7 @@ impl LlamaInferenceSession {
                     let src = (h * n + p) * head_dim;
                     // Canonical store, not a raw copy: the GPU KV is f16, so
                     // this data is f16-exact and the rounding inside is
-                    // idempotent — the routing enforces the invariant
+                    // idempotent â€” the routing enforces the invariant
                     // structurally instead of relying on the GPU dtype.
                     self.kv_cache.store_kv_head_row(
                         layer,
@@ -2386,7 +2471,7 @@ impl LlamaInferenceSession {
     /// id sampled ON the GPU. The token graph's tail runs the argmax (exactly
     /// `LlamaSampler::Greedy`: strict greater-than, lowest-index tie-break) and gathers the
     /// sampled token's embedding row into the next pre-encoded graph's input, and that next
-    /// graph is event-released before this one finishes — so consecutive tokens run
+    /// graph is event-released before this one finishes â€” so consecutive tokens run
     /// back-to-back on the GPU with no logits readback or CPU sampling on the critical
     /// path. Returns Ok(None) when the resident fast path is unavailable (the caller falls
     /// back to the general path, which this call then leaves untouched).
@@ -2427,7 +2512,7 @@ impl LlamaInferenceSession {
 
     /// Temperature-sampling analog of the greedy resident fast lane: when the
     /// sampler is plain temperature (no top-k / top-p / penalties / logit-bias),
-    /// draw the next token on the GPU via Gumbel-max — no 128K-logit host copy and
+    /// draw the next token on the GPU via Gumbel-max â€” no 128K-logit host copy and
     /// no CPU sort, which the profiler showed cost ~7 ms/token (more than the whole
     /// forward). Returns `Ok(None)` when the config isn't GPU-eligible or CUDA
     /// resident decode is off, so the caller uses the CPU logits path unchanged.
@@ -2488,7 +2573,7 @@ impl LlamaInferenceSession {
     /// proposes up to `max_draft` tokens from `history`; the model verifies them in
     /// ONE batched forward (`verify_batch`), and the longest correct prefix plus
     /// one bonus token are accepted. Output is exactly what greedy decode would
-    /// have produced (the model's argmax verifies every token) — lossless — but a
+    /// have produced (the model's argmax verifies every token) â€” lossless â€” but a
     /// single memory-bound forward can emit several tokens. Returns the accepted
     /// tokens (1..=max_draft+1) and advances the KV position, or `Ok(None)` when no
     /// draft is available or the GPU engine isn't ready (caller does a normal step).
@@ -2563,7 +2648,7 @@ impl LlamaInferenceSession {
         }
 
         // Same key the build/decode wrappers use (stable model identity when set,
-        // else the weights Arc pointer) — otherwise the readiness check never matches.
+        // else the weights Arc pointer) â€” otherwise the readiness check never matches.
         let key = self
             .resident_cache_key
             .map(|k| k as usize)
@@ -2728,7 +2813,7 @@ impl LlamaInferenceSession {
     /// Non-CUDA build: route the GPU resident tree speculative-verify to the Metal seam
     /// (`verify_tree_metal`), which runs the batched bit-identical `verify_batch_tree` when the
     /// resident engine is live and ready, else returns `Ok(None)` so the caller takes a normal
-    /// step. Lossless either way (the target verify is authoritative — every emitted token is the
+    /// step. Lossless either way (the target verify is authoritative â€” every emitted token is the
     /// model's own greedy argmax along the accepted path).
     #[cfg(not(feature = "cuda"))]
     pub fn verify_tree_gpu(
@@ -3441,7 +3526,7 @@ impl LlamaInferenceSession {
     /// accepted token followed by drafted tokens) in ONE batched pass through
     /// the chunked-prefill layer path, then compute logits for EVERY position
     /// and return the greedy argmax per position. One weight read serves all
-    /// M tokens — the same amortization the prefill path gets.
+    /// M tokens â€” the same amortization the prefill path gets.
     ///
     /// KV entries are appended for all `token_ids` (position advances by M);
     /// the caller drops rejected suffixes with `rollback_to_position`.
@@ -3999,7 +4084,7 @@ impl LlamaInferenceSession {
     }
 
     /// `allowed_tokens`, when set, is a vocab-sized mask applied to the logits
-    /// before sampling (disallowed tokens forced to `-inf`) — grammar-constrained
+    /// before sampling (disallowed tokens forced to `-inf`) â€” grammar-constrained
     /// decoding. The unmasked logits are still returned in the step (so logprobs /
     /// diagnostics see the real distribution).
     pub fn generate_next_token_with_history_diagnostics(
@@ -4301,9 +4386,9 @@ fn env_flag_enabled(key: &str) -> bool {
 /// forward pass: every Metal/GPU dispatch gate fails closed to its CPU equivalent,
 /// regardless of any `CAMELID_METAL_*` override. This makes the supported TinyLlama
 /// 1.1B Q8_0 forward pass bit-exact and reduction-order-stable across runs, thread
-/// counts, and processes (the CPU reduction order is already fixed — each output owns
+/// counts, and processes (the CPU reduction order is already fixed â€” each output owns
 /// its full serial K-dimension reduction; see `qa/determinism/determinism-baseline-*.md` and
-/// DECISIONS.md §D9). The library default is OFF, so the default (GPU fast) path and
+/// DECISIONS.md Â§D9). The library default is OFF, so the default (GPU fast) path and
 /// every embedder are byte-for-byte unchanged. The pinned reduction order mirrors the
 /// llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated against.
 pub fn deterministic_mode_enabled() -> bool {
@@ -4324,7 +4409,7 @@ pub const EXECUTION_TRACE_ALGORITHM_ROLLUP_V1: &str = "sha256-rollup-v1";
 /// This is a single *rollup*: a mismatch proves the run differs but does not localize which
 /// token or layer. It is only meaningful on the order-stable CPU lane (deterministic mode):
 /// the underlying values are reduction-order-stable there (see [`deterministic_mode_enabled`]
-/// and DECISIONS.md §D9), and byte-for-byte reproducibility requires greedy decoding
+/// and DECISIONS.md Â§D9), and byte-for-byte reproducibility requires greedy decoding
 /// (RECEIPTS.md rule 2). The digest is ISA-specific (i8mm vs scalar round differently), so it
 /// is re-derivable on the same deterministic lane/host, not portable across ISAs.
 #[derive(Clone)]
@@ -4451,12 +4536,12 @@ fn prefill_layer_major_enabled(weights: &LlamaLoadedWeights) -> bool {
 
 /// Dedicated, wider Rayon pool for the compute-bound prompt-prefill GEMM.
 ///
-/// Prompt prefill is a matrix–matrix multiply (high arithmetic intensity): it
+/// Prompt prefill is a matrixâ€“matrix multiply (high arithmetic intensity): it
 /// scales with *logical* cores, gaining throughput from SMT siblings. Single-token
-/// decode is the opposite — a matrix–vector stream that is memory-bandwidth-bound,
+/// decode is the opposite â€” a matrixâ€“vector stream that is memory-bandwidth-bound,
 /// where SMT siblings only add memory-controller contention and *cost* throughput.
-/// Measured on an i7-11800H (8C/16T): prefill 19.5→23.6 tok/s going 8→16 threads
-/// (+21%), while decode peaks near 6 threads and falls 5.7→5.2 over the same range
+/// Measured on an i7-11800H (8C/16T): prefill 19.5â†’23.6 tok/s going 8â†’16 threads
+/// (+21%), while decode peaks near 6 threads and falls 5.7â†’5.2 over the same range
 /// (see `docs/perf-deep-dive/PERF_RECEIPTS/.../p1-cpu-thread-sweep`). The global
 /// pool stays sized for decode (physical cores on Windows, see
 /// `configure_rayon_threads`); only the prefill forward pass installs onto this
@@ -4464,7 +4549,7 @@ fn prefill_layer_major_enabled(weights: &LlamaLoadedWeights) -> bool {
 ///
 /// Bit-exact: the prefill matmul parallelizes over *independent* output rows, and
 /// each row's block accumulation is serial, so the thread count never changes the
-/// numeric result (verified byte-identical across 4–16 threads in the sweep above).
+/// numeric result (verified byte-identical across 4â€“16 threads in the sweep above).
 ///
 /// Returns `None` (prefill stays on the global pool) on non-Windows/x86_64 targets,
 /// under an explicit `CAMELID_PREFILL_THREADS=0|off|global`, when the operator has
@@ -4512,10 +4597,10 @@ fn build_prefill_thread_pool() -> Option<rayon::ThreadPool> {
 
 /// Pure resolution of the prefill pool width, factored out for testing.
 ///
-/// * `spec` — the raw `CAMELID_PREFILL_THREADS` value, if set.
-/// * `global_pinned` — whether `CAMELID_THREADS` explicitly pinned the global pool.
-/// * `logical` — logical core count (the default widen target).
-/// * `widen_by_default` — whether this target auto-widens prefill (Windows/x86_64).
+/// * `spec` â€” the raw `CAMELID_PREFILL_THREADS` value, if set.
+/// * `global_pinned` â€” whether `CAMELID_THREADS` explicitly pinned the global pool.
+/// * `logical` â€” logical core count (the default widen target).
+/// * `widen_by_default` â€” whether this target auto-widens prefill (Windows/x86_64).
 fn resolve_prefill_thread_count_from(
     spec: Option<&str>,
     global_pinned: bool,
@@ -5488,7 +5573,7 @@ fn sample_with_config(
     // Advance the RNG per decode step: `token_history.len()` is the deterministic
     // stream position, so each step draws a fresh uniform while a fixed seed still
     // reproduces the whole sequence token-for-token. (Previously the draw depended
-    // only on the seed, so every step reused one identical value — a degenerate
+    // only on the seed, so every step reused one identical value â€” a degenerate
     // sampler.)
     let draw = seeded_unit_interval_at(config.seed.unwrap_or(0), token_history.len() as u64);
     let mut cumulative = 0.0;
@@ -5691,34 +5776,38 @@ fn forward_layer_timed(
         (q, k, v, Some(elapsed))
     } else {
         let started = Instant::now();
-        let q = linear_runtime_with_plan(
+        let q = linear_for_role_bound(
             &attn_norm,
             &layer.attention_q,
             format!("layer_{layer_idx}_attention_q"),
+            "linear",
             runtime_plan,
             collect_diagnostics,
+            &layer.decode_bindings.attention_q,
         )?;
         timings.attention_q = started.elapsed().as_micros();
 
         let started = Instant::now();
-        let k = linear_for_role_runtime_with_plan(
+        let k = linear_for_role_bound(
             &attn_norm,
             &layer.attention_k,
             format!("layer_{layer_idx}_attention_k"),
             "attention_k",
             runtime_plan,
             collect_diagnostics,
+            &layer.decode_bindings.attention_k,
         )?;
         timings.attention_k = started.elapsed().as_micros();
 
         let started = Instant::now();
-        let v = linear_for_role_runtime_with_plan(
+        let v = linear_for_role_bound(
             &attn_norm,
             &layer.attention_v,
             format!("layer_{layer_idx}_attention_v"),
             "attention_v",
             runtime_plan,
             collect_diagnostics,
+            &layer.decode_bindings.attention_v,
         )?;
         timings.attention_v = started.elapsed().as_micros();
         (q, k, v, None)
@@ -5873,12 +5962,14 @@ fn forward_layer_timed(
     trace_forward_layer_memory(layer_idx, "attention_context_done");
 
     let started = Instant::now();
-    let mut attn_out = linear_runtime_with_plan(
+    let mut attn_out = linear_for_role_bound(
         &context,
         &layer.attention_output,
         format!("layer_{layer_idx}_attention_output"),
+        "linear",
         runtime_plan,
         collect_diagnostics,
+        &layer.decode_bindings.attention_output,
     )?;
     if collect_diagnostics && diagnostic_zero_delta(DeltaZeroTarget::Attention, layer_idx)? {
         attn_out = zero_like(
@@ -6033,13 +6124,14 @@ fn forward_layer_timed(
             }
             trace_forward_layer_memory(layer_idx, "ffn_gate_up_activation_done");
             let started = Instant::now();
-            let ffn_out = linear_for_role_runtime_with_plan(
+            let ffn_out = linear_for_role_bound(
                 &activated,
                 &layer.ffn_down,
                 down_name,
                 "ffn_down",
                 runtime_plan,
                 collect_diagnostics,
+                &layer.decode_bindings.ffn_down,
             )?;
             let ffn_out_already_residual = false;
             let ffn_output_stats = collect_diagnostics
@@ -6946,87 +7038,249 @@ fn linear_for_role_runtime_with_plan(
     if collect_diagnostics {
         linear_for_role(input, weight, name, rectangular_role)
     } else {
-        let name = name.into();
-        // Lane 1: unified tiled Q8_0 prefill GEMM owner (default-off). Role-agnostic — covers
-        // every Q8_0 projection (q/k/v/o, gate/up, ffn_down) in ONE place. Returns None for
-        // decode, non-Q8, or non-PackedRows4 weights, so the default path is unchanged when off.
-        if let Some(output) =
-            try_q8_matmul_owner_prefill(input, weight, &name, rectangular_role, runtime_plan)?
-        {
-            return Ok(output);
-        }
-        if let Some(output) = try_x86_q8_attention_output_decode_consumer_path(
+        decode_linear_cascade(
             input,
             weight,
-            &name,
+            name.into(),
             rectangular_role,
             runtime_plan,
-        )? {
-            return Ok(output);
-        }
-        if let Some(output) = try_x86_q8_attention_output_packed_rows4_matmul_path(
-            input,
-            weight,
-            &name,
-            rectangular_role,
-            runtime_plan,
-        )? {
-            return Ok(output);
-        }
-        if let Some(output) = try_x86_q8_attention_projection_decode_consumer_path(
-            input,
-            weight,
-            &name,
-            rectangular_role,
-            runtime_plan,
-        )? {
-            return Ok(output);
-        }
-        if let Some(output) = try_x86_q8_ffn_down_gemm4_prefill_path(
-            input,
-            weight,
-            &name,
-            rectangular_role,
-            runtime_plan,
-        )? {
-            return Ok(output);
-        }
-        if let Some(output) = try_x86_q8_ffn_down_single_owner_path(
-            input,
-            weight,
-            &name,
-            rectangular_role,
-            runtime_plan,
-        )? {
-            return Ok(output);
-        }
-        if let Some(output) = try_x86_q8_ffn_down_decode_consumer_path(
-            input,
-            weight,
-            &name,
-            rectangular_role,
-            runtime_plan,
-        )? {
-            return Ok(output);
-        }
-        if let Some(output) = try_x86_q8_ffn_down_packed_rows4_matmul_path(
-            input,
-            weight,
-            &name,
-            rectangular_role,
-            runtime_plan,
-        )? {
-            return Ok(output);
-        }
-        linear_with_diagnostic_layouts_with_plan(
-            input,
-            weight,
-            name,
-            SquareLinearLayout::Transposed,
-            RectangularLinearLayout::Auto,
-            runtime_plan,
+            None,
         )
     }
+}
+
+/// Cascade arm identifiers recorded in [`DecodeBindingCell`]s. Prefill-only
+/// arms are never recorded (bindings apply to rows==1 decode calls).
+const DECODE_ARM_UNBOUND: u8 = 0;
+const DECODE_ARM_ATTN_OUTPUT_DECODE_CONSUMER: u8 = 1;
+const DECODE_ARM_ATTN_OUTPUT_PACKED_ROWS4: u8 = 2;
+const DECODE_ARM_ATTN_PROJECTION_DECODE_CONSUMER: u8 = 3;
+const DECODE_ARM_FFN_DOWN_SINGLE_OWNER: u8 = 4;
+const DECODE_ARM_FFN_DOWN_DECODE_CONSUMER: u8 = 5;
+const DECODE_ARM_FFN_DOWN_PACKED_ROWS4: u8 = 6;
+const DECODE_ARM_FALLBACK: u8 = 7;
+
+/// Decode-bound variant of [`linear_for_role_runtime_with_plan`]: the first
+/// rows==1 call per binding cell runs the historical cascade and records the
+/// winning arm; steady-state calls jump straight to that arm. The arm's own
+/// guards remain in force — if they ever miss (they cannot for a fixed plan
+/// and shape), the call falls back to the full cascade and rebinds, so the
+/// fail-closed ordering is preserved by construction. Prefill (rows > 1) and
+/// diagnostics calls always take the historical paths untouched.
+fn linear_for_role_bound(
+    input: &CpuTensor,
+    weight: &CpuTensor,
+    name: impl Into<String>,
+    rectangular_role: &str,
+    runtime_plan: &ResolvedRuntimePlan,
+    collect_diagnostics: bool,
+    binding: &DecodeBindingCell,
+) -> Result<CpuTensor> {
+    if collect_diagnostics {
+        return linear_for_role(input, weight, name, rectangular_role);
+    }
+    let name = name.into();
+    if input.dim(0)? != 1 {
+        return decode_linear_cascade(input, weight, name, rectangular_role, runtime_plan, None);
+    }
+    match binding.load() {
+        DECODE_ARM_ATTN_OUTPUT_DECODE_CONSUMER => {
+            if let Some(output) = try_x86_q8_attention_output_decode_consumer_path(
+                input,
+                weight,
+                &name,
+                rectangular_role,
+                runtime_plan,
+            )? {
+                return Ok(output);
+            }
+        }
+        DECODE_ARM_ATTN_OUTPUT_PACKED_ROWS4 => {
+            if let Some(output) = try_x86_q8_attention_output_packed_rows4_matmul_path(
+                input,
+                weight,
+                &name,
+                rectangular_role,
+                runtime_plan,
+            )? {
+                return Ok(output);
+            }
+        }
+        DECODE_ARM_ATTN_PROJECTION_DECODE_CONSUMER => {
+            if let Some(output) = try_x86_q8_attention_projection_decode_consumer_path(
+                input,
+                weight,
+                &name,
+                rectangular_role,
+                runtime_plan,
+            )? {
+                return Ok(output);
+            }
+        }
+        DECODE_ARM_FFN_DOWN_SINGLE_OWNER => {
+            if let Some(output) = try_x86_q8_ffn_down_single_owner_path(
+                input,
+                weight,
+                &name,
+                rectangular_role,
+                runtime_plan,
+            )? {
+                return Ok(output);
+            }
+        }
+        DECODE_ARM_FFN_DOWN_DECODE_CONSUMER => {
+            if let Some(output) = try_x86_q8_ffn_down_decode_consumer_path(
+                input,
+                weight,
+                &name,
+                rectangular_role,
+                runtime_plan,
+            )? {
+                return Ok(output);
+            }
+        }
+        DECODE_ARM_FFN_DOWN_PACKED_ROWS4 => {
+            if let Some(output) = try_x86_q8_ffn_down_packed_rows4_matmul_path(
+                input,
+                weight,
+                &name,
+                rectangular_role,
+                runtime_plan,
+            )? {
+                return Ok(output);
+            }
+        }
+        DECODE_ARM_FALLBACK => {
+            return linear_with_diagnostic_layouts_with_plan(
+                input,
+                weight,
+                name,
+                SquareLinearLayout::Transposed,
+                RectangularLinearLayout::Auto,
+                runtime_plan,
+            );
+        }
+        _ => {}
+    }
+    decode_linear_cascade(
+        input,
+        weight,
+        name,
+        rectangular_role,
+        runtime_plan,
+        Some(binding),
+    )
+}
+
+/// The historical role-dispatch cascade, unchanged in ORDER and guards; when
+/// `record` is provided (rows==1 bound calls), the winning decode-capable arm
+/// is written into the binding cell. This function remains the single
+/// authority on kernel selection — the bound fast path above only replays its
+/// recorded verdict.
+fn decode_linear_cascade(
+    input: &CpuTensor,
+    weight: &CpuTensor,
+    name: String,
+    rectangular_role: &str,
+    runtime_plan: &ResolvedRuntimePlan,
+    record: Option<&DecodeBindingCell>,
+) -> Result<CpuTensor> {
+    // Lane 1: unified tiled Q8_0 prefill GEMM owner (default-off). Role-agnostic — covers
+    // every Q8_0 projection (q/k/v/o, gate/up, ffn_down) in ONE place. Returns None for
+    // decode, non-Q8, or non-PackedRows4 weights, so the default path is unchanged when off.
+    if let Some(output) =
+        try_q8_matmul_owner_prefill(input, weight, &name, rectangular_role, runtime_plan)?
+    {
+        return Ok(output);
+    }
+    if let Some(output) = try_x86_q8_attention_output_decode_consumer_path(
+        input,
+        weight,
+        &name,
+        rectangular_role,
+        runtime_plan,
+    )? {
+        if let Some(binding) = record {
+            binding.store(DECODE_ARM_ATTN_OUTPUT_DECODE_CONSUMER);
+        }
+        return Ok(output);
+    }
+    if let Some(output) = try_x86_q8_attention_output_packed_rows4_matmul_path(
+        input,
+        weight,
+        &name,
+        rectangular_role,
+        runtime_plan,
+    )? {
+        if let Some(binding) = record {
+            binding.store(DECODE_ARM_ATTN_OUTPUT_PACKED_ROWS4);
+        }
+        return Ok(output);
+    }
+    if let Some(output) = try_x86_q8_attention_projection_decode_consumer_path(
+        input,
+        weight,
+        &name,
+        rectangular_role,
+        runtime_plan,
+    )? {
+        if let Some(binding) = record {
+            binding.store(DECODE_ARM_ATTN_PROJECTION_DECODE_CONSUMER);
+        }
+        return Ok(output);
+    }
+    if let Some(output) = try_x86_q8_ffn_down_gemm4_prefill_path(
+        input,
+        weight,
+        &name,
+        rectangular_role,
+        runtime_plan,
+    )? {
+        return Ok(output);
+    }
+    if let Some(output) =
+        try_x86_q8_ffn_down_single_owner_path(input, weight, &name, rectangular_role, runtime_plan)?
+    {
+        if let Some(binding) = record {
+            binding.store(DECODE_ARM_FFN_DOWN_SINGLE_OWNER);
+        }
+        return Ok(output);
+    }
+    if let Some(output) = try_x86_q8_ffn_down_decode_consumer_path(
+        input,
+        weight,
+        &name,
+        rectangular_role,
+        runtime_plan,
+    )? {
+        if let Some(binding) = record {
+            binding.store(DECODE_ARM_FFN_DOWN_DECODE_CONSUMER);
+        }
+        return Ok(output);
+    }
+    if let Some(output) = try_x86_q8_ffn_down_packed_rows4_matmul_path(
+        input,
+        weight,
+        &name,
+        rectangular_role,
+        runtime_plan,
+    )? {
+        if let Some(binding) = record {
+            binding.store(DECODE_ARM_FFN_DOWN_PACKED_ROWS4);
+        }
+        return Ok(output);
+    }
+    if let Some(binding) = record {
+        binding.store(DECODE_ARM_FALLBACK);
+    }
+    linear_with_diagnostic_layouts_with_plan(
+        input,
+        weight,
+        name,
+        SquareLinearLayout::Transposed,
+        RectangularLinearLayout::Auto,
+        runtime_plan,
+    )
 }
 
 fn linear_projection_diagnostics(
@@ -7270,8 +7524,8 @@ fn linear_with_diagnostic_layouts_with_plan(
     let rows = weight.dim(0)?;
     let cols = weight.dim(1)?;
     // K-quant (Q4_K / Q6_K) wire weights have no f32 data and no general CPU
-    // consumer; intercept them here — the single chokepoint both the diagnostic
-    // and runtime linear chains funnel through — with the original tensor, before
+    // consumer; intercept them here â€” the single chokepoint both the diagnostic
+    // and runtime linear chains funnel through â€” with the original tensor, before
     // any layout reinterpretation that would drop the wire bytes. The block-dot
     // is layout-agnostic: it takes the contraction width from the input and the
     // output width from the wire length, so a GGUF `[in, out]` weight (where
@@ -9992,7 +10246,7 @@ fn resident_cuda_cache() -> &'static std::sync::Mutex<Option<ResidentCudaSlot>> 
 
 /// Second resident-engine cache, dedicated to the speculative draft model. Draft
 /// and target are different models (different weight identities), so giving them
-/// separate single-slot caches lets BOTH stay GPU-resident at once — sharing one
+/// separate single-slot caches lets BOTH stay GPU-resident at once â€” sharing one
 /// slot would thrash (rebuild + 3.4 GB re-upload) every time control passed between
 /// drafter and target. Routed by `LlamaInferenceSession::is_drafter`.
 #[cfg(feature = "cuda")]
@@ -10013,7 +10267,7 @@ static SPEC_COEXIST_RESERVE_BYTES: std::sync::atomic::AtomicU64 =
 
 /// Record the draft model's resident footprint so the target leaves room for it. Pass 0 to
 /// disable (single-model path). Does NOT evict already-built engines: a resident target built
-/// before the reserve was set keeps running (reused, not rebuilt) — rebuilding it would free
+/// before the reserve was set keeps running (reused, not rebuilt) â€” rebuilding it would free
 /// its VRAM only to the cudarc pool (which the free-VRAM probe does not see), so the rebuild
 /// would wrongly fall to CPU. The reserve therefore only shapes engines built AFTER it is set
 /// (e.g. when the drafter is configured before the target's first decode).
@@ -10031,7 +10285,7 @@ fn spec_coexist_reserve_bytes() -> u64 {
 
 /// KV-cache positions a speculative draft engine is sized for (env-tunable). The draft only
 /// needs to span the prompt + generated tokens it drafts over; capping it keeps the draft's
-/// VRAM small so it fits beside the resident target. Lossless either way — the target verify is
+/// VRAM small so it fits beside the resident target. Lossless either way â€” the target verify is
 /// authoritative, so a shorter draft context only affects accept rate, never correctness.
 #[cfg(feature = "cuda")]
 fn spec_draft_kv_context() -> usize {
@@ -10054,7 +10308,7 @@ pub fn reset_resident_caches() {
         .unwrap_or_else(|p| p.into_inner()) = None;
     // The engines dropped above returned their VRAM to cudarc's stream-ordered async
     // pool (cuMemFreeAsync), where the free-VRAM probe cannot see it. Trim the pool so
-    // the next model's resident fit decision measures the real free VRAM — otherwise a
+    // the next model's resident fit decision measures the real free VRAM â€” otherwise a
     // larger model wrongly falls back to the CPU path (the ~20x-slower symptom this
     // unload path exists to prevent).
     crate::cuda::release_async_pool();
@@ -10065,7 +10319,7 @@ pub fn reset_resident_caches() {}
 /// Prompt-lookup n-gram drafter: find the most recent earlier occurrence of the
 /// last `ngram` tokens and propose the up-to-`max_draft` tokens that followed it.
 /// Cheap (no model), and it hits whenever the model repeats a phrase already in
-/// the context (code, lists, quoted text) — exactly where greedy decode is
+/// the context (code, lists, quoted text) â€” exactly where greedy decode is
 /// predictable. Empty when there's no match.
 #[cfg(feature = "cuda")]
 fn draft_ngram(history: &[u32], max_draft: usize, ngram: usize) -> Vec<u32> {
@@ -10154,9 +10408,9 @@ fn build_resident_cuda_engine(
     // VRAM-driven resident-context sizing (portability, not hardcoded to any card):
     //   resident weights are uploaded once and live for the engine's lifetime; the
     //   GPU KV cache is allocated once at `cap` positions, costing
-    //   kv_bytes_per_pos = n_layers · n_kv · head_dim · 2(K,V) · 2(f16 bits) each. Size the
+    //   kv_bytes_per_pos = n_layers Â· n_kv Â· head_dim Â· 2(K,V) Â· 2(f16 bits) each. Size the
     //   cap so weights + KV + a scratch/headroom reserve fit in *detected free* VRAM:
-    //     cap = min(requested, (free_vram − weights − headroom) / kv_bytes_per_pos)
+    //     cap = min(requested, (free_vram âˆ’ weights âˆ’ headroom) / kv_bytes_per_pos)
     //   On a 6 GB card this stays conservative; on a 24 GB card it grows automatically
     //   to a long context. If even the floor (256) cannot fit, return None so the
     //   caller runs the model on the CPU path rather than oversubscribing VRAM.
@@ -10181,10 +10435,10 @@ fn build_resident_cuda_engine(
         + raw(weights.output_projection())
             .map(|b| b.len() as u64)
             .unwrap_or(0);
-    // Scratch reserve: logits row (vocab·f32) + per-stage activation buffers + a flat
+    // Scratch reserve: logits row (vocabÂ·f32) + per-stage activation buffers + a flat
     // safety margin for driver/context overhead and fragmentation. The flat margin is
     // env-overridable (CAMELID_CUDA_RESIDENT_HEADROOM_MB) so a second engine can be
-    // packed onto a small card — e.g. drafter + target for speculative decode, where
+    // packed onto a small card â€” e.g. drafter + target for speculative decode, where
     // the default 512 MiB per engine would not leave room for both.
     // The flat margin defaults to 512 MiB for a sole resident engine. Under speculative
     // coexistence both engines pack onto the card, so 512 MiB each would not fit: the draft
@@ -10199,7 +10453,7 @@ fn build_resident_cuda_engine(
     // takes the remaining free VRAM). BUT only honor the reserve when the target still fits
     // FULLY resident after it, measured against the NORMAL single-engine headroom. If reserving
     // would force the target to offload trailing layers, that offload (a) slows the target
-    // forward and (b) pushes the batched verify onto the serial/CPU path — a different backend
+    // forward and (b) pushes the batched verify onto the serial/CPU path â€” a different backend
     // than the resident plain decode, which diverges at near-ties. Not worth it: drop the
     // reserve, build the target full-resident (NORMAL headroom), and let the draft fall back to
     // CPU (the prior, lossless behavior). So the resident-draft win is taken only on a GPU big
@@ -10220,7 +10474,7 @@ fn build_resident_cuda_engine(
     let coexist_fit_headroom = (vocab as u64 * 4) + (coexist_headroom_mb * 1024 * 1024);
     // Bounded over-allocation the WDDM driver pages to shared host memory (how llama.cpp fits both
     // models on a 6 GB card): treat free VRAM as larger by this much for the coexistence sizing.
-    // Default 0 (strict — no spill). Opt in via CAMELID_SPEC_COEXIST_SPILL_MB on a tight card.
+    // Default 0 (strict â€” no spill). Opt in via CAMELID_SPEC_COEXIST_SPILL_MB on a tight card.
     let coexist_spill = std::env::var("CAMELID_SPEC_COEXIST_SPILL_MB")
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
@@ -10238,7 +10492,7 @@ fn build_resident_cuda_engine(
     };
     // Honor the reserve only if the target still fits fully resident after it (measured with the
     // small coexist headroom; the reserve already accounts for the draft's footprint). If not,
-    // drop the reserve and build the target full-resident — offloading it to make room is a net
+    // drop the reserve and build the target full-resident â€” offloading it to make room is a net
     // loss (slow target + serial/CPU verify that diverges at near-ties from the resident plain
     // decode), so the draft falls back to CPU (the prior lossless behavior).
     let honor_reserve = raw_reserve > 0
@@ -10307,7 +10561,7 @@ fn build_resident_cuda_engine(
     // host RAM (test/override hook, fires even on a model that fits). Otherwise the
     // split is AUTOMATIC: when all weights + a minimum KV cache + headroom cannot fit
     // in free VRAM, offload the fewest TRAILING layers needed so the rest fit. Each
-    // offloaded layer streams its weights to a GPU scratch buffer every forward — a
+    // offloaded layer streams its weights to a GPU scratch buffer every forward â€” a
     // capacity tradeoff, token-identical to the all-resident path.
     let force_offload = std::env::var("CAMELID_OFFLOAD_FORCE_LAYERS")
         .ok()
@@ -10339,7 +10593,7 @@ fn build_resident_cuda_engine(
     let n_resident_layers = n_layers - offload_count;
 
     // VRAM left for the KV cache after the RESIDENT weights and (if offloading) the
-    // streaming scratch — so freed weight VRAM grows the resident context.
+    // streaming scratch â€” so freed weight VRAM grows the resident context.
     let offloaded_bytes: u64 = per_layer_bytes[n_resident_layers..].iter().sum();
     let resident_weights_bytes = weights_bytes.saturating_sub(offloaded_bytes);
     let scratch_reserve = if offload_count > 0 {
@@ -10384,7 +10638,7 @@ fn build_resident_cuda_engine(
         }
         return None;
     }
-    // Task 4 — explicit VRAM headroom policy. Project the actual device
+    // Task 4 â€” explicit VRAM headroom policy. Project the actual device
     // allocation (resident weights + streaming scratch + the sized KV cache) and
     // run it past the headroom policy *before* allocating. If it would OOM or
     // leave less than the minimum post-load headroom, refuse the resident load
@@ -10395,7 +10649,7 @@ fn build_resident_cuda_engine(
         let projected_alloc =
             resident_weights_bytes + scratch_reserve + (cap as u64) * kv_bytes_per_pos;
         // Evaluate against ACTUAL free VRAM. Under coexistence the budget already excludes the
-        // draft's reserve, so the target's sizing leaves that reserve free by construction —
+        // draft's reserve, so the target's sizing leaves that reserve free by construction â€”
         // here we only require a small absolute safety margin (NOT reserve+margin, which would
         // double-count and falsely refuse). The draft, allocating last, likewise needs only the
         // small margin. Outside coexistence this is the normal 512 MiB post-load floor.
@@ -10439,7 +10693,7 @@ fn build_resident_cuda_engine(
             }
             _ => return None,
         };
-        // Per-projection quant lanes (q,k,v,o,gate,up,down) — drives the per-tensor
+        // Per-projection quant lanes (q,k,v,o,gate,up,down) â€” drives the per-tensor
         // repack + GEMV kernel + activation quantizer. Q4_K_M is mixed: most
         // projections Q4_K, with attn_v/ffn_down promoted to Q6_K in ~half the layers.
         let quants = [
@@ -10532,7 +10786,7 @@ fn resident_gpu_temperature_sampling_enabled() -> bool {
 }
 
 /// CUDA GPU-resident decode gate (the NVIDIA analog of the Metal one). On
-/// automatically whenever a usable CUDA device is present — the end-user app
+/// automatically whenever a usable CUDA device is present â€” the end-user app
 /// "just works" fast on the GPU with no flag or toggle. Deterministic mode
 /// (opt-in) forces the CPU reference; `CAMELID_CUDA_RESIDENT_DECODE=0` is an
 /// explicit escape hatch for debugging. Falls back to CPU per token for any
@@ -10570,7 +10824,7 @@ fn resident_decode_cuda_enabled() -> bool {
 /// is NOT bit-identical to a fresh GPU prefill: a cache hit reseeds the GPU KV from the
 /// f16-rounded host history and resumes, a different reduction order than a clean GPU
 /// prefill, which flips borderline (near-tie) tokens. The CPU lane is reduction-order
-/// stable, so it keeps the cache; the GPU lane must bypass it — exactly as deterministic
+/// stable, so it keeps the cache; the GPU lane must bypass it â€” exactly as deterministic
 /// mode already bypasses the cache on the CPU lane.
 pub fn resident_decode_cuda_active() -> bool {
     resident_decode_cuda_enabled()
@@ -10578,9 +10832,9 @@ pub fn resident_decode_cuda_active() -> bool {
 
 /// Maximum sequence length the CUDA resident engine keeps on the GPU. The GPU KV
 /// cache is allocated once at this many positions, so it directly sets the engine's
-/// VRAM footprint (≈ n_layers·n_kv·head_dim·2·4 bytes per position) on top of the
+/// VRAM footprint (â‰ˆ n_layersÂ·n_kvÂ·head_dimÂ·2Â·4 bytes per position) on top of the
 /// resident weights. On a 6 GB laptop card a 3B Q8_0 model's weights already take
-/// ~3.4 GB, so an 8192-position KV (~1.8 GB for 3B) leaves almost no headroom — any
+/// ~3.4 GB, so an 8192-position KV (~1.8 GB for 3B) leaves almost no headroom â€” any
 /// other GPU app then pushes the engine past VRAM, it can no longer stay resident,
 /// and it is rebuilt (a multi-second 3.4 GB re-upload) on every request. A 4096 cap
 /// halves the KV footprint and keeps the engine resident with room to spare; beyond
@@ -10588,7 +10842,7 @@ pub fn resident_decode_cuda_active() -> bool {
 /// Optional hard ceiling on the resident KV context the wrappers *request*. The
 /// real limit is VRAM-driven inside `build_resident_cuda_engine` (which sizes the
 /// cap to detected free VRAM and reports it), so by default this imposes no extra
-/// cap — a big card gets a long resident context automatically. Set
+/// cap â€” a big card gets a long resident context automatically. Set
 /// `CAMELID_CUDA_RESIDENT_MAX_CONTEXT` to force a lower ceiling (e.g. to leave more
 /// VRAM for other apps).
 #[cfg(feature = "cuda")]
@@ -10660,8 +10914,8 @@ fn q8_0_hybrid_retained_gpu_rows(output_rows: usize) -> usize {
 }
 
 /// Explicit (and loud) opt-out from RAM-resident Q8_0 blocks: only an affirmatively set
-/// `CAMELID_LAZY_Q8_0_LINEAR` forces the per-token file-streaming path. Absence — and any
-/// disabled spelling — means weights are retained in RAM. There is no auto/budget fallback.
+/// `CAMELID_LAZY_Q8_0_LINEAR` forces the per-token file-streaming path. Absence â€” and any
+/// disabled spelling â€” means weights are retained in RAM. There is no auto/budget fallback.
 fn lazy_q8_0_linear_forced() -> bool {
     matches!(
         env::var("CAMELID_LAZY_Q8_0_LINEAR"),
@@ -10674,7 +10928,7 @@ fn lazy_q8_0_linear_forced() -> bool {
 }
 
 /// Fast-load gate: CAMELID_METAL_NOCOPY loads Q8_0 linears as page-aligned wire
-/// pages for in-place GPU consumption. macOS only — the storage is consumed by
+/// pages for in-place GPU consumption. macOS only â€” the storage is consumed by
 /// the Metal wire kernels.
 fn metal_nocopy_fast_load_enabled() -> bool {
     cfg!(target_os = "macos") && env_flag_enabled("CAMELID_METAL_NOCOPY")
@@ -13377,7 +13631,7 @@ fn q8_0_packed_rows4_gemm4_accumulate_block(
 
 /// Phase 3 (K-quant conductor): opt-in software prefetch of the weight stream ahead
 /// of the x86 packed decode dot. Default-off (`CAMELID_X86_PREFETCH`). Memory hint
-/// only — byte-identical output by construction. The macOS/aarch64 dot already issues
+/// only â€” byte-identical output by construction. The macOS/aarch64 dot already issues
 /// a NEON `prfm` two blocks ahead; this gives the x86 decode dot the same option so it
 /// can be measured on a bandwidth-bound host (the Q8 gated-SIMD history says prove the
 /// win on the box before promoting to default).
@@ -13536,16 +13790,16 @@ fn run_q8_0_packed_rows4_prefill_gemm4_kernel(
 // A role-agnostic, BIT-EXACT drop-in for the per-projection prefill block-dot. It reuses the
 // proven 4x4 register microkernel `q8_0_packed_rows4_gemm4_accumulate_block` VERBATIM, so every
 // output cell still accumulates `((int as f32) * weight_scale) * input_scale` over ascending
-// blocks with no FMA — byte-identical to the scalar oracle. The ONLY difference vs the (default-
+// blocks with no FMA â€” byte-identical to the scalar oracle. The ONLY difference vs the (default-
 // off, regressing) ffn_down GEMM4 lane is the loop nest: it parallelizes over OUTPUT-row bands
 // and streams every input group against an L1/L2-resident weight band, so each weight block is
-// read from DRAM ~once instead of once per 4-row input group — the arithmetic-intensity fix for
+// read from DRAM ~once instead of once per 4-row input group â€” the arithmetic-intensity fix for
 // the bandwidth-bound host. Tiling reorders only which cells co-compute, never the per-cell
 // arithmetic sequence, so the result is byte-identical to row-at-a-time for any band size.
 
 /// Raw output pointer shared across rayon tasks. SAFETY: each task writes a DISJOINT set of
-/// (output_row, output_channel) cells — output-group bands are partitioned across tasks and each
-/// task owns its channel range [og*4, og*4+4) exclusively — so no two tasks ever touch the same
+/// (output_row, output_channel) cells â€” output-group bands are partitioned across tasks and each
+/// task owns its channel range [og*4, og*4+4) exclusively â€” so no two tasks ever touch the same
 /// cell despite the shared base pointer.
 #[derive(Clone, Copy)]
 struct Q8UnifiedOutPtr(*mut f32);
@@ -13580,7 +13834,7 @@ fn run_q8_0_unified_prefill_tiled(
     // Parallelize over chunks of output-row groups. Each chunk keeps its weight band resident
     // (read once) and sweeps ALL input groups against it.
     (0..num_chunks).into_par_iter().for_each(|chunk_idx| {
-        // Capture the whole wrapper (Copy + Send + Sync), not the bare `*mut f32` field — Rust
+        // Capture the whole wrapper (Copy + Send + Sync), not the bare `*mut f32` field â€” Rust
         // 2021 disjoint closure capture would otherwise grab `out.0` and reject the raw pointer.
         #[allow(clippy::redundant_locals)]
         let out = out;
@@ -13757,7 +14011,7 @@ unsafe fn q8_0_packed_rows4_gemm4_accumulate_block_avx512vnni(
 }
 
 /// 4x8 dispatcher (v3): accumulate ONE input group against TWO weight groups, sharing the input
-/// load (VNNI only — wider AVX-512 register tile). Byte-identical to two independent 4x4 groups.
+/// load (VNNI only â€” wider AVX-512 register tile). Byte-identical to two independent 4x4 groups.
 /// On non-x86 this is never reached at runtime (use_vnni is always false) but must still compile.
 #[inline(always)]
 fn q8_0_unified_accumulate_pair(
@@ -15740,7 +15994,7 @@ unsafe fn q8_0_two_dot_rows_avx2(
     (first_sum, second_sum)
 }
 
-/// Q8×Q8 dot of one weight row read straight from the GGUF **wire** bytes (34-byte
+/// Q8Ã—Q8 dot of one weight row read straight from the GGUF **wire** bytes (34-byte
 /// blocks: a little-endian f16 scale + 32 i8 quants) against a pre-quantized
 /// activation row, dispatching to the same NEON `sdot` path as
 /// `cpu_neon::q8_0_dot_rows_neon_dotprod`. This lets the gemma4 wire-mmap runtime share
@@ -15780,7 +16034,7 @@ pub(crate) fn q8_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
 }
 
 // ---------------------------------------------------------------------------
-// Gemma 4 QAT (Q4_0 / Q6_K) wire kernels — groundwork for the QAT exact rows
+// Gemma 4 QAT (Q4_0 / Q6_K) wire kernels â€” groundwork for the QAT exact rows
 // (gemma-4-E4B_q4_0-it.gguf de-risk row, then 26B A4B). Marked allow(dead_code)
 // until the gemma4 loader's quant-aware wiring lands; unit-tested below.
 // ---------------------------------------------------------------------------
@@ -15790,10 +16044,10 @@ pub(crate) fn q8_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
 /// j+16 in its high nibble; both nibbles are unsigned with a -8 bias).
 pub(crate) const Q4_0_WIRE_BYTES_PER_BLOCK: usize = 18;
 
-/// Q4_0×Q8_0 dot of one weight row read straight from the GGUF wire bytes
+/// Q4_0Ã—Q8_0 dot of one weight row read straight from the GGUF wire bytes
 /// against a pre-quantized activation row. Same accumulation contract as
 /// [`q8_0_wire_row_dot`]: one exact integer dot per 32-weight block, then a
-/// sequential `int_sum * w_scale * x_scale` f32 accumulate — the gemma4 QAT
+/// sequential `int_sum * w_scale * x_scale` f32 accumulate â€” the gemma4 QAT
 /// (Q4_0) lane shares the comparator-pinning doctrine of the Q8 lane rather
 /// than mimicking any particular reference SIMD reduction shape.
 pub(crate) fn q4_0_wire_row_dot(weight_wire: &[u8], input: &[Q8_0Block]) -> f32 {
@@ -15832,7 +16086,7 @@ pub(crate) fn q4_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
     total
 }
 
-/// Scalar reference for the interleaved 8-row Q4_0×Q8_0 GEMV. Consumes one
+/// Scalar reference for the interleaved 8-row Q4_0Ã—Q8_0 GEMV. Consumes one
 /// [`crate::tensor::Q4_0PackedRows8`] row-group (`blocks_per_row` interleaved
 /// blocks starting at `group_block_start`) and one Q8 activation row, writing
 /// eight dot products (one per interleaved row) into `out`.
@@ -15878,7 +16132,7 @@ pub(crate) fn q4_0_packed_gemv8_scalar(
     let _ = bpr;
 }
 
-/// Runtime-dispatched interleaved 8-row Q4_0×Q8_0 GEMV: AVX2 when available,
+/// Runtime-dispatched interleaved 8-row Q4_0Ã—Q8_0 GEMV: AVX2 when available,
 /// else the scalar reference above. Both paths are bit-identical to
 /// [`q4_0_wire_row_dot_scalar`] run over the same eight rows.
 #[inline]
@@ -15900,17 +16154,17 @@ pub(crate) fn q4_0_packed_gemv8(
     q4_0_packed_gemv8_scalar(packed, group_block_start, input, out);
 }
 
-/// AVX2 interleaved 8-row Q4_0×Q8_0 GEMV. Ported from llama.cpp's
+/// AVX2 interleaved 8-row Q4_0Ã—Q8_0 GEMV. Ported from llama.cpp's
 /// `gemv_q4_b32_8x8_q8_0_lut_avx` (arch/x86/repack.cpp), tied to the Camelid
 /// scalar contract (nibbles carry a `-8` bias). All 8 output rows accumulate in
 /// parallel in the eight 32-bit lanes of one `__m256i`; nibbles are sign-biased
-/// via a `_mm256_shuffle_epi8` LUT and dotted with `maddubs`+`madd` — no
+/// via a `_mm256_shuffle_epi8` LUT and dotted with `maddubs`+`madd` â€” no
 /// AVX-512-VNNI dependency (the 11800H has none).
 ///
 /// Bit-exact vs [`q4_0_packed_gemv8_scalar`] / [`q4_0_wire_row_dot_scalar`]:
-/// the int32 per-block dot is exact (nibble×i8 pair-sums cannot overflow i16),
+/// the int32 per-block dot is exact (nibbleÃ—i8 pair-sums cannot overflow i16),
 /// integer accumulation is order-independent, and the per-block f32
-/// `isum·w_scale·x_scale` accumulate runs in the same block order.
+/// `isumÂ·w_scaleÂ·x_scale` accumulate runs in the same block order.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn q4_0_packed_gemv8_avx2(
@@ -16063,15 +16317,15 @@ unsafe fn q4_0_packed_gemv8_avx2(
     _mm256_storeu_ps(out.as_mut_ptr(), ordered);
 }
 
-/// int8×int8 pairwise-dot of two `__m256i` where each 32-bit lane holds 4
+/// int8Ã—int8 pairwise-dot of two `__m256i` where each 32-bit lane holds 4
 /// signed bytes of `x` (weights, [-8,7]) and 4 of `y` (activations, [-128,127]),
 /// producing 8 int32 lane-dots added to `acc`. Uses the `maddubs` sign-trick
-/// (no AVX-512-VNNI): `abs(x)` is the unsigned operand, `y·sign(x)` the signed
-/// operand. Bit-exact vs the scalar dot: `|x|` ∈ [0,8] is unsigned-safe, and
+/// (no AVX-512-VNNI): `abs(x)` is the unsigned operand, `yÂ·sign(x)` the signed
+/// operand. Bit-exact vs the scalar dot: `|x|` âˆˆ [0,8] is unsigned-safe, and
 /// because weights are never `i8::MIN`, `sign_epi8` never hits the `-(-128)`
 /// overflow; the only value that could is a `-128` activation, but that lands in
 /// the *signed* operand `y` (`sign_epi8(y,x)` negates `y` only where `x<0`), and
-/// `-128` negated stays `-128` — which is exactly what the scalar path computes
+/// `-128` negated stays `-128` â€” which is exactly what the scalar path computes
 /// too, since `(-8)*(-128) = 1024` would need the *weight* to be the one negated.
 /// The weight is `x`; its abs is taken, so no activation value is ever negated
 /// into a wrong magnitude. Verified bit-exact by
@@ -16133,14 +16387,14 @@ pub(crate) const Q6_K_VALUES_PER_BLOCK: usize = 256;
 pub(crate) const Q6_K_WIRE_BYTES_PER_BLOCK: usize = 210;
 
 /// A 256-value Q8_K activation superblock (the reference's activation format
-/// for K-quant dots). `bsums` are omitted — the q6_K dot does not read them.
+/// for K-quant dots). `bsums` are omitted â€” the q6_K dot does not read them.
 pub(crate) struct Q8KBlock {
     pub d: f32,
     pub qs: [i8; Q6_K_VALUES_PER_BLOCK],
 }
 
 /// The reference's magic-number round-to-nearest-even (`nearest_int`): adding
-/// 1.5·2^23 forces the value into the mantissa with round-to-nearest applied,
+/// 1.5Â·2^23 forces the value into the mantissa with round-to-nearest applied,
 /// matching its quantizer bit-for-bit (plain `round()` half-away-from-zero
 /// would differ on exact .5 ties).
 #[inline]
@@ -16210,8 +16464,8 @@ fn quantize_q8_k_with_bsums(input: &[f32]) -> (Vec<Q8KBlock>, Vec<[i16; 16]>) {
 }
 
 /// Scalar reference dot (parity floor): one TQ2_0 weight row against a Q8_K activation
-/// row. Port of ggml `ggml_vec_dot_tq2_0_q8_K_generic`: per block, sumi = Σ (code-1)·q8,
-/// scaled by d_x·d_y; the 2-bit codes {0,1,2} recenter to {-1,0,+1} via the `-1`.
+/// row. Port of ggml `ggml_vec_dot_tq2_0_q8_K_generic`: per block, sumi = Î£ (code-1)Â·q8,
+/// scaled by d_xÂ·d_y; the 2-bit codes {0,1,2} recenter to {-1,0,+1} via the `-1`.
 fn tq2_0_row_dot(w_row: &[u8], q8: &[Q8KBlock], blocks_per_row: usize) -> f32 {
     let mut sumf = 0f32;
     for b in 0..blocks_per_row {
@@ -16238,7 +16492,7 @@ fn tq2_0_row_dot(w_row: &[u8], q8: &[Q8KBlock], blocks_per_row: usize) -> f32 {
 
 /// AVX2 ternary dot, mirroring ggml `ggml_vec_dot_tq2_0_q8_K`: unpack the 2-bit codes,
 /// `maddubs` against the int8 activations (16-bit accumulate, safe within a 256-block),
-/// subtract the per-group activation sums (`bsums`) to recenter, then scale by d_x·d_y.
+/// subtract the per-group activation sums (`bsums`) to recenter, then scale by d_xÂ·d_y.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn tq2_0_row_dot_avx2(
@@ -16316,10 +16570,10 @@ fn tq2_0_dot(w_row: &[u8], q8: &[Q8KBlock], bsums: &[[i16; 16]], blocks_per_row:
     tq2_0_row_dot(w_row, q8, blocks_per_row)
 }
 
-/// Streaming TQ2_0 (ternary) linear: `output[n_rows, out_dim] = input @ weightᵀ`, with
+/// Streaming TQ2_0 (ternary) linear: `output[n_rows, out_dim] = input @ weightáµ€`, with
 /// the weight held as raw TQ2_0 wire bytes (never materialised to f32). PREFILL TILING:
 /// all `n_rows` activation rows are quantised once, then each weight row is streamed once
-/// (rayon-parallel over the output dimension) and dotted against every token — so the
+/// (rayon-parallel over the output dimension) and dotted against every token â€” so the
 /// weight is read once instead of once-per-token. This is the win llama.cpp's un-tiled
 /// per-element TQ kernel leaves on the table.
 fn matmul_rhs_transposed_tq2_0_block_dot(
@@ -16464,13 +16718,13 @@ fn matmul_rhs_transposed_q6_k_block_dot(
 /// Whether the experimental CPU Q4_K block-dot decode path is enabled. Default
 /// off (fail-closed): without it, Q4_K 2-D linears have no CPU consumer (their
 /// wire bytes are retained for the GPU resident path), so the gate cannot
-/// regress any working CPU behavior — it only adds one.
+/// regress any working CPU behavior â€” it only adds one.
 /// CPU K-quant (Q4_K / Q6_K) decode block-dot. **DEFAULT-ON** (opt out with
 /// `CAMELID_X86_Q4K_DECODE=0`). K-quant 2-D linears load WIRE-ONLY (no f32 `data`)
 /// for the resident GPU engine; with this gate off the CPU linear path has no
 /// consumer for them and errors (`no-row-major-data`, data_len=0). The GPU-resident
 /// decode lane never reaches this chokepoint (it runs q4k_gemv/q6k_gemv on-GPU), so
-/// default-on changes ONLY CPU-mode K-quant decode — turning a hard error into
+/// default-on changes ONLY CPU-mode K-quant decode â€” turning a hard error into
 /// parity-correct output (Q4_K via the AVX2 `q4_k_dot_arm`, Q6_K via the 8-lane
 /// `q6_k_wire_row_dot`). Windows greedy parity is proven vs llama.cpp acd79d6
 /// (K-quant conductor Phase 2); Linux/macOS f32-near-tie parity confirmation is a
@@ -16640,10 +16894,10 @@ pub(crate) fn q6_k_wire_block_dequant(block_bytes: &[u8]) -> [f32; Q6_K_VALUES_P
     out
 }
 
-/// Q6_K×Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q6_KÃ—Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel's numeric shape: per superblock the
-/// 6-bit weights are rebuilt exactly, the per-16-group `scale * Σ(q8·w)`
-/// products accumulate into 8 integer lanes, the superblock's `d_w · d_act`
+/// 6-bit weights are rebuilt exactly, the per-16-group `scale * Î£(q8Â·w)`
+/// products accumulate into 8 integer lanes, the superblock's `d_w Â· d_act`
 /// scales those lanes into 8 f32 accumulators, and the 8 lanes reduce
 /// sequentially at the end.
 pub(crate) fn q6_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
@@ -16696,11 +16950,11 @@ pub(crate) fn q6_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
 
 /// K-quant conductor Phase 2 follow-up: opt-in AVX2 Q6_K row dot
 /// (`CAMELID_X86_Q6K_AVX2`, default-off). BIT-IDENTICAL to [`q6_k_wire_row_dot`]
-/// by construction — it vectorizes ONLY the associative integer `aux32[8]` and
+/// by construction â€” it vectorizes ONLY the associative integer `aux32[8]` and
 /// keeps the load-bearing 8-lane f32 reduction (`sums[l] += d * aux32[l]`, then
 /// the left-fold `sums.iter().sum()`) exactly as the scalar oracle. (The refmath
 /// `q6_k_dot_avx2` is NOT a substitute: it mirrors the single-accumulator
-/// `q6_k_dot_scalar` order, a different bit pattern.) Default-off until measured —
+/// `q6_k_dot_scalar` order, a different bit pattern.) Default-off until measured â€”
 /// CPU decode is bandwidth-bound on the dev box, so this is expected to be ~null.
 #[cfg(target_arch = "x86_64")]
 fn q6k_avx2_enabled() -> bool {
@@ -16737,7 +16991,7 @@ fn q6_k_wire_row_dot_simd(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     q6_k_wire_row_dot(weight_wire, input)
 }
 
-/// AVX2 sibling of [`q6_k_wire_row_dot`] — see `q6k_avx2_enabled` for the parity
+/// AVX2 sibling of [`q6_k_wire_row_dot`] â€” see `q6k_avx2_enabled` for the parity
 /// contract. Vectorizes the per-superblock integer dot into the oracle's 8
 /// position-lanes (`aux32[l]`), exact integers; the 6-bit rebuild and the f32
 /// reduction stay byte-for-byte identical to the scalar path.
@@ -16774,8 +17028,8 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
             qh += 32;
         }
 
-        // aux32[l] = Σ_j scale_j · (q8[16j+l]·a[16j+l] + q8[16j+8+l]·a[16j+8+l]),
-        // l in 0..8, all exact integers (associative — SIMD lane order is free).
+        // aux32[l] = Î£_j scale_j Â· (q8[16j+l]Â·a[16j+l] + q8[16j+8+l]Â·a[16j+8+l]),
+        // l in 0..8, all exact integers (associative â€” SIMD lane order is free).
         let mut acc = _mm256_setzero_si256();
         let aptr = a.as_ptr();
         let qptr = y.qs.as_ptr();
@@ -16798,7 +17052,7 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
         let mut aux32 = [0i32; 8];
         _mm256_storeu_si256(aux32.as_mut_ptr() as *mut __m256i, acc);
 
-        // Load-bearing 8-lane f32 reduction — identical to the scalar oracle.
+        // Load-bearing 8-lane f32 reduction â€” identical to the scalar oracle.
         for l in 0..8 {
             sums[l] += d * aux32[l] as f32;
         }
@@ -16806,7 +17060,7 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
     sums.iter().sum()
 }
 
-/// Dequantize a single Q4_0 wire block (18 bytes) into 32 f32 values —
+/// Dequantize a single Q4_0 wire block (18 bytes) into 32 f32 values â€”
 /// the row-gather counterpart of [`q4_0_wire_row_dot`] for embedding-style
 /// lookups into Q4_0 tables.
 pub(crate) fn q4_0_wire_block_dequant(block_bytes: &[u8]) -> [f32; 32] {
@@ -16824,14 +17078,14 @@ pub(crate) fn q4_0_wire_block_dequant(block_bytes: &[u8]) -> [f32; 32] {
 pub(crate) const Q4_K_WIRE_BYTES_PER_BLOCK: usize = 144;
 pub(crate) const Q5_0_WIRE_BYTES_PER_BLOCK: usize = 22;
 
-/// Q4_K×Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q4_KÃ—Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel's numeric shape exactly
 /// (`ggml_vec_dot_q4_K_q8_K_generic`): per superblock the nibbles expand
 /// low-then-high in 64-value groups, the packed 6-bit scales/mins unpack via
-/// the kmask scheme, per-32-group `scale * Σ(q8·q4)` products accumulate into
-/// 8 integer lanes scaled by `d_w·d_act`, and the mins side subtracts
-/// `dmin·d_act · Σ(min_g · bsum_g)` with per-16 activation sums (computed
-/// inline; the reference precomputes them as Q8_K `bsums` — identical
+/// the kmask scheme, per-32-group `scale * Î£(q8Â·q4)` products accumulate into
+/// 8 integer lanes scaled by `d_wÂ·d_act`, and the mins side subtracts
+/// `dminÂ·d_act Â· Î£(min_g Â· bsum_g)` with per-16 activation sums (computed
+/// inline; the reference precomputes them as Q8_K `bsums` â€” identical
 /// integers). DiffusionGemma lane: correctness-first scalar, no SIMD.
 // index-based loops intentionally mirror the reference C kernel's structure
 // unit-tested ports of the reference GENERIC kernels (the DG runtime now
@@ -16859,7 +17113,7 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             }
         }
 
-        // unpack the 8 packed 6-bit (scale, min) pairs — kmask scheme
+        // unpack the 8 packed 6-bit (scale, min) pairs â€” kmask scheme
         let mut utmp = [0u32; 4];
         utmp[0] = u32::from_le_bytes([scales_raw[0], scales_raw[1], scales_raw[2], scales_raw[3]]);
         utmp[1] = u32::from_le_bytes([scales_raw[4], scales_raw[5], scales_raw[6], scales_raw[7]]);
@@ -16894,7 +17148,7 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             ((utmp[3] >> 24) & 0xff) as u8,
         ];
 
-        // mins side: Σ over the 16 per-16 activation sums × min of their group
+        // mins side: Î£ over the 16 per-16 activation sums Ã— min of their group
         let mut sumi = 0i32;
         for j in 0..16 {
             let bsum: i32 = y.qs[j * 16..(j + 1) * 16].iter().map(|&q| q as i32).sum();
@@ -16922,12 +17176,12 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf + sums.iter().sum::<f32>()
 }
 
-/// Q2_K × Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q2_K Ã— Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel `ggml_vec_dot_q2_K_q8_K`. Each 84-byte
 /// super-block is scales[16] (low nibble = quant scale, high nibble = min scale,
 /// one pair per 16-value sub-block), qs[64] (2-bit quants), d(f16), dmin(f16).
 /// Unlike Q4_K/Q6_K the reference keeps a SINGLE integer `isum` per super-block, so
-/// each super-block contributes `dall·isum − dmin·summs` (subtraction first) to the
+/// each super-block contributes `dallÂ·isum âˆ’ dminÂ·summs` (subtraction first) to the
 /// f32 sum, summed in order. The `q2k_gemv` CUDA kernel reproduces this exactly.
 /// Correctness-first scalar (the reference's "no SIMD" generic shape).
 #[allow(dead_code, clippy::needless_range_loop)]
@@ -16941,14 +17195,14 @@ pub(crate) fn q2_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
         let d = f16_bits_to_f32(u16::from_le_bytes([block[80], block[81]]));
         let dmin = f16_bits_to_f32(u16::from_le_bytes([block[82], block[83]]));
 
-        // mins side: Σ over the 16 sub-blocks of (per-16 activation sum) × min scale
+        // mins side: Î£ over the 16 sub-blocks of (per-16 activation sum) Ã— min scale
         let mut summs = 0i32;
         for j in 0..16 {
             let bsum: i32 = y.qs[j * 16..(j + 1) * 16].iter().map(|&q| q as i32).sum();
             summs += bsum * (scales[j] >> 4) as i32;
         }
 
-        // main side: 2 halves × 4 groups; each group reuses the same 32 qs bytes at
+        // main side: 2 halves Ã— 4 groups; each group reuses the same 32 qs bytes at
         // shift 2*group, split into a low (l<16) and high (l>=16) sub-block, each
         // with its own low-nibble quant scale. q8 advances 32 per group.
         let mut isum = 0i32;
@@ -16983,13 +17237,13 @@ pub(crate) fn q2_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf
 }
 
-/// Q3_K × Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q3_K Ã— Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel `ggml_vec_dot_q3_K_q8_K`. Each 110-byte
 /// super-block is hmask[32] (high bit of each 3-bit quant), qs[64] (low 2 bits),
 /// scales[12] (16 signed 6-bit scales, kmask-packed), d(f16). Q3_K has NO mins: the
 /// 3-bit quant is reconstructed as `((qs>>shift)&3) - (hmask_bit ? 0 : 4)` (centered
-/// to −4..3) and dequantized as `d·(scale−32)·value`. So each super-block contributes
-/// a single `d·isum` (isum = Σ_sb (scale−32)·Σ q8·value), summed in order. The
+/// to âˆ’4..3) and dequantized as `dÂ·(scaleâˆ’32)Â·value`. So each super-block contributes
+/// a single `dÂ·isum` (isum = Î£_sb (scaleâˆ’32)Â·Î£ q8Â·value), summed in order. The
 /// `q3k_gemv` CUDA kernel reproduces this exactly. Correctness-first scalar.
 #[allow(dead_code, clippy::needless_range_loop)]
 pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
@@ -17024,8 +17278,8 @@ pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             }
         }
 
-        // isum = Σ over the 16 sub-blocks of (scale−32) × Σ q8·value. 2 halves × 4
-        // groups × {low,high}; qs reused per group at shift 2*group; hmask bit advances
+        // isum = Î£ over the 16 sub-blocks of (scaleâˆ’32) Ã— Î£ q8Â·value. 2 halves Ã— 4
+        // groups Ã— {low,high}; qs reused per group at shift 2*group; hmask bit advances
         // per group (1<<(half*4+group)); q8 in natural order.
         let mut isum = 0i32;
         let mut sb = 0usize;
@@ -17063,11 +17317,11 @@ pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf
 }
 
-/// Q5_0×Q8_0 dot of one weight row read straight from the GGUF wire bytes,
+/// Q5_0Ã—Q8_0 dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel (`ggml_vec_dot_q5_0_q8_0_generic`):
 /// per 32-value block, rebuild the signed 5-bit weights from the nibble plus
 /// its qh bit, accumulate the two half-block integer dots, then scale by
-/// `d_w·d_act`. DiffusionGemma lane: correctness-first scalar, no SIMD.
+/// `d_wÂ·d_act`. DiffusionGemma lane: correctness-first scalar, no SIMD.
 // index-based loops intentionally mirror the reference C kernel's structure
 // unit-tested ports of the reference GENERIC kernels (the DG runtime now
 // uses the ARM-order variants in diffusion_gemma::refmath)
@@ -18144,7 +18398,7 @@ fn try_accumulate_descriptor_linear_row_metal(
     #[cfg(target_os = "macos")]
     {
         // Cheap existing check first so the default path (Metal linear off) short-circuits
-        // before the deterministic-mode env read — zero added work when the flag is unused.
+        // before the deterministic-mode env read â€” zero added work when the flag is unused.
         if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1")
             || deterministic_mode_enabled()
         {
@@ -19007,7 +19261,7 @@ fn matmul_rhs_transposed_q8_0_packed_rows4_prefill_i8mm(
     let mut output = vec![0.0_f32; rows * output_width];
     // The small-M weight-resident kernel absorbs the partial final row group as a
     // zero-padded lane set so the conservative per-row GEMV tail (a full weight pass
-    // per tail row — ruinous for 5-20 row speculative verify chunks) never runs.
+    // per tail row â€” ruinous for 5-20 row speculative verify chunks) never runs.
     let small_m = rows >= 4 && rows.div_ceil(4) <= mac_q8_i8mm_small_m_max_input_groups();
     let packed_rows = if small_m { rows } else { rows / 4 * 4 };
     let collect_q8_schedule = q8_schedule_telemetry_enabled();
@@ -19844,7 +20098,7 @@ fn q8_0_packed_rows4_dot(
                 }
             }
         }
-        // Phase 3: opt-in x86 weight-stream prefetch, two packed blocks ahead — the
+        // Phase 3: opt-in x86 weight-stream prefetch, two packed blocks ahead â€” the
         // x86 mirror of the macOS NEON `prfm` above. Default-off; a memory hint only,
         // so the decoded values are byte-identical regardless of the flag.
         #[cfg(all(
@@ -20217,7 +20471,7 @@ fn try_accumulate_transposed_linear_row_metal(
     #[cfg(target_os = "macos")]
     {
         // Cheap existing check first so the default path (Metal linear off) short-circuits
-        // before the deterministic-mode env read — zero added work when the flag is unused.
+        // before the deterministic-mode env read â€” zero added work when the flag is unused.
         if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1")
             || deterministic_mode_enabled()
         {
@@ -20929,7 +21183,7 @@ fn attention_f32_blocked_dot_enabled() -> bool {
 
 /// Flag gate for the decode attention head-parallel lane
 /// (`BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL`, default off). Scoped to
-/// Windows x86_64 per the standing Windows-first directive — the mechanism
+/// Windows x86_64 per the standing Windows-first directive â€” the mechanism
 /// itself is arch-agnostic (scheduling only, no arithmetic), so lifting the
 /// gate is a one-line follow-up decision, not a code change. Resolved once
 /// per process outside tests.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -11023,9 +11023,29 @@ const X86_Q8_PACKED_ROWS4_DECODE_PARALLEL_MIN_OUTPUTS: usize = 1024;
 const X86_Q8_PACKED_ROWS4_MATMUL_PARALLEL_MIN_GROUPS: usize = 64;
 const X86_Q8_FFN_DOWN_GEMM4_ROW_GROUP_MIN_INPUT_GROUPS: usize = 8;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct QuantizedQ8_0Row {
-    blocks: Vec<Q8_0Block>,
+    blocks: PooledQ8Blocks,
+}
+
+/// A pooled lease on a `Vec<Q8_0Block>`: derefs to the block slice for every
+/// consumer and returns the buffer to the decode scratch pool on drop, so
+/// per-call input quantization stops allocating once the pool is warm. The
+/// produced blocks are identical to a freshly allocated vector's.
+#[derive(Debug)]
+struct PooledQ8Blocks(Vec<Q8_0Block>);
+
+impl std::ops::Deref for PooledQ8Blocks {
+    type Target = [Q8_0Block];
+    fn deref(&self) -> &[Q8_0Block] {
+        &self.0
+    }
+}
+
+impl Drop for PooledQ8Blocks {
+    fn drop(&mut self) {
+        decode_scratch::recycle_q8_blocks(std::mem::take(&mut self.0));
+    }
 }
 
 #[cfg(test)]
@@ -12258,14 +12278,16 @@ fn q8_0_packed_rows4_single_input_projection_with_decode_chunking(
     name: &str,
     decode_group_chunking: bool,
 ) -> Result<CpuTensor> {
-    let mut output = vec![0.0_f32; output_width];
+    // Pooled output + tensor parts: this is the shared tail of every rows==1
+    // decode projection arm, so pooling here covers the whole cascade.
+    let mut output = decode_scratch::take(output_width);
     q8_0_packed_rows4_single_input_projection_into_with_decode_chunking(
         packed,
         quantized_input,
         &mut output,
         decode_group_chunking,
     )?;
-    CpuTensor::from_f32(name, vec![1, output_width], output)
+    decode_scratch::tensor_from_pooled(name, &[1, output_width], output)
 }
 
 fn x86_q8_packed_rows4_serial_decode_enabled() -> bool {
@@ -15737,8 +15759,10 @@ fn matmul_rhs_transposed_q8_0_block_dot_with_plan(
 }
 
 fn quantize_q8_0_row(input: &[f32]) -> QuantizedQ8_0Row {
+    let mut blocks = decode_scratch::take_q8_blocks();
+    quantize_q8_0_blocks_into(input, &mut blocks);
     QuantizedQ8_0Row {
-        blocks: quantize_q8_0_blocks(input),
+        blocks: PooledQ8Blocks(blocks),
     }
 }
 
@@ -21114,7 +21138,7 @@ fn causal_attention_context(
         )?;
     }
 
-    let tensor = decode_scratch::tensor_from_pooled(name, vec![1, expected_width], out)?;
+    let tensor = decode_scratch::tensor_from_pooled(name, &[1, expected_width], out)?;
     let trace = collect_diagnostics
         .then(|| {
             attention_trace_with_params(AttentionTraceParams {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -3304,7 +3304,8 @@ impl LlamaInferenceSession {
                     },
                     &mut self.kv_cache,
                 )?;
-                hidden = timed.output;
+                let prev_hidden = std::mem::replace(&mut hidden, timed.output);
+                decode_scratch::recycle_tensor(prev_hidden);
             }
             self.kv_cache.position = position + 1;
         }
@@ -3952,7 +3953,10 @@ impl LlamaInferenceSession {
                     },
                     &mut self.kv_cache,
                 )?;
-                hidden = timed.output;
+                let prev_hidden = std::mem::replace(&mut hidden, timed.output);
+                if !collect_diagnostics {
+                    decode_scratch::recycle_tensor(prev_hidden);
+                }
                 if let Some(trace) = execution_trace.as_mut() {
                     trace.fold_layer_hidden(layer_idx, &hidden.data);
                 }
@@ -5782,6 +5786,27 @@ struct PrefillLayerChunkParams<'a> {
     chunk_rows: usize,
 }
 
+/// [`CpuTensor::rms_norm`] with the output tensor built from the decode
+/// scratch pools (same kernel via `rms_norm_into`, so one numeric path).
+fn pooled_rms_norm(
+    input: &CpuTensor,
+    weight: &CpuTensor,
+    eps: f32,
+    name: &str,
+) -> Result<CpuTensor> {
+    let mut out = decode_scratch::take(input.data.len());
+    input.rms_norm_into(weight, eps, &mut out)?;
+    decode_scratch::tensor_from_pooled(name, &input.shape.dims, out)
+}
+
+/// [`CpuTensor::add`] with the output tensor built from the decode scratch
+/// pools (same kernel via `add_into`, so one numeric path).
+fn pooled_add(lhs: &CpuTensor, rhs: &CpuTensor, name: &str) -> Result<CpuTensor> {
+    let mut out = decode_scratch::take(lhs.data.len());
+    lhs.add_into(rhs, &mut out)?;
+    decode_scratch::tensor_from_pooled(name, &lhs.shape.dims, out)
+}
+
 fn forward_layer_timed(
     hidden: &CpuTensor,
     layer: &LlamaLayerWeights,
@@ -5804,10 +5829,11 @@ fn forward_layer_timed(
         .then(|| LlamaLayerMemoryTimings::new(layer_idx, capture_memory_sample(kv_cache)));
 
     let started = timings_on.then(Instant::now);
-    let attn_norm = hidden.rms_norm(
+    let attn_norm = pooled_rms_norm(
+        hidden,
         &layer.attention_norm,
         rms_norm_epsilon,
-        cached_layer_label!(layer_idx, "attention_norm"),
+        &cached_layer_label!(layer_idx, "attention_norm"),
     )?;
     let attention_norm_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&attn_norm))
@@ -5948,7 +5974,7 @@ fn forward_layer_timed(
         config.attention_head_count as usize,
         config,
         rope_freqs,
-        cached_layer_label!(layer_idx, "attention_q_rope"),
+        &cached_layer_label!(layer_idx, "attention_q_rope"),
     )?;
     let k = apply_rope(
         &k_before_rope,
@@ -5956,7 +5982,7 @@ fn forward_layer_timed(
         config.attention_head_count_kv as usize,
         config,
         rope_freqs,
-        cached_layer_label!(layer_idx, "attention_k_rope"),
+        &cached_layer_label!(layer_idx, "attention_k_rope"),
     )?;
     let attention_q_rope_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&q))
@@ -6071,9 +6097,10 @@ fn forward_layer_timed(
 
     let started = timings_on.then(Instant::now);
     metal_seam::synchronize_active_session();
-    let residual = hidden.add(
+    let residual = pooled_add(
+        hidden,
         &attn_out,
-        cached_layer_label!(layer_idx, "attention_residual"),
+        &cached_layer_label!(layer_idx, "attention_residual"),
     )?;
     let attention_residual_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&residual))
@@ -6091,10 +6118,11 @@ fn forward_layer_timed(
     trace_forward_layer_memory(layer_idx, "attention_residual_done");
 
     let started = timings_on.then(Instant::now);
-    let ffn_norm = residual.rms_norm(
+    let ffn_norm = pooled_rms_norm(
+        &residual,
         &layer.ffn_norm,
         rms_norm_epsilon,
-        cached_layer_label!(layer_idx, "ffn_norm"),
+        &cached_layer_label!(layer_idx, "ffn_norm"),
     )?;
     let ffn_norm_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&ffn_norm))
@@ -6252,7 +6280,11 @@ fn forward_layer_timed(
     let output = if ffn_out_already_residual {
         ffn_out.clone()
     } else {
-        residual.add(&ffn_out, cached_layer_label!(layer_idx, "ffn_residual"))?
+        pooled_add(
+            &residual,
+            &ffn_out,
+            &cached_layer_label!(layer_idx, "ffn_residual"),
+        )?
     };
     let ffn_residual_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&output))
@@ -6269,6 +6301,22 @@ fn forward_layer_timed(
         memory.record_end();
     }
     trace_forward_layer_memory(layer_idx, "ffn_residual_done");
+    if !collect_diagnostics {
+        // Every intermediate below is provably dead here (`output` is the only
+        // tensor that leaves this function); returning them keeps the scratch
+        // pools warm so the next layer's takes are allocation-free.
+        decode_scratch::recycle_tensor(attn_norm);
+        decode_scratch::recycle_tensor(q_before_rope);
+        decode_scratch::recycle_tensor(k_before_rope);
+        decode_scratch::recycle_tensor(q);
+        decode_scratch::recycle_tensor(k);
+        decode_scratch::recycle_tensor(v);
+        decode_scratch::recycle_tensor(context);
+        decode_scratch::recycle_tensor(attn_out);
+        decode_scratch::recycle_tensor(residual);
+        decode_scratch::recycle_tensor(ffn_norm);
+        decode_scratch::recycle_tensor(ffn_out);
+    }
     timings.total = timing_elapsed_us(&total_started);
     timings.memory = memory;
     let diagnostics = if collect_diagnostics {
@@ -12010,6 +12058,9 @@ fn try_x86_q8_ffn_decode_chain_path(
         down_route.output_width,
         down_elapsed,
     );
+    // The activated intermediate is dead once the down projection has
+    // consumed its quantized form.
+    decode_scratch::recycle_tensor(activated);
 
     let gate_elapsed = gate_up_elapsed / 2;
     Ok(Some(Q8FfnDecodeChainOutput {
@@ -12457,9 +12508,9 @@ fn q8_0_vnni_decode_1x64_projection(
         )));
     }
 
-    let mut output = vec![0.0_f32; output_width];
+    let mut output = decode_scratch::take(output_width);
     q8_0_vnni_decode_1x64_projection_into(packed, quantized_input, &mut output, use_rawptr)?;
-    CpuTensor::from_f32(name, vec![1, output_width], output)
+    decode_scratch::tensor_from_pooled(name, &[1, output_width], output)
 }
 
 fn q8_0_vnni_decode_1x64_projection_into(
@@ -13253,7 +13304,7 @@ fn q8_0_packed_rows4_single_input_projection_pair_activated_from_quantized(
         )));
     }
 
-    let mut output = vec![0.0_f32; output_width];
+    let mut output = decode_scratch::take(output_width);
     let use_hoisted_avx2 = x86_q8_packed_rows4_avx2_dot_decode_hoist_enabled();
     let compute_group = |group_idx: usize, output_chunk: &mut [f32]| {
         let group_start = group_idx * blocks_per_row;
@@ -13288,7 +13339,7 @@ fn q8_0_packed_rows4_single_input_projection_pair_activated_from_quantized(
             compute_group(group_idx, output_chunk);
         }
     }
-    CpuTensor::from_f32(name, vec![1, output_width], output)
+    decode_scratch::tensor_from_pooled(name, &[1, output_width], output)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -13333,9 +13384,9 @@ fn q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
     let q_groups = q8_0_packed_rows4_output_groups(q_width, "QKV decode q projection")?;
     let k_groups = q8_0_packed_rows4_output_groups(k_width, "QKV decode k projection")?;
     let v_groups = q8_0_packed_rows4_output_groups(v_width, "QKV decode v projection")?;
-    let mut q_output = vec![0.0_f32; q_width];
-    let mut k_output = vec![0.0_f32; k_width];
-    let mut v_output = vec![0.0_f32; v_width];
+    let mut q_output = decode_scratch::take(q_width);
+    let mut k_output = decode_scratch::take(k_width);
+    let mut v_output = decode_scratch::take(v_width);
     let use_hoisted_avx2 = x86_q8_packed_rows4_avx2_dot_decode_hoist_enabled();
 
     if q_width == k_width
@@ -13454,19 +13505,19 @@ fn q8_0_packed_rows4_single_input_projection_triplet_from_quantized(
     }
 
     Ok((
-        CpuTensor::from_f32(
+        decode_scratch::tensor_from_pooled(
             "attention_q_x86_q8_qkv_consumer",
-            vec![1, q_width],
+            &[1, q_width],
             q_output,
         )?,
-        CpuTensor::from_f32(
+        decode_scratch::tensor_from_pooled(
             "attention_k_x86_q8_qkv_consumer",
-            vec![1, k_width],
+            &[1, k_width],
             k_output,
         )?,
-        CpuTensor::from_f32(
+        decode_scratch::tensor_from_pooled(
             "attention_v_x86_q8_qkv_consumer",
-            vec![1, v_width],
+            &[1, v_width],
             v_output,
         )?,
     ))
@@ -20701,7 +20752,7 @@ fn rope_diagnostics(
             scaling,
             rope_freqs,
         },
-        format!("{role}_rope_diagnostic"),
+        &format!("{role}_rope_diagnostic"),
     )?;
 
     let mut max_abs_delta = 0.0_f32;

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -456,13 +456,13 @@ impl LlamaLoadedWeights {
         load_output: bool,
     ) -> Result<Self> {
         // Q8_0 linears are ALWAYS retained as plain RAM-resident blocks. The old policy
-        // estimated a retention budget over the WHOLE binding Ã¢â‚¬â€ even on a pipeline-sharded
-        // node that loads only its layer range Ã¢â‚¬â€ and silently fell back to per-token file
+        // estimated a retention budget over the WHOLE binding ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â even on a pipeline-sharded
+        // node that loads only its layer range ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â and silently fell back to per-token file
         // streaming when the estimate crossed a cap: ~100x slower decode, and it disqualified
         // the GPU-resident path (which requires q8_0_blocks). The only way off the resident
         // path now is the explicit CAMELID_LAZY_Q8_0_LINEAR opt-out, and it is loud.
         // Fast-load (CAMELID_METAL_NOCOPY): Q8_0 linears read their wire bytes once
-        // into page-aligned allocations the GPU wraps in place Ã¢â‚¬â€ no 36-byte decode, no
+        // into page-aligned allocations the GPU wraps in place ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â no 36-byte decode, no
         // upload copy, and the page cache stays warm so reloading a model is fast.
         let nocopy_fast_load = metal_nocopy_fast_load_enabled();
         if nocopy_fast_load {
@@ -480,7 +480,7 @@ impl LlamaLoadedWeights {
         }
         let load_linear = |name: &str| {
             // K-quant (Q4_K / Q6_K) 2-D linears: retain only the raw super-block wire
-            // bytes (no f32 materialization Ã¢â‚¬â€ an 8B model fully decoded to f32 is ~32 GB
+            // bytes (no f32 materialization ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â an 8B model fully decoded to f32 is ~32 GB
             // and OOMs). The GPU-resident decode reads these via q4k_gemv / q6k_gemv.
             if let Ok(desc) = store.descriptor(name) {
                 // Ternary TQ2_0 2-D linears: stream the wire bytes (the CPU ternary
@@ -598,7 +598,7 @@ impl LlamaLoadedWeights {
                     ),
                 };
                 // DEBUG ONLY: CAMELID_DEBUG_DISABLE_QK_NORM=1 skips loading the
-                // QK-norm weights so a Qwen3 forward runs as if it had none Ã¢â‚¬â€ used
+                // QK-norm weights so a Qwen3 forward runs as if it had none ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â used
                 // to bisect whether QK-norm is the source of a parity gap. Never
                 // set in production.
                 let debug_disable_qk_norm =
@@ -1353,7 +1353,7 @@ pub fn dump_stage_timings() {
 /// scalar chain (`tensor::dot_product`) vs the canonical blocked scalar
 /// reference vs the blocked AVX2/FMA realization. Returns
 /// `(variant, ns_per_call)` pairs; the AVX2 row is omitted when the CPU lacks
-/// AVX2+FMA. Bench-only entry point Ã¢â‚¬â€ never called on the inference path.
+/// AVX2+FMA. Bench-only entry point ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â never called on the inference path.
 pub fn attn_f32_dot_microbench(
     len: usize,
     repeats: usize,
@@ -1791,7 +1791,7 @@ pub struct LlamaInferenceSession {
     resident_paths_disabled: bool,
     /// When set, the deterministic forward pass folds each layer's output hidden state and the
     /// final logits into a streaming SHA-256 rollup (an execution-trace digest). Transient
-    /// proof-carrying state, not part of the session's logical identity Ã¢â‚¬â€ skipped by
+    /// proof-carrying state, not part of the session's logical identity ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â skipped by
     /// Clone/PartialEq/Debug like `resident_decode`. Only enabled in deterministic mode
     /// (`enable_execution_trace`); the default path never allocates it.
     execution_trace: Option<ExecutionTraceHasher>,
@@ -1800,7 +1800,7 @@ pub struct LlamaInferenceSession {
     /// without this the key would be the `weights` Arc pointer, which is not stable
     /// across separately-loaded `Arc<LlamaLoadedWeights>` for the same model (e.g. a
     /// prompt-prefix-cache-restored session vs a freshly loaded one). When two such
-    /// Arcs alternate, the single-slot engine cache thrashes Ã¢â‚¬â€ a multi-second 3.4 GB
+    /// Arcs alternate, the single-slot engine cache thrashes ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â a multi-second 3.4 GB
     /// re-upload on every request. The API sets this from the model id; when unset
     /// (tests, CLI), the wrappers fall back to the Arc pointer. Transient identity,
     /// copied by Clone/take_for_step so restored sessions keep the same key.
@@ -1836,7 +1836,7 @@ impl LlamaInferenceSession {
 
     /// Move the session out for a blocking generation step, leaving a hollow placeholder
     /// behind (same identity, empty KV, no resident state). Unlike `clone`, this PRESERVES
-    /// the resident GPU session Ã¢â‚¬â€ the on-GPU KV cache and encode-ahead pipeline Ã¢â‚¬â€ which is
+    /// the resident GPU session ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the on-GPU KV cache and encode-ahead pipeline ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â which is
     /// single-owner and dropped by `clone`. The caller must re-assign the returned session
     /// when the step finishes or the sequence loses its KV state entirely.
     pub fn take_for_step(&mut self) -> LlamaInferenceSession {
@@ -1885,7 +1885,7 @@ impl LlamaInferenceSession {
     }
 
     /// Approximate resident-weight footprint of this session in bytes: the raw Q8_0 block
-    /// bytes of every layer's attention + FFN tensors plus the output projection Ã¢â‚¬â€ the same
+    /// bytes of every layer's attention + FFN tensors plus the output projection ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the same
     /// unit `build_resident_cuda_engine` sizes VRAM against. Used to compute the
     /// speculative-coexistence reserve (how much VRAM a draft model needs to stay resident).
     #[cfg(feature = "cuda")]
@@ -2021,7 +2021,7 @@ impl LlamaInferenceSession {
 
     /// Arm the execution-trace rollup: subsequent forward passes fold every layer's output
     /// hidden state and the final logits into a streaming SHA-256 (see [`ExecutionTraceHasher`]).
-    /// Fails closed unless deterministic mode is active Ã¢â‚¬â€ the rollup is only meaningful on the
+    /// Fails closed unless deterministic mode is active ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the rollup is only meaningful on the
     /// order-stable CPU lane (RECEIPTS.md rule 2), and arming it would otherwise advertise a
     /// digest over a non-reproducible run. Returns whether the trace was armed.
     pub fn enable_execution_trace(&mut self) -> bool {
@@ -2053,7 +2053,7 @@ impl LlamaInferenceSession {
     }
 
     /// Roll the sequence back to `position`, discarding newer KV entries.
-    /// Requires CPU-authoritative KV state Ã¢â‚¬â€ the GPU-resident cache has no
+    /// Requires CPU-authoritative KV state ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the GPU-resident cache has no
     /// rollback, so any resident session is dropped and reseeds from CPU on
     /// next use.
     pub fn rollback_to_position(&mut self, position: usize) -> Result<()> {
@@ -2125,7 +2125,7 @@ impl LlamaInferenceSession {
             return Ok(false);
         }
         // Wire-page (fast-load) weights satisfy residency too, but only when the wire
-        // kernels are active Ã¢â‚¬â€ their bytes exist solely in the 34-byte wire layout.
+        // kernels are active ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â their bytes exist solely in the 34-byte wire layout.
         let wire_ok = metal_seam::wire_mode_active();
         let is_q8 = |t: &CpuTensor| {
             t.source_type == Some(GgufTensorType::Q8_0)
@@ -2138,7 +2138,7 @@ impl LlamaInferenceSession {
         // source_type, so a model may be all-Q8_0, all-Q4_K, or mixed.
         // The contraction dimension (in_features) is gguf dim(0) in the runtime shape:
         // a `[in, out]` gguf linear is stored out-major (out rows of `in` contiguous
-        // values), so each output row spans `in/256` super-blocks Ã¢â‚¬â€ the kernel's `n_sb`.
+        // values), so each output row spans `in/256` super-blocks ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the kernel's `n_sb`.
         // (The output/lm_head, with a non-256-aligned vocab in dim(1), is the case that
         // makes checking the wrong dim wrongly reject it.)
         let is_q4k = |t: &CpuTensor| {
@@ -2257,7 +2257,7 @@ impl LlamaInferenceSession {
     /// GPU prefill (CAMELID_METAL_RESIDENT_PREFILL=1): run the prompt's first N tokens
     /// through the resident session in ONE command buffer (weights stream once, attention
     /// per position). On success the GPU KV cache holds positions 0..N, the CPU KV cache is
-    /// advanced (positions left empty Ã¢â‚¬â€ only the resident path continues this sequence),
+    /// advanced (positions left empty ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â only the resident path continues this sequence),
     /// and the caller skips its CPU prefill loop entirely; the last prompt token then runs
     /// through the resident decode for logits.
     fn try_resident_prefill(&mut self, token_ids: &[u32]) -> Result<bool> {
@@ -2278,7 +2278,7 @@ impl LlamaInferenceSession {
     /// NVIDIA device (one forward per token, KV built incrementally, a single sync
     /// at the end), then leave the global engine ready at `position = n` so the
     /// last prompt token decodes straight into the first generated token. Replaces
-    /// the CPU prefill Ã¢â‚¬â€ the main time-to-first-token cost. Returns `false` to fall
+    /// the CPU prefill ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the main time-to-first-token cost. Returns `false` to fall
     /// back to the CPU prefill for any unsupported config.
     #[cfg(feature = "cuda")]
     fn try_resident_prefill_cuda(&mut self, token_ids: &[u32]) -> Result<bool> {
@@ -2393,7 +2393,7 @@ impl LlamaInferenceSession {
         }
         // Default to the batched prefill (each weight read once per MAX_VERIFY_K-token
         // chunk instead of once per token). `CAMELID_CUDA_RESIDENT_PREFILL_BATCHED=0`
-        // forces the serial per-token loop Ã¢â‚¬â€ an A/B switch for parity bisection. Both
+        // forces the serial per-token loop ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â an A/B switch for parity bisection. Both
         // write bit-identical KV (the batched stack reuses the same per-block dot and
         // block-ordered sum), so decode after either is token-identical.
         let serial_prefill = std::env::var_os("CAMELID_CUDA_RESIDENT_PREFILL_BATCHED")
@@ -2426,7 +2426,7 @@ impl LlamaInferenceSession {
         // KV cache is authoritative too: otherwise any later forward that takes the
         // CPU path (dense diagnostics, a GPU-decode fallback, or a KV rollback) reads
         // an all-zero history and generation degenerates. The copy is a few MB of
-        // device->host transfer Ã¢â‚¬â€ negligible next to the prefill compute it follows,
+        // device->host transfer ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â negligible next to the prefill compute it follows,
         // and it keeps both backends in lockstep.
         if let Err(e) =
             self.copy_resident_cuda_kv_to_host(&slot.engine, n_layers, n, n_kv, head_dim)
@@ -2471,7 +2471,7 @@ impl LlamaInferenceSession {
                     let src = (h * n + p) * head_dim;
                     // Canonical store, not a raw copy: the GPU KV is f16, so
                     // this data is f16-exact and the rounding inside is
-                    // idempotent Ã¢â‚¬â€ the routing enforces the invariant
+                    // idempotent ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the routing enforces the invariant
                     // structurally instead of relying on the GPU dtype.
                     self.kv_cache.store_kv_head_row(
                         layer,
@@ -2493,7 +2493,7 @@ impl LlamaInferenceSession {
     /// id sampled ON the GPU. The token graph's tail runs the argmax (exactly
     /// `LlamaSampler::Greedy`: strict greater-than, lowest-index tie-break) and gathers the
     /// sampled token's embedding row into the next pre-encoded graph's input, and that next
-    /// graph is event-released before this one finishes Ã¢â‚¬â€ so consecutive tokens run
+    /// graph is event-released before this one finishes ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â so consecutive tokens run
     /// back-to-back on the GPU with no logits readback or CPU sampling on the critical
     /// path. Returns Ok(None) when the resident fast path is unavailable (the caller falls
     /// back to the general path, which this call then leaves untouched).
@@ -2534,7 +2534,7 @@ impl LlamaInferenceSession {
 
     /// Temperature-sampling analog of the greedy resident fast lane: when the
     /// sampler is plain temperature (no top-k / top-p / penalties / logit-bias),
-    /// draw the next token on the GPU via Gumbel-max Ã¢â‚¬â€ no 128K-logit host copy and
+    /// draw the next token on the GPU via Gumbel-max ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â no 128K-logit host copy and
     /// no CPU sort, which the profiler showed cost ~7 ms/token (more than the whole
     /// forward). Returns `Ok(None)` when the config isn't GPU-eligible or CUDA
     /// resident decode is off, so the caller uses the CPU logits path unchanged.
@@ -2595,7 +2595,7 @@ impl LlamaInferenceSession {
     /// proposes up to `max_draft` tokens from `history`; the model verifies them in
     /// ONE batched forward (`verify_batch`), and the longest correct prefix plus
     /// one bonus token are accepted. Output is exactly what greedy decode would
-    /// have produced (the model's argmax verifies every token) Ã¢â‚¬â€ lossless Ã¢â‚¬â€ but a
+    /// have produced (the model's argmax verifies every token) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â lossless ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â but a
     /// single memory-bound forward can emit several tokens. Returns the accepted
     /// tokens (1..=max_draft+1) and advances the KV position, or `Ok(None)` when no
     /// draft is available or the GPU engine isn't ready (caller does a normal step).
@@ -2670,7 +2670,7 @@ impl LlamaInferenceSession {
         }
 
         // Same key the build/decode wrappers use (stable model identity when set,
-        // else the weights Arc pointer) Ã¢â‚¬â€ otherwise the readiness check never matches.
+        // else the weights Arc pointer) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â otherwise the readiness check never matches.
         let key = self
             .resident_cache_key
             .map(|k| k as usize)
@@ -2835,7 +2835,7 @@ impl LlamaInferenceSession {
     /// Non-CUDA build: route the GPU resident tree speculative-verify to the Metal seam
     /// (`verify_tree_metal`), which runs the batched bit-identical `verify_batch_tree` when the
     /// resident engine is live and ready, else returns `Ok(None)` so the caller takes a normal
-    /// step. Lossless either way (the target verify is authoritative Ã¢â‚¬â€ every emitted token is the
+    /// step. Lossless either way (the target verify is authoritative ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â every emitted token is the
     /// model's own greedy argmax along the accepted path).
     #[cfg(not(feature = "cuda"))]
     pub fn verify_tree_gpu(
@@ -3548,7 +3548,7 @@ impl LlamaInferenceSession {
     /// accepted token followed by drafted tokens) in ONE batched pass through
     /// the chunked-prefill layer path, then compute logits for EVERY position
     /// and return the greedy argmax per position. One weight read serves all
-    /// M tokens Ã¢â‚¬â€ the same amortization the prefill path gets.
+    /// M tokens ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the same amortization the prefill path gets.
     ///
     /// KV entries are appended for all `token_ids` (position advances by M);
     /// the caller drops rejected suffixes with `rollback_to_position`.
@@ -4106,7 +4106,7 @@ impl LlamaInferenceSession {
     }
 
     /// `allowed_tokens`, when set, is a vocab-sized mask applied to the logits
-    /// before sampling (disallowed tokens forced to `-inf`) Ã¢â‚¬â€ grammar-constrained
+    /// before sampling (disallowed tokens forced to `-inf`) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â grammar-constrained
     /// decoding. The unmasked logits are still returned in the step (so logprobs /
     /// diagnostics see the real distribution).
     pub fn generate_next_token_with_history_diagnostics(
@@ -4346,17 +4346,71 @@ fn copy_tensor_rows_into(
 }
 
 fn forward_memory_trace_enabled() -> bool {
-    env_flag_enabled("CAMELID_FORWARD_MEMORY_TRACE")
+    // Called per stage per layer per token as the trace guard; a raw env
+    // read here cost ~560 env::var lookups per decoded token. Resolved once
+    // outside tests (the flag is fixed post-startup, like every lane flag).
+    #[cfg(test)]
+    {
+        env_flag_enabled("CAMELID_FORWARD_MEMORY_TRACE")
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| env_flag_enabled("CAMELID_FORWARD_MEMORY_TRACE"))
+    }
 }
 
 fn structured_forward_memory_enabled() -> bool {
-    env_flag_enabled("CAMELID_FORWARD_RSS_TIMINGS")
-        || forward_memory_trace_enabled()
-        || prefill_layer_major_attribution_enabled()
+    #[cfg(test)]
+    {
+        env_flag_enabled("CAMELID_FORWARD_RSS_TIMINGS")
+            || forward_memory_trace_enabled()
+            || prefill_layer_major_attribution_enabled()
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            env_flag_enabled("CAMELID_FORWARD_RSS_TIMINGS")
+                || forward_memory_trace_enabled()
+                || prefill_layer_major_attribution_enabled()
+        })
+    }
 }
 
 fn prefill_layer_major_attribution_enabled() -> bool {
-    env_flag_enabled("CAMELID_PREFILL_LAYER_MAJOR_ATTRIBUTION")
+    #[cfg(test)]
+    {
+        env_flag_enabled("CAMELID_PREFILL_LAYER_MAJOR_ATTRIBUTION")
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| env_flag_enabled("CAMELID_PREFILL_LAYER_MAJOR_ATTRIBUTION"))
+    }
+}
+
+/// Gate for the per-stage decode timing probes
+/// (`BACKENDINFERENCE_DECODE_TIMINGS`, default ON to preserve current
+/// behavior â€” harnesses set it explicitly). Resolved once outside tests.
+fn decode_timings_enabled() -> bool {
+    #[cfg(test)]
+    {
+        q8_0_env_flag_enabled_default_on_fail_closed("BACKENDINFERENCE_DECODE_TIMINGS")
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            q8_0_env_flag_enabled_default_on_fail_closed("BACKENDINFERENCE_DECODE_TIMINGS")
+        })
+    }
+}
+
+/// Elapsed microseconds for a gated timing probe (0 when the gate was off).
+#[inline]
+fn timing_elapsed_us(started: &Option<Instant>) -> u128 {
+    started.map(|s| s.elapsed().as_micros()).unwrap_or(0)
 }
 
 const Q8_FILE_CACHE_BYTES_ENV: &str = "CAMELID_Q8_0_FILE_CACHE_BYTES";
@@ -4408,9 +4462,9 @@ fn env_flag_enabled(key: &str) -> bool {
 /// forward pass: every Metal/GPU dispatch gate fails closed to its CPU equivalent,
 /// regardless of any `CAMELID_METAL_*` override. This makes the supported TinyLlama
 /// 1.1B Q8_0 forward pass bit-exact and reduction-order-stable across runs, thread
-/// counts, and processes (the CPU reduction order is already fixed Ã¢â‚¬â€ each output owns
+/// counts, and processes (the CPU reduction order is already fixed ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â each output owns
 /// its full serial K-dimension reduction; see `qa/determinism/determinism-baseline-*.md` and
-/// DECISIONS.md Ã‚Â§D9). The library default is OFF, so the default (GPU fast) path and
+/// DECISIONS.md Ãƒâ€šÃ‚Â§D9). The library default is OFF, so the default (GPU fast) path and
 /// every embedder are byte-for-byte unchanged. The pinned reduction order mirrors the
 /// llama.cpp reference block-wise Q8_0 dot layout the parity contract is gated against.
 pub fn deterministic_mode_enabled() -> bool {
@@ -4431,7 +4485,7 @@ pub const EXECUTION_TRACE_ALGORITHM_ROLLUP_V1: &str = "sha256-rollup-v1";
 /// This is a single *rollup*: a mismatch proves the run differs but does not localize which
 /// token or layer. It is only meaningful on the order-stable CPU lane (deterministic mode):
 /// the underlying values are reduction-order-stable there (see [`deterministic_mode_enabled`]
-/// and DECISIONS.md Ã‚Â§D9), and byte-for-byte reproducibility requires greedy decoding
+/// and DECISIONS.md Ãƒâ€šÃ‚Â§D9), and byte-for-byte reproducibility requires greedy decoding
 /// (RECEIPTS.md rule 2). The digest is ISA-specific (i8mm vs scalar round differently), so it
 /// is re-derivable on the same deterministic lane/host, not portable across ISAs.
 #[derive(Clone)]
@@ -4558,12 +4612,12 @@ fn prefill_layer_major_enabled(weights: &LlamaLoadedWeights) -> bool {
 
 /// Dedicated, wider Rayon pool for the compute-bound prompt-prefill GEMM.
 ///
-/// Prompt prefill is a matrixÃ¢â‚¬â€œmatrix multiply (high arithmetic intensity): it
+/// Prompt prefill is a matrixÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“matrix multiply (high arithmetic intensity): it
 /// scales with *logical* cores, gaining throughput from SMT siblings. Single-token
-/// decode is the opposite Ã¢â‚¬â€ a matrixÃ¢â‚¬â€œvector stream that is memory-bandwidth-bound,
+/// decode is the opposite ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â a matrixÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“vector stream that is memory-bandwidth-bound,
 /// where SMT siblings only add memory-controller contention and *cost* throughput.
-/// Measured on an i7-11800H (8C/16T): prefill 19.5Ã¢â€ â€™23.6 tok/s going 8Ã¢â€ â€™16 threads
-/// (+21%), while decode peaks near 6 threads and falls 5.7Ã¢â€ â€™5.2 over the same range
+/// Measured on an i7-11800H (8C/16T): prefill 19.5ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢23.6 tok/s going 8ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢16 threads
+/// (+21%), while decode peaks near 6 threads and falls 5.7ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢5.2 over the same range
 /// (see `docs/perf-deep-dive/PERF_RECEIPTS/.../p1-cpu-thread-sweep`). The global
 /// pool stays sized for decode (physical cores on Windows, see
 /// `configure_rayon_threads`); only the prefill forward pass installs onto this
@@ -4571,7 +4625,7 @@ fn prefill_layer_major_enabled(weights: &LlamaLoadedWeights) -> bool {
 ///
 /// Bit-exact: the prefill matmul parallelizes over *independent* output rows, and
 /// each row's block accumulation is serial, so the thread count never changes the
-/// numeric result (verified byte-identical across 4Ã¢â‚¬â€œ16 threads in the sweep above).
+/// numeric result (verified byte-identical across 4ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“16 threads in the sweep above).
 ///
 /// Returns `None` (prefill stays on the global pool) on non-Windows/x86_64 targets,
 /// under an explicit `CAMELID_PREFILL_THREADS=0|off|global`, when the operator has
@@ -4619,10 +4673,10 @@ fn build_prefill_thread_pool() -> Option<rayon::ThreadPool> {
 
 /// Pure resolution of the prefill pool width, factored out for testing.
 ///
-/// * `spec` Ã¢â‚¬â€ the raw `CAMELID_PREFILL_THREADS` value, if set.
-/// * `global_pinned` Ã¢â‚¬â€ whether `CAMELID_THREADS` explicitly pinned the global pool.
-/// * `logical` Ã¢â‚¬â€ logical core count (the default widen target).
-/// * `widen_by_default` Ã¢â‚¬â€ whether this target auto-widens prefill (Windows/x86_64).
+/// * `spec` ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the raw `CAMELID_PREFILL_THREADS` value, if set.
+/// * `global_pinned` ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â whether `CAMELID_THREADS` explicitly pinned the global pool.
+/// * `logical` ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â logical core count (the default widen target).
+/// * `widen_by_default` ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â whether this target auto-widens prefill (Windows/x86_64).
 fn resolve_prefill_thread_count_from(
     spec: Option<&str>,
     global_pinned: bool,
@@ -5595,7 +5649,7 @@ fn sample_with_config(
     // Advance the RNG per decode step: `token_history.len()` is the deterministic
     // stream position, so each step draws a fresh uniform while a fixed seed still
     // reproduces the whole sequence token-for-token. (Previously the draw depended
-    // only on the seed, so every step reused one identical value Ã¢â‚¬â€ a degenerate
+    // only on the seed, so every step reused one identical value ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â a degenerate
     // sampler.)
     let draw = seeded_unit_interval_at(config.seed.unwrap_or(0), token_history.len() as u64);
     let mut cumulative = 0.0;
@@ -5738,8 +5792,9 @@ fn forward_layer_timed(
     let rms_norm_epsilon = params.rms_norm_epsilon;
     let layer_idx = params.layer_idx;
     let collect_diagnostics = params.collect_diagnostics;
+    let timings_on = decode_timings_enabled();
     let runtime_plan = params.runtime_plan;
-    let total_started = Instant::now();
+    let total_started = timings_on.then(Instant::now);
     let mut timings = LlamaLayerTimings {
         layer_index: layer_idx,
         ..LlamaLayerTimings::default()
@@ -5747,7 +5802,7 @@ fn forward_layer_timed(
     let mut memory = structured_forward_memory_enabled()
         .then(|| LlamaLayerMemoryTimings::new(layer_idx, capture_memory_sample(kv_cache)));
 
-    let started = Instant::now();
+    let started = timings_on.then(Instant::now);
     let attn_norm = hidden.rms_norm(
         &layer.attention_norm,
         rms_norm_epsilon,
@@ -5759,13 +5814,13 @@ fn forward_layer_timed(
     let attention_norm_diagnostic = collect_diagnostics
         .then(|| rms_norm_diagnostics(hidden, &layer.attention_norm, &attn_norm, rms_norm_epsilon))
         .transpose()?;
-    timings.attention_norm = started.elapsed().as_micros();
+    timings.attention_norm = timing_elapsed_us(&started);
     if let Some(memory) = &mut memory {
         memory.record_after_attention_norm(capture_memory_sample(kv_cache));
     }
     trace_forward_layer_memory(layer_idx, "attention_norm_done");
 
-    let qkv_started = Instant::now();
+    let qkv_started = timings_on.then(Instant::now);
     let shared_qkv = if collect_diagnostics {
         None
     } else if let Some(qkv) = try_x86_q8_attention_qkv_packed_rows4_matmul_path(
@@ -5794,10 +5849,10 @@ fn forward_layer_timed(
     };
 
     let (q, k, v, shared_qkv_elapsed) = if let Some((q, k, v)) = shared_qkv {
-        let elapsed = qkv_started.elapsed().as_micros();
+        let elapsed = timing_elapsed_us(&qkv_started);
         (q, k, v, Some(elapsed))
     } else {
-        let started = Instant::now();
+        let started = timings_on.then(Instant::now);
         let q = linear_for_role_bound(
             &attn_norm,
             &layer.attention_q,
@@ -5807,9 +5862,9 @@ fn forward_layer_timed(
             collect_diagnostics,
             &layer.decode_bindings.attention_q,
         )?;
-        timings.attention_q = started.elapsed().as_micros();
+        timings.attention_q = timing_elapsed_us(&started);
 
-        let started = Instant::now();
+        let started = timings_on.then(Instant::now);
         let k = linear_for_role_bound(
             &attn_norm,
             &layer.attention_k,
@@ -5819,9 +5874,9 @@ fn forward_layer_timed(
             collect_diagnostics,
             &layer.decode_bindings.attention_k,
         )?;
-        timings.attention_k = started.elapsed().as_micros();
+        timings.attention_k = timing_elapsed_us(&started);
 
-        let started = Instant::now();
+        let started = timings_on.then(Instant::now);
         let v = linear_for_role_bound(
             &attn_norm,
             &layer.attention_v,
@@ -5831,7 +5886,7 @@ fn forward_layer_timed(
             collect_diagnostics,
             &layer.decode_bindings.attention_v,
         )?;
-        timings.attention_v = started.elapsed().as_micros();
+        timings.attention_v = timing_elapsed_us(&started);
         (q, k, v, None)
     };
     if let Some(total_elapsed) = shared_qkv_elapsed {
@@ -5862,7 +5917,7 @@ fn forward_layer_timed(
     }
     trace_forward_layer_memory(layer_idx, "attention_k_done");
 
-    let started = Instant::now();
+    let started = timings_on.then(Instant::now);
     metal_seam::synchronize_active_session();
     // Qwen3 QK-norm: per-head RMSNorm on Q/K after the projections (reshaped to
     // heads) and BEFORE RoPE. No-op for plain Llama-family rows (norm is None).
@@ -5934,7 +5989,7 @@ fn forward_layer_timed(
             )
         })
         .transpose()?;
-    timings.attention_rope = started.elapsed().as_micros();
+    timings.attention_rope = timing_elapsed_us(&started);
     if let Some(memory) = &mut memory {
         memory.record_after_attention_rope(capture_memory_sample(kv_cache));
     }
@@ -5951,18 +6006,18 @@ fn forward_layer_timed(
     }
     trace_forward_layer_memory(layer_idx, "attention_v_done");
 
-    let started = Instant::now();
+    let started = timings_on.then(Instant::now);
     write_kv_cache(kv_cache, layer_idx, &k, &v)?;
     let kv_cache_diagnostic = collect_diagnostics
         .then(|| kv_cache_trace(kv_cache, layer_idx, kv_cache.position + 1))
         .transpose()?;
-    timings.kv_cache_write = started.elapsed().as_micros();
+    timings.kv_cache_write = timing_elapsed_us(&started);
     if let Some(memory) = &mut memory {
         memory.record_after_kv_cache_write(capture_memory_sample(kv_cache));
     }
     trace_forward_layer_memory(layer_idx, "kv_cache_write_done");
 
-    let started = Instant::now();
+    let started = timings_on.then(Instant::now);
     let attention_context = causal_attention_context(
         kv_cache,
         layer_idx,
@@ -5977,13 +6032,13 @@ fn forward_layer_timed(
     let attention_context_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&context))
         .transpose()?;
-    timings.attention_context = started.elapsed().as_micros();
+    timings.attention_context = timing_elapsed_us(&started);
     if let Some(memory) = &mut memory {
         memory.record_after_attention_context(capture_memory_sample(kv_cache));
     }
     trace_forward_layer_memory(layer_idx, "attention_context_done");
 
-    let started = Instant::now();
+    let started = timings_on.then(Instant::now);
     let mut attn_out = linear_for_role_bound(
         &context,
         &layer.attention_output,
@@ -6007,13 +6062,13 @@ fn forward_layer_timed(
             linear_projection_diagnostics(&context, &layer.attention_output, &attn_out, "linear")
         })
         .transpose()?;
-    timings.attention_output = started.elapsed().as_micros();
+    timings.attention_output = timing_elapsed_us(&started);
     if let Some(memory) = &mut memory {
         memory.record_after_attention_output(capture_memory_sample(kv_cache));
     }
     trace_forward_layer_memory(layer_idx, "attention_output_done");
 
-    let started = Instant::now();
+    let started = timings_on.then(Instant::now);
     metal_seam::synchronize_active_session();
     let residual = hidden.add(
         &attn_out,
@@ -6028,13 +6083,13 @@ fn forward_layer_timed(
     let attention_delta_diagnostic = collect_diagnostics
         .then(|| residual_reconstruction_diagnostic(hidden, &attn_out, &residual))
         .transpose()?;
-    timings.attention_residual = started.elapsed().as_micros();
+    timings.attention_residual = timing_elapsed_us(&started);
     if let Some(memory) = &mut memory {
         memory.record_after_attention_residual(capture_memory_sample(kv_cache));
     }
     trace_forward_layer_memory(layer_idx, "attention_residual_done");
 
-    let started = Instant::now();
+    let started = timings_on.then(Instant::now);
     let ffn_norm = residual.rms_norm(
         &layer.ffn_norm,
         rms_norm_epsilon,
@@ -6046,7 +6101,7 @@ fn forward_layer_timed(
     let ffn_norm_diagnostic = collect_diagnostics
         .then(|| rms_norm_diagnostics(&residual, &layer.ffn_norm, &ffn_norm, rms_norm_epsilon))
         .transpose()?;
-    timings.ffn_norm = started.elapsed().as_micros();
+    timings.ffn_norm = timing_elapsed_us(&started);
     if let Some(memory) = &mut memory {
         memory.record_after_ffn_norm(capture_memory_sample(kv_cache));
     }
@@ -6148,7 +6203,7 @@ fn forward_layer_timed(
                 memory.record_after_ffn_activation(capture_memory_sample(kv_cache));
             }
             trace_forward_layer_memory(layer_idx, "ffn_gate_up_activation_done");
-            let started = Instant::now();
+            let started = timings_on.then(Instant::now);
             let ffn_out = linear_for_role_bound(
                 &activated,
                 &layer.ffn_down,
@@ -6167,7 +6222,7 @@ fn forward_layer_timed(
                     linear_projection_diagnostics(&activated, &layer.ffn_down, &ffn_out, "ffn_down")
                 })
                 .transpose()?;
-            timings.ffn_down = started.elapsed().as_micros();
+            timings.ffn_down = timing_elapsed_us(&started);
             (
                 ffn_out,
                 ffn_gate_stats,
@@ -6191,7 +6246,7 @@ fn forward_layer_timed(
     }
     trace_forward_layer_memory(layer_idx, "ffn_down_done");
 
-    let started = Instant::now();
+    let started = timings_on.then(Instant::now);
     metal_seam::synchronize_active_session();
     let output = if ffn_out_already_residual {
         ffn_out.clone()
@@ -6207,13 +6262,13 @@ fn forward_layer_timed(
     let ffn_delta_diagnostic = collect_diagnostics
         .then(|| residual_reconstruction_diagnostic(&residual, &ffn_out, &output))
         .transpose()?;
-    timings.ffn_residual = started.elapsed().as_micros();
+    timings.ffn_residual = timing_elapsed_us(&started);
     if let Some(memory) = &mut memory {
         memory.record_after_ffn_residual(capture_memory_sample(kv_cache));
         memory.record_end();
     }
     trace_forward_layer_memory(layer_idx, "ffn_residual_done");
-    timings.total = total_started.elapsed().as_micros();
+    timings.total = timing_elapsed_us(&total_started);
     timings.memory = memory;
     let diagnostics = if collect_diagnostics {
         Some(LlamaLayerDiagnostics {
@@ -7091,7 +7146,7 @@ const DECODE_ARM_FALLBACK: u8 = 7;
 /// Decode-bound variant of [`linear_for_role_runtime_with_plan`]: the first
 /// rows==1 call per binding cell runs the historical cascade and records the
 /// winning arm; steady-state calls jump straight to that arm. The arm's own
-/// guards remain in force â€” if they ever miss (they cannot for a fixed plan
+/// guards remain in force Ã¢â‚¬â€ if they ever miss (they cannot for a fixed plan
 /// and shape), the call falls back to the full cascade and rebinds, so the
 /// fail-closed ordering is preserved by construction. Prefill (rows > 1) and
 /// diagnostics calls always take the historical paths untouched.
@@ -7203,7 +7258,7 @@ fn linear_for_role_bound(
 /// The historical role-dispatch cascade, unchanged in ORDER and guards; when
 /// `record` is provided (rows==1 bound calls), the winning decode-capable arm
 /// is written into the binding cell. This function remains the single
-/// authority on kernel selection â€” the bound fast path above only replays its
+/// authority on kernel selection Ã¢â‚¬â€ the bound fast path above only replays its
 /// recorded verdict.
 fn decode_linear_cascade(
     input: &CpuTensor,
@@ -7213,7 +7268,7 @@ fn decode_linear_cascade(
     runtime_plan: &ResolvedRuntimePlan,
     record: Option<&DecodeBindingCell>,
 ) -> Result<CpuTensor> {
-    // Lane 1: unified tiled Q8_0 prefill GEMM owner (default-off). Role-agnostic â€” covers
+    // Lane 1: unified tiled Q8_0 prefill GEMM owner (default-off). Role-agnostic Ã¢â‚¬â€ covers
     // every Q8_0 projection (q/k/v/o, gate/up, ffn_down) in ONE place. Returns None for
     // decode, non-Q8, or non-PackedRows4 weights, so the default path is unchanged when off.
     if let Some(output) =
@@ -7552,8 +7607,8 @@ fn linear_with_diagnostic_layouts_with_plan(
     let rows = weight.dim(0)?;
     let cols = weight.dim(1)?;
     // K-quant (Q4_K / Q6_K) wire weights have no f32 data and no general CPU
-    // consumer; intercept them here Ã¢â‚¬â€ the single chokepoint both the diagnostic
-    // and runtime linear chains funnel through Ã¢â‚¬â€ with the original tensor, before
+    // consumer; intercept them here ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the single chokepoint both the diagnostic
+    // and runtime linear chains funnel through ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â with the original tensor, before
     // any layout reinterpretation that would drop the wire bytes. The block-dot
     // is layout-agnostic: it takes the contraction width from the input and the
     // output width from the wire length, so a GGUF `[in, out]` weight (where
@@ -10274,7 +10329,7 @@ fn resident_cuda_cache() -> &'static std::sync::Mutex<Option<ResidentCudaSlot>> 
 
 /// Second resident-engine cache, dedicated to the speculative draft model. Draft
 /// and target are different models (different weight identities), so giving them
-/// separate single-slot caches lets BOTH stay GPU-resident at once Ã¢â‚¬â€ sharing one
+/// separate single-slot caches lets BOTH stay GPU-resident at once ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â sharing one
 /// slot would thrash (rebuild + 3.4 GB re-upload) every time control passed between
 /// drafter and target. Routed by `LlamaInferenceSession::is_drafter`.
 #[cfg(feature = "cuda")]
@@ -10295,7 +10350,7 @@ static SPEC_COEXIST_RESERVE_BYTES: std::sync::atomic::AtomicU64 =
 
 /// Record the draft model's resident footprint so the target leaves room for it. Pass 0 to
 /// disable (single-model path). Does NOT evict already-built engines: a resident target built
-/// before the reserve was set keeps running (reused, not rebuilt) Ã¢â‚¬â€ rebuilding it would free
+/// before the reserve was set keeps running (reused, not rebuilt) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â rebuilding it would free
 /// its VRAM only to the cudarc pool (which the free-VRAM probe does not see), so the rebuild
 /// would wrongly fall to CPU. The reserve therefore only shapes engines built AFTER it is set
 /// (e.g. when the drafter is configured before the target's first decode).
@@ -10313,7 +10368,7 @@ fn spec_coexist_reserve_bytes() -> u64 {
 
 /// KV-cache positions a speculative draft engine is sized for (env-tunable). The draft only
 /// needs to span the prompt + generated tokens it drafts over; capping it keeps the draft's
-/// VRAM small so it fits beside the resident target. Lossless either way Ã¢â‚¬â€ the target verify is
+/// VRAM small so it fits beside the resident target. Lossless either way ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the target verify is
 /// authoritative, so a shorter draft context only affects accept rate, never correctness.
 #[cfg(feature = "cuda")]
 fn spec_draft_kv_context() -> usize {
@@ -10336,7 +10391,7 @@ pub fn reset_resident_caches() {
         .unwrap_or_else(|p| p.into_inner()) = None;
     // The engines dropped above returned their VRAM to cudarc's stream-ordered async
     // pool (cuMemFreeAsync), where the free-VRAM probe cannot see it. Trim the pool so
-    // the next model's resident fit decision measures the real free VRAM Ã¢â‚¬â€ otherwise a
+    // the next model's resident fit decision measures the real free VRAM ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â otherwise a
     // larger model wrongly falls back to the CPU path (the ~20x-slower symptom this
     // unload path exists to prevent).
     crate::cuda::release_async_pool();
@@ -10347,7 +10402,7 @@ pub fn reset_resident_caches() {}
 /// Prompt-lookup n-gram drafter: find the most recent earlier occurrence of the
 /// last `ngram` tokens and propose the up-to-`max_draft` tokens that followed it.
 /// Cheap (no model), and it hits whenever the model repeats a phrase already in
-/// the context (code, lists, quoted text) Ã¢â‚¬â€ exactly where greedy decode is
+/// the context (code, lists, quoted text) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â exactly where greedy decode is
 /// predictable. Empty when there's no match.
 #[cfg(feature = "cuda")]
 fn draft_ngram(history: &[u32], max_draft: usize, ngram: usize) -> Vec<u32> {
@@ -10436,9 +10491,9 @@ fn build_resident_cuda_engine(
     // VRAM-driven resident-context sizing (portability, not hardcoded to any card):
     //   resident weights are uploaded once and live for the engine's lifetime; the
     //   GPU KV cache is allocated once at `cap` positions, costing
-    //   kv_bytes_per_pos = n_layers Ã‚Â· n_kv Ã‚Â· head_dim Ã‚Â· 2(K,V) Ã‚Â· 2(f16 bits) each. Size the
+    //   kv_bytes_per_pos = n_layers Ãƒâ€šÃ‚Â· n_kv Ãƒâ€šÃ‚Â· head_dim Ãƒâ€šÃ‚Â· 2(K,V) Ãƒâ€šÃ‚Â· 2(f16 bits) each. Size the
     //   cap so weights + KV + a scratch/headroom reserve fit in *detected free* VRAM:
-    //     cap = min(requested, (free_vram Ã¢Ë†â€™ weights Ã¢Ë†â€™ headroom) / kv_bytes_per_pos)
+    //     cap = min(requested, (free_vram ÃƒÂ¢Ã‹â€ Ã¢â‚¬â„¢ weights ÃƒÂ¢Ã‹â€ Ã¢â‚¬â„¢ headroom) / kv_bytes_per_pos)
     //   On a 6 GB card this stays conservative; on a 24 GB card it grows automatically
     //   to a long context. If even the floor (256) cannot fit, return None so the
     //   caller runs the model on the CPU path rather than oversubscribing VRAM.
@@ -10463,10 +10518,10 @@ fn build_resident_cuda_engine(
         + raw(weights.output_projection())
             .map(|b| b.len() as u64)
             .unwrap_or(0);
-    // Scratch reserve: logits row (vocabÃ‚Â·f32) + per-stage activation buffers + a flat
+    // Scratch reserve: logits row (vocabÃƒâ€šÃ‚Â·f32) + per-stage activation buffers + a flat
     // safety margin for driver/context overhead and fragmentation. The flat margin is
     // env-overridable (CAMELID_CUDA_RESIDENT_HEADROOM_MB) so a second engine can be
-    // packed onto a small card Ã¢â‚¬â€ e.g. drafter + target for speculative decode, where
+    // packed onto a small card ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â e.g. drafter + target for speculative decode, where
     // the default 512 MiB per engine would not leave room for both.
     // The flat margin defaults to 512 MiB for a sole resident engine. Under speculative
     // coexistence both engines pack onto the card, so 512 MiB each would not fit: the draft
@@ -10481,7 +10536,7 @@ fn build_resident_cuda_engine(
     // takes the remaining free VRAM). BUT only honor the reserve when the target still fits
     // FULLY resident after it, measured against the NORMAL single-engine headroom. If reserving
     // would force the target to offload trailing layers, that offload (a) slows the target
-    // forward and (b) pushes the batched verify onto the serial/CPU path Ã¢â‚¬â€ a different backend
+    // forward and (b) pushes the batched verify onto the serial/CPU path ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â a different backend
     // than the resident plain decode, which diverges at near-ties. Not worth it: drop the
     // reserve, build the target full-resident (NORMAL headroom), and let the draft fall back to
     // CPU (the prior, lossless behavior). So the resident-draft win is taken only on a GPU big
@@ -10502,7 +10557,7 @@ fn build_resident_cuda_engine(
     let coexist_fit_headroom = (vocab as u64 * 4) + (coexist_headroom_mb * 1024 * 1024);
     // Bounded over-allocation the WDDM driver pages to shared host memory (how llama.cpp fits both
     // models on a 6 GB card): treat free VRAM as larger by this much for the coexistence sizing.
-    // Default 0 (strict Ã¢â‚¬â€ no spill). Opt in via CAMELID_SPEC_COEXIST_SPILL_MB on a tight card.
+    // Default 0 (strict ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â no spill). Opt in via CAMELID_SPEC_COEXIST_SPILL_MB on a tight card.
     let coexist_spill = std::env::var("CAMELID_SPEC_COEXIST_SPILL_MB")
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
@@ -10520,7 +10575,7 @@ fn build_resident_cuda_engine(
     };
     // Honor the reserve only if the target still fits fully resident after it (measured with the
     // small coexist headroom; the reserve already accounts for the draft's footprint). If not,
-    // drop the reserve and build the target full-resident Ã¢â‚¬â€ offloading it to make room is a net
+    // drop the reserve and build the target full-resident ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â offloading it to make room is a net
     // loss (slow target + serial/CPU verify that diverges at near-ties from the resident plain
     // decode), so the draft falls back to CPU (the prior lossless behavior).
     let honor_reserve = raw_reserve > 0
@@ -10589,7 +10644,7 @@ fn build_resident_cuda_engine(
     // host RAM (test/override hook, fires even on a model that fits). Otherwise the
     // split is AUTOMATIC: when all weights + a minimum KV cache + headroom cannot fit
     // in free VRAM, offload the fewest TRAILING layers needed so the rest fit. Each
-    // offloaded layer streams its weights to a GPU scratch buffer every forward Ã¢â‚¬â€ a
+    // offloaded layer streams its weights to a GPU scratch buffer every forward ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â a
     // capacity tradeoff, token-identical to the all-resident path.
     let force_offload = std::env::var("CAMELID_OFFLOAD_FORCE_LAYERS")
         .ok()
@@ -10621,7 +10676,7 @@ fn build_resident_cuda_engine(
     let n_resident_layers = n_layers - offload_count;
 
     // VRAM left for the KV cache after the RESIDENT weights and (if offloading) the
-    // streaming scratch Ã¢â‚¬â€ so freed weight VRAM grows the resident context.
+    // streaming scratch ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â so freed weight VRAM grows the resident context.
     let offloaded_bytes: u64 = per_layer_bytes[n_resident_layers..].iter().sum();
     let resident_weights_bytes = weights_bytes.saturating_sub(offloaded_bytes);
     let scratch_reserve = if offload_count > 0 {
@@ -10666,7 +10721,7 @@ fn build_resident_cuda_engine(
         }
         return None;
     }
-    // Task 4 Ã¢â‚¬â€ explicit VRAM headroom policy. Project the actual device
+    // Task 4 ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â explicit VRAM headroom policy. Project the actual device
     // allocation (resident weights + streaming scratch + the sized KV cache) and
     // run it past the headroom policy *before* allocating. If it would OOM or
     // leave less than the minimum post-load headroom, refuse the resident load
@@ -10677,7 +10732,7 @@ fn build_resident_cuda_engine(
         let projected_alloc =
             resident_weights_bytes + scratch_reserve + (cap as u64) * kv_bytes_per_pos;
         // Evaluate against ACTUAL free VRAM. Under coexistence the budget already excludes the
-        // draft's reserve, so the target's sizing leaves that reserve free by construction Ã¢â‚¬â€
+        // draft's reserve, so the target's sizing leaves that reserve free by construction ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â
         // here we only require a small absolute safety margin (NOT reserve+margin, which would
         // double-count and falsely refuse). The draft, allocating last, likewise needs only the
         // small margin. Outside coexistence this is the normal 512 MiB post-load floor.
@@ -10721,7 +10776,7 @@ fn build_resident_cuda_engine(
             }
             _ => return None,
         };
-        // Per-projection quant lanes (q,k,v,o,gate,up,down) Ã¢â‚¬â€ drives the per-tensor
+        // Per-projection quant lanes (q,k,v,o,gate,up,down) ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â drives the per-tensor
         // repack + GEMV kernel + activation quantizer. Q4_K_M is mixed: most
         // projections Q4_K, with attn_v/ffn_down promoted to Q6_K in ~half the layers.
         let quants = [
@@ -10814,7 +10869,7 @@ fn resident_gpu_temperature_sampling_enabled() -> bool {
 }
 
 /// CUDA GPU-resident decode gate (the NVIDIA analog of the Metal one). On
-/// automatically whenever a usable CUDA device is present Ã¢â‚¬â€ the end-user app
+/// automatically whenever a usable CUDA device is present ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the end-user app
 /// "just works" fast on the GPU with no flag or toggle. Deterministic mode
 /// (opt-in) forces the CPU reference; `CAMELID_CUDA_RESIDENT_DECODE=0` is an
 /// explicit escape hatch for debugging. Falls back to CPU per token for any
@@ -10852,7 +10907,7 @@ fn resident_decode_cuda_enabled() -> bool {
 /// is NOT bit-identical to a fresh GPU prefill: a cache hit reseeds the GPU KV from the
 /// f16-rounded host history and resumes, a different reduction order than a clean GPU
 /// prefill, which flips borderline (near-tie) tokens. The CPU lane is reduction-order
-/// stable, so it keeps the cache; the GPU lane must bypass it Ã¢â‚¬â€ exactly as deterministic
+/// stable, so it keeps the cache; the GPU lane must bypass it ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â exactly as deterministic
 /// mode already bypasses the cache on the CPU lane.
 pub fn resident_decode_cuda_active() -> bool {
     resident_decode_cuda_enabled()
@@ -10860,9 +10915,9 @@ pub fn resident_decode_cuda_active() -> bool {
 
 /// Maximum sequence length the CUDA resident engine keeps on the GPU. The GPU KV
 /// cache is allocated once at this many positions, so it directly sets the engine's
-/// VRAM footprint (Ã¢â€°Ë† n_layersÃ‚Â·n_kvÃ‚Â·head_dimÃ‚Â·2Ã‚Â·4 bytes per position) on top of the
+/// VRAM footprint (ÃƒÂ¢Ã¢â‚¬Â°Ã‹â€  n_layersÃƒâ€šÃ‚Â·n_kvÃƒâ€šÃ‚Â·head_dimÃƒâ€šÃ‚Â·2Ãƒâ€šÃ‚Â·4 bytes per position) on top of the
 /// resident weights. On a 6 GB laptop card a 3B Q8_0 model's weights already take
-/// ~3.4 GB, so an 8192-position KV (~1.8 GB for 3B) leaves almost no headroom Ã¢â‚¬â€ any
+/// ~3.4 GB, so an 8192-position KV (~1.8 GB for 3B) leaves almost no headroom ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â any
 /// other GPU app then pushes the engine past VRAM, it can no longer stay resident,
 /// and it is rebuilt (a multi-second 3.4 GB re-upload) on every request. A 4096 cap
 /// halves the KV footprint and keeps the engine resident with room to spare; beyond
@@ -10870,7 +10925,7 @@ pub fn resident_decode_cuda_active() -> bool {
 /// Optional hard ceiling on the resident KV context the wrappers *request*. The
 /// real limit is VRAM-driven inside `build_resident_cuda_engine` (which sizes the
 /// cap to detected free VRAM and reports it), so by default this imposes no extra
-/// cap Ã¢â‚¬â€ a big card gets a long resident context automatically. Set
+/// cap ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â a big card gets a long resident context automatically. Set
 /// `CAMELID_CUDA_RESIDENT_MAX_CONTEXT` to force a lower ceiling (e.g. to leave more
 /// VRAM for other apps).
 #[cfg(feature = "cuda")]
@@ -10942,8 +10997,8 @@ fn q8_0_hybrid_retained_gpu_rows(output_rows: usize) -> usize {
 }
 
 /// Explicit (and loud) opt-out from RAM-resident Q8_0 blocks: only an affirmatively set
-/// `CAMELID_LAZY_Q8_0_LINEAR` forces the per-token file-streaming path. Absence Ã¢â‚¬â€ and any
-/// disabled spelling Ã¢â‚¬â€ means weights are retained in RAM. There is no auto/budget fallback.
+/// `CAMELID_LAZY_Q8_0_LINEAR` forces the per-token file-streaming path. Absence ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â and any
+/// disabled spelling ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â means weights are retained in RAM. There is no auto/budget fallback.
 fn lazy_q8_0_linear_forced() -> bool {
     matches!(
         env::var("CAMELID_LAZY_Q8_0_LINEAR"),
@@ -10956,7 +11011,7 @@ fn lazy_q8_0_linear_forced() -> bool {
 }
 
 /// Fast-load gate: CAMELID_METAL_NOCOPY loads Q8_0 linears as page-aligned wire
-/// pages for in-place GPU consumption. macOS only Ã¢â‚¬â€ the storage is consumed by
+/// pages for in-place GPU consumption. macOS only ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the storage is consumed by
 /// the Metal wire kernels.
 fn metal_nocopy_fast_load_enabled() -> bool {
     cfg!(target_os = "macos") && env_flag_enabled("CAMELID_METAL_NOCOPY")
@@ -13659,7 +13714,7 @@ fn q8_0_packed_rows4_gemm4_accumulate_block(
 
 /// Phase 3 (K-quant conductor): opt-in software prefetch of the weight stream ahead
 /// of the x86 packed decode dot. Default-off (`CAMELID_X86_PREFETCH`). Memory hint
-/// only Ã¢â‚¬â€ byte-identical output by construction. The macOS/aarch64 dot already issues
+/// only ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â byte-identical output by construction. The macOS/aarch64 dot already issues
 /// a NEON `prfm` two blocks ahead; this gives the x86 decode dot the same option so it
 /// can be measured on a bandwidth-bound host (the Q8 gated-SIMD history says prove the
 /// win on the box before promoting to default).
@@ -13818,16 +13873,16 @@ fn run_q8_0_packed_rows4_prefill_gemm4_kernel(
 // A role-agnostic, BIT-EXACT drop-in for the per-projection prefill block-dot. It reuses the
 // proven 4x4 register microkernel `q8_0_packed_rows4_gemm4_accumulate_block` VERBATIM, so every
 // output cell still accumulates `((int as f32) * weight_scale) * input_scale` over ascending
-// blocks with no FMA Ã¢â‚¬â€ byte-identical to the scalar oracle. The ONLY difference vs the (default-
+// blocks with no FMA ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â byte-identical to the scalar oracle. The ONLY difference vs the (default-
 // off, regressing) ffn_down GEMM4 lane is the loop nest: it parallelizes over OUTPUT-row bands
 // and streams every input group against an L1/L2-resident weight band, so each weight block is
-// read from DRAM ~once instead of once per 4-row input group Ã¢â‚¬â€ the arithmetic-intensity fix for
+// read from DRAM ~once instead of once per 4-row input group ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the arithmetic-intensity fix for
 // the bandwidth-bound host. Tiling reorders only which cells co-compute, never the per-cell
 // arithmetic sequence, so the result is byte-identical to row-at-a-time for any band size.
 
 /// Raw output pointer shared across rayon tasks. SAFETY: each task writes a DISJOINT set of
-/// (output_row, output_channel) cells Ã¢â‚¬â€ output-group bands are partitioned across tasks and each
-/// task owns its channel range [og*4, og*4+4) exclusively Ã¢â‚¬â€ so no two tasks ever touch the same
+/// (output_row, output_channel) cells ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â output-group bands are partitioned across tasks and each
+/// task owns its channel range [og*4, og*4+4) exclusively ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â so no two tasks ever touch the same
 /// cell despite the shared base pointer.
 #[derive(Clone, Copy)]
 struct Q8UnifiedOutPtr(*mut f32);
@@ -13862,7 +13917,7 @@ fn run_q8_0_unified_prefill_tiled(
     // Parallelize over chunks of output-row groups. Each chunk keeps its weight band resident
     // (read once) and sweeps ALL input groups against it.
     (0..num_chunks).into_par_iter().for_each(|chunk_idx| {
-        // Capture the whole wrapper (Copy + Send + Sync), not the bare `*mut f32` field Ã¢â‚¬â€ Rust
+        // Capture the whole wrapper (Copy + Send + Sync), not the bare `*mut f32` field ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â Rust
         // 2021 disjoint closure capture would otherwise grab `out.0` and reject the raw pointer.
         #[allow(clippy::redundant_locals)]
         let out = out;
@@ -14039,7 +14094,7 @@ unsafe fn q8_0_packed_rows4_gemm4_accumulate_block_avx512vnni(
 }
 
 /// 4x8 dispatcher (v3): accumulate ONE input group against TWO weight groups, sharing the input
-/// load (VNNI only Ã¢â‚¬â€ wider AVX-512 register tile). Byte-identical to two independent 4x4 groups.
+/// load (VNNI only ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â wider AVX-512 register tile). Byte-identical to two independent 4x4 groups.
 /// On non-x86 this is never reached at runtime (use_vnni is always false) but must still compile.
 #[inline(always)]
 fn q8_0_unified_accumulate_pair(
@@ -16022,7 +16077,7 @@ unsafe fn q8_0_two_dot_rows_avx2(
     (first_sum, second_sum)
 }
 
-/// Q8Ãƒâ€”Q8 dot of one weight row read straight from the GGUF **wire** bytes (34-byte
+/// Q8ÃƒÆ’Ã¢â‚¬â€Q8 dot of one weight row read straight from the GGUF **wire** bytes (34-byte
 /// blocks: a little-endian f16 scale + 32 i8 quants) against a pre-quantized
 /// activation row, dispatching to the same NEON `sdot` path as
 /// `cpu_neon::q8_0_dot_rows_neon_dotprod`. This lets the gemma4 wire-mmap runtime share
@@ -16062,7 +16117,7 @@ pub(crate) fn q8_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
 }
 
 // ---------------------------------------------------------------------------
-// Gemma 4 QAT (Q4_0 / Q6_K) wire kernels Ã¢â‚¬â€ groundwork for the QAT exact rows
+// Gemma 4 QAT (Q4_0 / Q6_K) wire kernels ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â groundwork for the QAT exact rows
 // (gemma-4-E4B_q4_0-it.gguf de-risk row, then 26B A4B). Marked allow(dead_code)
 // until the gemma4 loader's quant-aware wiring lands; unit-tested below.
 // ---------------------------------------------------------------------------
@@ -16072,10 +16127,10 @@ pub(crate) fn q8_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
 /// j+16 in its high nibble; both nibbles are unsigned with a -8 bias).
 pub(crate) const Q4_0_WIRE_BYTES_PER_BLOCK: usize = 18;
 
-/// Q4_0Ãƒâ€”Q8_0 dot of one weight row read straight from the GGUF wire bytes
+/// Q4_0ÃƒÆ’Ã¢â‚¬â€Q8_0 dot of one weight row read straight from the GGUF wire bytes
 /// against a pre-quantized activation row. Same accumulation contract as
 /// [`q8_0_wire_row_dot`]: one exact integer dot per 32-weight block, then a
-/// sequential `int_sum * w_scale * x_scale` f32 accumulate Ã¢â‚¬â€ the gemma4 QAT
+/// sequential `int_sum * w_scale * x_scale` f32 accumulate ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the gemma4 QAT
 /// (Q4_0) lane shares the comparator-pinning doctrine of the Q8 lane rather
 /// than mimicking any particular reference SIMD reduction shape.
 pub(crate) fn q4_0_wire_row_dot(weight_wire: &[u8], input: &[Q8_0Block]) -> f32 {
@@ -16114,7 +16169,7 @@ pub(crate) fn q4_0_wire_row_dot_scalar(weight_wire: &[u8], input: &[Q8_0Block]) 
     total
 }
 
-/// Scalar reference for the interleaved 8-row Q4_0Ãƒâ€”Q8_0 GEMV. Consumes one
+/// Scalar reference for the interleaved 8-row Q4_0ÃƒÆ’Ã¢â‚¬â€Q8_0 GEMV. Consumes one
 /// [`crate::tensor::Q4_0PackedRows8`] row-group (`blocks_per_row` interleaved
 /// blocks starting at `group_block_start`) and one Q8 activation row, writing
 /// eight dot products (one per interleaved row) into `out`.
@@ -16160,7 +16215,7 @@ pub(crate) fn q4_0_packed_gemv8_scalar(
     let _ = bpr;
 }
 
-/// Runtime-dispatched interleaved 8-row Q4_0Ãƒâ€”Q8_0 GEMV: AVX2 when available,
+/// Runtime-dispatched interleaved 8-row Q4_0ÃƒÆ’Ã¢â‚¬â€Q8_0 GEMV: AVX2 when available,
 /// else the scalar reference above. Both paths are bit-identical to
 /// [`q4_0_wire_row_dot_scalar`] run over the same eight rows.
 #[inline]
@@ -16182,17 +16237,17 @@ pub(crate) fn q4_0_packed_gemv8(
     q4_0_packed_gemv8_scalar(packed, group_block_start, input, out);
 }
 
-/// AVX2 interleaved 8-row Q4_0Ãƒâ€”Q8_0 GEMV. Ported from llama.cpp's
+/// AVX2 interleaved 8-row Q4_0ÃƒÆ’Ã¢â‚¬â€Q8_0 GEMV. Ported from llama.cpp's
 /// `gemv_q4_b32_8x8_q8_0_lut_avx` (arch/x86/repack.cpp), tied to the Camelid
 /// scalar contract (nibbles carry a `-8` bias). All 8 output rows accumulate in
 /// parallel in the eight 32-bit lanes of one `__m256i`; nibbles are sign-biased
-/// via a `_mm256_shuffle_epi8` LUT and dotted with `maddubs`+`madd` Ã¢â‚¬â€ no
+/// via a `_mm256_shuffle_epi8` LUT and dotted with `maddubs`+`madd` ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â no
 /// AVX-512-VNNI dependency (the 11800H has none).
 ///
 /// Bit-exact vs [`q4_0_packed_gemv8_scalar`] / [`q4_0_wire_row_dot_scalar`]:
-/// the int32 per-block dot is exact (nibbleÃƒâ€”i8 pair-sums cannot overflow i16),
+/// the int32 per-block dot is exact (nibbleÃƒÆ’Ã¢â‚¬â€i8 pair-sums cannot overflow i16),
 /// integer accumulation is order-independent, and the per-block f32
-/// `isumÃ‚Â·w_scaleÃ‚Â·x_scale` accumulate runs in the same block order.
+/// `isumÃƒâ€šÃ‚Â·w_scaleÃƒâ€šÃ‚Â·x_scale` accumulate runs in the same block order.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn q4_0_packed_gemv8_avx2(
@@ -16345,15 +16400,15 @@ unsafe fn q4_0_packed_gemv8_avx2(
     _mm256_storeu_ps(out.as_mut_ptr(), ordered);
 }
 
-/// int8Ãƒâ€”int8 pairwise-dot of two `__m256i` where each 32-bit lane holds 4
+/// int8ÃƒÆ’Ã¢â‚¬â€int8 pairwise-dot of two `__m256i` where each 32-bit lane holds 4
 /// signed bytes of `x` (weights, [-8,7]) and 4 of `y` (activations, [-128,127]),
 /// producing 8 int32 lane-dots added to `acc`. Uses the `maddubs` sign-trick
-/// (no AVX-512-VNNI): `abs(x)` is the unsigned operand, `yÃ‚Â·sign(x)` the signed
-/// operand. Bit-exact vs the scalar dot: `|x|` Ã¢Ë†Ë† [0,8] is unsigned-safe, and
+/// (no AVX-512-VNNI): `abs(x)` is the unsigned operand, `yÃƒâ€šÃ‚Â·sign(x)` the signed
+/// operand. Bit-exact vs the scalar dot: `|x|` ÃƒÂ¢Ã‹â€ Ã‹â€  [0,8] is unsigned-safe, and
 /// because weights are never `i8::MIN`, `sign_epi8` never hits the `-(-128)`
 /// overflow; the only value that could is a `-128` activation, but that lands in
 /// the *signed* operand `y` (`sign_epi8(y,x)` negates `y` only where `x<0`), and
-/// `-128` negated stays `-128` Ã¢â‚¬â€ which is exactly what the scalar path computes
+/// `-128` negated stays `-128` ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â which is exactly what the scalar path computes
 /// too, since `(-8)*(-128) = 1024` would need the *weight* to be the one negated.
 /// The weight is `x`; its abs is taken, so no activation value is ever negated
 /// into a wrong magnitude. Verified bit-exact by
@@ -16415,14 +16470,14 @@ pub(crate) const Q6_K_VALUES_PER_BLOCK: usize = 256;
 pub(crate) const Q6_K_WIRE_BYTES_PER_BLOCK: usize = 210;
 
 /// A 256-value Q8_K activation superblock (the reference's activation format
-/// for K-quant dots). `bsums` are omitted Ã¢â‚¬â€ the q6_K dot does not read them.
+/// for K-quant dots). `bsums` are omitted ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the q6_K dot does not read them.
 pub(crate) struct Q8KBlock {
     pub d: f32,
     pub qs: [i8; Q6_K_VALUES_PER_BLOCK],
 }
 
 /// The reference's magic-number round-to-nearest-even (`nearest_int`): adding
-/// 1.5Ã‚Â·2^23 forces the value into the mantissa with round-to-nearest applied,
+/// 1.5Ãƒâ€šÃ‚Â·2^23 forces the value into the mantissa with round-to-nearest applied,
 /// matching its quantizer bit-for-bit (plain `round()` half-away-from-zero
 /// would differ on exact .5 ties).
 #[inline]
@@ -16492,8 +16547,8 @@ fn quantize_q8_k_with_bsums(input: &[f32]) -> (Vec<Q8KBlock>, Vec<[i16; 16]>) {
 }
 
 /// Scalar reference dot (parity floor): one TQ2_0 weight row against a Q8_K activation
-/// row. Port of ggml `ggml_vec_dot_tq2_0_q8_K_generic`: per block, sumi = ÃŽÂ£ (code-1)Ã‚Â·q8,
-/// scaled by d_xÃ‚Â·d_y; the 2-bit codes {0,1,2} recenter to {-1,0,+1} via the `-1`.
+/// row. Port of ggml `ggml_vec_dot_tq2_0_q8_K_generic`: per block, sumi = ÃƒÅ½Ã‚Â£ (code-1)Ãƒâ€šÃ‚Â·q8,
+/// scaled by d_xÃƒâ€šÃ‚Â·d_y; the 2-bit codes {0,1,2} recenter to {-1,0,+1} via the `-1`.
 fn tq2_0_row_dot(w_row: &[u8], q8: &[Q8KBlock], blocks_per_row: usize) -> f32 {
     let mut sumf = 0f32;
     for b in 0..blocks_per_row {
@@ -16520,7 +16575,7 @@ fn tq2_0_row_dot(w_row: &[u8], q8: &[Q8KBlock], blocks_per_row: usize) -> f32 {
 
 /// AVX2 ternary dot, mirroring ggml `ggml_vec_dot_tq2_0_q8_K`: unpack the 2-bit codes,
 /// `maddubs` against the int8 activations (16-bit accumulate, safe within a 256-block),
-/// subtract the per-group activation sums (`bsums`) to recenter, then scale by d_xÃ‚Â·d_y.
+/// subtract the per-group activation sums (`bsums`) to recenter, then scale by d_xÃƒâ€šÃ‚Â·d_y.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn tq2_0_row_dot_avx2(
@@ -16598,10 +16653,10 @@ fn tq2_0_dot(w_row: &[u8], q8: &[Q8KBlock], bsums: &[[i16; 16]], blocks_per_row:
     tq2_0_row_dot(w_row, q8, blocks_per_row)
 }
 
-/// Streaming TQ2_0 (ternary) linear: `output[n_rows, out_dim] = input @ weightÃ¡Âµâ‚¬`, with
+/// Streaming TQ2_0 (ternary) linear: `output[n_rows, out_dim] = input @ weightÃƒÂ¡Ã‚ÂµÃ¢â€šÂ¬`, with
 /// the weight held as raw TQ2_0 wire bytes (never materialised to f32). PREFILL TILING:
 /// all `n_rows` activation rows are quantised once, then each weight row is streamed once
-/// (rayon-parallel over the output dimension) and dotted against every token Ã¢â‚¬â€ so the
+/// (rayon-parallel over the output dimension) and dotted against every token ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â so the
 /// weight is read once instead of once-per-token. This is the win llama.cpp's un-tiled
 /// per-element TQ kernel leaves on the table.
 fn matmul_rhs_transposed_tq2_0_block_dot(
@@ -16746,13 +16801,13 @@ fn matmul_rhs_transposed_q6_k_block_dot(
 /// Whether the experimental CPU Q4_K block-dot decode path is enabled. Default
 /// off (fail-closed): without it, Q4_K 2-D linears have no CPU consumer (their
 /// wire bytes are retained for the GPU resident path), so the gate cannot
-/// regress any working CPU behavior Ã¢â‚¬â€ it only adds one.
+/// regress any working CPU behavior ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â it only adds one.
 /// CPU K-quant (Q4_K / Q6_K) decode block-dot. **DEFAULT-ON** (opt out with
 /// `CAMELID_X86_Q4K_DECODE=0`). K-quant 2-D linears load WIRE-ONLY (no f32 `data`)
 /// for the resident GPU engine; with this gate off the CPU linear path has no
 /// consumer for them and errors (`no-row-major-data`, data_len=0). The GPU-resident
 /// decode lane never reaches this chokepoint (it runs q4k_gemv/q6k_gemv on-GPU), so
-/// default-on changes ONLY CPU-mode K-quant decode Ã¢â‚¬â€ turning a hard error into
+/// default-on changes ONLY CPU-mode K-quant decode ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â turning a hard error into
 /// parity-correct output (Q4_K via the AVX2 `q4_k_dot_arm`, Q6_K via the 8-lane
 /// `q6_k_wire_row_dot`). Windows greedy parity is proven vs llama.cpp acd79d6
 /// (K-quant conductor Phase 2); Linux/macOS f32-near-tie parity confirmation is a
@@ -16922,10 +16977,10 @@ pub(crate) fn q6_k_wire_block_dequant(block_bytes: &[u8]) -> [f32; Q6_K_VALUES_P
     out
 }
 
-/// Q6_KÃƒâ€”Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q6_KÃƒÆ’Ã¢â‚¬â€Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel's numeric shape: per superblock the
-/// 6-bit weights are rebuilt exactly, the per-16-group `scale * ÃŽÂ£(q8Ã‚Â·w)`
-/// products accumulate into 8 integer lanes, the superblock's `d_w Ã‚Â· d_act`
+/// 6-bit weights are rebuilt exactly, the per-16-group `scale * ÃƒÅ½Ã‚Â£(q8Ãƒâ€šÃ‚Â·w)`
+/// products accumulate into 8 integer lanes, the superblock's `d_w Ãƒâ€šÃ‚Â· d_act`
 /// scales those lanes into 8 f32 accumulators, and the 8 lanes reduce
 /// sequentially at the end.
 pub(crate) fn q6_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
@@ -16978,11 +17033,11 @@ pub(crate) fn q6_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
 
 /// K-quant conductor Phase 2 follow-up: opt-in AVX2 Q6_K row dot
 /// (`CAMELID_X86_Q6K_AVX2`, default-off). BIT-IDENTICAL to [`q6_k_wire_row_dot`]
-/// by construction Ã¢â‚¬â€ it vectorizes ONLY the associative integer `aux32[8]` and
+/// by construction ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â it vectorizes ONLY the associative integer `aux32[8]` and
 /// keeps the load-bearing 8-lane f32 reduction (`sums[l] += d * aux32[l]`, then
 /// the left-fold `sums.iter().sum()`) exactly as the scalar oracle. (The refmath
 /// `q6_k_dot_avx2` is NOT a substitute: it mirrors the single-accumulator
-/// `q6_k_dot_scalar` order, a different bit pattern.) Default-off until measured Ã¢â‚¬â€
+/// `q6_k_dot_scalar` order, a different bit pattern.) Default-off until measured ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â
 /// CPU decode is bandwidth-bound on the dev box, so this is expected to be ~null.
 #[cfg(target_arch = "x86_64")]
 fn q6k_avx2_enabled() -> bool {
@@ -17019,7 +17074,7 @@ fn q6_k_wire_row_dot_simd(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     q6_k_wire_row_dot(weight_wire, input)
 }
 
-/// AVX2 sibling of [`q6_k_wire_row_dot`] Ã¢â‚¬â€ see `q6k_avx2_enabled` for the parity
+/// AVX2 sibling of [`q6_k_wire_row_dot`] ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â see `q6k_avx2_enabled` for the parity
 /// contract. Vectorizes the per-superblock integer dot into the oracle's 8
 /// position-lanes (`aux32[l]`), exact integers; the 6-bit rebuild and the f32
 /// reduction stay byte-for-byte identical to the scalar path.
@@ -17056,8 +17111,8 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
             qh += 32;
         }
 
-        // aux32[l] = ÃŽÂ£_j scale_j Ã‚Â· (q8[16j+l]Ã‚Â·a[16j+l] + q8[16j+8+l]Ã‚Â·a[16j+8+l]),
-        // l in 0..8, all exact integers (associative Ã¢â‚¬â€ SIMD lane order is free).
+        // aux32[l] = ÃƒÅ½Ã‚Â£_j scale_j Ãƒâ€šÃ‚Â· (q8[16j+l]Ãƒâ€šÃ‚Â·a[16j+l] + q8[16j+8+l]Ãƒâ€šÃ‚Â·a[16j+8+l]),
+        // l in 0..8, all exact integers (associative ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â SIMD lane order is free).
         let mut acc = _mm256_setzero_si256();
         let aptr = a.as_ptr();
         let qptr = y.qs.as_ptr();
@@ -17080,7 +17135,7 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
         let mut aux32 = [0i32; 8];
         _mm256_storeu_si256(aux32.as_mut_ptr() as *mut __m256i, acc);
 
-        // Load-bearing 8-lane f32 reduction Ã¢â‚¬â€ identical to the scalar oracle.
+        // Load-bearing 8-lane f32 reduction ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â identical to the scalar oracle.
         for l in 0..8 {
             sums[l] += d * aux32[l] as f32;
         }
@@ -17088,7 +17143,7 @@ unsafe fn q6_k_wire_row_dot_avx2(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 
     sums.iter().sum()
 }
 
-/// Dequantize a single Q4_0 wire block (18 bytes) into 32 f32 values Ã¢â‚¬â€
+/// Dequantize a single Q4_0 wire block (18 bytes) into 32 f32 values ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â
 /// the row-gather counterpart of [`q4_0_wire_row_dot`] for embedding-style
 /// lookups into Q4_0 tables.
 pub(crate) fn q4_0_wire_block_dequant(block_bytes: &[u8]) -> [f32; 32] {
@@ -17106,14 +17161,14 @@ pub(crate) fn q4_0_wire_block_dequant(block_bytes: &[u8]) -> [f32; 32] {
 pub(crate) const Q4_K_WIRE_BYTES_PER_BLOCK: usize = 144;
 pub(crate) const Q5_0_WIRE_BYTES_PER_BLOCK: usize = 22;
 
-/// Q4_KÃƒâ€”Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q4_KÃƒÆ’Ã¢â‚¬â€Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel's numeric shape exactly
 /// (`ggml_vec_dot_q4_K_q8_K_generic`): per superblock the nibbles expand
 /// low-then-high in 64-value groups, the packed 6-bit scales/mins unpack via
-/// the kmask scheme, per-32-group `scale * ÃŽÂ£(q8Ã‚Â·q4)` products accumulate into
-/// 8 integer lanes scaled by `d_wÃ‚Â·d_act`, and the mins side subtracts
-/// `dminÃ‚Â·d_act Ã‚Â· ÃŽÂ£(min_g Ã‚Â· bsum_g)` with per-16 activation sums (computed
-/// inline; the reference precomputes them as Q8_K `bsums` Ã¢â‚¬â€ identical
+/// the kmask scheme, per-32-group `scale * ÃƒÅ½Ã‚Â£(q8Ãƒâ€šÃ‚Â·q4)` products accumulate into
+/// 8 integer lanes scaled by `d_wÃƒâ€šÃ‚Â·d_act`, and the mins side subtracts
+/// `dminÃƒâ€šÃ‚Â·d_act Ãƒâ€šÃ‚Â· ÃƒÅ½Ã‚Â£(min_g Ãƒâ€šÃ‚Â· bsum_g)` with per-16 activation sums (computed
+/// inline; the reference precomputes them as Q8_K `bsums` ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â identical
 /// integers). DiffusionGemma lane: correctness-first scalar, no SIMD.
 // index-based loops intentionally mirror the reference C kernel's structure
 // unit-tested ports of the reference GENERIC kernels (the DG runtime now
@@ -17141,7 +17196,7 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             }
         }
 
-        // unpack the 8 packed 6-bit (scale, min) pairs Ã¢â‚¬â€ kmask scheme
+        // unpack the 8 packed 6-bit (scale, min) pairs ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â kmask scheme
         let mut utmp = [0u32; 4];
         utmp[0] = u32::from_le_bytes([scales_raw[0], scales_raw[1], scales_raw[2], scales_raw[3]]);
         utmp[1] = u32::from_le_bytes([scales_raw[4], scales_raw[5], scales_raw[6], scales_raw[7]]);
@@ -17176,7 +17231,7 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             ((utmp[3] >> 24) & 0xff) as u8,
         ];
 
-        // mins side: ÃŽÂ£ over the 16 per-16 activation sums Ãƒâ€” min of their group
+        // mins side: ÃƒÅ½Ã‚Â£ over the 16 per-16 activation sums ÃƒÆ’Ã¢â‚¬â€ min of their group
         let mut sumi = 0i32;
         for j in 0..16 {
             let bsum: i32 = y.qs[j * 16..(j + 1) * 16].iter().map(|&q| q as i32).sum();
@@ -17204,12 +17259,12 @@ pub(crate) fn q4_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf + sums.iter().sum::<f32>()
 }
 
-/// Q2_K Ãƒâ€” Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q2_K ÃƒÆ’Ã¢â‚¬â€ Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel `ggml_vec_dot_q2_K_q8_K`. Each 84-byte
 /// super-block is scales[16] (low nibble = quant scale, high nibble = min scale,
 /// one pair per 16-value sub-block), qs[64] (2-bit quants), d(f16), dmin(f16).
 /// Unlike Q4_K/Q6_K the reference keeps a SINGLE integer `isum` per super-block, so
-/// each super-block contributes `dallÃ‚Â·isum Ã¢Ë†â€™ dminÃ‚Â·summs` (subtraction first) to the
+/// each super-block contributes `dallÃƒâ€šÃ‚Â·isum ÃƒÂ¢Ã‹â€ Ã¢â‚¬â„¢ dminÃƒâ€šÃ‚Â·summs` (subtraction first) to the
 /// f32 sum, summed in order. The `q2k_gemv` CUDA kernel reproduces this exactly.
 /// Correctness-first scalar (the reference's "no SIMD" generic shape).
 #[allow(dead_code, clippy::needless_range_loop)]
@@ -17223,14 +17278,14 @@ pub(crate) fn q2_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
         let d = f16_bits_to_f32(u16::from_le_bytes([block[80], block[81]]));
         let dmin = f16_bits_to_f32(u16::from_le_bytes([block[82], block[83]]));
 
-        // mins side: ÃŽÂ£ over the 16 sub-blocks of (per-16 activation sum) Ãƒâ€” min scale
+        // mins side: ÃƒÅ½Ã‚Â£ over the 16 sub-blocks of (per-16 activation sum) ÃƒÆ’Ã¢â‚¬â€ min scale
         let mut summs = 0i32;
         for j in 0..16 {
             let bsum: i32 = y.qs[j * 16..(j + 1) * 16].iter().map(|&q| q as i32).sum();
             summs += bsum * (scales[j] >> 4) as i32;
         }
 
-        // main side: 2 halves Ãƒâ€” 4 groups; each group reuses the same 32 qs bytes at
+        // main side: 2 halves ÃƒÆ’Ã¢â‚¬â€ 4 groups; each group reuses the same 32 qs bytes at
         // shift 2*group, split into a low (l<16) and high (l>=16) sub-block, each
         // with its own low-nibble quant scale. q8 advances 32 per group.
         let mut isum = 0i32;
@@ -17265,13 +17320,13 @@ pub(crate) fn q2_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf
 }
 
-/// Q3_K Ãƒâ€” Q8_K dot of one weight row read straight from the GGUF wire bytes,
+/// Q3_K ÃƒÆ’Ã¢â‚¬â€ Q8_K dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel `ggml_vec_dot_q3_K_q8_K`. Each 110-byte
 /// super-block is hmask[32] (high bit of each 3-bit quant), qs[64] (low 2 bits),
 /// scales[12] (16 signed 6-bit scales, kmask-packed), d(f16). Q3_K has NO mins: the
 /// 3-bit quant is reconstructed as `((qs>>shift)&3) - (hmask_bit ? 0 : 4)` (centered
-/// to Ã¢Ë†â€™4..3) and dequantized as `dÃ‚Â·(scaleÃ¢Ë†â€™32)Ã‚Â·value`. So each super-block contributes
-/// a single `dÃ‚Â·isum` (isum = ÃŽÂ£_sb (scaleÃ¢Ë†â€™32)Ã‚Â·ÃŽÂ£ q8Ã‚Â·value), summed in order. The
+/// to ÃƒÂ¢Ã‹â€ Ã¢â‚¬â„¢4..3) and dequantized as `dÃƒâ€šÃ‚Â·(scaleÃƒÂ¢Ã‹â€ Ã¢â‚¬â„¢32)Ãƒâ€šÃ‚Â·value`. So each super-block contributes
+/// a single `dÃƒâ€šÃ‚Â·isum` (isum = ÃƒÅ½Ã‚Â£_sb (scaleÃƒÂ¢Ã‹â€ Ã¢â‚¬â„¢32)Ãƒâ€šÃ‚Â·ÃƒÅ½Ã‚Â£ q8Ãƒâ€šÃ‚Â·value), summed in order. The
 /// `q3k_gemv` CUDA kernel reproduces this exactly. Correctness-first scalar.
 #[allow(dead_code, clippy::needless_range_loop)]
 pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
@@ -17306,8 +17361,8 @@ pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
             }
         }
 
-        // isum = ÃŽÂ£ over the 16 sub-blocks of (scaleÃ¢Ë†â€™32) Ãƒâ€” ÃŽÂ£ q8Ã‚Â·value. 2 halves Ãƒâ€” 4
-        // groups Ãƒâ€” {low,high}; qs reused per group at shift 2*group; hmask bit advances
+        // isum = ÃƒÅ½Ã‚Â£ over the 16 sub-blocks of (scaleÃƒÂ¢Ã‹â€ Ã¢â‚¬â„¢32) ÃƒÆ’Ã¢â‚¬â€ ÃƒÅ½Ã‚Â£ q8Ãƒâ€šÃ‚Â·value. 2 halves ÃƒÆ’Ã¢â‚¬â€ 4
+        // groups ÃƒÆ’Ã¢â‚¬â€ {low,high}; qs reused per group at shift 2*group; hmask bit advances
         // per group (1<<(half*4+group)); q8 in natural order.
         let mut isum = 0i32;
         let mut sb = 0usize;
@@ -17345,11 +17400,11 @@ pub(crate) fn q3_k_wire_row_dot(weight_wire: &[u8], input: &[Q8KBlock]) -> f32 {
     sumf
 }
 
-/// Q5_0Ãƒâ€”Q8_0 dot of one weight row read straight from the GGUF wire bytes,
+/// Q5_0ÃƒÆ’Ã¢â‚¬â€Q8_0 dot of one weight row read straight from the GGUF wire bytes,
 /// mirroring the reference generic kernel (`ggml_vec_dot_q5_0_q8_0_generic`):
 /// per 32-value block, rebuild the signed 5-bit weights from the nibble plus
 /// its qh bit, accumulate the two half-block integer dots, then scale by
-/// `d_wÃ‚Â·d_act`. DiffusionGemma lane: correctness-first scalar, no SIMD.
+/// `d_wÃƒâ€šÃ‚Â·d_act`. DiffusionGemma lane: correctness-first scalar, no SIMD.
 // index-based loops intentionally mirror the reference C kernel's structure
 // unit-tested ports of the reference GENERIC kernels (the DG runtime now
 // uses the ARM-order variants in diffusion_gemma::refmath)
@@ -18426,7 +18481,7 @@ fn try_accumulate_descriptor_linear_row_metal(
     #[cfg(target_os = "macos")]
     {
         // Cheap existing check first so the default path (Metal linear off) short-circuits
-        // before the deterministic-mode env read Ã¢â‚¬â€ zero added work when the flag is unused.
+        // before the deterministic-mode env read ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â zero added work when the flag is unused.
         if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1")
             || deterministic_mode_enabled()
         {
@@ -19289,7 +19344,7 @@ fn matmul_rhs_transposed_q8_0_packed_rows4_prefill_i8mm(
     let mut output = vec![0.0_f32; rows * output_width];
     // The small-M weight-resident kernel absorbs the partial final row group as a
     // zero-padded lane set so the conservative per-row GEMV tail (a full weight pass
-    // per tail row Ã¢â‚¬â€ ruinous for 5-20 row speculative verify chunks) never runs.
+    // per tail row ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â ruinous for 5-20 row speculative verify chunks) never runs.
     let small_m = rows >= 4 && rows.div_ceil(4) <= mac_q8_i8mm_small_m_max_input_groups();
     let packed_rows = if small_m { rows } else { rows / 4 * 4 };
     let collect_q8_schedule = q8_schedule_telemetry_enabled();
@@ -20126,7 +20181,7 @@ fn q8_0_packed_rows4_dot(
                 }
             }
         }
-        // Phase 3: opt-in x86 weight-stream prefetch, two packed blocks ahead Ã¢â‚¬â€ the
+        // Phase 3: opt-in x86 weight-stream prefetch, two packed blocks ahead ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the
         // x86 mirror of the macOS NEON `prfm` above. Default-off; a memory hint only,
         // so the decoded values are byte-identical regardless of the flag.
         #[cfg(all(
@@ -20499,7 +20554,7 @@ fn try_accumulate_transposed_linear_row_metal(
     #[cfg(target_os = "macos")]
     {
         // Cheap existing check first so the default path (Metal linear off) short-circuits
-        // before the deterministic-mode env read Ã¢â‚¬â€ zero added work when the flag is unused.
+        // before the deterministic-mode env read ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â zero added work when the flag is unused.
         if std::env::var("CAMELID_METAL_LINEAR").ok().as_deref() != Some("1")
             || deterministic_mode_enabled()
         {
@@ -21211,7 +21266,7 @@ fn attention_f32_blocked_dot_enabled() -> bool {
 
 /// Flag gate for the decode attention head-parallel lane
 /// (`BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL`, default off). Scoped to
-/// Windows x86_64 per the standing Windows-first directive Ã¢â‚¬â€ the mechanism
+/// Windows x86_64 per the standing Windows-first directive ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â the mechanism
 /// itself is arch-agnostic (scheduling only, no arithmetic), so lifting the
 /// gate is a one-line follow-up decision, not a code change. Resolved once
 /// per process outside tests.

--- a/src/inference/decode_scratch.rs
+++ b/src/inference/decode_scratch.rs
@@ -1,0 +1,126 @@
+//! Recycling buffer pool for the decode hot loop (Lane B step 5).
+//!
+//! Steady-state decode used to allocate a fresh `Vec<f32>` (and a fresh
+//! `String` name) for every op output — hundreds of heap round-trips per
+//! token, all layer-proportional. This pool turns those into reuse hits:
+//! `take(len)` returns a zeroed vector with EXACTLY the semantics of
+//! `vec![0.0; len]` (values and length identical — allocation source cannot
+//! affect arithmetic), backed by a recycled buffer whenever one with enough
+//! capacity is available; `recycle`/`recycle_tensor` return buffers at the
+//! points where the layer forward provably owns the dead intermediate.
+//!
+//! Concurrency: takes/recycles happen on the decode orchestrator thread
+//! (ops are dispatched serially per token), so the internal Mutex is
+//! uncontended; rayon WORKER scratch must NOT use this pool — workers keep
+//! `thread_local!` buffers instead (see the attention lane) so nothing
+//! contends inside parallel regions.
+//!
+//! The pool is unbounded in count but bounded in practice by the working
+//! set of one token (every take is matched by a recycle at layer/token
+//! end); buffers keep their high-water capacity, which is the point.
+
+use std::sync::Mutex;
+
+use crate::tensor::CpuTensor;
+
+static POOL: Mutex<Vec<Vec<f32>>> = Mutex::new(Vec::new());
+static NAME_POOL: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+/// A zeroed `Vec<f32>` of `len`, bit-identical in content to
+/// `vec![0.0; len]`, reusing a recycled buffer when one fits.
+pub(super) fn take(len: usize) -> Vec<f32> {
+    let mut pool = POOL.lock().expect("decode scratch pool poisoned");
+    // Last-in first-out keeps the hottest buffer (best cache behavior); scan
+    // a bounded tail for one with enough capacity so odd sizes don't strand
+    // large buffers.
+    let limit = pool.len().min(8);
+    for i in 0..limit {
+        let idx = pool.len() - 1 - i;
+        if pool[idx].capacity() >= len {
+            let mut buffer = pool.swap_remove(idx);
+            drop(pool);
+            buffer.clear();
+            buffer.resize(len, 0.0);
+            return buffer;
+        }
+    }
+    drop(pool);
+    vec![0.0; len]
+}
+
+/// Return a buffer to the pool.
+pub(super) fn recycle(buffer: Vec<f32>) {
+    if buffer.capacity() == 0 {
+        return;
+    }
+    POOL.lock()
+        .expect("decode scratch pool poisoned")
+        .push(buffer);
+}
+
+/// Build a tensor from pooled parts: the data buffer comes from the caller
+/// (usually via [`take`]) and the name String is recycled when one is
+/// available (clear + push_str reuses its capacity — no allocation once the
+/// pool is warm).
+pub(super) fn tensor_from_pooled(
+    name: &str,
+    dims: Vec<usize>,
+    data: Vec<f32>,
+) -> crate::Result<CpuTensor> {
+    let mut owned = NAME_POOL
+        .lock()
+        .expect("decode scratch name pool poisoned")
+        .pop()
+        .unwrap_or_default();
+    owned.clear();
+    owned.push_str(name);
+    CpuTensor::from_f32(owned, dims, data)
+}
+
+/// Reclaim a dead intermediate tensor: its data buffer and name String both
+/// return to their pools. Call ONLY where the tensor is provably dead (the
+/// layer forward's end-of-scope points).
+// Consumed by the layer-forward recycling pass (step 5c); until that lands
+// only the tests exercise it.
+#[allow(dead_code)]
+pub(super) fn recycle_tensor(tensor: CpuTensor) {
+    let (name, data) = tensor.into_parts();
+    recycle(data);
+    if name.capacity() > 0 {
+        NAME_POOL
+            .lock()
+            .expect("decode scratch name pool poisoned")
+            .push(name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_matches_vec_zero_semantics() {
+        for len in [0usize, 1, 63, 64, 3072] {
+            let a = take(len);
+            let b = vec![0.0f32; len];
+            assert_eq!(a.len(), b.len());
+            for (x, y) in a.iter().zip(&b) {
+                assert_eq!(x.to_bits(), y.to_bits());
+            }
+            recycle(a);
+        }
+    }
+
+    #[test]
+    fn recycled_buffers_are_reused_and_rezeroed() {
+        let mut a = take(128);
+        a.iter_mut().for_each(|v| *v = 7.0);
+        let ptr = a.as_ptr() as usize;
+        recycle(a);
+        let b = take(64);
+        // Reuse is capacity-based; content must be zero regardless.
+        assert!(b.iter().all(|v| v.to_bits() == 0));
+        let _ = ptr; // pointer identity is an implementation detail, not asserted
+        recycle(b);
+    }
+}

--- a/src/inference/decode_scratch.rs
+++ b/src/inference/decode_scratch.rs
@@ -112,9 +112,6 @@ pub(super) fn tensor_from_pooled(
 /// Reclaim a dead intermediate tensor: its data buffer, name String, and
 /// dims Vec all return to their pools. Call ONLY where the tensor is
 /// provably dead (the layer forward's end-of-scope points).
-// Consumed by the layer-forward recycling pass (step 5c); until that lands
-// only the tests exercise it.
-#[allow(dead_code)]
 pub(super) fn recycle_tensor(tensor: CpuTensor) {
     let (name, dims, data) = tensor.into_parts();
     recycle(data);

--- a/src/inference/decode_scratch.rs
+++ b/src/inference/decode_scratch.rs
@@ -21,10 +21,35 @@
 
 use std::sync::Mutex;
 
-use crate::tensor::CpuTensor;
+use crate::tensor::{CpuTensor, Q8_0Block};
 
 static POOL: Mutex<Vec<Vec<f32>>> = Mutex::new(Vec::new());
 static NAME_POOL: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static DIMS_POOL: Mutex<Vec<Vec<usize>>> = Mutex::new(Vec::new());
+static Q8_BLOCK_POOL: Mutex<Vec<Vec<Q8_0Block>>> = Mutex::new(Vec::new());
+
+/// An empty (cleared) `Vec<Q8_0Block>`, reusing a recycled buffer's capacity
+/// when one exists. Content is produced entirely by the caller.
+pub(super) fn take_q8_blocks() -> Vec<Q8_0Block> {
+    let mut blocks = Q8_BLOCK_POOL
+        .lock()
+        .expect("decode scratch q8 block pool poisoned")
+        .pop()
+        .unwrap_or_default();
+    blocks.clear();
+    blocks
+}
+
+/// Return a quantized-input block buffer to the pool.
+pub(super) fn recycle_q8_blocks(blocks: Vec<Q8_0Block>) {
+    if blocks.capacity() == 0 {
+        return;
+    }
+    Q8_BLOCK_POOL
+        .lock()
+        .expect("decode scratch q8 block pool poisoned")
+        .push(blocks);
+}
 
 /// A zeroed `Vec<f32>` of `len`, bit-identical in content to
 /// `vec![0.0; len]`, reusing a recycled buffer when one fits.
@@ -59,38 +84,51 @@ pub(super) fn recycle(buffer: Vec<f32>) {
 }
 
 /// Build a tensor from pooled parts: the data buffer comes from the caller
-/// (usually via [`take`]) and the name String is recycled when one is
-/// available (clear + push_str reuses its capacity — no allocation once the
+/// (usually via [`take`]); the name String and dims Vec are recycled when
+/// available (clear + refill reuses their capacity — no allocation once the
 /// pool is warm).
 pub(super) fn tensor_from_pooled(
     name: &str,
-    dims: Vec<usize>,
+    dims: &[usize],
     data: Vec<f32>,
 ) -> crate::Result<CpuTensor> {
-    let mut owned = NAME_POOL
+    let mut owned_name = NAME_POOL
         .lock()
         .expect("decode scratch name pool poisoned")
         .pop()
         .unwrap_or_default();
-    owned.clear();
-    owned.push_str(name);
-    CpuTensor::from_f32(owned, dims, data)
+    owned_name.clear();
+    owned_name.push_str(name);
+    let mut owned_dims = DIMS_POOL
+        .lock()
+        .expect("decode scratch dims pool poisoned")
+        .pop()
+        .unwrap_or_default();
+    owned_dims.clear();
+    owned_dims.extend_from_slice(dims);
+    CpuTensor::from_f32(owned_name, owned_dims, data)
 }
 
-/// Reclaim a dead intermediate tensor: its data buffer and name String both
-/// return to their pools. Call ONLY where the tensor is provably dead (the
-/// layer forward's end-of-scope points).
+/// Reclaim a dead intermediate tensor: its data buffer, name String, and
+/// dims Vec all return to their pools. Call ONLY where the tensor is
+/// provably dead (the layer forward's end-of-scope points).
 // Consumed by the layer-forward recycling pass (step 5c); until that lands
 // only the tests exercise it.
 #[allow(dead_code)]
 pub(super) fn recycle_tensor(tensor: CpuTensor) {
-    let (name, data) = tensor.into_parts();
+    let (name, dims, data) = tensor.into_parts();
     recycle(data);
     if name.capacity() > 0 {
         NAME_POOL
             .lock()
             .expect("decode scratch name pool poisoned")
             .push(name);
+    }
+    if dims.capacity() > 0 {
+        DIMS_POOL
+            .lock()
+            .expect("decode scratch dims pool poisoned")
+            .push(dims);
     }
 }
 

--- a/src/inference/diagnostic_config.rs
+++ b/src/inference/diagnostic_config.rs
@@ -183,6 +183,23 @@ pub(super) fn diagnostic_zero_delta_value(
 }
 
 pub fn diagnostic_gqa_head_mapping() -> Result<GqaHeadMapping> {
+    // Resolved once per process (non-test): the attention context consults
+    // this per call on the decode hot loop, and env reads allocate on
+    // Windows. Invalid values stay uncached (the error aborts the forward).
+    #[cfg(not(test))]
+    {
+        static RESOLVED: std::sync::OnceLock<GqaHeadMapping> = std::sync::OnceLock::new();
+        if let Some(mapping) = RESOLVED.get() {
+            return Ok(*mapping);
+        }
+        let mapping = diagnostic_gqa_head_mapping_uncached()?;
+        Ok(*RESOLVED.get_or_init(|| mapping))
+    }
+    #[cfg(test)]
+    diagnostic_gqa_head_mapping_uncached()
+}
+
+fn diagnostic_gqa_head_mapping_uncached() -> Result<GqaHeadMapping> {
     match env::var("CAMELID_GQA_HEAD_MAPPING") {
         Ok(value) if value == "modulo" => Ok(GqaHeadMapping::Modulo),
         Ok(value) if value == "grouped" || value.is_empty() => Ok(GqaHeadMapping::Grouped),
@@ -197,6 +214,20 @@ pub fn diagnostic_gqa_head_mapping() -> Result<GqaHeadMapping> {
 }
 
 pub fn diagnostic_attention_score_scale() -> Result<AttentionScoreScale> {
+    #[cfg(not(test))]
+    {
+        static RESOLVED: std::sync::OnceLock<AttentionScoreScale> = std::sync::OnceLock::new();
+        if let Some(scale) = RESOLVED.get() {
+            return Ok(*scale);
+        }
+        let scale = diagnostic_attention_score_scale_uncached()?;
+        Ok(*RESOLVED.get_or_init(|| scale))
+    }
+    #[cfg(test)]
+    diagnostic_attention_score_scale_uncached()
+}
+
+fn diagnostic_attention_score_scale_uncached() -> Result<AttentionScoreScale> {
     match env::var("CAMELID_ATTENTION_SCORE_SCALE") {
         Ok(value) if value == "none" => Ok(AttentionScoreScale::None),
         Ok(value) if value == "head_dim" || value.is_empty() => Ok(AttentionScoreScale::HeadDim),
@@ -225,6 +256,22 @@ pub fn diagnostic_linear_accumulation_precision() -> Result<LinearAccumulationPr
 }
 
 pub fn diagnostic_ffn_gate_up_order() -> Result<FfnGateUpOrder> {
+    // Resolved once per process (non-test): consulted per FFN activation on
+    // the decode hot loop, and env reads allocate on Windows.
+    #[cfg(not(test))]
+    {
+        static RESOLVED: std::sync::OnceLock<FfnGateUpOrder> = std::sync::OnceLock::new();
+        if let Some(order) = RESOLVED.get() {
+            return Ok(*order);
+        }
+        let order = diagnostic_ffn_gate_up_order_uncached()?;
+        Ok(*RESOLVED.get_or_init(|| order))
+    }
+    #[cfg(test)]
+    diagnostic_ffn_gate_up_order_uncached()
+}
+
+fn diagnostic_ffn_gate_up_order_uncached() -> Result<FfnGateUpOrder> {
     match env::var("CAMELID_FFN_GATE_UP_ORDER") {
         Ok(value) if value == "up_gate" => Ok(FfnGateUpOrder::UpGate),
         Ok(value) if value == "gate_up" || value.is_empty() => Ok(FfnGateUpOrder::GateUp),
@@ -308,6 +355,24 @@ pub fn diagnostic_rectangular_linear_layout() -> Result<RectangularLinearLayout>
 pub fn diagnostic_rectangular_linear_layout_for_role(
     role: &str,
 ) -> Result<RectangularLinearLayout> {
+    // Hot-path short-circuit (non-test): when NO rectangular-layout override
+    // is present in the environment — the overwhelmingly common case — every
+    // role resolves to Auto, and the per-call role-key/format!/env::var work
+    // below (three allocations per projection call) is skipped entirely. Any
+    // override present falls through to the exact per-call resolution.
+    #[cfg(not(test))]
+    {
+        static ANY_OVERRIDE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        let any_override = *ANY_OVERRIDE.get_or_init(|| {
+            env::vars_os().any(|(key, _)| {
+                key.to_string_lossy()
+                    .starts_with("CAMELID_RECTANGULAR_LINEAR_LAYOUT")
+            })
+        });
+        if !any_override {
+            return Ok(RectangularLinearLayout::Auto);
+        }
+    }
     let role_key = role
         .chars()
         .map(|ch| {

--- a/src/inference/q8_runtime.rs
+++ b/src/inference/q8_runtime.rs
@@ -142,6 +142,28 @@ impl ResolvedRuntimePlan {
 
 impl Q8RuntimeFlags {
     pub(super) fn from_env() -> Self {
+        // Same caching contract as `ResolvedRuntimePlan::from_env` above: the
+        // flags are fixed post-startup, and callers outside the resolved-plan
+        // path (e.g. the shared-QKV block-dot predicate) used to re-read ~30
+        // env vars per layer per decode token — on Windows every env::var
+        // read allocates, even on a miss. Tests keep the uncached read so
+        // env-manipulating tests observe their changes.
+        #[cfg(test)]
+        {
+            Self::from_env_uncached()
+        }
+        #[cfg(not(test))]
+        {
+            static RESOLVED: std::sync::OnceLock<Q8RuntimeFlags> = std::sync::OnceLock::new();
+            if let Some(flags) = RESOLVED.get() {
+                return *flags;
+            }
+            let flags = Self::from_env_uncached();
+            *RESOLVED.get_or_init(|| flags)
+        }
+    }
+
+    fn from_env_uncached() -> Self {
         Self {
             block_dot: q8_0_env_flag_enabled_default_on_fail_closed("CAMELID_Q8_0_BLOCK_DOT"),
             file_reader_block_dot: q8_0_env_flag_enabled_default_on_fail_closed(

--- a/src/inference/q8_runtime.rs
+++ b/src/inference/q8_runtime.rs
@@ -110,6 +110,27 @@ pub(super) struct ResolvedRuntimePlan {
 
 impl ResolvedRuntimePlan {
     pub(super) fn from_env() -> Result<Self> {
+        // Resolve ONCE per process outside tests: the ~20 env flags below are
+        // fixed post-startup (every lane flag already assumes this via its
+        // own OnceLock), and this constructor used to run on per-op paths —
+        // ~20 raw env::var reads per projection call. Tests keep the uncached
+        // read so env-manipulating tests observe their changes.
+        #[cfg(test)]
+        {
+            Self::from_env_uncached()
+        }
+        #[cfg(not(test))]
+        {
+            static RESOLVED: std::sync::OnceLock<ResolvedRuntimePlan> = std::sync::OnceLock::new();
+            if let Some(plan) = RESOLVED.get() {
+                return Ok(*plan);
+            }
+            let plan = Self::from_env_uncached()?;
+            Ok(*RESOLVED.get_or_init(|| plan))
+        }
+    }
+
+    fn from_env_uncached() -> Result<Self> {
         let q8 = Q8RuntimeFlags::from_env();
         Ok(Self {
             linear_accumulation_precision: diagnostic_linear_accumulation_precision()?,

--- a/src/inference/rope.rs
+++ b/src/inference/rope.rs
@@ -120,7 +120,7 @@ pub(super) fn apply_rope(
     head_count: usize,
     config: &LlamaModelConfig,
     rope_freqs: Option<&CpuTensor>,
-    name: impl Into<String>,
+    name: &str,
 ) -> Result<CpuTensor> {
     if head_count == 0 {
         return Err(BackendError::RuntimeShapeMismatch(
@@ -444,12 +444,15 @@ pub(super) struct RopeParams<'a> {
 pub(super) fn apply_rope_with_pairing(
     tensor: &CpuTensor,
     params: RopeParams<'_>,
-    name: impl Into<String>,
+    name: &str,
 ) -> Result<CpuTensor> {
-    let mut data = tensor.data.clone();
+    // Pooled copy of the input, bit-identical to `tensor.data.clone()` (RoPE
+    // rewrites the rope dims in place and leaves the rest as copied).
+    let mut data = super::decode_scratch::take(tensor.data.len());
+    data.copy_from_slice(&tensor.data);
     apply_rope_to_row(&mut data, params.position, params);
 
-    CpuTensor::from_f32(name, tensor.shape.dims.clone(), data)
+    super::decode_scratch::tensor_from_pooled(name, &tensor.shape.dims, data)
 }
 
 fn apply_rope_to_row(data: &mut [f32], position: usize, mut params: RopeParams<'_>) {

--- a/src/inference/rope.rs
+++ b/src/inference/rope.rs
@@ -87,6 +87,23 @@ pub fn diagnostic_rope_pairing() -> Result<RopePairing> {
 }
 
 pub fn diagnostic_rope_direction() -> Result<RopeDirection> {
+    // Resolved once per process (non-test): `apply_rope` consults this per
+    // call on the decode hot loop, and env reads allocate on Windows. Invalid
+    // values stay uncached (the error re-reads; it aborts the forward anyway).
+    #[cfg(not(test))]
+    {
+        static RESOLVED: std::sync::OnceLock<RopeDirection> = std::sync::OnceLock::new();
+        if let Some(direction) = RESOLVED.get() {
+            return Ok(*direction);
+        }
+        let direction = diagnostic_rope_direction_uncached()?;
+        Ok(*RESOLVED.get_or_init(|| direction))
+    }
+    #[cfg(test)]
+    diagnostic_rope_direction_uncached()
+}
+
+fn diagnostic_rope_direction_uncached() -> Result<RopeDirection> {
     match env::var("CAMELID_ROPE_DIRECTION") {
         Ok(value) if value == "inverse" => Ok(RopeDirection::Inverse),
         Ok(value) if value == "forward" || value.is_empty() => Ok(RopeDirection::Forward),
@@ -101,6 +118,20 @@ pub fn diagnostic_rope_direction() -> Result<RopeDirection> {
 }
 
 pub fn diagnostic_rope_position_mode() -> Result<RopePositionMode> {
+    #[cfg(not(test))]
+    {
+        static RESOLVED: std::sync::OnceLock<RopePositionMode> = std::sync::OnceLock::new();
+        if let Some(mode) = RESOLVED.get() {
+            return Ok(*mode);
+        }
+        let mode = diagnostic_rope_position_mode_uncached()?;
+        Ok(*RESOLVED.get_or_init(|| mode))
+    }
+    #[cfg(test)]
+    diagnostic_rope_position_mode_uncached()
+}
+
+fn diagnostic_rope_position_mode_uncached() -> Result<RopePositionMode> {
     match env::var("CAMELID_ROPE_POSITION_MODE") {
         Ok(value) if value == "one_based" => Ok(RopePositionMode::OneBased),
         Ok(value) if value == "zero_based" || value.is_empty() => Ok(RopePositionMode::ZeroBased),

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -6762,10 +6762,10 @@ fn q8_0_encoded_row_matches_decoded_scale_helper() {
         quants: std::array::from_fn(|idx| idx as i8 - 12),
     };
     let input = QuantizedQ8_0Row {
-        blocks: vec![Q8_0Block {
+        blocks: PooledQ8Blocks(vec![Q8_0Block {
             scale: f16_bits_to_f32(f32_to_f16_bits(0.25)),
             quants: std::array::from_fn(|idx| 15 - idx as i8),
-        }],
+        }]),
     };
     let mut row_bytes = Vec::with_capacity(Q8BlockReader::BLOCK_SIZE_BYTES);
     row_bytes.extend_from_slice(&f32_to_f16_bits(row.scale).to_le_bytes());

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -8388,6 +8388,96 @@ fn output_projection_diagnostics_support_loader_packed_and_retained_block_rows()
     }
 }
 
+/// The zero-clone borrowed block-dot path must be bitwise-identical to the
+/// cloning path it replaces (`linear_weight_reinterpreted_as_transposed` +
+/// tensor block-dot), for both weight forms the swap can present: retained
+/// blocks only, and runtime packed rows4 that survives the orientation swap.
+#[test]
+fn borrowed_q8_0_block_dot_matches_cloned_swapped_tensor_path() {
+    let _env_guard = env_lock();
+    let input_width = 64usize; // 2 Q8_0 blocks per weight row
+    let output_width = 8usize;
+    let blocks_per_row = input_width / Q8_0_BLOCK_VALUES;
+    let weight_blocks: Vec<Q8_0Block> = (0..output_width * blocks_per_row)
+        .map(|row| Q8_0Block {
+            scale: f16_bits_to_f32(f32_to_f16_bits(0.03 + row as f32 * 0.011)),
+            quants: std::array::from_fn(|idx| ((row * 31 + idx * 7) % 251) as i8),
+        })
+        .collect();
+    let input_data: Vec<f32> = (0..input_width)
+        .map(|i| (((i % 89) as f32) - 44.0) * 0.017)
+        .collect();
+    let input =
+        CpuTensor::from_f32("borrowed_dot_probe", vec![1, input_width], input_data).unwrap();
+
+    // GGUF orientation [input_width, output_width]: rows == input width, so the
+    // linear chain reinterprets by swapping the matrix shape.
+    let make_weight = || {
+        CpuTensor::q8_0_runtime_packed_rows4_linear(
+            "blk.0.ffn_down.weight",
+            TensorShape {
+                dims: vec![input_width, output_width],
+            },
+            Q8_0PackedRows4::from_rows(
+                output_width,
+                blocks_per_row,
+                Q8_0PackedRows4Interleave::I8,
+                &weight_blocks,
+            )
+            .unwrap(),
+        )
+    };
+    // Form 1: retained blocks only. Form 2: runtime packed rows4 that matches
+    // the swapped orientation (kept across the swap by both paths).
+    let mut blocks_weight = make_weight();
+    blocks_weight.q8_0_runtime_storage = None;
+    blocks_weight.q8_0_blocks = Some(weight_blocks.clone());
+    let packed_weight = make_weight();
+
+    let runtime_plan = ResolvedRuntimePlan::from_env().expect("plan");
+    for (label, weight) in [
+        ("blocks", &blocks_weight),
+        ("runtime_packed", &packed_weight),
+    ] {
+        let cloned =
+            linear_weight_reinterpreted_as_transposed(weight, input_width).expect("reinterpret");
+        assert!(
+            should_use_q8_0_block_dot_with_plan(&cloned, input_width, &runtime_plan),
+            "{label}: cloned path must route to block-dot for this probe"
+        );
+        let expected = matmul_rhs_transposed_q8_0_block_dot_with_plan(
+            &input,
+            &cloned,
+            "borrowed_dot_out",
+            &runtime_plan,
+        )
+        .expect("cloned kernel");
+
+        let borrowed =
+            borrowed_linear_weight_as_transposed(weight, input_width).expect("borrowed view");
+        assert!(
+            should_use_borrowed_q8_0_block_dot_with_plan(borrowed, input_width, &runtime_plan),
+            "{label}: borrowed predicate must match the cloned predicate"
+        );
+        let actual = matmul_rhs_transposed_q8_0_block_dot_borrowed_with_plan(
+            &input,
+            borrowed,
+            "borrowed_dot_out",
+            &runtime_plan,
+        )
+        .expect("borrowed kernel");
+
+        assert_eq!(expected.shape.dims, actual.shape.dims, "{label}");
+        for (idx, (a, b)) in expected.data.iter().zip(actual.data.iter()).enumerate() {
+            assert_eq!(
+                a.to_bits(),
+                b.to_bits(),
+                "{label}: divergence at output {idx}: {a} vs {b}"
+            );
+        }
+    }
+}
+
 #[test]
 fn output_projection_diagnostics_reject_q8_0_file_backed_unaligned_rows_before_read() {
     let _env_guard = env_lock();

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -792,6 +792,7 @@ fn tiny_prefill_schedule_weights(attention_q: CpuTensor) -> LlamaLoadedWeights {
         output: None,
         rope_freqs: None,
         layer_range: None,
+        output_projection_binding: DecodeBindingCell::default(),
         layers: vec![LlamaLayerWeights {
             attention_norm: CpuTensor::from_f32("blk.0.attn_norm.weight", vec![2], vec![1.0; 2])
                 .unwrap(),
@@ -815,6 +816,7 @@ fn tiny_prefill_schedule_weights(attention_q: CpuTensor) -> LlamaLoadedWeights {
             attention_q_norm: None,
             attention_k_norm: None,
             moe_router: None,
+            decode_bindings: DecodeLinearBindings::default(),
         }],
     }
 }
@@ -1158,6 +1160,7 @@ fn prefill_layer_major_scoped_q8_cache_reuses_file_reads_across_chunks() {
         output: None,
         rope_freqs: None,
         layer_range: None,
+        output_projection_binding: DecodeBindingCell::default(),
         layers: vec![LlamaLayerWeights {
             attention_norm: dense_vector("blk.0.attn_norm.weight"),
             attention_q,
@@ -1171,6 +1174,7 @@ fn prefill_layer_major_scoped_q8_cache_reuses_file_reads_across_chunks() {
             ffn_up: dense_matrix("blk.0.ffn_up.weight"),
             ffn_down: dense_matrix("blk.0.ffn_down.weight"),
             moe_router: None,
+            decode_bindings: DecodeLinearBindings::default(),
         }],
     };
     let mut session = LlamaInferenceSession::new(config, weights).unwrap();
@@ -8290,7 +8294,7 @@ fn output_projection_diagnostics_support_runtime_packed_tied_output_rows() {
 /// The CPU repack execution plan retains the output projection as loader-packed rows
 /// (`q8_0_packed_rows4_4x8`) or plain retained blocks (`q8_0_blocks`) with no dense
 /// values, no file backing, and no runtime storage. Dense diagnostics used to 503 on
-/// these ("... with 0 values") — both storages must now decode token rows.
+/// these ("... with 0 values") â€” both storages must now decode token rows.
 #[test]
 fn output_projection_diagnostics_support_loader_packed_and_retained_block_rows() {
     let _env_guard = env_lock();
@@ -9601,8 +9605,10 @@ fn single_token_forward_diagnostics_follow_llama_stage_order() {
             attention_q_norm: None,
             attention_k_norm: None,
             moe_router: None,
+            decode_bindings: DecodeLinearBindings::default(),
         }],
         layer_range: None,
+        output_projection_binding: DecodeBindingCell::default(),
     });
     let mut session = LlamaInferenceSession::new(config, weights).unwrap();
 
@@ -9860,8 +9866,10 @@ fn chunked_prefill_matches_sequential_prefill_outputs_and_cache() {
             attention_q_norm: None,
             attention_k_norm: None,
             moe_router: None,
+            decode_bindings: DecodeLinearBindings::default(),
         }],
         layer_range: None,
+        output_projection_binding: DecodeBindingCell::default(),
     });
 
     let prompt = [0, 1, 2, 3, 0, 1, 2];
@@ -10053,6 +10061,7 @@ fn prefill_layer_rejects_misaligned_kv_cache_cursor() {
         attention_q_norm: None,
         attention_k_norm: None,
         moe_router: None,
+        decode_bindings: DecodeLinearBindings::default(),
     };
     let hidden = CpuTensor::from_f32("hidden", vec![2, 2], vec![0.1, 0.2, 0.3, 0.4]).unwrap();
     let plan = LlamaKvCachePlan::from_config(&config).unwrap();
@@ -10318,8 +10327,10 @@ fn zero_prefill_chunk_env_falls_back_without_panicking() {
             attention_q_norm: None,
             attention_k_norm: None,
             moe_router: None,
+            decode_bindings: DecodeLinearBindings::default(),
         }],
         layer_range: None,
+        output_projection_binding: DecodeBindingCell::default(),
     });
 
     std::env::set_var("CAMELID_PREFILL_CHUNK_TOKENS", "0");
@@ -10968,6 +10979,7 @@ fn q8_0_residency_report_counts_resident_blocks_and_flags_file_backed() {
         rope_freqs: None,
         layers: Vec::new(),
         layer_range: None,
+        output_projection_binding: DecodeBindingCell::default(),
     };
 
     let report = weights.q8_0_residency_report();
@@ -11040,7 +11052,7 @@ fn resident_prefill_rope_tables_match_per_position_builder() {
 }
 
 /// Q4_0 wire dot: the scalar and NEON paths must agree bit-exactly with each
-/// other and track a plain f32 dequant·f32 reference closely (the integer dot
+/// other and track a plain f32 dequantÂ·f32 reference closely (the integer dot
 /// is exact per block; only the per-block f32 scale accumulate rounds).
 #[test]
 fn q4_0_wire_row_dot_scalar_matches_dequant_reference() {
@@ -11073,7 +11085,7 @@ fn q4_0_wire_row_dot_scalar_matches_dequant_reference() {
         .collect();
     let xq = super::quantize_q8_0_blocks(&activation);
 
-    // Reference: dequantized weights × dequantized activation, block-sequential.
+    // Reference: dequantized weights Ã— dequantized activation, block-sequential.
     let mut reference = 0f32;
     for (b, xb) in xq.iter().enumerate() {
         let mut isum = 0i32;
@@ -11241,7 +11253,7 @@ fn q6_k_wire_dot_consistent_with_dequant() {
 }
 
 /// Phase-2 follow-up parity gate: the opt-in AVX2 Q6_K row dot must be BIT-IDENTICAL
-/// to the 8-lane scalar oracle `q6_k_wire_row_dot` (not merely close) — it vectorizes
+/// to the 8-lane scalar oracle `q6_k_wire_row_dot` (not merely close) â€” it vectorizes
 /// only the associative integer dot and reproduces the same 8-lane f32 reduction. This
 /// is the proof obligation that lets `CAMELID_X86_Q6K_AVX2` ship without a parity risk.
 #[cfg(target_arch = "x86_64")]
@@ -11432,7 +11444,7 @@ fn perf_q4_q8_q6_dot() {
 
 /// Build a 1-layer `LlamaLoadedWeights` for the CUDA arch-guard test, with per-head
 /// QK-norm tensors present (`qk_norm = true`, i.e. a Qwen3-shaped row) or absent
-/// (`false`, a plain Llama row). All other tensors are trivial 2×2 placeholders; the
+/// (`false`, a plain Llama row). All other tensors are trivial 2Ã—2 placeholders; the
 /// guard only inspects `attention_q_norm` / `attention_k_norm`.
 #[cfg(feature = "cuda")]
 fn minimal_weights_with_qk_norm(qk_norm: bool) -> LlamaLoadedWeights {
@@ -11453,6 +11465,7 @@ fn minimal_weights_with_qk_norm(qk_norm: bool) -> LlamaLoadedWeights {
         output: None,
         rope_freqs: None,
         layer_range: None,
+        output_projection_binding: DecodeBindingCell::default(),
         layers: vec![LlamaLayerWeights {
             attention_norm: t("blk.0.attn_norm.weight", vec![2], 2),
             attention_q: t("blk.0.attn_q.weight", vec![2, 2], 4),
@@ -11466,6 +11479,7 @@ fn minimal_weights_with_qk_norm(qk_norm: bool) -> LlamaLoadedWeights {
             ffn_up: t("blk.0.ffn_up.weight", vec![2, 2], 4),
             ffn_down: t("blk.0.ffn_down.weight", vec![2, 2], 4),
             moe_router: None,
+            decode_bindings: DecodeLinearBindings::default(),
         }],
     }
 }
@@ -11491,7 +11505,7 @@ fn cuda_resident_accepts_qwen3_qk_norm() {
 /// Item 2 bitwise lock: the decode attention head-parallel lane is a
 /// scheduling-only change, so its full attention output must be bit-identical
 /// to the serial loop for every GQA shape, head_dim, position count, dot
-/// lane, and random content — and identical across repeated parallel runs.
+/// lane, and random content â€” and identical across repeated parallel runs.
 #[test]
 fn decode_attention_parallel_lane_is_bitwise_identical_to_serial() {
     struct XorShift64Star(u64);
@@ -11684,7 +11698,7 @@ fn decode_attention_parallel_lane_is_bitwise_identical_to_serial() {
 }
 
 /// Item 3 Lane A bitwise lock: the head-major KV layout is address math only.
-/// (KV content magnitudes cap below the f16 finite max — the real write path
+/// (KV content magnitudes cap below the f16 finite max â€” the real write path
 /// f16-rounds every stored element, on main too, and inf KV rejects softmax.)
 /// For every GQA shape, head_dim, and position count: build one cache per
 /// layout, drive them through the REAL write paths (write_kv_cache /
@@ -11715,7 +11729,7 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
                 5 => unit * 1e4,
                 // Cap below the f16 finite max (65504): the REAL write path
                 // rounds every stored element through f16, so bigger inputs
-                // become ±inf in the cache (true on main too) and inf KV
+                // become Â±inf in the cache (true on main too) and inf KV
                 // makes softmax reject the row.
                 _ => unit * 6e4,
             }
@@ -11939,7 +11953,7 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
                             // Lane B: f16 storage under the blocked lane must
                             // be bitwise-equal to f32 storage under the
                             // blocked lane, in both layouts (the values are
-                            // identical — the write path always rounded — and
+                            // identical â€” the write path always rounded â€” and
                             // the fused kernel is expand-then-blocked).
                             if use_blocked {
                                 let mut out_pm16 = vec![0.0f32; head_dim];
@@ -12010,4 +12024,132 @@ fn kv_head_major_layout_is_bitwise_identical_to_position_major() {
         "KV layout/dtype lanes diverged from the position-major f32 reference in \
          {mismatches} element(s)"
     );
+}
+
+/// Items 4+5 P1.1 binder equivalence: for EVERY projection weight of a real
+/// loaded 3B model, across runtime-plan flag combinations, (a) the recording
+/// cascade selects a stable arm across repeated fresh runs, (b) the bound
+/// fast path replays that arm without rebinding, and (c) bound and cascade
+/// outputs are bitwise-identical. Skips when the 3B GGUF is absent (CI).
+#[test]
+fn decode_linear_binder_matches_cascade_on_real_3b_weights() {
+    let model = std::env::var("CAMELID_3B_GGUF").unwrap_or_else(|_| {
+        r"C:\Users\timto\Camelid\models\Llama-3.2-3B-Instruct-Q8_0.gguf".to_string()
+    });
+    let model = std::path::PathBuf::from(model);
+    if !model.exists() {
+        eprintln!("skipping: 3B GGUF not present at {}", model.display());
+        return;
+    }
+    let gguf = crate::gguf::read_metadata(&model).expect("metadata");
+    let config = crate::model::LlamaModelConfig::from_gguf(&gguf).expect("config");
+    let binding = crate::model::LlamaTensorBinding::bind(&gguf, &config).expect("binding");
+    let store = crate::tensor::TensorStore::open(&model, &gguf);
+    let weights = LlamaLoadedWeights::load(&store, &binding, None).expect("weights");
+
+    let hidden = config.embedding_length as usize;
+    let ffn = config.feed_forward_length as usize;
+    let fill = |width: usize, scale: f32| -> CpuTensor {
+        let data: Vec<f32> = (0..width)
+            .map(|i| (((i % 97) as f32) - 48.0) * scale)
+            .collect();
+        CpuTensor::from_f32("binder_probe", vec![1, width], data).unwrap()
+    };
+
+    let base_plan = ResolvedRuntimePlan::from_env().expect("plan");
+    let mut packed_on = base_plan;
+    packed_on.q8.attention_output_packed_rows4_matmul = true;
+    packed_on.q8.ffn_down_packed_rows4_matmul = true;
+    packed_on.q8_packed_rows4_matmul_schedule =
+        Q8PackedRows4MatmulSchedule::from_q8_flags(packed_on.q8);
+    let mut consumers_on = packed_on;
+    consumers_on.q8.attention_output_decode_consumer = true;
+    consumers_on.q8.attention_projection_decode_consumer = true;
+    consumers_on.q8.ffn_down_decode_consumer = true;
+    consumers_on.q8_packed_rows4_matmul_schedule =
+        Q8PackedRows4MatmulSchedule::from_q8_flags(consumers_on.q8);
+    let plans = [
+        ("default", base_plan),
+        ("packed", packed_on),
+        ("consumers", consumers_on),
+    ];
+
+    let mut checked = 0usize;
+    for (plan_name, plan) in &plans {
+        for (layer_idx, layer) in weights.layers.iter().enumerate() {
+            let slots: [(&CpuTensor, &str, usize); 5] = [
+                (&layer.attention_q, "linear", hidden),
+                (&layer.attention_k, "attention_k", hidden),
+                (&layer.attention_v, "attention_v", hidden),
+                (&layer.attention_output, "linear", hidden),
+                (&layer.ffn_down, "ffn_down", ffn),
+            ];
+            for (slot_idx, (weight, role, width)) in slots.iter().enumerate() {
+                let input = fill(*width, 0.001 + slot_idx as f32 * 1e-4);
+                let cell_a = DecodeBindingCell::default();
+                let out_a = decode_linear_cascade(
+                    &input,
+                    weight,
+                    format!("binder_a_{layer_idx}_{slot_idx}"),
+                    role,
+                    plan,
+                    Some(&cell_a),
+                )
+                .expect("cascade a");
+                let arm_a = cell_a.load();
+                let cell_b = DecodeBindingCell::default();
+                let out_b = decode_linear_cascade(
+                    &input,
+                    weight,
+                    format!("binder_b_{layer_idx}_{slot_idx}"),
+                    role,
+                    plan,
+                    Some(&cell_b),
+                )
+                .expect("cascade b");
+                assert_eq!(
+                    arm_a,
+                    cell_b.load(),
+                    "unstable arm: plan {plan_name} layer {layer_idx} slot {slot_idx}"
+                );
+                let bound = linear_for_role_bound(
+                    &input,
+                    weight,
+                    format!("binder_c_{layer_idx}_{slot_idx}"),
+                    role,
+                    plan,
+                    false,
+                    &cell_a,
+                )
+                .expect("bound replay");
+                assert_eq!(
+                    arm_a,
+                    cell_a.load(),
+                    "bound path rebound: plan {plan_name} layer {layer_idx} slot {slot_idx}"
+                );
+                assert_eq!(out_a.data.len(), out_b.data.len());
+                assert_eq!(out_a.data.len(), bound.data.len());
+                for (i, ((a, b), c)) in out_a
+                    .data
+                    .iter()
+                    .zip(&out_b.data)
+                    .zip(&bound.data)
+                    .enumerate()
+                {
+                    assert_eq!(
+                        a.to_bits(),
+                        b.to_bits(),
+                        "cascade nondeterminism at {plan_name}/{layer_idx}/{slot_idx}/{i}"
+                    );
+                    assert_eq!(
+                        a.to_bits(),
+                        c.to_bits(),
+                        "bound output diverged at {plan_name}/{layer_idx}/{slot_idx}/{i}"
+                    );
+                }
+                checked += 1;
+            }
+        }
+    }
+    eprintln!("binder equivalence: {checked} (weight x plan) combinations checked, 0 mismatches");
 }

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -888,6 +888,42 @@ fn resolve_prefill_thread_count_widens_only_on_measured_default() {
 }
 
 #[test]
+fn resolve_decode_thread_count_defaults_off_and_prefers_explicit_width() {
+    // Neither flag: no decode pool — decode stays inline (the default path).
+    assert_eq!(resolve_decode_thread_count_from(None, false, 16), None);
+    // Explicit width wins.
+    assert_eq!(
+        resolve_decode_thread_count_from(Some("4"), false, 16),
+        Some(4)
+    );
+    assert_eq!(
+        resolve_decode_thread_count_from(Some(" 6 "), true, 16),
+        Some(6)
+    );
+    // 0/off/empty/invalid fall through to the dedicated check.
+    assert_eq!(resolve_decode_thread_count_from(Some("0"), false, 16), None);
+    assert_eq!(
+        resolve_decode_thread_count_from(Some("off"), false, 16),
+        None
+    );
+    assert_eq!(resolve_decode_thread_count_from(Some(""), false, 16), None);
+    assert_eq!(
+        resolve_decode_thread_count_from(Some("abc"), false, 16),
+        None
+    );
+    assert_eq!(
+        resolve_decode_thread_count_from(Some("0"), true, 16),
+        Some(16)
+    );
+    assert_eq!(
+        resolve_decode_thread_count_from(Some("abc"), true, 16),
+        Some(16)
+    );
+    // Dedicated alone isolates at the global width.
+    assert_eq!(resolve_decode_thread_count_from(None, true, 12), Some(12));
+}
+
+#[test]
 fn prefill_layer_major_chunk_token_count_has_separate_headroom_default() {
     let _env_guard = env_lock();
     std::env::remove_var("CAMELID_PREFILL_CHUNK_TOKENS");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "alloc-gate")]
+pub mod alloc_gate;
 pub mod api;
 pub mod capability;
 pub mod catalog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -677,6 +677,31 @@ enum Command {
         #[arg(long)]
         threads: Option<usize>,
     },
+    /// Hidden: decode zero-alloc gate — decode real tokens through a loaded
+    /// model under the counting global allocator and report steady-state heap
+    /// allocations per token. Requires `--features alloc-gate`.
+    #[cfg(feature = "alloc-gate")]
+    #[command(hide = true)]
+    BenchAllocGate {
+        /// GGUF model to decode.
+        #[arg(long)]
+        model: std::path::PathBuf,
+        /// Unmeasured tokens to warm pools, binding cells, and KV growth.
+        #[arg(long, default_value_t = 8)]
+        warmup: usize,
+        /// Measured steady-state tokens.
+        #[arg(long, default_value_t = 32)]
+        tokens: usize,
+        /// Skip the final norm + logits projection (attribution mode).
+        #[arg(long, default_value_t = false)]
+        skip_logits: bool,
+        /// Print backtraces for the first few >=1MiB steady-state allocations.
+        #[arg(long, default_value_t = false)]
+        trace_big: bool,
+        /// Fail (non-zero exit) if allocations per token exceed this.
+        #[arg(long)]
+        max_per_token: Option<f64>,
+    },
     /// Hidden: micro-benchmark rayon fork-join region overhead on the global
     /// pool (hot = back-to-back regions; cold = workers idle between regions).
     #[command(hide = true)]
@@ -1661,6 +1686,35 @@ async fn main() -> anyhow::Result<()> {
             configure_rayon_threads(threads)?;
             let report = bench_dense_hotloops(hidden, ffn, repeats, warmup)?;
             println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        #[cfg(feature = "alloc-gate")]
+        Command::BenchAllocGate {
+            model,
+            warmup,
+            tokens,
+            skip_logits,
+            trace_big,
+            max_per_token,
+        } => {
+            let report = camelid::alloc_gate::run_decode_alloc_gate(
+                &model,
+                warmup,
+                tokens,
+                !skip_logits,
+                trace_big,
+            )?;
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            if let Some(max_per_token) = max_per_token {
+                let per_token = report["allocations_per_token"]
+                    .as_f64()
+                    .expect("report always carries allocations_per_token");
+                if per_token > max_per_token {
+                    anyhow::bail!(
+                        "decode alloc gate FAILED: {per_token} allocations/token exceeds the \
+                         allowed {max_per_token}"
+                    );
+                }
+            }
         }
         Command::BenchRayonRegion {
             iterations,

--- a/src/main.rs
+++ b/src/main.rs
@@ -677,6 +677,20 @@ enum Command {
         #[arg(long)]
         threads: Option<usize>,
     },
+    /// Hidden: micro-benchmark rayon fork-join region overhead on the global
+    /// pool (hot = back-to-back regions; cold = workers idle between regions).
+    #[command(hide = true)]
+    BenchRayonRegion {
+        /// Measured regions per point.
+        #[arg(long, default_value_t = 10_000)]
+        iterations: usize,
+        /// Idle time between regions in microseconds (0 = hot).
+        #[arg(long, default_value_t = 0)]
+        idle_us: u64,
+        /// Override Rayon worker threads.
+        #[arg(long)]
+        threads: Option<usize>,
+    },
     /// Hidden: hot-cache micro-benchmark of the attention f32 dot kernels
     /// (legacy scalar chain vs canonical blocked scalar vs blocked AVX2/FMA).
     #[command(hide = true)]
@@ -1647,6 +1661,22 @@ async fn main() -> anyhow::Result<()> {
             configure_rayon_threads(threads)?;
             let report = bench_dense_hotloops(hidden, ffn, repeats, warmup)?;
             println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        Command::BenchRayonRegion {
+            iterations,
+            idle_us,
+            threads,
+        } => {
+            configure_rayon_threads(threads)?;
+            let us_per_region = camelid::inference::rayon_region_microbench(iterations, idle_us);
+            let record = serde_json::json!({
+                "schema": "camelid.bench-rayon-region/v1",
+                "threads": rayon::current_num_threads(),
+                "iterations": iterations,
+                "idle_us_between": idle_us,
+                "us_per_region": us_per_region,
+            });
+            println!("{}", serde_json::to_string(&record)?);
         }
         Command::BenchAttnDot {
             lens,

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1215,12 +1215,12 @@ impl Q8_0TensorBlocks {
 }
 
 impl CpuTensor {
-    /// Decompose into the owned name and f32 data buffer so the decode
-    /// scratch pool can recycle both. Only meaningful for plain-F32 tensors;
-    /// quantized side-storage (never present on decode intermediates) is
-    /// dropped.
-    pub(crate) fn into_parts(self) -> (String, Vec<f32>) {
-        (self.name, self.data)
+    /// Decompose into the owned name, dims, and f32 data buffer so the
+    /// decode scratch pool can recycle all three. Only meaningful for
+    /// plain-F32 tensors; quantized side-storage (never present on decode
+    /// intermediates) is dropped.
+    pub(crate) fn into_parts(self) -> (String, Vec<usize>, Vec<f32>) {
+        (self.name, self.shape.dims, self.data)
     }
 
     pub fn from_f32(name: impl Into<String>, dims: Vec<usize>, data: Vec<f32>) -> Result<Self> {

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1649,14 +1649,23 @@ impl CpuTensor {
     }
 
     pub fn add(&self, rhs: &Self, name: impl Into<String>) -> Result<Self> {
+        let mut out = vec![0.0; self.data.len()];
+        self.add_into(rhs, &mut out)?;
+        Self::from_f32(name, self.shape.dims.clone(), out)
+    }
+
+    /// The exact kernel of [`Self::add`], writing into a caller-provided
+    /// buffer (same length as `self.data`). Shared by the allocating path
+    /// above and the decode scratch-pool path so both are one numeric path.
+    pub(crate) fn add_into(&self, rhs: &Self, out: &mut [f32]) -> Result<()> {
         if self.shape != rhs.shape {
             return Err(BackendError::RuntimeShapeMismatch(format!(
                 "shape mismatch: lhs {:?}, rhs {:?}",
                 self.shape.dims, rhs.shape.dims
             )));
         }
-        let mut out = vec![0.0; self.data.len()];
         let len = self.data.len();
+        debug_assert_eq!(out.len(), len);
         if should_parallelize_linear_output(len) {
             out.par_iter_mut()
                 .zip(self.data.par_iter())
@@ -1690,7 +1699,7 @@ impl CpuTensor {
                 }
             }
         }
-        Self::from_f32(name, self.shape.dims.clone(), out)
+        Ok(())
     }
 
     pub fn mul(&self, rhs: &Self, name: impl Into<String>) -> Result<Self> {
@@ -1826,6 +1835,16 @@ impl CpuTensor {
     }
 
     pub fn rms_norm(&self, weight: &Self, eps: f32, name: impl Into<String>) -> Result<Self> {
+        let mut out = vec![0.0; self.data.len()];
+        self.rms_norm_into(weight, eps, &mut out)?;
+        Self::from_f32(name, self.shape.dims.clone(), out)
+    }
+
+    /// The exact kernel of [`Self::rms_norm`], writing into a caller-provided
+    /// buffer (same length as `self.data`). Shared by the allocating path
+    /// above and the decode scratch-pool path so both are one numeric path
+    /// (same reduction order, same parallel split).
+    pub(crate) fn rms_norm_into(&self, weight: &Self, eps: f32, out: &mut [f32]) -> Result<()> {
         require_rank(self, 2, "rms_norm input")?;
         require_rank(weight, 1, "rms_norm weight")?;
         let rows = self.dim(0)?;
@@ -1836,7 +1855,7 @@ impl CpuTensor {
                 weight.shape.dims, self.shape.dims
             )));
         }
-        let mut out = vec![0.0; self.data.len()];
+        debug_assert_eq!(out.len(), self.data.len());
 
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
@@ -1884,7 +1903,7 @@ impl CpuTensor {
             }
         }
 
-        Self::from_f32(name, self.shape.dims.clone(), out)
+        Ok(())
     }
 
     /// Per-head RMSNorm (Qwen3 QK-norm). Treats each row of this `[rows, cols]`

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -3260,21 +3260,46 @@ pub(crate) fn should_parallelize_linear_output(output_width: usize) -> bool {
 }
 
 fn parallel_linear_enabled() -> bool {
-    match env::var("CAMELID_PARALLEL_LINEAR") {
-        Ok(value) => matches!(
-            value.trim().to_ascii_lowercase().as_str(),
-            "1" | "true" | "on" | "yes" | "enabled"
-        ),
-        Err(_) => false,
+    // Read once per process (non-test): `should_parallelize_linear_output`
+    // runs on every elementwise/matmul call in the decode hot loop, and env
+    // reads allocate on Windows. Tests keep the uncached read.
+    fn uncached() -> bool {
+        match env::var("CAMELID_PARALLEL_LINEAR") {
+            Ok(value) => matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "on" | "yes" | "enabled"
+            ),
+            Err(_) => false,
+        }
+    }
+    #[cfg(test)]
+    {
+        uncached()
+    }
+    #[cfg(not(test))]
+    {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(uncached)
     }
 }
 
 fn parallel_linear_min_outputs() -> usize {
-    env::var("CAMELID_PARALLEL_LINEAR_MIN_OUTPUTS")
-        .ok()
-        .and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_PARALLEL_LINEAR_MIN_OUTPUTS)
+    fn uncached() -> usize {
+        env::var("CAMELID_PARALLEL_LINEAR_MIN_OUTPUTS")
+            .ok()
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_PARALLEL_LINEAR_MIN_OUTPUTS)
+    }
+    #[cfg(test)]
+    {
+        uncached()
+    }
+    #[cfg(not(test))]
+    {
+        static MIN_OUTPUTS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+        *MIN_OUTPUTS.get_or_init(uncached)
+    }
 }
 
 pub struct TensorStore {

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1215,6 +1215,14 @@ impl Q8_0TensorBlocks {
 }
 
 impl CpuTensor {
+    /// Decompose into the owned name and f32 data buffer so the decode
+    /// scratch pool can recycle both. Only meaningful for plain-F32 tensors;
+    /// quantized side-storage (never present on decode intermediates) is
+    /// dropped.
+    pub(crate) fn into_parts(self) -> (String, Vec<f32>) {
+        (self.name, self.data)
+    }
+
     pub fn from_f32(name: impl Into<String>, dims: Vec<usize>, data: Vec<f32>) -> Result<Self> {
         let shape = TensorShape { dims };
         let expected = shape.element_count()?;

--- a/tests/inference_session.rs
+++ b/tests/inference_session.rs
@@ -606,8 +606,10 @@ fn tiny_weights() -> LlamaLoadedWeights {
             attention_q_norm: None,
             attention_k_norm: None,
             moe_router: None,
+            decode_bindings: camelid::inference::DecodeLinearBindings::default(),
         }],
         layer_range: None,
+        output_projection_binding: camelid::inference::DecodeBindingCell::default(),
     }
 }
 


### PR DESCRIPTION
## Items 4+5: decode scheduling + hot-loop strip (conductor campaign)

Two lanes, receipts sealed on the dev box (SHA256 manifests in
`target/decode-sched-{diag,exit,p2,p4}-*`).

### Lane B (Item 5) — structural hot-loop strip, bitwise-gated per commit
- Per-weight-slot lazy kernel binding (420 weight-x-plan combos bitwise-equal to the cascade, 0 mismatches)
- Cached per-layer op labels; per-stage timing probes gated behind `BACKENDINFERENCE_DECODE_TIMINGS` (default on; measured cost 0.0%)
- Decode scratch pools: all per-op outputs, Q8 quantize blocks, rope buffers, layer-end recycling
- **Killed a 28 MB `Vec<Q8_0Block>` clone per layer per token** (~784 MB/token of memcpy in the shape-swapped ffn_down fallback), replaced by a borrowed view over the same kernel, pinned bitwise by a dedicated test
- OnceLock-cached 12 per-call env readers (Windows `env::var` allocates even on a miss; the worst was ~7,000 allocations/token)
- Steady-state decode: **9,369 -> 277 allocations/token, 797 MB -> 1.5 MB/token**, measured by the new feature-gated `bench-alloc-gate` counting-allocator harness
- Identity vs pre-strip base: **11/11 token-identical** (3B hello 1/5/50, TinyLlama five prompts, 2048 A/B pairs, serve completion)
- Honest wall-clock: **-1.3% decode @default-8T, -0.6% @4T** (the clone was allocator-huge but hidden behind DRAM-bound dots)

### Lane A (Item 4) — decode scheduling flags, default off
- `BACKENDINFERENCE_DECODE_THREADS=N` (dedicated decode pool) and `BACKENDINFERENCE_DECODE_POOL_DEDICATED=1` (isolation at global width), mirroring the prefill pool; default path byte-identical
- Width sweep on the stripped loop (identity 14/14): **peak at width 6** both depths (7.752 tok/s @512 / 7.155 @2048; 16T = 6.445/6.003)
- Serve A/B: POOL_DEDICATED -4.5% wall, DECODE_THREADS=6 -7.1%
- Spin pool (Phase 3) **not built**: region tax 1.6-2.2% @16T, ~0.5% @6T, under the >=5% entry bar

### Composed campaign A/B (all-defaults main-equivalent vs all lanes + width-6 policy)
| depth | base tok/s | composed tok/s | speedup |
|---|---|---|---|
| 512 | 4.777 | 7.799 | 1.633x |
| 2048 | 2.145 | 7.153 | 3.335x |
| 8192 | host-limited | 5.058 (6.13 GB peak) | enabled |

No default flips in this PR; everything ships behind flags except the strip
itself, which is bitwise-gated. Gates: fmt + clippy --all-targets
--all-features -D warnings clean; targeted bitwise suites green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)