### PR TITLE
feat: hardware-aware model fit advisor (capacity axis)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -86,6 +86,7 @@ Two rules keep this matrix honest across docs, API signals, and UI copy:
 
 - **Support rule:** nothing adjacent inherits support across model size, quantization, tokenizer lane, API surface, or frontend state.
 - **Credit rule:** visible llama.cpp / ggml acknowledgement and the MIT notice remain part of parity-backed release claims.
+- **Capacity rule:** the model-fit advisor is a *capacity* signal (can this host load/run a row), reported separately from support. A "fits" verdict never implies parity, validation, or support; it does not appear in `model_compatibility` and cannot promote any row. See [`docs/architecture/MODEL_FIT_ADVISOR_PLAN.md`](docs/architecture/MODEL_FIT_ADVISOR_PLAN.md).
 
 README, `STATUS.md`, `/api/capabilities`, and frontend readiness copy should continue to mirror this exact ledger. `/api/capabilities` exposes the same compatibility rows as `model_compatibility`; read each row literally. Metadata parsing does not imply tokenizer parity, tokenizer parity does not imply generation, tensor loading does not imply safe execution, and one supported row must never lend support to adjacent model sizes or quantizations.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -272,6 +272,14 @@ Portability and packaging should remain explicit:
 - no implied portable model-path assumptions without documentation
 - no release packaging claim before reproducible setup instructions exist
 
+### Model fit advisor (capacity axis)
+
+A **capacity** signal, deliberately separate from the support ledger: it estimates whether the *local machine* can load/run a catalog row, and never implies parity or support. See [`docs/architecture/MODEL_FIT_ADVISOR_PLAN.md`](docs/architecture/MODEL_FIT_ADVISOR_PLAN.md).
+
+- The verdict (`fits_resident` / `fits_with_offload` / `cpu_only_ok` / `wont_fit` / `unknown`) is derived from the detected `HardwareProfile` and the row's on-disk weight footprint; it is advisory, never a support claim, and degrades to `unknown` (never a failure) on hosts whose memory cannot be probed.
+- It informs but never enforces: catalog download stays un-gated, and the pre-load fail-fast (`model_too_large_for_host`) fires only on a `wont_fit` verdict from a probed host and is overridable with `CAMELID_SKIP_FIT_CHECK=1`.
+- The authoritative capacity guards remain the runtime VRAM headroom check (mid-load) and the KV predict-and-abort budget (mid-generation); the advisor never relaxes them.
+
 ## Promotion rules
 
 A row may move forward only when all of the following are true:

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -301,11 +301,12 @@ and fixes them:
   duplicate requests before they spawn, and a `tokio::Semaphore`
   (`MAX_CONCURRENT_FETCHES = 4`) caps live curls. The old code could spawn a
   fetch per GET per row; the fan-out is now structurally impossible.
-- **GET is side-effect-free.** `get_catalog` no longer warms curated rows on read.
-  Curated dims are warmed exactly once at server startup (`start_background`);
-  HF-search rows still schedule at most `HF_DIMS_WARM_LIMIT = 5` bounded,
-  de-duplicated fetches. `schedule()` is sync and non-blocking (spawns; never
-  awaits a permit on the request path).
+- **Reads are side-effect-free for curated rows.** `get_catalog` no longer warms
+  curated rows on read — their dims are warmed exactly once at server startup
+  (`start_background`). The HF-search branch is *not* side-effect-free: it schedules
+  at most `HF_DIMS_WARM_LIMIT = 5` bounded, de-duplicated background fetches.
+  `schedule()` is sync and non-blocking (spawns; never awaits a permit on the
+  request path).
 - **Bounded, versioned, TTL cache.** `DiskCache { version, entries }`
   (`CACHE_SCHEMA_VERSION = 1`) — a version bump or parse error loads as empty
   (self-healing). `ENTRY_TTL_SECS = 30 days` expiry, LRU eviction at
@@ -331,6 +332,50 @@ within ~1.5 s from disk with zero re-fetch**; disk cache persisted as
 - Gates: `cargo test --lib` → **707 passed, 0 failed**;
   `cargo clippy --all-targets --all-features -- -D warnings` clean;
   `cargo fmt --all -- --check` clean; `vite build` clean.
+
+### Slice 8 — review-round hardening + honest invariants — ✅ DONE
+
+Fixes from a second review pass, each verified against the fork (not the stale
+tree):
+
+- **Header-fetch robustness (`fit_dims.rs`).** Unique per-`(repo, filename)` temp
+  name (was filename-only → concurrent same-name fetches from different repos
+  raced one temp file); no `set_len` disk-allocation trick (parse the header
+  prefix against the declared full length via `gguf::read_metadata_with_len` —
+  `set_len` is *not* sparse on NTFS and would allocate the model's full size);
+  `curl --connect-timeout/--max-time` so a hung transfer can't hold a permit
+  forever; an RAII `InFlightGuard` clears the in-flight slot even if the fetch
+  task panics or early-returns.
+- **Guard off the async worker.** `fit_preload_guard` (blocking `metadata` + GGUF
+  read + `HardwareProfile::detect`, which inits a CUDA context on GPU hosts) now
+  runs under `spawn_blocking`, consistent with the header fetches; a panic in the
+  probe is non-fatal (falls through to the load).
+- **Honest RAM-budget docs (`fit.rs`).** The advisor's `max(80% available, 25% of
+  total)` mirrors the *values* of the KV-cache budget constants but is an
+  independent reimplementation over `HardwareProfile`. Documented the two real,
+  intentional divergences from the KV runtime guard: (1) different RAM source —
+  advisor probes Windows+Linux (unknown on macOS), the KV guard probes
+  Windows+macOS (unprobed on Linux), so the two enforce on *opposite* non-Windows
+  platforms; (2) on unprobed RAM the KV guard fails open (unbounded) while the
+  advisor abstains (`Unknown`).
+- **Cached badge vs live guard (documented).** The catalog badge uses the cached
+  startup hardware snapshot; the load guard re-probes live. After a model loads
+  and consumes VRAM a badge may still read "fits" while the guard returns 422. The
+  badge is a static capacity *hint*, not a reservation; the guard is
+  authoritative. Re-probing per GET would re-init CUDA on every catalog request.
+
+**Compatibility note (`POST /api/models/load`).** The advisor adds a fail-fast
+path: a request that previously always attempted the load can now return
+`422 model_too_large_for_host` on a `WontFit` verdict from a *probed* host. This
+is a behavior change on a stable endpoint. It is overridable — `CAMELID_SKIP_FIT_CHECK=1`
+restores the unconditional load-attempt behavior (covered by
+`skip_fit_check_override_matches_only_the_exact_flag`). It never fires on an
+unprobed host (`Unknown` is never `WontFit`), and the authoritative
+`VramShortfall`/`KvCache` guards remain the hard net after the load begins.
+
+- Gates: `cargo test --lib` → **710 passed, 0 failed**;
+  `cargo clippy --all-targets --all-features -- -D warnings` clean;
+  `cargo fmt --all -- --check` clean.
 
 ## 9. UX placement decision (locked)
 

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -223,6 +223,34 @@ total)`), so the advisor and the runtime guard agree.
 - No evidence bundle minted (no screenshot gate requested); the UI line is covered
   by `vite build` and the API/CLI by the Rust suite.
 
+### Slice 5 — Exact KV footprint at the load guard — ✅ DONE
+
+Replaces the flat 25% pad with the **real** KV formula *where it gates* (the load
+guard), following the "only exact data may block" principle.
+
+- `src/fit.rs`: `ModelDims { layers, kv_heads, head_dim }`, `KvDtype {F16,F32}`,
+  `kv_bytes(dims, ctx, dtype)` = `layers × kv_heads × head_dim × 2 × dtype_bytes ×
+  ctx` — the exact mirror of `kv_cache.rs::kv_bytes_per_token`. `exact_footprint`
+  = weights + KV(ctx) + a bounded `ACTIVATION_SCRATCH_BYTES` (512 MiB). Default
+  assessment context `ADVISORY_CONTEXT_TOKENS = 4096` (KV scales linearly, so the
+  trained max is *not* used — the runtime KV guard governs longer chats).
+- **Tested against the engine's own vectors:** `kv_bytes` returns exactly 45,056
+  (TinyLlama) / 229,376 (Llama 3.2 3B) B/token — the same figures `kv_cache.rs`
+  asserts — so it is correct by construction. Plus context-linearity and
+  f16 = ½·f32 tests.
+- Load guard (`fit_preload_guard`): now probes **live** memory
+  (`HardwareProfile::detect()`, not the cached snapshot) and computes an **exact**
+  footprint via `read_model_dims` (header-only `gguf::read_metadata` →
+  `LlamaModelConfig::from_gguf` → `DenseLlamaDims::from_config`), picking f16 KV on
+  a GPU host / f32 on CPU. Falls back to the coarse pad when the header can't be
+  parsed (non-GGUF / unknown arch). The catalog **badge stays on the pad** (it's
+  advisory, un-gated) — pre-download exact dims (build-time table / header
+  range-fetch) are the Phase-2/3 follow-ups.
+- Gates: `cargo test --lib` → **694 passed, 0 failed**; fmt + clippy(lib) clean.
+  Live-verified end-to-end: `POST /api/models/load` on a 40 GB file →
+  `422 model_too_large_for_host` with the actionable "largest that fits" message;
+  catalog chips unchanged (no regression).
+
 ## 9. UX placement decision (locked)
 
 The verdict is most valuable **at model-selection time**, embedded in the

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -251,6 +251,40 @@ guard), following the "only exact data may block" principle.
   `422 model_too_large_for_host` with the actionable "largest that fits" message;
   catalog chips unchanged (no regression).
 
+### Slice 6 — Exact pre-download badge via GGUF header range-fetch (Phase 2 + 3) — ✅ DONE
+
+Makes the catalog badge **exact** (not just the coarse pad) by reading each
+model's real dimensions from its GGUF **header only**, over the network, without
+downloading the weights.
+
+- **The trick** (`remote_model_dims`): GGUF stores all metadata + tensor-info at
+  the file start. Range-fetch a `HEADER_BYTES = 12 MiB` head (covers 128k-vocab
+  Llama metadata), write it to a temp file whose *length* is `set_len` to the real
+  size (sparse zero tail — `read_metadata` only validates tensor offsets against
+  the length, never reads the tail), then reuse the **trusted parser unchanged**.
+  A too-small/failed fetch → `None` → the caller keeps the pad. Live-verified:
+  Qwen3-0.6B → 28/8/128, Llama-3.2-1B → 16/8/64.
+- **Cache + confidence:** a process-wide `RemoteDimsCache` (keyed `repo/filename`,
+  stores `None` on failure to avoid re-hammering). `CatalogItemView` gains
+  `fit_confidence` (`"exact"` | `"approx"`). `curated_footprint` uses exact dims
+  when cached, else the pad. WebUI shows a `~` marker + tooltip on `approx`.
+- **Phase 2 (curated):** `get_catalog` background-warms all 15 curated rows
+  (`spawn_blocking`, never blocks the response). Rows start `approx` and upgrade to
+  `exact` as headers land. Live-verified: exact count climbed 0 → 3 → 12 across
+  renders; Llama 3.2 1B rendered exact "Fits your machine".
+- **Phase 3 (arbitrary Hugging Face rows):** `from_hf` gives an honest **exact**
+  fit once a header is cached (capacity is orthogonal to verification), else
+  `Unknown` — never a filename guess. The warm here is **bounded** to the top
+  `HF_DIMS_WARM_LIMIT = 5` rows (a query can return 100+ files; the first naive
+  version fanned out 119 fetches — fixed). Live-verified: HF rows upgraded to
+  `exact` with only ~11 concurrent fetches, not 119.
+- **Data cost / control:** header fetches are `12 MiB` each, cached for the process
+  lifetime, opt-out via `CAMELID_NO_REMOTE_DIMS=1`. Follow-ups: a disk cache (so
+  restarts don't re-fetch) and truly on-demand HF fetch (per row the user opens).
+- Gates: `cargo test --lib` → **698 passed, 0 failed**; fmt + clippy(lib) clean;
+  `vite build` clean; network path live-verified (gated test
+  `CAMELID_TEST_REMOTE_DIMS=1`).
+
 ## 9. UX placement decision (locked)
 
 The verdict is most valuable **at model-selection time**, embedded in the

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -285,6 +285,53 @@ downloading the weights.
   `vite build` clean; network path live-verified (gated test
   `CAMELID_TEST_REMOTE_DIMS=1`).
 
+### Slice 7 — `DimsResolver`: consolidate + harden the dims layer — ✅ DONE
+
+Slice 6 shipped the capability but the caching/fetch plumbing was scattered
+across `api/mod.rs` as a set of free functions (`store_remote_dims`,
+`cached_remote_dims`, `remote_dims_cache`, ...) with three real defects. Slice 7
+extracts one owner — `src/fit_dims.rs` (`DimsResolver`, a `OnceLock` singleton) —
+and fixes them:
+
+- **No write amplification.** The old path rewrote the *entire* JSON cache on
+  every successful fetch (O(n²) over a warm cycle). The resolver marks entries
+  dirty and a single debounced writer (`flush_loop`, 2 s coalescing window,
+  `spawn_blocking`) persists once per burst.
+- **In-flight de-duplication + bounded concurrency.** An `in_flight` set drops
+  duplicate requests before they spawn, and a `tokio::Semaphore`
+  (`MAX_CONCURRENT_FETCHES = 4`) caps live curls. The old code could spawn a
+  fetch per GET per row; the fan-out is now structurally impossible.
+- **GET is side-effect-free.** `get_catalog` no longer warms curated rows on read.
+  Curated dims are warmed exactly once at server startup (`start_background`);
+  HF-search rows still schedule at most `HF_DIMS_WARM_LIMIT = 5` bounded,
+  de-duplicated fetches. `schedule()` is sync and non-blocking (spawns; never
+  awaits a permit on the request path).
+- **Bounded, versioned, TTL cache.** `DiskCache { version, entries }`
+  (`CACHE_SCHEMA_VERSION = 1`) — a version bump or parse error loads as empty
+  (self-healing). `ENTRY_TTL_SECS = 30 days` expiry, LRU eviction at
+  `MAX_ENTRIES = 512`. The pre-versioned flat-map cache is read as empty and
+  rewritten in the new shape on first flush.
+- **Honest negatives.** An unparseable header (e.g. a non-dense architecture) is
+  cached as `dims: None` with a `FETCH_BACKOFF_SECS = 30 min` backoff, so failing
+  rows are attempted once and then left alone instead of re-fetched every run.
+- **Honest confidence on HF rows.** `from_hf` now reports `fit_confidence:
+  "unknown"` (was `"approx"`) when it has no dims, matching `fit: unknown`; the
+  WebUI renders an explicit dashed `~` estimate chip only for the genuine
+  `approx` (curated-pad) state.
+- **CI covers the parser.** A hermetic fixture test builds a minimal in-memory
+  GGUF header and asserts `dims_from_gguf_file` extracts `{layers, kv_heads,
+  head_dim}` — the network path is no longer the only coverage.
+
+Live-verified on an RTX 4060 host: fresh start warmed **11 exact / 4 approx** (the
+4 approx are all Gemma-4 E2B/E4B/12B/26B-A4B rows — non-dense-Llama metadata,
+correctly cached as negatives, not network failures); a restart served **11 exact
+within ~1.5 s from disk with zero re-fetch**; disk cache persisted as
+`{version:1, entries:{…}}` with 11 positive + 4 negative entries.
+
+- Gates: `cargo test --lib` → **707 passed, 0 failed**;
+  `cargo clippy --all-targets --all-features -- -D warnings` clean;
+  `cargo fmt --all -- --check` clean; `vite build` clean.
+
 ## 9. UX placement decision (locked)
 
 The verdict is most valuable **at model-selection time**, embedded in the

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -212,11 +212,16 @@ total)`), so the advisor and the runtime guard agree.
   `catalog_fit_tests`. Gates: `cargo fmt` ✅ · `cargo clippy --lib` ✅ ·
   `cargo test --lib` → **688 passed, 0 failed** ✅ · frontend `vite build` ✅.
 
-### Slice 4 — Docs/ledger alignment
-- Cross-link this plan from `ROADMAP.md`; note in `COMPATIBILITY.md` that the fit
-  axis is capacity-only and does not widen support.
-- Optional evidence bundle under `qa/` if a UI badge screenshot gate is wanted
-  (matches the existing `frontend-3b-catalog-*-badge` bundle pattern).
+### Slice 4 — Docs/ledger alignment — ✅ DONE
+- `ROADMAP.md`: added a **Model fit advisor (capacity axis)** lane under *Active
+  roadmap lanes*, cross-linking this plan and stating the capacity ≠ support
+  discipline (advisory verdict, un-gated download, overridable fail-fast, runtime
+  guards stay authoritative).
+- `COMPATIBILITY.md`: added a **Capacity rule** to *Governing rules* — the fit
+  advisor is capacity-only, never implies parity/validation/support, does not
+  appear in `model_compatibility`, and cannot promote any row.
+- No evidence bundle minted (no screenshot gate requested); the UI line is covered
+  by `vite build` and the API/CLI by the Rust suite.
 
 ## 9. UX placement decision (locked)
 

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -161,15 +161,34 @@ total)`), so the advisor and the runtime guard agree.
   `cargo test --lib fit::` → **13 passed** ✅. (Full `--all-features` clippy/test
   is the pre-merge gate; the CUDA build is long and run separately.)
 
