### PR TITLE
feat(frontend): improve capability evidence readability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,9 @@ jobs:
       - name: Frontend integration smoke
         run: npm run smoke:integration
 
+      - name: Frontend UI regression smoke
+        run: npm run smoke:ui
+
   # ---------------------------------------------------------------------------
   # Single aggregate gate. Make THIS the only required status check in branch
   # protection (see the note in the PR/commit). It runs on every event and

--- a/frontend/scripts/frontend-integration-smoke.mjs
+++ b/frontend/scripts/frontend-integration-smoke.mjs
@@ -26,9 +26,11 @@ try {
   const { default: TopBar } = await server.ssrLoadModule('/src/components/TopBar.jsx')
   const { getChatGateState } = await server.ssrLoadModule('/src/lib/chatGate.js')
   const {
+    capabilityRowMatchesSearch,
     exactRowSupportLanes,
     rowSupportBoundaryCopy,
     rowSupportNextStepCopy,
+    statusContainsSupportedEvidence,
   } = await server.ssrLoadModule('/src/lib/capabilities.js')
   const { resolveLoadedModelDisplayName } = await server.ssrLoadModule('/src/hooks/useDashboardData.js')
   const { LLAMA32_3B_ACCEPTANCE_TARGET } = await server.ssrLoadModule('/src/lib/acceptanceTargets.js')
@@ -105,6 +107,8 @@ try {
         status: 'planned',
         family: 'future_decoder',
         quantization: 'Q8_0',
+        bounded_context_512_pack: 'not_started',
+        bounded_context_512_pack_id: 'future-context-512-smoke-v1',
         next_step: 'Do not unlock selected chat.',
       },
     ],
@@ -117,6 +121,8 @@ try {
   }
   const selectedModelRunnable = getChatGateState(capabilities, selectedModel, readyRuntime).chatUnlocked
   assert.equal(selectedModelRunnable, true, '3B Q8_0 fixture must be end-to-end runnable only when model path, runtime readiness, and exact-row support are all green')
