### PR TITLE
fix(execution-plan): recognize models by filename when general.name is junk (v0.2.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"

--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -855,14 +855,24 @@ fn requested_profile() -> (ExecutionProfile, String) {
 }
 
 fn exact_model_row(model_path: &Path, gguf: &GgufFile) -> String {
-    gguf.model_name()
-        .map(|value| value.to_string())
-        .or_else(|| {
-            model_path
-                .file_name()
-                .map(|v| v.to_string_lossy().to_string())
-        })
-        .unwrap_or_else(|| "unknown".into())
+    let from_name = gguf.model_name().map(|value| value.to_string());
+    let from_file = model_path
+        .file_name()
+        .map(|v| v.to_string_lossy().to_string());
+    // Prefer the GGUF `general.name`, but if it does NOT map to a recognized support row
+    // while the FILENAME does, use the filename. Some GGUF conversions ship a junk
+    // `general.name` (e.g. "hub") that would otherwise shadow a perfectly recognizable
+    // filename and drop a known, validated model onto the slow cpu_reference path
+    // instead of its GPU lane. This only ever UPGRADES an unrecognized name to a
+    // recognized row — it never overrides a name that already matches a row.
+    if let (Some(name), Some(file)) = (&from_name, &from_file) {
+        if support_level(name) == "unknown_or_unvalidated"
+            && support_level(file) != "unknown_or_unvalidated"
+        {
+            return file.clone();
+        }
+    }
+    from_name.or(from_file).unwrap_or_else(|| "unknown".into())
 }
 
 fn support_level(row: &str) -> String {
@@ -1232,6 +1242,58 @@ mod tests {
         ] {
             env::remove_var(key);
         }
+    }
+
+    #[test]
+    fn junk_general_name_falls_back_to_recognizable_filename() {
+        // A junk general.name ("hub", from some conversions) maps to no support row; it
+        // must defer to a recognizable filename so the model reaches its validated row
+        // instead of failing closed — and must never override a name that already matches.
+        let row = exact_model_row(
+            &PathBuf::from("/models/Meta-Llama-3-8B-Instruct.Q8_0.gguf"),
+            &fixture("hub"),
+        );
+        assert!(
+            is_supported_exact_q8_row(&row),
+            "junk general.name must fall back to the recognized filename; got {row:?}"
+        );
+        // Junk name AND unrecognizable filename stays unrecognized.
+        assert_eq!(
+            support_level(&exact_model_row(
+                &PathBuf::from("/models/mystery.gguf"),
+                &fixture("hub")
+            )),
+            "unknown_or_unvalidated"
+        );
+        // A recognized general.name is never overridden by an unrelated filename.
+        assert_eq!(
+            exact_model_row(
+                &PathBuf::from("/models/whatever.gguf"),
+                &fixture("Llama 3.2 1B Instruct")
+            ),
+            "Llama 3.2 1B Instruct"
+        );
+    }
+
+    #[test]
+    fn junk_named_recognizable_8b_takes_gpu_lane_not_cpu() {
+        let _guard = env_lock();
+        clear_profile_env();
+        let outcome = plan_for_model_with_platform(
+            &PathBuf::from("/models/Meta-Llama-3-8B-Instruct.Q8_0.gguf"),
+            &fixture("hub"),
+            Some(8),
+            cuda_platform("windows", "x86_64", &["avx2"]),
+        );
+        clear_profile_env();
+        assert_eq!(
+            outcome.plan.exact_model_row,
+            "Meta-Llama-3-8B-Instruct.Q8_0.gguf"
+        );
+        assert_ne!(
+            outcome.plan.selected_backend, "cpu_reference",
+            "a recognizable 8B with a junk general.name must not fail closed to CPU"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
A `Meta-Llama-3-8B-Instruct.Q8_0.gguf` (with a valid tokenizer, arch=llama, Q8_0) loads onto the **slow CPU reference path** instead of the GPU-offload lane — even though a `meta_llama_3_8b_instruct` supported+GPU-eligible row already exists. Root cause: the GGUF's `general.name` is a junk `"hub"`, and `exact_model_row()` trusted `general.name` and only consulted the filename when it was *absent*. So `"hub"` → `unknown_or_unvalidated` → fail-closed to CPU.

## Fix
`exact_model_row()` now prefers `general.name` but falls back to the filename when the name maps to no support row and the filename does. This only ever **upgrades** an unrecognized name to a recognized row; it never overrides a name that already matches.

## Safety (reviewed adversarially)
The plan label carries no shape assumptions into execution: a mislabeled filename is caught by two runtime guards keyed off the real GGUF — the architecture whitelist (`model.rs` fails closed on a wrong arch) and `resident_decode_eligible` (`inference.rs` re-validates dense/Q8_0/shape from real tensors → CPU fallback, itself token-parity). The api support-ledger and chat-template selection are decoupled from the row string. Worst case is a cosmetic plan label, never a wrong kernel.

## Tests
`junk_general_name_falls_back_to_recognizable_filename` (upgrade + never-override + still-unknown guards) and `junk_named_recognizable_8b_takes_gpu_lane_not_cpu` (plan routes to GPU, not cpu_reference). Full local gate green (fmt + clippy -D warnings + execution_plan tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)