### PR TITLE
feat(ledger): CAIRN Phase 1 — camelid.ledger/v1 schema + validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Check public evidence claims
         run: node scripts/check-public-evidence-claims.mjs
 
+      - name: Check ledger schema (camelid.ledger/v1)
+        run: node scripts/check-ledger-schema.mjs
+
       - name: Check CUDA batched-prefill parity gate wiring
         run: node scripts/check-cuda-prefill-parity-gate.mjs
 

--- a/ledger/camelid-ledger.schema.json
+++ b/ledger/camelid-ledger.schema.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "camelid.ledger/v1",
+  "title": "camelid.ledger/v1 — Camelid claim ledger",
+  "description": "The single source of truth for Camelid's claim boundary (CAIRN). One populated ledger (ledger/camelid-ledger.json) is intended to GENERATE, byte-identically, the /api/capabilities response (src/api/capabilities_generated.rs), the README ledger tables, the COMPATIBILITY tables, and the STATUS snapshot. Design rules: (1) every current surface string is holdable VERBATIM so regeneration is byte-identical (the Phase 3 fixpoint) — prose fields are free strings, never lossy-normalized here; (2) the constrained enums (status, support_scope, full_support_status, latest_checked_result) are the code's own vocabulary from src/api/mod.rs, NOT a four-word display lane (CAIRN Amendment 1 #6); (3) identity.sha256 / identity.gguf_filename are ADDITIVE typed fields — they do not replace the verbatim contract prose that currently carries those values until the fixpoint proves them redundant (Phase 5). The `contract` block mirrors the ModelCompatibilityTarget struct field-for-field (40 fields) so an /api/capabilities row round-trips with zero loss.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["ledger_version", "capabilities", "model_rows"],
+  "properties": {
+    "ledger_version": { "const": "camelid.ledger/v1" },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "source_head": { "type": "string", "description": "git head the ledger was extracted from / is valid against" },
+        "note": { "type": "string" }
+      }
+    },
+    "capabilities": { "$ref": "#/definitions/capabilitiesEnvelope" },
+    "model_rows": {
+      "type": "array",
+      "description": "One entry per exact model row. Its `contract` generates the matching /api/capabilities model_compatibility[] element; its `surfaces` generate the README / COMPATIBILITY / STATUS cells for the same row.",
+      "items": { "$ref": "#/definitions/modelRow" }
+    }
+  },
+  "definitions": {
+    "statusVocabulary": {
+      "type": "string",
+      "$comment": "Code-derived from `status:` literals in src/api/mod.rs. check-ledger-schema.mjs asserts this list is a SUPERSET of the live code values (drift guard). Polymorphic by item type: model rows use the supported_*/active_validation_*/planned_* subset; SupportItem lists (quant/family/api_features) add ok/partial/future/downloading/error.",
+      "enum": [
+        "active_validation_partial_runtime",
+        "blocked_later_generation_divergence",
+        "blocked_pending_normalized_full_support",
+        "current_gate_refresh_under_stricter_bar",
+        "downloading",
+        "error",
+        "future",
+        "not_applicable_until_certified_row",
+        "not_applicable_until_runtime_support",
+        "ok",
+        "partial",
+        "planned",
+        "planned_beyond_named_certified_rows",
+        "planned_exact_row_candidate",
+        "planned_phase_10",
+        "supported",
+        "supported_current_gate",
+        "supported_exact_row_smoke",
+        "supported_exact_row_smoke_lane",
+        "supported_exact_row_smoke_lanes",
+        "supported_named_exact_rows_only",
+        "unsupported"
+      ]
+    },
+    "supportScopeVocabulary": {
+      "type": "string",
+      "$comment": "Code-derived from `support_scope:` literals in src/api/mod.rs (checked ⊇ by check-ledger-schema.mjs).",
+      "enum": [
+        "current_full_gate_exact_row",
+        "exact_row_bounded_moe_runtime_only",
+        "exact_row_chatml_thinking_disabled_gpu_resident_smoke_only",
+        "exact_row_chatml_thinking_disabled_smoke_only",
+        "exact_row_distributed_serve_smoke_only",
+        "exact_row_gpu_resident_raw_decode_parity_smoke_only",
+        "exact_row_single_node_cpu_smoke_only",
+        "exact_row_smoke_only",
+        "future_exact_row_planning_only"
+      ]
+    },
+    "fullSupportStatusVocabulary": {
+      "type": "string",
+      "$comment": "Code-derived from `full_support_status:` literals in src/api/mod.rs (checked ⊇ by check-ledger-schema.mjs).",
+      "enum": [
+        "blocked_later_generation_divergence",
+        "blocked_pending_normalized_full_support",
+        "current_gate_refresh_under_stricter_bar",
+        "not_applicable_until_certified_row",
+        "not_applicable_until_runtime_support"
+      ]
+    },
+    "latestCheckedResultVocabulary": {
+      "type": "string",
+      "$comment": "Code-derived from `latest_checked_result:` literals in src/api/mod.rs (checked ⊇ by check-ledger-schema.mjs).",
+      "enum": ["blocked_later_generation_divergence", "not_started", "pass", "planning_only"]
+    },
+    "supportItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "notes"],
+      "description": "Mirrors the Rust SupportItem struct (supported_quantization / planned_quantization / supported_model_families / planned_model_families / api_features).",
+      "properties": {
+        "id": { "type": "string" },
+        "status": { "$ref": "#/definitions/statusVocabulary" },
+        "notes": { "type": "string" }
+      }
+    },
+    "supportContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["current_gate", "support_policy", "unsupported_policy"],
+      "description": "Mirrors the Rust SupportContract struct.",
+      "properties": {
+        "current_gate": { "type": "string" },
+        "support_policy": { "type": "string" },
+        "unsupported_policy": { "type": "string" }
+      }
+    },
+    "capabilitiesEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The non-row parts of the CapabilitiesResponse struct. `execution_plan` is runtime-injected (capabilities_response() passes None), so it is null in the static contract the ledger owns.",
+      "required": [
+        "engine", "gguf_metadata", "tensor_loading", "tokenization", "inference",
+        "streaming", "model_downloads", "hf_catalog_install", "execution_plan",
+        "support_contract", "supported_quantization", "planned_quantization",
+        "supported_model_families", "planned_model_families", "api_features", "notes"
+      ],
+      "properties": {
+        "engine": { "type": "string" },
+        "gguf_metadata": { "type": "boolean" },
+        "tensor_loading": { "type": "boolean" },
+        "tokenization": { "type": "boolean" },
+        "inference": { "type": "boolean" },
+        "streaming": { "type": "boolean" },
+        "model_downloads": { "type": "boolean" },
+        "hf_catalog_install": { "type": "boolean" },
+        "execution_plan": { "type": ["object", "null"] },
+        "support_contract": { "$ref": "#/definitions/supportContract" },
+        "supported_quantization": { "type": "array", "items": { "$ref": "#/definitions/supportItem" } },
+        "planned_quantization": { "type": "array", "items": { "$ref": "#/definitions/supportItem" } },
+        "supported_model_families": { "type": "array", "items": { "$ref": "#/definitions/supportItem" } },
+        "planned_model_families": { "type": "array", "items": { "$ref": "#/definitions/supportItem" } },
+        "api_features": { "type": "array", "items": { "$ref": "#/definitions/supportItem" } },
+        "notes": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "modelContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Field-for-field mirror of the ModelCompatibilityTarget struct (40 fields). Every field is present on every row (the Rust struct has no Option), so all 40 are required — this is what makes byte-identical /api/capabilities regeneration possible. All fields are held verbatim; only status / support_scope / full_support_status / latest_checked_result are enum-constrained.",
+      "required": [
+        "id", "family", "quantization", "status", "tool_capable", "support_scope",
+        "full_support_status", "full_support_blockers", "metadata_parses", "tokenizer_works",
+        "tensors_load", "generation_runs", "parity_audited", "performance_measured",
+        "frontend_load_path_verified", "frontend_readiness_gate", "tested_context",
+        "chat_template_renderer", "chat_template_shape_pack", "chat_template_shape_pack_id",
+        "bounded_context_512_pack", "bounded_context_512_pack_id", "bounded_context_window",
+        "bounded_context_1024_pack", "bounded_context_1024_pack_id", "bounded_context_1024_window",
+        "bounded_context_2048_pack", "bounded_context_2048_pack_id", "bounded_context_2048_window",
+        "bounded_context_4096_pack", "bounded_context_4096_pack_id", "bounded_context_4096_window",
+        "bounded_context_8192_pack", "bounded_context_8192_pack_id", "bounded_context_8192_window",
+        "latest_checked_bucket", "latest_checked_result", "latest_checked_output", "evidence", "next_step"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "family": { "type": "string" },
+        "quantization": { "type": "string" },
+        "status": { "$ref": "#/definitions/statusVocabulary" },
+        "tool_capable": { "type": "boolean" },
+        "support_scope": { "$ref": "#/definitions/supportScopeVocabulary" },
+        "full_support_status": { "$ref": "#/definitions/fullSupportStatusVocabulary" },
+        "full_support_blockers": { "type": "string" },
+        "metadata_parses": { "type": "string" },
+        "tokenizer_works": { "type": "string" },
+        "tensors_load": { "type": "string" },
+        "generation_runs": { "type": "string" },
+        "parity_audited": { "type": "string" },
+        "performance_measured": { "type": "string" },
+        "frontend_load_path_verified": { "type": "string" },
+        "frontend_readiness_gate": { "type": "string" },
+        "tested_context": { "type": "string" },
+        "chat_template_renderer": { "type": "string" },
+        "chat_template_shape_pack": { "type": "string" },
+        "chat_template_shape_pack_id": { "type": "string" },
+        "bounded_context_512_pack": { "type": "string" },
+        "bounded_context_512_pack_id": { "type": "string" },
+        "bounded_context_window": { "type": "integer", "minimum": 0 },
+        "bounded_context_1024_pack": { "type": "string" },
+        "bounded_context_1024_pack_id": { "type": "string" },
+        "bounded_context_1024_window": { "type": "integer", "minimum": 0 },
+        "bounded_context_2048_pack": { "type": "string" },
+        "bounded_context_2048_pack_id": { "type": "string" },
+        "bounded_context_2048_window": { "type": "integer", "minimum": 0 },
+        "bounded_context_4096_pack": { "type": "string" },
+        "bounded_context_4096_pack_id": { "type": "string" },
+        "bounded_context_4096_window": { "type": "integer", "minimum": 0 },
+        "bounded_context_8192_pack": { "type": "string" },
+        "bounded_context_8192_pack_id": { "type": "string" },
+        "bounded_context_8192_window": { "type": "integer", "minimum": 0 },
+        "latest_checked_bucket": { "type": "string" },
+        "latest_checked_result": { "$ref": "#/definitions/latestCheckedResultVocabulary" },
+        "latest_checked_output": { "type": "string" },
+        "evidence": { "type": "string" },
+        "next_step": { "type": "string" }
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path"],
+      "description": "A resolvable evidence pointer. `path` is repo-relative; head/captured_at are the structured provenance currently flattened into evidence-bundle directory names.",
+      "properties": {
+        "path": { "type": "string" },
+        "head": { "type": "string" },
+        "captured_at": { "type": "string" }
+      }
+    },
+    "surfaceReadme": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The README supported-models table cells for this row (README.md:170 columns: Model row | Quant | Serve lane | Evidence). Row/Quant derive from identity; only the free-text cells live here.",
+      "properties": {
+        "serve_lane": { "type": "string" },
+        "evidence": { "type": "string" }
+      }
+    },
+    "surfaceCompatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The COMPATIBILITY at-a-glance cells for this row (COMPATIBILITY.md:45 columns: Exact row | Public claim | Checked context boundary | Do not claim).",
+      "properties": {
+        "public_claim": { "type": "string" },
+        "checked_context_boundary": { "type": "string" },
+        "do_not_claim": { "type": "string" }
+      }
+    },
+    "surfaceStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The STATUS per-row support-evidence cells (STATUS.md:211+): what is validated now, what gates are missing, and the exact blocker.",
+      "properties": {
+        "validated_now": { "type": "string" },
+        "gates_missing": { "type": "string" },
+        "blocker": { "type": "string" }
+      }
+    },
+    "modelRow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identity", "contract"],
+      "properties": {
+        "identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "family", "quantization"],
+          "description": "Exact-row identity. sha256 / gguf_filename / params are additive typed fields (today they live only inside prose contract fields); the validator requires identity.id === contract.id.",
+          "properties": {
+            "id": { "type": "string" },
+            "family": { "type": "string" },
+            "params": { "type": "string" },
+            "quantization": { "type": "string" },
+            "gguf_filename": { "type": "string" },
+            "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+          }
+        },
+        "contract": { "$ref": "#/definitions/modelContract" },
+        "surfaces": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "readme": { "$ref": "#/definitions/surfaceReadme" },
+            "compatibility": { "$ref": "#/definitions/surfaceCompatibility" },
+            "status": { "$ref": "#/definitions/surfaceStatus" }
+          }
+        },
+        "receipts": { "type": "array", "items": { "$ref": "#/definitions/receipt" } }
+      }
+    }
+  }
+}

