### PR TITLE
GPU-runnable tier: uncurated Q8_0 models run on GPU by default, gated by a parity self-check (v0.2.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7432,9 +7432,17 @@ pub async fn replay_receipt_request(
         default_max_tokens_cap: None,
         json_object_mode: false,
     };
-    let prepared = match prepare_generation(&state, session_request).await {
-        Ok(prepared) => prepared,
-        Err(response) => return Err(response_error_text(response).await),
+    let prepared = {
+        // Serialize the GPU-runnable-tier parity probe (fired inside prepare_generation) with
+        // every other decode: the probe drives the process-global single-slot resident CUDA
+        // engine, so without the lock it could evict a concurrently-running decode's engine
+        // mid-sequence. Scoped to just the probe; this is the standalone receipt-replay path,
+        // whose subsequent decode keeps its prior (unlocked) behavior.
+        let _gen_guard = state.generation_lock.clone().lock_owned().await;
+        match prepare_generation(&state, session_request).await {
+            Ok(prepared) => prepared,
+            Err(response) => return Err(response_error_text(response).await),
+        }
     };
     let generated = match generate_decoded_tokens_blocking(prepared).await {
         Ok(generated) => generated,
@@ -7465,7 +7473,13 @@ async fn validate_generation_request(
     state: &AppState,
     req: GenerationSessionRequest,
 ) -> std::result::Result<GenerationSessionSummary, Response> {
-    let prepared = prepare_generation(state, req).await?;
+    // Serialize the GPU-runnable-tier parity probe (fired inside prepare_generation) with every
+    // other decode — it drives the process-global single-slot resident CUDA engine. See the note
+    // in replay_receipt_request. This path validates/creates a session and does not itself decode.
+    let prepared = {
+        let _gen_guard = state.generation_lock.clone().lock_owned().await;
+        prepare_generation(state, req).await?
+    };
 
     Ok(GenerationSessionSummary {
         id: format!(
@@ -8058,13 +8072,56 @@ async fn prepare_generation(
     // Pin the GPU resident-decode engine cache to the model identity (not the
     // per-load weights Arc pointer), so every request for this model reuses the
     // uploaded weights instead of rebuilding the engine each time.
-    {
+    let resident_cache_key = {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         model.id.hash(&mut hasher);
-        session.set_resident_cache_key(hasher.finish());
-    }
+        let key = hasher.finish();
+        session.set_resident_cache_key(key);
+        key
+    };
     timings.session_create = session_create_started.elapsed().as_millis();
+
+    // GPU-runnable tier: an uncurated model whose plan routed it onto the resident path
+    // (its `selected_backend` carries the `_runnable_unvalidated` label) is admitted to the
+    // GPU only after a one-time parity self-check — greedy decode on the resident GPU path
+    // must be token-identical to the CPU reference. The verdict is cached per model and the
+    // resident-eligibility choke point consults it, so a FAIL runs the model on CPU. Runs on
+    // a blocking thread (it builds engines + decodes) and is awaited so the verdict is set
+    // BEFORE this request generates. Curated rows never take this branch.
+    if crate::inference::resident_decode_cuda_active() {
+        let is_runnable_tier = {
+            let plans = state.execution_plans.read().await;
+            plans
+                .get(&model.id)
+                .map(|plan| plan.selected_backend.contains("_runnable_unvalidated"))
+                .unwrap_or(false)
+        };
+        if is_runnable_tier {
+            let probe_weights = std::sync::Arc::clone(&session.weights);
+            let probe_config = config.clone();
+            let probe_label = model.id.clone();
+            // Fail CLOSED: if the probe closure panics (an uncurated, arbitrary model can hit
+            // an unwrap/index deep in the resident engine build or a CUDA kernel), the panic
+            // is caught by `spawn_blocking` and surfaced as `Err(JoinError)`. `unwrap_or(false)`
+            // turns that into a FAILED verdict, and we record it so the choke point forbids the
+            // resident path — otherwise a missing verdict would leave the model admitted to the
+            // GPU unvalidated. A normal FAIL is already recorded inside the probe itself.
+            let probe_passed = tokio::task::spawn_blocking(move || {
+                crate::inference::ensure_resident_parity_verdict(
+                    &probe_config,
+                    &probe_weights,
+                    resident_cache_key,
+                    &probe_label,
+                )
+            })
+            .await
+            .unwrap_or(false);
+            if !probe_passed {
+                crate::inference::record_resident_parity_fail(resident_cache_key);
+            }
+        }
+    }
 
     let collect_dense_diagnostics = req.camelid_dense_diagnostics.unwrap_or(false)
         || req.camelid_dense_diagnostic_generated_index.is_some();

--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -315,8 +315,12 @@ pub fn plan_for_model_with_platform(
     } else if quant_type == "Q8_0"
         && platform.cuda_resident_active
         && is_gpu_runnable_arch(gguf)
-        && env_flag_enabled("CAMELID_GPU_RUNNABLE_TIER")
+        && !env_flag_disabled("CAMELID_GPU_RUNNABLE_TIER")
     {
+        // On by DEFAULT: an uncurated but architecturally-compatible Q8_0 model should just run
+        // on the GPU without the user having to opt in. This is safe because admission is gated
+        // at runtime by the GPU-vs-CPU parity self-check — a model that is not bit-exact falls
+        // back to the CPU reference path. Opt out with CAMELID_GPU_RUNNABLE_TIER=0 (forces CPU).
         reasons.push(
             "non-curated Q8_0 on a resident-capable dense arch: GPU-runnable tier (NOT a \
              supported row) — resident path admitted subject to the runtime parity self-check"
@@ -1351,32 +1355,22 @@ mod tests {
     }
 
     #[test]
-    fn gpu_runnable_tier_admits_uncurated_q8_llama_only_when_flag_on() {
+    fn gpu_runnable_tier_admits_uncurated_q8_llama_by_default_optout_forces_cpu() {
         let _guard = env_lock();
         clear_profile_env();
-        env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
         // Uncurated: neither general.name ("hub") nor the filename maps to a support row.
         let uncurated = fixture("hub");
         let path = PathBuf::from("/models/my-custom-llama-Q8_0.gguf");
-        // Flag OFF (default): fails closed to CPU, unchanged from prior behavior.
-        let off = plan_for_model_with_platform(
-            &path,
-            &uncurated,
-            Some(8),
-            cuda_platform("windows", "x86_64", &["avx2"]),
-        );
-        assert_eq!(off.plan.selected_backend, "cpu_reference");
-        // Flag ON: admitted to the GPU-runnable tier with an honest, distinct label; the
-        // support_level stays unknown_or_unvalidated (never claims a supported row).
-        env::set_var("CAMELID_GPU_RUNNABLE_TIER", "1");
+        // DEFAULT (unset): admitted to the GPU-runnable tier with an honest, distinct label; the
+        // support_level stays unknown_or_unvalidated (never claims a supported row). Admission is
+        // gated at runtime by the parity self-check, so default-on is safe.
+        env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
         let on = plan_for_model_with_platform(
             &path,
             &uncurated,
             Some(8),
             cuda_platform("windows", "x86_64", &["avx2"]),
         );
-        env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
-        clear_profile_env();
         assert_eq!(
             on.plan.selected_backend,
             "cuda_resident_q8_runtime_runnable_unvalidated"
@@ -1385,6 +1379,17 @@ mod tests {
             on.plan.support_level, "unknown_or_unvalidated",
             "the runnable tier must never claim a supported row"
         );
+        // Explicit opt-out (=0): forced back to the safe CPU reference path.
+        env::set_var("CAMELID_GPU_RUNNABLE_TIER", "0");
+        let off = plan_for_model_with_platform(
+            &path,
+            &uncurated,
+            Some(8),
+            cuda_platform("windows", "x86_64", &["avx2"]),
+        );
+        env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
+        clear_profile_env();
+        assert_eq!(off.plan.selected_backend, "cpu_reference");
     }
 
     #[test]
@@ -1393,15 +1398,17 @@ mod tests {
         clear_profile_env();
         let curated = fixture("Llama 3.2 1B Instruct");
         let path = PathBuf::from("/models/Llama-3.2-1B-Instruct-Q8_0.gguf");
+        // Tier ON (default, unset).
         env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
-        let off = plan_for_model_with_platform(
+        let on = plan_for_model_with_platform(
             &path,
             &curated,
             Some(8),
             cuda_platform("windows", "x86_64", &["avx2"]),
         );
-        env::set_var("CAMELID_GPU_RUNNABLE_TIER", "1");
-        let on = plan_for_model_with_platform(
+        // Tier opted out (=0).
+        env::set_var("CAMELID_GPU_RUNNABLE_TIER", "0");
+        let off = plan_for_model_with_platform(
             &path,
             &curated,
             Some(8),
@@ -1409,8 +1416,9 @@ mod tests {
         );
         env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
         clear_profile_env();
-        // A curated row takes the supported plan and is byte-for-byte identical whether
-        // the tier flag is on or off — the tier is a pure additive else-branch.
+        // A curated row takes the supported plan and is byte-for-byte identical whether the tier
+        // is on (default) or opted out — the tier is a pure additive else-branch after the
+        // curated arm, so it can never alter a supported row.
         assert_eq!(on.plan.selected_backend, "cuda_resident_q8_runtime");
         assert_eq!(on.plan.selected_backend, off.plan.selected_backend);
         assert_eq!(on.plan.support_level, off.plan.support_level);

--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -312,6 +312,17 @@ pub fn plan_for_model_with_platform(
                 );
             safe_q8_plan()
         }
+    } else if quant_type == "Q8_0"
+        && platform.cuda_resident_active
+        && is_gpu_runnable_arch(gguf)
+        && env_flag_enabled("CAMELID_GPU_RUNNABLE_TIER")
+    {
+        reasons.push(
+            "non-curated Q8_0 on a resident-capable dense arch: GPU-runnable tier (NOT a \
+             supported row) — resident path admitted subject to the runtime parity self-check"
+                .into(),
+        );
+        cuda_resident_q8_runnable_plan()
     } else if quant_type == "Q4_K_M" {
         select_kquant_plan(&platform, &mut reasons)
     } else {
@@ -766,6 +777,49 @@ fn cuda_resident_q8_plan() -> (
         "q8_0_cuda_resident_decode",
         "retained_q8_reference_path",
     )
+}
+
+/// Plan labels for the GPU-runnable tier: a Q8_0 model on a resident-capable dense
+/// architecture that is NOT a curated supported exact-row. Byte-for-byte the same GPU
+/// route as [`cuda_resident_q8_plan`], but every label carries a `_runnable_unvalidated`
+/// suffix so telemetry, receipts, and the UI can never mistake it for a supported row.
+/// The support_level stays `unknown_or_unvalidated`; admission to this tier is gated at
+/// runtime by a GPU-vs-CPU parity self-check (see `inference.rs`), which falls the model
+/// back to the CPU reference path if the resident output is not token-identical.
+fn cuda_resident_q8_runnable_plan() -> (
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+) {
+    (
+        "cuda_resident_q8_runtime_runnable_unvalidated",
+        "cuda_resident_q8_0_wire",
+        "q8_0_cuda_resident_prefill_runnable_unvalidated",
+        "resident_single_shot_prefill",
+        "q8_0_cuda_resident_decode_runnable_unvalidated",
+        "retained_q8_reference_path",
+    )
+}
+
+/// Architectures the CUDA resident engine implements token-identically to the CPU
+/// reference, and for which the GPU-runnable tier is eligible when a model is Q8_0 but
+/// not a curated support row. Deliberately narrow — dense llama/qwen/mistral only; MoE
+/// (expert routing) and not-yet-resident archs (gemma/phi/ssm/qwen35) are excluded so we
+/// never route a model the resident dense kernel cannot run under a GPU label. The
+/// runtime `resident_decode_eligible` check + the parity self-check are the backstops.
+fn is_gpu_runnable_arch(gguf: &GgufFile) -> bool {
+    let arch = gguf.architecture().unwrap_or("");
+    if !matches!(arch, "llama" | "qwen2" | "qwen3" | "mistral") {
+        return false;
+    }
+    // Exclude MoE: the resident dense kernel does not implement expert routing. A missing
+    // key means dense (the common case); a present non-zero expert_count means MoE.
+    gguf.metadata_u32(&format!("{arch}.expert_count"))
+        .map(|experts| experts == 0)
+        .unwrap_or(true)
 }
 
 /// Plan labels for a mixed K-quant (Q4_K_M = Q4_K + Q6_K) model. K-quant 2-D linears
@@ -1294,6 +1348,73 @@ mod tests {
             outcome.plan.selected_backend, "cpu_reference",
             "a recognizable 8B with a junk general.name must not fail closed to CPU"
         );
+    }
+
+    #[test]
+    fn gpu_runnable_tier_admits_uncurated_q8_llama_only_when_flag_on() {
+        let _guard = env_lock();
+        clear_profile_env();
+        env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
+        // Uncurated: neither general.name ("hub") nor the filename maps to a support row.
+        let uncurated = fixture("hub");
+        let path = PathBuf::from("/models/my-custom-llama-Q8_0.gguf");
+        // Flag OFF (default): fails closed to CPU, unchanged from prior behavior.
+        let off = plan_for_model_with_platform(
+            &path,
+            &uncurated,
+            Some(8),
+            cuda_platform("windows", "x86_64", &["avx2"]),
+        );
+        assert_eq!(off.plan.selected_backend, "cpu_reference");
+        // Flag ON: admitted to the GPU-runnable tier with an honest, distinct label; the
+        // support_level stays unknown_or_unvalidated (never claims a supported row).
+        env::set_var("CAMELID_GPU_RUNNABLE_TIER", "1");
+        let on = plan_for_model_with_platform(
+            &path,
+            &uncurated,
+            Some(8),
+            cuda_platform("windows", "x86_64", &["avx2"]),
+        );
+        env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
+        clear_profile_env();
+        assert_eq!(
+            on.plan.selected_backend,
+            "cuda_resident_q8_runtime_runnable_unvalidated"
+        );
+        assert_eq!(
+            on.plan.support_level, "unknown_or_unvalidated",
+            "the runnable tier must never claim a supported row"
+        );
+    }
+
+    #[test]
+    fn gpu_runnable_tier_never_changes_a_curated_row() {
+        let _guard = env_lock();
+        clear_profile_env();
+        let curated = fixture("Llama 3.2 1B Instruct");
+        let path = PathBuf::from("/models/Llama-3.2-1B-Instruct-Q8_0.gguf");
+        env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
+        let off = plan_for_model_with_platform(
+            &path,
+            &curated,
+            Some(8),
+            cuda_platform("windows", "x86_64", &["avx2"]),
+        );
+        env::set_var("CAMELID_GPU_RUNNABLE_TIER", "1");
+        let on = plan_for_model_with_platform(
+            &path,
+            &curated,
+            Some(8),
+            cuda_platform("windows", "x86_64", &["avx2"]),
+        );
+        env::remove_var("CAMELID_GPU_RUNNABLE_TIER");
+        clear_profile_env();
+        // A curated row takes the supported plan and is byte-for-byte identical whether
+        // the tier flag is on or off — the tier is a pure additive else-branch.
+        assert_eq!(on.plan.selected_backend, "cuda_resident_q8_runtime");
+        assert_eq!(on.plan.selected_backend, off.plan.selected_backend);
+        assert_eq!(on.plan.support_level, off.plan.support_level);
+        assert_eq!(on.plan.decode_path, off.plan.decode_path);
     }
 
     #[test]

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2111,6 +2111,16 @@ impl LlamaInferenceSession {
         if self.resident_paths_disabled {
             bail!("resident paths disabled for this session (CPU-authoritative KV required)");
         }
+        // GPU-runnable tier: an uncurated model is admitted to the resident path only after
+        // it passes the one-time parity self-check. A recorded FAIL forbids the resident
+        // path here — the single choke point — so no `set_resident_paths_disabled` site can
+        // accidentally re-admit it. Curated rows never record a verdict, so this is a no-op
+        // for them.
+        if let Some(key) = self.resident_cache_key {
+            if resident_parity_forbids(key) {
+                bail!("GPU-runnable-tier parity self-check failed for this model; CPU reference");
+            }
+        }
         if !resident_decode_metal_enabled() && !resident_decode_cuda_enabled() {
             bail!("neither CAMELID_METAL_RESIDENT_DECODE nor CAMELID_CUDA_RESIDENT_DECODE enabled");
         }
@@ -10649,6 +10659,189 @@ fn resident_cuda_drafter_cache() -> &'static std::sync::Mutex<Option<ResidentCud
     static CACHE: std::sync::OnceLock<std::sync::Mutex<Option<ResidentCudaSlot>>> =
         std::sync::OnceLock::new();
     CACHE.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+/// Per-model verdict of the GPU-runnable-tier parity self-check, keyed by the model-id
+/// hash (the same key the resident engine uses). `true` = the resident GPU path was
+/// token-identical to the CPU reference on the probe, so the model may use the GPU;
+/// `false` = it diverged, so the resident/GPU paths must be disabled for it. Populated
+/// once per model per process by [`ensure_resident_parity_verdict`].
+fn resident_parity_verdicts() -> &'static std::sync::Mutex<std::collections::HashMap<u64, bool>> {
+    static VERDICTS: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<u64, bool>>> =
+        std::sync::OnceLock::new();
+    VERDICTS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// True when the GPU-runnable-tier parity self-check recorded a FAILED verdict for this
+/// model id, so its resident/GPU paths must be disabled and it must run on the CPU
+/// reference. A missing verdict (curated rows never probe, or not yet probed) returns
+/// false — the caller's normal path decision stands.
+pub fn resident_parity_forbids(model_cache_key: u64) -> bool {
+    resident_parity_verdicts()
+        .lock()
+        .map(|verdicts| verdicts.get(&model_cache_key) == Some(&false))
+        .unwrap_or(false)
+}
+
+/// Record a FAILED parity verdict for a model id, forcing its resident/GPU paths off. This is
+/// the fail-closed backstop for when the parity probe cannot record its own verdict — e.g. the
+/// probe closure panicked (an uncurated model can hit an unwrap/index deep in the resident
+/// engine build) and was surfaced as a `spawn_blocking` `JoinError`, so the normal in-probe
+/// `insert` never ran. Without this, a missing verdict reads as "not forbidden" and the model
+/// would reach the GPU unvalidated. Idempotent; keyed per model so curated rows are unaffected.
+pub fn record_resident_parity_fail(model_cache_key: u64) {
+    if let Ok(mut verdicts) = resident_parity_verdicts().lock() {
+        verdicts.insert(model_cache_key, false);
+    }
+}
+
+/// Greedy-decode `n` tokens from `prompt` on a throwaway session built from `weights`,
+/// with the resident/GPU path enabled or disabled. Isolated by construction: a fresh
+/// session + KV cache, and a caller-supplied `probe_cache_key` distinct from the model's
+/// real engine key so the GPU leg never leaves KV state on the model's real slot. Drives
+/// the SAME `generate_next_token_with_history` primitive the real decode loop uses (which
+/// internally dispatches resident-GPU vs CPU on `resident_paths_disabled`), so the two
+/// legs differ only in that dispatch.
+fn run_greedy_probe(
+    config: &LlamaModelConfig,
+    weights: &Arc<LlamaLoadedWeights>,
+    probe_cache_key: u64,
+    prompt: &[u32],
+    n: usize,
+    resident_enabled: bool,
+) -> Result<Vec<u32>> {
+    let mut session = LlamaInferenceSession::new(config.clone(), Arc::clone(weights))?;
+    session.set_resident_cache_key(probe_cache_key);
+    session.set_resident_paths_disabled(!resident_enabled);
+    let mut history: Vec<u32> = prompt.to_vec();
+    let mut input: Vec<u32> = prompt.to_vec();
+    let mut tokens = Vec::with_capacity(n);
+    for _ in 0..n {
+        let step =
+            session.generate_next_token_with_history(&input, LlamaSampler::Greedy, &history)?;
+        tokens.push(step.next_token_id);
+        history.push(step.next_token_id);
+        input.clear();
+        input.push(step.next_token_id);
+    }
+    Ok(tokens)
+}
+
+/// Whether the resident CUDA engine actually engaged during the probe's GPU leg — i.e. the
+/// process-global single-slot cache now holds an engine under the probe's key. If the GPU leg
+/// silently fell back to the CPU path (e.g. the model does not fit in VRAM, or an eligibility
+/// gate declined), the slot is NOT keyed to the probe and a token match would be a meaningless
+/// CPU-vs-CPU "pass". The caller treats "did not engage" as a FAIL so it never certifies the
+/// GPU-runnable tier for a model the resident engine never actually ran. Read while holding the
+/// generation lock (the caller does) so no concurrent decode has evicted the slot.
+#[cfg(feature = "cuda")]
+fn resident_probe_engaged(probe_key: u64) -> bool {
+    resident_cuda_cache()
+        .lock()
+        .map(|guard| guard.as_ref().map(|slot| slot.key) == Some(probe_key as usize))
+        .unwrap_or(false)
+}
+
+#[cfg(not(feature = "cuda"))]
+fn resident_probe_engaged(_probe_key: u64) -> bool {
+    // No resident CUDA engine exists without the cuda feature, and the probe is never triggered
+    // in that build (the runnable-tier plan requires an active resident CUDA engine). Dead but
+    // must compile; `true` keeps a would-be CPU-only probe from being spuriously failed.
+    true
+}
+
+/// The GPU-runnable-tier parity self-check: decide ONCE per model (cached) whether an
+/// uncurated model may use the resident/GPU path. Greedy-decodes a fixed probe prompt on
+/// the CPU reference and on the resident GPU path and requires BIT-EXACT token identity
+/// (the resident Q8_0 kernels are `--fmad=false` CPU-mirrors, so any divergence is a real
+/// bug for that model's architecture). The GPU leg runs under a probe-specific engine key
+/// so the model's real slot is rebuilt clean by the first real request. Fails closed to
+/// CPU (returns false) on any error. Callers gate `resident_paths_disabled` on the result
+/// via [`resident_parity_forbids`]. Should be called only when the resident path is
+/// actually available (`resident_decode_cuda_active`), else the GPU leg is just the CPU
+/// path and the check is a trivial pass.
+pub fn ensure_resident_parity_verdict(
+    config: &LlamaModelConfig,
+    weights: &Arc<LlamaLoadedWeights>,
+    model_cache_key: u64,
+    model_label: &str,
+) -> bool {
+    if let Ok(verdicts) = resident_parity_verdicts().lock() {
+        if let Some(&verdict) = verdicts.get(&model_cache_key) {
+            return verdict;
+        }
+    }
+    // A short, tokenizer-independent probe spanning a spread of the vocabulary rather than a
+    // trivial [1,2,3,4] run (which can greedy-decode into a degenerate repeat that hides a real
+    // divergence), decoded far enough to catch KV-accumulation drift, not just the first logit.
+    // Content is irrelevant — only GPU-vs-CPU token agreement matters. Every id is < 32k, valid
+    // for every arch this tier admits (llama/qwen2/qwen3/mistral, vocab >= 32k); a hypothetical
+    // smaller vocab would make the embedding lookup error, which fails closed below.
+    const PROBE_PROMPT: [u32; 8] = [1, 2, 13, 128, 512, 2048, 8192, 29871];
+    const PROBE_TOKENS: usize = 16;
+    // Distinct key so the probe's GPU engine build never occupies the model's real slot.
+    let probe_key = model_cache_key ^ 0x9E37_79B9_7F4A_7C15;
+    let verdict = match (
+        run_greedy_probe(
+            config,
+            weights,
+            probe_key,
+            &PROBE_PROMPT,
+            PROBE_TOKENS,
+            false,
+        ),
+        run_greedy_probe(
+            config,
+            weights,
+            probe_key,
+            &PROBE_PROMPT,
+            PROBE_TOKENS,
+            true,
+        ),
+    ) {
+        (Ok(cpu), Ok(gpu)) => {
+            // The GPU leg must have actually run on the resident engine; otherwise the token
+            // match is a meaningless CPU-vs-CPU pass and certifying the tier would be dishonest.
+            let engaged = resident_probe_engaged(probe_key);
+            let artifact = crate::cuda_parity::ParityArtifact::evaluate(
+                model_label.to_string(),
+                "gpu_runnable_parity_probe",
+                crate::cuda_parity::ToleranceGate::bit_exact(),
+                cpu,
+                gpu,
+            );
+            let passed = artifact.passed();
+            if !engaged {
+                eprintln!(
+                    "[gpu-runnable] parity self-check for {model_label}: the resident GPU path \
+                     never engaged during the probe (silent CPU fallback — e.g. the model does \
+                     not fit in VRAM); NOT certifying the GPU-runnable tier, this model runs on \
+                     the CPU reference path."
+                );
+            } else if !passed {
+                eprintln!(
+                    "[gpu-runnable] parity self-check FAILED for {model_label}: resident GPU \
+                     output diverged from the CPU reference (first divergence at token {:?}); \
+                     this model will run on the CPU reference path.",
+                    artifact.comparison.first_divergence
+                );
+            }
+            engaged && passed
+        }
+        (cpu, gpu) => {
+            eprintln!(
+                "[gpu-runnable] parity self-check could not run for {model_label} (cpu_ok={}, \
+                 gpu_ok={}); failing closed to the CPU reference path.",
+                cpu.is_ok(),
+                gpu.is_ok()
+            );
+            false
+        }
+    };
+    if let Ok(mut verdicts) = resident_parity_verdicts().lock() {
+        verdicts.insert(model_cache_key, verdict);
+    }
+    verdict
 }
 
 /// Speculative coexistence reserve, in bytes. When > 0, a draft model is in play and the

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -10,6 +10,40 @@ fn assert_close(actual: f32, expected: f32) {
 }
 
 #[test]
+fn resident_parity_forbids_reflects_the_cached_verdict() {
+    // A key unlikely to collide with other parallel tests sharing the process-global map.
+    let key = 0x5A5A_A5A5_1234_5678_u64;
+    assert!(!resident_parity_forbids(key), "no verdict -> not forbidden");
+    resident_parity_verdicts().lock().unwrap().insert(key, true);
+    assert!(
+        !resident_parity_forbids(key),
+        "PASS verdict -> not forbidden"
+    );
+    resident_parity_verdicts()
+        .lock()
+        .unwrap()
+        .insert(key, false);
+    assert!(resident_parity_forbids(key), "FAIL verdict -> forbidden");
+    // The fail-closed backstop (used when the probe panics) records a FAIL for a fresh key.
+    let panic_key = 0x1357_9BDF_2468_ACE0_u64;
+    assert!(
+        !resident_parity_forbids(panic_key),
+        "unprobed -> not forbidden"
+    );
+    record_resident_parity_fail(panic_key);
+    assert!(
+        resident_parity_forbids(panic_key),
+        "recorded FAIL -> forbidden"
+    );
+    // Do not leak state to other tests.
+    resident_parity_verdicts().lock().unwrap().remove(&key);
+    resident_parity_verdicts()
+        .lock()
+        .unwrap()
+        .remove(&panic_key);
+}
+
+#[test]
 #[allow(clippy::needless_range_loop)]
 fn test_row_dispatch_adversarial_parity() {
     let _env_guard = env_lock();


### PR DESCRIPTION
## What

Adds a **GPU-runnable tier**: an uncurated `Q8_0` dense model (`llama` / `qwen2` / `qwen3` / `mistral`, non-MoE) runs on the CUDA-resident path **by default** — but only after a one-time **parity self-check** proves the resident GPU decode is *bit-exact* to the CPU reference. If it isn't, the model falls back to the CPU reference path.

Goal: make it easy for users to run architecturally-compatible models we haven't hand-curated, without weakening the evidence-bound support discipline. The tier carries a distinct `_runnable_unvalidated` label (never a supported row); a model only reaches the GPU if it earns it at runtime. Opt out with `CAMELID_GPU_RUNNABLE_TIER=0` (forces the CPU path).

## How

- **Routing** (`execution_plan.rs`): a strict additive `else-if` (after the curated arm) routes uncurated Q8_0 dense archs to `cuda_resident_q8_runnable_plan()` when CUDA resident is active and the tier isn't opted out. Curated rows take the supported arm first and are byte-for-byte unchanged.
- **Parity self-check** (`inference.rs`, `api/mod.rs`): on the first request, `ensure_resident_parity_verdict` greedy-decodes a probe on both the CPU reference and the resident GPU path and requires bit-exact token identity. The verdict is cached per model; the single resident-eligibility choke point (`resident_decode_eligible`) consults it, so a FAIL runs the model on CPU. Every GPU/resident entry point routes through that choke point.

## Hardening (from adversarial review)

- **Fail closed on panic** — a probe-closure panic (`JoinError`) is recorded as a FAIL verdict, never a silent GPU admission.
- **Serialized under `generation_lock`** — the probe drives the process-global single-slot resident engine, so it's serialized with all decodes; it can't evict a live decode's engine mid-sequence.
- **Honest certification** — certify only if the resident engine actually engaged during the probe (not a silent CPU fallback).
- **Stronger probe** — a vocab-spanning prompt + more decode steps to surface KV-accumulation drift.

## Verification

- `cargo check` clean on default and `--features cuda`; `clippy --all-targets --all-features -D warnings` and `cargo fmt` clean.
- Unit tests: verdict logic + fail-closed backstop; tier routing (default-on, `=0` opt-out, curated byte-identity).
- Two independent adversarial reviews + a 3-lens re-review of the fixes: all fixes verified correct, no fail-open hole, no regression to curated/default paths.
- End-to-end probe validation on the signed v0.2.6 build to follow.

Also bumps version to **v0.2.6**.