### PR TITLE
DiffusionGemma fast engine: serve/GUI bridge + full-GPU CAMELID_DG_FAST (265s → 18s/step)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1681,8 +1681,14 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     // than the lazy runtime map (otherwise chat stays locked until you chat â†’ deadlock).
     let runnable_serve_ready = runnable_serve_enabled()
         && model.is_some_and(|m| is_runnable_serve_arch(m.gguf.architecture().unwrap_or_default()));
+    // Same shape for the DiffusionGemma serve bridge: ready once the model is
+    // loaded with the lane enabled (the runtime loads eagerly at model load,
+    // but gate on enabled + arch so a heal-path gap cannot lock the UI).
+    let dg_serve_ready = dg_serve_enabled()
+        && model.is_some_and(|m| is_dg_serve_arch(m.gguf.architecture().unwrap_or_default()));
     let generation_ready = gemma4_available
         || runnable_serve_ready
+        || dg_serve_ready
         || model.is_some_and(loaded_model_generation_ready);
     let execution_plans = state.execution_plans.read().await;
     let execution_plan = active_id_lock

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -90,6 +90,11 @@ pub struct AppState {
     /// loaded. Additive, parallel to the optimized engine â€” see the runnable serve
     /// bridge near `runnable_chat_nonstreaming`.
     runnable_runtimes: Arc<RwLock<HashMap<String, Arc<RunnableServeRuntime>>>>,
+    /// DiffusionGemma serve runtimes, keyed by model id. Populated only when
+    /// `CAMELID_DG_SERVE` is set and a diffusion-gemma model is loaded. Additive,
+    /// parallel to the optimized engine (which keeps failing closed for this
+    /// arch by design) — see the bridge near `dg_chat_nonstreaming`.
+    dg_runtimes: Arc<RwLock<HashMap<String, Arc<DgServeRuntime>>>>,
     execution_plans: Arc<RwLock<HashMap<String, ExecutionPlan>>>,
     cached_weights: Arc<RwLock<HashMap<String, Arc<LlamaLoadedWeights>>>>,
     active_model_id: Arc<RwLock<Option<String>>>,
@@ -119,6 +124,7 @@ impl Default for AppState {
             loaded_models: Arc::new(RwLock::new(HashMap::new())),
             gemma4_runtimes: Arc::new(RwLock::new(HashMap::new())),
             runnable_runtimes: Arc::new(RwLock::new(HashMap::new())),
+            dg_runtimes: Arc::new(RwLock::new(HashMap::new())),
             execution_plans: Arc::new(RwLock::new(HashMap::new())),
             cached_weights: Arc::new(RwLock::new(HashMap::new())),
             active_model_id: Arc::new(RwLock::new(None)),
@@ -4817,6 +4823,375 @@ async fn runnable_chat_streaming(
     Sse::new(events).into_response()
 }
 
+// ===================================================================================
+// DiffusionGemma serve bridge (additive, gated by CAMELID_DG_SERVE).
+//
+// The block-diffusion lane cannot run on the AR engine — `model.rs` fails closed for
+// this arch BY DESIGN and stays that way. This bridge mirrors the runnable-lane
+// pattern: a parallel per-model-id runtime map, a short-circuit at the top of
+// `chat_completions`, and dedicated handlers over `DgChat` (the Phase 6 bit-exact
+// chat wrapper). SINGLE-TURN: the DG chat template renders exactly one user message
+// (the parity-proven reference path), so the LAST user message wins and prior turns
+// are ignored. A denoise block is minutes of compute: steps per block come from
+// `CAMELID_DG_MAX_STEPS` (default: the reference 48 with adaptive early stop),
+// blocks per answer from `CAMELID_DG_MAX_BLOCKS` (default 1). The SSE stream emits
+// one content delta per COMMITTED BLOCK with keep-alive comments in between.
+// ===================================================================================
+
+/// The DiffusionGemma serve lane is gated behind `CAMELID_DG_SERVE` (1/true/yes).
+/// When off, a diffusion-gemma load stays metadata-only (fail-closed redirect).
+fn dg_serve_enabled() -> bool {
+    matches!(
+        std::env::var("CAMELID_DG_SERVE").as_deref(),
+        Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("YES")
+    )
+}
+
+/// True for the DiffusionGemma architecture spellings the loader recognizes.
+fn is_dg_serve_arch(arch: &str) -> bool {
+    let a = arch.to_ascii_lowercase().replace(['-', '_'], "");
+    a == "diffusiongemma" || a == "gemmadiffusion"
+}
+
+/// Per-block denoise step override for serve (`CAMELID_DG_MAX_STEPS`); `None`
+/// keeps the reference default (48, adaptive early stop — ~40 min/block on a
+/// 6 GB-GPU laptop; 8-16 trades quality for interactive latency).
+fn dg_serve_steps() -> Option<i32> {
+    std::env::var("CAMELID_DG_MAX_STEPS")
+        .ok()
+        .and_then(|v| v.parse::<i32>().ok())
+        .map(|v| v.max(1))
+}
+
+/// Blocks per answer for serve (`CAMELID_DG_MAX_BLOCKS`, default 1, clamped 1..=8).
+/// Each block is a full 256-token canvas denoise.
+fn dg_serve_blocks() -> i32 {
+    std::env::var("CAMELID_DG_MAX_BLOCKS")
+        .ok()
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(1)
+        .clamp(1, 8)
+}
+
+/// Map the multi-canvas stop reason onto an OpenAI finish_reason: hitting the
+/// block budget or the ubatch guard is a truncation ("length"); a trim (EOG /
+/// repetition cut) is a natural stop.
+fn dg_finish_reason(stop: &str) -> &'static str {
+    match stop {
+        "blocks" | "ubatch" => "length",
+        _ => "stop",
+    }
+}
+
+/// A DiffusionGemma model wrapped for the serve path: the Phase 6 `DgChat`
+/// (render + tokenize + multi-canvas denoise + detokenize).
+pub struct DgServeRuntime {
+    chat: crate::diffusion_gemma::chat::DgChat,
+}
+
+impl DgServeRuntime {
+    fn load(path: &std::path::Path) -> std::result::Result<Self, BackendError> {
+        Ok(Self {
+            chat: crate::diffusion_gemma::chat::DgChat::load(path)?,
+        })
+    }
+}
+
+/// Resolve a DiffusionGemma serve runtime for the requested (or active) model id.
+async fn resolve_dg_runtime(
+    state: &AppState,
+    model: &Option<String>,
+) -> std::result::Result<Option<(String, Arc<DgServeRuntime>)>, Response> {
+    let id = match model.clone() {
+        Some(m) => m,
+        None => match state.active_model_id.read().await.clone() {
+            Some(m) => m,
+            None => return Ok(None),
+        },
+    };
+    if let Some(runtime) = state.dg_runtimes.read().await.get(&id).cloned() {
+        return Ok(Some((id, runtime)));
+    }
+    // Loaded as a diffusion-gemma arch but no runtime → fail clearly rather than
+    // letting the Llama path return its unsupported-architecture error.
+    let needs_dg = state
+        .loaded_models
+        .read()
+        .await
+        .get(&id)
+        .map(|m| is_dg_serve_arch(m.gguf.architecture().unwrap_or_default()))
+        .unwrap_or(false);
+    if needs_dg {
+        return Err(api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "model_not_ready",
+            format!(
+                "model '{id}' (DiffusionGemma) is loaded but its serve runtime is \
+                 unavailable; set CAMELID_DG_SERVE=1 and reload the model"
+            ),
+            None,
+        ));
+    }
+    Ok(None)
+}
+
+/// Load the DiffusionGemma serve runtime for a model id (blocking thread; the
+/// GGUF is lazy-mmapped so this is seconds, not a full read).
+async fn load_dg_serve_runtime(
+    state: &AppState,
+    id: &str,
+    model_path: &std::path::Path,
+) -> std::result::Result<(), BackendError> {
+    let load_path = model_path.to_path_buf();
+    let runtime = tokio::task::spawn_blocking(move || DgServeRuntime::load(&load_path))
+        .await
+        .map_err(|e| {
+            BackendError::InvalidModelMetadata(format!("dg serve load task panicked: {e}"))
+        })??;
+    state
+        .dg_runtimes
+        .write()
+        .await
+        .insert(id.to_string(), Arc::new(runtime));
+    tracing::info!(model = %id, "diffusion-gemma serve runtime loaded");
+    Ok(())
+}
+
+/// The last user message — the DG chat template is single-turn (the
+/// parity-proven reference path renders exactly one message).
+fn dg_last_user_message(messages: &[ChatMessage]) -> Option<String> {
+    messages
+        .iter()
+        .rev()
+        .find(|m| m.role.trim().eq_ignore_ascii_case("user"))
+        .map(|m| m.content.clone())
+}
+
+/// EB sampler params for a serve request: request `seed` (reference default 0)
+/// + the `CAMELID_DG_MAX_STEPS` override.
+fn dg_serve_params(seed: Option<u64>) -> crate::diffusion_gemma::DgEbParams {
+    let defaults = crate::diffusion_gemma::DgEbParams::default();
+    crate::diffusion_gemma::DgEbParams {
+        seed: seed.unwrap_or(0) as u32,
+        max_steps: dg_serve_steps().unwrap_or(defaults.max_steps),
+        ..defaults
+    }
+}
+
+/// Non-streaming chat for a DiffusionGemma model: render the single-turn chat
+/// template for the last user message, run the multi-canvas denoise loop,
+/// detokenize. Minutes of compute — the client waits on one response.
+async fn dg_chat_nonstreaming(
+    id: String,
+    runtime: Arc<DgServeRuntime>,
+    req: &ChatCompletionRequest,
+) -> Response {
+    let messages = req.messages.clone().unwrap_or_default();
+    let Some(user_msg) = dg_last_user_message(&messages) else {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_parameter",
+            "the DiffusionGemma serve lane needs at least one user message".to_string(),
+            Some("messages"),
+        );
+    };
+    let params = dg_serve_params(req.seed);
+    let n_blocks = dg_serve_blocks();
+    let rt = runtime.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let prompt_tokens = rt.chat.render_prompt(&user_msg).map(|v| v.len())?;
+        rt.chat
+            .generate(&user_msg, &params, n_blocks, 1100, |_, _, _, _| {})
+            .map(|out| (prompt_tokens, out))
+    })
+    .await;
+    let (prompt_tokens, (text, stop, ids)) = match result {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => {
+            return api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "generation_error",
+                e.to_string(),
+                None,
+            )
+        }
+        Err(e) => {
+            return api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "generation_error",
+                format!("dg generation task panicked: {e}"),
+                None,
+            )
+        }
+    };
+    let body = serde_json::json!({
+        "id": "chatcmpl-diffusion-gemma",
+        "object": "chat.completion",
+        "created": unix_secs(),
+        "model": id,
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": text },
+            "finish_reason": dg_finish_reason(&stop),
+        }],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": ids.len(),
+            "total_tokens": prompt_tokens + ids.len(),
+        },
+        "camelid": { "lane": "diffusion_gemma", "stop": stop, "note": "single-turn template: last user message only" },
+    });
+    (StatusCode::OK, Json(body)).into_response()
+}
+
+/// Streaming chat for a DiffusionGemma model (SSE, OpenAI chunk shape): a role
+/// chunk, then ONE content delta per committed denoise block (a block is
+/// minutes of compute — SSE keep-alive comments cover the gaps), the
+/// finish_reason chunk, optional usage, `[DONE]`.
+async fn dg_chat_streaming(
+    id: String,
+    runtime: Arc<DgServeRuntime>,
+    req: &ChatCompletionRequest,
+) -> Response {
+    let messages = req.messages.clone().unwrap_or_default();
+    let Some(user_msg) = dg_last_user_message(&messages) else {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_parameter",
+            "the DiffusionGemma serve lane needs at least one user message".to_string(),
+            Some("messages"),
+        );
+    };
+    let params = dg_serve_params(req.seed);
+    let n_blocks = dg_serve_blocks();
+    let include_usage = stream_options_include_usage(req.stream_options.as_ref());
+    let created = unix_secs();
+
+    /// (prompt_tokens, text, stop, response ids) from a finished generation.
+    type DgDone = (usize, String, String, Vec<i32>);
+    enum StreamItem {
+        Block(Vec<i32>),
+        Done(DgDone),
+        Fail(String),
+    }
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<StreamItem>();
+    let rt = runtime.clone();
+    tokio::task::spawn_blocking(move || {
+        let send_tx = tx.clone();
+        let prompt_tokens = match rt.chat.render_prompt(&user_msg) {
+            Ok(ids) => ids.len(),
+            Err(e) => {
+                let _ = tx.send(StreamItem::Fail(e.to_string()));
+                return;
+            }
+        };
+        let result =
+            rt.chat
+                .generate_with_blocks(&user_msg, &params, n_blocks, 1100, |_b, committed| {
+                    let _ = send_tx.send(StreamItem::Block(committed.to_vec()));
+                });
+        match result {
+            Ok((text, stop, ids)) => {
+                let _ = tx.send(StreamItem::Done((prompt_tokens, text, stop, ids)));
+            }
+            Err(e) => {
+                let _ = tx.send(StreamItem::Fail(e.to_string()));
+            }
+        }
+    });
+
+    let rt = runtime.clone();
+    let events = async_stream::stream! {
+        let chunk = |delta: serde_json::Value, finish: Option<&str>| {
+            serde_json::json!({
+                "id": "chatcmpl-diffusion-gemma",
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": id,
+                "choices": [{ "index": 0, "delta": delta, "finish_reason": finish }],
+            })
+        };
+        yield Ok::<Event, std::convert::Infallible>(
+            Event::default().data(chunk(serde_json::json!({ "role": "assistant" }), None).to_string()),
+        );
+
+        // Incremental decode: the response is the concatenation of committed
+        // blocks; decode the whole accumulated id list each block (cheap next
+        // to a denoise) and emit only the new suffix.
+        let mut all_ids: Vec<i32> = Vec::new();
+        let mut emitted = 0usize;
+        let mut final_state: Option<std::result::Result<DgDone, String>> = None;
+
+        while let Some(item) = rx.recv().await {
+            match item {
+                StreamItem::Block(committed) => {
+                    all_ids.extend_from_slice(&committed);
+                    let decoded = rt.chat.decode_response(&all_ids).unwrap_or_default();
+                    if decoded.len() > emitted {
+                        let delta_text = decoded[emitted..].to_string();
+                        emitted = decoded.len();
+                        yield Ok(Event::default().data(
+                            chunk(serde_json::json!({ "content": delta_text }), None).to_string(),
+                        ));
+                    }
+                }
+                StreamItem::Done(done) => {
+                    final_state = Some(Ok(done));
+                    break;
+                }
+                StreamItem::Fail(e) => {
+                    final_state = Some(Err(e));
+                    break;
+                }
+            }
+        }
+
+        match final_state {
+            Some(Ok((prompt_tokens, text, stop, ids))) => {
+                // Any tail the block deltas missed (e.g. UTF-8 boundary).
+                if text.len() > emitted {
+                    yield Ok(Event::default().data(
+                        chunk(serde_json::json!({ "content": text[emitted..].to_string() }), None).to_string(),
+                    ));
+                }
+                yield Ok(Event::default().data(
+                    chunk(serde_json::json!({}), Some(dg_finish_reason(&stop))).to_string(),
+                ));
+                if include_usage {
+                    let usage = serde_json::json!({
+                        "id": "chatcmpl-diffusion-gemma",
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": id,
+                        "choices": [],
+                        "usage": {
+                            "prompt_tokens": prompt_tokens,
+                            "completion_tokens": ids.len(),
+                            "total_tokens": prompt_tokens + ids.len(),
+                        },
+                    });
+                    yield Ok(Event::default().data(usage.to_string()));
+                }
+            }
+            Some(Err(e)) => {
+                let err = serde_json::json!({ "error": { "message": e, "type": "generation_error" } });
+                yield Ok(Event::default().data(err.to_string()));
+            }
+            None => {}
+        }
+        yield Ok(Event::default().data("[DONE]"));
+    };
+    // A denoise block is minutes of silence; keep the SSE connection (and any
+    // proxies) alive with comment frames.
+    Sse::new(events)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(std::time::Duration::from_secs(10))
+                .text("dg-denoising"),
+        )
+        .into_response()
+}
+
 /// Streaming Gemma 4 chat (SSE). Mirrors the OpenAI `chat.completion.chunk`
 /// shape: a role chunk, one content delta per generated token, a final
 /// finish_reason chunk, then `[DONE]`. Generation runs on a blocking thread and
@@ -5061,6 +5436,14 @@ async fn load_model_from_path_with_activation(
         load_runnable_serve_runtime(state, &id, &loaded.path).await?;
     }
 
+    // DiffusionGemma serve path (additive, gated by CAMELID_DG_SERVE): the AR
+    // engine keeps failing closed for this arch (`unsupported_runtime` carries
+    // the dedicated-lane redirect); the bridge loads the Phase 6 DgChat runtime
+    // so /v1/chat routes to the diffusion lane instead.
+    if dg_serve_enabled() && is_dg_serve_arch(loaded.gguf.architecture().unwrap_or_default()) {
+        load_dg_serve_runtime(state, &id, &loaded.path).await?;
+    }
+
     Ok(loaded)
 }
 
