### PR TITLE
fix(telemetry): FFN decode-chain stage timings in nanoseconds — deterministic on fast boxes

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -12424,9 +12424,11 @@ fn try_x86_q8_ffn_decode_chain_path(
     let total_started = Instant::now();
     let input_quantize_started = Instant::now();
     let quantized_input = quantize_q8_0_row(&input.data[..input_width]);
+    // Chain stage timings accumulate nanoseconds: a single-row quantize is tens
+    // of ns, which microsecond truncation would record as a permanent 0.
     add_q8_schedule_counter(
-        &Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_US,
-        input_quantize_started.elapsed().as_micros() as u64,
+        &Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_NS,
+        input_quantize_started.elapsed().as_nanos() as u64,
     );
 
     let order = diagnostic_ffn_gate_up_order()?;
@@ -12474,8 +12476,8 @@ fn try_x86_q8_ffn_decode_chain_path(
     let activation_quantize_started = Instant::now();
     let quantized_activated = quantize_q8_0_row(&activated.data[..down_route.input_width]);
     add_q8_schedule_counter(
-        &Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_US,
-        activation_quantize_started.elapsed().as_micros() as u64,
+        &Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_NS,
+        activation_quantize_started.elapsed().as_nanos() as u64,
     );
 
     let down_started = Instant::now();
@@ -12572,14 +12574,20 @@ fn try_x86_q8_ffn_decode_chain_path(
             decode_group_chunking,
         )?
     };
-    let down_elapsed = down_started.elapsed().as_micros();
+    // The chain counters take nanoseconds; the by-route map stays microseconds
+    // (its `elapsed_us` field is shared by every projection route).
+    let down_duration = down_started.elapsed();
+    let down_elapsed = down_duration.as_micros();
     add_q8_schedule_counter(&Q8_SCHED_FFN_DOWN_DECODE_CONSUMER_TAKEN, 1);
     add_q8_schedule_counter(&Q8_SCHED_FFN_DECODE_CHAIN_TAKEN, 1);
     add_q8_schedule_counter(
-        &Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_US,
-        total_started.elapsed().as_micros() as u64,
+        &Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_NS,
+        total_started.elapsed().as_nanos() as u64,
     );
-    add_q8_schedule_counter(&Q8_SCHED_FFN_DECODE_CHAIN_DOWN_US, down_elapsed as u64);
+    add_q8_schedule_counter(
+        &Q8_SCHED_FFN_DECODE_CHAIN_DOWN_NS,
+        down_duration.as_nanos() as u64,
+    );
     record_q8_schedule_output_projection_route_call(
         "ffn_down",
         down_route_name,

--- a/src/inference/q8_telemetry.rs
+++ b/src/inference/q8_telemetry.rs
@@ -28,10 +28,14 @@ pub struct LlamaQ8ScheduleTelemetry {
     pub ffn_gate_up_decode_consumer_activation_us: u64,
     pub ffn_gate_up_decode_consumer_tensor_us: u64,
     pub ffn_decode_chain_taken: u64,
-    pub ffn_decode_chain_total_us: u64,
-    pub ffn_decode_chain_input_quantize_us: u64,
-    pub ffn_decode_chain_activation_quantize_us: u64,
-    pub ffn_decode_chain_down_us: u64,
+    // Chain stage timings accumulate NANOseconds: the per-call stages (a single
+    // row quantize is tens of ns) sit far below 1µs, so microsecond truncation
+    // recorded 0 forever on a fast box — underreporting real cost in perf work
+    // and making "the instrumentation is wired" untestable.
+    pub ffn_decode_chain_total_ns: u64,
+    pub ffn_decode_chain_input_quantize_ns: u64,
+    pub ffn_decode_chain_activation_quantize_ns: u64,
+    pub ffn_decode_chain_down_ns: u64,
     pub activation_pack_calls: u64,
     pub activation_pack_rows: u64,
     pub activation_pack_bytes_requested: u64,
@@ -127,10 +131,10 @@ pub(super) static Q8_SCHED_FFN_GATE_UP_DECODE_FUSED_ACTIVATION_TAKEN: AtomicU64 
 pub(super) static Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_ACTIVATION_US: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TENSOR_US: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_TAKEN: AtomicU64 = AtomicU64::new(0);
-pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_US: AtomicU64 = AtomicU64::new(0);
-pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_US: AtomicU64 = AtomicU64::new(0);
-pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_US: AtomicU64 = AtomicU64::new(0);
-pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_DOWN_US: AtomicU64 = AtomicU64::new(0);
+pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_NS: AtomicU64 = AtomicU64::new(0);
+pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_NS: AtomicU64 = AtomicU64::new(0);
+pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_NS: AtomicU64 = AtomicU64::new(0);
+pub(super) static Q8_SCHED_FFN_DECODE_CHAIN_DOWN_NS: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_ACTIVATION_PACK_CALLS: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_ACTIVATION_PACK_ROWS: AtomicU64 = AtomicU64::new(0);
 pub(super) static Q8_SCHED_ACTIVATION_PACK_BYTES_REQUESTED: AtomicU64 = AtomicU64::new(0);
@@ -204,10 +208,10 @@ pub fn reset_q8_schedule_telemetry() {
     Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_ACTIVATION_US.store(0, Ordering::Relaxed);
     Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TENSOR_US.store(0, Ordering::Relaxed);
     Q8_SCHED_FFN_DECODE_CHAIN_TAKEN.store(0, Ordering::Relaxed);
-    Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_US.store(0, Ordering::Relaxed);
-    Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_US.store(0, Ordering::Relaxed);
-    Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_US.store(0, Ordering::Relaxed);
-    Q8_SCHED_FFN_DECODE_CHAIN_DOWN_US.store(0, Ordering::Relaxed);
+    Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_NS.store(0, Ordering::Relaxed);
+    Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_NS.store(0, Ordering::Relaxed);
+    Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_NS.store(0, Ordering::Relaxed);
+    Q8_SCHED_FFN_DECODE_CHAIN_DOWN_NS.store(0, Ordering::Relaxed);
     Q8_SCHED_ACTIVATION_PACK_CALLS.store(0, Ordering::Relaxed);
     Q8_SCHED_ACTIVATION_PACK_ROWS.store(0, Ordering::Relaxed);
     Q8_SCHED_ACTIVATION_PACK_BYTES_REQUESTED.store(0, Ordering::Relaxed);
@@ -311,12 +315,12 @@ pub fn snapshot_q8_schedule_telemetry() -> LlamaQ8ScheduleTelemetry {
         ffn_gate_up_decode_consumer_tensor_us: Q8_SCHED_FFN_GATE_UP_DECODE_CONSUMER_TENSOR_US
             .load(Ordering::Relaxed),
         ffn_decode_chain_taken: Q8_SCHED_FFN_DECODE_CHAIN_TAKEN.load(Ordering::Relaxed),
-        ffn_decode_chain_total_us: Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_US.load(Ordering::Relaxed),
-        ffn_decode_chain_input_quantize_us: Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_US
+        ffn_decode_chain_total_ns: Q8_SCHED_FFN_DECODE_CHAIN_TOTAL_NS.load(Ordering::Relaxed),
+        ffn_decode_chain_input_quantize_ns: Q8_SCHED_FFN_DECODE_CHAIN_INPUT_QUANTIZE_NS
             .load(Ordering::Relaxed),
-        ffn_decode_chain_activation_quantize_us: Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_US
+        ffn_decode_chain_activation_quantize_ns: Q8_SCHED_FFN_DECODE_CHAIN_ACTIVATION_QUANTIZE_NS
             .load(Ordering::Relaxed),
-        ffn_decode_chain_down_us: Q8_SCHED_FFN_DECODE_CHAIN_DOWN_US.load(Ordering::Relaxed),
+        ffn_decode_chain_down_ns: Q8_SCHED_FFN_DECODE_CHAIN_DOWN_NS.load(Ordering::Relaxed),
         activation_pack_calls: Q8_SCHED_ACTIVATION_PACK_CALLS.load(Ordering::Relaxed),
         activation_pack_rows: Q8_SCHED_ACTIVATION_PACK_ROWS.load(Ordering::Relaxed),
         activation_pack_bytes_requested: Q8_SCHED_ACTIVATION_PACK_BYTES_REQUESTED

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -5163,29 +5163,44 @@ fn x86_q8_ffn_decode_chain_is_default_off_and_matches_split_consumers() {
     .unwrap();
     reset_q8_schedule_telemetry();
 
-    let actual = try_x86_q8_ffn_decode_chain_path(
-        &input,
-        &packed_gate,
-        &packed_up,
-        &packed_down,
-        "layer_0_ffn_activated",
-        "layer_0_ffn_down",
-        &plan,
-    )
-    .unwrap()
-    .expect("x86 FFN decode chain should cover runtime-packed gate/up/down");
+    // Run the chain enough times for the stage timings to be deterministic:
+    // they accumulate nanoseconds, but on Windows `Instant` ticks at QPC
+    // granularity (commonly 100ns), so one sub-tick stage (the 64-element row
+    // quantize is tens of ns) can legitimately measure 0 in a single call.
+    // Across 128 calls the accumulated readings cannot all round to zero.
+    const CHAIN_CALLS: u64 = 128;
+    let mut actual = None;
+    for _ in 0..CHAIN_CALLS {
+        actual = Some(
+            try_x86_q8_ffn_decode_chain_path(
+                &input,
+                &packed_gate,
+                &packed_up,
+                &packed_down,
+                "layer_0_ffn_activated",
+                "layer_0_ffn_down",
+                &plan,
+            )
+            .unwrap()
+            .expect("x86 FFN decode chain should cover runtime-packed gate/up/down"),
+        );
+    }
+    let actual = actual.expect("at least one chain call");
 
     assert_eq!(actual.tensor.shape.dims, expected.shape.dims);
     assert_slice_close_with_tolerance(&actual.tensor.data, &expected.data, 5e-4);
     let telemetry = snapshot_q8_schedule_telemetry();
     assert_eq!(telemetry.ffn_gate_up_decode_consumer_taken, 0);
-    assert_eq!(telemetry.ffn_gate_up_decode_fused_activation_taken, 1);
-    assert_eq!(telemetry.ffn_decode_chain_taken, 1);
-    assert_eq!(telemetry.ffn_down_decode_consumer_taken, 1);
-    assert!(telemetry.ffn_decode_chain_total_us > 0);
-    assert!(telemetry.ffn_decode_chain_input_quantize_us > 0);
-    assert!(telemetry.ffn_decode_chain_activation_quantize_us > 0);
-    assert!(telemetry.ffn_decode_chain_down_us > 0);
+    assert_eq!(
+        telemetry.ffn_gate_up_decode_fused_activation_taken,
+        CHAIN_CALLS
+    );
+    assert_eq!(telemetry.ffn_decode_chain_taken, CHAIN_CALLS);
+    assert_eq!(telemetry.ffn_down_decode_consumer_taken, CHAIN_CALLS);
+    assert!(telemetry.ffn_decode_chain_total_ns > 0);
+    assert!(telemetry.ffn_decode_chain_input_quantize_ns > 0);
+    assert!(telemetry.ffn_decode_chain_activation_quantize_ns > 0);
+    assert!(telemetry.ffn_decode_chain_down_ns > 0);
     assert!(telemetry
         .output_projection_by_route
         .contains_key("ffn_gate_up.decode_fused_activation"));


### PR DESCRIPTION
## Problem

`inference::tests::x86_q8_ffn_decode_chain_is_default_off_and_matches_split_consumers` fails **100% deterministically** on a fast Windows box (passes on CI runners):

```
assertion failed: telemetry.ffn_decode_chain_input_quantize_us > 0   (tests.rs:5186)
```

The chain's per-stage timings were recorded as truncated microseconds. A single 64-element row quantize (the test fixture) takes tens of nanoseconds, so every call measured `0µs` and the `>0` assertion could never pass. The same truncation silently underreports real sub-µs stage costs in production perf work (28 layers × ~0.9µs/token reads as 0).

## Fix

- `ffn_decode_chain_{total,input_quantize,activation_quantize,down}_us` → `_ns`, recorded via `elapsed().as_nanos()`. The by-route map keeps its shared `elapsed_us` semantics (that field is used by every projection route).
- Consumer sweep: no live script/doc parses the old keys — only frozen evidence-bundle receipts under `qa/evidence-bundles/` reference them (historical artifacts, not rewritten).
- The test now runs the chain **128×**: Windows `Instant` ticks at QPC granularity (commonly 100ns), so a single sub-tick stage can still legitimately read 0 in one call; 128 accumulated readings cannot all round to zero. Route counters tightened to `== 128`.

## What the test still guards (unchanged)

- The chain path is **default-off** (`is_none()` with the flag cleared).
- Enabling it **matches the split-consumer outputs** (same tolerance as before).
- Exact route accounting (consumer taken = 0, fused-activation/chain/down taken = 128, route-map keys present).

## Validation

- The previously-failing test: `1 passed` on the fast box (0.02s).
- `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, public-scrub clean.
- The linux-only sibling (`q8_ffn_decode_chain_uses_vnni_down_when_gated`) asserts only counters/route keys, not the renamed fields — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)