### PR TITLE
feat(defaults): promote bitwise-proven lanes on Windows x86_64

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -600,3 +600,24 @@ Consequences, recorded as binding context for future parity claims:
 Receipts: `target/kv-lanes-baseline-20260701T180113/`,
 `target/kv-lanes-ab-20260701T185422/`, `target/kv-lanes-ab2-20260701T195346/`
 (SHA256-sealed, dev box) and the PR #359 description.
+
+
+## D13 - Decode thread-width policy: detected physical cores, never SMT logical count (2026-07-02)
+
+**Decision:** on Windows x86_64, single-token decode runs by default on a dedicated
+rayon pool sized to the DETECTED physical core count (GetLogicalProcessorInformation,
+one RelationProcessorCore record per core). The SMT logical count is never used for
+decode. Detection failure, an operator-pinned global (CAMELID_THREADS), or a global
+already narrower than physical all fail closed to the previous inline-on-global
+behavior. `BACKENDINFERENCE_DECODE_THREADS=N` remains the explicit width override and
+`=0`/`=off` is the kill switch; `BACKENDINFERENCE_DECODE_POOL_DEDICATED=1` remains the
+isolate-at-global-width override.
+
+**Basis (receipts):** the Items-4/5 P2 sweep (`target/decode-sched-p2-20260702T011105/`,
+SHA256-sealed): decode tok/s is flat across widths 4-8 (within ~3%) and falls
+monotonically past the physical count (width 16 = -20% vs the plateau at depth 512,
+-19% at 2048); the serve-path A/B in the same receipt shows the dedicated-pool
+configuration at -4.5% wall and an explicit narrower width at -7.1%. This host's
+measured optimum (6) is deliberately NOT hardcoded: the portable, defensible policy is
+"physical, not logical"; per-host refinement of the exact width within the flat region
+is deferred to GAIT calibration.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4788,12 +4788,71 @@ fn decode_thread_pool() -> Option<&'static rayon::ThreadPool> {
     POOL.get_or_init(build_decode_thread_pool).as_ref()
 }
 
