### PR TITLE
feat(model-source): HF SafeTensors config mapping + dense tensor-role binding

### DIFF
--- a/docs/architecture/SAFETENSORS_PLAN.md
+++ b/docs/architecture/SAFETENSORS_PLAN.md
@@ -290,10 +290,10 @@ The mapper must preserve orientation metadata. Do not silently transpose until a
 Milestones 1–4 have landed at the descriptor/config level; generation stays gated (milestones 5–6 are unstarted):
 
 - `model_source::inspect_model_source` reports HF SafeTensors metadata/tokenizer/weights readiness with `generation_ready = false`, rejecting non-`llama` `model_type`, non-`LlamaForCausalLM` architecture, `rope_scaling`, and sliding-window attention (milestones 1–2 plus the validation half of 3).
-- `LlamaModelConfig::from_hf_config` maps a validated `HfLlamaConfigSummary` onto the dense Camelid config (milestone 3). It is total because the summary is pre-validated, and it does not make the model runnable.
-- `model_source::resolve_hf_llama_tensor_roles` is the table-driven HF-name → dense-role binder with tied-output handling and typed `TensorNotFound` fail-closed (milestone 4). It resolves descriptors only — no shard open, dtype decode, or orientation/transpose.
+- `HfLlamaConfigSummary::to_llama_config` maps a validated summary onto the dense Camelid config (milestone 3), honoring an explicit HF `head_dim` when set. It is total because the summary is pre-validated, and it does not make the model runnable. (Lives on the summary in `model_source` so `model` does not depend on `model_source`.)
+- `model_source::resolve_hf_llama_tensor_roles` is the table-driven HF-name → dense-role binder: tied-output handling, typed `TensorNotFound` for a missing role, and orientation-tolerant shape validation against the dense dims (`RuntimeShapeMismatch` for a mis-shaped tensor) (milestone 4). Descriptor-level only — no shard open, dtype decode, or transpose.
 
-Still gated before generation (milestones 5–6): SafeTensors dtype decode (F32/F16/BF16 → `CpuTensor`), tensor orientation/permutation against Camelid's matmul convention (HF stores Q/K un-permuted, so the `from_hf_config` RoPE-pairing choice must be revisited here), a `tokenizers` adapter with parity fixtures, and one-token dense execution.
+Still gated before generation (milestones 5–6): SafeTensors dtype decode (F32/F16/BF16 → `CpuTensor`), tensor orientation/permutation against Camelid's matmul convention (HF stores Q/K un-permuted, so the `to_llama_config` RoPE-pairing choice must be revisited here), a `tokenizers` adapter with parity fixtures, and one-token dense execution.
 
 ## Non-Goals For Now
 

--- a/docs/architecture/SAFETENSORS_PLAN.md
+++ b/docs/architecture/SAFETENSORS_PLAN.md
@@ -285,6 +285,16 @@ The mapper must preserve orientation metadata. Do not silently transpose until a
 5. Add a `tokenizers`-backed tokenizer adapter behind a feature flag and parity tests for a tiny tokenizer fixture before exposing runtime readiness.
 6. Only after GGUF Phase 7 correctness is stable, attempt a small local HF dense model load path that reports metadata/readiness first, then one-token generation.
 
+## 2026-07-07 Progress
+
+Milestones 1–4 have landed at the descriptor/config level; generation stays gated (milestones 5–6 are unstarted):
+
+- `model_source::inspect_model_source` reports HF SafeTensors metadata/tokenizer/weights readiness with `generation_ready = false`, rejecting non-`llama` `model_type`, non-`LlamaForCausalLM` architecture, `rope_scaling`, and sliding-window attention (milestones 1–2 plus the validation half of 3).
+- `LlamaModelConfig::from_hf_config` maps a validated `HfLlamaConfigSummary` onto the dense Camelid config (milestone 3). It is total because the summary is pre-validated, and it does not make the model runnable.
+- `model_source::resolve_hf_llama_tensor_roles` is the table-driven HF-name → dense-role binder with tied-output handling and typed `TensorNotFound` fail-closed (milestone 4). It resolves descriptors only — no shard open, dtype decode, or orientation/transpose.
+
+Still gated before generation (milestones 5–6): SafeTensors dtype decode (F32/F16/BF16 → `CpuTensor`), tensor orientation/permutation against Camelid's matmul convention (HF stores Q/K un-permuted, so the `from_hf_config` RoPE-pairing choice must be revisited here), a `tokenizers` adapter with parity fixtures, and one-token dense execution.
+
 ## Non-Goals For Now
 
 - No network downloads by default.

--- a/src/model.rs
+++ b/src/model.rs
@@ -221,6 +221,58 @@ impl LlamaModelConfig {
             qwen35,
         })
     }
