### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump **0.1.8 → 0.2.0** ahead of cutting the `v0.2.0` release tag.

First release since `v0.1.8` — **207 commits** on main since then, including:
- DiffusionGemma Windows + zero-copy tier (#368–#373)
- Ornith 1.0 9B qwen35 hybrid-SSM lane + GPU-resident decode (+55%) and exact-row promotion (#350–#376)
- Q5_K_M CPU + GPU exact-row support (#375, #376)
- Models-page rebuild (#364), Windows default-parallel promotion (#362), Neural Field Observatory (#363), decode/attn/KV lanes (#355/#358/#359/#361)

Bumps root `Cargo.toml`, `camelid-desktop/Cargo.toml`, `tauri.conf.json` (keeps the NSIS installer named for the release), and `Cargo.lock`. Pure version bump — no code changes.

Once CI is green this merges and a `v0.2.0` tag is pushed to trigger `release.yml` (signed Windows zip + desktop installer, macOS/Linux tarballs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)