+/// Best-effort physical (not logical) core count on Windows, via
+/// `GetLogicalProcessorInformation` (one `RelationProcessorCore` record per
+/// physical core). The memory-bound decode matvec does not benefit from SMT
+/// siblings — oversubscribing logical cores adds memory-controller contention
+/// and measurably regresses decode (P2 sweep: 16 logical threads run ~20%
+/// slower than the 4–8 physical plateau). Returns `None` on any ambiguity;
+/// callers fail closed to existing behavior.
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+pub fn windows_physical_core_count() -> Option<usize> {
+    use windows_sys::Win32::System::SystemInformation::{
+        GetLogicalProcessorInformation, SYSTEM_LOGICAL_PROCESSOR_INFORMATION,
+    };
+    // RelationProcessorCore == 0 (LOGICAL_PROCESSOR_RELATIONSHIP); one such record
+    // per physical core.
+    const RELATION_PROCESSOR_CORE: i32 = 0;
+    unsafe {
+        let mut len: u32 = 0;
+        // First call sizes the buffer (expected to fail with ERROR_INSUFFICIENT_BUFFER).
+        GetLogicalProcessorInformation(std::ptr::null_mut(), &mut len);
+        if len == 0 {
+            return None;
+        }
+        let count = len as usize / std::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION>();
+        if count == 0 {
+            return None;
+        }
+        let mut buf: Vec<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> = Vec::with_capacity(count);
+        if GetLogicalProcessorInformation(buf.as_mut_ptr(), &mut len) == 0 {
+            return None;
+        }
+        buf.set_len(count);
+        let physical = buf
+            .iter()
+            .filter(|info| info.Relationship == RELATION_PROCESSOR_CORE)
+            .count();
+        (physical > 0).then_some(physical)
+    }
+}
+
 fn build_decode_thread_pool() -> Option<rayon::ThreadPool> {
     let global = rayon::current_num_threads();
+    // Promoted default policy (Windows x86_64): decode runs on a dedicated
+    // pool at the DETECTED PHYSICAL core count, never the SMT logical count.
+    // Fail-closed: no detection → no pool (pre-promotion behavior); an
+    // operator-pinned global (CAMELID_THREADS, mirroring the prefill pool's
+    // pinning contract) or a global already narrower than physical is never
+    // silently overridden. The per-host optimum is deferred to GAIT; only
+    // the physical-core policy ships, not this host's tuned width.
+    let default_physical = if env::var("CAMELID_THREADS").is_ok() {
+        None
+    } else {
+        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        {
+            windows_physical_core_count()
+        }
+        #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
+        {
+            None
+        }
+    };
     let target = resolve_decode_thread_count_from(
         env::var("BACKENDINFERENCE_DECODE_THREADS").ok().as_deref(),
         q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_DECODE_POOL_DEDICATED"),
         global,
+        default_physical,
     )?;
     match rayon::ThreadPoolBuilder::new()
         .num_threads(target)
@@ -4820,23 +4879,34 @@ fn build_decode_thread_pool() -> Option<rayon::ThreadPool> {
 /// * `spec` — raw `BACKENDINFERENCE_DECODE_THREADS` value, if present.
 /// * `dedicated` — `BACKENDINFERENCE_DECODE_POOL_DEDICATED` flag.
 /// * `global` — current global pool width (the no-resize isolation width).
+/// * `default_physical` — the promoted default policy input: detected
+///   physical core count, already `None` off-Windows, on detection failure,
+///   or when the operator pinned the global via `CAMELID_THREADS`.
 ///
-/// An explicit positive `spec` wins; `0`/`off`/empty/invalid fall through to
-/// the `dedicated` check (isolate at global width) and otherwise `None`.
+/// Precedence: an explicit positive `spec` wins; an explicit `0`/`off` is
+/// the kill switch and disables the pool entirely (including the default
+/// policy); otherwise `dedicated` isolates at the global width; otherwise
+/// the default policy builds a pool at the physical width — but never wider
+/// than the global pool (an operator who narrowed the global keeps it).
 fn resolve_decode_thread_count_from(
     spec: Option<&str>,
     dedicated: bool,
     global: usize,
+    default_physical: Option<usize>,
 ) -> Option<usize> {
     if let Some(spec) = spec {
         let trimmed = spec.trim();
-        if !trimmed.is_empty() && !trimmed.eq_ignore_ascii_case("off") && trimmed != "0" {
-            if let Some(count) = trimmed.parse::<usize>().ok().filter(|n| *n > 0) {
-                return Some(count);
-            }
+        if trimmed.eq_ignore_ascii_case("off") || trimmed == "0" {
+            return None;
+        }
+        if let Some(count) = trimmed.parse::<usize>().ok().filter(|n| *n > 0) {
+            return Some(count);
         }
     }
-    dedicated.then_some(global)
+    if dedicated {
+        return Some(global);
+    }
+    default_physical.filter(|physical| *physical <= global)
 }
 
 /// Run the decode `op` on the dedicated decode pool when one is configured,
@@ -21713,15 +21783,21 @@ fn attention_f32_blocked_dot_enabled() -> bool {
 /// per process outside tests.
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 fn attention_decode_parallel_enabled() -> bool {
+    // DEFAULT ON (Windows x86_64 promotion): the lane carries a
+    // bitwise-identity contract (Item-2 matrix + A/B, zero divergent bits),
+    // so the flip cannot change any output byte. Explicit rollback:
+    // `BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL=0`.
     #[cfg(test)]
     {
-        q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL")
+        q8_0_env_flag_enabled_default_on_fail_closed("BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL")
     }
     #[cfg(not(test))]
     {
         static ATTENTION_DECODE_PARALLEL_ENABLED: OnceLock<bool> = OnceLock::new();
         *ATTENTION_DECODE_PARALLEL_ENABLED.get_or_init(|| {
-            q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL")
+            q8_0_env_flag_enabled_default_on_fail_closed(
+                "BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL",
+            )
         })
     }
 }

--- a/src/inference/kv_cache.rs
+++ b/src/inference/kv_cache.rs
@@ -135,9 +135,16 @@ pub enum KvLayout {
 /// Env gate for the head-major layout, read once per cache construction.
 /// Windows-first per the standing directive; the mechanism is arch-agnostic
 /// and lifting the gate is a one-line decision.
+///
+/// DEFAULT ON (Windows x86_64 promotion): the lane carries a bitwise-identity
+/// contract (Item-3 Lane-A matrix incl. rollback/growth/CUDA-mirror, zero
+/// divergent bits), so the flip cannot change any output byte. Explicit
+/// rollback: `BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR=0`.
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 fn kv_layout_head_major_enabled() -> bool {
-    super::q8_runtime::q8_0_env_flag_enabled_default_off("BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR")
+    super::q8_runtime::q8_0_env_flag_enabled_default_on_fail_closed(
+        "BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR",
+    )
 }
 
 /// Element storage for the K/V buffers. Chosen ONCE at cache construction

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -888,39 +888,64 @@ fn resolve_prefill_thread_count_widens_only_on_measured_default() {
 }
 
 #[test]
-fn resolve_decode_thread_count_defaults_off_and_prefers_explicit_width() {
-    // Neither flag: no decode pool — decode stays inline (the default path).
-    assert_eq!(resolve_decode_thread_count_from(None, false, 16), None);
-    // Explicit width wins.
+fn resolve_decode_thread_count_promotes_physical_default_with_kill_switch() {
+    // No flags, no policy input: no decode pool (pre-promotion inline path).
     assert_eq!(
-        resolve_decode_thread_count_from(Some("4"), false, 16),
+        resolve_decode_thread_count_from(None, false, 16, None),
+        None
+    );
+    // Promoted default policy: dedicated pool at detected physical cores...
+    assert_eq!(
+        resolve_decode_thread_count_from(None, false, 16, Some(8)),
+        Some(8)
+    );
+    // ...including physical == global (the isolation configuration)...
+    assert_eq!(
+        resolve_decode_thread_count_from(None, false, 8, Some(8)),
+        Some(8)
+    );
+    // ...but never wider than an operator-narrowed global.
+    assert_eq!(
+        resolve_decode_thread_count_from(None, false, 4, Some(8)),
+        None
+    );
+    // Explicit width wins over the policy.
+    assert_eq!(
+        resolve_decode_thread_count_from(Some("4"), false, 16, Some(8)),
         Some(4)
     );
     assert_eq!(
-        resolve_decode_thread_count_from(Some(" 6 "), true, 16),
+        resolve_decode_thread_count_from(Some(" 6 "), true, 16, Some(8)),
         Some(6)
     );
-    // 0/off/empty/invalid fall through to the dedicated check.
-    assert_eq!(resolve_decode_thread_count_from(Some("0"), false, 16), None);
+    // Explicit 0/off is the KILL SWITCH: disables the pool entirely, over
+    // both the dedicated flag and the default policy.
     assert_eq!(
-        resolve_decode_thread_count_from(Some("off"), false, 16),
-        None
-    );
-    assert_eq!(resolve_decode_thread_count_from(Some(""), false, 16), None);
-    assert_eq!(
-        resolve_decode_thread_count_from(Some("abc"), false, 16),
+        resolve_decode_thread_count_from(Some("0"), true, 16, Some(8)),
         None
     );
     assert_eq!(
-        resolve_decode_thread_count_from(Some("0"), true, 16),
+        resolve_decode_thread_count_from(Some("off"), false, 16, Some(8)),
+        None
+    );
+    // Empty/invalid specs fall through to dedicated, then the policy.
+    assert_eq!(
+        resolve_decode_thread_count_from(Some(""), false, 16, Some(8)),
+        Some(8)
+    );
+    assert_eq!(
+        resolve_decode_thread_count_from(Some("abc"), true, 16, None),
         Some(16)
     );
     assert_eq!(
-        resolve_decode_thread_count_from(Some("abc"), true, 16),
-        Some(16)
+        resolve_decode_thread_count_from(Some("abc"), false, 16, None),
+        None
     );
     // Dedicated alone isolates at the global width.
-    assert_eq!(resolve_decode_thread_count_from(None, true, 12), Some(12));
+    assert_eq!(
+        resolve_decode_thread_count_from(None, true, 12, None),
+        Some(12)
+    );
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5296,42 +5296,10 @@ fn log_acceleration_state() {
     );
 }
 
-// Best-effort physical (not logical) core count on Windows. Compute-bound SIMD
-// matvec does not benefit from SMT siblings — oversubscribing logical cores adds
-// scheduler contention and measurably regresses decode (16 logical threads run
-// slower than 8 physical on this i7-11800H). Returns None if the query fails, in
-// which case we fall back to Rayon's default (logical-core) sizing.
+// Physical-core detection moved into the library (the decode thread-policy
+// default needs it too); this alias keeps the call sites below unchanged.
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-fn windows_physical_core_count() -> Option<usize> {
-    use windows_sys::Win32::System::SystemInformation::{
-        GetLogicalProcessorInformation, SYSTEM_LOGICAL_PROCESSOR_INFORMATION,
-    };
-    // RelationProcessorCore == 0 (LOGICAL_PROCESSOR_RELATIONSHIP); one such record
-    // per physical core.
-    const RELATION_PROCESSOR_CORE: i32 = 0;
-    unsafe {
-        let mut len: u32 = 0;
-        // First call sizes the buffer (expected to fail with ERROR_INSUFFICIENT_BUFFER).
-        GetLogicalProcessorInformation(std::ptr::null_mut(), &mut len);
-        if len == 0 {
-            return None;
-        }
-        let count = len as usize / std::mem::size_of::<SYSTEM_LOGICAL_PROCESSOR_INFORMATION>();
-        if count == 0 {
-            return None;
-        }
-        let mut buf: Vec<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> = Vec::with_capacity(count);
-        if GetLogicalProcessorInformation(buf.as_mut_ptr(), &mut len) == 0 {
-            return None;
-        }
-        buf.set_len(count);
-        let physical = buf
-            .iter()
-            .filter(|info| info.Relationship == RELATION_PROCESSOR_CORE)
-            .count();
-        (physical > 0).then_some(physical)
-    }
-}
+use camelid::inference::windows_physical_core_count;
 
 /// §1.2 core-cap: clamp a resolved compute-thread count so the OS always keeps
 /// its reserve (see [`camelid::gait::compute_thread_budget`]). Windows x86-64


### PR DESCRIPTION
## Windows x86_64 default promotion — bitwise-proven lanes

Defaults-only PR: zero kernel, scheduling, or accessor changes. Every
promoted lane carries a bitwise-identity contract, proven again end-to-end
here: **old-defaults vs new-defaults outputs are byte-identical 11/11**
(3B hello 1/5/50, TinyLlama five-prompt pack, 512/2048 A/B pairs, one
serve-path generation). Receipts: `target/promo-gates-20260702T064629/`
(SHA256-sealed, dev box).

### Promoted (Windows x86_64 only)

| flag | new default | contract basis (sealed receipt) |
|---|---|---|
| `BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL` | on (MIN_POSITIONS stays 64) | Item-2 bitwise matrix + A/B, zero divergent bits (`target/attn-decode-parallel-ab-20260701T172315/`, PR #358) |
| `BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR` | on | Item-3 Lane-A matrix incl. rollback/growth/CUDA-mirror, zero divergent bits (`target/kv-lanes-ab-20260701T185422/`, PR #359) |
| decode thread policy | dedicated pool at **detected physical cores** (never SMT logical), fail-closed | Items-4/5 P2 sweep: flat 4-8T, -20% at 16T (`target/decode-sched-p2-20260702T011105/P2_RECEIPTS.md`); DECISIONS.md D13 |
| `BACKENDINFERENCE_DECODE_POOL_DEDICATED` | flag unchanged (explicit isolate-at-global override); the promoted default policy ships the dedicated-at-physical configuration the P2 serve A/B measured at -4.5% wall | `target/decode-sched-p2-20260702T011105/P2_RECEIPTS.md` serve table |

Physical-core detection: `GetLogicalProcessorInformation`, one
`RelationProcessorCore` record per core (detector moved from `main.rs` into
the library). Fail-closed to prior behavior on: detection failure, a
`CAMELID_THREADS`-pinned global, or a global narrower than physical. This
host's tuned width (6) is deliberately NOT hardcoded; per-host refinement is
deferred to GAIT (D13).

### Explicitly NOT promoted

| flag | stays | reason |
|---|---|---|
| `BACKENDINFERENCE_ATTENTION_F32_BLOCKED_DOT` | off | judged-divergence lane; promotion waits on the five-prompt gate re-certification (SPM mission, PR #357 doc) |
| `BACKENDINFERENCE_KV_F16` | off | **mechanically dependent on blocked-dot** (the f16 kernels exist only as blocked variants; the flag is inert and logs once without it — see `kv_f16_enabled`). Bitwise-proven itself (`target/kv-lanes-ab2-20260701T195346/`); promotes together with blocked-dot after re-cert, and carries the 8192-context capability (5.06 tok/s @ 6.13 GB, `target/decode-sched-p4-*/P4_RECEIPTS.md`) |
| `BACKENDINFERENCE_DECODE_SPIN_POOL` | off (parked, never built) | 0.6% recoverable at policy width vs the >=5% entry bar (`target/decode-sched-p2-20260702T011105/P2_RECEIPTS.md`) |
| `BACKENDINFERENCE_DECODE_TIMINGS` | on (unchanged) | receipt capability; measured cost 0.0% @default width (`target/decode-sched-exit-20260702T002931/PHASE1_EXIT.md`) |

### Delivered gain of THIS PR (old defaults vs new defaults, x3 interleaved medians)

| depth | old tok/s | new tok/s | delivered |
|---|---|---|---|
| 512 | 4.455 | 6.404 | 1.438x |
| 2048 | 2.028 | 5.113 | 2.522x |

Serve path: 9946 -> 9312 ms avg wall for a 64-token completion (-6.4%).
(The campaign's composed 3.34x @2048 includes blocked-dot + f16 and belongs
to the re-certification milestone, not this PR.)

Thread-policy verification on the dev host: detection resolves to 8
physical (`decode_threads=8 global_threads=8` in the serve log); auto-8 vs
explicit width-6 @2048 = 5.113 vs 5.060 tok/s (-1.0%, inside the P2 flat
region).

### Rollback (each lane individually)

- `BACKENDINFERENCE_ATTENTION_DECODE_PARALLEL=0`
- `BACKENDINFERENCE_KV_LAYOUT_HEAD_MAJOR=0`
- `BACKENDINFERENCE_DECODE_THREADS=0` (or `off`) — kill switch for the
  decode pool including the physical-core default policy

Flag-semantics audit: both promoted flags converted from default-off to the
`default_on_fail_closed` reader; explicit-off kill switches unit-tested
(`resolve_decode_thread_count_promotes_physical_default_with_kill_switch`).
Full lib suite under the new defaults: 631/631.

Campaign context: lanes measured to compose to 3.335x @2048 with everything
on; what remains gated on re-certification is blocked-dot + KV f16 + the
8192-context capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)