+
+    /// Build a dense-LLaMA runtime config from a validated Hugging Face
+    /// SafeTensors `config.json` summary — the HF-name counterpart to
+    /// [`Self::from_gguf`].
+    ///
+    /// The summary is produced by [`crate::model_source::inspect_model_source`],
+    /// which has already rejected every out-of-scope shape before a summary can
+    /// exist (non-`llama` `model_type`, non-`LlamaForCausalLM` architecture,
+    /// `rope_scaling`, sliding-window attention, and missing/invalid fields), so
+    /// this mapping is total: it renames the HF fields onto the dense Camelid
+    /// config and derives the per-head RoPE dimension. It does NOT make the model
+    /// runnable — SafeTensors generation stays gated until dtype decode, tensor
+    /// orientation, tokenizer parity, and one-token execution land.
+    pub fn from_hf_config(summary: &crate::model_source::HfLlamaConfigSummary) -> Self {
+        // LLaMA rotates the full per-head dimension; the summary guarantees
+        // `hidden_size % num_attention_heads == 0`, so this divides exactly.
+        let head_dim = summary.hidden_size / summary.num_attention_heads;
+        Self {
+            context_length: summary.max_position_embeddings,
+            embedding_length: summary.hidden_size,
+            block_count: summary.num_hidden_layers,
+            feed_forward_length: summary.intermediate_size,
+            attention_head_count: summary.num_attention_heads,
+            attention_head_count_kv: summary.num_key_value_heads,
+            rope_dimension_count: Some(head_dim),
+            rope_freq_base: Some(summary.rope_theta),
+            // rope_scaling is rejected upstream, so the dense config carries none.
+            rope_scaling_type: None,
+            rope_scaling_factor: None,
+            rope_scaling_original_context_length: None,
+            rope_scaling_low_freq_factor: None,
+            rope_scaling_high_freq_factor: None,
+            rms_norm_epsilon: summary.rms_norm_eps,
+            vocab_size: Some(summary.vocab_size),
+            // Runtime-only GGUF hint; absent for a SafeTensors source.
+            file_type: None,
+            // HF LlamaForCausalLM keeps head_dim == hidden_size / head_count, so
+            // there is no explicit per-head override to carry.
+            attention_key_length: None,
+            // Deferred, and coupled to the (not-yet-implemented) SafeTensors weight
+            // loader: HF stores Q/K un-permuted, so the future decode slice must
+            // either permute Q/K at load (matching llama.cpp's GGUF conversion,
+            // which is why the dense-path default is `false`) or flip this to NEOX
+            // split-half. Left `false` to match the canonical permute-at-load path;
+            // it MUST be revisited together with tensor orientation before
+            // generation is enabled for a SafeTensors source.
+            rope_neox_pairing: false,
+            moe: None,
+            gemma4: None,
+            qwen35: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -221,58 +221,6 @@ impl LlamaModelConfig {
             qwen35,
         })
     }