-### Slice 2 — Catalog metadata + API field
-- Add `params` + `task_tags` to `CatalogItem` and the ~16 curated rows
-  (`curated_catalog()`), sourced from each model card (cited in code comments).
-- Add `fit: FitVerdict` (+ optional `task_tags`) to `CatalogItemView`; populate
-  in `from_curated` using `HardwareProfile::detect()` (cached at startup like the
-  existing hardware log). `from_hf` → `fit: Unknown`.
-- API tests mirroring the existing `capabilities_*` tests: assert curated rows
-  carry a verdict and experimental rows stay `Unknown`; assert an unknown-RAM
-  host never yields `WontFit`.
+### Slice 2 — Catalog metadata + API field — ✅ DONE
+- Added `task_tags: &'static [&'static str]` to `CatalogItem` and all **15**
+  curated rows (`curated_catalog()`), constrained to `general` / `reasoning` /
+  `coding` / `tools`. Advisory positioning, **not** benchmarked (documented as
+  such on the field).
+- **`params` dropped (honest deviation):** authoritative parameter counts are not
+  available pre-download without loading the GGUF, and `size_bytes` is already the
+  exact weight footprint the fit math needs — so a hand-entered `params` would add
+  hallucinated precision for no gain. Deferred; revisit only if a UI needs a
+  human "size" label beyond `size_bytes`.
+- Added `fit: FitVerdict` + `task_tags: Vec<String>` to `CatalogItemView`.
+  `from_curated(item, hw)` computes `fit` via `fit::assess(hw,
+  fit::advisory_footprint(size_bytes))`; `from_hf` → `fit: Unknown`, empty tags.
+- **KV term (finalizes open Q1):** `fit::advisory_footprint` pads weight bytes by
+  a flat, conservative `ADVISORY_OVERHEAD_PERCENT = 25` to stand in for KV +
+  activations at a modest context (over-estimating keeps a "fits" badge safe). A
+  per-architecture bound is a documented future refinement; a flat pad avoids
+  inventing per-model dims we cannot know pre-download.
+- Hardware is probed once via a new `HardwareProfile::cached()` (`OnceLock`) so the
+  catalog handler does not re-probe CUDA per request.
+- API tests (`catalog_fit_tests`, 5): curated rows carry tags + a verdict; a huge
+  model won't fit a tiny host; experimental rows stay `Unknown`+untagged; an
+  unprobed host yields `Unknown` for **every** row (never `WontFit`); all tags are
+  in the allowed set.
+- Gates: `cargo fmt --all -- --check` ✅ · `cargo clippy --lib -- -D warnings` ✅ ·
+  `cargo test --lib` → **684 passed, 0 failed** (18 new/relevant among them) ✅.
+- JSON is **additive** (`fit`, `task_tags` new keys) — no frontend change yet;
+  the WebUI ignores them until Slice 3.
 
 ### Slice 3 — UX surfaces
 - **WebUI:** in `CatalogLaneBrowse.jsx`, add a fit chip beside the lane chip —

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -1,0 +1,229 @@
+# Model Fit Advisor — End-to-End Plan
+
+**Status:** Draft / docs-first. No runtime code written yet.
+**Branch:** `feat/model-fit-advisor`
+**Axis:** *Capacity/fit* — strictly separate from the *support/correctness* axis
+(`COMPATIBILITY.md`) and the *runnable-lane* axis (`src/runnable/`). A "fits your
+hardware" verdict is **never** a support or parity claim.
+
+---
+
+## 1. Problem
+
+Camelid honestly reports which model rows are *validated* (`/api/capabilities` →
+`model_compatibility`) and which `(architecture, quant)` combos are *runnable*
+(`src/runnable/smoke.rs::oracle_qualified`). It does **not** tell a user whether
+*their machine* can actually load and run a given model. Today the only fit
+feedback is reactive and late:
+
+- **CUDA:** `src/cuda_vram.rs::evaluate` returns a `VramShortfall` — but only
+  **mid-load**, after the user has already committed and (usually) downloaded.
+- **CPU:** `src/inference/kv_cache.rs::ensure_position_capacity` aborts with
+  `BackendError::KvCacheBudgetExceeded` — but only **during generation**.
+- **Catalog browser:** `frontend/src/components/models/CatalogLaneBrowse.jsx`
+  predicts each row's *support/runnable* lane before download, but explicitly
+  **ignores local hardware** (line ~67: *"we don't gate the download on local
+  hardware"*).
+
+So a user on an 8 GB laptop can repeatedly pick an 8B Q8_0 model, wait for a
+multi-GB download, and only then hit an OOM/abort — with no guidance toward a
+model that *would* fit (a smaller size, a K-quant, or GPU-offload).
+
+## 2. Goal
+
+Add a **capacity/fit advisory layer** that, given the already-detected
+`HardwareProfile`, annotates each catalog row with a *fit verdict* **before** the
+user commits, plus a lightweight "best for" tag (coding / reasoning / general /
+tools). Surface it in the model browser and as a fail-fast guard at the load
+boundary, so the CLI, WebUI, and desktop app all inherit it from one place.
+
+## 3. Verified inventory — what already exists (reuse, do not rebuild)
+
+Every item below was read in-tree on branch `feat/model-fit-advisor` at
+`origin/main` = `2b8b97c4`.
+
+| Concern | Location | What it gives us | Reused for |
+| --- | --- | --- | --- |
+| Host hardware probe | `src/capability.rs` → `HardwareProfile::detect()` | `cuda_available`, `cuda_vram_total_bytes`, `cuda_vram_free_bytes`, `cuda_compute_capability`, `cuda_tensor_cores`, `cpu_logical_cores`, `host_ram_total_bytes`, `host_ram_free_bytes`, `simd`. RAM probed on Windows (`GlobalMemoryStatusEx`) + Linux (`/proc/meminfo`); **returns `(0, 0)` = "unknown" elsewhere (incl. macOS)** | The complete input to the fit function |
+| VRAM headroom policy | `src/cuda_vram.rs` → `evaluate(free_bytes, alloc_bytes, min_headroom_mib) -> Result<VramPlan, VramShortfall>` | Pure, GPU-free, unit-tested arithmetic; default headroom `512 MiB` (env `CAMELID_MIN_VRAM_HEADROOM_MIB`) | Direct call for the VRAM branch of the verdict |
+| RAM/KV budget | `src/inference/kv_cache.rs::ensure_position_capacity` + `kv_bytes_per_token()` | KV projection; budget = `CAMELID_MAX_KV_CACHE_BYTES` else `max(80% avail, 25% total)` RAM | Reference for the KV term + the hard safety net that stays in place |
+| Curated catalog | `src/api/mod.rs` → `curated_catalog() -> Vec<CatalogItem>` (~16 rows) | `CatalogItem { catalog_id, name, repo_id, filename, size_bytes, downloads, likes, quant, architecture, license }` | The rows to annotate; `size_bytes` **is** the on-disk weight footprint |
+| Catalog view | `src/api/mod.rs` → `CatalogItemView::from_curated` | Adds `oracle_qualified`, `group`, `arch_detected` (the pre-download lane) | The struct we extend with a `fit` field |
+| Lane predictor | `src/runnable/smoke.rs::oracle_qualified(architecture, quant)` | Bool for anchored combos: `llama/qwen3/gemma3/phi3 × Q8_0` | Pattern to mirror; the fit axis sits **beside** it, not inside it |
+| CLI pull | `src/catalog.rs` → `run_pull` / `print_catalog` | Uses `curated_catalog()` | Where the CLI fit hint prints |
+| Frontend browser | `frontend/src/components/models/CatalogLaneBrowse.jsx` (~366 lines) | Per-row lane chips; currently hardware-blind | Where the fit badge renders |
+| Model metadata | `src/api/mod.rs:410` `n_params: Option<u64>` | Parameter count — **only available post-load** from GGUF `general.parameter_count`, **not** in the pre-download catalog | Informs the post-load exact path, not the pre-download estimate |
+
+## 4. The gap (what is genuinely new)
+
+1. A **fit-verdict type** and a **pure estimation function** combining
+   `HardwareProfile` + a model's footprint.
+2. **Per-row metadata the catalog lacks:** a canonical **parameter count** and
+   **task tags** (`coding` / `reasoning` / `general` / `tools`). Task tags are
+   curated, subjective, and must be labeled advisory — they are not measured.
+3. A **surface** (API field + UI badge + CLI line + load-time guard).
+
+## 5. Design principles (non-negotiable, from repo culture)
+
+- **Capacity ≠ support.** A `Fits` verdict never implies parity/validation. Copy
+  must say *"your hardware can load/run this"*, never *"this is supported"*.
+- **Advisory, not authoritative.** The estimate is a heuristic. The existing
+  `VramShortfall` (mid-load) and `KvCacheBudgetExceeded` (mid-gen) guards remain
+  the hard safety net and are the source of truth.
+- **Degrade to silence on unknowns.** When `host_ram_total_bytes == 0` (macOS) or
+  VRAM is unknown, the verdict is `Unknown` and the UI shows nothing scary — it
+  **never blocks** a download on an unknown.
+- **Pure and testable.** All math lives in a GPU-free, unit-tested function, in
+  the `src/cuda_vram.rs::evaluate` style.
+
+## 6. Data model
+
+### 6.1 Fit verdict (new)
+
+```
+enum FitVerdict {
+    FitsResident,      // weights + KV fit in VRAM within headroom (GPU) OR in RAM (CPU host)
+    FitsWithOffload,   // weights exceed VRAM but fit VRAM+host-RAM offload split (CUDA lane)
+    CpuOnlyOk,         // no usable GPU, but fits host RAM
+    WontFit,           // exceeds every available budget
+    Unknown,           // hardware unknown (e.g. macOS RAM probe returns 0) — advisory-blind
+}
+```
+
+### 6.2 Estimation inputs
+
+- **Weight bytes:** `CatalogItem.size_bytes` (already exact for curated rows — it
+  is the GGUF file size). No estimation needed for the pre-download weight term.
+- **KV bytes:** needs `n_layers`, `n_kv_heads`, `head_dim`, `context`, `kv_dtype`
+  — **not in the catalog**. Options, decided in Slice 1:
+  - (a) Add a small `kv_bytes_per_1k_ctx: u64` (or the raw dims) to `CatalogItem`
+    for curated rows only, OR
+  - (b) Use a conservative per-architecture heuristic bound and clearly mark the
+    KV term approximate. The precise KV path already exists post-load
+    (`kv_cache.rs`), so pre-download only needs a *safe* bound.
+- **Headroom:** reuse `cuda_vram::min_headroom_mib()` for VRAM; reuse the
+  `kv_cache` RAM-budget policy shape for the CPU branch.
+
+### 6.3 Catalog additions (curated only)
+
+```
+// added to CatalogItem
+params: u64,                 // canonical parameter count (e.g. 3_210_000_000)
+task_tags: &'static [&'static str],   // advisory: "coding" | "reasoning" | "general" | "tools"
+```
+
+Experimental (live HF) rows keep `arch_detected: false` and therefore report
+`FitVerdict::Unknown` for the KV-dependent portion — a filename guess can never
+anchor a fit verdict, exactly as it can never anchor a lane.
+
+## 7. Estimation function (Slice 1 core)
+
+New module `src/fit.rs` (pure; unit-tested with no GPU/model):
+
+```
+pub struct FitInputs {
+    pub weight_bytes: u64,
+    pub kv_bytes_at_ctx: u64,   // for the assessed context length
+}
+
+pub fn assess(hw: &HardwareProfile, m: &FitInputs) -> FitVerdict;
+```
+
+Decision order (host-honest):
+1. If `hw.host_ram_total_bytes == 0` and no VRAM info → `Unknown`.
+2. GPU present: try VRAM-resident via `cuda_vram::evaluate(vram_free,
+   weight+kv, headroom)`. Ok → `FitsResident`. Shortfall but
+   `weight+kv <= vram_free + usable_host_ram` → `FitsWithOffload` (mirrors the
+   documented VRAM+host-RAM offload split). Else fall through.
+3. No usable GPU: if `weight+kv <= usable_host_ram` → `CpuOnlyOk`, else
+   `WontFit`.
+
+`usable_host_ram` reuses the `kv_cache` budget shape (`max(80% avail, 25%
+total)`), so the advisor and the runtime guard agree.
+
+## 8. Slices (end-to-end)
+
+### Slice 1 — Docs + pure core (this PR) — ✅ DONE
+- This document.
+- `src/fit.rs`: `FitVerdict`, `FitInputs`, `assess()` + private pure
+  `assess_with_headroom()` — **pure, no I/O**. Registered in `src/lib.rs`.
+- 13 unit tests in `src/fit.rs` covering resident / headroom-nudge / offload /
+  won't-fit (VRAM+RAM and CPU-only) / cpu-only / RAM-floor-dominates /
+  unknown (no-GPU and GPU-overflow) / cuda-flag-without-VRAM / saturation /
+  label + serde stability. Footprints use real catalog byte sizes (3B, 8B).
+- **KV-term decision (resolves open Q1):** the pure core takes **explicit byte
+  inputs** (`FitInputs { weight_bytes, kv_bytes_at_ctx }`). Deriving
+  `kv_bytes_at_ctx` pre-download from architecture metadata is deferred to
+  Slice 2 (leaning §6.2b: a conservative per-arch bound, no `CatalogItem` schema
+  change). This keeps Slice 1 fully deterministic and schema-neutral.
+- **No** change to load/generation/catalog-serialization behavior.
+- Gates: `cargo fmt --all -- --check` ✅ · `cargo clippy --lib -- -D warnings` ✅ ·
+  `cargo test --lib fit::` → **13 passed** ✅. (Full `--all-features` clippy/test
+  is the pre-merge gate; the CUDA build is long and run separately.)
+
+### Slice 2 — Catalog metadata + API field
+- Add `params` + `task_tags` to `CatalogItem` and the ~16 curated rows
+  (`curated_catalog()`), sourced from each model card (cited in code comments).
+- Add `fit: FitVerdict` (+ optional `task_tags`) to `CatalogItemView`; populate
+  in `from_curated` using `HardwareProfile::detect()` (cached at startup like the
+  existing hardware log). `from_hf` → `fit: Unknown`.
+- API tests mirroring the existing `capabilities_*` tests: assert curated rows
+  carry a verdict and experimental rows stay `Unknown`; assert an unknown-RAM
+  host never yields `WontFit`.
+
+### Slice 3 — UX surfaces
+- **WebUI:** in `CatalogLaneBrowse.jsx`, add a fit chip beside the lane chip —
+  `✓ Fits · ⚠ Needs offload/quant · ✗ Too big for this machine · (unknown)`.
+  Copy is advisory and separate from the lane/support chip. Download stays
+  **un-gated** (parity with today's line ~67 stance); the chip informs, it does
+  not block.
+- **CLI:** `print_catalog` in `src/catalog.rs` gains a fit column when a
+  `HardwareProfile` is available.
+- **Load guard (fail-fast, friendly):** in the `load_model` handler behind
+  `POST /api/models/load` (`src/api/mod.rs:1475`), when a curated row assesses
+  `WontFit`, return a **typed** advisory error naming the best-fitting
+  alternative — *before* the existing mid-load `VramShortfall`/KV abort. This is
+  additive: unknown/`Fits*` paths are unchanged.
+
+### Slice 4 — Docs/ledger alignment
+- Cross-link this plan from `ROADMAP.md`; note in `COMPATIBILITY.md` that the fit
+  axis is capacity-only and does not widen support.
+- Optional evidence bundle under `qa/` if a UI badge screenshot gate is wanted
+  (matches the existing `frontend-3b-catalog-*-badge` bundle pattern).
+
+## 9. UX placement decision (locked)
+
+The verdict is most valuable **at model-selection time**, embedded in the
+existing `CatalogLaneBrowse` picker (which already consumes `/api/capabilities`
+and the catalog), **plus** a fail-fast guard at the single `load_model` boundary
+so every front-end (CLI, WebUI, desktop sidecar) inherits it. **No** separate
+"advisor screen." Rationale: one source of truth, mirrors how the support
+contract already flows to every surface, lowest friction.
+
+## 10. Testing strategy
+
+- **Unit (Slice 1):** table-driven `assess()` cases; deterministic, no GPU.
+- **API (Slice 2):** extend the `capabilities_*` / catalog serialization tests.
+- **Frontend (Slice 3):** chip render + advisory copy; download-not-gated
+  assertion.
+- **Regression:** existing `VramShortfall` and `KvCacheBudgetExceeded` behavior
+  unchanged (they remain the hard net).
+
+## 11. Non-goals / guardrails
+
+- No support-claim widening; a fit verdict is never parity/validation.
+- No download gating on hardware (informed choice, not enforcement).
+- No network or model-download behavior change in Slices 1–2.
+- No throughput/tokens-per-sec prediction (out of scope; footprint only).
+- Estimation is advisory; runtime guards are authoritative.
+
+## 12. Open questions (resolve before/within Slice 1)
+
+1. KV term: add per-row dims to `CatalogItem` (§6.2a, precise) vs conservative
+   per-arch bound (§6.2b, no schema change)? Leaning 6.2b for Slice 1 to stay
+   non-invasive, upgrade to 6.2a only if bounds are too loose.
+2. Which context length to assess the KV term at for the default badge — a fixed
+   modest default (e.g. 4096) vs the row's trained context? Leaning fixed default
+   for a stable, comparable badge, with the trained context noted in a tooltip.
+3. Source of task tags — pin to each model card's stated strengths, cite in code,
+   and keep the set tiny to avoid overclaiming.

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -190,19 +190,27 @@ total)`), so the advisor and the runtime guard agree.
 - JSON is **additive** (`fit`, `task_tags` new keys) — no frontend change yet;
   the WebUI ignores them until Slice 3.
 
-### Slice 3 — UX surfaces
-- **WebUI:** in `CatalogLaneBrowse.jsx`, add a fit chip beside the lane chip —
-  `✓ Fits · ⚠ Needs offload/quant · ✗ Too big for this machine · (unknown)`.
-  Copy is advisory and separate from the lane/support chip. Download stays
-  **un-gated** (parity with today's line ~67 stance); the chip informs, it does
-  not block.
-- **CLI:** `print_catalog` in `src/catalog.rs` gains a fit column when a
-  `HardwareProfile` is available.
-- **Load guard (fail-fast, friendly):** in the `load_model` handler behind
-  `POST /api/models/load` (`src/api/mod.rs:1475`), when a curated row assesses
-  `WontFit`, return a **typed** advisory error naming the best-fitting
-  alternative — *before* the existing mid-load `VramShortfall`/KV abort. This is
-  additive: unknown/`Fits*` paths are unchanged.
+### Slice 3 — UX surfaces — ✅ DONE
+- **WebUI** (`CatalogLaneBrowse.jsx`): a dedicated **"This machine:"** advisory
+  line per curated row — `Fits your machine` / `Fits (GPU + RAM offload)` /
+  `Fits (CPU)` / `Too big for this machine` — plus `· best for <tags>`. Kept on
+  its **own line**, visually distinct from the lane/support chip (fit axis ≠
+  support axis); `wont_fit` uses the existing `catalog-row-error` style, others
+  `catalog-row-faint`. `unknown`/experimental rows show nothing. Download stays
+  **un-gated** — the line informs, it does not block. `vite build` ✅.
+- **CLI** (`print_catalog`, `src/catalog.rs`): a `FIT (this host)` column via
+  `FitVerdict::cli_label()` (`fits` / `fits (offload)` / `fits (CPU)` / `too big`
+  / `unknown`), hardware probed once.
+- **Load guard** (`load_model`, `POST /api/models/load`): `fit_preload_guard`
+  stats the file, and on a `WontFit` verdict returns a typed **422
+  `model_too_large_for_host`** naming the largest catalog row that *does* fit —
+  **before** the long load / mid-load OOM. Fires only on `WontFit` from a probed
+  host; `Unknown`/`Fits*` and a `CAMELID_SKIP_FIT_CHECK=1` override proceed
+  unchanged, so it is a fail-fast convenience, not a new hard gate. Pure decision
+  split into testable `fit_preload_message` + `best_fitting_catalog_suggestion`.
+- Tests: 4 new (`preload_message_*`, `best_fitting_suggestion_*`) → 9 in
+  `catalog_fit_tests`. Gates: `cargo fmt` ✅ · `cargo clippy --lib` ✅ ·
+  `cargo test --lib` → **688 passed, 0 failed** ✅ · frontend `vite build` ✅.
 
 ### Slice 4 — Docs/ledger alignment
 - Cross-link this plan from `ROADMAP.md`; note in `COMPATIBILITY.md` that the fit

--- a/frontend/src/components/models/CatalogLaneBrowse.jsx
+++ b/frontend/src/components/models/CatalogLaneBrowse.jsx
@@ -201,8 +201,16 @@ function CatalogRow({
       </div>
       {item.group !== 'experimental' && fitLabel(item.fit) ? (
         <div className="catalog-fit-row">
-          <span className={`catalog-fit-chip catalog-fit-chip--${item.fit === 'wont_fit' ? 'bad' : 'good'}`}>
+          <span
+            className={`catalog-fit-chip catalog-fit-chip--${item.fit === 'wont_fit' ? 'bad' : 'good'}`}
+            title={
+              item.fit_confidence === 'exact'
+                ? "Sized from the model's real dimensions (KV cache computed exactly)"
+                : 'Estimate — upgrades to exact once the model header has been read'
+            }
+          >
             <FitIcon bad={item.fit === 'wont_fit'} />
+            {item.fit_confidence === 'approx' ? '~ ' : ''}
             {fitLabel(item.fit)}
           </span>
           {Array.isArray(item.task_tags) && item.task_tags.length ? (

--- a/frontend/src/components/models/CatalogLaneBrowse.jsx
+++ b/frontend/src/components/models/CatalogLaneBrowse.jsx
@@ -199,10 +199,12 @@ function CatalogRow({
         </div>
         {laneChip(lane)}
       </div>
-      {item.group !== 'experimental' && fitLabel(item.fit) ? (
+      {fitLabel(item.fit) ? (
         <div className="catalog-fit-row">
           <span
-            className={`catalog-fit-chip catalog-fit-chip--${item.fit === 'wont_fit' ? 'bad' : 'good'}`}
+            className={`catalog-fit-chip catalog-fit-chip--${item.fit === 'wont_fit' ? 'bad' : 'good'}${
+              item.fit_confidence === 'approx' ? ' catalog-fit-chip--estimate' : ''
+            }`}
             title={
               item.fit_confidence === 'exact'
                 ? "Sized from the model's real dimensions (KV cache computed exactly)"

--- a/frontend/src/components/models/CatalogLaneBrowse.jsx
+++ b/frontend/src/components/models/CatalogLaneBrowse.jsx
@@ -41,6 +41,25 @@ function laneChip(lane) {
   return <EvidenceChip state="unsupported" asText>Experimental · unverified</EvidenceChip>
 }
 
+/* Capacity advisory for THIS host (fit axis, NOT a support claim — kept on its own
+   line, never merged into the lane/support chip). `item.fit` is the backend
+   FitVerdict; `unknown`/missing (e.g. unprobed host, experimental rows) shows
+   nothing rather than guessing. */
+function fitLabel(fit) {
+  switch (fit) {
+    case 'fits_resident':
+      return 'Fits your machine'
+    case 'fits_with_offload':
+      return 'Fits (GPU + RAM offload)'
+    case 'cpu_only_ok':
+      return 'Fits (CPU)'
+    case 'wont_fit':
+      return 'Too big for this machine'
+    default:
+      return null
+  }
+}
+
 function CatalogRow({
   item,
   capabilities,
@@ -158,6 +177,14 @@ function CatalogRow({
         </div>
         {laneChip(lane)}
       </div>
+      {item.group !== 'experimental' && fitLabel(item.fit) ? (
+        <p className={item.fit === 'wont_fit' ? 'catalog-row-error' : 'catalog-row-faint'}>
+          This machine: {fitLabel(item.fit)}
+          {Array.isArray(item.task_tags) && item.task_tags.length
+            ? ` · best for ${item.task_tags.join(', ')}`
+            : ''}
+        </p>
+      ) : null}
       {decoration?.blurb ? <p className="catalog-row-blurb">{decoration.blurb}</p> : null}
 
       {installed ? (

--- a/frontend/src/components/models/CatalogLaneBrowse.jsx
+++ b/frontend/src/components/models/CatalogLaneBrowse.jsx
@@ -60,6 +60,28 @@ function fitLabel(fit) {
   }
 }
 
+/* A small CPU/chip glyph so the capacity chip reads as "your hardware" — distinct
+   from the support/lane chips. A check (fits) or cross (too big) sits in the die. */
+function FitIcon({ bad }) {
+  const stroke = 'currentColor'
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect x="4.5" y="4.5" width="7" height="7" rx="1.2" stroke={stroke} strokeWidth="1.3" />
+      {bad ? (
+        <path d="M6.4 6.4l3.2 3.2M9.6 6.4l-3.2 3.2" stroke={stroke} strokeWidth="1.3" strokeLinecap="round" />
+      ) : (
+        <path d="M6 8.2l1.4 1.4L10 6.6" stroke={stroke} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+      )}
+      <path
+        d="M6.5 2.6v1.9M9.5 2.6v1.9M6.5 11.5v1.9M9.5 11.5v1.9M2.6 6.5h1.9M2.6 9.5h1.9M11.5 6.5h1.9M11.5 9.5h1.9"
+        stroke={stroke}
+        strokeWidth="1.1"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
 function CatalogRow({
   item,
   capabilities,
@@ -178,12 +200,22 @@ function CatalogRow({
         {laneChip(lane)}
       </div>
       {item.group !== 'experimental' && fitLabel(item.fit) ? (
-        <p className={item.fit === 'wont_fit' ? 'catalog-row-error' : 'catalog-row-faint'}>
-          This machine: {fitLabel(item.fit)}
-          {Array.isArray(item.task_tags) && item.task_tags.length
-            ? ` · best for ${item.task_tags.join(', ')}`
-            : ''}
-        </p>
+        <div className="catalog-fit-row">
+          <span className={`catalog-fit-chip catalog-fit-chip--${item.fit === 'wont_fit' ? 'bad' : 'good'}`}>
+            <FitIcon bad={item.fit === 'wont_fit'} />
+            {fitLabel(item.fit)}
+          </span>
+          {Array.isArray(item.task_tags) && item.task_tags.length ? (
+            <span className="catalog-fit-tags">
+              <span className="catalog-fit-tags-label">best for</span>
+              {item.task_tags.map((tag) => (
+                <span key={tag} className="catalog-fit-tag">
+                  {tag}
+                </span>
+              ))}
+            </span>
+          ) : null}
+        </div>
       ) : null}
       {decoration?.blurb ? <p className="catalog-row-blurb">{decoration.blurb}</p> : null}
 

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -1101,6 +1101,14 @@
 .catalog-row-meta { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--color-text-muted); overflow-wrap: anywhere; }
 .catalog-row-faint { font-size: var(--text-xs); color: var(--color-text-faint); margin: var(--space-2) 0 0; overflow-wrap: anywhere; }
 .catalog-row-error { font-size: var(--text-sm); color: var(--color-warning); margin: var(--space-2) 0 0; overflow-wrap: anywhere; }
+.catalog-fit-row { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); margin-top: var(--space-2); }
+.catalog-fit-chip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 9px; border-radius: 999px; border: 1px solid transparent; font-size: var(--text-xs); font-weight: 600; letter-spacing: 0.01em; white-space: nowrap; }
+.catalog-fit-chip svg { flex: none; }
+.catalog-fit-chip--good { color: var(--color-accent-text); background: var(--color-accent-soft); border-color: color-mix(in srgb, var(--color-accent) 30%, transparent); }
+.catalog-fit-chip--bad { color: var(--color-error); background: color-mix(in srgb, var(--color-error) 12%, transparent); border-color: color-mix(in srgb, var(--color-error) 40%, transparent); }
+.catalog-fit-tags { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 4px; }
+.catalog-fit-tags-label { font-size: var(--text-xs); color: var(--color-text-faint); margin-right: 1px; }
+.catalog-fit-tag { display: inline-flex; padding: 1px 8px; border-radius: 999px; font-size: var(--text-xs); color: var(--color-text-muted); background: var(--color-surface-strong); border: 1px solid var(--color-border-soft); text-transform: capitalize; }
 .catalog-row-action { margin-top: var(--space-2); padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm); border: 1px solid var(--color-border-soft); background: var(--color-bg-elevated); color: var(--color-text); font-size: var(--text-xs); font-weight: 700; }
 .catalog-row-action:hover { background: var(--color-surface-hover); }
 .catalog-row-cancel { margin-top: var(--space-2); margin-left: var(--space-2); padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm); border: 1px solid transparent; background: transparent; color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 600; }

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -1104,6 +1104,7 @@
 .catalog-fit-row { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); margin-top: var(--space-2); }
 .catalog-fit-chip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 9px; border-radius: 999px; border: 1px solid transparent; font-size: var(--text-xs); font-weight: 600; letter-spacing: 0.01em; white-space: nowrap; }
 .catalog-fit-chip svg { flex: none; }
+.catalog-fit-chip--estimate { border-style: dashed; }
 .catalog-fit-chip--good { color: var(--color-accent-text); background: var(--color-accent-soft); border-color: color-mix(in srgb, var(--color-accent) 30%, transparent); }
 .catalog-fit-chip--bad { color: var(--color-error); background: color-mix(in srgb, var(--color-error) 12%, transparent); border-color: color-mix(in srgb, var(--color-error) 40%, transparent); }
 .catalog-fit-tags { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 4px; }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3722,6 +3722,95 @@ fn read_model_dims(path: &std::path::Path) -> Option<crate::fit::ModelDims> {
     })
 }
 
+/// Fetch a model's KV dimensions from its GGUF **header only** over the network,
+/// without downloading the weights. GGUF stores all metadata + tensor-info at the
+/// start of the file, so we range-fetch a generous header slice, write it into a
+/// temp file whose *length* is set to the model's real size (the unfetched tail is
+/// sparse zeros that `read_metadata` never reads — it only validates tensor offsets
+/// against the length), then reuse the trusted on-disk parser. `None` on any
+/// network/parse failure so callers fall back to the coarse estimate. The result is
+/// meant to be cached (see [`cached_remote_dims`]).
+fn remote_model_dims(
+    repo_id: &str,
+    filename: &str,
+    full_size: u64,
+) -> Option<crate::fit::ModelDims> {
+    /// How much of the file head to fetch — comfortably covers metadata (incl. the
+    /// tokenizer arrays, largest for 128k-vocab Llama rows) + tensor-info for current
+    /// catalog models, while keeping the per-row cost small (never the weights). A
+    /// too-small fetch just fails to parse and the caller falls back to the estimate.
+    const HEADER_BYTES: u64 = 12 * 1024 * 1024;
+    if full_size == 0 {
+        return None;
+    }
+    let safe: String = filename
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let tmp = std::env::temp_dir().join(format!("camelid-hdr-{}-{safe}", std::process::id()));
+    let range_end = HEADER_BYTES.min(full_size).saturating_sub(1);
+    let url = format!("https://huggingface.co/{repo_id}/resolve/main/{filename}");
+    let ok = std::process::Command::new("curl")
+        .args(["-fsSL", "-r", &format!("0-{range_end}"), "-o"])
+        .arg(&tmp)
+        .arg(&url)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    let dims = if ok {
+        // Extend the temp file to the real size so the parser's tensor-offset bounds
+        // checks pass; the tail is sparse zeros and is never read.
+        if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&tmp) {
+            let _ = f.set_len(full_size);
+        }
+        read_model_dims(&tmp)
+    } else {
+        None
+    };
+    let _ = std::fs::remove_file(&tmp);
+    dims
+}
+
+/// Process-wide cache of remote header dims, keyed by `repo/filename`. A stored
+/// `None` records a prior failed/unavailable fetch so we don't hammer the Hub.
+type RemoteDimsCache =
+    std::sync::Mutex<std::collections::HashMap<String, Option<crate::fit::ModelDims>>>;
+
+fn remote_dims_cache() -> &'static RemoteDimsCache {
+    static CACHE: std::sync::OnceLock<RemoteDimsCache> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+fn remote_dims_key(repo_id: &str, filename: &str) -> String {
+    format!("{repo_id}/{filename}")
+}
+
+/// Cached dims lookup: `Some(entry)` when a fetch has been attempted (`entry` may be
+/// `None` = it failed), `None` when never attempted (so a warm can be scheduled).
+fn cached_remote_dims(repo_id: &str, filename: &str) -> Option<Option<crate::fit::ModelDims>> {
+    remote_dims_cache()
+        .lock()
+        .ok()?
+        .get(&remote_dims_key(repo_id, filename))
+        .copied()
+}
+
+fn store_remote_dims(repo_id: &str, filename: &str, dims: Option<crate::fit::ModelDims>) {
+    if let Ok(mut map) = remote_dims_cache().lock() {
+        map.insert(remote_dims_key(repo_id, filename), dims);
+    }
+}
+
+/// True unless the operator opted out of the background header fetches that upgrade
+/// catalog fit badges from `approx` to `exact` (`CAMELID_NO_REMOTE_DIMS=1`).
+fn remote_dims_enabled() -> bool {
+    std::env::var("CAMELID_NO_REMOTE_DIMS")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        != Some("1")
+}
+
 /// Env + filesystem wrapper around [`fit_preload_message`]. Probes **live** host
 /// memory and computes an **exact** footprint from the GGUF's real dimensions
 /// (weights + KV at a normal-use context + a bounded scratch margin) whenever the
@@ -15612,12 +15701,43 @@ pub struct CatalogItemView {
     /// Advisory "best for" positioning (e.g. `general`, `reasoning`, `coding`,
     /// `tools`) — curated, not benchmarked. Empty for experimental rows.
     pub task_tags: Vec<String>,
+    /// Confidence of the `fit` estimate: `"exact"` when computed from the model's
+    /// real GGUF dimensions (KV cache sized precisely), `"approx"` when from the
+    /// coarse size-based heuristic.
+    pub fit_confidence: &'static str,
+}
+
+/// Footprint + confidence for a curated row: an **exact** footprint (weights + KV
+/// sized from the model's real GGUF dims) when those dims are cached, else the
+/// coarse size pad. Dims are warmed in the background by [`get_catalog`], so a row
+/// starts `approx` and upgrades to `exact` once its header has been read.
+fn curated_footprint(
+    item: &CatalogItem,
+    hw: &crate::capability::HardwareProfile,
+) -> (crate::fit::FitInputs, &'static str) {
+    if let Some(Some(dims)) = cached_remote_dims(item.repo_id, item.filename) {
+        let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
+            crate::fit::KvDtype::F16
+        } else {
+            crate::fit::KvDtype::F32
+        };
+        let fp = crate::fit::exact_footprint(
+            item.size_bytes,
+            dims,
+            crate::fit::ADVISORY_CONTEXT_TOKENS,
+            kv_dtype,
+        );
+        (fp, "exact")
+    } else {
+        (crate::fit::advisory_footprint(item.size_bytes), "approx")
+    }
 }
 
 impl CatalogItemView {
     /// Build a view for a curated row: authoritative architecture, lane predicted
     /// from the real `(architecture, quant)` via `runnable::oracle_qualified`.
     fn from_curated(item: &CatalogItem, hw: &crate::capability::HardwareProfile) -> Self {
+        let (footprint, fit_confidence) = curated_footprint(item, hw);
         CatalogItemView {
             catalog_id: item.catalog_id.to_string(),
             name: item.name.to_string(),
@@ -15632,16 +15752,40 @@ impl CatalogItemView {
             oracle_qualified: crate::runnable::oracle_qualified(item.architecture, item.quant),
             group: "curated",
             arch_detected: true,
-            fit: crate::fit::assess(hw, &crate::fit::advisory_footprint(item.size_bytes)),
+            fit: crate::fit::assess(hw, &footprint),
             task_tags: item.task_tags.iter().map(|t| t.to_string()).collect(),
+            fit_confidence,
         }
     }
 
     /// Build a view for a live Hugging Face result. Architecture/quant are filename
     /// guesses (`arch_detected: false`); `oracle_qualified` is forced `false` so the
     /// experimental row is never predicted Compatible/Supported on a guess alone.
-    fn from_hf(file: crate::hf_browse::HfGgufFile) -> Self {
+    /// Capacity is orthogonal to verification: when this file's real GGUF header has
+    /// been read (cached), we give an honest `exact` fit even for an unverified row;
+    /// otherwise we make **no** fit claim (`Unknown`) rather than guess on a filename.
+    fn from_hf(
+        file: crate::hf_browse::HfGgufFile,
+        hw: &crate::capability::HardwareProfile,
+    ) -> Self {
         let catalog_id = format!("hf::{}::{}", file.repo_id, file.filename);
+        let (fit, fit_confidence) = match cached_remote_dims(&file.repo_id, &file.filename) {
+            Some(Some(dims)) => {
+                let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
+                    crate::fit::KvDtype::F16
+                } else {
+                    crate::fit::KvDtype::F32
+                };
+                let fp = crate::fit::exact_footprint(
+                    file.size_bytes,
+                    dims,
+                    crate::fit::ADVISORY_CONTEXT_TOKENS,
+                    kv_dtype,
+                );
+                (crate::fit::assess(hw, &fp), "exact")
+            }
+            _ => (crate::fit::FitVerdict::Unknown, "approx"),
+        };
         CatalogItemView {
             catalog_id,
             name: file.filename.clone(),
@@ -15656,9 +15800,9 @@ impl CatalogItemView {
             oracle_qualified: false,
             group: "experimental",
             arch_detected: false,
-            // Experimental (filename-guess) rows never carry a fit or task claim.
-            fit: crate::fit::FitVerdict::Unknown,
+            fit,
             task_tags: Vec::new(),
+            fit_confidence,
         }
     }
 }
@@ -16315,6 +16459,25 @@ async fn get_catalog(
         .map(|item| CatalogItemView::from_curated(item, hw))
         .collect();
 
+    // Warm the remote-dims cache in the background so later catalog renders upgrade
+    // these rows from `approx` to `exact` (header-only fetch — no weights). Never
+    // blocks this response; a failed fetch caches as `None` to avoid re-hammering.
+    if remote_dims_enabled() {
+        for item in curated_catalog() {
+            if cached_remote_dims(item.repo_id, item.filename).is_none() {
+                let (repo, file, size) = (
+                    item.repo_id.to_string(),
+                    item.filename.to_string(),
+                    item.size_bytes,
+                );
+                tokio::task::spawn_blocking(move || {
+                    let dims = remote_model_dims(&repo, &file, size);
+                    store_remote_dims(&repo, &file, dims);
+                });
+            }
+        }
+    }
+
     let mut items = curated;
     let mut next_cursor = None;
 
@@ -16329,13 +16492,39 @@ async fn get_catalog(
                     .iter()
                     .map(|c| (c.repo_id.to_string(), c.filename.to_string()))
                     .collect();
+                // Warm dims for the experimental page too so a random Hugging Face
+                // model shows an honest capacity fit on the next render — header-only,
+                // never blocking, cached, opt-out via env. **Bounded** to the top few
+                // rows: a query can return 100+ files, and warming all of them would
+                // fan out into a huge fetch storm.
+                if remote_dims_enabled() {
+                    const HF_DIMS_WARM_LIMIT: usize = 5;
+                    let mut warmed = 0usize;
+                    for f in &page.files {
+                        if warmed >= HF_DIMS_WARM_LIMIT {
+                            break;
+                        }
+                        let key = (f.repo_id.clone(), f.filename.clone());
+                        if curated_files.contains(&key)
+                            || cached_remote_dims(&f.repo_id, &f.filename).is_some()
+                        {
+                            continue;
+                        }
+                        warmed += 1;
+                        let (repo, file, size) = (key.0, key.1, f.size_bytes);
+                        tokio::task::spawn_blocking(move || {
+                            let dims = remote_model_dims(&repo, &file, size);
+                            store_remote_dims(&repo, &file, dims);
+                        });
+                    }
+                }
                 items.extend(
                     page.files
                         .into_iter()
                         .filter(|f| {
                             !curated_files.contains(&(f.repo_id.clone(), f.filename.clone()))
                         })
-                        .map(CatalogItemView::from_hf),
+                        .map(|f| CatalogItemView::from_hf(f, hw)),
                 );
             }
             // Offline / Hub error: keep curated-only rather than failing the page.
@@ -16630,10 +16819,39 @@ mod catalog_fit_tests {
             architecture: "llama".to_string(),
             quant: "Q4_K_M".to_string(),
         };
-        let view = CatalogItemView::from_hf(file);
+        // No cached header dims for this repo → no fit claim (Unknown), untagged.
+        let hw = host(false, 0, 64 * GIB, 48 * GIB);
+        let view = CatalogItemView::from_hf(file, &hw);
         assert_eq!(view.fit, FitVerdict::Unknown);
         assert!(view.task_tags.is_empty());
         assert_eq!(view.group, "experimental");
+        assert_eq!(view.fit_confidence, "approx");
+    }
+
+    #[test]
+    fn hf_row_gets_an_exact_fit_once_its_header_dims_are_cached() {
+        let hw = host(false, 0, 4 * GIB, 3 * GIB);
+        let (repo, filename) = ("someone/Huge-Model-GGUF", "Huge-Model-Q8_0.gguf");
+        // Cache real dims for a genuinely too-big model → honest exact WontFit even on
+        // an unverified HF row (capacity is orthogonal to verification).
+        let dims = crate::fit::ModelDims {
+            layers: 80,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        super::store_remote_dims(repo, filename, Some(dims));
+        let file = crate::hf_browse::HfGgufFile {
+            repo_id: repo.to_string(),
+            filename: filename.to_string(),
+            size_bytes: 20 * GIB,
+            downloads: 0,
+            likes: 0,
+            architecture: "llama".to_string(),
+            quant: "Q8_0".to_string(),
+        };
+        let view = CatalogItemView::from_hf(file, &hw);
+        assert_eq!(view.fit_confidence, "exact");
+        assert_eq!(view.fit, FitVerdict::WontFit);
     }
 
     #[test]
@@ -16715,6 +16933,38 @@ mod catalog_fit_tests {
     }
 
     #[test]
+    fn remote_model_dims_reads_a_real_gguf_header_when_enabled() {
+        // Network-gated: self-skips offline / in normal CI. Enable with
+        // CAMELID_TEST_REMOTE_DIMS=1 to verify the header range-fetch end to end.
+        if std::env::var("CAMELID_TEST_REMOTE_DIMS").ok().as_deref() != Some("1") {
+            return;
+        }
+        // Qwen3-0.6B is the smallest curated model (~639 MB); fetch its header only.
+        let dims =
+            super::remote_model_dims("Qwen/Qwen3-0.6B-GGUF", "Qwen3-0.6B-Q8_0.gguf", 639_446_688)
+                .expect("remote header dims should parse from a real GGUF");
+        assert!(
+            dims.layers >= 1 && dims.layers <= 64,
+            "layers={}",
+            dims.layers
+        );
+        assert!(dims.kv_heads >= 1, "kv_heads={}", dims.kv_heads);
+        assert!(dims.head_dim >= 1, "head_dim={}", dims.head_dim);
+        eprintln!("Qwen3-0.6B header dims: {dims:?}");
+
+        // Also a 128k-vocab Llama row (biggest metadata) to confirm HEADER_BYTES is
+        // large enough for the worst case; otherwise it would fall back to the pad.
+        let llama = super::remote_model_dims(
+            "unsloth/Llama-3.2-1B-Instruct-GGUF",
+            "Llama-3.2-1B-Instruct-Q8_0.gguf",
+            1_321_082_528,
+        )
+        .expect("Llama 3.2 1B header dims should parse within HEADER_BYTES");
+        assert!(llama.layers >= 1 && llama.kv_heads >= 1 && llama.head_dim >= 1);
+        eprintln!("Llama-3.2-1B header dims: {llama:?}");
+    }
+
+    #[test]
     fn best_fitting_suggestion_picks_something_on_a_big_host_and_never_panics_on_tiny() {
         let big = host(false, 0, 64 * GIB, 48 * GIB);
         let s = super::best_fitting_catalog_suggestion(&big).expect("a row fits a 64 GB host");
@@ -16722,6 +16972,68 @@ mod catalog_fit_tests {
         // On a tiny host only small rows fit (or none) — must not panic either way.
         let tiny = host(false, 0, 4 * GIB, 3 * GIB);
         let _ = super::best_fitting_catalog_suggestion(&tiny);
+    }
+
+    fn fake_item(repo: &'static str, filename: &'static str) -> CatalogItem {
+        CatalogItem {
+            catalog_id: "test_row",
+            name: "Test Row",
+            repo_id: repo,
+            filename,
+            size_bytes: 8_000_000_000,
+            downloads: 0,
+            likes: 0,
+            quant: "Q8_0",
+            architecture: "llama",
+            license: "test",
+            task_tags: &["general"],
+        }
+    }
+
+    #[test]
+    fn remote_dims_cache_round_trips() {
+        let (repo, file) = ("test/round-trip-repo", "round-trip.gguf");
+        assert!(super::cached_remote_dims(repo, file).is_none());
+        let dims = crate::fit::ModelDims {
+            layers: 28,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        super::store_remote_dims(repo, file, Some(dims));
+        assert_eq!(super::cached_remote_dims(repo, file), Some(Some(dims)));
+        // A failed fetch caches as None so we don't re-hammer the Hub.
+        super::store_remote_dims(repo, file, None);
+        assert_eq!(super::cached_remote_dims(repo, file), Some(None));
+    }
+
+    #[test]
+    fn curated_footprint_is_exact_when_dims_cached_else_approx() {
+        let hw = host(false, 0, 64 * GIB, 48 * GIB);
+        // approx: dims not cached → coarse size pad.
+        let approx_item = fake_item("test/uncached-repo", "uncached.gguf");
+        let (fp_approx, conf) = super::curated_footprint(&approx_item, &hw);
+        assert_eq!(conf, "approx");
+        assert_eq!(
+            fp_approx,
+            crate::fit::advisory_footprint(approx_item.size_bytes)
+        );
+        // exact: cache real dims → confidence flips and the KV is sized precisely.
+        let exact_item = fake_item("test/cached-repo", "cached.gguf");
+        let dims = crate::fit::ModelDims {
+            layers: 32,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        super::store_remote_dims("test/cached-repo", "cached.gguf", Some(dims));
+        let (fp_exact, conf) = super::curated_footprint(&exact_item, &hw);
+        assert_eq!(conf, "exact");
+        let expected = crate::fit::exact_footprint(
+            exact_item.size_bytes,
+            dims,
+            crate::fit::ADVISORY_CONTEXT_TOKENS,
+            crate::fit::KvDtype::F32, // CPU host
+        );
+        assert_eq!(fp_exact, expected);
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3668,7 +3668,77 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
     }
 }
 
+/// The largest curated row that has a positive fit on `hw`, as a ready-to-run
+/// suggestion string. `None` when nothing in the catalog fits (or the host is
+/// unprobed). Used to make the pre-load "too big" error actionable.
+fn best_fitting_catalog_suggestion(hw: &crate::capability::HardwareProfile) -> Option<String> {
+    curated_catalog()
+        .into_iter()
+        .filter(|item| {
+            crate::fit::assess(hw, &crate::fit::advisory_footprint(item.size_bytes))
+                .is_positive_fit()
+        })
+        .max_by_key(|item| item.size_bytes)
+        .map(|item| format!("{} (`camelid pull {}`)", item.name, item.catalog_id))
+}
+
+/// Pure advisory message for a pre-load fit check: `Some(message)` when `hw` won't
+/// fit `size_bytes`, else `None`. Split from the IO wrapper so it is unit-testable
+/// with a synthetic host.
+fn fit_preload_message(hw: &crate::capability::HardwareProfile, size_bytes: u64) -> Option<String> {
+    if crate::fit::assess(hw, &crate::fit::advisory_footprint(size_bytes))
+        != crate::fit::FitVerdict::WontFit
+    {
+        return None;
+    }
+    let base = format!(
+        "This model (~{:.1} GB) is larger than this machine can hold in memory.",
+        size_bytes as f64 / 1e9
+    );
+    Some(match best_fitting_catalog_suggestion(hw) {
+        Some(alt) => format!(
+            "{base} The largest catalog model that fits here is {alt}. \
+             Set CAMELID_SKIP_FIT_CHECK=1 to attempt the load anyway."
+        ),
+        None => format!("{base} Set CAMELID_SKIP_FIT_CHECK=1 to attempt the load anyway."),
+    })
+}
+
+/// Env + filesystem wrapper around [`fit_preload_message`]. Reads the real file
+/// size and the cached host profile, returning a typed 422 only when the model
+/// won't fit. Returns `None` (proceed unchanged) on the `CAMELID_SKIP_FIT_CHECK=1`
+/// override, a missing/zero-size file, or any non-`WontFit` verdict — so this is a
+/// pure fail-fast convenience, never a new gate on the `Fits*`/`Unknown` paths.
+fn fit_preload_guard(path: &std::path::Path) -> Option<Response> {
+    if std::env::var("CAMELID_SKIP_FIT_CHECK")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        == Some("1")
+    {
+        return None;
+    }
+    let size = std::fs::metadata(path).ok()?.len();
+    if size == 0 {
+        return None;
+    }
+    let hw = crate::capability::HardwareProfile::cached();
+    let message = fit_preload_message(hw, size)?;
+    Some(api_error(
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "model_too_large_for_host",
+        message,
+        Some("path"),
+    ))
+}
+
 async fn load_model(State(state): State<AppState>, Json(req): Json<LoadModelRequest>) -> Response {
+    // Advisory fail-fast (fit axis, never a support claim): steer away from a
+    // near-certain OOM before the expensive load. Overridable via
+    // CAMELID_SKIP_FIT_CHECK=1; only fires on a WontFit verdict from a probed host.
+    if let Some(resp) = fit_preload_guard(&req.path) {
+        return resp;
+    }
     match load_model_from_path(&state, req.path, req.id).await {
         Ok(loaded) => (StatusCode::OK, Json(loaded)).into_response(),
         // Fail closed with the exact typed reason and a stable, switchable code.
@@ -16562,6 +16632,39 @@ mod catalog_fit_tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn preload_message_suggests_a_fitting_alternative_for_an_oversized_model() {
+        // 8 GB RAM, no GPU: a 40 GB model won't fit → actionable message.
+        let hw = host(false, 0, 8 * GIB, 5 * GIB);
+        let msg = super::fit_preload_message(&hw, 40 * GIB).expect("won't fit -> message");
+        assert!(msg.contains("larger than this machine"));
+        assert!(msg.contains("camelid pull"));
+        assert!(msg.contains("CAMELID_SKIP_FIT_CHECK=1"));
+    }
+
+    #[test]
+    fn preload_message_is_none_when_the_model_fits() {
+        let hw = host(false, 0, 64 * GIB, 48 * GIB);
+        assert!(super::fit_preload_message(&hw, 2 * GIB).is_none());
+    }
+
+    #[test]
+    fn preload_message_is_none_on_unprobed_host() {
+        // Unknown verdict must never hard-block a load.
+        let hw = host(false, 0, 0, 0);
+        assert!(super::fit_preload_message(&hw, 40 * GIB).is_none());
+    }
+
+    #[test]
+    fn best_fitting_suggestion_picks_something_on_a_big_host_and_never_panics_on_tiny() {
+        let big = host(false, 0, 64 * GIB, 48 * GIB);
+        let s = super::best_fitting_catalog_suggestion(&big).expect("a row fits a 64 GB host");
+        assert!(s.contains("camelid pull"));
+        // On a tiny host only small rows fit (or none) — must not panic either way.
+        let tiny = host(false, 0, 4 * GIB, 3 * GIB);
+        let _ = super::best_fitting_catalog_suggestion(&tiny);
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3683,12 +3683,15 @@ fn best_fitting_catalog_suggestion(hw: &crate::capability::HardwareProfile) -> O
 }
 
 /// Pure advisory message for a pre-load fit check: `Some(message)` when `hw` won't
-/// fit `size_bytes`, else `None`. Split from the IO wrapper so it is unit-testable
-/// with a synthetic host.
-fn fit_preload_message(hw: &crate::capability::HardwareProfile, size_bytes: u64) -> Option<String> {
-    if crate::fit::assess(hw, &crate::fit::advisory_footprint(size_bytes))
-        != crate::fit::FitVerdict::WontFit
-    {
+/// fit `footprint`, else `None`. `size_bytes` is the on-disk size, used only for the
+/// human-readable number. Split from the IO wrapper so it is unit-testable with a
+/// synthetic host and footprint.
+fn fit_preload_message(
+    hw: &crate::capability::HardwareProfile,
+    footprint: &crate::fit::FitInputs,
+    size_bytes: u64,
+) -> Option<String> {
+    if crate::fit::assess(hw, footprint) != crate::fit::FitVerdict::WontFit {
         return None;
     }
     let base = format!(
@@ -3704,11 +3707,28 @@ fn fit_preload_message(hw: &crate::capability::HardwareProfile, size_bytes: u64)
     })
 }
 
-/// Env + filesystem wrapper around [`fit_preload_message`]. Reads the real file
-/// size and the cached host profile, returning a typed 422 only when the model
-/// won't fit. Returns `None` (proceed unchanged) on the `CAMELID_SKIP_FIT_CHECK=1`
-/// override, a missing/zero-size file, or any non-`WontFit` verdict — so this is a
-/// pure fail-fast convenience, never a new gate on the `Fits*`/`Unknown` paths.
+/// Read the KV-relevant dimensions from a GGUF's metadata WITHOUT loading weights
+/// (header-only, the same cheap path `/api/models/inspect` uses). `None` for a
+/// non-GGUF, an unreadable header, or a non-dense/unknown architecture — callers
+/// then fall back to the coarse size-based estimate.
+fn read_model_dims(path: &std::path::Path) -> Option<crate::fit::ModelDims> {
+    let gguf = crate::gguf::read_metadata(path).ok()?;
+    let config = crate::model::LlamaModelConfig::from_gguf(&gguf).ok()?;
+    let dims = crate::model::DenseLlamaDims::from_config(&config).ok()?;
+    Some(crate::fit::ModelDims {
+        layers: dims.block_count as u64,
+        kv_heads: dims.attention_head_count_kv as u64,
+        head_dim: dims.head_dim as u64,
+    })
+}
+
+/// Env + filesystem wrapper around [`fit_preload_message`]. Probes **live** host
+/// memory and computes an **exact** footprint from the GGUF's real dimensions
+/// (weights + KV at a normal-use context + a bounded scratch margin) whenever the
+/// header parses, falling back to the coarse size pad otherwise. Returns a typed
+/// 422 only on a `WontFit` verdict; `None` (proceed unchanged) on the
+/// `CAMELID_SKIP_FIT_CHECK=1` override, a missing/zero-size file, or any
+/// `Fits*`/`Unknown` verdict — a fail-fast convenience, never a new hard gate.
 fn fit_preload_guard(path: &std::path::Path) -> Option<Response> {
     if std::env::var("CAMELID_SKIP_FIT_CHECK")
         .ok()
@@ -3722,8 +3742,23 @@ fn fit_preload_guard(path: &std::path::Path) -> Option<Response> {
     if size == 0 {
         return None;
     }
-    let hw = crate::capability::HardwareProfile::cached();
-    let message = fit_preload_message(hw, size)?;
+    // Live probe (not the cached startup snapshot): free VRAM/RAM shift as other
+    // apps run or a model is already loaded, and this decision must reflect *now*.
+    let hw = crate::capability::HardwareProfile::detect();
+    // Exact footprint from the GGUF's real dims when the header parses; else the pad.
+    let footprint = match read_model_dims(path) {
+        Some(dims) => {
+            // KV is stored f16 on the GPU-resident path, f32 on the CPU path.
+            let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
+                crate::fit::KvDtype::F16
+            } else {
+                crate::fit::KvDtype::F32
+            };
+            crate::fit::exact_footprint(size, dims, crate::fit::ADVISORY_CONTEXT_TOKENS, kv_dtype)
+        }
+        None => crate::fit::advisory_footprint(size),
+    };
+    let message = fit_preload_message(&hw, &footprint, size)?;
     Some(api_error(
         StatusCode::UNPROCESSABLE_ENTITY,
         "model_too_large_for_host",
@@ -16638,7 +16673,8 @@ mod catalog_fit_tests {
     fn preload_message_suggests_a_fitting_alternative_for_an_oversized_model() {
         // 8 GB RAM, no GPU: a 40 GB model won't fit → actionable message.
         let hw = host(false, 0, 8 * GIB, 5 * GIB);
-        let msg = super::fit_preload_message(&hw, 40 * GIB).expect("won't fit -> message");
+        let fp = crate::fit::advisory_footprint(40 * GIB);
+        let msg = super::fit_preload_message(&hw, &fp, 40 * GIB).expect("won't fit -> message");
         assert!(msg.contains("larger than this machine"));
         assert!(msg.contains("camelid pull"));
         assert!(msg.contains("CAMELID_SKIP_FIT_CHECK=1"));
@@ -16647,14 +16683,35 @@ mod catalog_fit_tests {
     #[test]
     fn preload_message_is_none_when_the_model_fits() {
         let hw = host(false, 0, 64 * GIB, 48 * GIB);
-        assert!(super::fit_preload_message(&hw, 2 * GIB).is_none());
+        let fp = crate::fit::advisory_footprint(2 * GIB);
+        assert!(super::fit_preload_message(&hw, &fp, 2 * GIB).is_none());
     }
 
     #[test]
     fn preload_message_is_none_on_unprobed_host() {
         // Unknown verdict must never hard-block a load.
         let hw = host(false, 0, 0, 0);
-        assert!(super::fit_preload_message(&hw, 40 * GIB).is_none());
+        let fp = crate::fit::advisory_footprint(40 * GIB);
+        assert!(super::fit_preload_message(&hw, &fp, 40 * GIB).is_none());
+    }
+
+    #[test]
+    fn preload_message_fires_from_an_exact_dims_footprint() {
+        // 4 GB RAM host, no GPU: a 5 GB-weights model's EXACT footprint (weights + KV
+        // at the default context + scratch) exceeds the budget → typed message.
+        let hw = host(false, 0, 4 * GIB, 3 * GIB);
+        let dims = crate::fit::ModelDims {
+            layers: 32,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        let fp = crate::fit::exact_footprint(
+            5 * GIB,
+            dims,
+            crate::fit::ADVISORY_CONTEXT_TOKENS,
+            crate::fit::KvDtype::F32,
+        );
+        assert!(super::fit_preload_message(&hw, &fp, 5 * GIB).is_some());
     }
 
     #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3725,13 +3725,17 @@ fn fit_preload_message(
 /// 422 only on a `WontFit` verdict; `None` (proceed unchanged) on the
 /// `CAMELID_SKIP_FIT_CHECK=1` override, a missing/zero-size file, or any
 /// `Fits*`/`Unknown` verdict — a fail-fast convenience, never a new hard gate.
+/// Whether the load-time fit preflight is overridden off. `CAMELID_SKIP_FIT_CHECK=1`
+/// restores the pre-advisor behavior: `POST /api/models/load` attempts the load
+/// unconditionally, letting the authoritative `VramShortfall`/`KvCache` guards be
+/// the only gate. Exactly the trimmed value `"1"` enables the override; anything
+/// else (including unset) keeps the preflight on.
+fn fit_check_skipped(raw: Option<&str>) -> bool {
+    raw.map(str::trim) == Some("1")
+}
+
 fn fit_preload_guard(path: &std::path::Path) -> Option<Response> {
-    if std::env::var("CAMELID_SKIP_FIT_CHECK")
-        .ok()
-        .as_deref()
-        .map(str::trim)
-        == Some("1")
-    {
+    if fit_check_skipped(std::env::var("CAMELID_SKIP_FIT_CHECK").ok().as_deref()) {
         return None;
     }
     let size = std::fs::metadata(path).ok()?.len();
@@ -3767,7 +3771,16 @@ async fn load_model(State(state): State<AppState>, Json(req): Json<LoadModelRequ
     // Advisory fail-fast (fit axis, never a support claim): steer away from a
     // near-certain OOM before the expensive load. Overridable via
     // CAMELID_SKIP_FIT_CHECK=1; only fires on a WontFit verdict from a probed host.
-    if let Some(resp) = fit_preload_guard(&req.path) {
+    //
+    // The guard does blocking I/O (metadata + GGUF header read) and a live hardware
+    // probe (HardwareProfile::detect initializes a CUDA context on GPU hosts), so run
+    // it on a blocking thread rather than stalling the async worker — consistent with
+    // how the header fetches use spawn_blocking. A panic in the probe is non-fatal: we
+    // fall through to the load, where VramShortfall/KvCache remain the hard net.
+    let guard_path = req.path.clone();
+    if let Ok(Some(resp)) =
+        tokio::task::spawn_blocking(move || fit_preload_guard(&guard_path)).await
+    {
         return resp;
     }
     match load_model_from_path(&state, req.path, req.id).await {
@@ -16359,6 +16372,12 @@ async fn get_catalog(
 
     // Curated group: filter by query exactly as before, always emitted first.
     // The fit verdict is host-specific, so probe (cached) once and annotate each row.
+    //
+    // Deliberate: the badge uses the cached startup snapshot, while the load-time
+    // guard (`fit_preload_guard`) re-probes live. So after a model loads and consumes
+    // VRAM, a badge may still read "fits" while the guard now rejects with 422. The
+    // badge is a static capacity hint, not a live reservation; the guard is
+    // authoritative. Re-probing on every GET would re-init CUDA per request.
     let hw = crate::capability::HardwareProfile::cached();
     let curated: Vec<CatalogItemView> = curated_catalog()
         .iter()
@@ -16373,8 +16392,10 @@ async fn get_catalog(
         .map(|item| CatalogItemView::from_curated(item, hw))
         .collect();
 
-    // (Curated dims are warmed once at server startup via `fit_dims::start_background`,
-    // never as a side-effect of serving this page.)
+    // Serving this page is side-effect-free for the *curated* rows: their dims are
+    // warmed once at server startup via `fit_dims::start_background`, never here. The
+    // Hugging Face search branch below is not side-effect-free — it schedules a
+    // bounded, de-duplicated set of background header fetches (see HF_DIMS_WARM_LIMIT).
     let mut items = curated;
     let mut next_cursor = None;
 
@@ -16831,6 +16852,20 @@ mod catalog_fit_tests {
         // On a tiny host only small rows fit (or none) — must not panic either way.
         let tiny = host(false, 0, 4 * GIB, 3 * GIB);
         let _ = super::best_fitting_catalog_suggestion(&tiny);
+    }
+
+    #[test]
+    fn skip_fit_check_override_matches_only_the_exact_flag() {
+        // The override restores the pre-advisor load-attempt behavior. It must engage
+        // for exactly `1` (trimmed) and nothing else, so the preflight can't be turned
+        // off by an unrelated or malformed value.
+        assert!(super::fit_check_skipped(Some("1")));
+        assert!(super::fit_check_skipped(Some("  1  ")));
+        assert!(!super::fit_check_skipped(Some("0")));
+        assert!(!super::fit_check_skipped(Some("true")));
+        assert!(!super::fit_check_skipped(Some("11")));
+        assert!(!super::fit_check_skipped(Some("")));
+        assert!(!super::fit_check_skipped(None));
     }
 
     #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1556,6 +1556,17 @@ pub async fn serve(
     tracing::info!(%addr, "camelid server listening");
     let url = format!("http://{addr}");
 
+    // Warm the model-fit dimension cache in the background: header-only reads
+    // (never weights), disk-cached across restarts, de-duplicated, and globally
+    // rate-limited. This is why catalog fit badges can be *exact* without any
+    // per-request fetching. Best-effort; opt out with CAMELID_NO_REMOTE_DIMS=1.
+    crate::fit_dims::start_background(
+        curated_catalog()
+            .iter()
+            .map(|c| (c.repo_id.to_string(), c.filename.to_string(), c.size_bytes))
+            .collect(),
+    );
+
     // Warm the generation path BEFORE telling the user we're ready. The GPU resident
     // engine (NVRTC kernel compile + multi-GB weight upload + first prefill) is built
     // lazily on the first generation â€” a one-time cost of several seconds. If it lands
@@ -3707,210 +3718,6 @@ fn fit_preload_message(
     })
 }
 
-/// Read the KV-relevant dimensions from a GGUF's metadata WITHOUT loading weights
-/// (header-only, the same cheap path `/api/models/inspect` uses). `None` for a
-/// non-GGUF, an unreadable header, or a non-dense/unknown architecture — callers
-/// then fall back to the coarse size-based estimate.
-fn read_model_dims(path: &std::path::Path) -> Option<crate::fit::ModelDims> {
-    let gguf = crate::gguf::read_metadata(path).ok()?;
-    let config = crate::model::LlamaModelConfig::from_gguf(&gguf).ok()?;
-    let dims = crate::model::DenseLlamaDims::from_config(&config).ok()?;
-    let dims = crate::fit::ModelDims {
-        layers: dims.block_count as u64,
-        kv_heads: dims.attention_head_count_kv as u64,
-        head_dim: dims.head_dim as u64,
-    };
-    // Reject a mis-parsed header that yielded absurd dims rather than trust it.
-    dims.is_plausible().then_some(dims)
-}
-
-/// A GGUF filename that is one shard of a split export (e.g.
-/// `model.shard-00001-of-00005.gguf` or `model-00001-of-00003.gguf`) is not a
-/// standalone loadable model, so we make no fit claim for it.
-fn is_gguf_shard(filename: &str) -> bool {
-    let lower = filename.to_ascii_lowercase();
-    let Some(idx) = lower.find("-of-") else {
-        return false;
-    };
-    let left_is_num = lower[..idx]
-        .rsplit('-')
-        .next()
-        .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()));
-    let right_is_num = lower[idx + 4..]
-        .split(['-', '.'])
-        .next()
-        .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()));
-    left_is_num && right_is_num
-}
-
-/// A Hugging Face repo id / filename we will safely interpolate into a resolve
-/// URL: non-empty, no path traversal, only expected URL-path characters.
-fn is_safe_hf_component(s: &str) -> bool {
-    !s.is_empty()
-        && !s.contains("..")
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/'))
-}
-
-/// Fetch a model's KV dimensions from its GGUF **header only** over the network,
-/// without downloading the weights. GGUF stores all metadata + tensor-info at the
-/// start of the file, so we range-fetch a generous header slice, write it into a
-/// temp file whose *length* is set to the model's real size (the unfetched tail is
-/// sparse zeros that `read_metadata` never reads — it only validates tensor offsets
-/// against the length), then reuse the trusted on-disk parser. `None` on any
-/// network/parse failure so callers fall back to the coarse estimate. The result is
-/// meant to be cached (see [`cached_remote_dims`]).
-fn remote_model_dims(
-    repo_id: &str,
-    filename: &str,
-    full_size: u64,
-) -> Option<crate::fit::ModelDims> {
-    /// How much of the file head to fetch — comfortably covers metadata (incl. the
-    /// tokenizer arrays, largest for 128k-vocab Llama rows) + tensor-info for current
-    /// catalog models, while keeping the per-row cost small (never the weights). A
-    /// too-small fetch just fails to parse and the caller falls back to the estimate.
-    const HEADER_BYTES: u64 = 12 * 1024 * 1024;
-    // Skip files we shouldn't fetch: unknown size, split-model shards (not a
-    // standalone model), and any unsafe repo/filename we'd put into a URL.
-    if full_size == 0 || is_gguf_shard(filename) {
-        return None;
-    }
-    if !is_safe_hf_component(repo_id) || filename.contains('/') || !is_safe_hf_component(filename) {
-        return None;
-    }
-    let safe: String = filename
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
-    let tmp = std::env::temp_dir().join(format!("camelid-hdr-{}-{safe}", std::process::id()));
-    let range_end = HEADER_BYTES.min(full_size).saturating_sub(1);
-    let url = format!("https://huggingface.co/{repo_id}/resolve/main/{filename}");
-    let ok = std::process::Command::new("curl")
-        .args(["-fsSL", "-r", &format!("0-{range_end}"), "-o"])
-        .arg(&tmp)
-        .arg(&url)
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-    let dims = if ok {
-        // Extend the temp file to the real size so the parser's tensor-offset bounds
-        // checks pass; the tail is sparse zeros and is never read.
-        if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&tmp) {
-            let _ = f.set_len(full_size);
-        }
-        read_model_dims(&tmp)
-    } else {
-        None
-    };
-    let _ = std::fs::remove_file(&tmp);
-    dims
-}
-
-/// Process-wide cache of remote header dims, keyed by `repo/filename`. A stored
-/// `None` records a prior failed/unavailable fetch so we don't hammer the Hub.
-/// Successful entries are persisted to disk (see [`fit_dims_cache_path`]) so a
-/// server restart doesn't re-fetch every header.
-type RemoteDimsCache =
-    std::sync::Mutex<std::collections::HashMap<String, Option<crate::fit::ModelDims>>>;
-
-/// Where the on-disk dims cache lives. Honors `CAMELID_FIT_DIMS_CACHE` (tests use
-/// it for isolation); otherwise the per-user OS cache dir, else the temp dir.
-fn fit_dims_cache_path() -> std::path::PathBuf {
-    if let Some(p) = std::env::var_os("CAMELID_FIT_DIMS_CACHE") {
-        return std::path::PathBuf::from(p);
-    }
-    let base = if cfg!(windows) {
-        std::env::var_os("LOCALAPPDATA").map(std::path::PathBuf::from)
-    } else {
-        std::env::var_os("XDG_CACHE_HOME")
-            .map(std::path::PathBuf::from)
-            .or_else(|| {
-                std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".cache"))
-            })
-    };
-    base.unwrap_or_else(std::env::temp_dir)
-        .join("camelid")
-        .join("fit-dims-cache.json")
-}
-
-/// Read the persisted (successful) dims map from `path`. Missing or corrupt → empty.
-fn read_dims_cache_file(
-    path: &std::path::Path,
-) -> std::collections::HashMap<String, crate::fit::ModelDims> {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default()
-}
-
-/// Persist the successful dims map to `path` (best-effort; creates the parent dir).
-fn write_dims_cache_file(
-    path: &std::path::Path,
-    map: &std::collections::HashMap<String, crate::fit::ModelDims>,
-) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(json) = serde_json::to_string(map) {
-        let _ = std::fs::write(path, json);
-    }
-}
-
-fn remote_dims_cache() -> &'static RemoteDimsCache {
-    static CACHE: std::sync::OnceLock<RemoteDimsCache> = std::sync::OnceLock::new();
-    CACHE.get_or_init(|| {
-        // Seed from the on-disk cache so restarts reuse previously-read headers.
-        // Skipped under test to keep the global cache hermetic.
-        let mut map = std::collections::HashMap::new();
-        if !cfg!(test) {
-            for (k, v) in read_dims_cache_file(&fit_dims_cache_path()) {
-                map.insert(k, Some(v));
-            }
-        }
-        std::sync::Mutex::new(map)
-    })
-}
-
-fn remote_dims_key(repo_id: &str, filename: &str) -> String {
-    format!("{repo_id}/{filename}")
-}
-
-/// Cached dims lookup: `Some(entry)` when a fetch has been attempted (`entry` may be
-/// `None` = it failed), `None` when never attempted (so a warm can be scheduled).
-fn cached_remote_dims(repo_id: &str, filename: &str) -> Option<Option<crate::fit::ModelDims>> {
-    remote_dims_cache()
-        .lock()
-        .ok()?
-        .get(&remote_dims_key(repo_id, filename))
-        .copied()
-}
-
-fn store_remote_dims(repo_id: &str, filename: &str, dims: Option<crate::fit::ModelDims>) {
-    if let Ok(mut map) = remote_dims_cache().lock() {
-        map.insert(remote_dims_key(repo_id, filename), dims);
-        // Persist the successful subset so a restart doesn't re-fetch. Failures
-        // (`None`) stay memory-only so a transient error retries next run. Skipped
-        // under test to avoid touching the real user cache.
-        if dims.is_some() && !cfg!(test) {
-            let persist: std::collections::HashMap<String, crate::fit::ModelDims> = map
-                .iter()
-                .filter_map(|(k, v)| v.map(|d| (k.clone(), d)))
-                .collect();
-            write_dims_cache_file(&fit_dims_cache_path(), &persist);
-        }
-    }
-}
-
-/// True unless the operator opted out of the background header fetches that upgrade
-/// catalog fit badges from `approx` to `exact` (`CAMELID_NO_REMOTE_DIMS=1`).
-fn remote_dims_enabled() -> bool {
-    std::env::var("CAMELID_NO_REMOTE_DIMS")
-        .ok()
-        .as_deref()
-        .map(str::trim)
-        != Some("1")
-}
-
 /// Env + filesystem wrapper around [`fit_preload_message`]. Probes **live** host
 /// memory and computes an **exact** footprint from the GGUF's real dimensions
 /// (weights + KV at a normal-use context + a bounded scratch margin) whenever the
@@ -3935,7 +3742,7 @@ fn fit_preload_guard(path: &std::path::Path) -> Option<Response> {
     // apps run or a model is already loaded, and this decision must reflect *now*.
     let hw = crate::capability::HardwareProfile::detect();
     // Exact footprint from the GGUF's real dims when the header parses; else the pad.
-    let footprint = match read_model_dims(path) {
+    let footprint = match crate::fit_dims::dims_from_gguf_file(path) {
         Some(dims) => {
             // KV is stored f16 on the GPU-resident path, f32 on the CPU path.
             let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
@@ -15808,28 +15615,30 @@ pub struct CatalogItemView {
 }
 
 /// Footprint + confidence for a curated row: an **exact** footprint (weights + KV
-/// sized from the model's real GGUF dims) when those dims are cached, else the
-/// coarse size pad. Dims are warmed in the background by [`get_catalog`], so a row
-/// starts `approx` and upgrades to `exact` once its header has been read.
+/// sized from the model's real GGUF dims) when `dims` are known, else the coarse
+/// size pad. Pure: the caller supplies the resolved dims (from `fit_dims`), so this
+/// is unit-testable without the global resolver.
 fn curated_footprint(
-    item: &CatalogItem,
+    size_bytes: u64,
+    dims: Option<crate::fit::ModelDims>,
     hw: &crate::capability::HardwareProfile,
 ) -> (crate::fit::FitInputs, &'static str) {
-    if let Some(Some(dims)) = cached_remote_dims(item.repo_id, item.filename) {
-        let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
-            crate::fit::KvDtype::F16
-        } else {
-            crate::fit::KvDtype::F32
-        };
-        let fp = crate::fit::exact_footprint(
-            item.size_bytes,
-            dims,
-            crate::fit::ADVISORY_CONTEXT_TOKENS,
-            kv_dtype,
-        );
-        (fp, "exact")
-    } else {
-        (crate::fit::advisory_footprint(item.size_bytes), "approx")
+    match dims {
+        Some(dims) => {
+            let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
+                crate::fit::KvDtype::F16
+            } else {
+                crate::fit::KvDtype::F32
+            };
+            let fp = crate::fit::exact_footprint(
+                size_bytes,
+                dims,
+                crate::fit::ADVISORY_CONTEXT_TOKENS,
+                kv_dtype,
+            );
+            (fp, "exact")
+        }
+        None => (crate::fit::advisory_footprint(size_bytes), "approx"),
     }
 }
 
@@ -15837,7 +15646,11 @@ impl CatalogItemView {
     /// Build a view for a curated row: authoritative architecture, lane predicted
     /// from the real `(architecture, quant)` via `runnable::oracle_qualified`.
     fn from_curated(item: &CatalogItem, hw: &crate::capability::HardwareProfile) -> Self {
-        let (footprint, fit_confidence) = curated_footprint(item, hw);
+        let (footprint, fit_confidence) = curated_footprint(
+            item.size_bytes,
+            crate::fit_dims::global().lookup(item.repo_id, item.filename),
+            hw,
+        );
         CatalogItemView {
             catalog_id: item.catalog_id.to_string(),
             name: item.name.to_string(),
@@ -15869,23 +15682,24 @@ impl CatalogItemView {
         hw: &crate::capability::HardwareProfile,
     ) -> Self {
         let catalog_id = format!("hf::{}::{}", file.repo_id, file.filename);
-        let (fit, fit_confidence) = match cached_remote_dims(&file.repo_id, &file.filename) {
-            Some(Some(dims)) => {
-                let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
-                    crate::fit::KvDtype::F16
-                } else {
-                    crate::fit::KvDtype::F32
-                };
-                let fp = crate::fit::exact_footprint(
-                    file.size_bytes,
-                    dims,
-                    crate::fit::ADVISORY_CONTEXT_TOKENS,
-                    kv_dtype,
-                );
-                (crate::fit::assess(hw, &fp), "exact")
-            }
-            _ => (crate::fit::FitVerdict::Unknown, "approx"),
-        };
+        let (fit, fit_confidence) =
+            match crate::fit_dims::global().lookup(&file.repo_id, &file.filename) {
+                Some(dims) => {
+                    let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
+                        crate::fit::KvDtype::F16
+                    } else {
+                        crate::fit::KvDtype::F32
+                    };
+                    let fp = crate::fit::exact_footprint(
+                        file.size_bytes,
+                        dims,
+                        crate::fit::ADVISORY_CONTEXT_TOKENS,
+                        kv_dtype,
+                    );
+                    (crate::fit::assess(hw, &fp), "exact")
+                }
+                None => (crate::fit::FitVerdict::Unknown, "unknown"),
+            };
         CatalogItemView {
             catalog_id,
             name: file.filename.clone(),
@@ -16559,25 +16373,8 @@ async fn get_catalog(
         .map(|item| CatalogItemView::from_curated(item, hw))
         .collect();
 
-    // Warm the remote-dims cache in the background so later catalog renders upgrade
-    // these rows from `approx` to `exact` (header-only fetch — no weights). Never
-    // blocks this response; a failed fetch caches as `None` to avoid re-hammering.
-    if remote_dims_enabled() {
-        for item in curated_catalog() {
-            if cached_remote_dims(item.repo_id, item.filename).is_none() {
-                let (repo, file, size) = (
-                    item.repo_id.to_string(),
-                    item.filename.to_string(),
-                    item.size_bytes,
-                );
-                tokio::task::spawn_blocking(move || {
-                    let dims = remote_model_dims(&repo, &file, size);
-                    store_remote_dims(&repo, &file, dims);
-                });
-            }
-        }
-    }
-
+    // (Curated dims are warmed once at server startup via `fit_dims::start_background`,
+    // never as a side-effect of serving this page.)
     let mut items = curated;
     let mut next_cursor = None;
 
@@ -16592,31 +16389,25 @@ async fn get_catalog(
                     .iter()
                     .map(|c| (c.repo_id.to_string(), c.filename.to_string()))
                     .collect();
-                // Warm dims for the experimental page too so a random Hugging Face
-                // model shows an honest capacity fit on the next render — header-only,
-                // never blocking, cached, opt-out via env. **Bounded** to the top few
-                // rows: a query can return 100+ files, and warming all of them would
-                // fan out into a huge fetch storm.
-                if remote_dims_enabled() {
-                    const HF_DIMS_WARM_LIMIT: usize = 5;
-                    let mut warmed = 0usize;
-                    for f in &page.files {
-                        if warmed >= HF_DIMS_WARM_LIMIT {
-                            break;
-                        }
-                        let key = (f.repo_id.clone(), f.filename.clone());
-                        if curated_files.contains(&key)
-                            || cached_remote_dims(&f.repo_id, &f.filename).is_some()
-                        {
-                            continue;
-                        }
-                        warmed += 1;
-                        let (repo, file, size) = (key.0, key.1, f.size_bytes);
-                        tokio::task::spawn_blocking(move || {
-                            let dims = remote_model_dims(&repo, &file, size);
-                            store_remote_dims(&repo, &file, dims);
-                        });
+                // Schedule header-dim fetches for the top experimental results so a
+                // random Hugging Face model shows an honest fit on the next render.
+                // The resolver de-dupes and globally rate-limits; we still cap the
+                // per-query scheduling so one search can't enqueue 100+ models.
+                const HF_DIMS_WARM_LIMIT: usize = 5;
+                let mut scheduled = 0usize;
+                for f in &page.files {
+                    if scheduled >= HF_DIMS_WARM_LIMIT {
+                        break;
                     }
+                    if curated_files.contains(&(f.repo_id.clone(), f.filename.clone())) {
+                        continue;
+                    }
+                    crate::fit_dims::global().schedule(
+                        f.repo_id.clone(),
+                        f.filename.clone(),
+                        f.size_bytes,
+                    );
+                    scheduled += 1;
                 }
                 items.extend(
                     page.files
@@ -16925,7 +16716,7 @@ mod catalog_fit_tests {
         assert_eq!(view.fit, FitVerdict::Unknown);
         assert!(view.task_tags.is_empty());
         assert_eq!(view.group, "experimental");
-        assert_eq!(view.fit_confidence, "approx");
+        assert_eq!(view.fit_confidence, "unknown");
     }
 
     #[test]
@@ -16939,7 +16730,7 @@ mod catalog_fit_tests {
             kv_heads: 8,
             head_dim: 128,
         };
-        super::store_remote_dims(repo, filename, Some(dims));
+        crate::fit_dims::global().insert_for_test(repo, filename, dims);
         let file = crate::hf_browse::HfGgufFile {
             repo_id: repo.to_string(),
             filename: filename.to_string(),
@@ -17033,38 +16824,6 @@ mod catalog_fit_tests {
     }
 
     #[test]
-    fn remote_model_dims_reads_a_real_gguf_header_when_enabled() {
-        // Network-gated: self-skips offline / in normal CI. Enable with
-        // CAMELID_TEST_REMOTE_DIMS=1 to verify the header range-fetch end to end.
-        if std::env::var("CAMELID_TEST_REMOTE_DIMS").ok().as_deref() != Some("1") {
-            return;
-        }
-        // Qwen3-0.6B is the smallest curated model (~639 MB); fetch its header only.
-        let dims =
-            super::remote_model_dims("Qwen/Qwen3-0.6B-GGUF", "Qwen3-0.6B-Q8_0.gguf", 639_446_688)
-                .expect("remote header dims should parse from a real GGUF");
-        assert!(
-            dims.layers >= 1 && dims.layers <= 64,
-            "layers={}",
-            dims.layers
-        );
-        assert!(dims.kv_heads >= 1, "kv_heads={}", dims.kv_heads);
-        assert!(dims.head_dim >= 1, "head_dim={}", dims.head_dim);
-        eprintln!("Qwen3-0.6B header dims: {dims:?}");
-
-        // Also a 128k-vocab Llama row (biggest metadata) to confirm HEADER_BYTES is
-        // large enough for the worst case; otherwise it would fall back to the pad.
-        let llama = super::remote_model_dims(
-            "unsloth/Llama-3.2-1B-Instruct-GGUF",
-            "Llama-3.2-1B-Instruct-Q8_0.gguf",
-            1_321_082_528,
-        )
-        .expect("Llama 3.2 1B header dims should parse within HEADER_BYTES");
-        assert!(llama.layers >= 1 && llama.kv_heads >= 1 && llama.head_dim >= 1);
-        eprintln!("Llama-3.2-1B header dims: {llama:?}");
-    }
-
-    #[test]
     fn best_fitting_suggestion_picks_something_on_a_big_host_and_never_panics_on_tiny() {
         let big = host(false, 0, 64 * GIB, 48 * GIB);
         let s = super::best_fitting_catalog_suggestion(&big).expect("a row fits a 64 GB host");
@@ -17074,110 +16833,29 @@ mod catalog_fit_tests {
         let _ = super::best_fitting_catalog_suggestion(&tiny);
     }
 
-    fn fake_item(repo: &'static str, filename: &'static str) -> CatalogItem {
-        CatalogItem {
-            catalog_id: "test_row",
-            name: "Test Row",
-            repo_id: repo,
-            filename,
-            size_bytes: 8_000_000_000,
-            downloads: 0,
-            likes: 0,
-            quant: "Q8_0",
-            architecture: "llama",
-            license: "test",
-            task_tags: &["general"],
-        }
-    }
-
     #[test]
-    fn remote_dims_cache_round_trips() {
-        let (repo, file) = ("test/round-trip-repo", "round-trip.gguf");
-        assert!(super::cached_remote_dims(repo, file).is_none());
-        let dims = crate::fit::ModelDims {
-            layers: 28,
-            kv_heads: 8,
-            head_dim: 128,
-        };
-        super::store_remote_dims(repo, file, Some(dims));
-        assert_eq!(super::cached_remote_dims(repo, file), Some(Some(dims)));
-        // A failed fetch caches as None so we don't re-hammer the Hub.
-        super::store_remote_dims(repo, file, None);
-        assert_eq!(super::cached_remote_dims(repo, file), Some(None));
-    }
-
-    #[test]
-    fn curated_footprint_is_exact_when_dims_cached_else_approx() {
+    fn curated_footprint_is_exact_when_dims_known_else_approx() {
         let hw = host(false, 0, 64 * GIB, 48 * GIB);
-        // approx: dims not cached → coarse size pad.
-        let approx_item = fake_item("test/uncached-repo", "uncached.gguf");
-        let (fp_approx, conf) = super::curated_footprint(&approx_item, &hw);
+        let size = 8_000_000_000u64;
+        // approx: no dims → coarse size pad.
+        let (fp_approx, conf) = super::curated_footprint(size, None, &hw);
         assert_eq!(conf, "approx");
-        assert_eq!(
-            fp_approx,
-            crate::fit::advisory_footprint(approx_item.size_bytes)
-        );
-        // exact: cache real dims → confidence flips and the KV is sized precisely.
-        let exact_item = fake_item("test/cached-repo", "cached.gguf");
+        assert_eq!(fp_approx, crate::fit::advisory_footprint(size));
+        // exact: real dims → precise KV cache sizing.
         let dims = crate::fit::ModelDims {
             layers: 32,
             kv_heads: 8,
             head_dim: 128,
         };
-        super::store_remote_dims("test/cached-repo", "cached.gguf", Some(dims));
-        let (fp_exact, conf) = super::curated_footprint(&exact_item, &hw);
+        let (fp_exact, conf) = super::curated_footprint(size, Some(dims), &hw);
         assert_eq!(conf, "exact");
         let expected = crate::fit::exact_footprint(
-            exact_item.size_bytes,
+            size,
             dims,
             crate::fit::ADVISORY_CONTEXT_TOKENS,
             crate::fit::KvDtype::F32, // CPU host
         );
         assert_eq!(fp_exact, expected);
-    }
-
-    #[test]
-    fn shard_filenames_are_detected() {
-        assert!(super::is_gguf_shard("model.shard-00001-of-00005.gguf"));
-        assert!(super::is_gguf_shard("Meta-Llama-70B-00001-of-00003.gguf"));
-        assert!(!super::is_gguf_shard("Qwen3-0.6B-Q8_0.gguf"));
-        assert!(!super::is_gguf_shard("Llama-3.2-1B-Instruct-Q8_0.gguf"));
-        assert!(!super::is_gguf_shard("something-of-value.gguf")); // "-of-" but not numeric
-    }
-
-    #[test]
-    fn unsafe_hf_components_are_rejected() {
-        assert!(super::is_safe_hf_component("Qwen/Qwen3-0.6B-GGUF"));
-        assert!(super::is_safe_hf_component("Model-Q8_0.gguf"));
-        assert!(!super::is_safe_hf_component("")); // empty
-        assert!(!super::is_safe_hf_component("../../etc/passwd")); // traversal
-        assert!(!super::is_safe_hf_component("repo/../x")); // traversal
-        assert!(!super::is_safe_hf_component("bad name.gguf?x=1")); // space + query char
-    }
-
-    #[test]
-    fn dims_cache_file_round_trips_and_tolerates_missing_corrupt() {
-        let dir =
-            std::env::temp_dir().join(format!("camelid-fit-cache-test-{}", std::process::id()));
-        let path = dir.join("dims.json");
-        // Missing file → empty (no panic).
-        assert!(super::read_dims_cache_file(&path).is_empty());
-        // Write then read back.
-        let mut map = std::collections::HashMap::new();
-        map.insert(
-            "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf".to_string(),
-            crate::fit::ModelDims {
-                layers: 28,
-                kv_heads: 8,
-                head_dim: 128,
-            },
-        );
-        super::write_dims_cache_file(&path, &map);
-        assert_eq!(super::read_dims_cache_file(&path), map);
-        // Corrupt content → empty (no panic).
-        std::fs::write(&path, b"{ not json").unwrap();
-        assert!(super::read_dims_cache_file(&path).is_empty());
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15465,6 +15465,9 @@ pub struct CatalogItem {
     /// inferred from the filename). Drives the catalog's predicted lane.
     pub architecture: &'static str,
     pub license: &'static str,
+    /// Advisory "best for" positioning for the Models tab (curated, not
+    /// benchmarked). Constrained to: `general`, `reasoning`, `coding`, `tools`.
+    pub task_tags: &'static [&'static str],
 }
 
 /// A catalog item plus its predicted runnable lane, so the Models tab can show which
@@ -15497,12 +15500,19 @@ pub struct CatalogItemView {
     pub group: &'static str,
     /// Whether `architecture` is authoritative (curated) vs a filename guess (live).
     pub arch_detected: bool,
+    /// Capacity advisory: whether THIS host can load/run the row (fit axis only —
+    /// never a support/parity claim). `Unknown` for experimental rows and for hosts
+    /// whose memory cannot be probed.
+    pub fit: crate::fit::FitVerdict,
+    /// Advisory "best for" positioning (e.g. `general`, `reasoning`, `coding`,
+    /// `tools`) — curated, not benchmarked. Empty for experimental rows.
+    pub task_tags: Vec<String>,
 }
 
 impl CatalogItemView {
     /// Build a view for a curated row: authoritative architecture, lane predicted
     /// from the real `(architecture, quant)` via `runnable::oracle_qualified`.
-    fn from_curated(item: &CatalogItem) -> Self {
+    fn from_curated(item: &CatalogItem, hw: &crate::capability::HardwareProfile) -> Self {
         CatalogItemView {
             catalog_id: item.catalog_id.to_string(),
             name: item.name.to_string(),
@@ -15517,6 +15527,8 @@ impl CatalogItemView {
             oracle_qualified: crate::runnable::oracle_qualified(item.architecture, item.quant),
             group: "curated",
             arch_detected: true,
+            fit: crate::fit::assess(hw, &crate::fit::advisory_footprint(item.size_bytes)),
+            task_tags: item.task_tags.iter().map(|t| t.to_string()).collect(),
         }
     }
 
@@ -15539,6 +15551,9 @@ impl CatalogItemView {
             oracle_qualified: false,
             group: "experimental",
             arch_detected: false,
+            // Experimental (filename-guess) rows never carry a fit or task claim.
+            fit: crate::fit::FitVerdict::Unknown,
+            task_tags: Vec::new(),
         }
     }
 }
@@ -15556,6 +15571,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "llama",
             license: "llama3.2",
+            task_tags: &["general", "tools"],
         },
         CatalogItem {
             catalog_id: "llama32_3b_instruct_q8_0",
@@ -15568,6 +15584,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "llama",
             license: "llama3.2",
+            task_tags: &["general", "tools"],
         },
         CatalogItem {
             catalog_id: "tinyllama_1_1b_chat_q8_0",
@@ -15582,6 +15599,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "llama",
             license: "other",
+            task_tags: &["general"],
         },
         CatalogItem {
             catalog_id: "llama3_8b_instruct_q8_0",
@@ -15594,6 +15612,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "llama",
             license: "llama3",
+            task_tags: &["general", "reasoning"],
         },
         CatalogItem {
             catalog_id: "mistral_7b_instruct_v0_3_q8_0",
@@ -15606,6 +15625,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "llama",
             license: "apache-2.0",
+            task_tags: &["general", "coding"],
         },
         CatalogItem {
             catalog_id: "qwen3_0_6b_instruct_q8_0",
@@ -15618,6 +15638,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "qwen3",
             license: "apache-2.0",
+            task_tags: &["general"],
         },
         CatalogItem {
             catalog_id: "qwen3_1_7b_instruct_q8_0",
@@ -15630,6 +15651,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "qwen3",
             license: "apache-2.0",
+            task_tags: &["general", "reasoning"],
         },
         CatalogItem {
             catalog_id: "qwen3_4b_instruct_q8_0",
@@ -15642,6 +15664,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "qwen3",
             license: "apache-2.0",
+            task_tags: &["reasoning", "coding"],
         },
         CatalogItem {
             catalog_id: "qwen3_8b_instruct_q8_0",
@@ -15654,6 +15677,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "qwen3",
             license: "apache-2.0",
+            task_tags: &["reasoning", "coding"],
         },
         CatalogItem {
             catalog_id: "gemma4_e4b_it_q8_0",
@@ -15666,6 +15690,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "gemma4",
             license: "gemma",
+            task_tags: &["general"],
         },
         CatalogItem {
             catalog_id: "gemma4_e2b_it_q8_0",
@@ -15678,6 +15703,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "gemma4",
             license: "gemma",
+            task_tags: &["general"],
         },
         CatalogItem {
             catalog_id: "gemma4_12b_it_q8_0",
@@ -15690,6 +15716,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "gemma4",
             license: "gemma",
+            task_tags: &["general", "reasoning"],
         },
         CatalogItem {
             catalog_id: "gemma4_26b_a4b_it_q4_0",
@@ -15702,6 +15729,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q4_0",
             architecture: "gemma4",
             license: "gemma",
+            task_tags: &["reasoning"],
         },
         CatalogItem {
             catalog_id: "gemma3_1b_it_q8_0",
@@ -15714,6 +15742,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "gemma3",
             license: "gemma",
+            task_tags: &["general"],
         },
         CatalogItem {
             catalog_id: "phi3_mini_4k_instruct_q8_0",
@@ -15726,6 +15755,7 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             quant: "Q8_0",
             architecture: "phi3",
             license: "mit",
+            task_tags: &["reasoning", "coding"],
         },
     ]
 }
@@ -16165,6 +16195,8 @@ async fn get_catalog(
     let trimmed = query.trim();
 
     // Curated group: filter by query exactly as before, always emitted first.
+    // The fit verdict is host-specific, so probe (cached) once and annotate each row.
+    let hw = crate::capability::HardwareProfile::cached();
     let curated: Vec<CatalogItemView> = curated_catalog()
         .iter()
         .filter(|item| {
@@ -16175,7 +16207,7 @@ async fn get_catalog(
                     || item.filename.to_lowercase().contains(&qs)
             }
         })
-        .map(CatalogItemView::from_curated)
+        .map(|item| CatalogItemView::from_curated(item, hw))
         .collect();
 
     let mut items = curated;
@@ -16428,6 +16460,108 @@ async fn cancel_catalog_download(Json(req): Json<CancelDownloadRequest>) -> Resp
         (StatusCode::OK, "Download canceled").into_response()
     } else {
         (StatusCode::NOT_FOUND, "Download not found").into_response()
+    }
+}
+
+#[cfg(test)]
+mod catalog_fit_tests {
+    use super::{curated_catalog, CatalogItem, CatalogItemView};
+    use crate::capability::{HardwareProfile, SimdCaps};
+    use crate::fit::FitVerdict;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    fn host(cuda: bool, vram_free: u64, ram_total: u64, ram_free: u64) -> HardwareProfile {
+        HardwareProfile {
+            cuda_available: cuda,
+            cuda_device_count: if cuda { 1 } else { 0 },
+            cuda_device_name: None,
+            cuda_compute_capability: None,
+            cuda_tensor_cores: false,
+            cuda_vram_total_bytes: vram_free,
+            cuda_vram_free_bytes: vram_free,
+            cpu_logical_cores: 8,
+            host_ram_total_bytes: ram_total,
+            host_ram_free_bytes: ram_free,
+            simd: SimdCaps::default(),
+        }
+    }
+
+    fn row(id: &str) -> CatalogItem {
+        curated_catalog()
+            .into_iter()
+            .find(|c| c.catalog_id == id)
+            .expect("known catalog row")
+    }
+
+    #[test]
+    fn curated_view_carries_task_tags_and_a_verdict() {
+        let hw = host(false, 0, 64 * GIB, 48 * GIB);
+        let item = row("tinyllama_1_1b_chat_q8_0");
+        let view = CatalogItemView::from_curated(&item, &hw);
+        assert_eq!(view.task_tags, vec!["general".to_string()]);
+        // ~1.1 GB model on a 64 GB CPU host → comfortably CPU-only.
+        assert_eq!(view.fit, FitVerdict::CpuOnlyOk);
+    }
+
+    #[test]
+    fn curated_huge_model_wont_fit_tiny_cpu_host() {
+        // 8 GB total RAM, no GPU → budget ~ max(80% of 5=4, 25% of 8=2)=4 GB;
+        // the ~8.5 GB Llama-3 8B (+overhead) cannot fit.
+        let hw = host(false, 0, 8 * GIB, 5 * GIB);
+        let item = row("llama3_8b_instruct_q8_0");
+        let view = CatalogItemView::from_curated(&item, &hw);
+        assert_eq!(view.fit, FitVerdict::WontFit);
+    }
+
+    #[test]
+    fn experimental_from_hf_is_unknown_and_untagged() {
+        let file = crate::hf_browse::HfGgufFile {
+            repo_id: "someone/Some-Model-GGUF".to_string(),
+            filename: "Some-Model-Q4_K_M.gguf".to_string(),
+            size_bytes: 2 * GIB,
+            downloads: 10,
+            likes: 1,
+            architecture: "llama".to_string(),
+            quant: "Q4_K_M".to_string(),
+        };
+        let view = CatalogItemView::from_hf(file);
+        assert_eq!(view.fit, FitVerdict::Unknown);
+        assert!(view.task_tags.is_empty());
+        assert_eq!(view.group, "experimental");
+    }
+
+    #[test]
+    fn unknown_host_never_reports_wont_fit_for_any_curated_row() {
+        // macOS-style: RAM unprobed (0) and no CUDA → advisory-blind, never WontFit.
+        let hw = host(false, 0, 0, 0);
+        for item in curated_catalog() {
+            let view = CatalogItemView::from_curated(&item, &hw);
+            assert_eq!(
+                view.fit,
+                FitVerdict::Unknown,
+                "row {} must be Unknown on an unprobed host",
+                view.catalog_id
+            );
+        }
+    }
+
+    #[test]
+    fn every_curated_row_is_tagged_within_the_allowed_set() {
+        for item in curated_catalog() {
+            assert!(
+                !item.task_tags.is_empty(),
+                "curated row {} must carry at least one task tag",
+                item.catalog_id
+            );
+            for tag in item.task_tags {
+                assert!(
+                    matches!(*tag, "general" | "reasoning" | "coding" | "tools"),
+                    "row {} has unexpected task tag {tag}",
+                    item.catalog_id
+                );
+            }
+        }
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3715,11 +3715,41 @@ fn read_model_dims(path: &std::path::Path) -> Option<crate::fit::ModelDims> {
     let gguf = crate::gguf::read_metadata(path).ok()?;
     let config = crate::model::LlamaModelConfig::from_gguf(&gguf).ok()?;
     let dims = crate::model::DenseLlamaDims::from_config(&config).ok()?;
-    Some(crate::fit::ModelDims {
+    let dims = crate::fit::ModelDims {
         layers: dims.block_count as u64,
         kv_heads: dims.attention_head_count_kv as u64,
         head_dim: dims.head_dim as u64,
-    })
+    };
+    // Reject a mis-parsed header that yielded absurd dims rather than trust it.
+    dims.is_plausible().then_some(dims)
+}
+
+/// A GGUF filename that is one shard of a split export (e.g.
+/// `model.shard-00001-of-00005.gguf` or `model-00001-of-00003.gguf`) is not a
+/// standalone loadable model, so we make no fit claim for it.
+fn is_gguf_shard(filename: &str) -> bool {
+    let lower = filename.to_ascii_lowercase();
+    let Some(idx) = lower.find("-of-") else {
+        return false;
+    };
+    let left_is_num = lower[..idx]
+        .rsplit('-')
+        .next()
+        .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()));
+    let right_is_num = lower[idx + 4..]
+        .split(['-', '.'])
+        .next()
+        .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()));
+    left_is_num && right_is_num
+}
+
+/// A Hugging Face repo id / filename we will safely interpolate into a resolve
+/// URL: non-empty, no path traversal, only expected URL-path characters.
+fn is_safe_hf_component(s: &str) -> bool {
+    !s.is_empty()
+        && !s.contains("..")
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/'))
 }
 
 /// Fetch a model's KV dimensions from its GGUF **header only** over the network,
@@ -3740,7 +3770,12 @@ fn remote_model_dims(
     /// catalog models, while keeping the per-row cost small (never the weights). A
     /// too-small fetch just fails to parse and the caller falls back to the estimate.
     const HEADER_BYTES: u64 = 12 * 1024 * 1024;
-    if full_size == 0 {
+    // Skip files we shouldn't fetch: unknown size, split-model shards (not a
+    // standalone model), and any unsafe repo/filename we'd put into a URL.
+    if full_size == 0 || is_gguf_shard(filename) {
+        return None;
+    }
+    if !is_safe_hf_component(repo_id) || filename.contains('/') || !is_safe_hf_component(filename) {
         return None;
     }
     let safe: String = filename
@@ -3773,12 +3808,67 @@ fn remote_model_dims(
 
 /// Process-wide cache of remote header dims, keyed by `repo/filename`. A stored
 /// `None` records a prior failed/unavailable fetch so we don't hammer the Hub.
+/// Successful entries are persisted to disk (see [`fit_dims_cache_path`]) so a
+/// server restart doesn't re-fetch every header.
 type RemoteDimsCache =
     std::sync::Mutex<std::collections::HashMap<String, Option<crate::fit::ModelDims>>>;
 
+/// Where the on-disk dims cache lives. Honors `CAMELID_FIT_DIMS_CACHE` (tests use
+/// it for isolation); otherwise the per-user OS cache dir, else the temp dir.
+fn fit_dims_cache_path() -> std::path::PathBuf {
+    if let Some(p) = std::env::var_os("CAMELID_FIT_DIMS_CACHE") {
+        return std::path::PathBuf::from(p);
+    }
+    let base = if cfg!(windows) {
+        std::env::var_os("LOCALAPPDATA").map(std::path::PathBuf::from)
+    } else {
+        std::env::var_os("XDG_CACHE_HOME")
+            .map(std::path::PathBuf::from)
+            .or_else(|| {
+                std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".cache"))
+            })
+    };
+    base.unwrap_or_else(std::env::temp_dir)
+        .join("camelid")
+        .join("fit-dims-cache.json")
+}
+
+/// Read the persisted (successful) dims map from `path`. Missing or corrupt → empty.
+fn read_dims_cache_file(
+    path: &std::path::Path,
+) -> std::collections::HashMap<String, crate::fit::ModelDims> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Persist the successful dims map to `path` (best-effort; creates the parent dir).
+fn write_dims_cache_file(
+    path: &std::path::Path,
+    map: &std::collections::HashMap<String, crate::fit::ModelDims>,
+) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string(map) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
 fn remote_dims_cache() -> &'static RemoteDimsCache {
     static CACHE: std::sync::OnceLock<RemoteDimsCache> = std::sync::OnceLock::new();
-    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+    CACHE.get_or_init(|| {
+        // Seed from the on-disk cache so restarts reuse previously-read headers.
+        // Skipped under test to keep the global cache hermetic.
+        let mut map = std::collections::HashMap::new();
+        if !cfg!(test) {
+            for (k, v) in read_dims_cache_file(&fit_dims_cache_path()) {
+                map.insert(k, Some(v));
+            }
+        }
+        std::sync::Mutex::new(map)
+    })
 }
 
 fn remote_dims_key(repo_id: &str, filename: &str) -> String {
@@ -3798,6 +3888,16 @@ fn cached_remote_dims(repo_id: &str, filename: &str) -> Option<Option<crate::fit
 fn store_remote_dims(repo_id: &str, filename: &str, dims: Option<crate::fit::ModelDims>) {
     if let Ok(mut map) = remote_dims_cache().lock() {
         map.insert(remote_dims_key(repo_id, filename), dims);
+        // Persist the successful subset so a restart doesn't re-fetch. Failures
+        // (`None`) stay memory-only so a transient error retries next run. Skipped
+        // under test to avoid touching the real user cache.
+        if dims.is_some() && !cfg!(test) {
+            let persist: std::collections::HashMap<String, crate::fit::ModelDims> = map
+                .iter()
+                .filter_map(|(k, v)| v.map(|d| (k.clone(), d)))
+                .collect();
+            write_dims_cache_file(&fit_dims_cache_path(), &persist);
+        }
     }
 }
 
@@ -17034,6 +17134,50 @@ mod catalog_fit_tests {
             crate::fit::KvDtype::F32, // CPU host
         );
         assert_eq!(fp_exact, expected);
+    }
+
+    #[test]
+    fn shard_filenames_are_detected() {
+        assert!(super::is_gguf_shard("model.shard-00001-of-00005.gguf"));
+        assert!(super::is_gguf_shard("Meta-Llama-70B-00001-of-00003.gguf"));
+        assert!(!super::is_gguf_shard("Qwen3-0.6B-Q8_0.gguf"));
+        assert!(!super::is_gguf_shard("Llama-3.2-1B-Instruct-Q8_0.gguf"));
+        assert!(!super::is_gguf_shard("something-of-value.gguf")); // "-of-" but not numeric
+    }
+
+    #[test]
+    fn unsafe_hf_components_are_rejected() {
+        assert!(super::is_safe_hf_component("Qwen/Qwen3-0.6B-GGUF"));
+        assert!(super::is_safe_hf_component("Model-Q8_0.gguf"));
+        assert!(!super::is_safe_hf_component("")); // empty
+        assert!(!super::is_safe_hf_component("../../etc/passwd")); // traversal
+        assert!(!super::is_safe_hf_component("repo/../x")); // traversal
+        assert!(!super::is_safe_hf_component("bad name.gguf?x=1")); // space + query char
+    }
+
+    #[test]
+    fn dims_cache_file_round_trips_and_tolerates_missing_corrupt() {
+        let dir =
+            std::env::temp_dir().join(format!("camelid-fit-cache-test-{}", std::process::id()));
+        let path = dir.join("dims.json");
+        // Missing file → empty (no panic).
+        assert!(super::read_dims_cache_file(&path).is_empty());
+        // Write then read back.
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf".to_string(),
+            crate::fit::ModelDims {
+                layers: 28,
+                kv_heads: 8,
+                head_dim: 128,
+            },
+        );
+        super::write_dims_cache_file(&path, &map);
+        assert_eq!(super::read_dims_cache_file(&path), map);
+        // Corrupt content → empty (no panic).
+        std::fs::write(&path, b"{ not json").unwrap();
+        assert!(super::read_dims_cache_file(&path).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }
 

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -94,6 +94,15 @@ impl HardwareProfile {
         }
     }
 
+    /// Process-wide cached probe. The first call probes the machine (opening a
+    /// CUDA context once); every later call reuses the same snapshot. Use this on
+    /// non-hot paths (e.g. the catalog handler) that want the profile without
+    /// re-probing the device on every request.
+    pub fn cached() -> &'static HardwareProfile {
+        static CACHED: std::sync::OnceLock<HardwareProfile> = std::sync::OnceLock::new();
+        CACHED.get_or_init(HardwareProfile::detect)
+    }
+
     /// Emit the detected profile to stderr, in the same `[hw]` voice as the other
     /// startup diagnostics. This is the line every tunable is justified against.
     pub fn log(&self) {

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -182,13 +182,21 @@ fn download(item: &CatalogItem, models_dir: &Path) -> anyhow::Result<PathBuf> {
 
 fn print_catalog(entries: &[CatalogItem]) {
     eprintln!("Supported models (download into ./models):\n");
-    eprintln!("  {:<28} {:<8} {:>8}  NAME", "ID", "QUANT", "SIZE");
+    // Annotate each row with a capacity verdict for THIS host (fit axis only — not
+    // a support claim). Probed once, reused across rows.
+    let hw = crate::capability::HardwareProfile::cached();
+    eprintln!(
+        "  {:<28} {:<8} {:>8}  {:<15} NAME",
+        "ID", "QUANT", "SIZE", "FIT (this host)"
+    );
     for item in entries {
+        let verdict = crate::fit::assess(hw, &crate::fit::advisory_footprint(item.size_bytes));
         eprintln!(
-            "  {:<28} {:<8} {:>6.1} GB  {}",
+            "  {:<28} {:<8} {:>6.1} GB  {:<15} {}",
             item.catalog_id,
             item.quant,
             item.size_bytes as f64 / 1e9,
+            verdict.cli_label(),
             item.name,
         );
     }

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -77,6 +77,18 @@ impl FitVerdict {
             FitVerdict::FitsResident | FitVerdict::FitsWithOffload | FitVerdict::CpuOnlyOk
         )
     }
+
+    /// Short human label for a CLI column or terse log. UI surfaces (WebUI) author
+    /// their own copy; this is the terminal-facing wording.
+    pub fn cli_label(self) -> &'static str {
+        match self {
+            FitVerdict::FitsResident => "fits",
+            FitVerdict::FitsWithOffload => "fits (offload)",
+            FitVerdict::CpuOnlyOk => "fits (CPU)",
+            FitVerdict::WontFit => "too big",
+            FitVerdict::Unknown => "unknown",
+        }
+    }
 }
 
 /// The footprint of a model to assess, in bytes.

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -167,6 +167,29 @@ pub fn assess(hw: &HardwareProfile, m: &FitInputs) -> FitVerdict {
     assess_with_headroom(hw, m, crate::cuda_vram::min_headroom_mib())
 }
 
+/// Advisory allowance, as a percent of weight bytes, for everything resident
+/// beyond the weights at a modest default context: the KV cache, activations, and
+/// scratch. This is a deliberately coarse, deliberately *conservative* (slightly
+/// over-estimating) heuristic for the **pre-download** badge — the exact KV cost
+/// is architecture- and context-specific and is enforced at runtime by the KV
+/// predict-and-abort guard (`src/inference/kv_cache.rs`). Over-estimating keeps a
+/// "fits" badge safe rather than optimistic. A per-architecture bound is a future
+/// refinement; a flat pad avoids inventing per-model dimensions we cannot know
+/// before the GGUF is on disk.
+pub const ADVISORY_OVERHEAD_PERCENT: u64 = 25;
+
+/// Build [`FitInputs`] for a catalog row from its known weight footprint
+/// (`CatalogItem.size_bytes`), padding by [`ADVISORY_OVERHEAD_PERCENT`] to stand
+/// in for KV + activations at a modest context. The pad is carried in
+/// `kv_bytes_at_ctx`; it is an estimate, not a measured KV size.
+pub fn advisory_footprint(weight_bytes: u64) -> FitInputs {
+    let overhead = weight_bytes.saturating_mul(ADVISORY_OVERHEAD_PERCENT) / 100;
+    FitInputs {
+        weight_bytes,
+        kv_bytes_at_ctx: overhead,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -21,15 +21,15 @@
 
 use crate::capability::HardwareProfile;
 
-/// Share of *available* host RAM the advisor treats as usable, mirroring the
-/// KV-cache budget policy in `src/inference/kv_cache.rs`
-/// (`KV_CACHE_BUDGET_AVAILABLE_PERCENT`) so the advisor and the runtime guard
-/// agree on what "usable RAM" means.
+/// Share of *available* host RAM the advisor treats as usable. Mirrors the *value*
+/// of `KV_CACHE_BUDGET_AVAILABLE_PERCENT` in `src/inference/kv_cache.rs` — an
+/// independent constant kept in sync by convention (see [`usable_host_ram_bytes`]
+/// for how the two policies relate), not a shared symbol.
 const USABLE_RAM_AVAILABLE_PERCENT: u64 = 80;
-/// Floor as a share of *total* host RAM, mirroring
-/// `KV_CACHE_BUDGET_TOTAL_FLOOR_PERCENT` — guards against a transient dip in the
-/// live `available` reading (which drops sharply as weights fault into the
-/// working set) collapsing the budget below what a normal run needs.
+/// Floor as a share of *total* host RAM, mirroring the *value* of
+/// `KV_CACHE_BUDGET_TOTAL_FLOOR_PERCENT`. Guards against a transient dip in the live
+/// `available` reading (which drops sharply as weights fault into the working set)
+/// collapsing the budget below what a normal run needs.
 const USABLE_RAM_TOTAL_FLOOR_PERCENT: u64 = 25;
 
 /// The advisor's verdict for a single (model footprint, host) pair.
@@ -111,8 +111,17 @@ impl FitInputs {
 }
 
 /// The usable host-RAM budget in bytes, or `None` when RAM is unknown
-/// (`host_ram_total_bytes == 0`). Mirrors the KV-cache budget policy:
-/// `max(80% of available, 25% of total)`.
+/// (`host_ram_total_bytes == 0`). Applies the same `max(80% of available, 25% of
+/// total)` formula as the KV-cache budget in `kv_cache.rs`, but is an independent
+/// reimplementation, not the same guard. Two intentional differences:
+///
+/// - Source: the advisor reads [`HardwareProfile`] RAM (probed on Windows and Linux;
+///   `(0, 0)` / unknown on macOS), whereas the KV guard reads `gait::host_ram_status`
+///   (probed on Windows and macOS; unprobed on Linux). So on Linux the advisor
+///   enforces a budget while the KV guard is unbounded; on macOS it is the reverse.
+/// - Unprobed RAM: the KV guard fails *open* (unbounded); the advisor abstains here
+///   with `None` (surfaced as [`FitVerdict::Unknown`]) rather than assert a capacity
+///   it cannot measure.
 fn usable_host_ram_bytes(hw: &HardwareProfile) -> Option<u64> {
     if hw.host_ram_total_bytes == 0 {
         return None;

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -202,6 +202,78 @@ pub fn advisory_footprint(weight_bytes: u64) -> FitInputs {
     }
 }
 
+/// Bytes-per-number of the KV cache, by execution path. The runtime stores KV as
+/// f32 on the CPU path and f16 (half) on the GPU-resident path — mirror that so the
+/// estimate matches what the engine actually allocates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KvDtype {
+    /// CPU path — f32 (4 bytes).
+    F32,
+    /// GPU-resident path — f16 (2 bytes).
+    F16,
+}
+
+impl KvDtype {
+    /// Bytes per stored KV element.
+    pub fn bytes(self) -> u64 {
+        match self {
+            KvDtype::F32 => 4,
+            KvDtype::F16 => 2,
+        }
+    }
+}
+
+/// The architecture dimensions the KV-cache size depends on. Read from GGUF
+/// metadata (`block_count`, `attention.head_count_kv`, `head_dim`) — never guessed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelDims {
+    pub layers: u64,
+    pub kv_heads: u64,
+    pub head_dim: u64,
+}
+
+/// Default context the advisor sizes the KV cache at — a "normal use" budget. KV
+/// grows linearly with context, and a model's *trained* max (e.g. 131072) would
+/// materialize a KV cache larger than the weights, so the advisory sizes at this
+/// fixed, realistic length rather than the theoretical max. The runtime's own KV
+/// predict-and-abort guard governs longer conversations.
+pub const ADVISORY_CONTEXT_TOKENS: u64 = 4096;
+
+/// Coarse, bounded allowance for activations + framework scratch beyond weights
+/// and KV. Small next to weights/KV for single-sequence decode; a fixed margin
+/// keeps a "fits" verdict from being optimistic without pretending precision.
+pub const ACTIVATION_SCRATCH_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Exact KV-cache bytes for `dims` at `context_tokens` and dtype `kv`. Mirrors the
+/// runtime `kv_bytes_per_token` (`src/inference/kv_cache.rs`):
+/// `layers × kv_heads × head_dim × 2 (K+V) × dtype_bytes`, times `context_tokens`.
+pub fn kv_bytes(dims: ModelDims, context_tokens: u64, kv: KvDtype) -> u64 {
+    dims.layers
+        .saturating_mul(dims.kv_heads)
+        .saturating_mul(dims.head_dim)
+        .saturating_mul(2) // K + V
+        .saturating_mul(kv.bytes())
+        .saturating_mul(context_tokens)
+}
+
+/// Build an **exact** footprint from real model dimensions: weights (on-disk size)
+/// plus KV at `context_tokens` plus a bounded activation/scratch margin. Use this
+/// wherever GGUF metadata is available (on-disk models, the load guard) instead of
+/// the coarse [`advisory_footprint`] pad.
+pub fn exact_footprint(
+    weight_bytes: u64,
+    dims: ModelDims,
+    context_tokens: u64,
+    kv: KvDtype,
+) -> FitInputs {
+    let kv_and_scratch =
+        kv_bytes(dims, context_tokens, kv).saturating_add(ACTIVATION_SCRATCH_BYTES);
+    FitInputs {
+        weight_bytes,
+        kv_bytes_at_ctx: kv_and_scratch,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -360,5 +432,81 @@ mod tests {
     fn verdict_serializes_to_snake_case() {
         let json = serde_json::to_string(&FitVerdict::FitsWithOffload).unwrap();
         assert_eq!(json, "\"fits_with_offload\"");
+    }
+
+    #[test]
+    fn kv_bytes_matches_runtime_vectors_at_one_token_f32() {
+        // These are the exact per-token figures kv_cache.rs asserts, so our estimate
+        // is correct by construction against the engine's own math.
+        // TinyLlama: 22 layers * 4 kv * 64 head_dim -> 45,056 B/token.
+        let tiny = ModelDims {
+            layers: 22,
+            kv_heads: 4,
+            head_dim: 64,
+        };
+        assert_eq!(kv_bytes(tiny, 1, KvDtype::F32), 45_056);
+        // Llama 3.2 3B: 28 * 8 * 128 -> 229,376 B/token.
+        let l3b = ModelDims {
+            layers: 28,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        assert_eq!(kv_bytes(l3b, 1, KvDtype::F32), 229_376);
+    }
+
+    #[test]
+    fn kv_bytes_scales_linearly_with_context() {
+        let d = ModelDims {
+            layers: 22,
+            kv_heads: 4,
+            head_dim: 64,
+        };
+        assert_eq!(kv_bytes(d, 4096, KvDtype::F32), 45_056 * 4096);
+        assert_eq!(kv_bytes(d, 0, KvDtype::F32), 0);
+    }
+
+    #[test]
+    fn kv_f16_is_exactly_half_of_f32() {
+        let d = ModelDims {
+            layers: 28,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        assert_eq!(
+            kv_bytes(d, 100, KvDtype::F16) * 2,
+            kv_bytes(d, 100, KvDtype::F32)
+        );
+    }
+
+    #[test]
+    fn exact_footprint_is_weights_plus_kv_plus_margin() {
+        let d = ModelDims {
+            layers: 28,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        let f = exact_footprint(3_000_000_000, d, 4096, KvDtype::F16);
+        let expected_kv = kv_bytes(d, 4096, KvDtype::F16) + ACTIVATION_SCRATCH_BYTES;
+        assert_eq!(f.weight_bytes, 3_000_000_000);
+        assert_eq!(f.kv_bytes_at_ctx, expected_kv);
+        assert_eq!(f.footprint_bytes(), 3_000_000_000 + expected_kv);
+    }
+
+    #[test]
+    fn exact_kv_for_a_big_model_at_default_context_is_bounded() {
+        // Llama-3 8B (32 layers, 8 kv, 128 head_dim) f16 KV at 4096 tokens is ~512 MiB
+        // — the KV term is modest at normal context; the trained-max context is NOT
+        // used here (that would be many GiB), which is the whole point of the default.
+        let d = ModelDims {
+            layers: 32,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        let kv = kv_bytes(d, ADVISORY_CONTEXT_TOKENS, KvDtype::F16);
+        assert_eq!(kv, 32 * 8 * 128 * 2 * 2 * 4096); // exact
+        assert!(
+            kv < 1024 * 1024 * 1024,
+            "KV at default ctx should be < 1 GiB, got {kv}"
+        );
     }
 }

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -1,0 +1,329 @@
+//! Model *fit* advisor — a capacity verdict for "can this machine run this model?".
+//!
+//! This is a **capacity axis only**. A [`FitVerdict::FitsResident`] means the
+//! model's footprint fits the detected memory budget — it says **nothing** about
+//! whether the model is *supported* (`COMPATIBILITY.md`) or *runnable-lane
+//! anchored* (`crate::runnable`). Those are separate axes and must never be
+//! conflated in copy or code.
+//!
+//! The math is a pure, GPU-free heuristic over byte counts, in the same spirit as
+//! [`crate::cuda_vram::evaluate`] (which this module reuses for the VRAM branch).
+//! It is **advisory**: the authoritative guards remain the mid-load
+//! [`crate::cuda_vram::VramShortfall`] and the mid-generation
+//! `BackendError::KvCacheBudgetExceeded` (`src/inference/kv_cache.rs`). This layer
+//! only helps a user *choose* before they commit; it never gates a download and
+//! never relaxes a runtime guard.
+//!
+//! On hosts where memory cannot be probed (e.g. macOS, where
+//! [`crate::capability::HardwareProfile`] reports `host_ram_total_bytes == 0`) the
+//! verdict degrades to [`FitVerdict::Unknown`] rather than guessing — an unknown
+//! host must never read as "won't fit".
+
+use crate::capability::HardwareProfile;
+
+/// Share of *available* host RAM the advisor treats as usable, mirroring the
+/// KV-cache budget policy in `src/inference/kv_cache.rs`
+/// (`KV_CACHE_BUDGET_AVAILABLE_PERCENT`) so the advisor and the runtime guard
+/// agree on what "usable RAM" means.
+const USABLE_RAM_AVAILABLE_PERCENT: u64 = 80;
+/// Floor as a share of *total* host RAM, mirroring
+/// `KV_CACHE_BUDGET_TOTAL_FLOOR_PERCENT` — guards against a transient dip in the
+/// live `available` reading (which drops sharply as weights fault into the
+/// working set) collapsing the budget below what a normal run needs.
+const USABLE_RAM_TOTAL_FLOOR_PERCENT: u64 = 25;
+
+/// The advisor's verdict for a single (model footprint, host) pair.
+///
+/// Serialized in `snake_case` for the catalog API (Slice 2); the string form is
+/// also exposed via [`FitVerdict::as_str`] for the CLI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FitVerdict {
+    /// Weights + KV fit within the GPU's VRAM (respecting headroom), or — with no
+    /// usable GPU — within the host RAM budget. The comfortable case.
+    FitsResident,
+    /// Weights + KV exceed VRAM alone but fit the combined VRAM + host-RAM budget,
+    /// i.e. the documented CUDA VRAM+host-RAM layer-offload split can carry it.
+    FitsWithOffload,
+    /// No usable GPU, but the footprint fits the host RAM budget (CPU backend).
+    CpuOnlyOk,
+    /// Exceeds every available budget on this host. The pick would fail at load or
+    /// generation time; the UI should steer the user to a smaller/quantized row.
+    WontFit,
+    /// The host's memory could not be probed (e.g. macOS), so no honest capacity
+    /// claim can be made. Advisory-blind: never treated as a failure.
+    Unknown,
+}
+
+impl FitVerdict {
+    /// Stable lowercase label, matching the serialized form. For CLI columns/logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FitVerdict::FitsResident => "fits_resident",
+            FitVerdict::FitsWithOffload => "fits_with_offload",
+            FitVerdict::CpuOnlyOk => "cpu_only_ok",
+            FitVerdict::WontFit => "wont_fit",
+            FitVerdict::Unknown => "unknown",
+        }
+    }
+
+    /// Whether the verdict says the model can run *somehow* on this host. `Unknown`
+    /// is **not** runnable-negative — it is the absence of a claim — so it returns
+    /// `false` here only in the sense of "no positive fit was proven". Callers that
+    /// must not block on unknowns should test `!= WontFit` instead.
+    pub fn is_positive_fit(self) -> bool {
+        matches!(
+            self,
+            FitVerdict::FitsResident | FitVerdict::FitsWithOffload | FitVerdict::CpuOnlyOk
+        )
+    }
+}
+
+/// The footprint of a model to assess, in bytes.
+///
+/// `weight_bytes` is exact for curated catalog rows (`CatalogItem.size_bytes` is
+/// the GGUF file size). `kv_bytes_at_ctx` is the projected key+value cache for the
+/// context length being assessed; deriving it pre-download from architecture
+/// metadata is the Slice-2 concern — this pure core simply takes both byte counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FitInputs {
+    pub weight_bytes: u64,
+    pub kv_bytes_at_ctx: u64,
+}
+
+impl FitInputs {
+    /// Total resident footprint (weights + KV), saturating.
+    pub fn footprint_bytes(&self) -> u64 {
+        self.weight_bytes.saturating_add(self.kv_bytes_at_ctx)
+    }
+}
+
+/// The usable host-RAM budget in bytes, or `None` when RAM is unknown
+/// (`host_ram_total_bytes == 0`). Mirrors the KV-cache budget policy:
+/// `max(80% of available, 25% of total)`.
+fn usable_host_ram_bytes(hw: &HardwareProfile) -> Option<u64> {
+    if hw.host_ram_total_bytes == 0 {
+        return None;
+    }
+    let by_available = hw
+        .host_ram_free_bytes
+        .saturating_mul(USABLE_RAM_AVAILABLE_PERCENT)
+        / 100;
+    let floor = hw
+        .host_ram_total_bytes
+        .saturating_mul(USABLE_RAM_TOTAL_FLOOR_PERCENT)
+        / 100;
+    Some(by_available.max(floor))
+}
+
+/// Whether the host has a GPU we can actually place weights on.
+fn has_usable_gpu(hw: &HardwareProfile) -> bool {
+    hw.cuda_available && hw.cuda_vram_free_bytes > 0
+}
+
+/// Pure fit decision with an explicit VRAM headroom (in MiB), so the whole thing
+/// is deterministic and unit-testable without touching process env or a GPU.
+///
+/// Decision order (host-honest):
+/// 1. Usable GPU present → try VRAM-resident via [`crate::cuda_vram::evaluate`].
+///    - Ok → [`FitVerdict::FitsResident`].
+///    - Shortfall → offload: fits VRAM + usable host RAM → [`FitVerdict::FitsWithOffload`];
+///      RAM known but too small → [`FitVerdict::WontFit`]; RAM unknown → [`FitVerdict::Unknown`].
+/// 2. No usable GPU → fits host RAM → [`FitVerdict::CpuOnlyOk`]; too small →
+///    [`FitVerdict::WontFit`]; RAM unknown → [`FitVerdict::Unknown`].
+fn assess_with_headroom(hw: &HardwareProfile, m: &FitInputs, vram_headroom_mib: u64) -> FitVerdict {
+    let footprint = m.footprint_bytes();
+    let usable_ram = usable_host_ram_bytes(hw);
+
+    if has_usable_gpu(hw) {
+        match crate::cuda_vram::evaluate(hw.cuda_vram_free_bytes, footprint, vram_headroom_mib) {
+            Ok(_) => return FitVerdict::FitsResident,
+            Err(_) => {
+                return match usable_ram {
+                    Some(ram) if footprint <= hw.cuda_vram_free_bytes.saturating_add(ram) => {
+                        FitVerdict::FitsWithOffload
+                    }
+                    Some(_) => FitVerdict::WontFit,
+                    None => FitVerdict::Unknown,
+                };
+            }
+        }
+    }
+
+    match usable_ram {
+        Some(ram) if footprint <= ram => FitVerdict::CpuOnlyOk,
+        Some(_) => FitVerdict::WontFit,
+        None => FitVerdict::Unknown,
+    }
+}
+
+/// Assess whether `m` fits `hw`, using the configured VRAM headroom
+/// ([`crate::cuda_vram::min_headroom_mib`], env `CAMELID_MIN_VRAM_HEADROOM_MIB`).
+///
+/// This is the public entry point. It is deterministic given the process env and
+/// the passed hardware profile; the pure arithmetic lives in
+/// [`assess_with_headroom`] for env-free testing.
+pub fn assess(hw: &HardwareProfile, m: &FitInputs) -> FitVerdict {
+    assess_with_headroom(hw, m, crate::cuda_vram::min_headroom_mib())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::SimdCaps;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+
+    /// A hardware profile with only the memory-relevant fields set; everything
+    /// else defaulted. Keeps the fit tests focused on the capacity math.
+    fn profile(
+        cuda_available: bool,
+        vram_free_bytes: u64,
+        ram_total_bytes: u64,
+        ram_free_bytes: u64,
+    ) -> HardwareProfile {
+        HardwareProfile {
+            cuda_available,
+            cuda_device_count: if cuda_available { 1 } else { 0 },
+            cuda_device_name: None,
+            cuda_compute_capability: None,
+            cuda_tensor_cores: false,
+            cuda_vram_total_bytes: vram_free_bytes,
+            cuda_vram_free_bytes: vram_free_bytes,
+            cpu_logical_cores: 8,
+            host_ram_total_bytes: ram_total_bytes,
+            host_ram_free_bytes: ram_free_bytes,
+            simd: SimdCaps::default(),
+        }
+    }
+
+    fn inputs(weight_bytes: u64, kv_bytes: u64) -> FitInputs {
+        FitInputs {
+            weight_bytes,
+            kv_bytes_at_ctx: kv_bytes,
+        }
+    }
+
+    // A small headroom so tests reason in round GiB without the default 512 MiB
+    // nudging boundary cases.
+    const H: u64 = 0;
+
+    #[test]
+    fn resident_when_footprint_fits_vram_with_headroom() {
+        // 8 GB card, a ~3.4 GB weight + 0.5 GB KV = ~3.9 GB → resident.
+        let hw = profile(true, 8 * GIB, 16 * GIB, 12 * GIB);
+        let m = inputs(3_421_898_816, 512 * MIB);
+        assert_eq!(assess_with_headroom(&hw, &m, 512), FitVerdict::FitsResident);
+    }
+
+    #[test]
+    fn headroom_pushes_a_tight_fit_out_of_resident() {
+        // Footprint is just under free VRAM, but the 512 MiB headroom is violated,
+        // so it must NOT be resident. With host RAM available it becomes offload.
+        let hw = profile(true, 8 * GIB, 32 * GIB, 24 * GIB);
+        let m = inputs(8 * GIB - 100 * MIB, 0);
+        let verdict = assess_with_headroom(&hw, &m, 512);
+        assert_eq!(verdict, FitVerdict::FitsWithOffload);
+    }
+
+    #[test]
+    fn offload_when_weights_exceed_vram_but_fit_vram_plus_ram() {
+        // 8B Q8_0 (~8.5 GB) on a 6 GB card with 32 GB RAM → VRAM+host-RAM offload.
+        let hw = profile(true, 6 * GIB, 32 * GIB, 24 * GIB);
+        let m = inputs(8_541_283_552, 512 * MIB);
+        assert_eq!(
+            assess_with_headroom(&hw, &m, H),
+            FitVerdict::FitsWithOffload
+        );
+    }
+
+    #[test]
+    fn wont_fit_when_footprint_exceeds_vram_plus_ram() {
+        // Tiny VRAM + tiny RAM cannot carry a 12 GB model even with offload.
+        let hw = profile(true, 2 * GIB, 4 * GIB, 3 * GIB);
+        let m = inputs(12 * GIB, 512 * MIB);
+        assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::WontFit);
+    }
+
+    #[test]
+    fn cpu_only_ok_when_no_gpu_and_fits_ram() {
+        // No GPU, 16 GB RAM (healthy) → 80%-of-available = ~9.6 GB budget carries a
+        // ~3.4 GB model comfortably.
+        let hw = profile(false, 0, 16 * GIB, 12 * GIB);
+        let m = inputs(3_421_898_816, 256 * MIB);
+        assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::CpuOnlyOk);
+    }
+
+    #[test]
+    fn wont_fit_cpu_only_when_model_exceeds_ram_budget() {
+        // No GPU, 8 GB RAM → budget ~ max(80% of 5 GB=4 GB, 25% of 8 GB=2 GB)=4 GB;
+        // an 8.5 GB model won't fit.
+        let hw = profile(false, 0, 8 * GIB, 5 * GIB);
+        let m = inputs(8_541_283_552, 512 * MIB);
+        assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::WontFit);
+    }
+
+    #[test]
+    fn ram_floor_dominates_when_available_dips_transiently() {
+        // 32 GB total but a transient low available (2 GB). The 25%-of-total floor
+        // (8 GB) must dominate the 80%-of-available (1.6 GB), so a ~3.4 GB model
+        // still fits CPU-only rather than spuriously "won't fit".
+        let hw = profile(false, 0, 32 * GIB, 2 * GIB);
+        let m = inputs(3_421_898_816, 256 * MIB);
+        assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::CpuOnlyOk);
+    }
+
+    #[test]
+    fn unknown_when_ram_unprobed_and_no_gpu() {
+        // macOS-style: RAM probe returns 0 and no CUDA. No honest claim possible.
+        let hw = profile(false, 0, 0, 0);
+        let m = inputs(3_421_898_816, 256 * MIB);
+        assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::Unknown);
+    }
+
+    #[test]
+    fn unknown_when_gpu_overflows_and_ram_unprobed() {
+        // GPU present but too small, and RAM cannot be probed → offload can't be
+        // judged → Unknown (never WontFit on an unknown host).
+        let hw = profile(true, 2 * GIB, 0, 0);
+        let m = inputs(8_541_283_552, 512 * MIB);
+        assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::Unknown);
+    }
+
+    #[test]
+    fn cuda_flag_without_vram_is_not_a_usable_gpu() {
+        // cuda_available=true but 0 free VRAM → treated as CPU host; fits RAM.
+        let hw = profile(true, 0, 16 * GIB, 12 * GIB);
+        let m = inputs(2 * GIB, 128 * MIB);
+        assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::CpuOnlyOk);
+    }
+
+    #[test]
+    fn footprint_saturates_and_wont_fit_on_extreme_values() {
+        let m = inputs(u64::MAX, u64::MAX);
+        assert_eq!(m.footprint_bytes(), u64::MAX);
+        let hw = profile(false, 0, 16 * GIB, 12 * GIB);
+        assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::WontFit);
+    }
+
+    #[test]
+    fn verdict_labels_are_stable() {
+        assert_eq!(FitVerdict::FitsResident.as_str(), "fits_resident");
+        assert_eq!(FitVerdict::FitsWithOffload.as_str(), "fits_with_offload");
+        assert_eq!(FitVerdict::CpuOnlyOk.as_str(), "cpu_only_ok");
+        assert_eq!(FitVerdict::WontFit.as_str(), "wont_fit");
+        assert_eq!(FitVerdict::Unknown.as_str(), "unknown");
+        assert!(FitVerdict::FitsResident.is_positive_fit());
+        assert!(FitVerdict::FitsWithOffload.is_positive_fit());
+        assert!(FitVerdict::CpuOnlyOk.is_positive_fit());
+        assert!(!FitVerdict::WontFit.is_positive_fit());
+        assert!(!FitVerdict::Unknown.is_positive_fit());
+    }
+
+    #[test]
+    fn verdict_serializes_to_snake_case() {
+        let json = serde_json::to_string(&FitVerdict::FitsWithOffload).unwrap();
+        assert_eq!(json, "\"fits_with_offload\"");
+    }
+}

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -225,11 +225,22 @@ impl KvDtype {
 
 /// The architecture dimensions the KV-cache size depends on. Read from GGUF
 /// metadata (`block_count`, `attention.head_count_kv`, `head_dim`) — never guessed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ModelDims {
     pub layers: u64,
     pub kv_heads: u64,
     pub head_dim: u64,
+}
+
+impl ModelDims {
+    /// Sanity bounds so a mis-parsed or adversarial header can't drive absurd KV
+    /// math. Comfortably covers every real dense LLM (largest today ~140 layers,
+    /// ~128 kv heads, 256 head_dim) with wide headroom.
+    pub fn is_plausible(self) -> bool {
+        (1..=400).contains(&self.layers)
+            && (1..=256).contains(&self.kv_heads)
+            && (1..=2048).contains(&self.head_dim)
+    }
 }
 
 /// Default context the advisor sizes the KV cache at — a "normal use" budget. KV