+  assert.equal(statusContainsSupportedEvidence('not_started'), false, 'reserved future pack ids must not count as verified evidence')
+  assert.equal(capabilityRowMatchesSearch(capabilities.model_compatibility[2], 'future-context-512-smoke-v1'), true, 'ledger search should include displayed evidence bundle ids')
 
   const wrongArtifactModel = {
     ...selectedModel,
@@ -792,6 +798,8 @@ try {
   assert.match(ledgerMarkup, /tinyllama_1_1b_chat_q8_0/, 'ledger rows must come from the capabilities payload')
   assert.match(ledgerMarkup, /Not claimed/, 'every ledger row must carry the not-claimed column')
   assert.match(ledgerMarkup, /arbitrary\/Jinja templates, production throughput, portability/, 'the not-claimed column must render the contract blocker copy verbatim')
+    assert.match(ledgerMarkup, /other_future_row_q8_0[\s\S]*?0<\/b> verified of 1 tracked lanes[\s\S]*?no verified pack/, 'planned pack ids must not be presented as verified evidence or checked contexts')
+    assert.match(blockedApiMarkup, /Q8_0[\s\S]*2 supported[\s\S]*1 guarded/, 'grouped quant evidence must keep supported and guarded postures visible')
   assert.match(ledgerMarkup, /How to read this ledger/, 'the ledger must keep its explainer')
   assert.doesNotMatch(ledgerMarkup, /broad_family_trap|broad_quant_trap/, 'the ledger must not render non-row capability lists as support evidence')
   const emptyLedgerMarkup = renderToStaticMarkup(React.createElement(CompatibilityView, { capabilities: null }))

--- a/frontend/scripts/ui-regression-smoke.mjs
+++ b/frontend/scripts/ui-regression-smoke.mjs
@@ -17,11 +17,23 @@ import {
 } from '../src/lib/chatState.js'
 import { normalizeStoredConversations } from '../src/lib/conversationStorage.js'
 import { conversationToJson, conversationToMarkdown } from '../src/lib/conversationExport.js'
+import { canonicalStatementLabel, splitCanonicalStatement } from '../src/lib/canonicalStatement.js'
 
 /* ---- Behavioral asserts: conversation selection + stored-stream recovery ---- */
 const oldChat = { id: 'old-chat', title: 'Old chat', messages: [{ role: 'user', content: 'old prompt' }] }
 const newerChat = { id: 'newer-chat', title: 'Newer chat', messages: [{ role: 'user', content: 'newer prompt' }] }
 const conversations = [newerChat, oldChat]
+
+const canonicalStatementSample = 'Current exact-row support: Alpha (detail; retained); Beta evidence. These are exact bounded lanes only.'
+const canonicalStatementParts = splitCanonicalStatement(canonicalStatementSample)
+assert.deepEqual(canonicalStatementParts, [
+  'Current exact-row support: Alpha (detail; retained);',
+  'Beta evidence.',
+  'These are exact bounded lanes only.',
+], 'canonical statements should split only at top-level evidence boundaries')
+assert.equal(canonicalStatementParts.join(' '), canonicalStatementSample, 'structured canonical statements must preserve the complete source text')
+assert.equal(canonicalStatementLabel(canonicalStatementParts[0], 0), 'Current gate', 'the opening contract claim should retain its current-gate identity')
+assert.equal(canonicalStatementLabel(canonicalStatementParts[2], 2), 'Contract statement', 'prose-derived blocks should stay neutral unless the backend explicitly names their semantic type')
 
 assert.equal(resolveSelectedConversation(conversations, NEW_CHAT_SENTINEL), null, 'new-chat sentinel must render an empty landing, not the newest old chat')
 assert.equal(resolveSelectedConversation(conversations, null), newerChat, 'null selection should recover to the newest available chat so the main pane does not blank during streaming')
@@ -76,6 +88,8 @@ const analyticsViewSource = read('../src/views/AnalyticsView.jsx')
 const capabilitiesSource = read('../src/lib/capabilities.js')
 const streamParserSource = read('../src/lib/chatCompletionStream.js')
 const evidenceChipSource = read('../src/components/ui/EvidenceChip.jsx')
+const canonicalStatementSource = read('../src/components/ui/CanonicalStatement.jsx')
+const exactRowEvidenceSummarySource = read('../src/components/ui/ExactRowEvidenceSummary.jsx')
 const modelInspectorSource = read('../src/components/models/ModelInspector.jsx')
 const compatibilityViewSource = read('../src/views/CompatibilityView.jsx')
 const apiWorkbenchSource = read('../src/components/api/ApiWorkbench.jsx')
@@ -162,6 +176,7 @@ assert.match(streamParserSource, /split\('\\n\\n'\)/, 'stream parser should spli
 
 /* ---- API view ---- */
 assert.match(apiViewSource, /Selected exact-row evidence/, 'API support view should show selected exact-row evidence instead of a broad validated-target claim')
+assert.match(apiViewSource, /<CanonicalStatement text=\{supportContractCurrentGate\}/, 'API should render the complete gate through the shared structured canonical statement')
 assert.match(apiViewSource, /selectedChatGate\s*=\s*getChatGateState\(capabilities, selectedModel, runtime\)/, 'API endpoint readiness should use the shared exact-row chat gate')
 assert.match(apiViewSource, /selectedExactRowReady\s*=\s*selectedChatGate\.chatUnlocked/, 'API endpoint readiness should stay aligned with Chat/System exact-row chat unlocks')
 assert.match(apiViewSource, /selectedRuntimeMatches/, 'API endpoint readiness should require active_model_id to match the selected model')
@@ -178,7 +193,9 @@ assert.match(apiViewSource, /rowSupportBoundaryCopy\(selectedCompatibilityTarget
 assert.match(apiViewSource, /rowSupportNextStepCopy\(target, apiFeatures\)/, 'API support view should filter resolved template/Jinja and throughput blockers out of row next-step copy')
 assert.match(capabilitiesSource, /function frontendSupportContractCopy/, 'frontend support contract copy should filter resolved template/Jinja and throughput caveats for current supported rows')
 assert.match(capabilitiesSource, /Production-throughput readiness is green/, 'capability helpers should describe production-throughput as a green exact-row readiness lane when perf evidence is supported')
-assert.match(apiViewSource, /function summarizeExactRowField/, 'API support view should summarize quant and family evidence from exact compatibility rows')
+assert.match(exactRowEvidenceSummarySource, /function groupExactRows[\s\S]*target\?\.id && target\?\.\[field\]/, 'exact-row evidence summaries should group only concrete compatibility rows with the requested field')
+assert.match(apiViewSource, /<ExactRowEvidenceSummary targets=\{compatibilityTargets\} field="quantization"/, 'API support view should summarize quant evidence with the shared exact-row renderer')
+assert.match(apiViewSource, /<ExactRowEvidenceSummary targets=\{compatibilityTargets\} field="family"/, 'API support view should summarize family evidence with the shared exact-row renderer')
 assert.match(apiViewSource, /Exact-row quant evidence/, 'API support view should label quant evidence as exact-row scoped')
 assert.match(apiViewSource, /Exact-row family evidence/, 'API support view should label family evidence as exact-row scoped')
 assert.match(apiViewSource, /broad quant lists do not unlock chat/, 'API support view should not promote broad quant lists into chat readiness')
@@ -194,12 +211,22 @@ assert.match(apiViewSource, /<EvidenceChip/, 'API contract rows should render th
 
 /* ---- System view ---- */
 assert.match(systemViewSource, /Selected exact-row evidence/, 'System support view should show selected exact-row evidence instead of broad quant or family capability lists')
+assert.match(systemViewSource, /<CanonicalStatement text=\{supportContractCurrentGate\}/, 'System should render the complete gate through the shared structured canonical statement')
 assert.match(systemViewSource, /Exact-row quant evidence/, 'System support view should scope quant evidence to compatibility rows')
 assert.match(systemViewSource, /Exact-row family evidence/, 'System support view should scope family evidence to compatibility rows')
+assert.match(systemViewSource, /<ExactRowEvidenceSummary targets=\{compatibilityTargets\} field="quantization"/, 'System support view should summarize quant evidence with the shared exact-row renderer')
+assert.match(systemViewSource, /<ExactRowEvidenceSummary targets=\{compatibilityTargets\} field="family"/, 'System support view should summarize family evidence with the shared exact-row renderer')
 assert.doesNotMatch(systemViewSource, /supported_quantization|planned_quantization|supported_model_families|planned_model_families|summarizeCapabilityItems/, 'System support view should not render non-row capability lists as support evidence')
 assert.match(systemViewSource, /displayCapabilityId\(feature\.id\)/, 'System view should not render raw provider-scoped API feature ids')
 assert.match(systemViewSource, /getRuntimeRequestModelId\(selectedModel, runtime, '<loaded-model-id>'\)/, 'System curl examples should use the loaded backend model id for alias-selected exact rows')
 assert.match(systemViewSource, /<EvidenceChip/, 'System contract rows should render their status claims through the Evidence Chip')
+assert.match(compatibilityViewSource, /<CanonicalStatement text=\{displayCapabilityCopy\(supportContract\.current_gate\)\}/, 'Compatibility should render the complete gate through the shared structured canonical statement')
+assert.match(canonicalStatementSource, /View as one canonical paragraph/, 'the structured disclosure should retain one-click access to the unbroken canonical paragraph')
+assert.match(compatibilityViewSource, /if \(query \|\| posture !== 'all'\)[\s\S]*setQuery\(''\)[\s\S]*setPosture\('all'\)/, 'ledger deep-links should clear filters before resolving their target row')
+assert.match(compatibilityViewSource, /if \(!node\) return undefined[\s\S]*node\.scrollIntoView[\s\S]*onFocusConsumed/, 'ledger deep-links should be consumed only after the target row exists')
+assert.match(compatibilityViewSource, /node\.focus\(\{ preventScroll: true \}\)[\s\S]*node\.scrollIntoView/, 'ledger deep-links should transfer keyboard focus before scrolling the destination into view')
+assert.match(compatibilityViewSource, /data-row-id=\{row\.id\}[\s\S]*tabIndex=\{-1\}/, 'model evidence rows should be programmatically focusable')
+assert.match(compatibilityViewSource, /data-row-id=\{feature\.id\} tabIndex=\{-1\}/, 'API feature evidence rows should be programmatically focusable')
 
 /* ---- Models view ----
    Redesign (2026-07, D14): the page was rebuilt as five derived zones. The tracked-row

--- a/frontend/src/components/ui/CanonicalStatement.jsx
+++ b/frontend/src/components/ui/CanonicalStatement.jsx
@@ -1,0 +1,35 @@
+import { canonicalStatementLabel, splitCanonicalStatement } from '../../lib/canonicalStatement'
+
+function StatementCopy({ text }) {
+  const colonIndex = text.indexOf(':')
+  if (colonIndex < 1 || colonIndex > 90) return <p>{text}</p>
+
+  return (
+    <p>
+      <strong>{text.slice(0, colonIndex + 1)}</strong>
+      <span>{text.slice(colonIndex + 1)}</span>
+    </p>
+  )
+}
+
+export function CanonicalStatement({ text }) {
+  const statements = splitCanonicalStatement(text)
+  if (!statements.length) return null
+
+  return (
+    <div className="canonical-statement">
+      <ol className="canonical-statement__claims">
+        {statements.map((statement, index) => (
+          <li key={`${index}-${statement.slice(0, 24)}`}>
+            <span className="canonical-statement__label">{canonicalStatementLabel(statement, index)}</span>
+            <StatementCopy text={statement} />
+          </li>
+        ))}
+      </ol>
+      <details className="canonical-statement__raw">
+        <summary>View as one canonical paragraph</summary>
+        <p>{text}</p>
+      </details>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/ExactRowEvidenceSummary.jsx
+++ b/frontend/src/components/ui/ExactRowEvidenceSummary.jsx
@@ -1,0 +1,55 @@
+import { displayCapabilityCopy, formatCapabilityStatus, isSupportedCapabilityStatus } from '../../lib/capabilities'
+
+function groupExactRows(targets, field) {
+  const groups = new Map()
+  targets
+    .filter((target) => target?.id && target?.[field])
+    .forEach((target) => {
+      const label = displayCapabilityCopy(target[field])
+      const rows = groups.get(label) || []
+      rows.push(target)
+      groups.set(label, rows)
+    })
+  return Array.from(groups, ([label, rows]) => ({ label, rows }))
+}
+
+export function ExactRowEvidenceSummary({ targets = [], field, fallback = 'No exact compatibility rows advertised by this backend.' }) {
+  const groups = groupExactRows(targets, field)
+  if (!groups.length) return <p>{fallback}</p>
+
+  const rowCount = groups.reduce((count, group) => count + group.rows.length, 0)
+  return (
+    <>
+      <ul className="sys-evidence-groups">
+        {groups.map((group) => (
+          <li key={group.label}>
+            <strong>{group.label}</strong>
+            <span>
+              {group.rows.filter((row) => isSupportedCapabilityStatus(row.status)).length} supported
+              {' · '}
+              {group.rows.filter((row) => !isSupportedCapabilityStatus(row.status)).length} guarded
+            </span>
+          </li>
+        ))}
+      </ul>
+      <details className="sys-evidence-details">
+        <summary>View all {rowCount} row mappings</summary>
+        <div className="sys-evidence-mappings">
+          {groups.map((group) => (
+            <section key={group.label}>
+              <h3>{group.label}</h3>
+              <ul>
+                {group.rows.map((target) => (
+                  <li key={target.id}>
+                    <code>{target.id}</code>
+                    <span>{formatCapabilityStatus(target.status)}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </details>
+    </>
+  )
+}

--- a/frontend/src/lib/canonicalStatement.js
+++ b/frontend/src/lib/canonicalStatement.js
@@ -1,0 +1,37 @@
+function pushSegment(segments, text, start, end) {
+  const segment = text.slice(start, end).trim()
+  if (segment) segments.push(segment)
+}
+
+export function splitCanonicalStatement(value = '') {
+  const text = String(value).trim()
+  if (!text) return []
+
+  const segments = []
+  let depth = 0
+  let start = 0
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index]
+    if (character === '(') depth += 1
+    if (character === ')' && depth > 0) depth -= 1
+    if (depth !== 0) continue
+
+    const nextCharacter = text[index + 1]
+    const afterWhitespace = text.slice(index + 1).match(/^\s+([A-Z])/)
+    const isTopLevelClause = character === ';' && /\s/.test(nextCharacter || '')
+    const isSentenceEnd = /[.!?]/.test(character) && Boolean(afterWhitespace)
+    if (!isTopLevelClause && !isSentenceEnd) continue
+
+    pushSegment(segments, text, start, index + 1)
+    start = index + 1
+  }
+
+  pushSegment(segments, text, start, text.length)
+  return segments
+}
+
+export function canonicalStatementLabel(segment, index) {
+  if (index === 0 && /^Current exact-row support:/i.test(segment)) return 'Current gate'
+  return 'Contract statement'
+}

--- a/frontend/src/lib/capabilities.js
+++ b/frontend/src/lib/capabilities.js
@@ -220,10 +220,20 @@ function isReadyEvidenceStatus(status = '') {
   return value === 'validated' || value.startsWith('validated_') || value === 'measured' || value.startsWith('measured_') || value === 'pass' || value.startsWith('pass_')
 }
 
-function statusContainsSupportedEvidence(value = '') {
+export function statusContainsSupportedEvidence(value = '') {
   const status = String(value || '').toLowerCase()
   if (!status || status.includes('not_') || status.includes('unsupported') || status.includes('blocked') || status.includes('missing') || status.includes('planned')) return false
   return isSupportedCapabilityStatus(status) || isReadyEvidenceStatus(status) || status.includes('supported') || status.includes('validated') || status.includes('measured') || status.includes('pass')
+}
+export function capabilityRowMatchesSearch(row, query = '') {
+  const normalizedQuery = String(query).trim().toLowerCase()
+  if (!normalizedQuery) return true
+  return Object.values(row || {}).some((value) => (
+    value !== null
+    && value !== undefined
+    && typeof value !== 'object'
+    && String(value).toLowerCase().includes(normalizedQuery)
+  ))
 }
 
 function findSupportedFeature(features = [], pattern) {

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -564,6 +564,65 @@
 .sys-evidence > strong { font-size: var(--text-sm); font-weight: 650; color: var(--color-text); }
 .sys-evidence p { margin: 0; font-size: var(--text-sm); color: var(--color-text-muted); line-height: var(--leading-snug); overflow-wrap: anywhere; }
 .sys-evidence p b { color: var(--color-text); font-weight: 650; }
+.sys-contract-overview { display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-5); color: var(--color-text-muted); font-size: var(--text-sm); }
+.sys-contract-overview b { color: var(--color-text); font-size: var(--text-lg); }
+.sys-policy-list { display: flex; flex-direction: column; gap: var(--space-2); margin: 0; }
+.sys-policy-list > div { display: grid; grid-template-columns: 120px minmax(0, 1fr); gap: var(--space-3); padding-top: var(--space-2); border-top: 1px solid var(--color-border-soft); }
+.sys-policy-list dt { color: var(--color-text-faint); font-family: var(--font-mono); font-size: 0.6875rem; letter-spacing: var(--tracking-wide); text-transform: uppercase; }
+.sys-policy-list dd { margin: 0; color: var(--color-text-muted); font-size: var(--text-sm); line-height: var(--leading-snug); }
+.sys-evidence-groups { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
+.sys-evidence-groups li { display: flex; flex-direction: column; gap: 1px; padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-soft); border-radius: var(--radius-md); background: var(--color-surface-subtle); }
+.sys-evidence-groups strong { color: var(--color-text); font-family: var(--font-mono); font-size: var(--text-xs); overflow-wrap: anywhere; }
+.sys-evidence-groups span { color: var(--color-text-faint); font-size: var(--text-xs); }
+.sys-evidence-details { border-top: 1px solid var(--color-border-soft); }
+.sys-evidence-details summary { padding: var(--space-2) 0 0; color: var(--color-accent-text); font-size: var(--text-xs); font-weight: 650; cursor: pointer; }
+.sys-evidence-details summary:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 3px; }
+.sys-evidence-details--canonical[open] summary { margin-bottom: var(--space-3); }
+.canonical-statement { display: flex; flex-direction: column; gap: var(--space-4); }
+.canonical-statement__claims { margin: 0; padding: 0; list-style: none; border-bottom: 1px solid var(--color-border-soft); }
+.canonical-statement__claims > li {
+  position: relative;
+  display: grid;
+  grid-template-columns: 116px minmax(0, 1fr);
+  gap: var(--space-4);
+  padding: var(--space-4) 0 var(--space-4) var(--space-4);
+  border-top: 1px solid var(--color-border-soft);
+}
+.canonical-statement__claims > li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: calc(var(--space-4) + 0.38rem);
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  opacity: 0.7;
+}
+.canonical-statement__label {
+  padding-top: 2px;
+  color: var(--color-text-faint);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-wide);
+  line-height: var(--leading-snug);
+  text-transform: uppercase;
+}
+.canonical-statement__claims p { margin: 0; max-width: 72ch; color: var(--color-text); font-size: var(--text-sm); line-height: var(--leading-normal); overflow-wrap: anywhere; }
+.canonical-statement__claims p strong { display: block; margin-bottom: 2px; color: var(--color-text); font-weight: 700; }
+.canonical-statement__claims p span { color: var(--color-text-muted); }
+.canonical-statement__raw { padding-top: var(--space-1); }
+.canonical-statement__raw summary { color: var(--color-text-faint); font-size: var(--text-xs); font-weight: 600; cursor: pointer; }
+.canonical-statement__raw[open] summary { margin-bottom: var(--space-3); }
+.canonical-statement__raw > p { margin: 0; max-width: 76ch; padding-left: var(--space-4); border-left: 2px solid var(--color-border-soft); color: var(--color-text-muted); font-size: var(--text-xs); line-height: var(--leading-normal); }
+.sys-evidence-mappings { display: flex; flex-direction: column; gap: var(--space-3); max-height: 420px; margin-top: var(--space-3); padding-right: var(--space-2); overflow-y: auto; }
+.sys-evidence-mappings section { display: flex; flex-direction: column; gap: var(--space-1); }
+.sys-evidence-mappings h3 { margin: 0; color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 650; }
+.sys-evidence-mappings ul { display: flex; flex-direction: column; gap: 2px; margin: 0; padding: 0; list-style: none; }
+.sys-evidence-mappings li { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: var(--space-3); align-items: baseline; padding: var(--space-1) 0; border-bottom: 1px solid var(--color-border-soft); }
+.sys-evidence-mappings code { color: var(--color-text); font-family: var(--font-mono); font-size: var(--text-xs); overflow-wrap: anywhere; }
+.sys-evidence-mappings span { color: var(--color-text-faint); font-size: var(--text-xs); text-align: right; }
 .sys-rows-block { display: flex; flex-direction: column; gap: var(--space-3); }
 .sys-rows-block > strong { font-size: var(--text-sm); font-weight: 650; color: var(--color-text); }
 .sys-rows { display: flex; flex-direction: column; gap: var(--space-2); }
@@ -712,6 +771,65 @@
   color: var(--color-text-faint);
   padding-top: 2px;
 }
+.ledger-contract__summary { display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-5); color: var(--color-text-muted); font-size: var(--text-sm); }
+.ledger-contract__summary b { color: var(--color-text); font-size: var(--text-lg); }
+.ledger-contract__canonical { border-top: 1px solid var(--color-border-soft); }
+.ledger-contract__canonical summary { padding-top: var(--space-3); color: var(--color-accent-text); font-size: var(--text-sm); font-weight: 650; cursor: pointer; }
+.ledger-contract__canonical summary:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 3px; }
+.ledger-contract__canonical p { margin: var(--space-3) 0 0; max-width: 76ch; color: var(--color-text); font-size: var(--text-sm); line-height: var(--leading-normal); }
+
+.ledger-toolbar {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) auto auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+.ledger-search {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 38px;
+  padding: 0 var(--space-3);
+  color: var(--color-text-faint);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+}
+.ledger-search:focus-within { border-color: var(--color-accent); box-shadow: var(--shadow-focus); }
+.ledger-search input {
+  width: 100%;
+  min-width: 0;
+  color: var(--color-text);
+  background: transparent;
+  border: 0;
+  outline: 0;
+  font: inherit;
+  font-size: var(--text-sm);
+}
+.ledger-search input::placeholder { color: var(--color-text-faint); }
+.ledger-filters {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+.ledger-filters button {
+  min-height: 30px;
+  padding: 0 var(--space-3);
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  background: transparent;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+.ledger-filters button:hover { color: var(--color-text); }
+.ledger-filters button[aria-pressed='true'] { color: var(--color-text); background: var(--color-bg-elevated); box-shadow: var(--shadow-1); }
+.ledger-toolbar__count { color: var(--color-text-faint); font-size: var(--text-xs); white-space: nowrap; }
 
 .ledger-rows { display: flex; flex-direction: column; gap: var(--space-3); margin-bottom: var(--space-5); }
 .ledger-row {
@@ -722,12 +840,12 @@
   transition: border-color var(--dur-base) var(--ease-standard), box-shadow var(--dur-base) var(--ease-standard);
 }
 .ledger-row.is-focused { border-color: var(--color-accent); box-shadow: var(--shadow-focus); }
+.ledger-row:focus { outline: none; }
 .ledger-row__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  cursor: pointer;
   flex-wrap: wrap;
 }
 .ledger-row__identity { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
@@ -735,7 +853,11 @@
 .ledger-row__family { font-size: var(--text-xs); color: var(--color-text-muted); }
 .ledger-row__posture { display: flex; align-items: center; gap: var(--space-2); flex: none; }
 .ledger-row__toggle {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
   font-family: var(--font-mono);
+    padding: 2px var(--space-3);
   font-size: 0.6875rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -747,12 +869,47 @@
   cursor: pointer;
 }
 .ledger-row__toggle:hover { border-color: var(--color-border-strong); }
+.ledger-row__toggle:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+
+.ledger-row__summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-5);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border-soft);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+.ledger-row__summary span { min-width: 0; }
+.ledger-row__summary b { color: var(--color-text); font-weight: 650; }
+.ledger-row__boundary {
+  display: grid;
+  grid-template-columns: 116px minmax(0, 1fr);
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border-soft);
+}
+.ledger-row__boundary .ledger-row__col-title { margin: 0; padding-top: 2px; }
+.ledger-row__boundary p {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+.ledger-row__evidence { margin-top: var(--space-4); padding-top: var(--space-4); border-top: 1px solid var(--color-border-soft); }
 
 .ledger-row__columns {
   display: grid;
   grid-template-columns: 1fr 1fr;   /* equal weight — the restraint is the product */
   gap: var(--space-5);
-  margin-top: var(--space-3);
 }
 .ledger-row__col { min-width: 0; }
 .ledger-row__col--not-claimed {
@@ -768,7 +925,7 @@
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
-.ledger-row__copy { margin: 0; font-size: var(--text-sm); color: var(--color-text); line-height: var(--leading-snug); }
+.ledger-row__copy { margin: 0; font-size: var(--text-sm); color: var(--color-text); line-height: var(--leading-normal); }
 .ledger-row__meta { margin: var(--space-2) 0 0; font-size: var(--text-xs); color: var(--color-text-faint); line-height: var(--leading-snug); word-break: break-word; }
 .ledger-row__meta code { font-family: var(--font-mono); color: var(--color-text-muted); }
 
@@ -798,6 +955,7 @@
   border-radius: var(--radius-md);
   background: var(--color-planned-soft);
 }
+.ledger-no-results { margin: 0; padding: var(--space-7); border: 1px dashed var(--color-border-soft); border-radius: var(--radius-lg); color: var(--color-text-muted); font-size: var(--text-sm); text-align: center; }
 
 .ledger-features { margin-bottom: var(--space-5); }
 .ledger-features__list { list-style: none; margin: 0; padding: 0; }
@@ -810,6 +968,7 @@
   border-bottom: 1px solid var(--color-border-soft);
 }
 .ledger-features__item:last-child { border-bottom: none; }
+.ledger-features__item:focus { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .ledger-features__id { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--color-text); }
 .ledger-features__id.is-focused { color: var(--color-accent-text); }
 
@@ -837,9 +996,26 @@
 .ev-pop__ledger-link:hover { text-decoration: underline; }
 
 @media (max-width: 860px) {
+  .sys-policy-list > div { grid-template-columns: 1fr; gap: var(--space-1); }
+  .sys-evidence-mappings li { grid-template-columns: 1fr; gap: 1px; }
+  .sys-evidence-mappings span { text-align: left; }
+  .ledger-contract__line { grid-template-columns: 1fr; gap: var(--space-1); }
+  .ledger-toolbar { grid-template-columns: 1fr; }
+  .ledger-filters { justify-self: start; max-width: 100%; overflow-x: auto; }
+  .ledger-toolbar__count { justify-self: start; }
   .ledger-row__columns { grid-template-columns: 1fr; gap: var(--space-3); }
   .ledger-row__col--not-claimed { border-left: none; padding-left: 0; border-top: 1px solid var(--color-border-soft); padding-top: var(--space-3); }
   .ledger-row__track-label { width: 130px; }
+}
+
+@media (max-width: 520px) {
+  .canonical-statement__claims > li { grid-template-columns: 1fr; gap: var(--space-2); }
+  .canonical-statement__label { padding-top: 0; }
+  .ledger-row__boundary { grid-template-columns: 1fr; gap: var(--space-1); }
+  .ledger-row__boundary .ledger-row__col-title { padding-top: 0; }
+  .ledger-row { padding: var(--space-4); }
+  .ledger-row__posture { width: 100%; justify-content: space-between; }
+  .ledger-filters button { padding-inline: var(--space-2); }
 }
 
 /* ==========================================================================

--- a/frontend/src/views/ApiView.jsx
+++ b/frontend/src/views/ApiView.jsx
@@ -3,19 +3,14 @@ import { getChatGateState } from '../lib/chatGate'
 import { getRuntimeRequestModelId, modelRuntimeIdMatches } from '../lib/modelState'
 import { StatusDot } from '../components/ui/StatusDot'
 import { EvidenceChip } from '../components/ui/EvidenceChip'
+import { CanonicalStatement } from '../components/ui/CanonicalStatement'
+import { ExactRowEvidenceSummary } from '../components/ui/ExactRowEvidenceSummary'
 import { ApiWorkbench } from '../components/api/ApiWorkbench'
 import { EmptyState } from '../components/ui/EmptyState'
 import { IconApi } from '../components/ui/icons'
 
 function guardedApiFeatures(features = []) {
   return features.filter((feature) => isGuardedCapabilityStatus(feature.status))
-}
-
-function summarizeExactRowField(targets = [], field, fallback = 'No exact compatibility rows advertised by this backend.') {
-  const rows = targets
-    .filter((target) => target?.id && target?.[field])
-    .map((target) => `${displayCapabilityCopy(target[field])}: ${formatCapabilityStatus(target.status)} (${target.id})`)
-  return rows.length ? rows.join(' · ') : fallback
 }
 
 function supportLaneTitle(lane) {
@@ -31,6 +26,7 @@ export default function ApiView({ runtime, selectedModel, capabilities }) {
   const supportContractCurrentGate = frontendSupportContractCopy(capabilities)
   const compatibilityTargets = capabilities?.model_compatibility || []
   const apiFeatures = capabilities?.api_features || []
+  const supportedCompatibilityCount = compatibilityTargets.filter((target) => isSupportedCapabilityStatus(target.status)).length
   const supportedFeatures = apiFeatures.filter((feature) => isSupportedCapabilityStatus(feature.status))
   const guardedFeatures = guardedApiFeatures(apiFeatures)
   const selectedChatGate = getChatGateState(capabilities, selectedModel, runtime)
@@ -126,9 +122,18 @@ export default function ApiView({ runtime, selectedModel, capabilities }) {
             <strong>Current gate</strong>
             {supportContract ? (
               <>
-                <p><b>{supportContractCurrentGate}</b></p>
-                <p>{supportContract.support_policy}</p>
-                <p>{supportContract.unsupported_policy}</p>
+                <div className="sys-contract-overview">
+                  <span><b>{supportedCompatibilityCount}</b> supported exact rows</span>
+                  <span><b>{compatibilityTargets.length - supportedCompatibilityCount}</b> guarded or unclaimed rows</span>
+                </div>
+                <details className="sys-evidence-details sys-evidence-details--canonical">
+                  <summary>Read the complete current-gate statement</summary>
+                  <CanonicalStatement text={supportContractCurrentGate} />
+                </details>
+                <dl className="sys-policy-list">
+                  <div><dt>Support policy</dt><dd>{supportContract.support_policy}</dd></div>
+                  <div><dt>Unsupported policy</dt><dd>{supportContract.unsupported_policy}</dd></div>
+                </dl>
               </>
             ) : (
               <p>/api/capabilities is unavailable, so this frontend falls back to runtime health only and will not infer broad support from filenames or saved browser entries.</p>
@@ -148,12 +153,12 @@ export default function ApiView({ runtime, selectedModel, capabilities }) {
         <div className="cxv-grid cxv-grid--two">
           <div className="cxv-card cxv-card--flat sys-evidence">
             <strong>Exact-row quant evidence</strong>
-            <p>{summarizeExactRowField(compatibilityTargets, 'quantization')}</p>
+            <ExactRowEvidenceSummary targets={compatibilityTargets} field="quantization" />
             <p>Quant labels here come from compatibility rows only; broad quant lists do not unlock chat.</p>
           </div>
           <div className="cxv-card cxv-card--flat sys-evidence">
             <strong>Exact-row family evidence</strong>
-            <p>{summarizeExactRowField(compatibilityTargets, 'family')}</p>
+            <ExactRowEvidenceSummary targets={compatibilityTargets} field="family" />
             <p>Family names remain row-scoped evidence boundaries, not inherited support for neighboring files.</p>
           </div>
         </div>

--- a/frontend/src/views/CompatibilityView.jsx
+++ b/frontend/src/views/CompatibilityView.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { displayCapabilityCopy, displayCapabilityId, formatCapabilityStatus, isSupportedCapabilityStatus } from '../lib/capabilities'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { capabilityRowMatchesSearch, displayCapabilityCopy, displayCapabilityId, formatCapabilityStatus, isSupportedCapabilityStatus, statusContainsSupportedEvidence } from '../lib/capabilities'
 import { EvidenceChip } from '../components/ui/EvidenceChip'
+import { CanonicalStatement } from '../components/ui/CanonicalStatement'
 import { EmptyState } from '../components/ui/EmptyState'
-import { IconReceipt } from '../components/ui/icons'
+import { IconReceipt, IconSearch } from '../components/ui/icons'
 
 /* Compatibility & evidence explorer (Phase 4) — the signature view.
 
@@ -23,12 +24,18 @@ const EVIDENCE_TRACKS = [
   { field: 'parity_audited', label: 'prompt-token parity' },
   { field: 'frontend_load_path_verified', label: 'frontend load path' },
   { field: 'chat_template_shape_pack', label: 'template-shape pack', packIdField: 'chat_template_shape_pack_id' },
-  { field: 'bounded_context_512_pack', label: 'bounded 512 context', packIdField: 'bounded_context_512_pack_id' },
-  { field: 'bounded_context_1024_pack', label: 'bounded 1024 context', packIdField: 'bounded_context_1024_pack_id' },
-  { field: 'bounded_context_2048_pack', label: 'bounded 2048 context', packIdField: 'bounded_context_2048_pack_id' },
-  { field: 'bounded_context_4096_pack', label: 'bounded 4096 context', packIdField: 'bounded_context_4096_pack_id' },
-  { field: 'bounded_context_8192_pack', label: 'bounded 8192 context', packIdField: 'bounded_context_8192_pack_id' },
+  { field: 'bounded_context_512_pack', label: 'bounded 512 context', packIdField: 'bounded_context_512_pack_id', window: 512 },
+  { field: 'bounded_context_1024_pack', label: 'bounded 1024 context', packIdField: 'bounded_context_1024_pack_id', window: 1024 },
+  { field: 'bounded_context_2048_pack', label: 'bounded 2048 context', packIdField: 'bounded_context_2048_pack_id', window: 2048 },
+  { field: 'bounded_context_4096_pack', label: 'bounded 4096 context', packIdField: 'bounded_context_4096_pack_id', window: 4096 },
+  { field: 'bounded_context_8192_pack', label: 'bounded 8192 context', packIdField: 'bounded_context_8192_pack_id', window: 8192 },
   { field: 'performance_measured', label: 'perf / RSS (bounded)' },
+]
+
+const LEDGER_FILTERS = [
+  { value: 'all', label: 'All rows' },
+  { value: 'supported', label: 'Supported' },
+  { value: 'other', label: 'Not supported' },
 ]
 
 function evidenceTracksForRow(row) {
@@ -46,8 +53,11 @@ function evidenceTracksForRow(row) {
 
 function LedgerRow({ row, focused, registerRef }) {
   const [open, setOpen] = useState(false)
+  const evidenceId = useId()
   const supported = isSupportedCapabilityStatus(row.status)
   const tracks = evidenceTracksForRow(row)
+  const verifiedTracks = tracks.filter((track) => statusContainsSupportedEvidence(track.status))
+  const checkedContexts = verifiedTracks.filter((track) => track.window && track.packId).map((track) => track.window)
 
   useEffect(() => {
     if (focused) setOpen(true)
@@ -58,8 +68,9 @@ function LedgerRow({ row, focused, registerRef }) {
       ref={(node) => registerRef(row.id, node)}
       className={`ledger-row ${supported ? 'ledger-row--supported' : ''} ${focused ? 'is-focused' : ''}`}
       data-row-id={row.id}
+      tabIndex={-1}
     >
-      <header className="ledger-row__head" onClick={() => setOpen((v) => !v)}>
+      <header className="ledger-row__head">
         <div className="ledger-row__identity">
           <code className="ledger-row__id">{row.id}</code>
           <span className="ledger-row__family">{row.family} · {row.quantization}</span>
@@ -70,63 +81,76 @@ function LedgerRow({ row, focused, registerRef }) {
             source={{ rowId: row.id, detail: row.support_scope ? displayCapabilityCopy(row.support_scope) : undefined }}
             size="sm"
           />
-          <button type="button" className="ledger-row__toggle" aria-expanded={open} onClick={(event) => { event.stopPropagation(); setOpen((v) => !v) }}>
-            {open ? 'Collapse' : 'Evidence'}
+          <button type="button" className="ledger-row__toggle" aria-expanded={open} aria-controls={evidenceId} onClick={() => setOpen((value) => !value)}>
+            {open ? 'Close evidence' : 'View evidence'}
           </button>
         </div>
       </header>
 
-      <div className="ledger-row__columns">
-        <div className="ledger-row__col">
-          <h3 className="ledger-row__col-title">Proven</h3>
-          <p className="ledger-row__copy">{displayCapabilityCopy(row.evidence) || 'No evidence copy advertised for this row.'}</p>
-          {row.tested_context && <p className="ledger-row__meta">tested context: <code>{row.tested_context}</code></p>}
-        </div>
-        <div className="ledger-row__col ledger-row__col--not-claimed">
-          <h3 className="ledger-row__col-title">Not claimed</h3>
-          <p className="ledger-row__copy">{displayCapabilityCopy(row.full_support_blockers) || 'This row advertises no explicit boundary copy; nothing beyond the proven column is claimed.'}</p>
-          {row.support_scope && <p className="ledger-row__meta">scope: <code>{row.support_scope}</code></p>}
-        </div>
+      <div className="ledger-row__summary" aria-label="Tested envelope">
+        <span><b>{verifiedTracks.length}</b> verified of {tracks.length} tracked lanes</span>
+        <span><b>Contexts</b> {checkedContexts.length ? checkedContexts.join(' · ') : 'no verified pack'}</span>
+        <span>{row.tool_capable ? <><b>Tools</b> receipt verified</> : <><b>Tools</b> not claimed</>}</span>
+      </div>
+
+      <div className="ledger-row__boundary">
+        <span className="ledger-row__col-title">Not claimed</span>
+        <p>{displayCapabilityCopy(row.full_support_blockers) || 'This row advertises no explicit boundary copy; nothing beyond its proven evidence is claimed.'}</p>
       </div>
 
       {open && (
-        <div className="ledger-row__drill">
-          <h3 className="ledger-row__col-title">Evidence checklist</h3>
-          <ul className="ledger-row__tracks">
-            {tracks.map((track) => (
-              <li key={track.field} className="ledger-row__track">
-                <span className="ledger-row__track-label">{track.label}</span>
-                <EvidenceChip
-                  status={track.status}
-                  source={{
-                    rowId: row.id,
-                    detail: `${track.label} — field ${track.field}`,
-                    note: track.packId ? `Evidence bundle: ${track.packId}` : 'No evidence-bundle id advertised for this lane.',
-                  }}
-                  size="sm"
-                />
-                {track.packId && <code className="ledger-row__pack">{track.packId}</code>}
-              </li>
-            ))}
-          </ul>
-
-          {(row.latest_checked_bucket || row.latest_checked_result) && (
-            <p className="ledger-row__meta">
-              latest checked: <code>{row.latest_checked_bucket || '—'}</code> → <code>{row.latest_checked_result || '—'}</code>
-              {row.latest_checked_output && <> · output starts <code>{String(row.latest_checked_output).slice(0, 60)}</code></>}
-            </p>
-          )}
-          {row.frontend_readiness_gate && (
-            <p className="ledger-row__meta">readiness gate: {displayCapabilityCopy(row.frontend_readiness_gate)}</p>
-          )}
-
-          {!supported && row.next_step && (
-            <div className="ledger-row__promotion">
-              <h3 className="ledger-row__col-title">Promotion path</h3>
-              <p className="ledger-row__copy">{displayCapabilityCopy(row.next_step)}</p>
-              <p className="ledger-row__meta">An honest checklist, not a promise — this row moves only when the evidence above does.</p>
+        <div id={evidenceId} className="ledger-row__evidence">
+          <div className="ledger-row__columns">
+            <div className="ledger-row__col">
+              <h3 className="ledger-row__col-title">Proven</h3>
+              <p className="ledger-row__copy">{displayCapabilityCopy(row.evidence) || 'No evidence copy advertised for this row.'}</p>
+              {row.tested_context && <p className="ledger-row__meta">tested context: <code>{row.tested_context}</code></p>}
             </div>
-          )}
+            <div className="ledger-row__col ledger-row__col--not-claimed">
+              <h3 className="ledger-row__col-title">Not claimed</h3>
+              <p className="ledger-row__copy">{displayCapabilityCopy(row.full_support_blockers) || 'This row advertises no explicit boundary copy; nothing beyond the proven column is claimed.'}</p>
+              {row.support_scope && <p className="ledger-row__meta">scope: <code>{row.support_scope}</code></p>}
+            </div>
+          </div>
+
+          <div className="ledger-row__drill">
+            <h3 className="ledger-row__col-title">Evidence checklist</h3>
+            <ul className="ledger-row__tracks">
+              {tracks.map((track) => (
+                <li key={track.field} className="ledger-row__track">
+                  <span className="ledger-row__track-label">{track.label}</span>
+                  <EvidenceChip
+                    status={track.status}
+                    source={{
+                      rowId: row.id,
+                      detail: `${track.label} — field ${track.field}`,
+                      note: track.packId ? `Evidence bundle: ${track.packId}` : 'No evidence-bundle id advertised for this lane.',
+                    }}
+                    size="sm"
+                  />
+                  {track.packId && <code className="ledger-row__pack">{track.packId}</code>}
+                </li>
+              ))}
+            </ul>
+
+            {(row.latest_checked_bucket || row.latest_checked_result) && (
+              <p className="ledger-row__meta">
+                latest checked: <code>{row.latest_checked_bucket || '—'}</code> → <code>{row.latest_checked_result || '—'}</code>
+                {row.latest_checked_output && <> · output starts <code>{String(row.latest_checked_output).slice(0, 60)}</code></>}
+              </p>
+            )}
+            {row.frontend_readiness_gate && (
+              <p className="ledger-row__meta">readiness gate: {displayCapabilityCopy(row.frontend_readiness_gate)}</p>
+            )}
+
+            {!supported && row.next_step && (
+              <div className="ledger-row__promotion">
+                <h3 className="ledger-row__col-title">Promotion path</h3>
+                <p className="ledger-row__copy">{displayCapabilityCopy(row.next_step)}</p>
+                <p className="ledger-row__meta">An honest checklist, not a promise — this row moves only when the evidence above does.</p>
+              </div>
+            )}
+          </div>
         </div>
       )}
     </article>
@@ -137,6 +161,8 @@ export default function CompatibilityView({ capabilities, focusRowId = null, onF
   const rows = capabilities?.model_compatibility || []
   const apiFeatures = capabilities?.api_features || []
   const supportContract = capabilities?.support_contract
+  const [query, setQuery] = useState('')
+  const [posture, setPosture] = useState('all')
   const rowRefs = useRef(new Map())
   const registerRef = (id, node) => {
     if (node) rowRefs.current.set(id, node)
@@ -144,14 +170,30 @@ export default function CompatibilityView({ capabilities, focusRowId = null, onF
   }
 
   const supportedCount = useMemo(() => rows.filter((row) => isSupportedCapabilityStatus(row.status)).length, [rows])
+  const filteredRows = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+    return rows.filter((row) => {
+      const supported = isSupportedCapabilityStatus(row.status)
+      if (posture === 'supported' && !supported) return false
+      if (posture === 'other' && supported) return false
+      return capabilityRowMatchesSearch(row, normalizedQuery)
+    })
+  }, [posture, query, rows])
 
   useEffect(() => {
     if (!focusRowId) return undefined
+    if (query || posture !== 'all') {
+      setQuery('')
+      setPosture('all')
+      return undefined
+    }
     const node = rowRefs.current.get(focusRowId)
-    if (node) node.scrollIntoView({ block: 'start', behavior: 'smooth' })
+    if (!node) return undefined
+    node.focus({ preventScroll: true })
+    node.scrollIntoView({ block: 'start', behavior: 'smooth' })
     const timer = window.setTimeout(() => onFocusConsumed?.(), 2400)
     return () => window.clearTimeout(timer)
-  }, [focusRowId, onFocusConsumed, rows.length])
+  }, [filteredRows.length, focusRowId, onFocusConsumed, posture, query])
 
   return (
     <section className="compatibility-view cxv">
@@ -172,7 +214,16 @@ export default function CompatibilityView({ capabilities, focusRowId = null, onF
       {supportContract && (
         <div className="cxv-card cxv-card--flat ledger-contract">
           <strong>Support contract</strong>
-          {supportContract.current_gate && <p className="ledger-contract__line"><span className="ledger-contract__key">current gate</span>{displayCapabilityCopy(supportContract.current_gate)}</p>}
+          <div className="ledger-contract__summary">
+            <span><b>{supportedCount}</b> supported exact rows</span>
+            <span><b>{rows.length - supportedCount}</b> guarded or unclaimed rows</span>
+          </div>
+          {supportContract.current_gate && (
+            <details className="ledger-contract__canonical">
+              <summary>Read the complete current-gate statement</summary>
+              <CanonicalStatement text={displayCapabilityCopy(supportContract.current_gate)} />
+            </details>
+          )}
           {supportContract.support_policy && <p className="ledger-contract__line"><span className="ledger-contract__key">support policy</span>{displayCapabilityCopy(supportContract.support_policy)}</p>}
           {supportContract.unsupported_policy && <p className="ledger-contract__line"><span className="ledger-contract__key">unsupported policy</span>{displayCapabilityCopy(supportContract.unsupported_policy)}</p>}
         </div>
@@ -193,10 +244,29 @@ export default function CompatibilityView({ capabilities, focusRowId = null, onF
             <div className="cxv-stat"><span>Everything else</span><strong>{rows.length - supportedCount}</strong><small>tracked, honestly not claimed</small></div>
           </div>
 
+          <div className="ledger-toolbar">
+            <label className="ledger-search">
+              <IconSearch size={16} />
+              <span className="sr-only">Search compatibility rows</span>
+              <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search model, family, quant, evidence…" />
+            </label>
+            <div className="ledger-filters" role="group" aria-label="Filter compatibility rows by support posture">
+              {LEDGER_FILTERS.map((filter) => (
+                <button key={filter.value} type="button" aria-pressed={posture === filter.value} onClick={() => setPosture(filter.value)}>
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+            <span className="ledger-toolbar__count">{filteredRows.length} of {rows.length} rows</span>
+          </div>
+
           <div className="ledger-rows">
-            {rows.map((row) => (
+            {filteredRows.map((row) => (
               <LedgerRow key={row.id} row={row} focused={focusRowId === row.id} registerRef={registerRef} />
             ))}
+            {filteredRows.length === 0 && (
+              <p className="ledger-no-results">No compatibility rows match this search and support filter.</p>
+            )}
           </div>
         </>
       )}
@@ -207,7 +277,7 @@ export default function CompatibilityView({ capabilities, focusRowId = null, onF
           <p className="cxv-sub">Feature lanes from the same contract. They gate API affordances and never widen any model row above.</p>
           <ul className="ledger-features__list">
             {apiFeatures.map((feature) => (
-              <li key={feature.id} className="ledger-features__item" ref={(node) => registerRef(feature.id, node)} data-row-id={feature.id}>
+              <li key={feature.id} className="ledger-features__item" ref={(node) => registerRef(feature.id, node)} data-row-id={feature.id} tabIndex={-1}>
                 <span className={`ledger-features__id ${focusRowId === feature.id ? 'is-focused' : ''}`}>{displayCapabilityId(feature.id)}</span>
                 <EvidenceChip status={feature.status} source={{ rowId: feature.id, note: displayCapabilityCopy(feature.notes) }} size="sm" />
               </li>

--- a/frontend/src/views/SystemView.jsx
+++ b/frontend/src/views/SystemView.jsx
@@ -3,6 +3,8 @@ import { getChatGateState } from '../lib/chatGate'
 import { describeModelState, getRuntimeRequestModelId } from '../lib/modelState'
 import { StatusDot } from '../components/ui/StatusDot'
 import { EvidenceChip } from '../components/ui/EvidenceChip'
+import { CanonicalStatement } from '../components/ui/CanonicalStatement'
+import { ExactRowEvidenceSummary } from '../components/ui/ExactRowEvidenceSummary'
 import { EmptyState } from '../components/ui/EmptyState'
 import { IconSystem } from '../components/ui/icons'
 
@@ -26,6 +28,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
   const supportContract = capabilities?.support_contract
   const supportContractCurrentGate = frontendSupportContractCopy(capabilities)
   const compatibilityTargets = capabilities?.model_compatibility || []
+  const supportedCompatibilityCount = compatibilityTargets.filter((target) => isSupportedCapabilityStatus(target.status)).length
   const apiFeatures = capabilities?.api_features || []
   const supportedFeatures = apiFeatures.filter((feature) => isSupportedCapabilityStatus(feature.status))
   const unsupportedFeatures = apiFeatures.filter((feature) => isGuardedCapabilityStatus(feature.status))
@@ -59,12 +62,6 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
     : `# Blocked for UX chat until selected exact row evidence and runtime readiness both match
 # loaded_now=${runtime?.loaded_now ? 'true' : 'false'} generation_ready=${runtime?.generation_ready ? 'true' : 'false'} active_model_id=${runtime?.active_model_id || 'none'}
 # selected_exact_row=${selectedCompatibilityTarget?.id || 'none'} support_gate=${selectedChatGate.label}`
-  const exactRowQuantEvidence = compatibilityTargets.length
-    ? compatibilityTargets.map((target) => `${target.id}: ${target.quantization} (${formatCapabilityStatus(target.status)})`).join(' · ')
-    : 'No exact compatibility rows advertised.'
-  const exactRowFamilyEvidence = compatibilityTargets.length
-    ? compatibilityTargets.map((target) => `${target.id}: ${target.family} (${formatCapabilityStatus(target.status)})`).join(' · ')
-    : 'No exact compatibility rows advertised.'
   const q8Runtime = runtime?.q8_runtime
   const q8RuntimeLabel = q8Runtime?.retain_q8_blocks
     ? 'Retained Q8 blocks'
@@ -184,9 +181,18 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
             <strong>Current contract</strong>
             {supportContract ? (
               <>
-                <p><b>Current gate:</b> {supportContractCurrentGate}</p>
-                <p>{supportContract.support_policy}</p>
-                <p>{supportContract.unsupported_policy}</p>
+                <div className="sys-contract-overview">
+                  <span><b>{supportedCompatibilityCount}</b> supported exact rows</span>
+                  <span><b>{compatibilityTargets.length - supportedCompatibilityCount}</b> guarded or unclaimed rows</span>
+                </div>
+                <details className="sys-evidence-details sys-evidence-details--canonical">
+                  <summary>Read the complete current-gate statement</summary>
+                  <CanonicalStatement text={supportContractCurrentGate} />
+                </details>
+                <dl className="sys-policy-list">
+                  <div><dt>Support policy</dt><dd>{supportContract.support_policy}</dd></div>
+                  <div><dt>Unsupported policy</dt><dd>{supportContract.unsupported_policy}</dd></div>
+                </dl>
               </>
             ) : (
               <p>/api/capabilities is unavailable, so Camelid falls back to health/model readiness only and does not infer broader support.</p>
@@ -215,12 +221,12 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
         <div className="cxv-grid cxv-grid--two">
           <div className="cxv-card cxv-card--flat sys-evidence">
             <strong>Exact-row quant evidence</strong>
-            <p>{exactRowQuantEvidence}</p>
+            <ExactRowEvidenceSummary targets={compatibilityTargets} field="quantization" />
             <p>Quant labels here come only from compatibility rows and do not unlock chat without a matching loaded model.</p>
           </div>
           <div className="cxv-card cxv-card--flat sys-evidence">
             <strong>Exact-row family evidence</strong>
-            <p>{exactRowFamilyEvidence}</p>
+            <ExactRowEvidenceSummary targets={compatibilityTargets} field="family" />
             <p>Family labels remain row-scoped evidence boundaries, not broad support for neighboring files.</p>
           </div>
         </div>
@@ -228,9 +234,17 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
         <div className="cxv-card cxv-card--flat sys-evidence">
           <strong>Validated API features</strong>
           {supportedFeatures.length ? (
-            supportedFeatures.map((feature) => (
-              <p key={feature.id}><b>{displayCapabilityId(feature.id)}:</b> {displayCapabilityCopy(feature.notes)}</p>
-            ))
+            <div className="sys-rows">
+              {supportedFeatures.map((feature) => (
+                <div key={feature.id} className="sys-row">
+                  <div className="sys-row__head">
+                    <span>{displayCapabilityId(feature.id)}</span>
+                    <EvidenceChip status={feature.status} source={{ rowId: feature.id }} size="sm" />
+                  </div>
+                  <small>{displayCapabilityCopy(feature.notes)}</small>
+                </div>
+              ))}
+            </div>
           ) : (
             <p>No supported API feature rows advertised yet.</p>
           )}


### PR DESCRIPTION
## Summary

- Replace dense capability and compatibility prose with compact, status-aware summaries, grouped exact-row evidence, and explicit disclosure.
- Add complete contract-field search and support-posture filters to the compatibility ledger, with reliable evidence-chip deep links through active filters.
- Structure the complete current-gate statement into readable neutral contract statements while preserving the canonical paragraph verbatim.
- Keep each collapsed ledger row's `Not claimed` boundary visible and retain the full equal-weight `Proven` / `Not claimed` evidence view when expanded.

## Why this change exists

The API, System, and Compatibility views expose a precise support contract, but long undifferentiated paragraphs made that contract difficult to scan and compare. This change improves the user-visible information hierarchy without changing capability data, runtime gating, or support semantics. Status-aware summaries keep supported and guarded rows distinguishable, verified context packs are derived from evidence status rather than reserved IDs, and the raw canonical statement remains available for exact review.

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets --all-features`
- [x] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included
- [x] Remote validation blockers are summarized generically, for example: `Remote Linux x86_64 validation was unavailable during this cycle; no fresh same-host timing/parity claim is made.`
- [x] `bash scripts/check-public-scrub.sh`
- [x] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [x] This PR does not overclaim support
- [x] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [x] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

No binary review artifacts are committed by this PR. Validation evidence:

- Full frontend CI sequence passes locally: build, model-state smoke, model-lanes smoke, 3B closure smoke, integration smoke, and UI regression smoke.
- `smoke:ui` is now enforced by the frontend CI job.
- Planned rows with reserved context-pack IDs render `no verified pack`; supported and guarded row counts remain visible in grouped summaries.
- Bundle-ID search, filtered evidence-chip deep links, keyboard focus transfer for model/API destinations, target sizing, and 390 px mobile containment were browser-verified.
- Capability-readiness smoke and all 124 WCAG AA contrast token checks pass.
- Structured current-gate statements recombine exactly to the canonical paragraph.

## Before
<img width="1280" height="936" alt="01-current-gate-BEFORE" src="https://github.com/user-attachments/assets/52dec6c4-c2e4-4425-8a49-91bc2ddc258d" />
<img width="1280" height="848" alt="02-quant-evidence-BEFORE" src="https://github.com/user-attachments/assets/21e7b4e0-7cfd-4142-9c2e-a236abb0c79e" />
<img width="2400" height="1062" alt="03-compatibility-ledger-BEFORE" src="https://github.com/user-attachments/assets/a2a10e02-c2b0-4770-af42-7277e81a8109" />


## After
<img width="2400" height="866" alt="03-compatibility-ledger-AFTER" src="https://github.com/user-attachments/assets/65ca48fb-07e3-410e-b704-f44c1b82e7a8" />
<img width="1280" height="1300" alt="01-current-gate-AFTER" src="https://github.com/user-attachments/assets/1b112934-876e-4d7f-902e-3cf5bba16f59" />
<img width="1280" height="642" alt="02-quant-evidence-AFTER" src="https://github.com/user-attachments/assets/c505f358-8971-48eb-ac5d-bc6d3dc61e94" />



## Docs impact

None. No README, compatibility, status, roadmap, or `docs/assets` files are changed by this PR.
