### PR TITLE
fix(api): resilient catalog downloads (v0.2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15924,7 +15924,36 @@ async fn install_catalog_model(Json(req): Json<InstallCatalogRequest>) -> Respon
     // error page to the output file and exiting 0 â€” which previously looked like an
     // instant successful download.
     match std::process::Command::new("curl")
-        .args(["-f", "-L", "-C", "-", "-o", &part_path, &url])
+        // Resilience flags for large multi-GB pulls over flaky/throttled CDNs:
+        //   --speed-limit/--speed-time: abort (exit 28) if throughput stays below
+        //     1 KiB/s for 30s. Without this, a silently stalled-but-still-Established
+        //     TCP connection makes curl wait on a dead stream forever, so the download
+        //     freezes mid-file and never recovers (the bug this fixes).
+        //   --retry/--retry-delay/--retry-all-errors: reconnect on transient errors
+        //     AND on that speed-abort (--retry-all-errors covers exit 28); `-C -`
+        //     resumes from the existing `.part` offset on each retry, so no bytes are
+        //     re-downloaded.
+        //   --connect-timeout caps a dead connect attempt.
+        .args([
+            "-f",
+            "-L",
+            "-C",
+            "-",
+            "--connect-timeout",
+            "30",
+            "--speed-limit",
+            "1024",
+            "--speed-time",
+            "30",
+            "--retry",
+            "10",
+            "--retry-delay",
+            "2",
+            "--retry-all-errors",
+            "-o",
+            &part_path,
+            &url,
+        ])
         .spawn()
     {
         Ok(child) => {


### PR DESCRIPTION
## Bug
Catalog model downloads stall mid-file and never recover. The downloader spawned `curl -f -L -C - -o <part> <url>` with **no stall detection, retry, or timeout flags**. On a large multi-GB pull, when a HuggingFace CDN connection goes silent mid-transfer, the TCP socket stays `Established` but no bytes flow and curl waits on the dead stream forever — the app is stuck on "downloading" indefinitely. Reproduced live: two concurrent 8 GB Q8_0 pulls froze at 63% and 22%, sockets Established, `.part` files not growing.

## Fix
Add resilience flags to the download curl (`src/api/mod.rs` `install_catalog_model`):
- `--speed-limit 1024 --speed-time 30` — abort (exit 28) a stream stuck below 1 KiB/s for 30s
- `--retry 10 --retry-delay 2 --retry-all-errors` — reconnect on transient errors **and** the speed-abort
- `--connect-timeout 30` — cap a dead connect attempt

With the existing `-C -`, each retry resumes from the `.part` offset, so a silent stall self-heals with no bytes re-downloaded.

## Release
Bumps version `0.2.0 → 0.2.1` (root `Cargo.toml`, `camelid-desktop/Cargo.toml`, `tauri.conf.json`, `Cargo.lock`). On merge, tag `v0.2.1` → `release.yml` builds + signs the artifacts.

`cargo check` + `cargo fmt` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)