@@ -508,5 +519,58 @@ mod tests {
             kv < 1024 * 1024 * 1024,
             "KV at default ctx should be < 1 GiB, got {kv}"
         );
+    }
+
+    #[test]
+    fn model_dims_plausibility_bounds() {
+        assert!(ModelDims {
+            layers: 32,
+            kv_heads: 8,
+            head_dim: 128
+        }
+        .is_plausible());
+        assert!(ModelDims {
+            layers: 1,
+            kv_heads: 1,
+            head_dim: 1
+        }
+        .is_plausible());
+        // Zero or absurd values (a mis-parsed header) are rejected.
+        assert!(!ModelDims {
+            layers: 0,
+            kv_heads: 8,
+            head_dim: 128
+        }
+        .is_plausible());
+        assert!(!ModelDims {
+            layers: 32,
+            kv_heads: 0,
+            head_dim: 128
+        }
+        .is_plausible());
+        assert!(!ModelDims {
+            layers: 100_000,
+            kv_heads: 8,
+            head_dim: 128
+        }
+        .is_plausible());
+        assert!(!ModelDims {
+            layers: 32,
+            kv_heads: 8,
+            head_dim: 999_999
+        }
+        .is_plausible());
+    }
+
+    #[test]
+    fn model_dims_serde_round_trips() {
+        let d = ModelDims {
+            layers: 28,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        let back: ModelDims = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, back);
     }
 }

