### PR TITLE
fix(api): serialize DiffusionGemma serve generations (dg-vs-dg CUDA corruption)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5276,6 +5276,28 @@ pub struct DgServeRuntime {
     chat: crate::diffusion_gemma::chat::DgChat,
 }
 
+/// Whole-generation serialization for the DiffusionGemma serve lane. On CUDA
+/// builds every dg request funnels through the process-global engine singleton
+/// (`diffusion_gemma::cuda::ENGINE`), whose internal `Mutex` is held only per
+/// kernel op — state like `Engine::last_logits` is handed BETWEEN ops within a
+/// forward step, so two concurrent requests interleaving ops logically corrupt
+/// each other's generations. This lane-global lock mirrors the gemma4 Cuda
+/// pattern (`Gemma4ServeRuntime::Cuda`'s whole-decode `Mutex`): held for the
+/// entire generate call, acquired INSIDE the `spawn_blocking` closure so a
+/// dropped SSE stream (client disconnect drops the async frame, not the
+/// blocking thread) can never release it mid-decode. Unconditional on CPU
+/// builds too — harmless, and it keeps the invariant build-independent.
+static DG_GENERATION_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire the dg whole-generation lock. Poisoning is handled the way the
+/// gemma4 Cuda lane handles its runtime lock (`.expect`): a panicked
+/// generation poisons the lane and later requests fail loudly (surfaced as a
+/// generation_error by the handlers' panic paths) rather than decode against
+/// possibly-corrupt engine state.
+fn dg_generation_guard() -> std::sync::MutexGuard<'static, ()> {
+    DG_GENERATION_LOCK.lock().expect("dg generation lock")
+}
+
 impl DgServeRuntime {
     fn load(path: &std::path::Path) -> std::result::Result<Self, BackendError> {
         Ok(Self {
@@ -5386,6 +5408,9 @@ async fn dg_chat_nonstreaming(
     let n_blocks = dg_serve_blocks();
     let rt = runtime.clone();
     let result = tokio::task::spawn_blocking(move || {
+        // Serialize the WHOLE generation (see `DG_GENERATION_LOCK`): the CUDA
+        // engine is process-global and its internal lock is per-kernel-op only.
+        let _generation_guard = dg_generation_guard();
         let prompt_tokens = rt.chat.render_prompt(&user_msg).map(|v| v.len())?;
         rt.chat
             .generate(&user_msg, &params, n_blocks, 1100, |_, _, _, _| {})
@@ -5469,6 +5494,10 @@ async fn dg_chat_streaming(
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<StreamItem>();
     let rt = runtime.clone();
     tokio::task::spawn_blocking(move || {
+        // Serialize the WHOLE generation (see `DG_GENERATION_LOCK`). Acquired
+        // here on the blocking thread — NOT in the async frame — so a dropped
+        // SSE stream cannot release the guard while the decode is in flight.
+        let _generation_guard = dg_generation_guard();
         let send_tx = tx.clone();
         let step_tx = tx.clone();
         let prompt_tokens = match rt.chat.render_prompt(&user_msg) {
@@ -12030,6 +12059,52 @@ mod tests {
             max_seen.load(Ordering::SeqCst),
             1,
             "generation_lock must serialize decoding: never more than one decode in flight",
+        );
+    }
+
+    /// Regression test for the dg-vs-dg CUDA corruption hazard: on CUDA builds
+    /// every DiffusionGemma serve request runs through the process-global
+    /// engine singleton whose internal Mutex is per-kernel-op only, so
+    /// `dg_chat_nonstreaming` / `dg_chat_streaming` must hold
+    /// `DG_GENERATION_LOCK` for the whole generation inside their
+    /// `spawn_blocking` closures. This verifies the lock serializes — with
+    /// many blocking tasks acquiring it the way the handlers do, never more
+    /// than one is inside the critical section at a time.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn dg_generation_lock_serializes_generations() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let active = active.clone();
+            let max_seen = max_seen.clone();
+            handles.push(tokio::task::spawn_blocking(move || {
+                // Same acquisition both dg handlers perform: the guard is
+                // taken on the blocking thread, around the whole generation.
+                let _generation_guard = dg_generation_guard();
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_seen.fetch_max(now, Ordering::SeqCst);
+                // Linger while holding the guard. If the lock failed to
+                // serialize, another task would enter here and push
+                // `active` > 1.
+                for _ in 0..8 {
+                    std::thread::yield_now();
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1));
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(
+            max_seen.load(Ordering::SeqCst),
+            1,
+            "DG_GENERATION_LOCK must serialize dg generations: never more than one in flight",
         );
     }
 


### PR DESCRIPTION
## Hazard

The DiffusionGemma serve lane (env-gated `CAMELID_DG_SERVE=1`) has no whole-generation serialization (verified at ffada00f):

- `DgServeRuntime` is stored as a bare `Arc` with no lock (`src/api/mod.rs:5275-5285`); the handlers `dg_chat_nonstreaming` (spawn_blocking at :5388) and `dg_chat_streaming` (spawn_blocking at :5471) take no guard and call `rt.chat.generate...` on `&self`.
- On CUDA builds (default-on win-x86_64 via build.rs), all dg requests funnel through a process-global `static ENGINE: OnceLock<Mutex<Option<Engine>>>` (`src/diffusion_gemma/cuda.rs:1160`) whose Mutex is held only **per kernel op** (lock sites ~:1341, :1422, :1528, :1863, :2447, :2547, :2643). `Engine::last_logits` is handed between ops within a forward step (:2646) and `dg_generation_reset` mutates it per block (:2619-2627).
- Two concurrent dg requests interleave kernel ops on that shared state, logically corrupting each other's generations (wrong output, not Rust UB).

Recon memo: `docs/recon/ENGINE_INVERSION_R1_LANE_RECON.md` (engine-inversion mission, P0-R1 lane recon) — the dg lane is the one lane classified SHARED-AND-UNSERIALIZED (dg-vs-dg).

## Fix

Mirrors the proven gemma4 Cuda pattern (`Gemma4ServeRuntime::Cuda` holds a `std::sync::Mutex` across the whole decode on the blocking thread, `src/api/mod.rs:4276-4296`):

- New lane-global `static DG_GENERATION_LOCK: std::sync::Mutex<()>` + `dg_generation_guard()` helper (the CUDA engine is process-global, so a lane-global lock is the right granularity).
- Acquired **inside** both `spawn_blocking` closures around the entire generate call (nonstreaming and streaming), so a dropped SSE stream — which drops the async frame, not the blocking thread — can never release the guard mid-decode (the hold-then-detach hazard the engine-inversion mission is fixing on the main lane is deliberately not reintroduced here).
- Unconditional on CPU builds too (harmless; keeps the invariant build-independent).
- Poisoning handled the way the gemma4 lane handles its runtime lock (`.expect` — fail loudly, surfaced as a generation_error by the handlers' existing panic paths).

## Evidence / gates

- New regression test `api::tests::dg_generation_lock_serializes_generations`: AtomicUsize max-concurrency probe over 32 `spawn_blocking` tasks acquiring the lock exactly as the handlers do (mirrors `generation_lock_serializes_decoding`). Passes.
- `cargo fmt --check` clean; `cargo clippy --all-targets --all-features -D warnings` clean.
- Full `cargo test --lib`: 673 passed, 0 failed, 55 ignored.
- `scripts/check-public-scrub.sh` clean.
- No behavior change for a single in-flight dg request; concurrent dg requests now queue instead of corrupting each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)