### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
## Summary

- Version bump 0.3.0 → 0.3.1 across Cargo.toml, Cargo.lock, camelid-desktop/Cargo.toml, and tauri.conf.json — the same four-file set as the v0.3.0 bump (#425).

## Why this change exists

v0.3.1 packages this campaign's work on top of v0.3.0: the anchored 3B context ladder + file-identity disclosure (#429), the BACKENDINFERENCE_* → CAMELID_* flag clean break (#430), and the three post-v0.3.0 fixes already on main (#426 live System/health copy, #427 truthful plan labels, #428 live streaming tok/s footer). Tag + release.yml follow on the merge sha; release notes will carry the rename notice and the evidence-bounded promotion story.

## Validation

- [x] `git diff --check`
- [x] `cargo update -w` regenerated the lock (camelid + camelid-desktop → 0.3.1; no dependency changes)
- [ ] Full suite in CI (version-only change)

## Public-repo privacy check

- [x] No private paths or hostnames — version strings only

## Support-contract check

- [x] No support language touched

## Docs impact

None (release notes are authored on the GitHub release, per the established flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)