--- a/src/fit_dims.rs
+++ b/src/fit_dims.rs
@@ -324,8 +324,13 @@ pub fn start_background(curated: Vec<(String, String, u64)>) {
 /// only, the same cheap path `/api/models/inspect` uses). `None` for a non-GGUF, an
 /// unreadable header, a non-dense/unknown architecture, or implausible dims.
 pub fn dims_from_gguf_file(path: &Path) -> Option<ModelDims> {
-    let gguf = crate::gguf::read_metadata(path).ok()?;
-    let config = crate::model::LlamaModelConfig::from_gguf(&gguf).ok()?;
+    dims_from_gguf(&crate::gguf::read_metadata(path).ok()?)
+}
+
+/// Map a parsed GGUF's metadata to dense-Llama KV dims, or `None` for a
+/// non-dense/unknown architecture or implausible values.
+fn dims_from_gguf(gguf: &crate::gguf::GgufFile) -> Option<ModelDims> {
+    let config = crate::model::LlamaModelConfig::from_gguf(gguf).ok()?;
     let dims = crate::model::DenseLlamaDims::from_config(&config).ok()?;
     let dims = ModelDims {
         layers: dims.block_count as u64,
@@ -364,10 +369,11 @@ pub fn is_safe_hf_component(s: &str) -> bool {
 }
 
 /// Fetch a model's KV dims from its GGUF header over the network. GGUF stores all
-/// metadata + tensor-info at the file start, so we range-fetch a header slice into a
-/// temp file whose *length* is set to the real size (the unfetched tail is sparse
-/// zeros the parser never reads — it only validates tensor offsets against the
-/// length), then reuse the trusted on-disk parser. Blocking; call off the executor.
+/// metadata + tensor-info at the file start, so we range-fetch a header slice and
+/// parse it directly, telling the trusted parser the model's true full length so
+/// its tensor-offset bounds checks still hold. We do NOT extend the temp file to
+/// the full size: on NTFS that allocates the whole (multi-GB) length on disk even
+/// though only the header is fetched. Blocking; call off the executor.
 fn fetch_header_dims(repo_id: &str, filename: &str, full_size: u64) -> FetchOutcome {
     // Skip inputs we shouldn't fetch: unknown size, split-model shards, and any
     // unsafe repo/filename we'd interpolate into a URL.
@@ -384,7 +390,7 @@ fn fetch_header_dims(repo_id: &str, filename: &str, full_size: u64) -> FetchOutc
     // The temp path must be unique per (repo, filename): different repos routinely
     // ship the same filename, and `in_flight` dedup is keyed by the full pair, so
     // those fetch concurrently. Filename alone would collide into one temp file and
-    // race set_len/parse/remove_file. Hash the full key for a collision-free name.
+    // race the write/parse/remove. Hash the full key for a collision-free name.
     let token = {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         std::hash::Hash::hash(repo_id, &mut hasher);
@@ -408,14 +414,12 @@ fn fetch_header_dims(repo_id: &str, filename: &str, full_size: u64) -> FetchOutc
         let _ = std::fs::remove_file(&tmp);
         return FetchOutcome::FetchError;
     }
-    // Extend the temp file to the real size so the parser's tensor-offset bounds
-    // checks pass; the tail is sparse zeros and is never read.
-    if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&tmp) {
-        let _ = f.set_len(full_size);
-    }
-    let dims = dims_from_gguf_file(&tmp);
+    // Parse the header prefix directly, validating tensor offsets against the real
+    // full length. No file extension, so no disk is allocated for the unfetched
+    // body.
+    let parsed = crate::gguf::read_metadata_with_len(&tmp, full_size);
     let _ = std::fs::remove_file(&tmp);
-    match dims {
+    match parsed.ok().as_ref().and_then(dims_from_gguf) {
         Some(d) => FetchOutcome::Resolved(d),
         // Fetched fine but not dense-parseable → negative (don't re-fetch).
         None => FetchOutcome::Unparseable,
@@ -676,6 +680,60 @@ mod tests {
         let dims = dims_from_gguf_file(&path).expect("minimal llama fixture should parse");
         assert_eq!(
             dims,
+            ModelDims {
+                layers: 4,
+                kv_heads: 8,
+                head_dim: 8,
+            }
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_metadata_with_len_parses_a_header_prefix_without_the_body() {
+        // The same minimal llama header, but we persist ONLY the header prefix (no
+        // tensor data) and declare the true full length — exactly what the header
+        // range-fetch does, and without extending the file to the full size on disk.
+        let mut hdr = Vec::new();
+        hdr.extend_from_slice(b"GGUF");
+        push_u32(&mut hdr, 3);
+        push_i64(&mut hdr, 1);
+        push_i64(&mut hdr, 8);
+        kv_str(&mut hdr, "general.architecture", "llama");
+        kv_u32(&mut hdr, "llama.context_length", 4096);
+        kv_u32(&mut hdr, "llama.embedding_length", 64);
+        kv_u32(&mut hdr, "llama.block_count", 4);
+        kv_u32(&mut hdr, "llama.feed_forward_length", 128);
+        kv_u32(&mut hdr, "llama.attention.head_count", 8);
+        kv_u32(&mut hdr, "llama.attention.head_count_kv", 8);
+        kv_u32(&mut hdr, "llama.vocab_size", 1000);
+        push_str(&mut hdr, "token_embd.weight");
+        push_u32(&mut hdr, 2);
+        push_i64(&mut hdr, 4);
+        push_i64(&mut hdr, 2);
+        push_i32(&mut hdr, 0);
+        push_u64(&mut hdr, 0);
+        while !hdr.len().is_multiple_of(32) {
+            hdr.push(0);
+        }
+        // The tensor body we deliberately never write nor fetch.
+        let full_len = hdr.len() as u64 + 4 * 2 * 4;
+
+        let dir =
+            std::env::temp_dir().join(format!("camelid-fitdims-prefix-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("prefix-llama.gguf");
+        std::fs::write(&path, &hdr).unwrap(); // header prefix only
+
+        // The ordinary stat-based parser rejects it — the tensor data runs past the
+        // truncated EOF...
+        assert!(crate::gguf::read_metadata(&path).is_err());
+        // ...but validating against the declared full length parses the prefix, with
+        // no disk allocated for the absent body.
+        let gguf = crate::gguf::read_metadata_with_len(&path, full_len)
+            .expect("header prefix should parse against the declared full length");
+        assert_eq!(
+            dims_from_gguf(&gguf).unwrap(),
             ModelDims {
                 layers: 4,
                 kv_heads: 8,

--- a/src/fit_dims.rs
+++ b/src/fit_dims.rs
@@ -41,6 +41,11 @@ const ENTRY_TTL_SECS: u64 = 60 * 60 * 24 * 30;
 const FETCH_BACKOFF_SECS: u64 = 60 * 30;
 /// Max concurrent header fetches — bounds bandwidth and subprocess count.
 const MAX_CONCURRENT_FETCHES: usize = 4;
+/// curl connect timeout — a stalled TCP/TLS handshake must not hold a permit.
+const CONNECT_TIMEOUT_SECS: u64 = 10;
+/// curl overall timeout — a slow/hung transfer must release its permit and in-flight
+/// slot in bounded time (the outcome is a retriable transient error).
+const FETCH_MAX_TIME_SECS: u64 = 60;
 /// Bytes of the file head to fetch — covers metadata (incl. 128k-vocab tokenizer
 /// arrays) plus tensor-info for current catalog models; a too-small fetch simply
 /// fails to parse and the caller falls back to the estimate.
@@ -214,14 +219,22 @@ impl DimsResolver {
         }
         let permits = Arc::clone(&self.permits);
         tokio::spawn(async move {
+            // Release the in-flight slot no matter how this task ends — a permit
+            // error, or a panic anywhere in the fetch/parse/record path. Without
+            // this, a panicking fetch would pin the key and `should_fetch` would
+            // return false for it for the whole process lifetime. The happy path
+            // also clears it in `record` (atomically with the cache write); this is
+            // the panic/early-return safety net.
+            let slot = InFlightGuard {
+                resolver: self,
+                key: key.clone(),
+            };
             let permit = match permits.acquire_owned().await {
                 Ok(p) => p,
-                Err(_) => {
-                    self.clear_in_flight(&key);
-                    return;
-                }
+                Err(_) => return,
             };
             tokio::task::spawn_blocking(move || {
+                let _slot = slot;
                 let outcome = fetch_header_dims(&repo_id, &filename, size);
                 self.record(&key, outcome);
                 drop(permit);
@@ -318,6 +331,19 @@ pub fn start_background(curated: Vec<(String, String, u64)>) {
     resolver.warm(curated);
 }
 
+/// RAII marker that clears a key's in-flight slot on drop, so an early return or a
+/// panic in the spawned fetch task can never pin the key for the process lifetime.
+struct InFlightGuard {
+    resolver: &'static DimsResolver,
+    key: String,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.resolver.clear_in_flight(&self.key);
+    }
+}
+
 // --- GGUF header fetch + parse ---------------------------------------------
 
 /// Read a GGUF's KV dimensions from a local file WITHOUT loading weights (header
@@ -404,7 +430,16 @@ fn fetch_header_dims(repo_id: &str, filename: &str, full_size: u64) -> FetchOutc
     let range_end = HEADER_BYTES.min(full_size).saturating_sub(1);
     let url = format!("https://huggingface.co/{repo_id}/resolve/main/{filename}");
     let fetched = std::process::Command::new("curl")
-        .args(["-fsSL", "-r", &format!("0-{range_end}"), "-o"])
+        .args([
+            "-fsSL",
+            "--connect-timeout",
+            &CONNECT_TIMEOUT_SECS.to_string(),
+            "--max-time",
+            &FETCH_MAX_TIME_SECS.to_string(),
+            "-r",
+            &format!("0-{range_end}"),
+            "-o",
+        ])
         .arg(&tmp)
         .arg(&url)
         .status()
@@ -741,6 +776,23 @@ mod tests {
             }
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn in_flight_guard_releases_the_slot_on_drop() {
+        // A panic or early return in the spawned fetch task must not pin the key: the
+        // RAII guard clears the in-flight marker regardless of how the task ends.
+        let resolver = global();
+        let key = "test-fitdims/in-flight-guard.gguf".to_string();
+        resolver.inner.lock().unwrap().in_flight.insert(key.clone());
+        assert!(resolver.inner.lock().unwrap().in_flight.contains(&key));
+        {
+            let _slot = InFlightGuard {
+                resolver,
+                key: key.clone(),
+            };
+        } // drop here
+        assert!(!resolver.inner.lock().unwrap().in_flight.contains(&key));
     }
 
     #[test]

--- a/src/fit_dims.rs
+++ b/src/fit_dims.rs
@@ -1,0 +1,728 @@
+//! Resolver for a model's KV-cache dimensions, read from its GGUF **header** over
+//! the network (never the weights), so the catalog fit badge can be *exact* before
+//! a model is downloaded.
+//!
+//! This is a dedicated module rather than ad-hoc background spawns because the
+//! caching/fetch behavior is where a naive version goes wrong. The invariants it
+//! enforces:
+//!
+//! - **De-duplicated & rate-limited.** At most one in-flight fetch per model, and
+//!   at most [`MAX_CONCURRENT_FETCHES`] fetches across the process. A page render
+//!   can never fan out an unbounded burst of subprocesses.
+//! - **No hot-path fetches.** [`lookup`](DimsResolver::lookup) is a pure, sync map
+//!   read for the badge. Fetches are *scheduled* explicitly ([`ensure`],
+//!   [`warm`]) — never as a side-effect of serving a page.
+//! - **Write-behind, bounded, TTL'd disk cache.** Results persist so a restart
+//!   doesn't re-fetch, but writes are debounced (N fetches → O(1) writes by a
+//!   single flusher), the cache is size-capped with oldest-eviction, and entries
+//!   expire so a re-upload eventually re-resolves.
+//! - **Honest failure modes.** A header that parsed but is not a dense LLaMA-family
+//!   model is cached as a *negative* (never re-fetched); a transient fetch error
+//!   backs off (retried next process). Either way the caller falls back to the
+//!   coarse size estimate — nothing here can block a load or a page.
+//!
+//! HTTP egress uses the same `curl` subprocess pattern as `hf_browse` / `catalog`
+//! (the project deliberately avoids a heavy HTTP-client dependency); the fetch runs
+//! on the blocking pool, never the async executor.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::fit::ModelDims;
+
+/// Max cache entries kept on disk; the oldest are evicted past this.
+const MAX_ENTRIES: usize = 512;
+/// Entries older than this are dropped on load (a re-quant/re-upload re-resolves).
+const ENTRY_TTL_SECS: u64 = 60 * 60 * 24 * 30;
+/// After a *transient* fetch error, don't retry the same model for this long
+/// (process-local; cleared on restart so genuine transients recover).
+const FETCH_BACKOFF_SECS: u64 = 60 * 30;
+/// Max concurrent header fetches — bounds bandwidth and subprocess count.
+const MAX_CONCURRENT_FETCHES: usize = 4;
+/// Bytes of the file head to fetch — covers metadata (incl. 128k-vocab tokenizer
+/// arrays) plus tensor-info for current catalog models; a too-small fetch simply
+/// fails to parse and the caller falls back to the estimate.
+const HEADER_BYTES: u64 = 12 * 1024 * 1024;
+/// Persisted-cache schema version; a mismatch is ignored (treated as empty).
+const CACHE_SCHEMA_VERSION: u32 = 1;
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Outcome of a single header fetch+parse.
+enum FetchOutcome {
+    /// Parsed real dense dims.
+    Resolved(ModelDims),
+    /// Header fetched and parsed, but not a dense LLaMA-family model — caching this
+    /// as a negative avoids re-fetching a model we can never resolve.
+    Unparseable,
+    /// The fetch itself failed (offline, HTTP error, unsafe input). Retried later.
+    FetchError,
+}
+
+/// A persisted cache entry. `dims: None` is a *negative* (fetched, parsed, but not a
+/// dense model). `Some` is resolved. `fetched_at` drives TTL and LRU eviction.
+#[derive(Clone, Copy, serde::Serialize, serde::Deserialize)]
+struct CacheEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dims: Option<ModelDims>,
+    fetched_at: u64,
+}
+
+/// On-disk cache document (versioned for forward-compatibility).
+#[derive(serde::Serialize, serde::Deserialize)]
+struct DiskCache {
+    version: u32,
+    entries: HashMap<String, CacheEntry>,
+}
+
+struct Inner {
+    /// Persisted: resolved dims and known-unparseable negatives.
+    entries: HashMap<String, CacheEntry>,
+    /// Memory-only transient-error backoff: key → unix secs of last failure.
+    backoff: HashMap<String, u64>,
+    /// De-dup: models with a fetch in flight right now.
+    in_flight: HashSet<String>,
+    /// Set when `entries` changed since the last flush.
+    dirty: bool,
+}
+
+/// Process-wide resolver. Access via [`global`].
+pub struct DimsResolver {
+    inner: Mutex<Inner>,
+    permits: Arc<tokio::sync::Semaphore>,
+    disabled: bool,
+    cache_path: PathBuf,
+}
+
+fn key_of(repo_id: &str, filename: &str) -> String {
+    format!("{repo_id}/{filename}")
+}
+
+/// The process-wide resolver, seeded from the on-disk cache on first use.
+pub fn global() -> &'static DimsResolver {
+    static RESOLVER: OnceLock<DimsResolver> = OnceLock::new();
+    RESOLVER.get_or_init(DimsResolver::new)
+}
+
+impl DimsResolver {
+    fn new() -> Self {
+        let disabled = std::env::var("CAMELID_NO_REMOTE_DIMS")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            == Some("1");
+        let cache_path = cache_path();
+        // Seed from disk (dropping expired), unless under test — tests keep the
+        // global resolver hermetic and never touch the real user cache.
+        let entries = if cfg!(test) {
+            HashMap::new()
+        } else {
+            load_disk_cache(&cache_path)
+        };
+        DimsResolver {
+            inner: Mutex::new(Inner {
+                entries,
+                backoff: HashMap::new(),
+                in_flight: HashSet::new(),
+                dirty: false,
+            }),
+            permits: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_FETCHES)),
+            disabled,
+            cache_path,
+        }
+    }
+
+    /// Sync, non-blocking lookup for the badge: the resolved dims, or `None` if not
+    /// resolved (never fetched, in flight, a negative, or expired).
+    pub fn lookup(&self, repo_id: &str, filename: &str) -> Option<ModelDims> {
+        let key = key_of(repo_id, filename);
+        let guard = self.inner.lock().ok()?;
+        let entry = guard.entries.get(&key)?;
+        if now_secs().saturating_sub(entry.fetched_at) > ENTRY_TTL_SECS {
+            return None;
+        }
+        entry.dims
+    }
+
+    /// Directly seed a resolved entry. Test-only: lets tests exercise the exact-fit
+    /// path deterministically without a network fetch.
+    #[cfg(test)]
+    pub fn insert_for_test(&self, repo_id: &str, filename: &str, dims: ModelDims) {
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.entries.insert(
+                key_of(repo_id, filename),
+                CacheEntry {
+                    dims: Some(dims),
+                    fetched_at: now_secs(),
+                },
+            );
+        }
+    }
+
+    /// Whether a fetch should be scheduled now: not disabled, not already resolved
+    /// (or a fresh negative), not in flight, not inside the transient-error backoff.
+    fn should_fetch(&self, key: &str) -> bool {
+        if self.disabled {
+            return false;
+        }
+        let guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(_) => return false,
+        };
+        if guard.in_flight.contains(key) {
+            return false;
+        }
+        if let Some(entry) = guard.entries.get(key) {
+            // A fresh entry (resolved OR a known-unparseable negative) is final.
+            if now_secs().saturating_sub(entry.fetched_at) <= ENTRY_TTL_SECS {
+                return false;
+            }
+        }
+        if let Some(&at) = guard.backoff.get(key) {
+            if now_secs().saturating_sub(at) < FETCH_BACKOFF_SECS {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Schedule a header fetch for one model if warranted (de-duplicated, rate
+    /// limited) and return **immediately** — the fetch runs in the background and the
+    /// badge upgrades on a later render. Never blocks the caller (the permit is
+    /// awaited inside the spawned task, not here).
+    pub fn schedule(&'static self, repo_id: String, filename: String, size: u64) {
+        let key = key_of(&repo_id, &filename);
+        if !self.should_fetch(&key) {
+            return;
+        }
+        // Claim the in-flight slot; bail if another task raced us to it.
+        {
+            let mut guard = match self.inner.lock() {
+                Ok(g) => g,
+                Err(_) => return,
+            };
+            if !guard.in_flight.insert(key.clone()) {
+                return;
+            }
+        }
+        let permits = Arc::clone(&self.permits);
+        tokio::spawn(async move {
+            let permit = match permits.acquire_owned().await {
+                Ok(p) => p,
+                Err(_) => {
+                    self.clear_in_flight(&key);
+                    return;
+                }
+            };
+            tokio::task::spawn_blocking(move || {
+                let outcome = fetch_header_dims(&repo_id, &filename, size);
+                self.record(&key, outcome);
+                drop(permit);
+            });
+        });
+    }
+
+    /// Schedule fetches for a set of models (the startup curated warm).
+    pub fn warm(&'static self, models: Vec<(String, String, u64)>) {
+        for (repo, file, size) in models {
+            self.schedule(repo, file, size);
+        }
+    }
+
+    fn clear_in_flight(&self, key: &str) {
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.in_flight.remove(key);
+        }
+    }
+
+    /// Store a fetch outcome, updating the caches and eviction, then mark dirty.
+    fn record(&self, key: &str, outcome: FetchOutcome) {
+        let Ok(mut guard) = self.inner.lock() else {
+            return;
+        };
+        guard.in_flight.remove(key);
+        match outcome {
+            FetchOutcome::Resolved(dims) => {
+                guard.backoff.remove(key);
+                guard.entries.insert(
+                    key.to_string(),
+                    CacheEntry {
+                        dims: Some(dims),
+                        fetched_at: now_secs(),
+                    },
+                );
+                evict_if_needed(&mut guard.entries);
+                guard.dirty = true;
+            }
+            FetchOutcome::Unparseable => {
+                guard.backoff.remove(key);
+                guard.entries.insert(
+                    key.to_string(),
+                    CacheEntry {
+                        dims: None,
+                        fetched_at: now_secs(),
+                    },
+                );
+                evict_if_needed(&mut guard.entries);
+                guard.dirty = true;
+            }
+            FetchOutcome::FetchError => {
+                // Transient: don't persist; just back off so we retry later.
+                guard.backoff.insert(key.to_string(), now_secs());
+            }
+        }
+    }
+
+    /// Debounced single-writer flush loop. Spawned once by `serve`; coalesces bursts
+    /// of stores into one write. Never runs under test (keeps tests off disk).
+    pub async fn flush_loop(&'static self) {
+        if self.disabled {
+            return;
+        }
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
+        loop {
+            interval.tick().await;
+            let snapshot = {
+                let mut guard = match self.inner.lock() {
+                    Ok(g) => g,
+                    Err(_) => continue,
+                };
+                if !guard.dirty {
+                    continue;
+                }
+                guard.dirty = false;
+                guard.entries.clone()
+            };
+            let path = self.cache_path.clone();
+            let _ = tokio::task::spawn_blocking(move || write_disk_cache(&path, &snapshot)).await;
+        }
+    }
+}
+
+/// Kick off the background lifecycle from `serve`: seed is lazy on first `global()`;
+/// here we start the debounced flusher and warm the curated rows once. Both are
+/// best-effort background tasks and never block startup.
+pub fn start_background(curated: Vec<(String, String, u64)>) {
+    let resolver = global();
+    if resolver.disabled {
+        return;
+    }
+    tokio::spawn(resolver.flush_loop());
+    resolver.warm(curated);
+}
+
+// --- GGUF header fetch + parse ---------------------------------------------
+
+/// Read a GGUF's KV dimensions from a local file WITHOUT loading weights (header
+/// only, the same cheap path `/api/models/inspect` uses). `None` for a non-GGUF, an
+/// unreadable header, a non-dense/unknown architecture, or implausible dims.
+pub fn dims_from_gguf_file(path: &Path) -> Option<ModelDims> {
+    let gguf = crate::gguf::read_metadata(path).ok()?;
+    let config = crate::model::LlamaModelConfig::from_gguf(&gguf).ok()?;
+    let dims = crate::model::DenseLlamaDims::from_config(&config).ok()?;
+    let dims = ModelDims {
+        layers: dims.block_count as u64,
+        kv_heads: dims.attention_head_count_kv as u64,
+        head_dim: dims.head_dim as u64,
+    };
+    dims.is_plausible().then_some(dims)
+}
+
+/// A GGUF filename that is one shard of a split export (e.g.
+/// `model.shard-00001-of-00005.gguf` or `model-00001-of-00003.gguf`) is not a
+/// standalone loadable model, so we never fetch or make a fit claim for it.
+pub fn is_gguf_shard(filename: &str) -> bool {
+    let lower = filename.to_ascii_lowercase();
+    let Some(idx) = lower.find("-of-") else {
+        return false;
+    };
+    let left_is_num = lower[..idx]
+        .rsplit('-')
+        .next()
+        .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()));
+    let right_is_num = lower[idx + 4..]
+        .split(['-', '.'])
+        .next()
+        .is_some_and(|s| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()));
+    left_is_num && right_is_num
+}
+
+/// A Hugging Face repo id / filename safe to interpolate into a resolve URL:
+/// non-empty, no path traversal, only expected URL-path characters.
+pub fn is_safe_hf_component(s: &str) -> bool {
+    !s.is_empty()
+        && !s.contains("..")
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/'))
+}
+
+/// Fetch a model's KV dims from its GGUF header over the network. GGUF stores all
+/// metadata + tensor-info at the file start, so we range-fetch a header slice into a
+/// temp file whose *length* is set to the real size (the unfetched tail is sparse
+/// zeros the parser never reads — it only validates tensor offsets against the
+/// length), then reuse the trusted on-disk parser. Blocking; call off the executor.
+fn fetch_header_dims(repo_id: &str, filename: &str, full_size: u64) -> FetchOutcome {
+    // Skip inputs we shouldn't fetch: unknown size, split-model shards, and any
+    // unsafe repo/filename we'd interpolate into a URL.
+    if full_size == 0 || is_gguf_shard(filename) {
+        return FetchOutcome::Unparseable;
+    }
+    if !is_safe_hf_component(repo_id) || filename.contains('/') || !is_safe_hf_component(filename) {
+        return FetchOutcome::Unparseable;
+    }
+    let safe: String = filename
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let tmp = std::env::temp_dir().join(format!("camelid-hdr-{}-{safe}", std::process::id()));
+    let range_end = HEADER_BYTES.min(full_size).saturating_sub(1);
+    let url = format!("https://huggingface.co/{repo_id}/resolve/main/{filename}");
+    let fetched = std::process::Command::new("curl")
+        .args(["-fsSL", "-r", &format!("0-{range_end}"), "-o"])
+        .arg(&tmp)
+        .arg(&url)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !fetched {
+        let _ = std::fs::remove_file(&tmp);
+        return FetchOutcome::FetchError;
+    }
+    // Extend the temp file to the real size so the parser's tensor-offset bounds
+    // checks pass; the tail is sparse zeros and is never read.
+    if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&tmp) {
+        let _ = f.set_len(full_size);
+    }
+    let dims = dims_from_gguf_file(&tmp);
+    let _ = std::fs::remove_file(&tmp);
+    match dims {
+        Some(d) => FetchOutcome::Resolved(d),
+        // Fetched fine but not dense-parseable → negative (don't re-fetch).
+        None => FetchOutcome::Unparseable,
+    }
+}
+
+// --- disk cache -------------------------------------------------------------
+
+/// Where the persisted dims cache lives. Honors `CAMELID_FIT_DIMS_CACHE` (tests use
+/// it for isolation); otherwise the per-user OS cache dir, else the temp dir.
+fn cache_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("CAMELID_FIT_DIMS_CACHE") {
+        return PathBuf::from(p);
+    }
+    let base = if cfg!(windows) {
+        std::env::var_os("LOCALAPPDATA").map(PathBuf::from)
+    } else {
+        std::env::var_os("XDG_CACHE_HOME")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))
+    };
+    base.unwrap_or_else(std::env::temp_dir)
+        .join("camelid")
+        .join("fit-dims-cache.json")
+}
+
+/// Read + validate the persisted cache, dropping expired entries. Missing, corrupt,
+/// or wrong-version → empty (never panics).
+fn load_disk_cache(path: &Path) -> HashMap<String, CacheEntry> {
+    let Some(doc) = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<DiskCache>(&s).ok())
+    else {
+        return HashMap::new();
+    };
+    if doc.version != CACHE_SCHEMA_VERSION {
+        return HashMap::new();
+    }
+    let now = now_secs();
+    doc.entries
+        .into_iter()
+        .filter(|(_, e)| now.saturating_sub(e.fetched_at) <= ENTRY_TTL_SECS)
+        .collect()
+}
+
+/// Persist the cache (best-effort; creates the parent dir).
+fn write_disk_cache(path: &Path, entries: &HashMap<String, CacheEntry>) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let doc = DiskCache {
+        version: CACHE_SCHEMA_VERSION,
+        entries: entries.clone(),
+    };
+    if let Ok(json) = serde_json::to_string(&doc) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+/// Evict the oldest entries (by `fetched_at`) until at most [`MAX_ENTRIES`] remain.
+fn evict_if_needed(entries: &mut HashMap<String, CacheEntry>) {
+    if entries.len() <= MAX_ENTRIES {
+        return;
+    }
+    let mut by_age: Vec<(u64, String)> = entries
+        .iter()
+        .map(|(k, e)| (e.fetched_at, k.clone()))
+        .collect();
+    by_age.sort_unstable();
+    let excess = entries.len() - MAX_ENTRIES;
+    for (_, key) in by_age.into_iter().take(excess) {
+        entries.remove(&key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dims(l: u64) -> ModelDims {
+        ModelDims {
+            layers: l,
+            kv_heads: 8,
+            head_dim: 128,
+        }
+    }
+
+    #[test]
+    fn shard_filenames_are_detected() {
+        assert!(is_gguf_shard("model.shard-00001-of-00005.gguf"));
+        assert!(is_gguf_shard("Meta-Llama-70B-00001-of-00003.gguf"));
+        assert!(!is_gguf_shard("Qwen3-0.6B-Q8_0.gguf"));
+        assert!(!is_gguf_shard("something-of-value.gguf")); // "-of-" but not numeric
+    }
+
+    #[test]
+    fn unsafe_hf_components_are_rejected() {
+        assert!(is_safe_hf_component("Qwen/Qwen3-0.6B-GGUF"));
+        assert!(is_safe_hf_component("Model-Q8_0.gguf"));
+        assert!(!is_safe_hf_component(""));
+        assert!(!is_safe_hf_component("../../etc/passwd"));
+        assert!(!is_safe_hf_component("repo/../x"));
+        assert!(!is_safe_hf_component("bad name.gguf?x=1"));
+    }
+
+    #[test]
+    fn disk_cache_round_trips_and_tolerates_missing_corrupt_and_version() {
+        let dir = std::env::temp_dir().join(format!("camelid-fitdims-test-{}", std::process::id()));
+        let path = dir.join("dims.json");
+        assert!(load_disk_cache(&path).is_empty()); // missing → empty
+        let mut map = HashMap::new();
+        map.insert(
+            "Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf".to_string(),
+            CacheEntry {
+                dims: Some(dims(28)),
+                fetched_at: now_secs(),
+            },
+        );
+        write_disk_cache(&path, &map);
+        let back = load_disk_cache(&path);
+        assert_eq!(back.len(), 1);
+        assert_eq!(back.values().next().unwrap().dims, Some(dims(28)));
+        // Corrupt → empty.
+        std::fs::write(&path, b"{ not json").unwrap();
+        assert!(load_disk_cache(&path).is_empty());
+        // Wrong version → empty.
+        std::fs::write(&path, br#"{"version":999,"entries":{}}"#).unwrap();
+        assert!(load_disk_cache(&path).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn expired_entries_are_dropped_on_load() {
+        let dir = std::env::temp_dir().join(format!("camelid-fitdims-ttl-{}", std::process::id()));
+        let path = dir.join("dims.json");
+        let mut map = HashMap::new();
+        map.insert(
+            "fresh".to_string(),
+            CacheEntry {
+                dims: Some(dims(1)),
+                fetched_at: now_secs(),
+            },
+        );
+        map.insert(
+            "stale".to_string(),
+            CacheEntry {
+                dims: Some(dims(2)),
+                fetched_at: now_secs().saturating_sub(ENTRY_TTL_SECS + 1),
+            },
+        );
+        write_disk_cache(&path, &map);
+        let back = load_disk_cache(&path);
+        assert!(back.contains_key("fresh"));
+        assert!(!back.contains_key("stale"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn eviction_keeps_the_newest_entries() {
+        let mut entries = HashMap::new();
+        for i in 0..(MAX_ENTRIES as u64 + 10) {
+            entries.insert(
+                format!("k{i}"),
+                CacheEntry {
+                    dims: Some(dims(i.max(1))),
+                    fetched_at: 1000 + i, // higher i = newer
+                },
+            );
+        }
+        evict_if_needed(&mut entries);
+        assert_eq!(entries.len(), MAX_ENTRIES);
+        assert!(entries.contains_key(&format!("k{}", MAX_ENTRIES as u64 + 9))); // newest kept
+        assert!(!entries.contains_key("k0")); // oldest evicted
+    }
+
+    #[test]
+    fn negative_entries_serialize_compactly_and_round_trip() {
+        let dir = std::env::temp_dir().join(format!("camelid-fitdims-neg-{}", std::process::id()));
+        let path = dir.join("dims.json");
+        let mut map = HashMap::new();
+        map.insert(
+            "some/moe-model.gguf".to_string(),
+            CacheEntry {
+                dims: None, // negative: fetched but not dense-parseable
+                fetched_at: now_secs(),
+            },
+        );
+        write_disk_cache(&path, &map);
+        let back = load_disk_cache(&path);
+        assert_eq!(back.get("some/moe-model.gguf").unwrap().dims, None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // --- minimal GGUF fixture: proves `dims_from_gguf_file` end to end in CI,
+    // with no network and no committed binary blob. Byte layout mirrors the GGUF v3
+    // reader (magic, version, i64 counts, typed metadata KVs, tensor directory).
+    fn push_u32(b: &mut Vec<u8>, v: u32) {
+        b.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_i32(b: &mut Vec<u8>, v: i32) {
+        b.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_i64(b: &mut Vec<u8>, v: i64) {
+        b.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_u64(b: &mut Vec<u8>, v: u64) {
+        b.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_str(b: &mut Vec<u8>, s: &str) {
+        push_u64(b, s.len() as u64);
+        b.extend_from_slice(s.as_bytes());
+    }
+    fn kv_str(b: &mut Vec<u8>, k: &str, v: &str) {
+        push_str(b, k);
+        push_u32(b, 8); // string type id
+        push_str(b, v);
+    }
+    fn kv_u32(b: &mut Vec<u8>, k: &str, v: u32) {
+        push_str(b, k);
+        push_u32(b, 4); // u32 type id
+        push_u32(b, v);
+    }
+
+    #[test]
+    fn dims_from_gguf_file_parses_a_minimal_llama_fixture() {
+        let mut b = Vec::new();
+        b.extend_from_slice(b"GGUF");
+        push_u32(&mut b, 3); // version
+        push_i64(&mut b, 1); // tensor_count
+        push_i64(&mut b, 8); // metadata_count
+        kv_str(&mut b, "general.architecture", "llama");
+        kv_u32(&mut b, "llama.context_length", 4096);
+        kv_u32(&mut b, "llama.embedding_length", 64);
+        kv_u32(&mut b, "llama.block_count", 4);
+        kv_u32(&mut b, "llama.feed_forward_length", 128);
+        kv_u32(&mut b, "llama.attention.head_count", 8);
+        kv_u32(&mut b, "llama.attention.head_count_kv", 8);
+        kv_u32(&mut b, "llama.vocab_size", 1000);
+        // One tensor so the directory + offset checks exercise the real parser.
+        push_str(&mut b, "token_embd.weight");
+        push_u32(&mut b, 2); // n_dims
+        push_i64(&mut b, 4);
+        push_i64(&mut b, 2);
+        push_i32(&mut b, 0); // f32
+        push_u64(&mut b, 0); // relative offset
+        while !b.len().is_multiple_of(32) {
+            b.push(0);
+        }
+        b.extend_from_slice(&[0u8; 4 * 2 * 4]); // tensor data
+
+        let dir =
+            std::env::temp_dir().join(format!("camelid-fitdims-fixture-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("minimal-llama.gguf");
+        std::fs::write(&path, &b).unwrap();
+
+        // embedding 64 / head_count 8 → head_dim 8.
+        let dims = dims_from_gguf_file(&path).expect("minimal llama fixture should parse");
+        assert_eq!(
+            dims,
+            ModelDims {
+                layers: 4,
+                kv_heads: 8,
+                head_dim: 8,
+            }
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn lookup_round_trips_via_the_test_injector() {
+        // Uses a unique key so it can't collide with other tests on the shared global.
+        let (repo, file) = ("test-fitdims/lookup-repo", "lookup.gguf");
+        assert!(global().lookup(repo, file).is_none());
+        global().insert_for_test(
+            repo,
+            file,
+            ModelDims {
+                layers: 12,
+                kv_heads: 2,
+                head_dim: 64,
+            },
+        );
+        assert_eq!(
+            global().lookup(repo, file),
+            Some(ModelDims {
+                layers: 12,
+                kv_heads: 2,
+                head_dim: 64
+            })
+        );
+    }
+
+    #[test]
+    fn header_fetch_reads_a_real_gguf_when_enabled() {
+        // Network-gated: self-skips offline / in normal CI. Enable with
+        // CAMELID_TEST_REMOTE_DIMS=1 to verify the header range-fetch end to end.
+        if std::env::var("CAMELID_TEST_REMOTE_DIMS").ok().as_deref() != Some("1") {
+            return;
+        }
+        // Qwen3-0.6B (~639 MB) and a 128k-vocab Llama (biggest metadata) — header only.
+        for (repo, file, size) in [
+            (
+                "Qwen/Qwen3-0.6B-GGUF",
+                "Qwen3-0.6B-Q8_0.gguf",
+                639_446_688u64,
+            ),
+            (
+                "unsloth/Llama-3.2-1B-Instruct-GGUF",
+                "Llama-3.2-1B-Instruct-Q8_0.gguf",
+                1_321_082_528u64,
+            ),
+        ] {
+            match fetch_header_dims(repo, file, size) {
+                FetchOutcome::Resolved(d) => {
+                    assert!(d.is_plausible(), "{file}: implausible dims {d:?}");
+                    eprintln!("{file} header dims: {d:?}");
+                }
+                _ => panic!("{file}: expected resolved dims from a real header"),
+            }
+        }
+    }
+}

--- a/src/fit_dims.rs
+++ b/src/fit_dims.rs
@@ -381,7 +381,20 @@ fn fetch_header_dims(repo_id: &str, filename: &str, full_size: u64) -> FetchOutc
         .chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
         .collect();
-    let tmp = std::env::temp_dir().join(format!("camelid-hdr-{}-{safe}", std::process::id()));
+    // The temp path must be unique per (repo, filename): different repos routinely
+    // ship the same filename, and `in_flight` dedup is keyed by the full pair, so
+    // those fetch concurrently. Filename alone would collide into one temp file and
+    // race set_len/parse/remove_file. Hash the full key for a collision-free name.
+    let token = {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash(repo_id, &mut hasher);
+        std::hash::Hash::hash(filename, &mut hasher);
+        std::hash::Hasher::finish(&hasher)
+    };
+    let tmp = std::env::temp_dir().join(format!(
+        "camelid-hdr-{}-{token:016x}-{safe}",
+        std::process::id()
+    ));
     let range_end = HEADER_BYTES.min(full_size).saturating_sub(1);
     let url = format!("https://huggingface.co/{repo_id}/resolve/main/{filename}");
     let fetched = std::process::Command::new("curl")

--- a/src/gguf/mod.rs
+++ b/src/gguf/mod.rs
@@ -9,3 +9,9 @@ use crate::Result;
 pub fn read_metadata(path: impl AsRef<Path>) -> Result<GgufFile> {
     reader::read_metadata(path.as_ref())
 }
+
+/// Parse a GGUF header prefix, validating tensor bounds against `declared_len`
+/// instead of the on-disk length. See [`reader::read_metadata_with_len`].
+pub fn read_metadata_with_len(path: impl AsRef<Path>, declared_len: u64) -> Result<GgufFile> {
+    reader::read_metadata_with_len(path.as_ref(), declared_len)
+}

--- a/src/gguf/reader.rs
+++ b/src/gguf/reader.rs
@@ -312,16 +312,30 @@ impl GgufFile {
 }
 
 pub fn read_metadata(path: &Path) -> Result<GgufFile> {
-    let file = File::open(path).map_err(|source| BackendError::Io {
-        path: path.to_path_buf(),
-        source,
-    })?;
     let file_len = fs::metadata(path)
         .map_err(|source| BackendError::Io {
             path: path.to_path_buf(),
             source,
         })?
         .len();
+    read_metadata_with_len(path, file_len)
+}
+
+/// Parse a GGUF's metadata and tensor descriptors, validating tensor byte ranges
+/// against `declared_len` rather than the on-disk file length.
+///
+/// A GGUF stores all metadata and the tensor-info block at the file start, so a
+/// caller holding only a ranged header *prefix* can parse it fully by passing the
+/// model's true full length here: every offset bounds check still runs against
+/// the real size, but no tensor data is read and the local file need not be
+/// extended to that size. `read_metadata` is the ordinary path and passes the
+/// actual file length.
+pub fn read_metadata_with_len(path: &Path, declared_len: u64) -> Result<GgufFile> {
+    let file = File::open(path).map_err(|source| BackendError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let file_len = declared_len;
     let mut cursor = Cursor::new(file, path.to_path_buf());
 
     let magic = cursor.read_bytes(4)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod diffusion_gemma;
 pub mod distributed;
 pub mod error;
 pub mod execution_plan;
+pub mod fit;
 pub mod gait;
 pub mod gemma4_distributed;
 pub mod gemma4_runtime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod distributed;
 pub mod error;
 pub mod execution_plan;
 pub mod fit;
+pub mod fit_dims;
 pub mod gait;
 pub mod gemma4_distributed;
 pub mod gemma4_runtime;


### PR DESCRIPTION
## Summary

- Adds a hardware-aware **model fit advisor** — a *capacity* signal estimating whether the local machine can load/run each catalog model, surfaced across API, WebUI, and CLI. Strictly separate from support/parity.
- `src/fit.rs`: `FitVerdict` + pure `assess()`, reusing `cuda_vram::evaluate` for the VRAM branch and a host-RAM budget **modeled on** the `kv_cache` `max(80% available, 25% total)` policy (independent reimplementation over `HardwareProfile`; documented platform divergences). Degrades to `unknown` (never a failure) when memory can't be probed.
- **Exact pre-download sizing:** `src/fit_dims.rs` (`DimsResolver`) reads each model's real GGUF dimensions from a **12 MiB header range-fetch** — no weight download — and computes an exact KV-cache footprint. Rows carry `fit_confidence: exact | approx | unknown`; the WebUI shows a solid chip for `exact` and a dashed `~` estimate chip for the coarse `approx` fallback (non-dense/unparseable archs, e.g. Gemma-4 MoE, are honestly left `approx`).
- `DimsResolver` is production-hardened: in-flight de-dup, bounded concurrency (semaphore) with curl `--connect-timeout/--max-time`, an RAII drop-guard so a panicked/early-returned fetch can't pin a slot, a debounced single-writer, and a **versioned + TTL + LRU** disk cache with negative caching. `GET /api/models/catalog` is side-effect-free for curated rows (warmed once at startup); HF-search rows schedule ≤5 bounded background fetches.
- WebUI capacity chip (blue "fits" / red "too big" + CPU-chip icon) with advisory "best for" tags; CLI `pull` gains a `FIT (this host)` column; `POST /api/models/load` fail-fasts with a typed **`422 model_too_large_for_host`** (overridable via `CAMELID_SKIP_FIT_CHECK=1`). The load guard runs on a blocking thread (off the async executor).
- **Capacity axis only** — a "fits" verdict never appears in `model_compatibility` and cannot promote any row.

## Why this change exists

Camelid reports which models are supported/runnable but never whether your machine can hold one, so a user can download an 8B and only discover it won't fit via a mid-load OOM or a mid-generation KV abort. This gives an honest, up-front capacity signal (before download and at load time) so users pick a model that actually runs — without touching the support ledger. The runtime `VramShortfall`/KV guards remain the authoritative safety net; this layer only informs.

## Compatibility note

`POST /api/models/load` can now fail-fast with `422 model_too_large_for_host` on a `WontFit` verdict from a **probed** host, where it previously always attempted the load. It never fires on an unprobed host (`Unknown` is never `WontFit`), and `CAMELID_SKIP_FIT_CHECK=1` restores the unconditional load-attempt behavior. The authoritative `VramShortfall`/`KvCache` guards remain the hard net after the load begins.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --lib` → **710 passed, 0 failed** (incl. `fit::tests`, `api::catalog_fit_tests`, `fit_dims::tests`, and a hermetic GGUF header-prefix parse test)
- `cd frontend && npm run build` — clean
- Gated live network test `CAMELID_TEST_REMOTE_DIMS=1` (Qwen3-0.6B, Llama-3.2-1B) verifies the header fetch end-to-end.

## Evidence / artifacts

- Live on an RTX 4060 (8 GB) / 16 GB host: catalog warmed **11 exact / 4 approx** (the 4 approx are Gemma-4 E2B/E4B/12B/26B-A4B — non-dense metadata, correctly negative-cached, not network failures). A restart served **11 exact from the disk cache in ~1.5 s with zero re-fetch**. Small/mid rows → "fits", 7–8B → "fits (offload)", 12B/26B → "too big" — consistent across API JSON, CLI column, and the WebUI chip.
- Behavior is advisory only; the badge is a static capacity hint (cached startup snapshot), while the load guard re-probes live — documented as an intentional hint-vs-authoritative split.

## Public-repo privacy check

No private hostnames, SSH commands, user home paths, key paths, or raw infrastructure output are included. Remote validation blockers are summarized generically. `bash scripts/check-public-scrub.sh`; `node audit-evidence-bundle-privacy.mjs --strict`.

## Support-contract check

No support wording changed. TinyLlama Q8_0 remains the full-support gate; 1B/3B/8B rows stay within their documented exact-row smoke envelopes. The only ledger edit is a new "Capacity rule" in COMPATIBILITY.md stating the fit verdict is not a support claim.

## Docs impact

- `docs/architecture/MODEL_FIT_ADVISOR_PLAN.md` — end-to-end design/plan (Slices 1–8, incl. the DimsResolver redesign and review-hardening).
- `ROADMAP.md` — new "Model fit advisor (capacity axis)" lane.
- `COMPATIBILITY.md` — new "Capacity rule" in Governing rules.