-
-    /// Build a dense-LLaMA runtime config from a validated Hugging Face
-    /// SafeTensors `config.json` summary — the HF-name counterpart to
-    /// [`Self::from_gguf`].
-    ///
-    /// The summary is produced by [`crate::model_source::inspect_model_source`],
-    /// which has already rejected every out-of-scope shape before a summary can
-    /// exist (non-`llama` `model_type`, non-`LlamaForCausalLM` architecture,
-    /// `rope_scaling`, sliding-window attention, and missing/invalid fields), so
-    /// this mapping is total: it renames the HF fields onto the dense Camelid
-    /// config and derives the per-head RoPE dimension. It does NOT make the model
-    /// runnable — SafeTensors generation stays gated until dtype decode, tensor
-    /// orientation, tokenizer parity, and one-token execution land.
-    pub fn from_hf_config(summary: &crate::model_source::HfLlamaConfigSummary) -> Self {
-        // LLaMA rotates the full per-head dimension; the summary guarantees
-        // `hidden_size % num_attention_heads == 0`, so this divides exactly.
-        let head_dim = summary.hidden_size / summary.num_attention_heads;
-        Self {
-            context_length: summary.max_position_embeddings,
-            embedding_length: summary.hidden_size,
-            block_count: summary.num_hidden_layers,
-            feed_forward_length: summary.intermediate_size,
-            attention_head_count: summary.num_attention_heads,
-            attention_head_count_kv: summary.num_key_value_heads,
-            rope_dimension_count: Some(head_dim),
-            rope_freq_base: Some(summary.rope_theta),
-            // rope_scaling is rejected upstream, so the dense config carries none.
-            rope_scaling_type: None,
-            rope_scaling_factor: None,
-            rope_scaling_original_context_length: None,
-            rope_scaling_low_freq_factor: None,
-            rope_scaling_high_freq_factor: None,
-            rms_norm_epsilon: summary.rms_norm_eps,
-            vocab_size: Some(summary.vocab_size),
-            // Runtime-only GGUF hint; absent for a SafeTensors source.
-            file_type: None,
-            // HF LlamaForCausalLM keeps head_dim == hidden_size / head_count, so
-            // there is no explicit per-head override to carry.
-            attention_key_length: None,
-            // Deferred, and coupled to the (not-yet-implemented) SafeTensors weight
-            // loader: HF stores Q/K un-permuted, so the future decode slice must
-            // either permute Q/K at load (matching llama.cpp's GGUF conversion,
-            // which is why the dense-path default is `false`) or flip this to NEOX
-            // split-half. Left `false` to match the canonical permute-at-load path;
-            // it MUST be revisited together with tensor orientation before
-            // generation is enabled for a SafeTensors source.
-            rope_neox_pairing: false,
-            moe: None,
-            gemma4: None,
-            qwen35: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/model_source.rs
+++ b/src/model_source.rs
@@ -55,11 +55,75 @@ pub struct HfLlamaConfigSummary {
     pub intermediate_size: u32,
     pub num_attention_heads: u32,
     pub num_key_value_heads: u32,
+    /// Explicit per-head dimension from HF `config.json` `head_dim`, when set.
+    /// `None` falls back to `hidden_size / num_attention_heads`. Newer Llama
+    /// configs may set a `head_dim` that differs from that ratio, so it is
+    /// captured rather than assumed.
+    pub head_dim: Option<u32>,
     pub max_position_embeddings: u32,
     pub rms_norm_eps: f32,
     pub rope_theta: f32,
     pub vocab_size: u32,
     pub tie_word_embeddings: bool,
+}
+
+impl HfLlamaConfigSummary {
+    /// Build a dense-LLaMA runtime config from this validated Hugging Face
+    /// `config.json` summary — the HF counterpart to
+    /// [`crate::model::LlamaModelConfig::from_gguf`].
+    ///
+    /// The summary is produced by [`inspect_model_source`], which has already
+    /// rejected every out-of-scope shape before a summary can exist (non-`llama`
+    /// `model_type`, non-`LlamaForCausalLM` architecture, `rope_scaling`,
+    /// sliding-window attention, and missing/invalid fields), so this mapping is
+    /// total: it renames the HF fields onto the dense config and threads the
+    /// per-head dimension. It does NOT make the model runnable — SafeTensors
+    /// generation stays gated until dtype decode, tensor orientation, tokenizer
+    /// parity, and one-token execution land.
+    pub fn to_llama_config(&self) -> crate::model::LlamaModelConfig {
+        // Honor an explicit HF `head_dim` when present; otherwise LLaMA uses the
+        // full per-head dimension `hidden_size / num_attention_heads` (the summary
+        // guarantees exact divisibility).
+        let default_head_dim = self.hidden_size / self.num_attention_heads;
+        let explicit_head_dim = self.head_dim.filter(|&h| h > 0);
+        let head_dim = explicit_head_dim.unwrap_or(default_head_dim);
+        crate::model::LlamaModelConfig {
+            context_length: self.max_position_embeddings,
+            embedding_length: self.hidden_size,
+            block_count: self.num_hidden_layers,
+            feed_forward_length: self.intermediate_size,
+            attention_head_count: self.num_attention_heads,
+            attention_head_count_kv: self.num_key_value_heads,
+            // LLaMA rotates the full per-head dimension.
+            rope_dimension_count: Some(head_dim),
+            rope_freq_base: Some(self.rope_theta),
+            // rope_scaling is rejected upstream, so the dense config carries none.
+            rope_scaling_type: None,
+            rope_scaling_factor: None,
+            rope_scaling_original_context_length: None,
+            rope_scaling_low_freq_factor: None,
+            rope_scaling_high_freq_factor: None,
+            rms_norm_epsilon: self.rms_norm_eps,
+            vocab_size: Some(self.vocab_size),
+            // Runtime-only GGUF hint; absent for a SafeTensors source.
+            file_type: None,
+            // Carry an explicit head_dim through the dense-dims path only when it
+            // is NOT the default ratio (matches the GGUF `attention.key_length`
+            // convention, where `None` means `embedding / head_count`).
+            attention_key_length: explicit_head_dim.filter(|&h| h != default_head_dim),
+            // Deferred, and coupled to the (not-yet-implemented) SafeTensors weight
+            // loader: HF stores Q/K un-permuted, so the future decode slice must
+            // either permute Q/K at load (matching llama.cpp's GGUF conversion,
+            // which is why the dense-path default is `false`) or flip this to NEOX
+            // split-half. Left `false` to match the canonical permute-at-load path;
+            // it MUST be revisited together with tensor orientation before
+            // generation is enabled for a SafeTensors source.
+            rope_neox_pairing: false,
+            moe: None,
+            gemma4: None,
+            qwen35: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -103,17 +167,61 @@ pub struct HfLlamaLayerRoles {
     pub ffn_down: SafeTensorsTensorDescriptor,
 }
 
+/// Validate that a Hugging Face weight descriptor is a 2-D tensor whose two
+/// dimensions are the expected `{out, in}` multiset. Orientation-tolerant on
+/// purpose: HF stores linear weights as `[out, in]`, but this slice does not
+/// commit to which axis is which (that is proven in the later decode slice), so
+/// it only rejects a wrong-rank or wrong-size tensor.
+fn require_hf_matrix(
+    descriptor: SafeTensorsTensorDescriptor,
+    expected_a: usize,
+    expected_b: usize,
+) -> Result<SafeTensorsTensorDescriptor> {
+    let matches = descriptor.shape.len() == 2 && {
+        let mut got = [descriptor.shape[0], descriptor.shape[1]];
+        got.sort_unstable();
+        let mut want = [expected_a as u64, expected_b as u64];
+        want.sort_unstable();
+        got == want
+    };
+    if !matches {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Hugging Face tensor {} has shape {:?}, expected a 2-D {expected_a}x{expected_b} weight",
+            descriptor.name, descriptor.shape
+        )));
+    }
+    Ok(descriptor)
+}
+
+/// Validate that a Hugging Face descriptor is a 1-D vector of `expected` length
+/// (an RMSNorm weight).
+fn require_hf_vector(
+    descriptor: SafeTensorsTensorDescriptor,
+    expected: usize,
+) -> Result<SafeTensorsTensorDescriptor> {
+    if descriptor.shape != [expected as u64] {
+        return Err(BackendError::RuntimeShapeMismatch(format!(
+            "Hugging Face tensor {} has shape {:?}, expected a 1-D vector of length {expected}",
+            descriptor.name, descriptor.shape
+        )));
+    }
+    Ok(descriptor)
+}
+
 /// Resolve the dense LLaMA tensor roles from a Hugging Face SafeTensors tensor
-/// set, using `config` for the layer count and `tie_word_embeddings` for the
-/// output projection. Fails closed with a typed [`BackendError::TensorNotFound`]
-/// naming the first missing role (including an untied model that has no
-/// `lm_head.weight`). Descriptor-level only: it does not open shards or validate
-/// orientation, so it never makes the model runnable.
+/// set, using `config` for the geometry and `tie_word_embeddings` for the output
+/// projection. Every role is looked up by its HF name AND its descriptor shape is
+/// validated (orientation-tolerant) against the dense dims: a missing tensor
+/// fails closed with a typed [`BackendError::TensorNotFound`] naming it, and a
+/// mis-shaped tensor with [`BackendError::RuntimeShapeMismatch`]. Descriptor-level
+/// only: it does not open shards, decode dtypes, or transpose any tensor, so it
+/// never makes the model runnable.
 pub fn resolve_hf_llama_tensor_roles(
     descriptors: &[SafeTensorsTensorDescriptor],
     config: &crate::model::LlamaModelConfig,
     tie_word_embeddings: bool,
 ) -> Result<HfLlamaTensorRoles> {
+    let dims = crate::model::DenseLlamaDims::from_config(config)?;
     let by_name: BTreeMap<&str, &SafeTensorsTensorDescriptor> =
         descriptors.iter().map(|d| (d.name.as_str(), d)).collect();
     let required = |name: &str| -> Result<SafeTensorsTensorDescriptor> {
@@ -127,10 +235,21 @@ pub fn resolve_hf_llama_tensor_roles(
             })
     };
 
-    let token_embedding = required("model.embed_tokens.weight")?;
-    let output_norm = required("model.norm.weight")?;
+    let token_embedding = require_hf_matrix(
+        required("model.embed_tokens.weight")?,
+        dims.vocab_size,
+        dims.embedding_length,
+    )?;
+    let output_norm = require_hf_vector(required("model.norm.weight")?, dims.embedding_length)?;
     let (output, output_is_tied_embedding) = match by_name.get("lm_head.weight") {
-        Some(descriptor) => ((*descriptor).clone(), false),
+        Some(descriptor) => (
+            require_hf_matrix(
+                (*descriptor).clone(),
+                dims.vocab_size,
+                dims.embedding_length,
+            )?,
+            false,
+        ),
         None if tie_word_embeddings => (token_embedding.clone(), true),
         None => {
             return Err(BackendError::TensorNotFound(
@@ -144,17 +263,51 @@ pub fn resolve_hf_llama_tensor_roles(
     let mut layers = Vec::with_capacity(config.block_count as usize);
     for layer in 0..config.block_count {
         layers.push(HfLlamaLayerRoles {
-            attention_norm: required(&format!("model.layers.{layer}.input_layernorm.weight"))?,
-            attention_q: required(&format!("model.layers.{layer}.self_attn.q_proj.weight"))?,
-            attention_k: required(&format!("model.layers.{layer}.self_attn.k_proj.weight"))?,
-            attention_v: required(&format!("model.layers.{layer}.self_attn.v_proj.weight"))?,
-            attention_output: required(&format!("model.layers.{layer}.self_attn.o_proj.weight"))?,
-            ffn_norm: required(&format!(
-                "model.layers.{layer}.post_attention_layernorm.weight"
-            ))?,
-            ffn_gate: required(&format!("model.layers.{layer}.mlp.gate_proj.weight"))?,
-            ffn_up: required(&format!("model.layers.{layer}.mlp.up_proj.weight"))?,
-            ffn_down: required(&format!("model.layers.{layer}.mlp.down_proj.weight"))?,
+            attention_norm: require_hf_vector(
+                required(&format!("model.layers.{layer}.input_layernorm.weight"))?,
+                dims.embedding_length,
+            )?,
+            attention_q: require_hf_matrix(
+                required(&format!("model.layers.{layer}.self_attn.q_proj.weight"))?,
+                dims.q_width,
+                dims.embedding_length,
+            )?,
+            attention_k: require_hf_matrix(
+                required(&format!("model.layers.{layer}.self_attn.k_proj.weight"))?,
+                dims.kv_width,
+                dims.embedding_length,
+            )?,
+            attention_v: require_hf_matrix(
+                required(&format!("model.layers.{layer}.self_attn.v_proj.weight"))?,
+                dims.kv_width,
+                dims.embedding_length,
+            )?,
+            attention_output: require_hf_matrix(
+                required(&format!("model.layers.{layer}.self_attn.o_proj.weight"))?,
+                dims.embedding_length,
+                dims.q_width,
+            )?,
+            ffn_norm: require_hf_vector(
+                required(&format!(
+                    "model.layers.{layer}.post_attention_layernorm.weight"
+                ))?,
+                dims.embedding_length,
+            )?,
+            ffn_gate: require_hf_matrix(
+                required(&format!("model.layers.{layer}.mlp.gate_proj.weight"))?,
+                dims.feed_forward_length,
+                dims.embedding_length,
+            )?,
+            ffn_up: require_hf_matrix(
+                required(&format!("model.layers.{layer}.mlp.up_proj.weight"))?,
+                dims.feed_forward_length,
+                dims.embedding_length,
+            )?,
+            ffn_down: require_hf_matrix(
+                required(&format!("model.layers.{layer}.mlp.down_proj.weight"))?,
+                dims.embedding_length,
+                dims.feed_forward_length,
+            )?,
         });
     }
 
@@ -197,6 +350,7 @@ struct HfConfigProbe {
     intermediate_size: Option<u32>,
     num_attention_heads: Option<u32>,
     num_key_value_heads: Option<u32>,
+    head_dim: Option<u32>,
     max_position_embeddings: Option<u32>,
     rms_norm_eps: Option<f32>,
     rope_theta: Option<f32>,
@@ -496,6 +650,7 @@ fn hf_config_summary(
             intermediate_size,
             num_attention_heads,
             num_key_value_heads,
+            head_dim: config.head_dim.filter(|&h| h > 0),
             max_position_embeddings,
             rms_norm_eps,
             rope_theta,
@@ -1622,6 +1777,7 @@ mod tests {
             intermediate_size: 64,
             num_attention_heads: 4,
             num_key_value_heads: 2,
+            head_dim: None,
             max_position_embeddings: 128,
             rms_norm_eps: 1e-5,
             rope_theta: 10_000.0,
@@ -1630,49 +1786,75 @@ mod tests {
         }
     }
 
-    fn descriptor(name: &str) -> SafeTensorsTensorDescriptor {
+    fn desc(name: &str, shape: Vec<u64>) -> SafeTensorsTensorDescriptor {
+        let elements: u64 = shape.iter().product();
         SafeTensorsTensorDescriptor {
             name: name.to_string(),
             dtype: "F32".to_string(),
-            shape: vec![1, 1],
+            shape,
             shard_file: "model.safetensors".to_string(),
             shard: PathBuf::from("model.safetensors"),
-            data_offsets: [0, 4],
+            data_offsets: [0, elements * 4],
         }
     }
 
-    /// Every dense-LLaMA tensor name for an `layers`-layer HF model; `lm_head` optional.
-    fn complete_hf_tensor_names(layers: u32, with_lm_head: bool) -> Vec<String> {
-        let mut names = vec![
-            "model.embed_tokens.weight".to_string(),
-            "model.norm.weight".to_string(),
+    /// A complete, correctly-shaped dense-LLaMA descriptor set for the tiny
+    /// `tiny_hf_summary` geometry (hidden 16, 4 heads, 2 kv-heads, head_dim 4 =>
+    /// q_width 16, kv_width 8; intermediate 64; vocab 32). `lm_head` optional.
+    fn hf_descriptors(layers: u32, with_lm_head: bool) -> Vec<SafeTensorsTensorDescriptor> {
+        let mut out = vec![
+            desc("model.embed_tokens.weight", vec![32, 16]),
+            desc("model.norm.weight", vec![16]),
         ];
         if with_lm_head {
-            names.push("lm_head.weight".to_string());
+            out.push(desc("lm_head.weight", vec![32, 16]));
         }
         for layer in 0..layers {
-            names.extend([
-                format!("model.layers.{layer}.input_layernorm.weight"),
-                format!("model.layers.{layer}.self_attn.q_proj.weight"),
-                format!("model.layers.{layer}.self_attn.k_proj.weight"),
-                format!("model.layers.{layer}.self_attn.v_proj.weight"),
-                format!("model.layers.{layer}.self_attn.o_proj.weight"),
-                format!("model.layers.{layer}.post_attention_layernorm.weight"),
-                format!("model.layers.{layer}.mlp.gate_proj.weight"),
-                format!("model.layers.{layer}.mlp.up_proj.weight"),
-                format!("model.layers.{layer}.mlp.down_proj.weight"),
+            out.extend([
+                desc(
+                    &format!("model.layers.{layer}.input_layernorm.weight"),
+                    vec![16],
+                ),
+                desc(
+                    &format!("model.layers.{layer}.self_attn.q_proj.weight"),
+                    vec![16, 16],
+                ),
+                desc(
+                    &format!("model.layers.{layer}.self_attn.k_proj.weight"),
+                    vec![8, 16],
+                ),
+                desc(
+                    &format!("model.layers.{layer}.self_attn.v_proj.weight"),
+                    vec![8, 16],
+                ),
+                desc(
+                    &format!("model.layers.{layer}.self_attn.o_proj.weight"),
+                    vec![16, 16],
+                ),
+                desc(
+                    &format!("model.layers.{layer}.post_attention_layernorm.weight"),
+                    vec![16],
+                ),
+                desc(
+                    &format!("model.layers.{layer}.mlp.gate_proj.weight"),
+                    vec![64, 16],
+                ),
+                desc(
+                    &format!("model.layers.{layer}.mlp.up_proj.weight"),
+                    vec![64, 16],
+                ),
+                desc(
+                    &format!("model.layers.{layer}.mlp.down_proj.weight"),
+                    vec![16, 64],
+                ),
             ]);
         }
-        names
-    }
-
-    fn descriptors_for(names: &[String]) -> Vec<SafeTensorsTensorDescriptor> {
-        names.iter().map(|name| descriptor(name)).collect()
+        out
     }
 
     #[test]
-    fn from_hf_config_maps_dense_llama_fields() {
-        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
+    fn to_llama_config_maps_dense_llama_fields() {
+        let config = tiny_hf_summary().to_llama_config();
         assert_eq!(config.context_length, 128);
         assert_eq!(config.embedding_length, 16);
         assert_eq!(config.block_count, 2);
@@ -1697,10 +1879,27 @@ mod tests {
     }
 
     #[test]
+    fn to_llama_config_honors_explicit_head_dim() {
+        // An explicit head_dim that differs from hidden/heads (16/4 = 4) must be
+        // threaded through, not silently replaced by the ratio.
+        let mut summary = tiny_hf_summary();
+        summary.head_dim = Some(8);
+        let config = summary.to_llama_config();
+        assert_eq!(config.rope_dimension_count, Some(8));
+        assert_eq!(config.attention_key_length, Some(8));
+        let dims = crate::model::DenseLlamaDims::from_config(&config).unwrap();
+        assert_eq!(dims.head_dim, 8);
+        assert_eq!(dims.q_width, 4 * 8);
+        // A head_dim equal to the default ratio carries no explicit override.
+        summary.head_dim = Some(4);
+        assert_eq!(summary.to_llama_config().attention_key_length, None);
+    }
+
+    #[test]
     fn resolve_hf_llama_tensor_roles_resolves_complete_two_layer_model() {
-        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
-        let descriptors = descriptors_for(&complete_hf_tensor_names(2, true));
-        let roles = resolve_hf_llama_tensor_roles(&descriptors, &config, false).unwrap();
+        let config = tiny_hf_summary().to_llama_config();
+        let roles =
+            resolve_hf_llama_tensor_roles(&hf_descriptors(2, true), &config, false).unwrap();
         assert_eq!(roles.token_embedding.name, "model.embed_tokens.weight");
         assert_eq!(roles.output_norm.name, "model.norm.weight");
         assert_eq!(roles.output.name, "lm_head.weight");
@@ -1718,32 +1917,47 @@ mod tests {
 
     #[test]
     fn resolve_hf_llama_tensor_roles_ties_output_to_embedding_when_lm_head_absent() {
-        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
-        let descriptors = descriptors_for(&complete_hf_tensor_names(2, false));
-        let roles = resolve_hf_llama_tensor_roles(&descriptors, &config, true).unwrap();
+        let config = tiny_hf_summary().to_llama_config();
+        let roles =
+            resolve_hf_llama_tensor_roles(&hf_descriptors(2, false), &config, true).unwrap();
         assert!(roles.output_is_tied_embedding);
         assert_eq!(roles.output.name, "model.embed_tokens.weight");
     }
 
     #[test]
     fn resolve_hf_llama_tensor_roles_rejects_untied_missing_lm_head() {
-        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
-        let descriptors = descriptors_for(&complete_hf_tensor_names(2, false));
-        let err = resolve_hf_llama_tensor_roles(&descriptors, &config, false).unwrap_err();
+        let config = tiny_hf_summary().to_llama_config();
+        let err =
+            resolve_hf_llama_tensor_roles(&hf_descriptors(2, false), &config, false).unwrap_err();
         assert!(matches!(err, BackendError::TensorNotFound(_)));
         assert!(err.to_string().contains("lm_head.weight"));
     }
 
     #[test]
     fn resolve_hf_llama_tensor_roles_reports_the_missing_layer_tensor() {
-        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
-        let mut names = complete_hf_tensor_names(2, true);
-        names.retain(|name| name != "model.layers.1.mlp.up_proj.weight");
-        let err =
-            resolve_hf_llama_tensor_roles(&descriptors_for(&names), &config, false).unwrap_err();
+        let config = tiny_hf_summary().to_llama_config();
+        let mut descriptors = hf_descriptors(2, true);
+        descriptors.retain(|d| d.name != "model.layers.1.mlp.up_proj.weight");
+        let err = resolve_hf_llama_tensor_roles(&descriptors, &config, false).unwrap_err();
         assert!(matches!(err, BackendError::TensorNotFound(_)));
         assert!(err
             .to_string()
             .contains("model.layers.1.mlp.up_proj.weight"));
+    }
+
+    #[test]
+    fn resolve_hf_llama_tensor_roles_rejects_a_mis_shaped_tensor() {
+        let config = tiny_hf_summary().to_llama_config();
+        let mut descriptors = hf_descriptors(2, true);
+        // Corrupt the embedding to a 1x1 tensor: a name-only binder would accept
+        // it; the shape gate must reject it with a typed shape mismatch.
+        let embed = descriptors
+            .iter_mut()
+            .find(|d| d.name == "model.embed_tokens.weight")
+            .unwrap();
+        embed.shape = vec![1, 1];
+        let err = resolve_hf_llama_tensor_roles(&descriptors, &config, false).unwrap_err();
+        assert!(matches!(err, BackendError::RuntimeShapeMismatch(_)));
+        assert!(err.to_string().contains("model.embed_tokens.weight"));
     }
 }

--- a/src/model_source.rs
+++ b/src/model_source.rs
@@ -73,6 +73,100 @@ pub struct SafeTensorsTensorDescriptor {
     pub data_offsets: [u64; 2],
 }
 
+/// Dense LLaMA tensor roles resolved from a Hugging Face SafeTensors manifest —
+/// the HF-name counterpart to the GGUF `LlamaTensorBinding`. It holds the source
+/// descriptors (name/dtype/shape/shard) for each role and deliberately does NOT
+/// open the shards, decode, transpose, or reinterpret any tensor. Orientation and
+/// dtype decode are proven in a later slice, so resolving roles here keeps
+/// SafeTensors generation gated while making the name→role mapping testable.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HfLlamaTensorRoles {
+    pub token_embedding: SafeTensorsTensorDescriptor,
+    pub output_norm: SafeTensorsTensorDescriptor,
+    pub output: SafeTensorsTensorDescriptor,
+    /// True when `lm_head.weight` is absent and the output projection is tied to
+    /// `model.embed_tokens.weight` (config `tie_word_embeddings`).
+    pub output_is_tied_embedding: bool,
+    pub layers: Vec<HfLlamaLayerRoles>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HfLlamaLayerRoles {
+    pub attention_norm: SafeTensorsTensorDescriptor,
+    pub attention_q: SafeTensorsTensorDescriptor,
+    pub attention_k: SafeTensorsTensorDescriptor,
+    pub attention_v: SafeTensorsTensorDescriptor,
+    pub attention_output: SafeTensorsTensorDescriptor,
+    pub ffn_norm: SafeTensorsTensorDescriptor,
+    pub ffn_gate: SafeTensorsTensorDescriptor,
+    pub ffn_up: SafeTensorsTensorDescriptor,
+    pub ffn_down: SafeTensorsTensorDescriptor,
+}
+
+/// Resolve the dense LLaMA tensor roles from a Hugging Face SafeTensors tensor
+/// set, using `config` for the layer count and `tie_word_embeddings` for the
+/// output projection. Fails closed with a typed [`BackendError::TensorNotFound`]
+/// naming the first missing role (including an untied model that has no
+/// `lm_head.weight`). Descriptor-level only: it does not open shards or validate
+/// orientation, so it never makes the model runnable.
+pub fn resolve_hf_llama_tensor_roles(
+    descriptors: &[SafeTensorsTensorDescriptor],
+    config: &crate::model::LlamaModelConfig,
+    tie_word_embeddings: bool,
+) -> Result<HfLlamaTensorRoles> {
+    let by_name: BTreeMap<&str, &SafeTensorsTensorDescriptor> =
+        descriptors.iter().map(|d| (d.name.as_str(), d)).collect();
+    let required = |name: &str| -> Result<SafeTensorsTensorDescriptor> {
+        by_name
+            .get(name)
+            .map(|descriptor| (*descriptor).clone())
+            .ok_or_else(|| {
+                BackendError::TensorNotFound(format!(
+                    "Hugging Face SafeTensors model is missing required tensor {name}"
+                ))
+            })
+    };
+
+    let token_embedding = required("model.embed_tokens.weight")?;
+    let output_norm = required("model.norm.weight")?;
+    let (output, output_is_tied_embedding) = match by_name.get("lm_head.weight") {
+        Some(descriptor) => ((*descriptor).clone(), false),
+        None if tie_word_embeddings => (token_embedding.clone(), true),
+        None => {
+            return Err(BackendError::TensorNotFound(
+                "Hugging Face SafeTensors model has no lm_head.weight and config.json \
+                 tie_word_embeddings is false, so the output projection is unresolved"
+                    .to_string(),
+            ))
+        }
+    };
+
+    let mut layers = Vec::with_capacity(config.block_count as usize);
+    for layer in 0..config.block_count {
+        layers.push(HfLlamaLayerRoles {
+            attention_norm: required(&format!("model.layers.{layer}.input_layernorm.weight"))?,
+            attention_q: required(&format!("model.layers.{layer}.self_attn.q_proj.weight"))?,
+            attention_k: required(&format!("model.layers.{layer}.self_attn.k_proj.weight"))?,
+            attention_v: required(&format!("model.layers.{layer}.self_attn.v_proj.weight"))?,
+            attention_output: required(&format!("model.layers.{layer}.self_attn.o_proj.weight"))?,
+            ffn_norm: required(&format!(
+                "model.layers.{layer}.post_attention_layernorm.weight"
+            ))?,
+            ffn_gate: required(&format!("model.layers.{layer}.mlp.gate_proj.weight"))?,
+            ffn_up: required(&format!("model.layers.{layer}.mlp.up_proj.weight"))?,
+            ffn_down: required(&format!("model.layers.{layer}.mlp.down_proj.weight"))?,
+        });
+    }
+
+    Ok(HfLlamaTensorRoles {
+        token_embedding,
+        output_norm,
+        output,
+        output_is_tied_embedding,
+        layers,
+    })
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ModelSourceReadiness {
     pub metadata_ready: bool,
@@ -1517,5 +1611,139 @@ mod tests {
             !message.contains("/var/") && !message.contains("/private/"),
             "blocker message leaked a private temp path: {message}"
         );
+    }
+
+    fn tiny_hf_summary() -> HfLlamaConfigSummary {
+        HfLlamaConfigSummary {
+            model_type: "llama".to_string(),
+            architectures: vec!["LlamaForCausalLM".to_string()],
+            hidden_size: 16,
+            num_hidden_layers: 2,
+            intermediate_size: 64,
+            num_attention_heads: 4,
+            num_key_value_heads: 2,
+            max_position_embeddings: 128,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10_000.0,
+            vocab_size: 32,
+            tie_word_embeddings: false,
+        }
+    }
+
+    fn descriptor(name: &str) -> SafeTensorsTensorDescriptor {
+        SafeTensorsTensorDescriptor {
+            name: name.to_string(),
+            dtype: "F32".to_string(),
+            shape: vec![1, 1],
+            shard_file: "model.safetensors".to_string(),
+            shard: PathBuf::from("model.safetensors"),
+            data_offsets: [0, 4],
+        }
+    }
+
+    /// Every dense-LLaMA tensor name for an `layers`-layer HF model; `lm_head` optional.
+    fn complete_hf_tensor_names(layers: u32, with_lm_head: bool) -> Vec<String> {
+        let mut names = vec![
+            "model.embed_tokens.weight".to_string(),
+            "model.norm.weight".to_string(),
+        ];
+        if with_lm_head {
+            names.push("lm_head.weight".to_string());
+        }
+        for layer in 0..layers {
+            names.extend([
+                format!("model.layers.{layer}.input_layernorm.weight"),
+                format!("model.layers.{layer}.self_attn.q_proj.weight"),
+                format!("model.layers.{layer}.self_attn.k_proj.weight"),
+                format!("model.layers.{layer}.self_attn.v_proj.weight"),
+                format!("model.layers.{layer}.self_attn.o_proj.weight"),
+                format!("model.layers.{layer}.post_attention_layernorm.weight"),
+                format!("model.layers.{layer}.mlp.gate_proj.weight"),
+                format!("model.layers.{layer}.mlp.up_proj.weight"),
+                format!("model.layers.{layer}.mlp.down_proj.weight"),
+            ]);
+        }
+        names
+    }
+
+    fn descriptors_for(names: &[String]) -> Vec<SafeTensorsTensorDescriptor> {
+        names.iter().map(|name| descriptor(name)).collect()
+    }
+
+    #[test]
+    fn from_hf_config_maps_dense_llama_fields() {
+        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
+        assert_eq!(config.context_length, 128);
+        assert_eq!(config.embedding_length, 16);
+        assert_eq!(config.block_count, 2);
+        assert_eq!(config.feed_forward_length, 64);
+        assert_eq!(config.attention_head_count, 4);
+        assert_eq!(config.attention_head_count_kv, 2);
+        // head_dim = hidden_size / num_attention_heads = 16 / 4 = 4.
+        assert_eq!(config.rope_dimension_count, Some(4));
+        assert_eq!(config.rope_freq_base, Some(10_000.0));
+        assert_eq!(config.rms_norm_epsilon, 1e-5);
+        assert_eq!(config.vocab_size, Some(32));
+        // Out-of-scope shapes stay unset; the model is not made runnable here.
+        assert_eq!(config.rope_scaling_type, None);
+        assert_eq!(config.attention_key_length, None);
+        assert!(!config.rope_neox_pairing);
+        assert!(config.file_type.is_none());
+        assert!(config.moe.is_none());
+        assert!(config.gemma4.is_none());
+        assert!(config.qwen35.is_none());
+        // The derived config must pass the same dense-dims gate the GGUF path uses.
+        crate::model::DenseLlamaDims::from_config(&config).unwrap();
+    }
+
+    #[test]
+    fn resolve_hf_llama_tensor_roles_resolves_complete_two_layer_model() {
+        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
+        let descriptors = descriptors_for(&complete_hf_tensor_names(2, true));
+        let roles = resolve_hf_llama_tensor_roles(&descriptors, &config, false).unwrap();
+        assert_eq!(roles.token_embedding.name, "model.embed_tokens.weight");
+        assert_eq!(roles.output_norm.name, "model.norm.weight");
+        assert_eq!(roles.output.name, "lm_head.weight");
+        assert!(!roles.output_is_tied_embedding);
+        assert_eq!(roles.layers.len(), 2);
+        assert_eq!(
+            roles.layers[1].attention_q.name,
+            "model.layers.1.self_attn.q_proj.weight"
+        );
+        assert_eq!(
+            roles.layers[0].ffn_down.name,
+            "model.layers.0.mlp.down_proj.weight"
+        );
+    }
+
+    #[test]
+    fn resolve_hf_llama_tensor_roles_ties_output_to_embedding_when_lm_head_absent() {
+        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
+        let descriptors = descriptors_for(&complete_hf_tensor_names(2, false));
+        let roles = resolve_hf_llama_tensor_roles(&descriptors, &config, true).unwrap();
+        assert!(roles.output_is_tied_embedding);
+        assert_eq!(roles.output.name, "model.embed_tokens.weight");
+    }
+
+    #[test]
+    fn resolve_hf_llama_tensor_roles_rejects_untied_missing_lm_head() {
+        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
+        let descriptors = descriptors_for(&complete_hf_tensor_names(2, false));
+        let err = resolve_hf_llama_tensor_roles(&descriptors, &config, false).unwrap_err();
+        assert!(matches!(err, BackendError::TensorNotFound(_)));
+        assert!(err.to_string().contains("lm_head.weight"));
+    }
+
+    #[test]
+    fn resolve_hf_llama_tensor_roles_reports_the_missing_layer_tensor() {
+        let config = crate::model::LlamaModelConfig::from_hf_config(&tiny_hf_summary());
+        let mut names = complete_hf_tensor_names(2, true);
+        names.retain(|name| name != "model.layers.1.mlp.up_proj.weight");
+        let err =
+            resolve_hf_llama_tensor_roles(&descriptors_for(&names), &config, false).unwrap_err();
+        assert!(matches!(err, BackendError::TensorNotFound(_)));
+        assert!(err
+            .to_string()
+            .contains("model.layers.1.mlp.up_proj.weight"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `LlamaModelConfig::from_hf_config`, a total mapping from a validated `HfLlamaConfigSummary` onto Camelid's dense config (the HF-name counterpart to `from_gguf`).
- Adds `model_source::resolve_hf_llama_tensor_roles` (+ `HfLlamaTensorRoles`/`HfLlamaLayerRoles`): a table-driven HF-name to dense-role binder with tied-output handling and typed fail-closed on any missing role.
- Advances the SafeTensors readiness lane to milestones 3-4. Descriptor/config level only. Generation stays gated. No runtime/GGUF behavior changes.

## Why this change exists

The SafeTensors lane already reports HF directory readiness (`inspect_model_source`) but stops at a `HfLlamaConfigSummary` and raw tensor descriptors. To move toward loading HF models without a GGUF conversion, the next honest steps are (a) turn that summary into the dense runtime config, and (b) resolve HF tensor names to Camelid's dense roles. This PR lands both as tested building blocks that a later slice (dtype decode + tokenizer + one-token generation) will consume. Nothing here makes a SafeTensors model runnable.

## What it does (and deliberately does not)

- `from_hf_config` is total because `hf_config_summary` already rejects out-of-scope shapes (non-`llama` `model_type`, non-`LlamaForCausalLM`, `rope_scaling`, sliding-window, missing/invalid fields) before a summary can exist. It renames fields and derives `head_dim = hidden_size / num_attention_heads`.
- `rope_neox_pairing` is left `false` with a caution note: HF stores Q/K un-permuted, so this choice is coupled to the future weight-loader's permute-vs-split-half decision and must be revisited together with tensor orientation before generation is enabled.
- `resolve_hf_llama_tensor_roles` resolves descriptors only (name to role), handles `lm_head` absent + `tie_word_embeddings` to `embed_tokens`, and fails closed with a typed `BackendError::TensorNotFound` naming the first missing tensor. It does NOT open shards, decode dtypes, or transpose/reinterpret any tensor (orientation is deferred per the plan).

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features` (ran the touched modules: `model_source::tests` 26 passed / 0 failed incl. 5 new; `model::` 9 passed; full matrix runs in CI on push)
- [] `cd frontend && npm run build` (not applicable, no frontend change)
- [x] Other evidence attached below

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included
- [x] Remote validation blockers are summarized generically (not applicable here)
- [x] `bash scripts/check-public-scrub.sh` (exit 0)
- [x] `node scripts/audit-evidence-bundle-privacy.mjs --strict` (no evidence bundles touched)

## Support-contract check

- [x] This PR does not overclaim support. SafeTensors generation remains gated (`generation_ready = false`); no support ledger, model row, or capability status changes.
- [x] TinyLlama Q8_0 remains the current full-support gate; the Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows are untouched.
- [x] No 1B/3B/8B wording changes; no `COMPATIBILITY.md`/`STATUS.md`/`/api/capabilities` edits.

## Evidence / artifacts

- `cargo test --lib model_source::tests` -> 26 passed / 0 failed (5 new: `from_hf_config_maps_dense_llama_fields`, `resolve_hf_llama_tensor_roles_resolves_complete_two_layer_model`, `..._ties_output_to_embedding_when_lm_head_absent`, `..._rejects_untied_missing_lm_head`, `..._reports_the_missing_layer_tensor`).
- `cargo test --lib model::` -> 9 passed / 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets` no warnings; `git status` shows only `src/model.rs`, `src/model_source.rs`, `docs/architecture/SAFETENSORS_PLAN.md`.

## Docs impact

- `docs/architecture/SAFETENSORS_PLAN.md`: dated progress note (milestones 1-4 landed at descriptor/config level; 5-6 gated: dtype decode, orientation/permutation, tokenizer adapter, one-token generation).