### PR TITLE
test(inference): fix Q8_0FileReadStats race in chunked-prefill test

### DIFF
--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -9925,6 +9925,15 @@ fn single_token_forward_diagnostics_follow_llama_stage_order() {
 #[test]
 fn chunked_prefill_matches_sequential_prefill_outputs_and_cache() {
     let _env_guard = env_lock();
+    // This test asserts the chunked prefill's q8_file_reads delta is all-zero.
+    // The delta is measured from the PROCESS-GLOBAL Q8 file-read counters
+    // (tensor::q8_0_file_read_stats), so any concurrently running test that
+    // records reads — e.g. layer_memory_record_end_captures_tail_q8_file_read_
+    // phase's record_q8_0_file_read(32)+(64) = the exact "2 calls / 96 bytes"
+    // seen in flaky runs — bleeds into the snapshot. Hold the same
+    // q8_file_state_lock every other stats-touching test holds; lock order
+    // (env -> q8) matches the dual-guard tests in this file.
+    let _q8_guard = crate::test_support::q8_file_state_lock();
     clear_dense_diagnostic_env();
 
     let config = LlamaModelConfig {


### PR DESCRIPTION
The full parallel test suite intermittently failed `inference::tests::chunked_prefill_matches_sequential_prefill_outputs_and_cache` with a non-zero `Q8_0FileReadStats` snapshot (`read_calls: 2, read_bytes: 96`) while the test passed reliably in isolation.

**Root cause:** the test asserts the chunked prefill's `q8_file_reads` delta is all-zero, but the delta is computed from the process-global Q8 file-read counters. A concurrently scheduled stats test — `layer_memory_record_end_captures_tail_q8_file_read_phase`, which calls `record_q8_0_file_read(32)` + `(64)` — contributes exactly the observed 2 calls / 96 bytes when the two overlap.

**Fix:** hold `test_support::q8_file_state_lock()` like every other stats-touching test in this file (and `tensor::tests`) already does, in the established `env → q8` lock order. An audit confirmed this was the only stats-sensitive test missing the guard and that no test acquires the locks in reverse order.

**Verification:** 3 consecutive full `cargo test --lib` parallel runs, 635/635 green each; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)