@@ -5163,6 +5546,7 @@ async fn unload_model(
         state.loaded_models.write().await.remove(&id);
         state.gemma4_runtimes.write().await.remove(&id);
         state.runnable_runtimes.write().await.remove(&id);
+        state.dg_runtimes.write().await.remove(&id);
         state.execution_plans.write().await.remove(&id);
         state.cached_weights.write().await.remove(&id);
         state.model_last_used.write().await.remove(&id);
@@ -6375,6 +6759,19 @@ async fn chat_completions(
                 return runnable_chat_streaming(id, runtime, &req).await;
             }
             return runnable_chat_nonstreaming(id, runtime, &req).await;
+        }
+        Ok(None) => {}
+        Err(resp) => return resp,
+    }
+    // DiffusionGemma serve path (additive, gated by CAMELID_DG_SERVE):
+    // short-circuits a diffusion-gemma model to the dedicated diffusion lane
+    // (block-level SSE; a denoise block is minutes of compute).
+    match resolve_dg_runtime(&state, &req.model).await {
+        Ok(Some((id, runtime))) => {
+            if req.stream.unwrap_or(false) {
+                return dg_chat_streaming(id, runtime, &req).await;
+            }
+            return dg_chat_nonstreaming(id, runtime, &req).await;
         }
         Ok(None) => {}
         Err(resp) => return resp,

--- a/src/diffusion_gemma.rs
+++ b/src/diffusion_gemma.rs
@@ -176,6 +176,359 @@ fn expert_rows_gpu(
     None
 }
 
+/// FAST mode (`CAMELID_DG_FAST=1`, cuda builds): batch the per-step FFN+MoE
+/// across ALL positions on the GPU so each weight is read once per step
+/// instead of once per position. NOT bit-exact (GPU f32 accumulation, GEMM
+/// batching) — the parity lane is the default; this exists for interactive
+/// latency. Token-closeness is the bar, like the SC GPU stage.
+fn dg_fast_enabled() -> bool {
+    cfg!(feature = "cuda")
+        && matches!(
+            std::env::var("CAMELID_DG_FAST").as_deref(),
+            Ok("1") | Ok("true") | Ok("TRUE") | Ok("yes") | Ok("YES")
+        )
+}
+
+/// FAST-mode whole-layer FFN+MoE across all positions. Mirrors the
+/// per-position loop's math mechanically (same helpers, same accumulation
+/// formulas, same region-aware output scalar) but runs the six heavy matmuls
+/// as batched GPU GEMMs — dense gate/up/down over all `n` positions and the
+/// expert gate_up/down over all `n×k` (position, expert) pairs — so each
+/// weight tensor is read/streamed ONCE per step. Mutates `h` only after every
+/// GPU call has succeeded; `None` leaves the state untouched for the CPU
+/// fallback loop.
+#[cfg(feature = "cuda")]
+fn ffn_moe_layer_fast(
+    rt: &DgEncoderRuntime,
+    lw: &DgLayer,
+    h: &mut [Vec<f32>],
+    p: usize,
+    eps: f32,
+) -> Option<()> {
+    use rayon::prelude::*;
+    // Q4_K_M mixes the down-projection quants per layer (Q8_0 on some layers,
+    // Q5_0 on others); both have batched kernels. The gate/up sides are Q4_K
+    // on every layer of the tracked file.
+    let down_kind = |f: DgFormat| -> Option<cuda::DgExpertKind> {
+        match f {
+            DgFormat::Q8_0 => Some(cuda::DgExpertKind::Q80),
+            DgFormat::Q5_0 => Some(cuda::DgExpertKind::Q50),
+            _ => None,
+        }
+    };
+    if lw.ffn_gate.format != DgFormat::Q4K
+        || lw.ffn_up.format != DgFormat::Q4K
+        || lw.gate_up_exps.format != DgFormat::Q4K
+    {
+        return None;
+    }
+    let dense_down_kind = down_kind(lw.ffn_down.format)?;
+    let exp_down_kind = down_kind(lw.down_exps.format)?;
+    let hidden = h.first()?.len();
+    if !hidden.is_multiple_of(256) {
+        return None;
+    }
+    let n = h.len();
+    let k = rt.n_expert_used;
+    let n_ff_exp = rt.n_ff_exp;
+    let two_nff = 2 * n_ff_exp;
+    let ffn_dim = lw.ffn_gate.rows;
+    let inv = 1.0f32 / (hidden as f32).sqrt();
+    let prof = std::env::var("CAMELID_DG_STAGE_TIMINGS").is_ok();
+    let dbg_bail = |st: &str| {
+        if prof {
+            eprintln!("[dg-fast] BAIL {st}");
+        }
+    };
+    let t0 = std::time::Instant::now();
+    macro_rules! mark {
+        ($label:expr, $t:ident) => {
+            let now = std::time::Instant::now();
+            if prof {
+                eprint!("[dg-fast] {}={}ms ", $label, ($t.elapsed()).as_millis());
+            }
+            #[allow(unused)]
+            let $t = now;
+        };
+    }
+    let t = t0;
+
+    // ---- per-position prep (parallel; no h mutation): dense input act,
+    // router selection + normalized weights, MoE input act ----
+    struct Prep {
+        xq: DgActivation,
+        cur_q: DgActivation,
+        idx: Vec<usize>,
+        w_norm: Vec<f32>,
+    }
+    let preps: Vec<Prep> = h
+        .par_iter()
+        .map(|hp| {
+            let xn = refmath::rms_norm(hp, Some(&lw.ffn_norm), eps);
+            let xq = DgActivation::new(&xn);
+            let mut r = refmath::rms_norm(hp, None, eps);
+            for (rv, sv) in r.iter_mut().zip(&lw.gate_inp_scale) {
+                *rv = *rv * inv * sv;
+            }
+            let logits: Vec<f32> = (0..rt.n_expert)
+                .map(|e| refmath::vec_dot_f32(&lw.gate_inp[e * hidden..(e + 1) * hidden], &r))
+                .collect();
+            let mut probs = logits.clone();
+            refmath::softmax_row(&mut probs);
+            let order = argsort_desc_experts(&logits);
+            let idx: Vec<usize> = order[..k].iter().map(|&e| e as usize).collect();
+            let selected: Vec<f32> = idx.iter().map(|&e| probs[e]).collect();
+            let mut wsum = refmath::vec_sum_f32(&selected);
+            wsum = wsum.max(f32::from_bits(0x3880_0000));
+            let w_norm: Vec<f32> = idx
+                .iter()
+                .map(|&e| refmath::vdsp_div(probs[e], wsum))
+                .collect();
+            let cur_moe = refmath::rms_norm(hp, Some(&lw.pre_norm_2), eps);
+            let cur_q = DgActivation::new(&cur_moe);
+            Prep {
+                xq,
+                cur_q,
+                idx,
+                w_norm,
+            }
+        })
+        .collect();
+    mark!("prep", t);
+
+    // ---- SoA packing helpers ----
+    let bpr = hidden / 256;
+    fn pack_q8k_soa(acts: &[&DgActivation], bpr: usize) -> Option<(Vec<f32>, Vec<i8>)> {
+        let n = acts.len();
+        let mut scales = vec![0f32; n * bpr];
+        let mut quants = vec![0i8; n * bpr * 256];
+        for (pos, a) in acts.iter().enumerate() {
+            let blocks = a.q8_k.as_ref()?;
+            if blocks.len() != bpr {
+                return None;
+            }
+            for (b, blk) in blocks.iter().enumerate() {
+                scales[pos * bpr + b] = blk.d;
+                let off = (pos * bpr + b) * 256;
+                quants[off..off + 256].copy_from_slice(&blk.qs);
+            }
+        }
+        Some((scales, quants))
+    }
+    fn whole(w: &DgWire) -> Option<&[u8]> {
+        w.mmap.bytes(w.offset, w.rows * w.row_bytes()).ok()
+    }
+
+    // ---- dense branch: gate/up (Q4_K), geglu, down (Q8_0), post-norm ----
+    let xq_refs: Vec<&DgActivation> = preps.iter().map(|pr| &pr.xq).collect();
+    let (xs, xqn) = pack_q8k_soa(&xq_refs, bpr).or_else(|| {
+        dbg_bail("pack_xq");
+        None
+    })?;
+    let ident_base = vec![0i64; n];
+    let ident_pos: Vec<i32> = (0..n as i32).collect();
+    let gate = cuda::fast_gemm_id(
+        whole(&lw.ffn_gate)?,
+        (lw.ffn_gate.mmap.path(), lw.ffn_gate.offset),
+        cuda::DgExpertKind::Q4K,
+        &ident_base,
+        &ident_pos,
+        ffn_dim,
+        bpr,
+        &xs,
+        &xqn,
+    )?;
+    let up = cuda::fast_gemm_id(
+        whole(&lw.ffn_up)?,
+        (lw.ffn_up.mmap.path(), lw.ffn_up.offset),
+        cuda::DgExpertKind::Q4K,
+        &ident_base,
+        &ident_pos,
+        ffn_dim,
+        bpr,
+        &xs,
+        &xqn,
+    )
+    .or_else(|| {
+        dbg_bail("dense_gemm");
+        None
+    })?;
+    mark!("dense_gemm", t);
+    let dense_acts: Vec<DgActivation> = (0..n)
+        .into_par_iter()
+        .map(|pos| {
+            let g = &gate[pos * ffn_dim..(pos + 1) * ffn_dim];
+            let u = &up[pos * ffn_dim..(pos + 1) * ffn_dim];
+            let act: Vec<f32> = g.iter().zip(u).map(|(gv, uv)| dg_gelu(*gv) * uv).collect();
+            DgActivation::new(&act)
+        })
+        .collect();
+    let nb_dense = ffn_dim / 32;
+    let mut das = vec![0f32; n * nb_dense];
+    let mut daq = vec![0i8; n * nb_dense * 32];
+    for (pos, a) in dense_acts.iter().enumerate() {
+        if a.q8_0.len() != nb_dense {
+            dbg_bail("nb_dense");
+            return None;
+        }
+        for (b, blk) in a.q8_0.iter().enumerate() {
+            das[pos * nb_dense + b] = blk.scale;
+            let off = (pos * nb_dense + b) * 32;
+            daq[off..off + 32].copy_from_slice(&blk.quants);
+        }
+    }
+    let mlp_raw = cuda::fast_gemm_id(
+        whole(&lw.ffn_down)?,
+        (lw.ffn_down.mmap.path(), lw.ffn_down.offset),
+        dense_down_kind,
+        &ident_base,
+        &ident_pos,
+        hidden,
+        nb_dense,
+        &das,
+        &daq,
+    )
+    .or_else(|| {
+        dbg_bail("mlp");
+        None
+    })?;
+    let mlps: Vec<Vec<f32>> = (0..n)
+        .into_par_iter()
+        .map(|pos| {
+            refmath::rms_norm(
+                &mlp_raw[pos * hidden..(pos + 1) * hidden],
+                Some(&lw.post_norm_1),
+                eps,
+            )
+        })
+        .collect();
+    mark!("dense_down", t);
+
+    // ---- MoE branch: expert gate_up (Q4_K) + down (Q8_0) over (pos, slot)
+    // pairs ----
+    let cq_refs: Vec<&DgActivation> = preps.iter().map(|pr| &pr.cur_q).collect();
+    let (cs, cq) = pack_q8k_soa(&cq_refs, bpr).or_else(|| {
+        dbg_bail("pack_cq");
+        None
+    })?;
+    let n_pairs = n * k;
+    let mut gu_base = Vec::with_capacity(n_pairs);
+    let mut gu_pos = Vec::with_capacity(n_pairs);
+    let mut dn_base = Vec::with_capacity(n_pairs);
+    for (pos, prep) in preps.iter().enumerate() {
+        for &e in &prep.idx {
+            gu_base.push((e * two_nff) as i64);
+            gu_pos.push(pos as i32);
+            dn_base.push((e * hidden) as i64);
+        }
+    }
+    let gate_up = cuda::fast_gemm_id(
+        whole(&lw.gate_up_exps)?,
+        (lw.gate_up_exps.mmap.path(), lw.gate_up_exps.offset),
+        cuda::DgExpertKind::Q4K,
+        &gu_base,
+        &gu_pos,
+        two_nff,
+        bpr,
+        &cs,
+        &cq,
+    )
+    .or_else(|| {
+        dbg_bail("exp_gate_up");
+        None
+    })?;
+    mark!("exp_gate_up", t);
+    let hexp_acts: Vec<DgActivation> = (0..n_pairs)
+        .into_par_iter()
+        .map(|pair| {
+            let gu = &gate_up[pair * two_nff..(pair + 1) * two_nff];
+            let hexp: Vec<f32> = (0..n_ff_exp)
+                .map(|o| dg_gelu(gu[o]) * gu[o + n_ff_exp])
+                .collect();
+            DgActivation::new(&hexp)
+        })
+        .collect();
+    let nb_exp = n_ff_exp / 32;
+    let mut hs = vec![0f32; n_pairs * nb_exp];
+    let mut hq = vec![0i8; n_pairs * nb_exp * 32];
+    for (pair, a) in hexp_acts.iter().enumerate() {
+        if a.q8_0.len() != nb_exp {
+            dbg_bail("nb_exp");
+            return None;
+        }
+        for (b, blk) in a.q8_0.iter().enumerate() {
+            hs[pair * nb_exp + b] = blk.scale;
+            let off = (pair * nb_exp + b) * 32;
+            hq[off..off + 32].copy_from_slice(&blk.quants);
+        }
+    }
+    mark!("hexp", t);
+    let pair_ident: Vec<i32> = (0..n_pairs as i32).collect();
+    let down = cuda::fast_gemm_id(
+        whole(&lw.down_exps)?,
+        (lw.down_exps.mmap.path(), lw.down_exps.offset),
+        exp_down_kind,
+        &dn_base,
+        &pair_ident,
+        hidden,
+        nb_exp,
+        &hs,
+        &hq,
+    )
+    .or_else(|| {
+        dbg_bail("exp_down");
+        None
+    })?;
+    mark!("exp_down", t);
+
+    // ---- finalize (parallel; the only h mutation, after all GPU calls) ----
+    h.par_iter_mut().enumerate().for_each(|(pos, hp)| {
+        let prep = &preps[pos];
+        let mut moe_acc = vec![0f32; hidden];
+        for (slot, &e) in prep.idx.iter().enumerate() {
+            let pair = pos * k + slot;
+            let y = &down[pair * hidden..(pair + 1) * hidden];
+            let s_e = lw.down_exps_scale[e];
+            let w = prep.w_norm[slot];
+            for (a, yv) in moe_acc.iter_mut().zip(y) {
+                *a += yv * s_e * w;
+            }
+        }
+        let moe_out = refmath::rms_norm(&moe_acc, Some(&lw.post_norm_2), eps);
+        let mut combined = mlps[pos].clone();
+        for (cv, m) in combined.iter_mut().zip(&moe_out) {
+            *cv += m;
+        }
+        let ffn_out = refmath::rms_norm(&combined, Some(&lw.post_ffw_norm), eps);
+        for (a, b) in hp.iter_mut().zip(&ffn_out) {
+            *a += b;
+        }
+        let scale = if pos < p {
+            lw.enc_out_scale
+        } else {
+            lw.out_scale
+        };
+        for v in hp.iter_mut() {
+            *v *= scale;
+        }
+    });
+    mark!("finalize", t);
+    if prof {
+        eprintln!("total={}ms", t0.elapsed().as_millis());
+    }
+    Some(())
+}
+#[cfg(not(feature = "cuda"))]
+fn ffn_moe_layer_fast(
+    _rt: &DgEncoderRuntime,
+    _lw: &DgLayer,
+    _h: &mut [Vec<f32>],
+    _p: usize,
+    _eps: f32,
+) -> Option<()> {
+    None
+}
+
 use crate::gguf::{read_metadata, GgufTensorDescriptor, GgufTensorType};
 
 // Expert-selection argsort matching the reference's `ggml_argsort_top_k`
@@ -1560,7 +1913,16 @@ impl DgEncoderRuntime {
             let mut moe_down_all = Vec::new();
             let mut moe_down_scaled_all = Vec::new();
             let mut ffn_block_out_all = Vec::new();
-            for (pos, hp) in h.iter_mut().enumerate() {
+            // FAST mode: run the whole layer's FFN+MoE as batched GPU GEMMs
+            // (weights read once per step, not once per position). Falls back
+            // to the per-position loop below on any failure; never taken when
+            // tracing (the trace buffers need the per-position intermediates).
+            let fast_done = !want_trace
+                && dg_fast_enabled()
+                && ffn_moe_layer_fast(self, lw, &mut h, p, eps).is_some();
+            let pos_range = if fast_done { 0..0 } else { 0..h.len() };
+            for pos in pos_range {
+                let hp = &mut h[pos];
                 let attn_resid = hp.clone();
                 let xn = refmath::rms_norm(&attn_resid, Some(&lw.ffn_norm), eps);
                 let xq = DgActivation::new(&xn);

--- a/src/diffusion_gemma.rs
+++ b/src/diffusion_gemma.rs
@@ -742,6 +742,29 @@ fn attn_layer_fast(
     None
 }
 
+/// FAST-mode fused SC (device softmax over the resident previous-step
+/// logits). A no-op when the `cuda` feature is off.
+#[cfg(feature = "cuda")]
+fn sc_soft_fused(
+    temp_inv: f32,
+    embed_scale: f32,
+    c: usize,
+    hidden: usize,
+    n_vocab: usize,
+) -> Option<Vec<f32>> {
+    cuda::sc_soft_fused_gpu(temp_inv, embed_scale, c, hidden, n_vocab)
+}
+#[cfg(not(feature = "cuda"))]
+fn sc_soft_fused(
+    _temp_inv: f32,
+    _embed_scale: f32,
+    _c: usize,
+    _hidden: usize,
+    _n_vocab: usize,
+) -> Option<Vec<f32>> {
+    None
+}
+
 /// FAST-mode lm_head: flatten the canvas activations and run the tiled f16
 /// GEMM against the resident SC embedding transpose. `None` → the existing
 /// (parity-grade) lm_head paths.
@@ -1834,27 +1857,39 @@ impl DgEncoderRuntime {
         let mut d_g: Vec<f32> = Vec::new();
         let mut d_sig: Vec<f32> = Vec::new();
 
+        // FAST mode: fused device path — softmax+f16 straight from the
+        // device-resident previous-step logits into the soft matmul (no host
+        // softmax, no 134 MB probs upload). Falls through to the plain paths.
+        let fused = if dg_fast_enabled() {
+            sc_soft_fused(sc.temp_inv, embed_scale, c, hidden, n_vocab)
+        } else {
+            None
+        };
         // probs = softmax(scale(sc_logits, temp_inv)) per position, then the
         // F16 src1 conversion (ggml quantizes src1 rows to the f16 vec_dot
         // type). Gathered for all positions so the soft-embedding matmul can
-        // run as one batched GPU kernel.
-        let mut probs_f16_all = vec![0u16; c * n_vocab];
-        for pos in 0..c {
-            let mut probs: Vec<f32> = sc.logits[pos * n_vocab..(pos + 1) * n_vocab]
-                .iter()
-                .map(|&x| x * sc.temp_inv)
-                .collect();
-            refmath::softmax_row(&mut probs);
-            for (v, &p) in probs.iter().enumerate() {
-                probs_f16_all[pos * n_vocab + v] = crate::tensor::f32_to_f16_bits(p);
+        // run as one batched GPU kernel. Skipped entirely on the fused path.
+        let mut probs_f16_all = Vec::new();
+        let soft_all = match fused {
+            Some(v) => Some(v),
+            None => {
+                probs_f16_all = vec![0u16; c * n_vocab];
+                for pos in 0..c {
+                    let mut probs: Vec<f32> = sc.logits[pos * n_vocab..(pos + 1) * n_vocab]
+                        .iter()
+                        .map(|&x| x * sc.temp_inv)
+                        .collect();
+                    refmath::softmax_row(&mut probs);
+                    for (v, &p) in probs.iter().enumerate() {
+                        probs_f16_all[pos * n_vocab + v] = crate::tensor::f32_to_f16_bits(p);
+                    }
+                }
+                // soft[pos] = (embT @ probs[pos]) * sqrt(n_embd). GPU when
+                // available (f32 reduction — NOT bit-identical to the CPU f16
+                // emulation); else the reference per-row f16 dot below.
+                sc_soft_gpu(emb_t, &probs_f16_all, c, hidden, n_vocab, embed_scale)
             }
-        }
-
-        // soft[pos] = (embT @ probs[pos]) * sqrt(n_embd). GPU when available
-        // (f32 reduction — NOT bit-identical to the CPU f16 emulation, but this
-        // matmul is ~87% of a multi-step denoise step); else the reference
-        // per-row f16 dot.
-        let soft_all = sc_soft_gpu(emb_t, &probs_f16_all, c, hidden, n_vocab, embed_scale);
+        };
 
         for pos in 0..c {
             let soft: Vec<f32> = match &soft_all {
@@ -1973,10 +2008,14 @@ impl DgEncoderRuntime {
         // ~1.9e11-MAC soft-embedding matmul entirely. Bit-identical: every
         // embedding row is left unchanged either way (the reference's step-0
         // graph likewise contributes nothing).
+        let _t_sc = std::time::Instant::now();
         let sigs = match sc {
             Some(sc_in) if sc_in.use_sc != 0.0 => Some(self.sc_signal(sc_in, c)?),
             _ => None,
         };
+        if sigs.is_some() && std::env::var("CAMELID_DG_STAGE_TIMINGS").is_ok() {
+            eprintln!("[dg-prof] sc={}ms", _t_sc.elapsed().as_millis());
+        }
 
         // embeddings: every row scaled by sqrt(n_embd); canvas rows add the
         // gated SC signal (when enabled) and then take the weightless
@@ -2588,6 +2627,7 @@ impl DgEncoderRuntime {
             let out = self.unified_forward_sc(prompt, &canvas_u32, Some(&sc_in), false)?;
             sc_buffer.copy_from_slice(&out.logits);
 
+            let _t_eb = std::time::Instant::now();
             let step = Self::eb_step(
                 &out.logits,
                 n_vocab,
@@ -2599,6 +2639,9 @@ impl DgEncoderRuntime {
                 &draws.u[step_idx as usize],
                 &draws.renoise[step_idx as usize],
             );
+            if std::env::var("CAMELID_DG_STAGE_TIMINGS").is_ok() {
+                eprintln!("[dg-prof] eb_step={}ms", _t_eb.elapsed().as_millis());
+            }
 
             current_canvas = step.next_canvas.clone();
             held = if prev_argmax == step.argmax {

--- a/src/diffusion_gemma.rs
+++ b/src/diffusion_gemma.rs
@@ -529,6 +529,250 @@ fn ffn_moe_layer_fast(
     None
 }
 
+/// FAST-mode whole-layer attention block: qkv projections, per-head norms +
+/// RoPE (CPU — cheap and keeps the libm sincos semantics), the bidirectional
+/// masked attention (GPU kernel), and the output projection + residual.
+/// Mirrors the per-position path's math shape; not bit-exact (f32 GPU
+/// attention). Mutates `h` only after every GPU call has succeeded.
+#[cfg(feature = "cuda")]
+#[allow(clippy::too_many_arguments)]
+fn attn_layer_fast(
+    lw: &DgLayer,
+    h: &mut [Vec<f32>],
+    heads: usize,
+    head_dim: usize,
+    kv_heads: usize,
+    group: usize,
+    theta: f32,
+    rope_factors: Option<&[f32]>,
+    sliding: bool,
+    win: usize,
+    p: usize,
+    canvas_prompt_lo: i64,
+    eps: f32,
+) -> Option<()> {
+    use rayon::prelude::*;
+    if lw.attn_q.format != DgFormat::Q4K || lw.attn_k.format != DgFormat::Q4K {
+        return None;
+    }
+    let v_kind = match lw.attn_v.as_ref().map(|w| w.format) {
+        None => None,
+        Some(DgFormat::Q4K) => Some(cuda::DgExpertKind::Q4K),
+        Some(DgFormat::Q6K) => Some(cuda::DgExpertKind::Q6K),
+        Some(_) => return None,
+    };
+    if lw.attn_output.format != DgFormat::Q4K {
+        return None;
+    }
+    let hidden = h.first()?.len();
+    if !hidden.is_multiple_of(256) {
+        return None;
+    }
+    let n = h.len();
+    let q_dim = heads * head_dim;
+    let kv_dim = kv_heads * head_dim;
+    if !q_dim.is_multiple_of(256) {
+        return None;
+    }
+
+    // Per-position input activation (parallel; no h mutation).
+    let acts: Vec<DgActivation> = h
+        .par_iter()
+        .map(|hp| {
+            let xn = refmath::rms_norm(hp, Some(&lw.attn_norm), eps);
+            DgActivation::new(&xn)
+        })
+        .collect();
+    let bpr = hidden / 256;
+    let mut xs = vec![0f32; n * bpr];
+    let mut xqn = vec![0i8; n * bpr * 256];
+    for (pos, a) in acts.iter().enumerate() {
+        let blocks = a.q8_k.as_ref()?;
+        if blocks.len() != bpr {
+            return None;
+        }
+        for (b, blk) in blocks.iter().enumerate() {
+            xs[pos * bpr + b] = blk.d;
+            let off = (pos * bpr + b) * 256;
+            xqn[off..off + 256].copy_from_slice(&blk.qs);
+        }
+    }
+    let ident_base = vec![0i64; n];
+    let ident_pos: Vec<i32> = (0..n as i32).collect();
+    fn whole(w: &DgWire) -> Option<&[u8]> {
+        w.mmap.bytes(w.offset, w.rows * w.row_bytes()).ok()
+    }
+
+    // Projections (batched GPU GEMMs).
+    let mut q_all = cuda::fast_gemm_id(
+        whole(&lw.attn_q)?,
+        (lw.attn_q.mmap.path(), lw.attn_q.offset),
+        cuda::DgExpertKind::Q4K,
+        &ident_base,
+        &ident_pos,
+        q_dim,
+        bpr,
+        &xs,
+        &xqn,
+    )?;
+    let mut k_all = cuda::fast_gemm_id(
+        whole(&lw.attn_k)?,
+        (lw.attn_k.mmap.path(), lw.attn_k.offset),
+        cuda::DgExpertKind::Q4K,
+        &ident_base,
+        &ident_pos,
+        kv_dim,
+        bpr,
+        &xs,
+        &xqn,
+    )?;
+    let mut v_all = match (lw.attn_v.as_ref(), v_kind) {
+        (Some(wv), Some(kind)) => cuda::fast_gemm_id(
+            whole(wv)?,
+            (wv.mmap.path(), wv.offset),
+            kind,
+            &ident_base,
+            &ident_pos,
+            kv_dim,
+            bpr,
+            &xs,
+            &xqn,
+        )?,
+        // V-less layer: V is the RAW K projection (pre-norm, pre-RoPE).
+        _ => k_all.clone(),
+    };
+
+    // Per-head norms + RoPE (parallel per position; mirrors the CPU path).
+    q_all
+        .par_chunks_mut(q_dim)
+        .zip(
+            k_all
+                .par_chunks_mut(kv_dim)
+                .zip(v_all.par_chunks_mut(kv_dim)),
+        )
+        .enumerate()
+        .for_each(|(pos, (qp, (kp, vp)))| {
+            for hh in 0..heads {
+                let s = &mut qp[hh * head_dim..(hh + 1) * head_dim];
+                s.copy_from_slice(&refmath::rms_norm(s, Some(&lw.q_norm), eps));
+            }
+            refmath::rope_neox(qp, heads, head_dim, pos, theta, rope_factors);
+            for hh in 0..kv_heads {
+                let s = &mut kp[hh * head_dim..(hh + 1) * head_dim];
+                s.copy_from_slice(&refmath::rms_norm(s, Some(&lw.k_norm), eps));
+                let sv = &mut vp[hh * head_dim..(hh + 1) * head_dim];
+                sv.copy_from_slice(&refmath::rms_norm(sv, None, eps));
+            }
+            refmath::rope_neox(kp, kv_heads, head_dim, pos, theta, rope_factors);
+        });
+
+    // Attention (GPU kernel).
+    let attn = cuda::dg_attention_gpu(
+        &q_all,
+        &k_all,
+        &v_all,
+        n,
+        heads,
+        kv_heads,
+        head_dim,
+        group,
+        p,
+        win,
+        sliding,
+        canvas_prompt_lo,
+    )?;
+
+    // Output projection: quantize the attention mix, batched GEMM, post-norm
+    // + residual (the only h mutation, after all GPU calls).
+    let attn_acts: Vec<DgActivation> = attn.par_chunks(q_dim).map(DgActivation::new).collect();
+    let abpr = q_dim / 256;
+    let mut asx = vec![0f32; n * abpr];
+    let mut aqn = vec![0i8; n * abpr * 256];
+    for (pos, a) in attn_acts.iter().enumerate() {
+        let blocks = a.q8_k.as_ref()?;
+        if blocks.len() != abpr {
+            return None;
+        }
+        for (b, blk) in blocks.iter().enumerate() {
+            asx[pos * abpr + b] = blk.d;
+            let off = (pos * abpr + b) * 256;
+            aqn[off..off + 256].copy_from_slice(&blk.qs);
+        }
+    }
+    let o_all = cuda::fast_gemm_id(
+        whole(&lw.attn_output)?,
+        (lw.attn_output.mmap.path(), lw.attn_output.offset),
+        cuda::DgExpertKind::Q4K,
+        &ident_base,
+        &ident_pos,
+        hidden,
+        abpr,
+        &asx,
+        &aqn,
+    )?;
+    h.par_iter_mut().enumerate().for_each(|(pos, hp)| {
+        let on = refmath::rms_norm(
+            &o_all[pos * hidden..(pos + 1) * hidden],
+            Some(&lw.post_attn_norm),
+            eps,
+        );
+        for (a, b) in hp.iter_mut().zip(&on) {
+            *a += b;
+        }
+    });
+    Some(())
+}
+#[cfg(not(feature = "cuda"))]
+#[allow(clippy::too_many_arguments)]
+fn attn_layer_fast(
+    _lw: &DgLayer,
+    _h: &mut [Vec<f32>],
+    _heads: usize,
+    _head_dim: usize,
+    _kv_heads: usize,
+    _group: usize,
+    _theta: f32,
+    _rope_factors: Option<&[f32]>,
+    _sliding: bool,
+    _win: usize,
+    _p: usize,
+    _canvas_prompt_lo: i64,
+    _eps: f32,
+) -> Option<()> {
+    None
+}
+
+/// FAST-mode lm_head: flatten the canvas activations and run the tiled f16
+/// GEMM against the resident SC embedding transpose. `None` → the existing
+/// (parity-grade) lm_head paths.
+#[cfg(feature = "cuda")]
+fn lm_head_fast_gemm(
+    rt: &DgEncoderRuntime,
+    canvas_rns: &[Vec<f32>],
+    c: usize,
+    hidden: usize,
+) -> Option<Vec<f32>> {
+    let emb_t = rt.sc_emb_t().ok()?;
+    let n_vocab = rt.token_embd.rows;
+    let mut flat = Vec::with_capacity(c * hidden);
+    for rn in canvas_rns {
+        flat.extend_from_slice(rn);
+    }
+    // Softcapping fuses into the GEMM store (0.0 = none) — the caller must
+    // NOT re-apply the host softcap to these logits.
+    let cap = rt.final_logit_softcapping.unwrap_or(0.0);
+    cuda::lm_head_f16_gemm_gpu(emb_t, &flat, c, hidden, n_vocab, cap)
+}
+#[cfg(not(feature = "cuda"))]
+fn lm_head_fast_gemm(
+    _rt: &DgEncoderRuntime,
+    _canvas_rns: &[Vec<f32>],
+    _c: usize,
+    _hidden: usize,
+) -> Option<Vec<f32>> {
+    None
+}
+
 use crate::gguf::{read_metadata, GgufTensorDescriptor, GgufTensorType};
 
 // Expert-selection argsort matching the reference's `ggml_argsort_top_k`
@@ -1787,7 +2031,30 @@ impl DgEncoderRuntime {
             let mut ks: Vec<Vec<f32>> = Vec::with_capacity(n);
             let mut vs: Vec<Vec<f32>> = Vec::with_capacity(n);
             let _t_qkv = std::time::Instant::now();
-            for (pos, hp) in h.iter().enumerate() {
+            // FAST mode: whole attention block (projections + masked
+            // bidirectional attention + output projection) as batched GPU
+            // work; the per-position loops below are skipped on success.
+            let fast_attn = !want_trace
+                && dg_fast_enabled()
+                && attn_layer_fast(
+                    lw,
+                    &mut h,
+                    heads,
+                    head_dim,
+                    kv_heads,
+                    group,
+                    theta,
+                    rope_factors,
+                    sliding,
+                    win,
+                    p,
+                    canvas_prompt_lo,
+                    eps,
+                )
+                .is_some();
+            let qkv_range = if fast_attn { 0..0 } else { 0..h.len() };
+            for pos in qkv_range {
+                let hp = &h[pos];
                 let xn = refmath::rms_norm(hp, Some(&lw.attn_norm), eps);
                 let xq = DgActivation::new(&xn);
                 let mut q = lw.attn_q.matvec_dense(&xq)?;
@@ -1833,7 +2100,11 @@ impl DgEncoderRuntime {
                 }
             };
 
-            let mut v_cols: Vec<Vec<f32>> = vec![vec![0f32; n]; kv_heads * head_dim];
+            let mut v_cols: Vec<Vec<f32>> = if fast_attn {
+                Vec::new()
+            } else {
+                vec![vec![0f32; n]; kv_heads * head_dim]
+            };
             for (pp, vp) in vs.iter().enumerate() {
                 for (di, &val) in vp.iter().enumerate() {
                     v_cols[di][pp] = val;
@@ -1854,7 +2125,8 @@ impl DgEncoderRuntime {
             } else {
                 Vec::new()
             };
-            for pos in 0..n {
+            let attn_range = if fast_attn { 0..0 } else { 0..n };
+            for pos in attn_range {
                 let mut attn = vec![0f32; q_dim];
                 for hh in 0..heads {
                     let kvh = hh / group;
@@ -2073,12 +2345,27 @@ impl DgEncoderRuntime {
                 result_norm_all.extend_from_slice(rn);
             }
         }
-        // Canvas rows finish through the tied Q6_K lm_head. Quantize each canvas
-        // activation to Q8_K, then run one batched GPU GEMV (bit-close to the
+        // Canvas rows finish through the tied Q6_K lm_head. FAST mode runs a
+        // tiled f16 GEMM against the resident SC embedding transpose (shared
+        // VRAM slot, ~100x fewer weight reads); otherwise quantize each canvas
+        // activation to Q8_K and run one batched GPU GEMV (bit-close to the
         // CPU q6_k_dot) when available, else the per-position CPU matvec.
-        let canvas_acts: Vec<DgActivation> =
-            rns[p..].iter().map(|rn| DgActivation::new(rn)).collect();
-        let gpu_logits = lm_head_gpu(&self.token_embd, &canvas_acts, c, hidden);
+        let fast_logits = if !want_trace && dg_fast_enabled() {
+            lm_head_fast_gemm(self, &rns[p..], c, hidden)
+        } else {
+            None
+        };
+        // The fast GEMM fuses the softcap into its store; do not re-apply.
+        let fast_capped = fast_logits.is_some();
+        let canvas_acts: Vec<DgActivation> = if fast_capped {
+            Vec::new()
+        } else {
+            rns[p..].iter().map(|rn| DgActivation::new(rn)).collect()
+        };
+        let gpu_logits = match fast_logits {
+            Some(v) => Some(v),
+            None => lm_head_gpu(&self.token_embd, &canvas_acts, c, hidden),
+        };
         let mut logits = Vec::with_capacity(c * n_vocab);
         let softcap = |row: &mut [f32]| {
             if let Some(cap) = self.final_logit_softcapping {
@@ -2092,10 +2379,14 @@ impl DgEncoderRuntime {
         };
         match gpu_logits {
             Some(all) => {
-                for pos in 0..c {
-                    let mut row = all[pos * n_vocab..(pos + 1) * n_vocab].to_vec();
-                    softcap(&mut row);
-                    logits.extend_from_slice(&row);
+                if fast_capped {
+                    logits = all;
+                } else {
+                    for pos in 0..c {
+                        let mut row = all[pos * n_vocab..(pos + 1) * n_vocab].to_vec();
+                        softcap(&mut row);
+                        logits.extend_from_slice(&row);
+                    }
                 }
             }
             None => {

--- a/src/diffusion_gemma/chat.rs
+++ b/src/diffusion_gemma/chat.rs
@@ -214,4 +214,30 @@ impl DgChat {
         let text = self.decode_response(&response)?;
         Ok((text, stop, response))
     }
+
+    /// [`generate`](Self::generate) with a per-block committed-ids callback —
+    /// the serve lane's block-level SSE source. `on_committed` receives the
+    /// block index and the trimmed canvas ids that block committed (the
+    /// response grows by exactly these ids). Identical generation by
+    /// construction.
+    pub fn generate_with_blocks(
+        &self,
+        user_message: &str,
+        params: &DgEbParams,
+        n_blocks: i32,
+        max_ubatch: i32,
+        mut on_committed: impl FnMut(usize, &[i32]),
+    ) -> Result<(String, String, Vec<i32>)> {
+        let prompt = self.render_prompt(user_message)?;
+        let (_blocks, response, stop) = self.runtime.mc_generate(
+            &prompt,
+            params,
+            n_blocks,
+            max_ubatch,
+            &self.eog,
+            |b, _prefix, _records, canvas, cut| on_committed(b, &canvas[..cut]),
+        )?;
+        let text = self.decode_response(&response)?;
+        Ok((text, stop, response))
+    }
 }

--- a/src/diffusion_gemma/cuda.rs
+++ b/src/diffusion_gemma/cuda.rs
@@ -33,6 +33,9 @@ use cudarc::nvrtc::{compile_ptx_with_opts, CompileOptions};
 // NVRTC has no cuda_fp16.h here, so f16->f32 is hand-rolled (mirrors the
 // resident engine's `f16_bits_to_f32`).
 const KERNEL: &str = r#"
+// NVRTC has no math.h: spell -inf via the bit pattern.
+#define DG_NEG_INF (__int_as_float(0xff800000))
+
 __device__ __forceinline__ float f16_bits_to_f32(unsigned short bits) {
     unsigned int sign = ((unsigned int)(bits & 0x8000u)) << 16;
     unsigned int exp = (bits & 0x7c00u) >> 10;
@@ -385,6 +388,181 @@ extern "C" __global__ void q5_0_gemm_id(
         + ((acc1[0] + acc1[1]) + (acc1[2] + acc1[3]));
 }
 
+// Q6_K x Q8_K batched-ID GEMM (210-byte superblocks; same decode as
+// q6k_gemv_q8k above, with the (pair_base, pair_pos) indexing).
+extern "C" __global__ void q6k_gemm_id(
+    const unsigned char* __restrict__ wire,
+    const float* __restrict__ act_scales,
+    const signed char* __restrict__ act_quants,
+    const long long* __restrict__ pair_base,
+    const int* __restrict__ pair_pos,
+    int n_pairs, int rows_per, int bpr,
+    float* __restrict__ out)
+{
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)n_pairs * rows_per;
+    if (idx >= total) return;
+    int pair = (int)(idx / rows_per);
+    int r = (int)(idx % rows_per);
+    const unsigned char* rowp = wire + (pair_base[pair] + r) * (long long)bpr * 210;
+    const float* a_s = act_scales + (long long)pair_pos[pair] * bpr;
+    const signed char* a_q = act_quants + (long long)pair_pos[pair] * bpr * 256;
+    float sumf = 0.0f;
+    for (int b = 0; b < bpr; b++) {
+        const unsigned char* block = rowp + (long long)b * 210;
+        const unsigned char* ql = block;
+        const unsigned char* qh = block + 128;
+        const signed char* scales = (const signed char*)(block + 192);
+        float d_all = f16_bits_to_f32((unsigned short)block[208]
+            | ((unsigned short)block[209] << 8));
+        const signed char* q8 = a_q + (long long)b * 256;
+        float y_d = a_s[b];
+        long long isum = 0;
+        for (int half = 0; half < 2; half++) {
+            const unsigned char* qlh = ql + half * 64;
+            const unsigned char* qhh = qh + half * 32;
+            const signed char* q8h = q8 + half * 128;
+            const signed char* sc = scales + half * 8;
+            long long gs0 = 0, gs1 = 0, gs2 = 0, gs3 = 0,
+                gs4 = 0, gs5 = 0, gs6 = 0, gs7 = 0;
+            for (int l = 0; l < 32; l++) {
+                int v0 = (qlh[l] & 0xF) | ((qhh[l] & 3) << 4);
+                int v1 = (qlh[32 + l] & 0xF) | (((qhh[l] >> 2) & 3) << 4);
+                int v2 = (qlh[l] >> 4) | (((qhh[l] >> 4) & 3) << 4);
+                int v3 = (qlh[32 + l] >> 4) | (((qhh[l] >> 6) & 3) << 4);
+                if (l < 16) {
+                    gs0 += (long long)v0 * q8h[l];
+                    gs2 += (long long)v1 * q8h[32 + l];
+                    gs4 += (long long)v2 * q8h[64 + l];
+                    gs6 += (long long)v3 * q8h[96 + l];
+                } else {
+                    gs1 += (long long)v0 * q8h[l];
+                    gs3 += (long long)v1 * q8h[32 + l];
+                    gs5 += (long long)v2 * q8h[64 + l];
+                    gs7 += (long long)v3 * q8h[96 + l];
+                }
+            }
+            isum += gs0 * (long long)sc[0] + gs1 * (long long)sc[1]
+                + gs2 * (long long)sc[2] + gs3 * (long long)sc[3]
+                + gs4 * (long long)sc[4] + gs5 * (long long)sc[5]
+                + gs6 * (long long)sc[6] + gs7 * (long long)sc[7];
+        }
+        long long isum_mins = 0;
+        for (int t = 0; t < 16; t++) {
+            long long bs = 0;
+            for (int l = 0; l < 16; l++) bs += q8[t * 16 + l];
+            isum_mins += bs * (long long)scales[t];
+        }
+        sumf = fmaf(d_all * y_d, (float)(isum - 32 * isum_mins), sumf);
+    }
+    out[idx] = sumf;
+}
+
+// FAST-mode bidirectional diffusion attention: one block per (pos, head).
+// Mirrors the CPU path's math shape (raw QK dots -> masked softmax -> V mix)
+// with the region-aware mask: prompt queries are causal over the prompt
+// (SWA-clipped on sliding layers); canvas queries see everything on global
+// layers, and all canvas plus the last (n_swa - 1) prompt positions on
+// sliding layers. f32 throughout (fast mode: not bit-exact).
+extern "C" __global__ void dg_attn(
+    const float* __restrict__ q,   // [n * heads * hd]
+    const float* __restrict__ k,   // [n * kv_heads * hd]
+    const float* __restrict__ v,   // [n * kv_heads * hd]
+    float* __restrict__ out,       // [n * heads * hd]
+    int n, int heads, int kv_heads, int hd, int group,
+    int p, int win, int sliding, long long lo)
+{
+    int pos = blockIdx.x / heads;
+    int hh = blockIdx.x % heads;
+    if (pos >= n) return;
+    int kvh = hh / group;
+    extern __shared__ float row[]; // [n] scores
+    __shared__ float red[256];
+    const float* qh = q + ((long long)pos * heads + hh) * hd;
+    for (int kp = threadIdx.x; kp < n; kp += blockDim.x) {
+        bool ok;
+        if (pos >= p) {
+            ok = sliding ? (kp >= p || (long long)kp >= lo) : true;
+        } else {
+            ok = (kp <= pos) && (!sliding || kp + win > pos);
+        }
+        float s = DG_NEG_INF;
+        if (ok) {
+            const float* kk = k + ((long long)kp * kv_heads + kvh) * hd;
+            float acc = 0.0f;
+            for (int d = 0; d < hd; d++) acc += qh[d] * kk[d];
+            s = acc;
+        }
+        row[kp] = s;
+    }
+    __syncthreads();
+    float m = DG_NEG_INF;
+    for (int i = threadIdx.x; i < n; i += blockDim.x) m = fmaxf(m, row[i]);
+    red[threadIdx.x] = m;
+    __syncthreads();
+    for (int s2 = blockDim.x >> 1; s2 > 0; s2 >>= 1) {
+        if (threadIdx.x < s2)
+            red[threadIdx.x] = fmaxf(red[threadIdx.x], red[threadIdx.x + s2]);
+        __syncthreads();
+    }
+    m = red[0];
+    __syncthreads();
+    float sum = 0.0f;
+    for (int i = threadIdx.x; i < n; i += blockDim.x) {
+        float e = expf(row[i] - m);
+        row[i] = e;
+        sum += e;
+    }
+    red[threadIdx.x] = sum;
+    __syncthreads();
+    for (int s2 = blockDim.x >> 1; s2 > 0; s2 >>= 1) {
+        if (threadIdx.x < s2) red[threadIdx.x] += red[threadIdx.x + s2];
+        __syncthreads();
+    }
+    float inv = 1.0f / red[0];
+    __syncthreads();
+    float* op = out + ((long long)pos * heads + hh) * hd;
+    for (int d = threadIdx.x; d < hd; d += blockDim.x) {
+        float acc = 0.0f;
+        for (int kp = 0; kp < n; kp++) {
+            acc += row[kp] * v[((long long)kp * kv_heads + kvh) * hd + d];
+        }
+        op[d] = acc * inv;
+    }
+}
+
+// FAST-mode lm_head: tiled f32xf16 GEMM against the RESIDENT transposed
+// embedding (the SC stage's emb_t, [hidden][vocab] row-major — already the
+// B-matrix layout a GEMM wants, and already in VRAM). C[m*n] = A[m*k] x B[k*n].
+// cap > 0 fuses the final-logit softcapping (tanh(x/cap)*cap) into the store.
+extern "C" __global__ void lm_head_f16_gemm(
+    const float* __restrict__ a,
+    const unsigned short* __restrict__ bt,
+    float* __restrict__ cmat,
+    int m, int k, int n, float cap)
+{
+    __shared__ float As[16][16];
+    __shared__ float Bs[16][17];
+    int tx = threadIdx.x, ty = threadIdx.y;
+    int col = blockIdx.x * 16 + tx;
+    int rowc = blockIdx.y * 16 + ty;
+    float acc = 0.0f;
+    for (int k0 = 0; k0 < k; k0 += 16) {
+        As[ty][tx] = (rowc < m && (k0 + tx) < k) ? a[(long long)rowc * k + k0 + tx] : 0.0f;
+        int brow = k0 + ty;
+        Bs[ty][tx] = (brow < k && col < n)
+            ? f16_bits_to_f32(bt[(long long)brow * n + col])
+            : 0.0f;
+        __syncthreads();
+        for (int kk = 0; kk < 16; kk++) acc += As[ty][kk] * Bs[kk][tx];
+        __syncthreads();
+    }
+    if (rowc < m && col < n) {
+        if (cap > 0.0f) acc = tanhf(acc * (1.0f / cap)) * cap;
+        cmat[(long long)rowc * n + col] = acc;
+    }
+}
+
 extern "C" __global__ void q8_0_gemm_id(
     const unsigned char* __restrict__ wire,
     const float* __restrict__ act_scales,      // [P * nb]
@@ -436,6 +614,9 @@ struct Engine {
     q4k_id_func: CudaFunction,
     q80_id_func: CudaFunction,
     q50_id_func: CudaFunction,
+    q6k_id_func: CudaFunction,
+    attn_func: CudaFunction,
+    lm_gemm_func: CudaFunction,
     /// FAST-mode streaming scratch for tensors that miss the resident pool
     /// (grown to the largest streamed tensor; one at a time).
     scratch: Option<CudaSlice<u8>>,
@@ -443,6 +624,16 @@ struct Engine {
     /// pageable-mmap → pinned memcpy + pinned → device DMA is several times
     /// faster than a pageable `memcpy_htod`. Grown like `scratch`.
     pinned: Option<cudarc::driver::PinnedHostSlice<u8>>,
+    /// Second pinned buffer: the read-ahead worker fills this one with the
+    /// NEXT streamed tensor while `pinned` feeds the current htod.
+    pinned2: Option<cudarc::driver::PinnedHostSlice<u8>>,
+    /// Which pinned buffer the read-ahead worker owns right now (0/1).
+    ra_buf: usize,
+    /// Read-ahead pipeline (see `ReadAhead`): the per-step streamed-tensor
+    /// sequence is deterministic, so step 0 learns it and steps 1+ overlap
+    /// each tensor's FILE READ (the actual wall, ~10x the PCIe copy) with
+    /// the previous tensor's GPU work.
+    ra: Option<ReadAhead>,
     /// Resident transposed embedding (f16) for the SC matmul.
     sc_emb: Option<(CudaSlice<u16>, (usize, usize))>,
     /// Resident Q6_K lm_head weight (wire bytes).
@@ -455,6 +646,10 @@ struct Engine {
     /// Remaining expert-pool byte budget; `None` until first use (computed
     /// from free VRAM minus a reserve, or `CAMELID_DG_EXPERT_VRAM_MB`).
     expert_budget: Option<u64>,
+    /// Carve-out for SMALL tensors (attention/dense projections, ~40 MiB per
+    /// layer total). Without it the greedy expert uploads exhaust the budget
+    /// first and the small HOT tensors re-stream every layer, every step.
+    small_budget: Option<u64>,
 }
 
 // SAFETY: the engine is only touched while holding ENGINE's mutex (the same
@@ -463,8 +658,54 @@ unsafe impl Send for Engine {}
 
 static ENGINE: OnceLock<Mutex<Option<Engine>>> = OnceLock::new();
 
+/// Largest streamable tensor (pinned staging buffers are fixed at this cap;
+/// the biggest streamed DG tensor is ~285 MiB).
+const DG_PIN_CAP: usize = 300 * 1024 * 1024;
+
+/// Residency split: tensors under this size (attention/dense projections)
+/// draw from the small carve-out; expert tensors draw from the remainder.
+const DG_SMALL_TENSOR: usize = 32 * 1024 * 1024;
+/// Carve-out for the small hot tensors (all 30 layers' attn+dense ≈ 1.2 GiB).
+const DG_SMALL_BUDGET: u64 = 1300 * 1024 * 1024;
+
+/// Initialize the split pool budgets on first use.
+fn ensure_budgets(eng: &mut Engine) {
+    if eng.expert_budget.is_some() {
+        return;
+    }
+    let total = match std::env::var("CAMELID_DG_EXPERT_VRAM_MB")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        Some(mb) => mb * 1024 * 1024,
+        None => {
+            const RESERVE: u64 = 1700 * 1024 * 1024;
+            let free = cudarc::driver::result::mem_get_info()
+                .map(|(f, _)| f as u64)
+                .unwrap_or(0);
+            free.saturating_sub(RESERVE)
+        }
+    };
+    let small = total.min(DG_SMALL_BUDGET);
+    eng.small_budget = Some(small);
+    eng.expert_budget = Some(total - small);
+    eprintln!(
+        "[dg-cuda] pool budgets: {:.2} GiB experts + {:.2} GiB small tensors",
+        (total - small) as f64 / (1u64 << 30) as f64,
+        small as f64 / (1u64 << 30) as f64
+    );
+}
+
+/// Set once when the NVRTC engine build fails: every later GPU call must
+/// fail FAST to the CPU path. Without this, each of the thousands of
+/// per-step calls would retry the full kernel compile (~0.5 s each) and a
+/// broken kernel would run 20-30x SLOWER than plain CPU.
+static ENGINE_FAILED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 fn gate_off() -> bool {
-    std::env::var("CAMELID_DG_CUDA").as_deref() == Ok("0") || !crate::cuda::is_available()
+    ENGINE_FAILED.load(std::sync::atomic::Ordering::Relaxed)
+        || std::env::var("CAMELID_DG_CUDA").as_deref() == Ok("0")
+        || !crate::cuda::is_available()
 }
 
 fn build_engine() -> Result<Engine, String> {
@@ -501,6 +742,15 @@ fn build_engine() -> Result<Engine, String> {
     let q50_id_func = m
         .load_function("q5_0_gemm_id")
         .map_err(|e| format!("load q5_0_gemm_id: {e}"))?;
+    let q6k_id_func = m
+        .load_function("q6k_gemm_id")
+        .map_err(|e| format!("load q6k_gemm_id: {e}"))?;
+    let attn_func = m
+        .load_function("dg_attn")
+        .map_err(|e| format!("load dg_attn: {e}"))?;
+    let lm_gemm_func = m
+        .load_function("lm_head_f16_gemm")
+        .map_err(|e| format!("load lm_head_f16_gemm: {e}"))?;
     Ok(Engine {
         stream,
         ctx,
@@ -511,13 +761,20 @@ fn build_engine() -> Result<Engine, String> {
         q4k_id_func,
         q80_id_func,
         q50_id_func,
+        q6k_id_func,
+        attn_func,
+        lm_gemm_func,
         scratch: None,
         pinned: None,
+        pinned2: None,
+        ra_buf: 0,
+        ra: None,
         sc_emb: None,
         lm_wire: None,
         expert_pool: std::collections::HashMap::new(),
         expert_rejected: std::collections::HashSet::new(),
         expert_budget: None,
+        small_budget: None,
     })
 }
 
@@ -548,6 +805,7 @@ pub(crate) fn sc_soft_embedding_gpu(
         match build_engine() {
             Ok(e) => *guard = Some(e),
             Err(err) => {
+                ENGINE_FAILED.store(true, std::sync::atomic::Ordering::Relaxed);
                 eprintln!("[dg-cuda] engine build failed ({err}); CPU fallback");
                 return None;
             }
@@ -628,6 +886,7 @@ pub(crate) fn lm_head_q6k_gpu(
         match build_engine() {
             Ok(e) => *guard = Some(e),
             Err(err) => {
+                ENGINE_FAILED.store(true, std::sync::atomic::Ordering::Relaxed);
                 eprintln!("[dg-cuda] engine build failed ({err}); CPU fallback");
                 return None;
             }
@@ -700,6 +959,9 @@ pub(crate) enum DgExpertKind {
     Q80,
     /// 22-byte blocks; activation is Q8_0 (same layout as `Q80`). FAST mode only.
     Q50,
+    /// 210-byte superblocks; activation is Q8_K (same layout as `Q4K`).
+    /// FAST mode only (attn_v / lm_head class tensors).
+    Q6K,
 }
 
 /// MoE expert row-range GEMV on the VRAM-resident expert pool.
@@ -730,6 +992,7 @@ pub(crate) fn expert_rows_gemv_gpu(
         match build_engine() {
             Ok(e) => *guard = Some(e),
             Err(err) => {
+                ENGINE_FAILED.store(true, std::sync::atomic::Ordering::Relaxed);
                 eprintln!("[dg-cuda] engine build failed ({err}); CPU fallback");
                 return None;
             }
@@ -741,27 +1004,9 @@ pub(crate) fn expert_rows_gemv_gpu(
         return None;
     }
     if !eng.expert_pool.contains_key(&key) {
-        // Initialize the pool budget on first use.
-        if eng.expert_budget.is_none() {
-            let budget = match std::env::var("CAMELID_DG_EXPERT_VRAM_MB")
-                .ok()
-                .and_then(|v| v.parse::<u64>().ok())
-            {
-                Some(mb) => mb * 1024 * 1024,
-                None => {
-                    const RESERVE: u64 = 2200 * 1024 * 1024;
-                    let free = cudarc::driver::result::mem_get_info()
-                        .map(|(f, _)| f as u64)
-                        .unwrap_or(0);
-                    free.saturating_sub(RESERVE)
-                }
-            };
-            eprintln!(
-                "[dg-cuda] expert pool budget {:.2} GiB",
-                budget as f64 / (1u64 << 30) as f64
-            );
-            eng.expert_budget = Some(budget);
-        }
+        // Initialize the pool budgets on first use (expert tensors draw from
+        // the big-tensor share; see `ensure_budgets`).
+        ensure_budgets(eng);
         let budget = eng.expert_budget.unwrap();
         if (tensor.len() as u64) > budget {
             eng.expert_rejected.insert(key);
@@ -798,8 +1043,9 @@ pub(crate) fn expert_rows_gemv_gpu(
     let func = match kind {
         DgExpertKind::Q4K => &eng.q4k_rows_func,
         DgExpertKind::Q80 => &eng.q80_rows_func,
-        // No single-activation Q5_0 kernel: the parity path never routes it.
-        DgExpertKind::Q50 => return None,
+        // No single-activation Q5_0/Q6_K kernels: the parity path never
+        // routes them (fast-mode-only kinds).
+        DgExpertKind::Q50 | DgExpertKind::Q6K => return None,
     };
     let run = || -> Result<Vec<f32>, String> {
         let s = eng.stream.clone();
@@ -855,6 +1101,77 @@ pub(crate) fn expert_rows_gemv_gpu(
 /// reusable scratch upload (~tens of ms for a 272 MiB expert tensor — amortized
 /// over ALL pairs, which is the whole point vs per-position reads). Returns
 /// `[n_pairs * rows_per]` outputs or `None` (→ CPU fallback).
+/// A prefetch request to the read-ahead worker: read `len` bytes at `off`
+/// of `path` into the raw pinned buffer at `ptr`.
+struct RaReq {
+    key: (usize, usize),
+    ptr: usize,
+    len: usize,
+    path: std::path::PathBuf,
+    off: u64,
+}
+
+/// Read-ahead pipeline for streamed tensors. Two fixed pinned buffers
+/// alternate: one feeds the current htod while a worker thread fills the
+/// other with the NEXT streamed tensor's bytes (the streamed order repeats
+/// exactly every denoise step, learned on step 0). The worker does file I/O
+/// only — no CUDA — so there is no cross-thread context juggling; buffer
+/// handoff is strictly dispatch → recv done → consume.
+struct ReadAhead {
+    tx: std::sync::mpsc::Sender<RaReq>,
+    done_rx: std::sync::mpsc::Receiver<(usize, usize)>,
+    /// (key, pinned-buffer index) dispatched and not yet consumed.
+    in_flight: Option<((usize, usize), usize)>,
+    /// Learned per-step order of streamed tensors: (key, path, offset, len).
+    order: Vec<((usize, usize), std::path::PathBuf, u64, usize)>,
+    learned: bool,
+}
+
+impl ReadAhead {
+    fn new() -> Self {
+        let (tx, rx) = std::sync::mpsc::channel::<RaReq>();
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<(usize, usize)>();
+        std::thread::Builder::new()
+            .name("dg-readahead".into())
+            .spawn(move || {
+                while let Ok(req) = rx.recv() {
+                    // SAFETY: ptr/len name an exclusively-handed-off pinned
+                    // buffer region; the dispatcher does not touch it until
+                    // the done message for this key arrives.
+                    let dst =
+                        unsafe { std::slice::from_raw_parts_mut(req.ptr as *mut u8, req.len) };
+                    let ok = std::fs::File::open(&req.path)
+                        .and_then(|f| read_at_into(&f, req.off, dst))
+                        .is_ok();
+                    // A failed read reports key (ptr, 0) so the consumer
+                    // falls back to its own synchronous read.
+                    let _ = done_tx.send(if ok { req.key } else { (req.key.0, 0) });
+                }
+            })
+            .expect("spawn dg-readahead");
+        Self {
+            tx,
+            done_rx,
+            in_flight: None,
+            order: Vec::new(),
+            learned: false,
+        }
+    }
+
+    /// The entry AFTER `key` in the learned order (wrapping), if any.
+    #[allow(clippy::type_complexity)]
+    fn next_after(
+        &self,
+        key: (usize, usize),
+    ) -> Option<&((usize, usize), std::path::PathBuf, u64, usize)> {
+        if !self.learned || self.order.is_empty() {
+            return None;
+        }
+        let i = self.order.iter().position(|(k, ..)| *k == key)?;
+        Some(&self.order[(i + 1) % self.order.len()])
+    }
+}
+
 /// Positioned read into `dst` (Windows `seek_read` / Unix `read_exact_at`).
 fn read_at_into(file: &std::fs::File, offset: u64, dst: &mut [u8]) -> std::io::Result<()> {
     #[cfg(windows)]
@@ -905,6 +1222,7 @@ pub(crate) fn fast_gemm_id(
         match build_engine() {
             Ok(e) => *guard = Some(e),
             Err(err) => {
+                ENGINE_FAILED.store(true, std::sync::atomic::Ordering::Relaxed);
                 eprintln!("[dg-cuda] engine build failed ({err}); CPU fallback");
                 return None;
             }
@@ -915,34 +1233,29 @@ pub(crate) fn fast_gemm_id(
     // Residency: pool if the budget allows (same accounting as the parity
     // expert pool), else stream through the scratch buffer.
     let mut streamed = false;
+    let mut streamed_upload_done = false;
+    // (consumed key, pinned-buffer index) when a streamed upload used a
+    // pinned buffer — the post-sync prefetch dispatch reuses that buffer.
+    let mut stream_consumed: Option<((usize, usize), usize)> = None;
     if !eng.expert_pool.contains_key(&key) && !eng.expert_rejected.contains(&key) {
-        if eng.expert_budget.is_none() {
-            let budget = match std::env::var("CAMELID_DG_EXPERT_VRAM_MB")
-                .ok()
-                .and_then(|v| v.parse::<u64>().ok())
-            {
-                Some(mb) => mb * 1024 * 1024,
-                None => {
-                    const RESERVE: u64 = 2200 * 1024 * 1024;
-                    let free = cudarc::driver::result::mem_get_info()
-                        .map(|(f, _)| f as u64)
-                        .unwrap_or(0);
-                    free.saturating_sub(RESERVE)
-                }
-            };
-            eprintln!(
-                "[dg-cuda] expert pool budget {:.2} GiB",
-                budget as f64 / (1u64 << 30) as f64
-            );
-            eng.expert_budget = Some(budget);
-        }
-        let budget = eng.expert_budget.unwrap();
+        ensure_budgets(eng);
+        let is_small = tensor.len() < DG_SMALL_TENSOR;
+        let budget = if is_small {
+            eng.small_budget.unwrap()
+        } else {
+            eng.expert_budget.unwrap()
+        };
         if (tensor.len() as u64) <= budget {
             let s = eng.stream.clone();
             match s.alloc_zeros::<u8>(tensor.len()) {
                 Ok(mut dev) => {
                     if s.memcpy_htod(tensor, &mut dev).is_ok() {
-                        eng.expert_budget = Some(budget - tensor.len() as u64);
+                        let left = budget - tensor.len() as u64;
+                        if is_small {
+                            eng.small_budget = Some(left);
+                        } else {
+                            eng.expert_budget = Some(left);
+                        }
                         eng.expert_pool.insert(key, dev);
                     } else {
                         eng.expert_rejected.insert(key);
@@ -976,46 +1289,116 @@ pub(crate) fn fast_gemm_id(
             }
         }
         // Stage through pinned memory, filled by a DIRECT positioned file
-        // read. Under RAM pressure the mmap's demand paging re-reads evicted
-        // pages at random-fault speed (~0.6 GB/s observed); a sequential
-        // buffered read hits NVMe read-ahead speed instead, and the pinned
-        // buffer gives the htod full DMA rate. Falls back to the mmap slice.
-        let pin_ok = eng
-            .pinned
-            .as_ref()
-            .map(|pin| pin.len() >= need)
-            .unwrap_or(false);
-        if !pin_ok {
-            eng.pinned = unsafe { eng.ctx.alloc_pinned::<u8>(need) }.ok();
-        }
-        let staged: Option<&[u8]> = eng.pinned.as_mut().and_then(|pin| {
-            let dst = pin.as_mut_ptr().ok()?;
-            // SAFETY: pin.len() >= need (grown above).
-            let dst_slice = unsafe { std::slice::from_raw_parts_mut(dst, need) };
-            let read_ok = std::fs::File::open(src.0)
-                .and_then(|f| read_at_into(&f, src.1, dst_slice))
-                .is_ok();
-            if !read_ok {
-                // SAFETY: as above; the mmap slice is the fallback source.
-                unsafe { std::ptr::copy_nonoverlapping(tensor.as_ptr(), dst, need) };
-            }
-            pin.as_slice().ok().map(|sl| &sl[..need])
-        });
-        let buf = eng.scratch.as_mut().unwrap();
-        let mut view = buf.slice_mut(0..need);
-        let copied = match staged {
-            Some(host) => s.memcpy_htod(host, &mut view),
-            None => s.memcpy_htod(tensor, &mut view),
-        };
-        if let Err(e) = copied {
-            eprintln!("[dg-cuda] fast stream upload failed ({e}); CPU fallback");
+        // read (mmap demand paging under RAM pressure runs at random-fault
+        // speed, ~0.6 GB/s observed; a sequential read + pinned DMA is far
+        // faster). The read-ahead worker overlaps the NEXT streamed tensor's
+        // read (the dominant cost) with this call's GPU work, alternating two
+        // fixed pinned buffers; the per-step sequence is learned on step 0.
+        if need > DG_PIN_CAP {
+            eprintln!("[dg-cuda] streamed tensor exceeds pin cap; CPU fallback");
             return None;
+        }
+        if eng.pinned.is_none() {
+            eng.pinned = unsafe { eng.ctx.alloc_pinned::<u8>(DG_PIN_CAP) }.ok();
+        }
+        if eng.pinned2.is_none() {
+            eng.pinned2 = unsafe { eng.ctx.alloc_pinned::<u8>(DG_PIN_CAP) }.ok();
+        }
+        if eng.ra.is_none() {
+            eng.ra = Some(ReadAhead::new());
+        }
+        // 1. Resolve the host bytes: a matching completed prefetch, else a
+        // synchronous read into whichever buffer the worker does not hold.
+        let mut ready_buf: Option<usize> = None;
+        {
+            let ra = eng.ra.as_mut().unwrap();
+            if let Some((k, bi)) = ra.in_flight {
+                if k == key {
+                    match ra.done_rx.recv() {
+                        Ok(done) if done == key => ready_buf = Some(bi),
+                        _ => {} // read failed → fall through to sync read
+                    }
+                    ra.in_flight = None;
+                } else {
+                    // Mispredict (should not happen once learned): reclaim
+                    // the buffer by draining the done message, then ignore it.
+                    let _ = ra.done_rx.recv();
+                    ra.in_flight = None;
+                }
+            }
+            // Learn the per-step sequence on the first pass.
+            if !ra.learned {
+                if ra.order.first().map(|(k, ..)| *k == key).unwrap_or(false) {
+                    ra.learned = true;
+                    eprintln!(
+                        "[dg-cuda] read-ahead learned {} streamed tensors/step",
+                        ra.order.len()
+                    );
+                } else {
+                    ra.order.push((key, src.0.to_path_buf(), src.1, need));
+                }
+            }
+        }
+        let use_buf = ready_buf.unwrap_or(eng.ra_buf);
+        if ready_buf.is_none() {
+            // Synchronous read into `use_buf` (the worker holds no buffer or
+            // holds the other one).
+            let pin = if use_buf == 0 {
+                eng.pinned.as_mut()
+            } else {
+                eng.pinned2.as_mut()
+            };
+            let read_ok = pin.is_some_and(|pin| {
+                let Ok(dst) = pin.as_mut_ptr() else {
+                    return false;
+                };
+                // SAFETY: PIN_CAP >= need (checked above).
+                let dst_slice = unsafe { std::slice::from_raw_parts_mut(dst, need) };
+                std::fs::File::open(src.0)
+                    .and_then(|f| read_at_into(&f, src.1, dst_slice))
+                    .is_ok()
+            });
+            if !read_ok {
+                // Last-resort: pageable upload straight from the mmap slice.
+                let buf = eng.scratch.as_mut().unwrap();
+                let mut view = buf.slice_mut(0..need);
+                if let Err(e) = s.memcpy_htod(tensor, &mut view) {
+                    eprintln!("[dg-cuda] fast stream upload failed ({e}); CPU fallback");
+                    return None;
+                }
+                eng.ra_buf = use_buf; // buffer unused; stays available
+                streamed_upload_done = true;
+            }
+        }
+        if !streamed_upload_done {
+            let pin = if use_buf == 0 {
+                eng.pinned.as_ref()
+            } else {
+                eng.pinned2.as_ref()
+            };
+            let host = pin
+                .and_then(|pin| pin.as_slice().ok())
+                .map(|sl| &sl[..need]);
+            let Some(host) = host else {
+                eprintln!("[dg-cuda] pinned staging unavailable; CPU fallback");
+                return None;
+            };
+            let buf = eng.scratch.as_mut().unwrap();
+            let mut view = buf.slice_mut(0..need);
+            if let Err(e) = s.memcpy_htod(host, &mut view) {
+                eprintln!("[dg-cuda] fast stream upload failed ({e}); CPU fallback");
+                return None;
+            }
+            // The other buffer is free for the worker after this call's sync.
+            eng.ra_buf = use_buf ^ 1;
+            stream_consumed = Some((key, use_buf));
         }
     }
     let func = match kind {
         DgExpertKind::Q4K => &eng.q4k_id_func,
         DgExpertKind::Q80 => &eng.q80_id_func,
         DgExpertKind::Q50 => &eng.q50_id_func,
+        DgExpertKind::Q6K => &eng.q6k_id_func,
     };
     let run = || -> Result<Vec<f32>, String> {
         let s = eng.stream.clone();
@@ -1072,10 +1455,230 @@ pub(crate) fn fast_gemm_id(
         eng.ctx.synchronize().map_err(|e| format!("sync: {e}"))?;
         Ok(out)
     };
-    match run() {
+    let result = run();
+    // Post-sync prefetch dispatch: the buffer this call consumed is free
+    // again (run() ends with a full sync); hand it to the read-ahead worker
+    // for the NEXT streamed tensor in the learned per-step order. The wrap
+    // at the sequence end prefetches the next STEP's first tensor across the
+    // attention/lm_head/sampler gap.
+    if result.is_ok() {
+        if let Some((ck, buf_idx)) = stream_consumed {
+            let next = eng
+                .ra
+                .as_ref()
+                .filter(|ra| ra.learned && ra.in_flight.is_none())
+                .and_then(|ra| ra.next_after(ck).cloned());
+            if let Some((nk, npath, noff, nlen)) = next {
+                if !eng.expert_pool.contains_key(&nk) && nlen > 0 && nlen <= DG_PIN_CAP {
+                    let ptr = if buf_idx == 0 {
+                        eng.pinned.as_mut().and_then(|p| p.as_mut_ptr().ok())
+                    } else {
+                        eng.pinned2.as_mut().and_then(|p| p.as_mut_ptr().ok())
+                    };
+                    if let (Some(ptr), Some(ra)) = (ptr, eng.ra.as_mut()) {
+                        if ra
+                            .tx
+                            .send(RaReq {
+                                key: nk,
+                                ptr: ptr as usize,
+                                len: nlen,
+                                path: npath,
+                                off: noff,
+                            })
+                            .is_ok()
+                        {
+                            ra.in_flight = Some((nk, buf_idx));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    match result {
         Ok(v) => Some(v),
         Err(err) => {
             eprintln!("[dg-cuda] fast gemm failed ({err}); CPU fallback");
+            None
+        }
+    }
+}
+
+/// FAST-mode bidirectional diffusion attention on the GPU (see the `dg_attn`
+/// kernel). `q` is `[n*heads*hd]`, `k`/`v` are `[n*kv_heads*hd]` (post
+/// norm+RoPE, f32). Returns the pre-`attn_output` mix `[n*heads*hd]`, or
+/// `None` on any failure (→ CPU fallback).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn dg_attention_gpu(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    n: usize,
+    heads: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    group: usize,
+    p: usize,
+    win: usize,
+    sliding: bool,
+    canvas_prompt_lo: i64,
+) -> Option<Vec<f32>> {
+    if gate_off() {
+        return None;
+    }
+    let cell = ENGINE.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().ok()?;
+    if guard.is_none() {
+        match build_engine() {
+            Ok(e) => *guard = Some(e),
+            Err(err) => {
+                ENGINE_FAILED.store(true, std::sync::atomic::Ordering::Relaxed);
+                eprintln!("[dg-cuda] engine build failed ({err}); CPU fallback");
+                return None;
+            }
+        }
+    }
+    let eng = guard.as_mut()?;
+    let run = || -> Result<Vec<f32>, String> {
+        let s = eng.stream.clone();
+        let mut q_dev = s
+            .alloc_zeros::<f32>(q.len())
+            .map_err(|e| format!("alloc q: {e}"))?;
+        s.memcpy_htod(q, &mut q_dev)
+            .map_err(|e| format!("upload q: {e}"))?;
+        let mut k_dev = s
+            .alloc_zeros::<f32>(k.len())
+            .map_err(|e| format!("alloc k: {e}"))?;
+        s.memcpy_htod(k, &mut k_dev)
+            .map_err(|e| format!("upload k: {e}"))?;
+        let mut v_dev = s
+            .alloc_zeros::<f32>(v.len())
+            .map_err(|e| format!("alloc v: {e}"))?;
+        s.memcpy_htod(v, &mut v_dev)
+            .map_err(|e| format!("upload v: {e}"))?;
+        let mut out_dev = s
+            .alloc_zeros::<f32>(n * heads * head_dim)
+            .map_err(|e| format!("alloc attn out: {e}"))?;
+        let cfg = LaunchConfig {
+            grid_dim: ((n * heads) as u32, 1, 1),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: (n * 4) as u32,
+        };
+        let (ni, hi, kvi, hdi, gi, pi, wi, sl) = (
+            n as i32,
+            heads as i32,
+            kv_heads as i32,
+            head_dim as i32,
+            group as i32,
+            p as i32,
+            win as i32,
+            sliding as i32,
+        );
+        let mut b = s.launch_builder(&eng.attn_func);
+        b.arg(&q_dev)
+            .arg(&k_dev)
+            .arg(&v_dev)
+            .arg(&mut out_dev)
+            .arg(&ni)
+            .arg(&hi)
+            .arg(&kvi)
+            .arg(&hdi)
+            .arg(&gi)
+            .arg(&pi)
+            .arg(&wi)
+            .arg(&sl)
+            .arg(&canvas_prompt_lo);
+        unsafe { b.launch(cfg) }.map_err(|e| format!("launch attn: {e}"))?;
+        let mut out = vec![0f32; n * heads * head_dim];
+        s.memcpy_dtoh(&out_dev, &mut out)
+            .map_err(|e| format!("download attn: {e}"))?;
+        eng.ctx.synchronize().map_err(|e| format!("sync: {e}"))?;
+        Ok(out)
+    };
+    match run() {
+        Ok(out) => Some(out),
+        Err(err) => {
+            eprintln!("[dg-cuda] attention failed ({err}); CPU fallback");
+            None
+        }
+    }
+}
+
+/// FAST-mode lm_head over the canvas rows: `logits[pos][v] = Σ_e h[pos][e] ×
+/// emb_t[e][v]` as a tiled f32×f16 GEMM against the SC stage's RESIDENT
+/// transposed embedding (uploaded once, shared with `sc_soft_embedding_gpu`
+/// via the same cache slot). Not bit-exact vs the Q6_K integer dot (f16
+/// weights, f32 accumulation) — FAST mode only.
+pub(crate) fn lm_head_f16_gemm_gpu(
+    emb_t: &[u16],
+    h_canvas: &[f32],
+    c: usize,
+    hidden: usize,
+    n_vocab: usize,
+    softcap: f32,
+) -> Option<Vec<f32>> {
+    if gate_off() {
+        return None;
+    }
+    debug_assert_eq!(emb_t.len(), hidden * n_vocab);
+    debug_assert_eq!(h_canvas.len(), c * hidden);
+    let cell = ENGINE.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().ok()?;
+    if guard.is_none() {
+        match build_engine() {
+            Ok(e) => *guard = Some(e),
+            Err(err) => {
+                ENGINE_FAILED.store(true, std::sync::atomic::Ordering::Relaxed);
+                eprintln!("[dg-cuda] engine build failed ({err}); CPU fallback");
+                return None;
+            }
+        }
+    }
+    let eng = guard.as_mut()?;
+    let mut run = || -> Result<Vec<f32>, String> {
+        let s = eng.stream.clone();
+        let key = (emb_t.as_ptr() as usize, emb_t.len());
+        if eng.sc_emb.as_ref().map(|(_, k)| *k != key).unwrap_or(true) {
+            let mut dev = s
+                .alloc_zeros::<u16>(emb_t.len())
+                .map_err(|e| format!("alloc emb_t: {e}"))?;
+            s.memcpy_htod(emb_t, &mut dev)
+                .map_err(|e| format!("upload emb_t: {e}"))?;
+            eng.sc_emb = Some((dev, key));
+        }
+        let emb_dev = &eng.sc_emb.as_ref().unwrap().0;
+        let mut a_dev = s
+            .alloc_zeros::<f32>(h_canvas.len())
+            .map_err(|e| format!("alloc h: {e}"))?;
+        s.memcpy_htod(h_canvas, &mut a_dev)
+            .map_err(|e| format!("upload h: {e}"))?;
+        let mut c_dev = s
+            .alloc_zeros::<f32>(c * n_vocab)
+            .map_err(|e| format!("alloc logits: {e}"))?;
+        let cfg = LaunchConfig {
+            grid_dim: ((n_vocab as u32).div_ceil(16), (c as u32).div_ceil(16), 1),
+            block_dim: (16, 16, 1),
+            shared_mem_bytes: 0,
+        };
+        let (mi, ki, ni) = (c as i32, hidden as i32, n_vocab as i32);
+        let mut b = s.launch_builder(&eng.lm_gemm_func);
+        b.arg(&a_dev)
+            .arg(emb_dev)
+            .arg(&mut c_dev)
+            .arg(&mi)
+            .arg(&ki)
+            .arg(&ni)
+            .arg(&softcap);
+        unsafe { b.launch(cfg) }.map_err(|e| format!("launch lm gemm: {e}"))?;
+        let mut out = vec![0f32; c * n_vocab];
+        s.memcpy_dtoh(&c_dev, &mut out)
+            .map_err(|e| format!("download logits: {e}"))?;
+        eng.ctx.synchronize().map_err(|e| format!("sync: {e}"))?;
+        Ok(out)
+    };
+    match run() {
+        Ok(v) => Some(v),
+        Err(err) => {
+            eprintln!("[dg-cuda] lm gemm failed ({err}); CPU fallback");
             None
         }
     }
@@ -1331,7 +1934,7 @@ mod fast_tests {
                         DgExpertKind::Q50 => {
                             super::super::refmath::q5_0_dot_arm(row, &q80_acts[a as usize])
                         }
-                        DgExpertKind::Q4K => unreachable!(),
+                        DgExpertKind::Q4K | DgExpertKind::Q6K => unreachable!(),
                     };
                     assert_eq!(
                         cpu.to_bits(),

--- a/src/diffusion_gemma/cuda.rs
+++ b/src/diffusion_gemma/cuda.rs
@@ -60,6 +60,104 @@ __device__ __forceinline__ float f16_bits_to_f32(unsigned short bits) {
     return __uint_as_float(out);
 }
 
+// f32 -> f16 bits, round-to-nearest-even (no cuda_fp16.h under NVRTC).
+__device__ __forceinline__ unsigned short f32_to_f16_bits_rne(float f) {
+    unsigned int x = __float_as_uint(f);
+    unsigned int sign = (x >> 16) & 0x8000u;
+    unsigned int e8 = (x >> 23) & 0xffu;
+    unsigned int mant = x & 0x7fffffu;
+    if (e8 == 0xffu) return (unsigned short)(sign | 0x7c00u | (mant ? 0x200u : 0u));
+    int exp = (int)e8 - 127 + 15;
+    if (exp >= 0x1f) return (unsigned short)(sign | 0x7c00u);
+    if (exp <= 0) {
+        if (exp < -10) return (unsigned short)sign;
+        mant |= 0x800000u;
+        unsigned int shift = (unsigned int)(14 - exp);
+        unsigned int half = mant >> shift;
+        unsigned int rem = mant & ((1u << shift) - 1u);
+        unsigned int halfway = 1u << (shift - 1u);
+        if (rem > halfway || (rem == halfway && (half & 1u))) half++;
+        return (unsigned short)(sign | half);
+    }
+    unsigned int half = ((unsigned int)exp << 10) | (mant >> 13);
+    unsigned int rem = mant & 0x1fffu;
+    if (rem > 0x1000u || (rem == 0x1000u && (half & 1u))) half++;
+    return (unsigned short)(sign | half);
+}
+
+// FAST-mode fused SC probabilities: probs[pos] = f16(softmax(logits[pos] *
+// temp_inv)) computed straight from the DEVICE-RESIDENT previous-step logits
+// (the lm_head GEMM output) — no host softmax, no 134 MB re-upload. One block
+// per canvas position.
+extern "C" __global__ void sc_probs_f16(
+    const float* __restrict__ logits,
+    unsigned short* __restrict__ probs,
+    int n_vocab, float temp_inv)
+{
+    int pos = blockIdx.x;
+    const float* row = logits + (long long)pos * n_vocab;
+    unsigned short* out = probs + (long long)pos * n_vocab;
+    __shared__ float red[256];
+    float m = DG_NEG_INF;
+    for (int v = threadIdx.x; v < n_vocab; v += blockDim.x)
+        m = fmaxf(m, row[v] * temp_inv);
+    red[threadIdx.x] = m;
+    __syncthreads();
+    for (int s2 = blockDim.x >> 1; s2 > 0; s2 >>= 1) {
+        if (threadIdx.x < s2)
+            red[threadIdx.x] = fmaxf(red[threadIdx.x], red[threadIdx.x + s2]);
+        __syncthreads();
+    }
+    m = red[0];
+    __syncthreads();
+    float sum = 0.0f;
+    for (int v = threadIdx.x; v < n_vocab; v += blockDim.x)
+        sum += expf(row[v] * temp_inv - m);
+    red[threadIdx.x] = sum;
+    __syncthreads();
+    for (int s2 = blockDim.x >> 1; s2 > 0; s2 >>= 1) {
+        if (threadIdx.x < s2) red[threadIdx.x] += red[threadIdx.x + s2];
+        __syncthreads();
+    }
+    float inv = 1.0f / red[0];
+    __syncthreads();
+    for (int v = threadIdx.x; v < n_vocab; v += blockDim.x)
+        out[v] = f32_to_f16_bits_rne(expf(row[v] * temp_inv - m) * inv);
+}
+
+// FAST-mode SC soft-embedding as a tiled f16xf16 GEMM:
+// soft[pos][e] = scale * sum_v emb_t[e][v] * probs[pos][v].
+// A = emb_t [m=hidden][k=vocab] (row-major, coalesced k-tiles); B = probs
+// [n=c][k=vocab] (row-major, loaded coalesced along k and transposed in
+// shared). Reads A once per 16-wide n-stripe (~23 GB total) instead of the
+// naive per-(pos,e) shape's ~377 GB.
+extern "C" __global__ void sc_f16_gemm(
+    const unsigned short* __restrict__ a,
+    const unsigned short* __restrict__ bt,
+    float* __restrict__ cmat,
+    int m, int k, int n, float scale)
+{
+    __shared__ float As[16][17];
+    __shared__ float Bs[16][17];
+    int tx = threadIdx.x, ty = threadIdx.y;
+    int row = blockIdx.y * 16 + ty;
+    int col = blockIdx.x * 16 + tx;
+    float acc = 0.0f;
+    for (int k0 = 0; k0 < k; k0 += 16) {
+        As[ty][tx] = (row < m && (k0 + tx) < k)
+            ? f16_bits_to_f32(a[(long long)row * k + k0 + tx])
+            : 0.0f;
+        int bcol = blockIdx.x * 16 + ty;
+        Bs[tx][ty] = (bcol < n && (k0 + tx) < k)
+            ? f16_bits_to_f32(bt[(long long)bcol * k + k0 + tx])
+            : 0.0f;
+        __syncthreads();
+        for (int kk = 0; kk < 16; kk++) acc += As[ty][kk] * Bs[kk][tx];
+        __syncthreads();
+    }
+    if (row < m && col < n) cmat[(long long)col * m + row] = acc * scale;
+}
+
 // Self-conditioning soft-embedding: one block per output (pos, e); the block
 // strides over the vocab, accumulates in f32, reduces in shared.
 extern "C" __global__ void sc_soft_embedding(
@@ -617,18 +715,19 @@ struct Engine {
     q6k_id_func: CudaFunction,
     attn_func: CudaFunction,
     lm_gemm_func: CudaFunction,
+    sc_probs_func: CudaFunction,
+    sc_gemm_func: CudaFunction,
+    /// Previous step's lm_head logits, left device-resident by the fast lm
+    /// GEMM for the next step's fused SC probs. Consumed one-shot (`take`)
+    /// so a stale buffer can never silently feed the SC stage.
+    last_logits: Option<(CudaSlice<f32>, usize, usize)>,
     /// FAST-mode streaming scratch for tensors that miss the resident pool
     /// (grown to the largest streamed tensor; one at a time).
     scratch: Option<CudaSlice<u8>>,
-    /// Pinned (page-locked, write-combined) host staging for streamed uploads:
-    /// pageable-mmap → pinned memcpy + pinned → device DMA is several times
-    /// faster than a pageable `memcpy_htod`. Grown like `scratch`.
-    pinned: Option<cudarc::driver::PinnedHostSlice<u8>>,
-    /// Second pinned buffer: the read-ahead worker fills this one with the
-    /// NEXT streamed tensor while `pinned` feeds the current htod.
-    pinned2: Option<cudarc::driver::PinnedHostSlice<u8>>,
-    /// Which pinned buffer the read-ahead worker owns right now (0/1).
-    ra_buf: usize,
+    /// Pinned (page-locked) host staging ring for streamed uploads. The
+    /// read-ahead worker fills upcoming buffers while the current one feeds
+    /// the htod; a deeper ring keeps the disk continuously busy.
+    pin_bufs: Vec<cudarc::driver::PinnedHostSlice<u8>>,
     /// Read-ahead pipeline (see `ReadAhead`): the per-step streamed-tensor
     /// sequence is deterministic, so step 0 learns it and steps 1+ overlap
     /// each tensor's FILE READ (the actual wall, ~10x the PCIe copy) with
@@ -661,6 +760,10 @@ static ENGINE: OnceLock<Mutex<Option<Engine>>> = OnceLock::new();
 /// Largest streamable tensor (pinned staging buffers are fixed at this cap;
 /// the biggest streamed DG tensor is ~285 MiB).
 const DG_PIN_CAP: usize = 300 * 1024 * 1024;
+
+/// Pinned staging ring depth (buffers): 1 feeds the current htod while the
+/// worker reads up to DG_RA_BUFS-1 upcoming tensors, keeping the disk busy.
+const DG_RA_BUFS: usize = 4;
 
 /// Residency split: tensors under this size (attention/dense projections)
 /// draw from the small carve-out; expert tensors draw from the remainder.
@@ -751,6 +854,12 @@ fn build_engine() -> Result<Engine, String> {
     let lm_gemm_func = m
         .load_function("lm_head_f16_gemm")
         .map_err(|e| format!("load lm_head_f16_gemm: {e}"))?;
+    let sc_probs_func = m
+        .load_function("sc_probs_f16")
+        .map_err(|e| format!("load sc_probs_f16: {e}"))?;
+    let sc_gemm_func = m
+        .load_function("sc_f16_gemm")
+        .map_err(|e| format!("load sc_f16_gemm: {e}"))?;
     Ok(Engine {
         stream,
         ctx,
@@ -764,10 +873,11 @@ fn build_engine() -> Result<Engine, String> {
         q6k_id_func,
         attn_func,
         lm_gemm_func,
+        sc_probs_func,
+        sc_gemm_func,
+        last_logits: None,
         scratch: None,
-        pinned: None,
-        pinned2: None,
-        ra_buf: 0,
+        pin_bufs: Vec::new(),
         ra: None,
         sc_emb: None,
         lm_wire: None,
@@ -1111,24 +1221,30 @@ struct RaReq {
     off: u64,
 }
 
-/// Read-ahead pipeline for streamed tensors. Two fixed pinned buffers
-/// alternate: one feeds the current htod while a worker thread fills the
-/// other with the NEXT streamed tensor's bytes (the streamed order repeats
-/// exactly every denoise step, learned on step 0). The worker does file I/O
+/// Read-ahead pipeline for streamed tensors. A ring of fixed pinned buffers:
+/// the worker thread fills upcoming buffers with the NEXT streamed tensors'
+/// bytes (the streamed order repeats exactly every denoise step, learned on
+/// step 0) while the current one feeds the htod — a depth > 1 keeps the disk
+/// continuously busy instead of one-read-per-gap. The worker does file I/O
 /// only — no CUDA — so there is no cross-thread context juggling; buffer
-/// handoff is strictly dispatch → recv done → consume.
+/// handoff is strictly dispatch → recv done (FIFO) → consume.
 struct ReadAhead {
     tx: std::sync::mpsc::Sender<RaReq>,
     done_rx: std::sync::mpsc::Receiver<(usize, usize)>,
-    /// (key, pinned-buffer index) dispatched and not yet consumed.
-    in_flight: Option<((usize, usize), usize)>,
+    /// FIFO of (key, pinned-buffer index) dispatched and not yet consumed;
+    /// the single worker completes strictly in this order.
+    in_flight: std::collections::VecDeque<((usize, usize), usize)>,
+    /// Pinned-buffer indices free for dispatch or synchronous use.
+    free: Vec<usize>,
     /// Learned per-step order of streamed tensors: (key, path, offset, len).
     order: Vec<((usize, usize), std::path::PathBuf, u64, usize)>,
     learned: bool,
+    /// Index into `order` (mod len) of the next tensor to dispatch.
+    cursor: usize,
 }
 
 impl ReadAhead {
-    fn new() -> Self {
+    fn new(n_bufs: usize) -> Self {
         let (tx, rx) = std::sync::mpsc::channel::<RaReq>();
         let (done_tx, done_rx) = std::sync::mpsc::channel::<(usize, usize)>();
         std::thread::Builder::new()
@@ -1152,23 +1268,20 @@ impl ReadAhead {
         Self {
             tx,
             done_rx,
-            in_flight: None,
+            in_flight: std::collections::VecDeque::new(),
+            free: (0..n_bufs).collect(),
             order: Vec::new(),
             learned: false,
+            cursor: 0,
         }
     }
 
-    /// The entry AFTER `key` in the learned order (wrapping), if any.
-    #[allow(clippy::type_complexity)]
-    fn next_after(
-        &self,
-        key: (usize, usize),
-    ) -> Option<&((usize, usize), std::path::PathBuf, u64, usize)> {
-        if !self.learned || self.order.is_empty() {
-            return None;
+    /// Drain every in-flight read (blocking) and reclaim the buffers.
+    fn drain(&mut self) {
+        while let Some((_, bi)) = self.in_flight.pop_front() {
+            let _ = self.done_rx.recv();
+            self.free.push(bi);
         }
-        let i = self.order.iter().position(|(k, ..)| *k == key)?;
-        Some(&self.order[(i + 1) % self.order.len()])
     }
 }
 
@@ -1291,45 +1404,49 @@ pub(crate) fn fast_gemm_id(
         // Stage through pinned memory, filled by a DIRECT positioned file
         // read (mmap demand paging under RAM pressure runs at random-fault
         // speed, ~0.6 GB/s observed; a sequential read + pinned DMA is far
-        // faster). The read-ahead worker overlaps the NEXT streamed tensor's
-        // read (the dominant cost) with this call's GPU work, alternating two
-        // fixed pinned buffers; the per-step sequence is learned on step 0.
+        // faster). The read-ahead ring overlaps upcoming tensors' reads (the
+        // dominant cost) with GPU work; the per-step sequence is learned on
+        // step 0 and the pipeline refills after every call.
         if need > DG_PIN_CAP {
             eprintln!("[dg-cuda] streamed tensor exceeds pin cap; CPU fallback");
             return None;
         }
-        if eng.pinned.is_none() {
-            eng.pinned = unsafe { eng.ctx.alloc_pinned::<u8>(DG_PIN_CAP) }.ok();
-        }
-        if eng.pinned2.is_none() {
-            eng.pinned2 = unsafe { eng.ctx.alloc_pinned::<u8>(DG_PIN_CAP) }.ok();
+        while eng.pin_bufs.len() < DG_RA_BUFS {
+            match unsafe { eng.ctx.alloc_pinned::<u8>(DG_PIN_CAP) } {
+                Ok(b) => eng.pin_bufs.push(b),
+                Err(e) => {
+                    eprintln!("[dg-cuda] pinned ring alloc failed ({e}); CPU fallback");
+                    return None;
+                }
+            }
         }
         if eng.ra.is_none() {
-            eng.ra = Some(ReadAhead::new());
+            eng.ra = Some(ReadAhead::new(DG_RA_BUFS));
         }
-        // 1. Resolve the host bytes: a matching completed prefetch, else a
-        // synchronous read into whichever buffer the worker does not hold.
+        // 1. Resolve the host bytes: the front of the prefetch FIFO if it is
+        // this tensor (the common steady-state case), else a synchronous
+        // read into a free buffer.
         let mut ready_buf: Option<usize> = None;
         {
             let ra = eng.ra.as_mut().unwrap();
-            if let Some((k, bi)) = ra.in_flight {
+            if let Some(&(k, bi)) = ra.in_flight.front() {
                 if k == key {
+                    ra.in_flight.pop_front();
                     match ra.done_rx.recv() {
                         Ok(done) if done == key => ready_buf = Some(bi),
-                        _ => {} // read failed → fall through to sync read
+                        _ => ra.free.push(bi), // read failed → sync fallback
                     }
-                    ra.in_flight = None;
                 } else {
-                    // Mispredict (should not happen once learned): reclaim
-                    // the buffer by draining the done message, then ignore it.
-                    let _ = ra.done_rx.recv();
-                    ra.in_flight = None;
+                    // Mispredict (block-boundary or order change): drain the
+                    // whole pipeline and restart it after this call.
+                    ra.drain();
                 }
             }
             // Learn the per-step sequence on the first pass.
             if !ra.learned {
                 if ra.order.first().map(|(k, ..)| *k == key).unwrap_or(false) {
                     ra.learned = true;
+                    ra.cursor = 1; // this call consumes order[0]
                     eprintln!(
                         "[dg-cuda] read-ahead learned {} streamed tensors/step",
                         ra.order.len()
@@ -1339,46 +1456,45 @@ pub(crate) fn fast_gemm_id(
                 }
             }
         }
-        let use_buf = ready_buf.unwrap_or(eng.ra_buf);
-        if ready_buf.is_none() {
-            // Synchronous read into `use_buf` (the worker holds no buffer or
-            // holds the other one).
-            let pin = if use_buf == 0 {
-                eng.pinned.as_mut()
-            } else {
-                eng.pinned2.as_mut()
+        let sync_buf = if ready_buf.is_none() {
+            let ra = eng.ra.as_mut().unwrap();
+            let Some(bi) = ra.free.pop() else {
+                eprintln!("[dg-cuda] pinned ring exhausted; CPU fallback");
+                return None;
             };
-            let read_ok = pin.is_some_and(|pin| {
-                let Ok(dst) = pin.as_mut_ptr() else {
-                    return false;
-                };
-                // SAFETY: PIN_CAP >= need (checked above).
-                let dst_slice = unsafe { std::slice::from_raw_parts_mut(dst, need) };
-                std::fs::File::open(src.0)
-                    .and_then(|f| read_at_into(&f, src.1, dst_slice))
-                    .is_ok()
-            });
+            Some(bi)
+        } else {
+            None
+        };
+        let use_buf = ready_buf.or(sync_buf).unwrap();
+        if ready_buf.is_none() {
+            let read_ok = {
+                let pin = &mut eng.pin_bufs[use_buf];
+                match pin.as_mut_ptr() {
+                    Ok(dst) => {
+                        // SAFETY: DG_PIN_CAP >= need (checked above).
+                        let dst_slice = unsafe { std::slice::from_raw_parts_mut(dst, need) };
+                        std::fs::File::open(src.0)
+                            .and_then(|f| read_at_into(&f, src.1, dst_slice))
+                            .is_ok()
+                    }
+                    Err(_) => false,
+                }
+            };
             if !read_ok {
                 // Last-resort: pageable upload straight from the mmap slice.
+                eng.ra.as_mut().unwrap().free.push(use_buf);
                 let buf = eng.scratch.as_mut().unwrap();
                 let mut view = buf.slice_mut(0..need);
                 if let Err(e) = s.memcpy_htod(tensor, &mut view) {
                     eprintln!("[dg-cuda] fast stream upload failed ({e}); CPU fallback");
                     return None;
                 }
-                eng.ra_buf = use_buf; // buffer unused; stays available
                 streamed_upload_done = true;
             }
         }
         if !streamed_upload_done {
-            let pin = if use_buf == 0 {
-                eng.pinned.as_ref()
-            } else {
-                eng.pinned2.as_ref()
-            };
-            let host = pin
-                .and_then(|pin| pin.as_slice().ok())
-                .map(|sl| &sl[..need]);
+            let host = eng.pin_bufs[use_buf].as_slice().ok().map(|sl| &sl[..need]);
             let Some(host) = host else {
                 eprintln!("[dg-cuda] pinned staging unavailable; CPU fallback");
                 return None;
@@ -1389,8 +1505,6 @@ pub(crate) fn fast_gemm_id(
                 eprintln!("[dg-cuda] fast stream upload failed ({e}); CPU fallback");
                 return None;
             }
-            // The other buffer is free for the worker after this call's sync.
-            eng.ra_buf = use_buf ^ 1;
             stream_consumed = Some((key, use_buf));
         }
     }
@@ -1463,32 +1577,79 @@ pub(crate) fn fast_gemm_id(
     // attention/lm_head/sampler gap.
     if result.is_ok() {
         if let Some((ck, buf_idx)) = stream_consumed {
-            let next = eng
-                .ra
-                .as_ref()
-                .filter(|ra| ra.learned && ra.in_flight.is_none())
-                .and_then(|ra| ra.next_after(ck).cloned());
-            if let Some((nk, npath, noff, nlen)) = next {
-                if !eng.expert_pool.contains_key(&nk) && nlen > 0 && nlen <= DG_PIN_CAP {
-                    let ptr = if buf_idx == 0 {
-                        eng.pinned.as_mut().and_then(|p| p.as_mut_ptr().ok())
-                    } else {
-                        eng.pinned2.as_mut().and_then(|p| p.as_mut_ptr().ok())
-                    };
-                    if let (Some(ptr), Some(ra)) = (ptr, eng.ra.as_mut()) {
-                        if ra
-                            .tx
-                            .send(RaReq {
-                                key: nk,
-                                ptr: ptr as usize,
-                                len: nlen,
-                                path: npath,
-                                off: noff,
-                            })
-                            .is_ok()
-                        {
-                            ra.in_flight = Some((nk, buf_idx));
+            // The consumed buffer is free again (run() ends with a full sync).
+            if let Some(ra) = eng.ra.as_mut() {
+                ra.free.push(buf_idx);
+            }
+            // Refill the pipeline: dispatch reads for upcoming streamed
+            // tensors (skipping pool-resident entries) while free buffers
+            // remain. The cursor wraps, so the sequence end prefetches the
+            // next STEP's first tensors across the attention/lm_head gap.
+            let learned = eng.ra.as_ref().map(|ra| ra.learned).unwrap_or(false);
+            if learned {
+                // Keep the cursor ahead of the just-consumed entry.
+                {
+                    let ra = eng.ra.as_mut().unwrap();
+                    if let Some(i) = ra.order.iter().position(|(k, ..)| *k == ck) {
+                        let len = ra.order.len();
+                        let ahead = ra.in_flight.len();
+                        // cursor must sit `ahead` entries past i+1's stream
+                        // position at minimum; a simple monotonic bump keeps
+                        // it consistent because consumption follows order.
+                        if ahead == 0 {
+                            ra.cursor = (i + 1) % len;
                         }
+                    }
+                }
+                let order_len = eng.ra.as_ref().unwrap().order.len();
+                let mut scanned = 0;
+                while scanned < order_len {
+                    let ra = eng.ra.as_ref().unwrap();
+                    if ra.free.is_empty() {
+                        break;
+                    }
+                    let (nk, npath, noff, nlen) = ra.order[ra.cursor % order_len].clone();
+                    scanned += 1;
+                    if eng.expert_pool.contains_key(&nk)
+                        || nlen == 0
+                        || nlen > DG_PIN_CAP
+                        || eng
+                            .ra
+                            .as_ref()
+                            .unwrap()
+                            .in_flight
+                            .iter()
+                            .any(|(k, _)| *k == nk)
+                    {
+                        eng.ra.as_mut().unwrap().cursor += 1;
+                        continue;
+                    }
+                    let ra = eng.ra.as_mut().unwrap();
+                    let bi = ra.free.pop().unwrap();
+                    let ptr = match eng.pin_bufs[bi].as_mut_ptr() {
+                        Ok(p) => p as usize,
+                        Err(_) => {
+                            eng.ra.as_mut().unwrap().free.push(bi);
+                            break;
+                        }
+                    };
+                    let ra = eng.ra.as_mut().unwrap();
+                    if ra
+                        .tx
+                        .send(RaReq {
+                            key: nk,
+                            ptr,
+                            len: nlen,
+                            path: npath,
+                            off: noff,
+                        })
+                        .is_ok()
+                    {
+                        ra.in_flight.push_back((nk, bi));
+                        ra.cursor += 1;
+                    } else {
+                        ra.free.push(bi);
+                        break;
                     }
                 }
             }
@@ -1634,7 +1795,7 @@ pub(crate) fn lm_head_f16_gemm_gpu(
         }
     }
     let eng = guard.as_mut()?;
-    let mut run = || -> Result<Vec<f32>, String> {
+    let mut run = || -> Result<(Vec<f32>, CudaSlice<f32>), String> {
         let s = eng.stream.clone();
         let key = (emb_t.as_ptr() as usize, emb_t.len());
         if eng.sc_emb.as_ref().map(|(_, k)| *k != key).unwrap_or(true) {
@@ -1673,12 +1834,94 @@ pub(crate) fn lm_head_f16_gemm_gpu(
         s.memcpy_dtoh(&c_dev, &mut out)
             .map_err(|e| format!("download logits: {e}"))?;
         eng.ctx.synchronize().map_err(|e| format!("sync: {e}"))?;
+        Ok((out, c_dev))
+    };
+    match run() {
+        Ok((v, c_dev)) => {
+            // Leave the logits device-resident for the next step's fused SC.
+            eng.last_logits = Some((c_dev, c, n_vocab));
+            Some(v)
+        }
+        Err(err) => {
+            eprintln!("[dg-cuda] lm gemm failed ({err}); CPU fallback");
+            None
+        }
+    }
+}
+
+/// FAST-mode fused SC soft-embedding: consume the device-resident previous
+/// lm_head logits (one-shot), compute f16 softmax probs on the GPU, and run
+/// the resident-embedding soft matmul — no host softmax, no probs upload.
+/// `None` → the plain `sc_soft_embedding_gpu` / CPU paths.
+pub(crate) fn sc_soft_fused_gpu(
+    temp_inv: f32,
+    embed_scale: f32,
+    c: usize,
+    hidden: usize,
+    n_vocab: usize,
+) -> Option<Vec<f32>> {
+    if gate_off() || std::env::var("CAMELID_DG_CUDA_SC").as_deref() == Ok("0") {
+        return None;
+    }
+    let cell = ENGINE.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().ok()?;
+    let eng = guard.as_mut()?;
+    let (logits_dev, lc, lv) = eng.last_logits.take()?;
+    if lc != c || lv != n_vocab {
+        return None;
+    }
+    // The resident embedding must already be uploaded (the lm_head GEMM and
+    // SC share the slot; it is by the time SC runs).
+    let (emb_dev_len, _) = eng.sc_emb.as_ref().map(|(d, k)| (d.len(), k))?;
+    if emb_dev_len != hidden * n_vocab {
+        return None;
+    }
+    let run = || -> Result<Vec<f32>, String> {
+        let s = eng.stream.clone();
+        let mut probs_dev = s
+            .alloc_zeros::<u16>(c * n_vocab)
+            .map_err(|e| format!("alloc probs: {e}"))?;
+        let cfg = LaunchConfig {
+            grid_dim: (c as u32, 1, 1),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        let nv = n_vocab as i32;
+        let mut b = s.launch_builder(&eng.sc_probs_func);
+        b.arg(&logits_dev)
+            .arg(&mut probs_dev)
+            .arg(&nv)
+            .arg(&temp_inv);
+        unsafe { b.launch(cfg) }.map_err(|e| format!("launch sc probs: {e}"))?;
+        let emb_dev = &eng.sc_emb.as_ref().unwrap().0;
+        let mut soft_dev = s
+            .alloc_zeros::<f32>(c * hidden)
+            .map_err(|e| format!("alloc soft: {e}"))?;
+        let cfg2 = LaunchConfig {
+            grid_dim: ((c as u32).div_ceil(16), (hidden as u32).div_ceil(16), 1),
+            block_dim: (16, 16, 1),
+            shared_mem_bytes: 0,
+        };
+        let (h, cc) = (hidden as i32, c as i32);
+        let mut b = s.launch_builder(&eng.sc_gemm_func);
+        b.arg(emb_dev)
+            .arg(&probs_dev)
+            .arg(&mut soft_dev)
+            .arg(&h)
+            .arg(&nv)
+            .arg(&cc)
+            .arg(&embed_scale);
+        unsafe { b.launch(cfg2) }.map_err(|e| format!("launch sc gemm: {e}"))?;
+        let mut out = vec![0f32; c * hidden];
+        s.memcpy_dtoh(&soft_dev, &mut out)
+            .map_err(|e| format!("download soft: {e}"))?;
+        eng.ctx.synchronize().map_err(|e| format!("sync: {e}"))?;
         Ok(out)
     };
     match run() {
         Ok(v) => Some(v),
         Err(err) => {
-            eprintln!("[dg-cuda] lm gemm failed ({err}); CPU fallback");
+            eprintln!("[dg-cuda] fused sc failed ({err}); CPU fallback");
             None
         }
     }

--- a/src/diffusion_gemma/cuda.rs
+++ b/src/diffusion_gemma/cuda.rs
@@ -265,6 +265,165 @@ extern "C" __global__ void q8_0_rows_gemv(
     out[r] = ((acc0[0] + acc0[1]) + (acc0[2] + acc0[3]))
         + ((acc1[0] + acc1[1]) + (acc1[2] + acc1[3]));
 }
+
+// ---- FAST-mode batched-ID GEMM kernels (CAMELID_DG_FAST) -------------------
+// One thread per (pair, row): pair_base[pair] selects the row window (expert
+// offset, or 0 for dense), pair_pos[pair] selects the activation column. Same
+// per-row math as the parity kernels above; fast mode does not claim
+// bit-exactness (it exists to amortize weight reads across all positions).
+
+extern "C" __global__ void q4k_gemm_id(
+    const unsigned char* __restrict__ wire,
+    const float* __restrict__ act_scales,      // [P * bpr]
+    const signed char* __restrict__ act_quants, // [P * bpr * 256]
+    const long long* __restrict__ pair_base,   // [n_pairs] first row
+    const int* __restrict__ pair_pos,          // [n_pairs] activation index
+    int n_pairs, int rows_per, int bpr,
+    float* __restrict__ out)                   // [n_pairs * rows_per]
+{
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)n_pairs * rows_per;
+    if (idx >= total) return;
+    int pair = (int)(idx / rows_per);
+    int r = (int)(idx % rows_per);
+    const unsigned char* rowp = wire + (pair_base[pair] + r) * (long long)bpr * 144;
+    const float* a_s = act_scales + (long long)pair_pos[pair] * bpr;
+    const signed char* a_q = act_quants + (long long)pair_pos[pair] * bpr * 256;
+    float sumf = 0.0f;
+    for (int i = 0; i < bpr; i++) {
+        const unsigned char* block = rowp + (long long)i * 144;
+        float yd = a_s[i];
+        const signed char* q8 = a_q + (long long)i * 256;
+        float d = yd * f16_bits_to_f32((unsigned short)block[0]
+            | ((unsigned short)block[1] << 8));
+        float dmin = yd * f16_bits_to_f32((unsigned short)block[2]
+            | ((unsigned short)block[3] << 8));
+        const unsigned char* sc = block + 4;
+        const unsigned char* qs = block + 16;
+        unsigned int utmp0 = (unsigned int)sc[0] | ((unsigned int)sc[1] << 8)
+            | ((unsigned int)sc[2] << 16) | ((unsigned int)sc[3] << 24);
+        unsigned int utmp1 = (unsigned int)sc[4] | ((unsigned int)sc[5] << 8)
+            | ((unsigned int)sc[6] << 16) | ((unsigned int)sc[7] << 24);
+        unsigned int utmp2 = (unsigned int)sc[8] | ((unsigned int)sc[9] << 8)
+            | ((unsigned int)sc[10] << 16) | ((unsigned int)sc[11] << 24);
+        unsigned int mins0 = utmp1 & 0x3f3f3f3fu;
+        unsigned int mins1 = ((utmp2 >> 4) & 0x0f0f0f0fu)
+            | (((utmp1 >> 6) & 0x03030303u) << 4);
+        unsigned int scw0 = utmp0 & 0x3f3f3f3fu;
+        unsigned int scw1 = (utmp2 & 0x0f0f0f0fu)
+            | (((utmp0 >> 6) & 0x03030303u) << 4);
+        long long prod = 0;
+        for (int g = 0; g < 8; g++) {
+            int bs = 0;
+            for (int t = 0; t < 32; t++) bs += q8[g * 32 + t];
+            prod += (long long)bs * kq4_byte(mins0, mins1, g);
+        }
+        sumf = fmaf(-dmin, (float)prod, sumf);
+        long long sumi1 = 0, sumi2 = 0;
+        for (int j = 0; j < 4; j++) {
+            const unsigned char* q4 = qs + j * 32;
+            const signed char* q8j = q8 + j * 64;
+            long long lo = 0, hi = 0;
+            for (int t = 0; t < 32; t++) {
+                lo += (long long)(q4[t] & 0xf) * q8j[t];
+                hi += (long long)(q4[t] >> 4) * q8j[32 + t];
+            }
+            sumi1 += lo * kq4_byte(scw0, scw1, 2 * j);
+            sumi2 += hi * kq4_byte(scw0, scw1, 2 * j + 1);
+        }
+        sumf = fmaf(d, (float)(sumi1 + sumi2), sumf);
+    }
+    out[idx] = sumf;
+}
+
+// Q5_0 x Q8_0 batched-ID GEMM: 22-byte blocks (f16 d, u32 qh, 16 nibble
+// bytes); weight w[idx] = ((nibble | (qh_bit << 4)) - 16). Same accumulator
+// structure as the Q8_0 kernel (q0_pair_dot shape).
+extern "C" __global__ void q5_0_gemm_id(
+    const unsigned char* __restrict__ wire,
+    const float* __restrict__ act_scales,
+    const signed char* __restrict__ act_quants,
+    const long long* __restrict__ pair_base,
+    const int* __restrict__ pair_pos,
+    int n_pairs, int rows_per, int nb,
+    float* __restrict__ out)
+{
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)n_pairs * rows_per;
+    if (idx >= total) return;
+    int pair = (int)(idx / rows_per);
+    int r = (int)(idx % rows_per);
+    const unsigned char* rowp = wire + (pair_base[pair] + r) * (long long)nb * 22;
+    const float* a_s = act_scales + (long long)pair_pos[pair] * nb;
+    const signed char* a_q = act_quants + (long long)pair_pos[pair] * nb * 32;
+    float acc0[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float acc1[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    for (int i = 0; i < nb; i++) {
+        const unsigned char* block = rowp + (long long)i * 22;
+        float dw = f16_bits_to_f32((unsigned short)block[0]
+            | ((unsigned short)block[1] << 8));
+        unsigned int qh = (unsigned int)block[2] | ((unsigned int)block[3] << 8)
+            | ((unsigned int)block[4] << 16) | ((unsigned int)block[5] << 24);
+        const unsigned char* qs = block + 6;
+        float s = dw * a_s[i];
+        const signed char* yq = a_q + (long long)i * 32;
+        float* acc = (i & 1) ? acc1 : acc0;
+        for (int l = 0; l < 4; l++) {
+            int lane = 0;
+            for (int t = 0; t < 4; t++) {
+                int i0 = 4 * l + t;
+                int w0 = (int)((qs[i0] & 0x0f) | (((qh >> i0) & 1) << 4)) - 16;
+                lane += w0 * (int)yq[i0];
+                int i1 = 16 + 4 * l + t;
+                int w1 = (int)((qs[i1 - 16] >> 4) | (((qh >> i1) & 1) << 4)) - 16;
+                lane += w1 * (int)yq[i1];
+            }
+            acc[l] = fmaf((float)lane, s, acc[l]);
+        }
+    }
+    out[idx] = ((acc0[0] + acc0[1]) + (acc0[2] + acc0[3]))
+        + ((acc1[0] + acc1[1]) + (acc1[2] + acc1[3]));
+}
+
+extern "C" __global__ void q8_0_gemm_id(
+    const unsigned char* __restrict__ wire,
+    const float* __restrict__ act_scales,      // [P * nb]
+    const signed char* __restrict__ act_quants, // [P * nb * 32]
+    const long long* __restrict__ pair_base,
+    const int* __restrict__ pair_pos,
+    int n_pairs, int rows_per, int nb,
+    float* __restrict__ out)
+{
+    long long idx = (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    long long total = (long long)n_pairs * rows_per;
+    if (idx >= total) return;
+    int pair = (int)(idx / rows_per);
+    int r = (int)(idx % rows_per);
+    const unsigned char* rowp = wire + (pair_base[pair] + r) * (long long)nb * 34;
+    const float* a_s = act_scales + (long long)pair_pos[pair] * nb;
+    const signed char* a_q = act_quants + (long long)pair_pos[pair] * nb * 32;
+    float acc0[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float acc1[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    for (int i = 0; i < nb; i++) {
+        const unsigned char* block = rowp + (long long)i * 34;
+        float dw = f16_bits_to_f32((unsigned short)block[0]
+            | ((unsigned short)block[1] << 8));
+        float s = dw * a_s[i];
+        const signed char* wq = (const signed char*)(block + 2);
+        const signed char* yq = a_q + (long long)i * 32;
+        float* acc = (i & 1) ? acc1 : acc0;
+        for (int l = 0; l < 4; l++) {
+            int lane = 0;
+            for (int t = 0; t < 4; t++) {
+                lane += (int)wq[4 * l + t] * (int)yq[4 * l + t];
+                lane += (int)wq[16 + 4 * l + t] * (int)yq[16 + 4 * l + t];
+            }
+            acc[l] = fmaf((float)lane, s, acc[l]);
+        }
+    }
+    out[idx] = ((acc0[0] + acc0[1]) + (acc0[2] + acc0[3]))
+        + ((acc1[0] + acc1[1]) + (acc1[2] + acc1[3]));
+}
 "#;
 
 struct Engine {
@@ -274,6 +433,16 @@ struct Engine {
     lm_func: CudaFunction,
     q4k_rows_func: CudaFunction,
     q80_rows_func: CudaFunction,
+    q4k_id_func: CudaFunction,
+    q80_id_func: CudaFunction,
+    q50_id_func: CudaFunction,
+    /// FAST-mode streaming scratch for tensors that miss the resident pool
+    /// (grown to the largest streamed tensor; one at a time).
+    scratch: Option<CudaSlice<u8>>,
+    /// Pinned (page-locked, write-combined) host staging for streamed uploads:
+    /// pageable-mmap → pinned memcpy + pinned → device DMA is several times
+    /// faster than a pageable `memcpy_htod`. Grown like `scratch`.
+    pinned: Option<cudarc::driver::PinnedHostSlice<u8>>,
     /// Resident transposed embedding (f16) for the SC matmul.
     sc_emb: Option<(CudaSlice<u16>, (usize, usize))>,
     /// Resident Q6_K lm_head weight (wire bytes).
@@ -323,6 +492,15 @@ fn build_engine() -> Result<Engine, String> {
     let q80_rows_func = m
         .load_function("q8_0_rows_gemv")
         .map_err(|e| format!("load q8_0_rows_gemv: {e}"))?;
+    let q4k_id_func = m
+        .load_function("q4k_gemm_id")
+        .map_err(|e| format!("load q4k_gemm_id: {e}"))?;
+    let q80_id_func = m
+        .load_function("q8_0_gemm_id")
+        .map_err(|e| format!("load q8_0_gemm_id: {e}"))?;
+    let q50_id_func = m
+        .load_function("q5_0_gemm_id")
+        .map_err(|e| format!("load q5_0_gemm_id: {e}"))?;
     Ok(Engine {
         stream,
         ctx,
@@ -330,6 +508,11 @@ fn build_engine() -> Result<Engine, String> {
         lm_func,
         q4k_rows_func,
         q80_rows_func,
+        q4k_id_func,
+        q80_id_func,
+        q50_id_func,
+        scratch: None,
+        pinned: None,
         sc_emb: None,
         lm_wire: None,
         expert_pool: std::collections::HashMap::new(),
@@ -515,6 +698,8 @@ pub(crate) enum DgExpertKind {
     Q4K,
     /// 34-byte blocks; activation is Q8_0 (scales [nb], quants [nb*32]).
     Q80,
+    /// 22-byte blocks; activation is Q8_0 (same layout as `Q80`). FAST mode only.
+    Q50,
 }
 
 /// MoE expert row-range GEMV on the VRAM-resident expert pool.
@@ -613,6 +798,8 @@ pub(crate) fn expert_rows_gemv_gpu(
     let func = match kind {
         DgExpertKind::Q4K => &eng.q4k_rows_func,
         DgExpertKind::Q80 => &eng.q80_rows_func,
+        // No single-activation Q5_0 kernel: the parity path never routes it.
+        DgExpertKind::Q50 => return None,
     };
     let run = || -> Result<Vec<f32>, String> {
         let s = eng.stream.clone();
@@ -656,6 +843,239 @@ pub(crate) fn expert_rows_gemv_gpu(
         Ok(v) => Some(v),
         Err(err) => {
             eprintln!("[dg-cuda] expert gemv failed ({err}); CPU fallback");
+            None
+        }
+    }
+}
+
+/// FAST-mode batched-ID GEMM (`CAMELID_DG_FAST`): every (pair, row) output in
+/// one launch. `pair_base[n]` selects the row window (expert offset, 0 for a
+/// dense tensor), `pair_pos[n]` selects the activation. The tensor computes
+/// from the resident pool when it fits the budget, else it streams through a
+/// reusable scratch upload (~tens of ms for a 272 MiB expert tensor — amortized
+/// over ALL pairs, which is the whole point vs per-position reads). Returns
+/// `[n_pairs * rows_per]` outputs or `None` (→ CPU fallback).
+/// Positioned read into `dst` (Windows `seek_read` / Unix `read_exact_at`).
+fn read_at_into(file: &std::fs::File, offset: u64, dst: &mut [u8]) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileExt;
+        let mut done = 0usize;
+        while done < dst.len() {
+            let k = file.seek_read(&mut dst[done..], offset + done as u64)?;
+            if k == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "tensor read hit EOF",
+                ));
+            }
+            done += k;
+        }
+        Ok(())
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+        file.read_exact_at(dst, offset)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn fast_gemm_id(
+    tensor: &[u8],
+    src: (&std::path::Path, u64),
+    kind: DgExpertKind,
+    pair_base: &[i64],
+    pair_pos: &[i32],
+    rows_per: usize,
+    blocks_per_row: usize,
+    act_scales: &[f32],
+    act_quants: &[i8],
+) -> Option<Vec<f32>> {
+    if gate_off() {
+        return None;
+    }
+    let n_pairs = pair_base.len();
+    if n_pairs == 0 || n_pairs != pair_pos.len() {
+        return None;
+    }
+    let cell = ENGINE.get_or_init(|| Mutex::new(None));
+    let mut guard = cell.lock().ok()?;
+    if guard.is_none() {
+        match build_engine() {
+            Ok(e) => *guard = Some(e),
+            Err(err) => {
+                eprintln!("[dg-cuda] engine build failed ({err}); CPU fallback");
+                return None;
+            }
+        }
+    }
+    let eng = guard.as_mut()?;
+    let key = (tensor.as_ptr() as usize, tensor.len());
+    // Residency: pool if the budget allows (same accounting as the parity
+    // expert pool), else stream through the scratch buffer.
+    let mut streamed = false;
+    if !eng.expert_pool.contains_key(&key) && !eng.expert_rejected.contains(&key) {
+        if eng.expert_budget.is_none() {
+            let budget = match std::env::var("CAMELID_DG_EXPERT_VRAM_MB")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+            {
+                Some(mb) => mb * 1024 * 1024,
+                None => {
+                    const RESERVE: u64 = 2200 * 1024 * 1024;
+                    let free = cudarc::driver::result::mem_get_info()
+                        .map(|(f, _)| f as u64)
+                        .unwrap_or(0);
+                    free.saturating_sub(RESERVE)
+                }
+            };
+            eprintln!(
+                "[dg-cuda] expert pool budget {:.2} GiB",
+                budget as f64 / (1u64 << 30) as f64
+            );
+            eng.expert_budget = Some(budget);
+        }
+        let budget = eng.expert_budget.unwrap();
+        if (tensor.len() as u64) <= budget {
+            let s = eng.stream.clone();
+            match s.alloc_zeros::<u8>(tensor.len()) {
+                Ok(mut dev) => {
+                    if s.memcpy_htod(tensor, &mut dev).is_ok() {
+                        eng.expert_budget = Some(budget - tensor.len() as u64);
+                        eng.expert_pool.insert(key, dev);
+                    } else {
+                        eng.expert_rejected.insert(key);
+                    }
+                }
+                Err(_) => {
+                    eng.expert_rejected.insert(key);
+                }
+            }
+        } else {
+            eng.expert_rejected.insert(key);
+        }
+    }
+    if !eng.expert_pool.contains_key(&key) {
+        streamed = true;
+        // Grow the scratch to fit and stream the tensor for this call.
+        let s = eng.stream.clone();
+        let need = tensor.len();
+        let cap_ok = eng
+            .scratch
+            .as_ref()
+            .map(|b| b.len() >= need)
+            .unwrap_or(false);
+        if !cap_ok {
+            match s.alloc_zeros::<u8>(need) {
+                Ok(b) => eng.scratch = Some(b),
+                Err(e) => {
+                    eprintln!("[dg-cuda] fast scratch alloc failed ({e}); CPU fallback");
+                    return None;
+                }
+            }
+        }
+        // Stage through pinned memory, filled by a DIRECT positioned file
+        // read. Under RAM pressure the mmap's demand paging re-reads evicted
+        // pages at random-fault speed (~0.6 GB/s observed); a sequential
+        // buffered read hits NVMe read-ahead speed instead, and the pinned
+        // buffer gives the htod full DMA rate. Falls back to the mmap slice.
+        let pin_ok = eng
+            .pinned
+            .as_ref()
+            .map(|pin| pin.len() >= need)
+            .unwrap_or(false);
+        if !pin_ok {
+            eng.pinned = unsafe { eng.ctx.alloc_pinned::<u8>(need) }.ok();
+        }
+        let staged: Option<&[u8]> = eng.pinned.as_mut().and_then(|pin| {
+            let dst = pin.as_mut_ptr().ok()?;
+            // SAFETY: pin.len() >= need (grown above).
+            let dst_slice = unsafe { std::slice::from_raw_parts_mut(dst, need) };
+            let read_ok = std::fs::File::open(src.0)
+                .and_then(|f| read_at_into(&f, src.1, dst_slice))
+                .is_ok();
+            if !read_ok {
+                // SAFETY: as above; the mmap slice is the fallback source.
+                unsafe { std::ptr::copy_nonoverlapping(tensor.as_ptr(), dst, need) };
+            }
+            pin.as_slice().ok().map(|sl| &sl[..need])
+        });
+        let buf = eng.scratch.as_mut().unwrap();
+        let mut view = buf.slice_mut(0..need);
+        let copied = match staged {
+            Some(host) => s.memcpy_htod(host, &mut view),
+            None => s.memcpy_htod(tensor, &mut view),
+        };
+        if let Err(e) = copied {
+            eprintln!("[dg-cuda] fast stream upload failed ({e}); CPU fallback");
+            return None;
+        }
+    }
+    let func = match kind {
+        DgExpertKind::Q4K => &eng.q4k_id_func,
+        DgExpertKind::Q80 => &eng.q80_id_func,
+        DgExpertKind::Q50 => &eng.q50_id_func,
+    };
+    let run = || -> Result<Vec<f32>, String> {
+        let s = eng.stream.clone();
+        let mut sc_dev = s
+            .alloc_zeros::<f32>(act_scales.len())
+            .map_err(|e| format!("alloc act scales: {e}"))?;
+        s.memcpy_htod(act_scales, &mut sc_dev)
+            .map_err(|e| format!("upload act scales: {e}"))?;
+        let mut q_dev = s
+            .alloc_zeros::<i8>(act_quants.len())
+            .map_err(|e| format!("alloc act quants: {e}"))?;
+        s.memcpy_htod(act_quants, &mut q_dev)
+            .map_err(|e| format!("upload act quants: {e}"))?;
+        let mut base_dev = s
+            .alloc_zeros::<i64>(n_pairs)
+            .map_err(|e| format!("alloc pair base: {e}"))?;
+        s.memcpy_htod(pair_base, &mut base_dev)
+            .map_err(|e| format!("upload pair base: {e}"))?;
+        let mut pos_dev = s
+            .alloc_zeros::<i32>(n_pairs)
+            .map_err(|e| format!("alloc pair pos: {e}"))?;
+        s.memcpy_htod(pair_pos, &mut pos_dev)
+            .map_err(|e| format!("upload pair pos: {e}"))?;
+        let mut out_dev = s
+            .alloc_zeros::<f32>(n_pairs * rows_per)
+            .map_err(|e| format!("alloc out: {e}"))?;
+        let total = (n_pairs * rows_per) as u64;
+        let block = 256u32;
+        let cfg = LaunchConfig {
+            grid_dim: ((total as u32).div_ceil(block), 1, 1),
+            block_dim: (block, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        let (np, rp, bp) = (n_pairs as i32, rows_per as i32, blocks_per_row as i32);
+        let mut b = s.launch_builder(func);
+        if streamed {
+            let buf = eng.scratch.as_ref().unwrap();
+            b.arg(buf);
+        } else {
+            b.arg(eng.expert_pool.get(&key).unwrap());
+        }
+        b.arg(&sc_dev)
+            .arg(&q_dev)
+            .arg(&base_dev)
+            .arg(&pos_dev)
+            .arg(&np)
+            .arg(&rp)
+            .arg(&bp)
+            .arg(&mut out_dev);
+        unsafe { b.launch(cfg) }.map_err(|e| format!("launch: {e}"))?;
+        let mut out = vec![0f32; n_pairs * rows_per];
+        s.memcpy_dtoh(&out_dev, &mut out)
+            .map_err(|e| format!("download: {e}"))?;
+        eng.ctx.synchronize().map_err(|e| format!("sync: {e}"))?;
+        Ok(out)
+    };
+    match run() {
+        Ok(v) => Some(v),
+        Err(err) => {
+            eprintln!("[dg-cuda] fast gemm failed ({err}); CPU fallback");
             None
         }
     }
@@ -767,6 +1187,158 @@ mod tests {
                     first + r,
                     gpu[r]
                 );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod fast_tests {
+    use super::*;
+
+    fn xorshift(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
+    }
+
+    /// FAST batched-ID kernels vs the CPU reference dots on random data with
+    /// random (base, pos) pairs — per-row bit-identical (the kernels mirror
+    /// the scalar reductions; fast mode's non-bit-exact caveats are about
+    /// GEMM batching effects elsewhere, not these kernels). Skips without CUDA.
+    #[test]
+    fn fast_gemm_id_matches_cpu_dots() {
+        if gate_off() {
+            eprintln!("skipping: CUDA unavailable or gated off");
+            return;
+        }
+        let mut state: u64 = 0xfa57_f00d_5eed_0001;
+        let dummy = std::path::Path::new("unused-resident-path");
+
+        // 3 "experts" x 5 rows each, 2 activations, 4 random pairs.
+        let (n_exp, rows_per, n_acts) = (3usize, 5usize, 2usize);
+        let total_rows = n_exp * rows_per;
+        let pairs: Vec<(i64, i32)> = vec![(0, 0), (5, 1), (10, 0), (5, 0)];
+        let base: Vec<i64> = pairs.iter().map(|p| p.0).collect();
+        let pos: Vec<i32> = pairs.iter().map(|p| p.1).collect();
+
+        // ---- Q4_K (bpr superblocks of 256) ----
+        let bpr = 2usize;
+        let mut wire = vec![0u8; total_rows * bpr * 144];
+        for b in wire.iter_mut() {
+            *b = (xorshift(&mut state) & 0xff) as u8;
+        }
+        for sb in 0..total_rows * bpr {
+            wire[sb * 144 + 1] &= 0x3f;
+            wire[sb * 144 + 3] &= 0x3f;
+        }
+        let mut blocks: Vec<Vec<crate::inference::Q8KBlock>> = Vec::new();
+        let mut scales = vec![0f32; n_acts * bpr];
+        let mut quants = vec![0i8; n_acts * bpr * 256];
+        for a in 0..n_acts {
+            let mut act = Vec::new();
+            for b in 0..bpr {
+                let mut qs = [0i8; 256];
+                for q in qs.iter_mut() {
+                    *q = (xorshift(&mut state) & 0xff) as u8 as i8;
+                }
+                let d = (xorshift(&mut state) % 1000) as f32 / 333.0 + 0.001;
+                scales[a * bpr + b] = d;
+                quants[(a * bpr + b) * 256..(a * bpr + b + 1) * 256].copy_from_slice(&qs);
+                act.push(crate::inference::Q8KBlock { d, qs });
+            }
+            blocks.push(act);
+        }
+        let out = fast_gemm_id(
+            &wire,
+            (dummy, 0),
+            DgExpertKind::Q4K,
+            &base,
+            &pos,
+            rows_per,
+            bpr,
+            &scales,
+            &quants,
+        )
+        .expect("q4k id gemm");
+        for (pi, &(b, a)) in pairs.iter().enumerate() {
+            for r in 0..rows_per {
+                let row_i = b as usize + r;
+                let row = &wire[row_i * bpr * 144..(row_i + 1) * bpr * 144];
+                let cpu = super::super::refmath::q4_k_dot_arm(row, &blocks[a as usize]);
+                assert_eq!(
+                    cpu.to_bits(),
+                    out[pi * rows_per + r].to_bits(),
+                    "q4k pair {pi} row {r}"
+                );
+            }
+        }
+
+        // ---- Q8_0 and Q5_0 (nb 32-value blocks; shared activation form) ----
+        let nb = 4usize;
+        let mut q80_acts: Vec<Vec<crate::tensor::Q8_0Block>> = Vec::new();
+        let mut scales = vec![0f32; n_acts * nb];
+        let mut quants = vec![0i8; n_acts * nb * 32];
+        for a in 0..n_acts {
+            let mut act = Vec::new();
+            for b in 0..nb {
+                let mut qv = [0i8; 32];
+                for q in qv.iter_mut() {
+                    *q = (xorshift(&mut state) & 0xff) as u8 as i8;
+                }
+                let s = (xorshift(&mut state) % 1000) as f32 / 777.0 + 0.002;
+                scales[a * nb + b] = s;
+                quants[(a * nb + b) * 32..(a * nb + b + 1) * 32].copy_from_slice(&qv);
+                act.push(crate::tensor::Q8_0Block {
+                    scale: s,
+                    quants: qv,
+                });
+            }
+            q80_acts.push(act);
+        }
+        for (kind, wire_bytes, name) in [
+            (DgExpertKind::Q80, 34usize, "q8_0"),
+            (DgExpertKind::Q50, 22usize, "q5_0"),
+        ] {
+            let mut wire = vec![0u8; total_rows * nb * wire_bytes];
+            for b in wire.iter_mut() {
+                *b = (xorshift(&mut state) & 0xff) as u8;
+            }
+            for blk in 0..total_rows * nb {
+                wire[blk * wire_bytes + 1] &= 0x3f;
+            }
+            let out = fast_gemm_id(
+                &wire,
+                (dummy, 0),
+                kind,
+                &base,
+                &pos,
+                rows_per,
+                nb,
+                &scales,
+                &quants,
+            )
+            .unwrap_or_else(|| panic!("{name} id gemm"));
+            for (pi, &(b, a)) in pairs.iter().enumerate() {
+                for r in 0..rows_per {
+                    let row_i = b as usize + r;
+                    let row = &wire[row_i * nb * wire_bytes..(row_i + 1) * nb * wire_bytes];
+                    let cpu = match kind {
+                        DgExpertKind::Q80 => {
+                            super::super::refmath::q8_0_dot_arm(row, &q80_acts[a as usize])
+                        }
+                        DgExpertKind::Q50 => {
+                            super::super::refmath::q5_0_dot_arm(row, &q80_acts[a as usize])
+                        }
+                        DgExpertKind::Q4K => unreachable!(),
+                    };
+                    assert_eq!(
+                        cpu.to_bits(),
+                        out[pi * rows_per + r].to_bits(),
+                        "{name} pair {pi} row {r}"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## What

The remainder of the DG Windows/VRAM program — PR #368 was merged while these were still landing on the branch. Six commits:

1. **Serve/GUI bridge** (`CAMELID_DG_SERVE=1`): diffusion-gemma models route `/v1/chat/completions` through the Phase 6 `DgChat` wrapper (block-level SSE with keep-alives, single-turn contract, `CAMELID_DG_MAX_STEPS`/`_MAX_BLOCKS` knobs) + health `generation_ready` coverage. Verified live: API + streaming + embedded WebUI.
2. **`CAMELID_DG_FAST` engine** (opt-in; parity lane untouched): batched-ID GEMM kernels (Q4_K/Q8_0/Q5_0/Q6_K), whole-layer GPU FFN+MoE and attention blocks, tiled f16 GEMM lm_head + SC against the shared resident embedding (softcap and softmax fused in-kernel, device-resident logits handoff), split residency budgets, and a depth-3 pinned read-ahead ring fed by direct file reads.
3. **Robustness**: NVRTC-broken-kernel failure is cached (`ENGINE_FAILED`) — previously every call retried the compile, running 28× slower than CPU.

## Measured (RTX 3060 Laptop 6 GB, 273-position step, steady state)

~265 s (CPU parity) → 85 → 57 → 36 → 30 → 24 → **~18 s** (14.7×). Full-quality 24-step answer: **603 s** measured end-to-end with coherent, self-consistent output. Unit gates: all id-kernels bit-identical per-row to the scalar oracles; 22/22 DG lib tests; clippy `-D warnings`; fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)