### PR TITLE
fix(build): reserve more stack for Windows CLI

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,8 @@ fn main() {
         println!(
             "cargo:rustc-link-arg-bin=camelid=/EXPORT:AmdPowerXpressRequestHighPerformance,DATA"
         );
+        // Windows' default 1 MiB stack overflows while Clap builds this binary's CLI.
+        println!("cargo:rustc-link-arg-bin=camelid=/STACK:8388608");
     }
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     if target_os != "linux" || target_arch != "x86_64" {


### PR DESCRIPTION
## Summary

- Increase the Windows stack reserve for the `camelid` binary.
- Fix `camelid --version`, `camelid --help`, and `camelid serve --help` stack overflows on Windows.
- Keep the change scoped to the Windows `camelid` executable; no runtime/model behavior changes.

## Why this change exists

On Windows, the default 1 MiB main-thread stack is too small for the current CLI command graph before any model/runtime code runs.

This blocked local API/WebUI smoke work because the server could not even reach startup reliably. Reserving a larger stack fixes the CLI startup path without changing inference, loading, CUDA, API behavior, or support claims.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo build --bin camelid --quiet --jobs 1`
- `target\debug\camelid.exe --version`
- `target\debug\camelid.exe --help`
- `target\debug\camelid.exe serve --help`

Results:

- `--version`: exit 0
- `--help`: exit 0
- `serve --help`: exit 0

## Public-repo privacy check

- No private hostnames, SSH commands, user home paths, key paths, raw infrastructure output, or validation host details are included.
- No evidence bundle or remote validation artifact is included.

## Support-contract check

- This PR does not overclaim support.
- No model row, quantization row, context row, API capability, or WebUI readiness state is promoted.
- TinyLlama Q8_0 remains the current full-support gate; existing exact-row lanes stay within their documented envelopes.

## Evidence / artifacts

- Branch: `karan68:fix/windows-cli-stack-overflow`
- Commit: `2266d57f fix(build): reserve more stack for Windows CLI`

## Docs impact

No README, compatibility, status, or roadmap updates are included.