### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump 0.2.6 -> 0.3.0 for the next release (root Cargo.toml, camelid-desktop/Cargo.toml, tauri.conf.json, Cargo.lock).

Minor bump: since v0.2.6 main has landed the engine-inversion rework (#411/#414: generation_lock removed, single engine worker + bounded queue), OpenAI-compatible structured outputs (#419), the STAMPEDE decode/prefill perf wave (#404-#415), broad K-quant/context model promotions, and the fit advisor (#416).

After merge: tag the merge commit v0.3.0 to trigger release.yml (build + Azure Artifact Signing + publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)