### PR TITLE
feat(tokenizer): recover llama-bpe for Llama-3 GGUFs missing tokenizer.ggml.pre (v0.2.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -252,6 +252,29 @@ fn is_llama3_bpe_signature(token_texts: &[String]) -> bool {
         && token_texts.get(128_009).map(String::as_str) == Some("<|eot_id|>")
 }
 
+/// Resolve the GPT-2/BPE pre-tokenizer dialect from `tokenizer.ggml.pre`. The three
+/// known dialects differ only in the split regex (digit grouping / mark folding); the
+/// byte-BPE merge step is identical (verified against llama.cpp llama-vocab.cpp). When
+/// the key is ABSENT, recover llama-bpe iff the vocab carries the Llama-3 signature —
+/// some Llama-3 GGUF conversions omit the key, and llama.cpp then silently mis-tokenizes
+/// them under a raw GPT-2 fallback ("GENERATION QUALITY WILL BE DEGRADED"). An
+/// explicit-but-unknown `pre`, or a missing key without the signature (e.g. a de-labeled
+/// Qwen), is refused. Extracted from `from_gguf` so the decision is unit-testable.
+fn resolve_gpt2_pre_tokenizer(
+    pre: Option<&str>,
+    token_texts: &[String],
+) -> Result<BpePreTokenizer> {
+    match pre {
+        Some("llama-bpe") => Ok(BpePreTokenizer::Llama3),
+        Some("qwen2") => Ok(BpePreTokenizer::Qwen2),
+        Some("qwen35") => Ok(BpePreTokenizer::Qwen35),
+        None if is_llama3_bpe_signature(token_texts) => Ok(BpePreTokenizer::Llama3),
+        other => Err(BackendError::UnsupportedTokenizer(format!(
+            "unsupported GPT-2/BPE pre-tokenizer {other:?}; currently supported: llama-bpe, qwen2, qwen35"
+        ))),
+    }
+}
+
 impl Tokenizer {
     pub fn from_gguf(file: &GgufFile) -> Result<Self> {
         let model_name = file
@@ -280,32 +303,7 @@ impl Tokenizer {
         }
 
         let bpe_pre_tokenizer = if model == TokenizerModel::Gpt2Bpe {
-            let pre_tokenizer = file.metadata_string("tokenizer.ggml.pre");
-            match pre_tokenizer {
-                Some("llama-bpe") => BpePreTokenizer::Llama3,
-                // Qwen2/Qwen3 differ from llama-bpe only in digit grouping
-                // (single digit vs runs of three); the byte-BPE merge step is
-                // identical. Verified against llama.cpp llama-vocab.cpp.
-                Some("qwen2") => BpePreTokenizer::Qwen2,
-                // Qwen3.5 / Ornith: same single-digit split as qwen2; its `\p{M}`
-                // mark-folding is a documented deferral (see `BpePreTokenizer::Qwen35`).
-                Some("qwen35") => BpePreTokenizer::Qwen35,
-                // Some GGUF conversions of Llama 3 omit `tokenizer.ggml.pre` entirely.
-                // llama.cpp then warns "missing pre-tokenizer type, using: 'default'"
-                // and silently tokenizes WRONG (raw GPT-2 splitting). When the key is
-                // absent AND the vocab carries the exact Llama-3 tiktoken special-token
-                // signature (only that family places these markers at these ids),
-                // recover the correct llama-bpe pre-tokenizer — the byte-BPE merges are
-                // identical across the GPT-2/BPE dialects, so only the split regex is
-                // fixed. An explicit-but-unknown `pre`, or a non-Llama-3 vocab (e.g. a
-                // Qwen GGUF that lost its `pre`), fails the signature and stays refused.
-                None if is_llama3_bpe_signature(&token_texts) => BpePreTokenizer::Llama3,
-                other => {
-                    return Err(BackendError::UnsupportedTokenizer(format!(
-                        "unsupported GPT-2/BPE pre-tokenizer {other:?}; currently supported: llama-bpe, qwen2, qwen35"
-                    )))
-                }
-            }
+            resolve_gpt2_pre_tokenizer(file.metadata_string("tokenizer.ggml.pre"), &token_texts)?
         } else {
             BpePreTokenizer::default()
         };
@@ -1361,6 +1359,45 @@ mod tests {
         assert!(!is_llama3_bpe_signature(&missing));
     }
 
+    #[test]
+    fn resolve_gpt2_pre_tokenizer_gates_the_missing_pre_recovery() {
+        use super::{resolve_gpt2_pre_tokenizer, BpePreTokenizer};
+        let mut sig = vec![String::new(); 128_256];
+        sig[128_000] = "<|begin_of_text|>".to_string();
+        sig[128_001] = "<|end_of_text|>".to_string();
+        sig[128_006] = "<|start_header_id|>".to_string();
+        sig[128_007] = "<|end_header_id|>".to_string();
+        sig[128_009] = "<|eot_id|>".to_string();
+        let no_sig = vec!["x".to_string(); 128_256];
+
+        // Explicit dialects resolve regardless of the vocab.
+        assert!(matches!(
+            resolve_gpt2_pre_tokenizer(Some("llama-bpe"), &no_sig),
+            Ok(BpePreTokenizer::Llama3)
+        ));
+        assert!(matches!(
+            resolve_gpt2_pre_tokenizer(Some("qwen2"), &no_sig),
+            Ok(BpePreTokenizer::Qwen2)
+        ));
+        assert!(matches!(
+            resolve_gpt2_pre_tokenizer(Some("qwen35"), &no_sig),
+            Ok(BpePreTokenizer::Qwen35)
+        ));
+
+        // Missing pre + Llama-3 signature => recovered as Llama3 (the fix).
+        assert!(matches!(
+            resolve_gpt2_pre_tokenizer(None, &sig),
+            Ok(BpePreTokenizer::Llama3)
+        ));
+
+        // Missing pre WITHOUT the signature => still refused (guards a de-labeled Qwen).
+        assert!(resolve_gpt2_pre_tokenizer(None, &no_sig).is_err());
+
+        // An explicit-but-unknown pre is refused EVEN WITH the signature — we only
+        // rescue an absent key, never override a stated (if unrecognized) dialect.
+        assert!(resolve_gpt2_pre_tokenizer(Some("smaug-bpe"), &sig).is_err());
+    }
+
     // Parity gate for the missing-`pre` Llama-3 rescue: the exact Meta-Llama-3-8B GGUF
     // that omits tokenizer.ggml.pre must tokenize BYTE-IDENTICALLY to a known-good
     // pre=llama-bpe Llama-3 GGUF. Ignored by default (needs the multi-GB models); run
@@ -1376,12 +1413,27 @@ mod tests {
             .expect("set CAMELID_LLAMA3_REFERENCE_GGUF");
         let ga = crate::gguf::read_metadata(&a).expect("read missing-pre gguf");
         let gb = crate::gguf::read_metadata(&b).expect("read reference gguf");
+        // Guard against a tautological pass: the reference MUST carry an explicit
+        // pre=llama-bpe (a genuine oracle), and the file under test MUST actually omit
+        // the key (so it drives the recovery branch, not the normal path). Without
+        // these, pointing both env vars at missing-pre files would pass trivially.
+        assert_eq!(
+            gb.metadata_string("tokenizer.ggml.pre"),
+            Some("llama-bpe"),
+            "CAMELID_LLAMA3_REFERENCE_GGUF must be an explicit pre=llama-bpe oracle"
+        );
+        assert_eq!(
+            ga.metadata_string("tokenizer.ggml.pre"),
+            None,
+            "CAMELID_LLAMA3_MISSING_PRE_GGUF must actually omit tokenizer.ggml.pre"
+        );
         let ta = Tokenizer::from_gguf(&ga)
             .expect("missing-pre Llama-3 gguf must now load (llama-bpe recovered)");
         let tb = Tokenizer::from_gguf(&gb).expect("reference gguf loads");
-        // Strings that EXERCISE the pre-tokenizer (the only thing recovery decides):
-        // contractions, multi-digit runs (llama-bpe groups 3s, qwen groups singles),
-        // whitespace, unicode, and the chat markers.
+        // This proves the RECOVERED tokenizer equals an explicit pre=llama-bpe oracle
+        // over strings that exercise the split regex (contractions, multi-digit runs,
+        // whitespace, unicode, chat markers). The llama-bpe-vs-qwen digit-grouping
+        // discrimination itself is covered by qwen2_pretokenizer_splits_digits_singly.
         let battery = [
             "It's a test, don't you think? We'll see.",
             "1234567890 and 42 plus 007 and 100000",

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -235,6 +235,23 @@ pub struct Tokenizer {
     pub chat_template: Option<String>,
 }
 
+/// The Llama-3 tiktoken tokenizer's special-token signature. Llama 3 / 3.1 / 3.2 all
+/// place these five stable chat markers at these exact ids in a 128,256-token vocab,
+/// and no other tokenizer family does — so a GPT-2/BPE GGUF carrying them IS the
+/// llama-bpe tokenizer. Used only to recover a MISSING `tokenizer.ggml.pre` (see
+/// `Tokenizer::from_gguf`); the checked ids deliberately exclude the reserved slots
+/// that were renamed between Llama-3 and 3.2 (e.g. 128008 `<|eom_id|>`). Proven
+/// byte-identical base vocab `[0, 128000)` and merges against a `pre=llama-bpe`
+/// Llama-3.2 GGUF.
+fn is_llama3_bpe_signature(token_texts: &[String]) -> bool {
+    token_texts.len() == 128_256
+        && token_texts.get(128_000).map(String::as_str) == Some("<|begin_of_text|>")
+        && token_texts.get(128_001).map(String::as_str) == Some("<|end_of_text|>")
+        && token_texts.get(128_006).map(String::as_str) == Some("<|start_header_id|>")
+        && token_texts.get(128_007).map(String::as_str) == Some("<|end_header_id|>")
+        && token_texts.get(128_009).map(String::as_str) == Some("<|eot_id|>")
+}
+
 impl Tokenizer {
     pub fn from_gguf(file: &GgufFile) -> Result<Self> {
         let model_name = file
@@ -253,6 +270,15 @@ impl Tokenizer {
                 )))
             }
         };
+        // Read the token list up front: it is needed both to recover a missing
+        // pre-tokenizer from the vocab signature (below) and to build the vocab.
+        let token_texts = file.metadata_array_strings("tokenizer.ggml.tokens")?;
+        if token_texts.is_empty() {
+            return Err(BackendError::InvalidTokenizerMetadata(
+                "tokenizer.ggml.tokens must not be empty".to_string(),
+            ));
+        }
+
         let bpe_pre_tokenizer = if model == TokenizerModel::Gpt2Bpe {
             let pre_tokenizer = file.metadata_string("tokenizer.ggml.pre");
             match pre_tokenizer {
@@ -264,6 +290,16 @@ impl Tokenizer {
                 // Qwen3.5 / Ornith: same single-digit split as qwen2; its `\p{M}`
                 // mark-folding is a documented deferral (see `BpePreTokenizer::Qwen35`).
                 Some("qwen35") => BpePreTokenizer::Qwen35,
+                // Some GGUF conversions of Llama 3 omit `tokenizer.ggml.pre` entirely.
+                // llama.cpp then warns "missing pre-tokenizer type, using: 'default'"
+                // and silently tokenizes WRONG (raw GPT-2 splitting). When the key is
+                // absent AND the vocab carries the exact Llama-3 tiktoken special-token
+                // signature (only that family places these markers at these ids),
+                // recover the correct llama-bpe pre-tokenizer — the byte-BPE merges are
+                // identical across the GPT-2/BPE dialects, so only the split regex is
+                // fixed. An explicit-but-unknown `pre`, or a non-Llama-3 vocab (e.g. a
+                // Qwen GGUF that lost its `pre`), fails the signature and stays refused.
+                None if is_llama3_bpe_signature(&token_texts) => BpePreTokenizer::Llama3,
                 other => {
                     return Err(BackendError::UnsupportedTokenizer(format!(
                         "unsupported GPT-2/BPE pre-tokenizer {other:?}; currently supported: llama-bpe, qwen2, qwen35"
@@ -273,13 +309,6 @@ impl Tokenizer {
         } else {
             BpePreTokenizer::default()
         };
-
-        let token_texts = file.metadata_array_strings("tokenizer.ggml.tokens")?;
-        if token_texts.is_empty() {
-            return Err(BackendError::InvalidTokenizerMetadata(
-                "tokenizer.ggml.tokens must not be empty".to_string(),
-            ));
-        }
 
         let scores = file
             .metadata_array_f32_optional("tokenizer.ggml.scores")?
@@ -1304,6 +1333,70 @@ mod tests {
             text: text.to_string(),
             score: 0.0,
             kind,
+        }
+    }
+
+    #[test]
+    fn llama3_bpe_signature_matches_only_the_llama3_vocab() {
+        use super::is_llama3_bpe_signature;
+        // Minimal stand-in for the Llama-3 vocab: 128,256 entries with the five
+        // stable chat markers at their canonical ids.
+        let mut v = vec![String::new(); 128_256];
+        v[128_000] = "<|begin_of_text|>".to_string();
+        v[128_001] = "<|end_of_text|>".to_string();
+        v[128_006] = "<|start_header_id|>".to_string();
+        v[128_007] = "<|end_header_id|>".to_string();
+        v[128_009] = "<|eot_id|>".to_string();
+        assert!(is_llama3_bpe_signature(&v));
+
+        // Wrong vocab size never matches (Qwen's 151,936, or a truncated vocab).
+        assert!(!is_llama3_bpe_signature(&v[..128_255]));
+        let qwen_sized = vec!["x".to_string(); 151_936];
+        assert!(!is_llama3_bpe_signature(&qwen_sized));
+
+        // Missing any core marker fails — this is what refuses a de-pre'd non-Llama-3
+        // vocab that happens to be 128,256 tokens.
+        let mut missing = v.clone();
+        missing[128_009] = "<|not_eot|>".to_string();
+        assert!(!is_llama3_bpe_signature(&missing));
+    }
+
+    // Parity gate for the missing-`pre` Llama-3 rescue: the exact Meta-Llama-3-8B GGUF
+    // that omits tokenizer.ggml.pre must tokenize BYTE-IDENTICALLY to a known-good
+    // pre=llama-bpe Llama-3 GGUF. Ignored by default (needs the multi-GB models); run
+    // locally with both env vars set:
+    //   CAMELID_LLAMA3_MISSING_PRE_GGUF, CAMELID_LLAMA3_REFERENCE_GGUF
+    #[test]
+    #[ignore = "needs real Llama-3 GGUFs; set CAMELID_LLAMA3_MISSING_PRE_GGUF and CAMELID_LLAMA3_REFERENCE_GGUF"]
+    fn missing_pre_llama3_tokenizes_identically_to_reference() {
+        use super::Tokenizer;
+        let a = std::env::var("CAMELID_LLAMA3_MISSING_PRE_GGUF")
+            .expect("set CAMELID_LLAMA3_MISSING_PRE_GGUF");
+        let b = std::env::var("CAMELID_LLAMA3_REFERENCE_GGUF")
+            .expect("set CAMELID_LLAMA3_REFERENCE_GGUF");
+        let ga = crate::gguf::read_metadata(&a).expect("read missing-pre gguf");
+        let gb = crate::gguf::read_metadata(&b).expect("read reference gguf");
+        let ta = Tokenizer::from_gguf(&ga)
+            .expect("missing-pre Llama-3 gguf must now load (llama-bpe recovered)");
+        let tb = Tokenizer::from_gguf(&gb).expect("reference gguf loads");
+        // Strings that EXERCISE the pre-tokenizer (the only thing recovery decides):
+        // contractions, multi-digit runs (llama-bpe groups 3s, qwen groups singles),
+        // whitespace, unicode, and the chat markers.
+        let battery = [
+            "It's a test, don't you think? We'll see.",
+            "1234567890 and 42 plus 007 and 100000",
+            "The quick brown fox jumps over 13 lazy dogs.",
+            "café — naïve — Zürich — 你好 — 🚀",
+            "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\nhi<|eot_id|>",
+            "    leading and    inner   spaces\tand\ttabs",
+        ];
+        for s in battery {
+            let ea = ta.encode(s, false, true).expect("encode missing-pre");
+            let eb = tb.encode(s, false, true).expect("encode reference");
+            assert_eq!(
+                ea, eb,
+                "token mismatch for {s:?}:\n  missing-pre: {ea:?}\n  reference:   {eb:?}"
+            );
         }
     }
 


### PR DESCRIPTION
## Problem
Loading `Meta-Llama-3-8B-Instruct.Q8_0.gguf` fails with `unsupported GPT-2/BPE pre-tokenizer None`. This GGUF (a common older conversion) omits `tokenizer.ggml.pre`, and Camelid strictly refuses it — even though its tokenizer IS the standard Llama-3 tiktoken BPE. (llama.cpp instead falls back to raw GPT-2 splitting and warns "GENERATION QUALITY WILL BE DEGRADED".)

## Fix (evidence-gated)
When `tokenizer.ggml.pre` is **absent** *and* the vocab carries the exact Llama-3 signature — 128,256 tokens with `<|begin_of_text|>`@128000, `<|end_of_text|>`@128001, `<|start_header_id|>`@128006, `<|end_header_id|>`@128007, `<|eot_id|>`@128009 — recover `BpePreTokenizer::Llama3`. Only that family places these markers at these ids. An explicit-but-unknown `pre`, or a vocab without the signature (e.g. a de-labeled Qwen), still refuses. The byte-BPE merges are identical across the GPT-2/BPE dialects, so this only corrects the split regex.

## Why it's safe (proven, not assumed)
The real 8B GGUF's base vocab `[0,128000)` and all 280,147 merges are **byte-identical** to a working `pre=llama-bpe` Llama-3.2 GGUF (only 249 renamed reserved specials at id≥128004 differ). With the fix, the 8B tokenizes **byte-identically** to the llama-bpe reference across a discriminating battery (contractions, multi-digit runs, unicode, chat markers).

## Tests
- `resolve_gpt2_pre_tokenizer_gates_the_missing_pre_recovery` (CI) — locks the decision wiring.
- `llama3_bpe_signature_matches_only_the_llama3_vocab` (CI) — locks the signature.
- `missing_pre_llama3_tokenizes_identically_to_reference` (`#[ignore]`, real models) — the parity gate; asserts the reference is genuinely `pre=llama-bpe` and the subject genuinely lacks `pre` (non-tautological).

Full local gate green: `fmt`, `clippy --all-targets --all-features -D warnings`, tokenizer tests + parity gate. Reviewed adversarially (5 review findings; 2 refuted, 3 test-quality fixes applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)