### PR TITLE
fix(system): derive execution copy from health

### DIFF
--- a/frontend/scripts/frontend-integration-smoke.mjs
+++ b/frontend/scripts/frontend-integration-smoke.mjs
@@ -41,6 +41,12 @@ try {
     loaded_now: true,
     generation_ready: true,
     active_model_id: 'llama32_3b_instruct_q8_0',
+    status: 'online',
+    backend: 'llama',
+    execution_plan: {
+      selected_backend: 'cpu_q8_runtime_repack',
+      cuda_resident_active: false,
+    },
   }
   const selectedModel = {
     id: 'llama32_3b_instruct_q8_0',
@@ -363,6 +369,21 @@ try {
   assert.match(exactReadySystemMarkup, /COMPATIBILITY\.md rows from \/api\/capabilities[\s\S]*Template\/Jinja: Template rendering ready for this exact row[\s\S]*Checked context: Checked context packs ready for this exact row[\s\S]*Throughput: Production throughput not promoted/, 'System compatibility row list should render row-scoped 3B capability lanes, not just raw row status')
   assert.doesNotMatch(exactReadySystemMarkup, /normalizing model-native\/larger context; arbitrary\/Jinja template behavior; production throughput/, 'System compatibility list next-step copy should filter resolved template/Jinja caveats while retaining production-throughput blockers')
   assert.doesNotMatch(exactReadySystemMarkup, /# Use only after \/v1\/health returns generation_ready=true/, 'System curl should not imply generation_ready alone is sufficient for 3B UX chat')
+  assert.match(exactReadySystemMarkup, /Selected device at load[\s\S]*CPU[\s\S]*Selected backend at load[\s\S]*cpu q8 runtime repack/, 'System should render the selected CPU load plan instead of static backend prose')
+  assert.doesNotMatch(exactReadySystemMarkup, /GPU acceleration remains future work|local CPU generation path today/, 'System should not render stale static execution claims')
+  const cudaSystemMarkup = renderToStaticMarkup(React.createElement(SystemView, {
+    runtime: { ...readyRuntime, execution_plan: { selected_backend: 'cuda_resident_q8_runtime', cuda_resident_active: true } },
+    selectedModel,
+    capabilities,
+  }))
+  assert.match(cudaSystemMarkup, /Selected device at load[\s\S]*CUDA GPU[\s\S]*cuda resident q8 runtime/, 'System should render a consistent CUDA load plan without implying current effective execution')
+  const idleSystemMarkup = renderToStaticMarkup(React.createElement(SystemView, {
+    runtime: { api_base: 'http://127.0.0.1:8181', status: 'online', loaded_now: false, generation_ready: false },
+    selectedModel: null,
+    capabilities: { ...capabilities, execution_plan: null },
+  }))
+  assert.match(idleSystemMarkup, /Runtime[\s\S]*Idle[\s\S]*Runtime state[\s\S]*Online, no model loaded/, 'online no-model System state should report idle rather than offline')
+  assert.match(idleSystemMarkup, /Selected device at load[\s\S]*No model loaded[\s\S]*Selected backend at load[\s\S]*No active plan/, 'online no-model System state should not infer CPU or GPU execution')
   assert.match(exactReadyMarkup, /chat completions/, 'API view should display provider-scoped feature ids as neutral capability names')
   assert.match(exactReadyMarkup, /standard-compatible streaming stays enabled\./, 'API view should sanitize provider-specific feature notes before rendering')
 

--- a/frontend/scripts/ui-regression-smoke.mjs
+++ b/frontend/scripts/ui-regression-smoke.mjs
@@ -18,11 +18,42 @@ import {
 import { normalizeStoredConversations } from '../src/lib/conversationStorage.js'
 import { conversationToJson, conversationToMarkdown } from '../src/lib/conversationExport.js'
 import { canonicalStatementLabel, splitCanonicalStatement } from '../src/lib/canonicalStatement.js'
+import { describeExecutionPlan, executionRuntimeFields } from '../src/lib/executionPlan.js'
 
 /* ---- Behavioral asserts: conversation selection + stored-stream recovery ---- */
 const oldChat = { id: 'old-chat', title: 'Old chat', messages: [{ role: 'user', content: 'old prompt' }] }
 const newerChat = { id: 'newer-chat', title: 'Newer chat', messages: [{ role: 'user', content: 'newer prompt' }] }
 const conversations = [newerChat, oldChat]
+
+const healthExecutionPlan = { selected_backend: 'cpu_reference' }
+assert.deepEqual(executionRuntimeFields({ execution_plan: healthExecutionPlan, backend: 'llama' }), {
+  execution_plan: healthExecutionPlan,
+  backend: 'llama',
+}, 'dashboard normalization should preserve health execution plan identity and serving backend')
+assert.deepEqual(executionRuntimeFields(null), { execution_plan: null, backend: 'none' }, 'missing health should fail closed to no plan and no backend')
+
+assert.deepEqual(describeExecutionPlan({ status: 'offline' }), {
+  state: 'offline', device: 'Unavailable', backend: 'Backend offline', summary: 'Execution details are unavailable while the Camelid backend is offline.',
+}, 'offline runtime must not infer an execution device')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: false }).state, 'idle', 'online runtime without a model should report no active plan')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama' }).state, 'unknown', 'generation-ready runtime without plan data should stay neutral')
+assert.deepEqual(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama', execution_plan: { selected_backend: 'cpu_q8_runtime_repack' } }), {
+  state: 'cpu', device: 'CPU', backend: 'cpu q8 runtime repack', summary: 'At model load, Camelid selected CPU using cpu q8 runtime repack. Runtime controls may change the effective path afterward.',
+}, 'CPU plan copy should come from selected_backend')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama', execution_plan: { selected_backend: 'cuda_resident_q8_runtime', cuda_resident_active: true } }).device, 'CUDA GPU', 'consistent CUDA load plan should select GPU copy')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama', execution_plan: { selected_backend: 'cuda_resident_q8_runtime', cuda_resident_active: false } }).state, 'unknown', 'contradictory CUDA plan should fail neutral')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama', execution_plan: { selected_backend: 'cpu_reference', cuda_resident_active: true } }).state, 'unknown', 'contradictory CPU plan should fail neutral')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama', execution_plan: { selected_backend: 'metal_resident_q8_runtime' } }).device, 'Metal GPU', 'Metal load plan should select GPU copy')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama', execution_plan: { selected_backend: 'future_accelerator' } }).state, 'unknown', 'unknown future backends should fail neutral')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama', execution_plan: { selected_backend: 'cuda_resident_future', cuda_resident_active: true } }).state, 'unknown', 'unknown CUDA-prefixed backends should fail neutral')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama', execution_plan: { selected_backend: 'metal_resident_future' } }).state, 'unknown', 'unknown Metal-prefixed backends should fail neutral')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: false, backend: 'llama', execution_plan: { selected_backend: 'cpu_reference' } }).state, 'pending', 'non-ready models should not produce execution claims')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'gemma4-runtime', execution_plan: { selected_backend: 'cpu_reference' } }).state, 'specialized', 'specialized serving runtimes should not inherit generic plan device claims')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'runnable-runtime', execution_plan: { selected_backend: 'cpu_reference' } }).state, 'specialized', 'runnable serving runtime should not inherit generic plan device claims')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'diffusion-gemma-runtime', execution_plan: { selected_backend: 'cpu_reference' } }).state, 'specialized', 'DiffusionGemma serving runtime should not inherit generic plan device claims')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'none', execution_plan: { selected_backend: 'cpu_reference' } }).state, 'unknown', 'ready payload with no serving backend should fail neutral')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'future-runtime', execution_plan: { selected_backend: 'cpu_reference' } }).state, 'unknown', 'unknown serving backends should fail neutral')
+assert.equal(describeExecutionPlan({ status: 'online', loaded_now: true, generation_ready: true, backend: 'llama' }, { execution_plan: { selected_backend: 'cpu_reference' } }).state, 'unknown', 'capabilities must not resurrect a plan missing from health')
 
 const canonicalStatementSample = 'Current exact-row support: Alpha (detail; retained); Beta evidence. These are exact bounded lanes only.'
 const canonicalStatementParts = splitCanonicalStatement(canonicalStatementSample)