--- a/ledger/examples/example-ledger.json
+++ b/ledger/examples/example-ledger.json
@@ -1,0 +1,163 @@
+{
+  "ledger_version": "camelid.ledger/v1",
+  "provenance": {
+    "source_head": "d243d5bd",
+    "note": "CAIRN Phase 1 example ledger. Row 1 is the REAL llama32_3b_instruct_q8_0 ModelCompatibilityTarget transcribed verbatim from src/api/mod.rs (all 40 contract fields) — the zero-loss round-trip proof. Row 2 is a synthetic active-validation MoE row that exercises additional enum values. NOT the authoritative populated ledger (that is Phase 2)."
+  },
+  "capabilities": {
+    "engine": "camelid",
+    "gguf_metadata": true,
+    "tensor_loading": true,
+    "tokenization": true,
+    "inference": true,
+    "streaming": true,
+    "model_downloads": true,
+    "hf_catalog_install": true,
+    "execution_plan": null,
+    "support_contract": {
+      "current_gate": "Current exact-row support gate — see model_compatibility for the authoritative per-row boundary.",
+      "support_policy": "Support is per exact GGUF row and evidence-bounded; it never spreads to neighboring files, quants, or families.",
+      "unsupported_policy": "Rows without a promotion receipt fail closed; implemented-but-unpromoted architectures run in the clearly-marked experimental/runnable lane."
+    },
+    "supported_quantization": [
+      { "id": "Q8_0", "status": "supported", "notes": "The primary supported dense quant for the promoted exact rows." }
+    ],
+    "planned_quantization": [
+      { "id": "Q2_K", "status": "planned", "notes": "Not certified for any exact row yet." }
+    ],
+    "supported_model_families": [
+      { "id": "llama_bpe_decoder", "status": "supported_named_exact_rows_only", "notes": "Only the named exact rows are supported; family membership is not a support claim." }
+    ],
+    "planned_model_families": [
+      { "id": "qwen2", "status": "planned_exact_row_candidate", "notes": "Runtime/tokenizer bring-up pending." }
+    ],
+    "api_features": [
+      { "id": "chat_completions", "status": "ok", "notes": "OpenAI-style /v1/chat/completions, streaming and non-streaming." },
+      { "id": "structured_outputs", "status": "partial", "notes": "JSON-schema constrained decoding present; see STRUCTURED_OUTPUTS.md for the contract." }
+    ],
+    "notes": [
+      "This example envelope is illustrative; the authoritative envelope is generated from the populated ledger in a later phase."
+    ]
+  },
+  "model_rows": [
+    {
+      "identity": {
+        "id": "llama32_3b_instruct_q8_0",
+        "family": "llama_bpe_decoder",
+        "params": "3B",
+        "quantization": "Q8_0",
+        "gguf_filename": "Llama-3.2-3B-Instruct-Q8_0.gguf"
+      },
+      "contract": {
+        "id": "llama32_3b_instruct_q8_0",
+        "family": "llama_bpe_decoder",
+        "quantization": "Q8_0",
+        "status": "supported_exact_row_smoke",
+        "tool_capable": true,
+        "support_scope": "exact_row_smoke_only",
+        "full_support_status": "blocked_pending_normalized_full_support",
+        "full_support_blockers": "the May-era typed lanes (template shapes, perf/RSS, API/WebUI smoke, broader prompt-pack parity) were measured on the prior upload (sha256 b5607b50...) and await re-anchoring to the canonical file; plus model-native/larger context beyond the anchored 512-8192 ladder, broader arbitrary/Jinja templates beyond row-scoped metadata-Jinja renderer and template-shape evidence, production throughput beyond bounded perf/RSS and the first-token direction probe, portability, and durable repeated current-head bundles remain missing",
+        "metadata_parses": "validated",
+        "tokenizer_works": "validated_for_compact_and_small_prompt_pack",
+        "tensors_load": "validated",
+        "generation_runs": "api_completion_and_chat_smoke_plus_five_prompt_api_smoke",
+        "parity_audited": "compact_and_broader_prompt_pack_50_token_match",
+        "performance_measured": "bounded_unique_chat_perf_rss_validated",
+        "frontend_load_path_verified": "validated",
+        "frontend_readiness_gate": "green only when this exact GGUF row plus Q8_0 quant match /api/capabilities and the runtime reports loaded_now=true, generation_ready=true, and matching active_model_id",
+        "tested_context": "short_api_webui_smoke_with_broader_prompt_pack_parity_plus_anchored_raw_decode_512_1024_2048_4096_8192_context_ladder",
+        "chat_template_renderer": "metadata_jinja_supported_for_exact_row",
+        "chat_template_shape_pack": "validated_bounded_pack",
+        "chat_template_shape_pack_id": "llama3-chat-template-shapes-v1",
+        "bounded_context_512_pack": "validated_anchored_raw_decode_ladder",
+        "bounded_context_512_pack_id": "llama32-3b-anchored-raw-ladder-v1",
+        "bounded_context_window": 512,
+        "bounded_context_1024_pack": "validated_anchored_raw_decode_ladder",
+        "bounded_context_1024_pack_id": "llama32-3b-anchored-raw-ladder-v1",
+        "bounded_context_1024_window": 1024,
+        "bounded_context_2048_pack": "validated_anchored_raw_decode_ladder",
+        "bounded_context_2048_pack_id": "llama32-3b-anchored-raw-ladder-v1",
+        "bounded_context_2048_window": 2048,
+        "bounded_context_4096_pack": "validated_anchored_raw_decode_ladder",
+        "bounded_context_4096_pack_id": "llama32-3b-anchored-raw-ladder-v1",
+        "bounded_context_4096_window": 4096,
+        "bounded_context_8192_pack": "validated_anchored_raw_decode_ladder",
+        "bounded_context_8192_pack_id": "llama32-3b-anchored-raw-ladder-v1",
+        "bounded_context_8192_window": 8192,
+        "latest_checked_bucket": "llama32-3b-anchored-raw-ladder-v1",
+        "latest_checked_result": "pass",
+        "latest_checked_output": "50/50 greedy tokens identical on all five buckets",
+        "evidence": "the exact tracked Llama-3.2-3B-Instruct-Q8_0 GGUF (sha256 f34112a1..., the file pinned by the June capability-matrix receipts) has a fresh anchored raw-decode context ladder — 512/1024/2048/4096/8192 buckets (408/885/1893/3978/8049 llama3 tokens), token-AND-text identical to pinned llama.cpp acd79d603 at 50 greedy tokens, fully GPU-resident, at qa/evidence-bundles/llama32-3b-context-512-8192-anchored-20260710T2119-head-6527a770/manifest.json — plus June 2026 capability-matrix receipts on the same file. Earlier evidence (canonical Ubuntu API/WebUI refresh at qa/evidence-bundles/llama32-3b-api-webui-current-head-20260513T2005Z-head-e9f926e/manifest.json, compact/broader prompt-pack parity, the May 512/1024/2048 template-context packs, template-shape coverage, and bounded unique-chat perf/RSS) was produced against a PRIOR upload of this model name (sha256 b5607b50...) and is retained as historical evidence for that file; it is disclosed, not inherited. Camelid supports exact-row smoke for this row only, not broader/full support",
+        "next_step": "preserve exact-row smoke plus the anchored checked 512/1024/2048/4096/8192 raw-decode context ladder while re-anchoring the remaining May-era evidence families (API/WebUI refresh, template shapes, perf/RSS) to the canonical file and normalizing model-native/larger context, broader arbitrary/Jinja template behavior, production throughput, portability, and durable full-support bundle evidence before any broader/full-support claim"
+      },
+      "surfaces": {
+        "readme": {
+          "serve_lane": "single-node",
+          "evidence": "Exact-row smoke + API/WebUI, single-node Apple Silicon or CPU; anchored 512-8192 raw-decode context ladder."
+        },
+        "compatibility": {
+          "public_claim": "Supported exact-row smoke",
+          "checked_context_boundary": "512/1024/2048/4096/8192 (anchored raw-decode ladder on the canonical GGUF)",
+          "do_not_claim": "model-native/larger context beyond the checked ladder, broad Llama-family support, neighboring quants, production throughput, or portability"
+        }
+      },
+      "receipts": [
+        {
+          "path": "qa/evidence-bundles/llama32-3b-context-512-8192-anchored-20260710T2119-head-6527a770/manifest.json",
+          "head": "6527a770",
+          "captured_at": "20260710T2119"
+        }
+      ]
+    },
+    {
+      "identity": {
+        "id": "example_moe_active_validation",
+        "family": "mixtral_moe",
+        "params": "8x7B",
+        "quantization": "Q8_0"
+      },
+      "contract": {
+        "id": "example_moe_active_validation",
+        "family": "mixtral_moe",
+        "quantization": "Q8_0",
+        "status": "active_validation_partial_runtime",
+        "tool_capable": false,
+        "support_scope": "exact_row_bounded_moe_runtime_only",
+        "full_support_status": "blocked_later_generation_divergence",
+        "full_support_blockers": "later short-prompt generation diverges from the reference; API/WebUI readiness, long-context evidence, throughput, and portability are missing",
+        "metadata_parses": "validated",
+        "tokenizer_works": "validated",
+        "tensors_load": "validated",
+        "generation_runs": "bounded_one_token_backend_moe_runtime_only",
+        "parity_audited": "one_token_backend_match_later_generation_divergence",
+        "performance_measured": "not_measured",
+        "frontend_load_path_verified": "fail_closed",
+        "frontend_readiness_gate": "fail-closed for broad readiness until later-generation parity and API/WebUI gates close",
+        "tested_context": "bounded_one_token_backend_runtime_only",
+        "chat_template_renderer": "none",
+        "chat_template_shape_pack": "not_validated",
+        "chat_template_shape_pack_id": "none",
+        "bounded_context_512_pack": "not_validated",
+        "bounded_context_512_pack_id": "none",
+        "bounded_context_window": 0,
+        "bounded_context_1024_pack": "not_validated",
+        "bounded_context_1024_pack_id": "none",
+        "bounded_context_1024_window": 0,
+        "bounded_context_2048_pack": "not_validated",
+        "bounded_context_2048_pack_id": "none",
+        "bounded_context_2048_window": 0,
+        "bounded_context_4096_pack": "not_validated",
+        "bounded_context_4096_pack_id": "none",
+        "bounded_context_4096_window": 0,
+        "bounded_context_8192_pack": "not_validated",
+        "bounded_context_8192_pack_id": "none",
+        "bounded_context_8192_window": 0,
+        "latest_checked_bucket": "none",
+        "latest_checked_result": "blocked_later_generation_divergence",
+        "latest_checked_output": "later-generation divergence",
+        "evidence": "bounded one-token backend MoE runtime evidence only; later-generation divergence keeps frontend/API/WebUI support blocked",
+        "next_step": "fix later-generation divergence, then rerun row-specific API/WebUI/RSS/frontend evidence before any support/readiness claim"
+      }
+    }
+  ]
+}

