### PR TITLE
feat(ledger): CAIRN Phase 3 — make drift a build failure (code-is-source)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
       - name: Check ledger schema (camelid.ledger/v1)
         run: node scripts/check-ledger-schema.mjs
 
+      - name: Check ledger drift (ledger == code contract; surfaces consistent)
+        run: node scripts/check-ledger-drift.mjs
+
       - name: Check CUDA batched-prefill parity gate wiring
         run: node scripts/check-cuda-prefill-parity-gate.mjs
 

--- a/ledger/camelid-ledger.json
+++ b/ledger/camelid-ledger.json
@@ -1,8 +1,8 @@
 {
   "ledger_version": "camelid.ledger/v1",
   "provenance": {
-    "source_head": "4e725058",
-    "note": "Bootstrapped by scripts/extract-capabilities-to-ledger.mjs from the static CapabilitiesResponse literal in src/api/mod.rs (CAIRN Phase 2). Contract fields are byte-faithful (plain serde Serialize, no renames). surfaces (README/COMPAT/STATUS cells) are populated in Phase 3 where the generators byte-check them."
+    "source_head": "32bef842",
+    "note": "Derived from the static CapabilitiesResponse literal in src/api/mod.rs by scripts/extract-capabilities-to-ledger.mjs. Contract fields are byte-faithful (plain serde Serialize, no renames). Per CAIRN Amendment 1, the CODE is the contract source of truth; this ledger is its derived canonical form, and scripts/check-ledger-drift.mjs re-derives from code and fails CI if code and ledger disagree (provenance excluded)."
   },
   "capabilities": {
     "engine": "camelid",

--- a/scripts/check-ledger-drift.mjs
+++ b/scripts/check-ledger-drift.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// check-ledger-drift.mjs — CAIRN Phase 3/4 (drift-check model; CAIRN Amendment 1).
+//
+// The CODE (the ModelCompatibilityTarget table in src/api/mod.rs) is the contract
+// source of truth. ledger/camelid-ledger.json is its derived canonical form. This
+// check makes drift a build failure:
+//
+//   A. Freshness — re-derive the ledger from the code and fail if the committed
+//      ledger disagrees (provenance excluded). This is what makes "the ledger" ==
+//      "the code": a contract change with no `extract-capabilities-to-ledger.mjs`
+//      re-run is caught here.
+//   B. Surface non-contradiction — the public supported-models tables (README and
+//      COMPATIBILITY) may not claim support the contract denies. A doc row that
+//      maps to a ledger row whose status is not `supported*` is a hard failure.
+//      Rows that don't map are LOGGED, never silently skipped, and never fail
+//      (no false positives — only a confirmed contradiction goes red). This is the
+//      class of drift that produced the Mistral fixture bug fixed under Amendment 1.
+//
+// Zero dependencies (pure node); reuses buildLedger() from the extractor.
+import { readFile, access } from 'node:fs/promises'
+import { resolve, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { buildLedger } from './extract-capabilities-to-ledger.mjs'
+
+const ROOT = resolve(process.argv[2] === '--root' ? process.argv[3] : '.')
+const failures = []
+const fail = (m) => failures.push(m)
+const info = (m) => console.log('  ' + m)
+
+// --- helpers ---------------------------------------------------------------
+const norm = (s) => String(s).toLowerCase().replace(/[^a-z0-9]/g, '')
+// clean a display label: drop parentheticals, a trailing .gguf, and markdown.
+const clean = (s) => String(s).replace(/\([^)]*\)/g, ' ').replace(/\.gguf\b/gi, ' ').replace(/[*`]/g, ' ')
+// filler tokens present in some ids but omitted in display labels (and vice versa)
+const FILLERS = /\b(instruct|chat|it|qat|community|hybrid|arch|moe)\b/gi
+// split id/filename separators to spaces first so \b filler-word boundaries fire
+const fillerKey = (s) => norm(clean(s).replace(/[_-]/g, ' ').replace(FILLERS, ' '))
+const stripMd = (s) => String(s).replace(/[*`]/g, '').trim()
+const isSupported = (st) => typeof st === 'string' && (st === 'supported' || st.startsWith('supported_'))
+async function exists(p) { try { await access(p); return true } catch { return false } }
+
+function canon(v) {
+  if (Array.isArray(v)) return v.map(canon)
+  if (v && typeof v === 'object') { const o = {}; for (const k of Object.keys(v).sort()) o[k] = canon(v[k]); return o }
+  return v
+}
+function firstDiff(a, b, path = '') {
+  const ta = Array.isArray(a) ? 'array' : a === null ? 'null' : typeof a
+  const tb = Array.isArray(b) ? 'array' : b === null ? 'null' : typeof b
+  if (ta !== tb) return `${path} (type ${ta} vs ${tb})`
+  if (ta === 'array') {
+    if (a.length !== b.length) return `${path}.length (${a.length} vs ${b.length})`
+    for (let i = 0; i < a.length; i++) { const d = firstDiff(a[i], b[i], `${path}[${i}]`); if (d) return d }
+    return null
+  }
+  if (ta === 'object') {
+    for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
+      if (!(k in a)) return `${path}.${k} (missing in fresh)`
+      if (!(k in b)) return `${path}.${k} (missing in committed)`
+      const d = firstDiff(a[k], b[k], `${path}.${k}`); if (d) return d
+    }
+    return null
+  }
+  return a === b ? null : `${path} (${JSON.stringify(a)} vs ${JSON.stringify(b)})`
+}
+
+// parse the first markdown table whose header line matches headerRe; return rows
+// as arrays of trimmed cell strings.
+function parseTable(md, headerRe) {
+  const lines = md.split('\n')
+  const h = lines.findIndex((l) => headerRe.test(l))
+  if (h < 0) return null
+  const rows = []
+  for (let i = h + 2; i < lines.length && lines[i].trim().startsWith('|'); i++) {
+    const cells = lines[i].split('|').slice(1, -1).map((c) => c.trim())
+    if (cells.length) rows.push(cells)
+  }
+  return rows
+}
+
+// --- Check A: freshness (ledger == code contract) --------------------------
+async function checkFreshness(committed) {
+  const { ledger: fresh } = await buildLedger(ROOT)
+  const strip = (l) => { const { provenance, ...rest } = l; return rest }
+  const d = firstDiff(canon(strip(fresh)), canon(strip(committed)))
+  if (d) fail(`ledger is STALE vs the code contract at ${d} — regenerate with: node scripts/extract-capabilities-to-ledger.mjs`)
+  else info('freshness ok: ledger/camelid-ledger.json matches the code contract (provenance excluded)')
+}
+
+// --- Check B: supported-table non-contradiction ----------------------------
+async function checkSupportedTables(committed) {
+  const index = new Map()
+  const put = (k, row) => { if (k && !index.has(k)) index.set(k, row) }
+  for (const row of committed.model_rows) {
+    for (const src of [row.identity.id, row.identity.gguf_filename]) {
+      if (!src) continue
+      put(norm(clean(src)), row)
+      put(fillerKey(src), row)
+    }
+  }
+  const lookup = (...labels) => {
+    for (const l of labels) { const r = index.get(norm(clean(l))) || index.get(fillerKey(l)); if (r) return r }
+    return null
+  }
+
+  let mapped = 0, total = 0
+  const unmapped = []
+  const consider = (surface, label, quant, claimIsSupported) => {
+    if (!claimIsSupported) return
+    total++
+    const row = lookup(`${label} ${quant || ''}`, label)
+    if (!row) { unmapped.push(`${surface}: "${stripMd(label)}"${quant ? ` (${stripMd(quant)})` : ''}`); return }
+    mapped++
+    if (!isSupported(row.contract.status)) {
+      fail(`${surface} presents "${stripMd(label)}" as supported, but the code contract status for ${row.contract.id} is "${row.contract.status}"`)
+    }
+  }
+
+  // README supported-models table (every data row is a support claim)
+  const readme = await readFile(join(ROOT, 'README.md'), 'utf8')
+  const rt = parseTable(readme, /^\|\s*Model row\s*\|\s*Quant\s*\|/)
+  if (!rt) fail('README.md supported-models table (| Model row | Quant | ...) not found')
+  else for (const c of rt) consider('README supported-models', c[0], c[1], true)
+
+  // COMPATIBILITY at-a-glance (support claim = "Public claim" says supported)
+  const compat = await readFile(join(ROOT, 'COMPATIBILITY.md'), 'utf8')
+  const ct = parseTable(compat, /^\|\s*Exact row\s*\|\s*Public claim\s*\|/)
+  if (!ct) fail('COMPATIBILITY.md at-a-glance table (| Exact row | Public claim | ...) not found')
+  else for (const c of ct) {
+    const claim = c[1] || ''
+    const supportedClaim = /supported/i.test(claim) && !/unsupported|not a supported/i.test(claim)
+    consider('COMPATIBILITY at-a-glance', c[0], null, supportedClaim)
+  }
+
+  info(`supported-table non-contradiction: ${mapped}/${total} support-claim rows mapped to a ledger row and consistent`)
+  if (unmapped.length) {
+    info(`unmapped support-claim rows (not checkable by exact key — logged, not failed): ${unmapped.length}`)
+    unmapped.forEach((u) => info('  · ' + u))
+  }
+}
+
+// ---------------------------------------------------------------------------
+async function main() {
+  const ledgerPath = join(ROOT, 'ledger', 'camelid-ledger.json')
+  if (!(await exists(ledgerPath))) { console.error(`no ledger at ${ledgerPath}`); process.exit(1) }
+  const committed = JSON.parse(await readFile(ledgerPath, 'utf8'))
+
+  await checkFreshness(committed)
+  await checkSupportedTables(committed)
+
+  if (failures.length) {
+    console.error(`\nledger drift check FAILED (${failures.length}):`)
+    for (const f of failures) console.error(`  - ${f}`)
+    process.exit(1)
+  }
+  console.log('\nledger drift check passed: ledger == code contract, and no surface contradicts it')
+}
+
+export { firstDiff, canon, norm, fillerKey, parseTable, isSupported }
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((e) => { console.error(e); process.exit(1) })
+}