@@ -79,6 +110,7 @@ const chatWorkspaceSource = read('../src/views/ChatWorkspace.jsx')
 const messageTurnSource = read('../src/components/chat/MessageTurn.jsx')
 const markdownSource = read('../src/lib/markdown.jsx')
 const dashboardHookSource = read('../src/hooks/useDashboardData.js')
+const executionPlanSource = read('../src/lib/executionPlan.js')
 const loadedModelDisplaySource = read('../src/lib/loadedModelDisplay.js')
 const apiViewSource = read('../src/views/ApiView.jsx')
 const systemViewSource = read('../src/views/SystemView.jsx')
@@ -220,6 +252,10 @@ assert.doesNotMatch(systemViewSource, /supported_quantization|planned_quantizati
 assert.match(systemViewSource, /displayCapabilityId\(feature\.id\)/, 'System view should not render raw provider-scoped API feature ids')
 assert.match(systemViewSource, /getRuntimeRequestModelId\(selectedModel, runtime, '<loaded-model-id>'\)/, 'System curl examples should use the loaded backend model id for alias-selected exact rows')
 assert.match(systemViewSource, /<EvidenceChip/, 'System contract rows should render their status claims through the Evidence Chip')
+assert.match(dashboardHookSource, /\.\.\.executionRuntimeFields\(health\)/, 'dashboard runtime state should use the tested health execution-field mapper')
+assert.match(systemViewSource, /describeExecutionPlan\(runtime\)/, 'System execution copy should come only from the health-derived runtime snapshot')
+assert.doesNotMatch(systemViewSource, /GPU acceleration remains future work|local CPU generation path today/, 'System must not retain static backend execution claims')
+assert.match(executionPlanSource, /CUDA_BACKENDS\.has\(selectedBackend\)[\s\S]*METAL_BACKENDS\.has\(selectedBackend\)/, 'execution-plan presenter should classify only explicitly known CUDA and Metal backends')
 assert.match(compatibilityViewSource, /<CanonicalStatement text=\{displayCapabilityCopy\(supportContract\.current_gate\)\}/, 'Compatibility should render the complete gate through the shared structured canonical statement')
 assert.match(canonicalStatementSource, /View as one canonical paragraph/, 'the structured disclosure should retain one-click access to the unbroken canonical paragraph')
 assert.match(compatibilityViewSource, /if \(query \|\| posture !== 'all'\)[\s\S]*setQuery\(''\)[\s\S]*setPosture\('all'\)/, 'ledger deep-links should clear filters before resolving their target row')

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -7,6 +7,7 @@ import { NEW_CHAT_SENTINEL, resolveSelectedConversation, shouldCreateConversatio
 import { normalizeStoredConversations } from '../lib/conversationStorage.js'
 import { getRuntimeRequestModelId, isExternalModel, modelRuntimeIdMatches } from '../lib/modelState'
 import { contractSamplingOverrides } from '../lib/samplingContract'
+import { executionRuntimeFields } from '../lib/executionPlan'
 import { createPacerState, paceDrain, paceStep } from '../lib/streamPacing'
 import { getConfiguredMaxTokens as getModelMaxTokens } from '../lib/responseLimits'
 import { beginRequest, emitFirstContent, emitProgress, getTelemetrySnapshot, recordChatGeneration, recordHealthPoll } from '../lib/telemetryLog'
@@ -433,6 +434,7 @@ function makeDashboard({ health, models, currentModel, capabilities, conversatio
       active_model_id: health?.active_model_id || null,
       generation_ready: Boolean(health?.generation_ready),
       q8_runtime: health?.q8_runtime || null,
+      ...executionRuntimeFields(health),
       status: health?.ok ? 'online' : 'offline',
       api_base: apiBase,
       current_model: currentModel || null,

--- a/frontend/src/lib/executionPlan.js
+++ b/frontend/src/lib/executionPlan.js
@@ -1,0 +1,124 @@
+function displayPlanValue(value = '') {
+  return String(value).trim().replace(/_/g, ' ')
+}
+
+const CPU_BACKENDS = new Set([
+  'cpu_reference',
+  'cpu_q8_runtime_repack',
+  'cpu_kquant_block_dot',
+])
+
+const CUDA_BACKENDS = new Set([
+  'cuda_resident_q8_runtime',
+  'cuda_resident_q8_runtime_runnable_unvalidated',
+  'cuda_resident_kquant_runtime',
+])
+
+const METAL_BACKENDS = new Set([
+  'metal_resident_q8_runtime',
+])
+
+const SPECIALIZED_BACKENDS = new Set([
+  'gemma4-runtime',
+  'runnable-runtime',
+  'diffusion-gemma-runtime',
+])
+
+export function executionRuntimeFields(health) {
+  return {
+    execution_plan: health?.execution_plan || null,
+    backend: health?.backend || 'none',
+  }
+}
+
+export function describeExecutionPlan(runtime) {
+  if (runtime?.status === 'offline') {
+    return {
+      state: 'offline',
+      device: 'Unavailable',
+      backend: 'Backend offline',
+      summary: 'Execution details are unavailable while the Camelid backend is offline.',
+    }
+  }
+
+  if (!runtime?.loaded_now) {
+    return {
+      state: 'idle',
+      device: 'No model loaded',
+      backend: 'No active plan',
+      summary: 'No model is loaded, so Camelid has no active execution plan.',
+    }
+  }
+
+  if (!runtime?.generation_ready) {
+    return {
+      state: 'pending',
+      device: 'Not active',
+      backend: 'Model not generation-ready',
+      summary: 'A model is loaded, but Camelid is not generation-ready, so no execution claim is shown.',
+    }
+  }
+
+  if (SPECIALIZED_BACKENDS.has(runtime?.backend)) {
+    const backend = displayPlanValue(runtime.backend)
+    return {
+      state: 'specialized',
+      device: 'Runtime-specific',
+      backend,
+      summary: `Camelid reports the active model is served by ${backend}; the generic load-time execution plan is not used for a device claim.`,
+    }
+  }
+
+  if (runtime?.backend !== 'llama') {
+    return {
+      state: 'unknown',
+      device: 'Not reported',
+      backend: displayPlanValue(runtime?.backend) || 'Backend unavailable',
+      summary: 'Camelid did not report a recognized serving backend for the loaded model.',
+    }
+  }
+
+  const plan = runtime?.execution_plan || null
+  if (!plan) {
+    return {
+      state: 'unknown',
+      device: 'Not reported',
+      backend: 'Plan unavailable',
+      summary: 'A model is loaded, but Camelid did not return an active execution plan.',
+    }
+  }
+
+  const selectedBackend = String(plan.selected_backend || '')
+  if (!selectedBackend) {
+    return {
+      state: 'unknown',
+      device: 'Not reported',
+      backend: 'Plan unavailable',
+      summary: 'Camelid returned an execution plan without a selected backend.',
+    }
+  }
+
+  const cudaSelected = CUDA_BACKENDS.has(selectedBackend)
+  const metalActive = METAL_BACKENDS.has(selectedBackend)
+  const cpuSelected = CPU_BACKENDS.has(selectedBackend)
+  const cudaConsistent = cudaSelected && plan.cuda_resident_active === true
+  const contradictoryCuda = cudaSelected !== (plan.cuda_resident_active === true)
+  if ((!cpuSelected && !cudaSelected && !metalActive) || contradictoryCuda) {
+    return {
+      state: 'unknown',
+      device: 'Not reported',
+      backend: displayPlanValue(selectedBackend),
+      summary: 'Camelid returned a load-time execution plan that this UI cannot classify safely.',
+    }
+  }
+
+  const device = cudaConsistent ? 'CUDA GPU' : metalActive ? 'Metal GPU' : 'CPU'
+  const backend = displayPlanValue(selectedBackend)
+
+  return {
+    state: cudaConsistent ? 'cuda' : metalActive ? 'metal' : 'cpu',
+    device,
+    backend,
+    summary: `At model load, Camelid selected ${device} using ${backend}. Runtime controls may change the effective path afterward.`,
+  }
+}

--- a/frontend/src/views/SystemView.jsx
+++ b/frontend/src/views/SystemView.jsx
@@ -1,6 +1,7 @@
 import { displayCapabilityCopy, displayCapabilityId, exactRowSupportLanes, findCompatibilityHint, formatCapabilityStatus, frontendSupportContractCopy, guardedCapabilityCopy, isExactCompatibilityHint, isGuardedCapabilityStatus, isSupportedCapabilityStatus, rowSupportNextStepCopy } from '../lib/capabilities'
 import { getChatGateState } from '../lib/chatGate'
 import { describeModelState, getRuntimeRequestModelId } from '../lib/modelState'
+import { describeExecutionPlan } from '../lib/executionPlan'
 import { StatusDot } from '../components/ui/StatusDot'
 import { EvidenceChip } from '../components/ui/EvidenceChip'
 import { CanonicalStatement } from '../components/ui/CanonicalStatement'
@@ -28,6 +29,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
   const supportContract = capabilities?.support_contract
   const supportContractCurrentGate = frontendSupportContractCopy(capabilities)
   const compatibilityTargets = capabilities?.model_compatibility || []
+  const execution = describeExecutionPlan(runtime)
   const supportedCompatibilityCount = compatibilityTargets.filter((target) => isSupportedCapabilityStatus(target.status)).length
   const apiFeatures = capabilities?.api_features || []
   const supportedFeatures = apiFeatures.filter((feature) => isSupportedCapabilityStatus(feature.status))
@@ -74,7 +76,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
     ? `${q8Runtime.policy}${Number.isFinite(q8Runtime.file_cache_bytes) ? ` · cache ${q8Runtime.file_cache_bytes} bytes` : ''}`
     : 'Start the local runtime to inspect Q8 storage policy.'
 
-  const runtimeState = runtime?.generation_ready ? 'Ready' : runtime?.loaded_now ? 'Loaded' : 'Offline'
+  const runtimeState = runtime?.generation_ready ? 'Ready' : runtime?.loaded_now ? 'Loaded' : runtime?.status === 'offline' ? 'Offline' : 'Idle'
   const runtimeTone = runtime?.generation_ready ? 'ready' : runtime?.loaded_now ? 'warn' : 'neutral'
   const gateStat = selectedExactRowReady ? 'Ready' : selectedChatGate.runtimeReady ? 'Gated' : 'Blocked'
   const gateStatSub = selectedExactRowReady ? 'chat + API unlocked' : selectedChatGate.runtimeReady ? 'runtime ready, support gated' : 'exact row required'
@@ -113,10 +115,12 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
         <section className="cxv-card cxv-panel">
           <div className="cxv-section__head"><h2>Runtime</h2><span className="cxv-section__count">local engine</span></div>
           <div className="sys-defs">
-            <div><span>Runtime state</span><strong>{runtime?.generation_ready ? 'Generation-ready' : runtime?.loaded_now ? 'Loaded, not generation-ready' : 'No generation-ready model'}</strong></div>
+            <div><span>Runtime state</span><strong>{runtime?.generation_ready ? 'Generation-ready' : runtime?.loaded_now ? 'Loaded, not generation-ready' : runtime?.status === 'offline' ? 'Backend offline' : 'Online, no model loaded'}</strong></div>
             <div><span>Local engine</span><strong>{runtime?.engine || 'Unknown'}</strong></div>
             <div><span>Loaded model</span><strong>{runtime?.loaded_now ? runtime?.active_model_id : 'Nothing loaded'}</strong></div>
             <div><span>Generation ready</span><strong>{runtime?.generation_ready ? 'Yes' : 'No'}</strong></div>
+            <div><span>Selected device at load</span><strong>{execution.device}</strong></div>
+            <div><span>Selected backend at load</span><strong>{execution.backend}</strong></div>
             <div><span>Selected exact-row gate</span><strong>{selectedExactRowReady ? 'Ready for chat/API' : selectedChatGate.runtimeReady ? 'Runtime ready; support gated' : selectedChatGate.label}</strong></div>
             <div><span>Q8 storage</span><strong>{q8RuntimeLabel}</strong></div>
             <div><span>Next chat selection</span><strong>{selectedModelName}</strong></div>
@@ -129,7 +133,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
           <ul className="sys-feed">
             <li>Persistent conversations are already available from local storage.</li>
             <li>Saved memory remains on-device and can be recalled in later chats.</li>
-            <li>Camelid is using the local CPU generation path today; GPU acceleration remains future work.</li>
+            <li>{execution.summary}</li>
             <li>Q8 runtime policy: {q8RuntimeDetail}. {q8Runtime?.note || ''}</li>
             <li>Current next-chat model state: {describeModelState(selectedModel)}</li>
             <li>Chat stays blocked until loaded_now=true, generation_ready=true, active_model_id matches the selected local GGUF, and COMPATIBILITY.md plus /api/capabilities expose an exact supported row.</li>
@@ -158,7 +162,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
           <div className="sys-endpoint">
             <div className="sys-endpoint__head"><strong>Health</strong><span className="cxv-tag">GET</span></div>
             <code>{runtime?.api_base ? `${runtime.api_base}/v1/health` : 'Unavailable until the local API is running'}</code>
-            <p>Source of truth for active_model_id and generation_ready.</p>
+            <p>Source of truth for active_model_id, generation_ready, and the selected load-time execution plan.</p>
           </div>
           <div className="sys-endpoint">
             <div className="sys-endpoint__head"><strong>Capabilities</strong><span className="cxv-tag">GET</span></div>

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -285,7 +285,8 @@ pub struct HealthResponse {
     pub active_model_id: Option<String>,
     pub q8_runtime: Q8RuntimeHealth,
     pub execution_plan: Option<ExecutionPlan>,
-    /// Which backend serves the active model: "gemma4-runtime", "llama", or "none".
+    /// Which backend serves the active model: "gemma4-runtime", "runnable-runtime",
+    /// "diffusion-gemma-runtime", "llama", or "none".
     pub backend: &'static str,
     /// Model family of the active model ("gemma4", "llama-family", ...), if loaded.
     pub model_family: Option<&'static str>,
@@ -1796,26 +1797,24 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         None => false,
     };
     let model_family = model.map(|m| model_family(&m.gguf));
-    let backend = if gemma4_available {
-        "gemma4-runtime"
-    } else if model.is_some() {
-        "llama"
-    } else {
-        "none"
+    // Specialized serve lanes are ready only when their active runtime instance exists.
+    // Model load inserts the generic metadata before initializing these runtimes, and a
+    // failed initialization leaves the model visible but intentionally not ready. Health
+    // must agree with request routing, which also requires the runtime-map entry.
+    let runnable_serve_ready = match active_id_lock.as_ref() {
+        Some(id) => state.runnable_runtimes.read().await.contains_key(id),
+        None => false,
     };
-    // The gemma4 runtime (Q8-resident) is ready as soon as it is loaded; the Llama
-    // f32-budget check does not apply to it. Likewise, a model served by the runnable
-    // lane (CAMELID_RUNNABLE_SERVE + a runnable-served arch, e.g. qwen35/Ornith) is
-    // generation-ready once loaded â€” the runnable serve runtime is built lazily on the
-    // first chat, so gate on "runnable-serve enabled + runnable arch + loaded" rather
-    // than the lazy runtime map (otherwise chat stays locked until you chat â†’ deadlock).
-    let runnable_serve_ready = runnable_serve_enabled()
-        && model.is_some_and(|m| is_runnable_serve_arch(m.gguf.architecture().unwrap_or_default()));
-    // Same shape for the DiffusionGemma serve bridge: ready once the model is
-    // loaded with the lane enabled (the runtime loads eagerly at model load,
-    // but gate on enabled + arch so a heal-path gap cannot lock the UI).
-    let dg_serve_ready = dg_serve_enabled()
-        && model.is_some_and(|m| is_dg_serve_arch(m.gguf.architecture().unwrap_or_default()));
+    let dg_serve_ready = match active_id_lock.as_ref() {
+        Some(id) => state.dg_runtimes.read().await.contains_key(id),
+        None => false,
+    };
+    let backend = health_backend(
+        gemma4_available,
+        runnable_serve_ready,
+        dg_serve_ready,
+        model.is_some(),
+    );
     let generation_ready = gemma4_available
         || runnable_serve_ready
         || dg_serve_ready
@@ -1838,6 +1837,25 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         gemma4_available,
         engine_queue_depth: state.engine.depth(),
     })
+}
+
+fn health_backend(
+    gemma4_available: bool,
+    runnable_serve_ready: bool,
+    dg_serve_ready: bool,
+    model_loaded: bool,
+) -> &'static str {
+    if gemma4_available {
+        "gemma4-runtime"
+    } else if runnable_serve_ready {
+        "runnable-runtime"
+    } else if dg_serve_ready {
+        "diffusion-gemma-runtime"
+    } else if model_loaded {
+        "llama"
+    } else {
+        "none"
+    }
 }
 
 async fn llama_server_models(
@@ -6231,6 +6249,7 @@ async fn unload_model(
         state.loaded_models.write().await.clear();
         state.gemma4_runtimes.write().await.clear();
         state.runnable_runtimes.write().await.clear();
+        state.dg_runtimes.write().await.clear();
         state.execution_plans.write().await.clear();
         state.cached_weights.write().await.clear();
         state.model_last_used.write().await.clear();
@@ -12595,6 +12614,22 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn health_backend_reports_the_effective_serving_lane() {
+        assert_eq!(health_backend(false, false, false, false), "none");
+        assert_eq!(health_backend(false, false, false, true), "llama");
+        assert_eq!(health_backend(false, true, false, true), "runnable-runtime");
+        assert_eq!(
+            health_backend(false, false, true, true),
+            "diffusion-gemma-runtime"
+        );
+        assert_eq!(
+            health_backend(true, true, true, true),
+            "gemma4-runtime",
+            "the eagerly loaded Gemma4 runtime has highest precedence"
+        );
+    }
 
     // ---------------------------------------------------------------------
     // Engine-inversion orphan-decode harness (P0-T1 / P0-T2 / P0-T3).


### PR DESCRIPTION
## Summary

- Preserve the active health execution plan and serving backend in normalized frontend runtime state.
- Replace the stale System CPU/GPU sentence with fail-closed load-time plan copy and explicit idle/offline/specialized states.
- Make health readiness and backend labels agree with actual Gemma4, runnable, DiffusionGemma, or generic Llama runtime-map ownership.
- Add backend and frontend regression coverage for idle, CPU, CUDA, Metal, specialized, unknown, contradictory, and non-ready states.

## Why this change exists

The System page contained a static claim that Camelid was using CPU and that GPU acceleration was future work. That sentence could contradict the loaded model's selected execution plan. This change derives System copy from `/v1/health`, labels the data honestly as the plan selected at model load, and fails neutral when the backend cannot support a device claim. It also fixes an existing health mismatch where specialized lanes could report ready from architecture and environment eligibility even when their runtime instance was unavailable.

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features`
- [x] `cd frontend && npm run build`
- [ ] Other evidence attached below

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included
- [x] Remote validation blockers are summarized generically, for example: `Remote Linux x86_64 validation was unavailable during this cycle; no fresh same-host timing/parity claim is made.`
- [x] `bash scripts/check-public-scrub.sh`
- [x] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [x] This PR does not overclaim support
- [x] TinyLlama Q8_0 remains the current full-support gate; exact Llama 3.2 1B/3B and Llama 3 8B Q8_0 rows stay limited to their documented exact-row smoke envelopes unless exact new evidence is included
- [x] Any 1B / 3B / 8B wording stays aligned with `COMPATIBILITY.md`, `STATUS.md`, and `/api/capabilities`, including bounded-pack caveats for 8B broader 50-token, 512-context, compact template-shapes, and measurement-only lazy-Q8 hot-path evidence

## Evidence / artifacts

- Focused backend test: `api::tests::health_backend_reports_the_effective_serving_lane`
- Frontend build, integration smoke, UI regression smoke, model-state/model-lanes/3B closure smokes, and all 124 WCAG AA contrast checks pass locally.
- Live no-model System state reports `Idle`, `Online, no model loaded`, and `No active plan`; the stale CPU/GPU sentence is absent.
- CPU, CUDA, Metal, specialized-runtime, contradictory, unknown, and non-ready presentation states are covered by deterministic fixtures.
- Before/after screenshots were captured outside the repository and can be attached to this PR without adding binary assets to source history.

## Docs impact

None. Product direction, roadmap, support, and status documents are unchanged by this PR.

## Before 
<img width="1280" height="960" alt="camelid-p0 1-system-before" src="https://github.com/user-attachments/assets/8dfc6881-5cee-44d1-9fb4-c007195af86d" />

## After

<img width="1280" height="922" alt="camelid-p0 1-system-after" src="https://github.com/user-attachments/assets/727daf69-ea56-4167-b0d4-121f86aa76ac" />