--- a/scripts/check-ledger-schema.mjs
+++ b/scripts/check-ledger-schema.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// check-ledger-schema.mjs — CAIRN Phase 1.
+// Validates camelid.ledger/v1 documents against ledger/camelid-ledger.schema.json
+// with a zero-dependency JSON Schema subset validator (the repo has no root
+// package.json; check-*.mjs scripts are pure node), plus two ledger-specific
+// invariants:
+//   1. code-enum coverage — the schema's status / support_scope /
+//      full_support_status / latest_checked_result enums must be a SUPERSET of
+//      the literal values in src/api/mod.rs, so nothing the contract emits is
+//      unexpressible (CAIRN Phase 1 "zero loss / anything it cannot express is
+//      reported"). This also front-runs Phase 4 drift: a new code enum fails CI.
+//   2. identity.id === contract.id on every model row.
+//
+// Usage: node scripts/check-ledger-schema.mjs [ledger.json ...]
+// With no args: validates ledger/examples/*.json and, if present,
+// ledger/camelid-ledger.json.
+import { readFile, readdir, access } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const ROOT = resolve(process.argv[2] === '--root' ? process.argv[3] : '.')
+const SCHEMA_PATH = join(ROOT, 'ledger', 'camelid-ledger.schema.json')
+const MODRS_PATH = join(ROOT, 'src', 'api', 'mod.rs')
+const failures = []
+const fail = (msg) => failures.push(msg)
+
+// ---------------------------------------------------------------------------
+// zero-dependency JSON Schema subset validator
+// supports: $ref(#/definitions/*), type (incl. array-of-types + integer/null),
+// const, enum, required, properties, additionalProperties:false, items,
+// pattern, minimum.
+// ---------------------------------------------------------------------------
+function jsonType(v) {
+  if (v === null) return 'null'
+  if (Array.isArray(v)) return 'array'
+  return typeof v // 'string' | 'number' | 'boolean' | 'object'
+}
+function typeMatches(v, t) {
+  if (t === 'integer') return typeof v === 'number' && Number.isInteger(v)
+  if (t === 'number') return typeof v === 'number'
+  if (t === 'object') return jsonType(v) === 'object'
+  return jsonType(v) === t
+}
+function deref(schema, root) {
+  let s = schema
+  const seen = new Set()
+  while (s && typeof s.$ref === 'string') {
+    if (seen.has(s.$ref)) throw new Error(`circular $ref ${s.$ref}`)
+    seen.add(s.$ref)
+    const m = /^#\/definitions\/(.+)$/.exec(s.$ref)
+    if (!m) throw new Error(`unsupported $ref ${s.$ref}`)
+    s = root.definitions?.[m[1]]
+    if (!s) throw new Error(`missing definition ${m[1]}`)
+  }
+  return s
+}
+function validate(value, schema, root, path, errors) {
+  schema = deref(schema, root)
+  if ('const' in schema && JSON.stringify(value) !== JSON.stringify(schema.const)) {
+    errors.push(`${path}: expected const ${JSON.stringify(schema.const)}, got ${JSON.stringify(value)}`)
+    return
+  }
+  if (schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type]
+    if (!types.some((t) => typeMatches(value, t))) {
+      errors.push(`${path}: expected type ${types.join('|')}, got ${jsonType(value)}`)
+      return
+    }
+  }
+  if (schema.enum && !schema.enum.some((e) => JSON.stringify(e) === JSON.stringify(value))) {
+    errors.push(`${path}: value ${JSON.stringify(value)} not in enum`)
+  }
+  if (typeof value === 'string' && schema.pattern && !new RegExp(schema.pattern).test(value)) {
+    errors.push(`${path}: string does not match /${schema.pattern}/`)
+  }
+  if (typeof value === 'number' && typeof schema.minimum === 'number' && value < schema.minimum) {
+    errors.push(`${path}: ${value} < minimum ${schema.minimum}`)
+  }
+  if (jsonType(value) === 'object') {
+    for (const req of schema.required || []) {
+      if (!(req in value)) errors.push(`${path}: missing required property "${req}"`)
+    }
+    const props = schema.properties || {}
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!(key in props)) errors.push(`${path}: unexpected property "${key}" (additionalProperties:false)`)
+      }
+    }
+    for (const [key, sub] of Object.entries(props)) {
+      if (key in value) validate(value[key], sub, root, `${path}.${key}`, errors)
+    }
+  }
+  if (jsonType(value) === 'array' && schema.items) {
+    value.forEach((el, i) => validate(el, schema.items, root, `${path}[${i}]`, errors))
+  }
+}
+
+function validateLedger(data, schema, label) {
+  const errors = []
+  validate(data, schema, schema, label, errors)
+  // invariant 2: identity.id === contract.id
+  for (const [i, row] of (data.model_rows || []).entries()) {
+    if (row?.identity?.id && row?.contract?.id && row.identity.id !== row.contract.id) {
+      errors.push(`${label}.model_rows[${i}]: identity.id "${row.identity.id}" !== contract.id "${row.contract.id}"`)
+    }
+  }
+  return errors
+}
+
+// ---------------------------------------------------------------------------
+// invariant 1: code-enum coverage (schema enum ⊇ live src/api/mod.rs values)
+// ---------------------------------------------------------------------------
+function extractCodeEnum(src, field) {
+  const re = new RegExp(`\\b${field}:\\s*"([a-z0-9_]+)"`, 'g')
+  const out = new Set()
+  let m
+  while ((m = re.exec(src))) out.add(m[1])
+  return out
+}
+function checkCoverage(schema, src) {
+  const pairs = [
+    ['status', 'statusVocabulary'],
+    ['support_scope', 'supportScopeVocabulary'],
+    ['full_support_status', 'fullSupportStatusVocabulary'],
+    ['latest_checked_result', 'latestCheckedResultVocabulary'],
+  ]
+  for (const [field, defName] of pairs) {
+    const schemaEnum = new Set(schema.definitions?.[defName]?.enum || [])
+    if (!schemaEnum.size) { fail(`schema definition ${defName} has no enum`); continue }
+    const codeValues = extractCodeEnum(src, field)
+    if (!codeValues.size) { fail(`no \`${field}:\` literals found in src/api/mod.rs (coverage check cannot run)`); continue }
+    const missing = [...codeValues].filter((v) => !schemaEnum.has(v)).sort()
+    if (missing.length) {
+      fail(`schema ${defName} is not a superset of code \`${field}:\` values — missing: ${missing.join(', ')}`)
+    } else {
+      console.log(`  coverage ok: ${defName} ⊇ ${codeValues.size} live \`${field}:\` value(s) from src/api/mod.rs`)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+async function exists(p) { try { await access(p); return true } catch { return false } }
+
+async function main() {
+  const schema = JSON.parse(await readFile(SCHEMA_PATH, 'utf8'))
+  if (schema.$id !== 'camelid.ledger/v1') fail(`schema $id is "${schema.$id}", expected "camelid.ledger/v1"`)
+
+  // coverage against the code (source of truth)
+  if (await exists(MODRS_PATH)) {
+    checkCoverage(schema, await readFile(MODRS_PATH, 'utf8'))
+  } else {
+    fail(`src/api/mod.rs not found at ${MODRS_PATH}; cannot run code-enum coverage`)
+  }
+
+  // pick the ledgers to validate
+  let targets = process.argv.slice(2).filter((a) => a !== '--root' && a !== ROOT && a.endsWith('.json'))
+  if (!targets.length) {
+    const exDir = join(ROOT, 'ledger', 'examples')
+    if (await exists(exDir)) {
+      for (const f of await readdir(exDir)) if (f.endsWith('.json')) targets.push(join(exDir, f))
+    }
+    const authoritative = join(ROOT, 'ledger', 'camelid-ledger.json')
+    if (await exists(authoritative)) targets.push(authoritative)
+  }
+  if (!targets.length) fail('no ledger documents found to validate (expected ledger/examples/*.json or ledger/camelid-ledger.json)')
+
+  for (const t of targets) {
+    let data
+    try { data = JSON.parse(await readFile(t, 'utf8')) }
+    catch (e) { fail(`${t}: not valid JSON — ${e.message}`); continue }
+    const errors = validateLedger(data, schema, t)
+    if (errors.length) errors.forEach((e) => fail(e))
+    else console.log(`  valid: ${t} (${(data.model_rows || []).length} model row(s))`)
+  }
+
+  if (failures.length) {
+    console.error(`\nledger schema check FAILED (${failures.length}):`)
+    for (const f of failures) console.error(`  - ${f}`)
+    process.exit(1)
+  }
+  console.log(`\nledger schema check passed: ${targets.length} document(s), coverage ⊇ code enums`)
+}
+
+export { validate, validateLedger, extractCodeEnum, deref }
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((e) => { console.error(e); process.exit(1) })
+}

--- a/scripts/test-check-ledger-schema.mjs
+++ b/scripts/test-check-ledger-schema.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Self-test for check-ledger-schema.mjs (run in CI by the validation-scripts
+// job's test-*.mjs glob). Exercises the zero-dep validator against the real
+// example ledger plus a battery of corruptions.
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { validateLedger, extractCodeEnum } from './check-ledger-schema.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const schema = JSON.parse(await readFile(join(repoRoot, 'ledger', 'camelid-ledger.schema.json'), 'utf8'))
+const example = JSON.parse(await readFile(join(repoRoot, 'ledger', 'examples', 'example-ledger.json'), 'utf8'))
+
+const clone = (o) => structuredClone(o)
+const errsFor = (mutate) => { const d = clone(example); mutate(d); return validateLedger(d, schema, 'test') }
+
+// baseline: the committed example is valid
+assert.deepEqual(validateLedger(example, schema, 'example'), [], 'the committed example ledger must validate with zero errors')
+
+// bad status enum value
+assert.ok(
+  errsFor((d) => { d.model_rows[0].contract.status = 'totally_bogus_status' }).some((e) => /status.*not in enum/.test(e)),
+  'an out-of-vocabulary status must be rejected',
+)
+
+// missing required contract field
+assert.ok(
+  errsFor((d) => { delete d.model_rows[0].contract.evidence }).some((e) => /missing required property "evidence"/.test(e)),
+  'a missing required contract field must be reported',
+)
+
+// identity.id / contract.id mismatch
+assert.ok(
+  errsFor((d) => { d.model_rows[0].identity.id = 'not_the_contract_id' }).some((e) => /identity\.id.*!==.*contract\.id/.test(e)),
+  'identity.id must equal contract.id',
+)
+
+// additionalProperties:false on contract
+assert.ok(
+  errsFor((d) => { d.model_rows[0].contract.surprise = 'x' }).some((e) => /unexpected property "surprise"/.test(e)),
+  'an unknown contract field must be rejected (additionalProperties:false)',
+)
+
+// wrong type: window must be integer
+assert.ok(
+  errsFor((d) => { d.model_rows[0].contract.bounded_context_window = '512' }).some((e) => /expected type integer/.test(e)),
+  'a stringified integer window must be rejected',
+)
+
+// sha256 pattern
+assert.ok(
+  errsFor((d) => { d.model_rows[0].identity.sha256 = 'not-a-real-hash' }).some((e) => /does not match/.test(e)),
+  'a malformed sha256 must be rejected by pattern',
+)
+
+// bad top-level const
+assert.ok(
+  errsFor((d) => { d.ledger_version = 'camelid.ledger/v2' }).some((e) => /expected const/.test(e)),
+  'the ledger_version const must be enforced',
+)
+
+// extractCodeEnum pulls literal values from a source string
+const enums = extractCodeEnum('status: "supported_exact_row_smoke", x, status: "planned"', 'status')
+assert.deepEqual([...enums].sort(), ['planned', 'supported_exact_row_smoke'], 'extractCodeEnum must find all literal values')
+
+console.log('test-check-ledger-schema: all checks passed')


### PR DESCRIPTION
**CAIRN Phase 1 (schema design).** Introduces the single-source-of-truth schema for Camelid's claim boundary and the zero-dependency check that guards it. Does **not** populate the authoritative ledger (Phase 2), generate any surface (Phase 3), or wire the surface-drift gate (Phase 4).

### Files
- **`ledger/camelid-ledger.schema.json`** — the `camelid.ledger/v1` JSON Schema. Its `contract` block mirrors the `ModelCompatibilityTarget` struct **field-for-field (all 40, all required)** so an `/api/capabilities` row round-trips with zero loss — the precondition for byte-identical regeneration in Phase 3. Envelope mirrors `CapabilitiesResponse`; per-row `surfaces` carry the README/COMPAT/STATUS cells; `receipts` carry evidence pointers.
- **`scripts/check-ledger-schema.mjs`** — zero-dep validator (no root `package.json` → no `ajv`). Validates ledgers + runs the **code-enum coverage guard**. Wired into the `public-scrub` CI job.
- **`scripts/test-check-ledger-schema.mjs`** — self-test (runs via the `validation-scripts` `test-*.mjs` glob): the example validates, and each corruption (bad enum, missing field, id mismatch, extra property, wrong type, bad sha256, bad const) is caught.
- **`ledger/examples/example-ledger.json`** — proof: row 1 is the **real** `llama32_3b_instruct_q8_0` row transcribed verbatim (all 40 fields); row 2 exercises more enum values.

### Design (per Amendment 1)
- **Vocabulary = the code's enums, not four words (#6).** `status` / `support_scope` / `full_support_status` / `latest_checked_result` are constrained to the exact `src/api/mod.rs` literals; all prose stays free strings (verbatim-holdable for the byte-fixpoint).
- **Coverage guard = machine proof of zero loss.** The validator asserts each schema enum ⊇ the live code values (17 status / 9 support_scope / 5 full_support_status / 4 latest_checked_result today). A new code enum with no schema home fails CI — front-running Phase 4 drift.
- **`sha256`/`gguf_filename` are additive**; they don't replace the prose that carries them until the fixpoint proves them redundant (Phase 5). `identity.id === contract.id` enforced.

Local: validator + self-test + scrub pass. (Three sibling `test-*.mjs` fail only on Windows via POSIX-path assertions — they pass on the ubuntu `validation-scripts` runner and are unrelated; confirmed failing on clean `main` too.)