--- a/scripts/extract-capabilities-to-ledger.mjs
+++ b/scripts/extract-capabilities-to-ledger.mjs
@@ -14,10 +14,10 @@
 // validated by scripts/check-ledger-schema.mjs.
 import { readFile, writeFile, mkdir, access } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { execSync } from 'node:child_process'
 
 const ROOT = resolve('.')
-const MODRS = join(ROOT, 'src', 'api', 'mod.rs')
 const OUT = join(ROOT, 'ledger', 'camelid-ledger.json')
 
 // --- extract the balanced CapabilitiesResponse { ... } block ---------------
@@ -102,8 +102,8 @@ const RECEIPT_RE = /qa\/evidence-bundles\/[A-Za-z0-9._/-]+?\/(?:manifest\.json|S
 
 async function exists(p) { try { await access(p); return true } catch { return false } }
 
-async function main() {
-  const src = await readFile(MODRS, 'utf8')
+export async function buildLedger(root = ROOT) {
+  const src = await readFile(join(root, 'src', 'api', 'mod.rs'), 'utf8')
   const marker = 'CapabilitiesResponse {'
   const fnPos = src.indexOf('fn capabilities_response_with_plan')
   // The fn signature ends `-> CapabilitiesResponse {` (the fn body brace); the
@@ -137,7 +137,7 @@ async function main() {
       const path = m[0]
       if (seen.has(path)) continue
       seen.add(path)
-      if (await exists(join(ROOT, path))) receipts.push({ path })
+      if (await exists(join(root, path))) receipts.push({ path })
       else receiptWarnings.push(`${contract.id}: receipt ${path} does not resolve on disk (omitted)`)
     }
     const row = { identity, contract }
@@ -165,27 +165,33 @@ async function main() {
   }
 
   let head = 'unknown'
-  try { head = execSync('git rev-parse --short HEAD', { cwd: ROOT }).toString().trim() } catch {}
+  try { head = execSync('git rev-parse --short HEAD', { cwd: root }).toString().trim() } catch {}
 
   const ledger = {
     ledger_version: 'camelid.ledger/v1',
     provenance: {
       source_head: head,
-      note: 'Bootstrapped by scripts/extract-capabilities-to-ledger.mjs from the static CapabilitiesResponse literal in src/api/mod.rs (CAIRN Phase 2). Contract fields are byte-faithful (plain serde Serialize, no renames). surfaces (README/COMPAT/STATUS cells) are populated in Phase 3 where the generators byte-check them.',
+      note: 'Derived from the static CapabilitiesResponse literal in src/api/mod.rs by scripts/extract-capabilities-to-ledger.mjs. Contract fields are byte-faithful (plain serde Serialize, no renames). Per CAIRN Amendment 1, the CODE is the contract source of truth; this ledger is its derived canonical form, and scripts/check-ledger-drift.mjs re-derives from code and fails CI if code and ledger disagree (provenance excluded).',
     },
     capabilities,
     model_rows,
   }
 
+  return { ledger, receiptWarnings, fieldCount: Object.keys(rows[0]).length }
+}
+
+async function main() {
+  const { ledger, receiptWarnings, fieldCount } = await buildLedger(ROOT)
   await mkdir(join(ROOT, 'ledger'), { recursive: true })
   await writeFile(OUT, JSON.stringify(ledger, null, 2) + '\n')
-
-  // report
-  console.log(`extracted ${model_rows.length} model row(s); each contract has ${Object.keys(rows[0]).length} fields`)
-  console.log(`envelope: ${capabilities.supported_quantization.length} supported_quant, ${capabilities.planned_quantization.length} planned_quant, ${capabilities.supported_model_families.length} supported_fam, ${capabilities.planned_model_families.length} planned_fam, ${capabilities.api_features.length} api_features, ${capabilities.notes.length} notes`)
-  console.log(`receipts attached: ${model_rows.reduce((n, r) => n + (r.receipts?.length || 0), 0)} (resolved on disk)`)
+  const c = ledger.capabilities
+  console.log(`extracted ${ledger.model_rows.length} model row(s); each contract has ${fieldCount} fields`)
+  console.log(`envelope: ${c.supported_quantization.length} supported_quant, ${c.planned_quantization.length} planned_quant, ${c.supported_model_families.length} supported_fam, ${c.planned_model_families.length} planned_fam, ${c.api_features.length} api_features, ${c.notes.length} notes`)
+  console.log(`receipts attached: ${ledger.model_rows.reduce((n, r) => n + (r.receipts?.length || 0), 0)} (resolved on disk)`)
   if (receiptWarnings.length) { console.log('receipt notes:'); receiptWarnings.forEach((w) => console.log('  - ' + w)) }
   console.log(`wrote ${OUT}`)
 }
 
-main().catch((e) => { console.error(e); process.exit(1) })
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((e) => { console.error(e); process.exit(1) })
+}

--- a/scripts/test-check-ledger-drift.mjs
+++ b/scripts/test-check-ledger-drift.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Self-test for check-ledger-drift.mjs (run in CI by the validation-scripts
+// test-*.mjs glob). Exercises the pure helpers that back the two drift checks.
+import assert from 'node:assert/strict'
+import { firstDiff, canon, norm, fillerKey, parseTable, isSupported } from './check-ledger-drift.mjs'
+
+// --- firstDiff / canon (freshness engine) ---
+assert.equal(firstDiff({ a: 1, b: [1, 2] }, { b: [1, 2], a: 1 }), null, 'key order must not matter after canon-free deep compare')
+assert.match(firstDiff({ s: 'supported_exact_row_smoke' }, { s: 'active_validation_unsupported' }), /\.s \(/, 'a status change must be located')
+assert.match(firstDiff({ rows: [{ id: 'a' }] }, { rows: [{ id: 'a' }, { id: 'b' }] }), /rows\.length/, 'a row-count change must be located')
+// canon makes key order irrelevant
+assert.equal(JSON.stringify(canon({ b: 1, a: 2 })), JSON.stringify({ a: 2, b: 1 }))
+
+// --- isSupported (the support predicate) ---
+assert.equal(isSupported('supported_exact_row_smoke'), true)
+assert.equal(isSupported('supported'), true)
+assert.equal(isSupported('active_validation_partial_runtime'), false)
+assert.equal(isSupported('planned_exact_row_candidate'), false)
+assert.equal(isSupported('unsupported'), false)
+
+// --- label -> id mapping (the non-contradiction key) ---
+// display labels that omit filler tokens must still map to the underscore ids
+assert.equal(fillerKey('Qwen3 1.7B Q8_0'), fillerKey('qwen3_1_7b_instruct_q8_0'), 'Qwen label maps to its instruct id')
+assert.equal(fillerKey('Gemma 4 26B-A4B-It QAT Q4_0'), fillerKey('gemma4_26b_a4b_it_q4_0'), 'QAT/It fillers + underscores align')
+assert.equal(norm('Mistral-7B-Instruct-v0.3.Q8_0.gguf'.replace(/\.gguf$/, '')), norm('mistral_7b_instruct_v0_3_q8_0'), 'filename (minus .gguf) normalizes to the id')
+// distinct rows must NOT collide
+assert.notEqual(fillerKey('Qwen3 4B Q8_0'), fillerKey('qwen3_4b_q4_k_m'), 'different quants stay distinct')
+
+// --- parseTable (surface table extraction) ---
+const md = [
+  'intro',
+  '| Model row | Quant | Serve lane | Evidence |',
+  '| --- | --- | --- | --- |',
+  '| TinyLlama 1.1B Chat | Q8_0 | single-node | gate |',
+  '| Llama 3.2 3B Instruct | Q8_0 | single-node | smoke |',
+  '',
+  'after',
+].join('\n')
+const rows = parseTable(md, /^\|\s*Model row\s*\|\s*Quant\s*\|/)
+assert.equal(rows.length, 2, 'parseTable stops at the blank line')
+assert.equal(rows[0][0], 'TinyLlama 1.1B Chat')
+assert.equal(rows[1][1], 'Q8_0')
+assert.equal(parseTable(md, /^\|\s*Nope\s*\|/), null, 'missing header returns null')
+
+console.log('test-check-ledger-drift: all checks passed')


### PR DESCRIPTION
**CAIRN Phase 3.** Per your Phase-3 decision (and Amendment 1: the code IS the contract), the ledger is the **derived canonical form** of the code, and CI now fails on drift — instead of byte-regenerating human-authored surfaces.

### Why not the conductor's byte-fixpoint
- The `/api/capabilities` Rust literal carries `//` comments the ledger can't reconstruct → byte-identical *source* regen is impossible.
- The doc tables don't derive from the contract: COMPAT:293 API-features = **16** hand rows vs **12** machine `api_features`; README:170 uses human labels, **combines quants** (Ornith = 1 row / 3 contract rows), lists **DiffusionGemma** (not a contract row).

So the surfaces can't be a lossless function of the ledger — the honest, robust mechanism is a drift check.

### `scripts/check-ledger-drift.mjs` (wired into `public-scrub`)
- **A · Freshness** — re-derives the ledger from `src/api/mod.rs` via `buildLedger()` and fails if the committed ledger disagrees (provenance excluded). This makes **"the ledger" == "the code"**: a contract change with no ledger re-run is caught. (Verified: a simulated status flip is detected.)
- **B · Surface non-contradiction** — README + COMPATIBILITY supported tables may not present as supported any row whose contract status isn't `supported*`. **31/34** support-claim rows map by an exact normalized/filler-aware key and are consistent; the **3** that don't map (DiffusionGemma ×2 — not a contract row; bare-name Ornith Q8_0 filename) are **logged, never silently skipped, never failed**. Only a confirmed contradiction goes red — the exact class of drift behind the Mistral fixture bug (Amendment 1 F1).

### Also
- `extract-capabilities-to-ledger.mjs` refactored to export `buildLedger()` (reused by the drift check); regenerated ledger updates provenance only.
- `test-check-ledger-drift.mjs` self-test (runs via the `validation-scripts` glob).

Delivers the CAIRN thesis: **drift is a build failure.** Phase 4 can broaden coverage (sha256 agreement, frontend catalog, context/quant over-claims); Phase 5 is the diverged-anchors reconciliation.