### PR TITLE
feat(ledger): CAIRN Phase 4 — broaden drift coverage (frontend catalog + sha256)

### DIFF
--- a/scripts/check-ledger-drift.mjs
+++ b/scripts/check-ledger-drift.mjs
@@ -139,6 +139,63 @@ async function checkSupportedTables(committed) {
   }
 }
 
+// --- Check C: frontend catalog consistency ---------------------------------
+// The frontend download catalog keys entries by the exact contract id, so this
+// is an id-exact membership check: a catalog entry with no contract row is drift.
+async function checkFrontendCatalog(committed) {
+  const contractIds = new Set(committed.model_rows.map((r) => r.contract.id))
+  const p = join(ROOT, 'frontend', 'src', 'lib', 'supportedModels.js')
+  if (!(await exists(p))) { info('frontend catalog: supportedModels.js not present, skipped'); return }
+  const catalogIds = [...(await readFile(p, 'utf8')).matchAll(/catalog_id:\s*'([a-z0-9_]+)'/g)].map((m) => m[1])
+  if (!catalogIds.length) { fail('no catalog_id entries parsed from frontend/src/lib/supportedModels.js'); return }
+  let ok = 0
+  for (const cid of catalogIds) {
+    if (contractIds.has(cid)) ok++
+    else fail(`frontend catalog lists catalog_id "${cid}" with no matching /api/capabilities contract row`)
+  }
+  info(`frontend catalog: ${ok}/${catalogIds.length} catalog_id(s) resolve to a contract row`)
+}
+
+// --- Check D: sha256 cross-surface agreement -------------------------------
+// For each ledger-anchored (gguf_filename -> sha256), any surface line that names
+// that file AND states a full sha must state the ledger's sha. A full sha that is
+// some OTHER known file's sha (co-occurring on the same line) is ignored, so this
+// only fires on a genuinely wrong/stale hash — no false positives.
+const SHA256 = /\b[a-f0-9]{64}\b/g
+function shaFindings(rel, text, canonicalByFile, knownShas) {
+  const findings = []
+  let verified = 0
+  text.split('\n').forEach((line, i) => {
+    const shas = line.match(SHA256)
+    if (!shas) return
+    for (const [fname, canon] of canonicalByFile) {
+      if (!line.includes(fname)) continue
+      for (const sha of shas) {
+        if (sha === canon.sha) verified++
+        else if (!knownShas.has(sha)) findings.push(`${rel}:${i + 1} states sha256 ${sha.slice(0, 12)}… for ${fname}, but the ledger records ${canon.sha.slice(0, 12)}… (row ${canon.id})`)
+      }
+    }
+  })
+  return { verified, findings }
+}
+async function checkSha256(committed) {
+  const canonicalByFile = new Map()
+  for (const r of committed.model_rows) {
+    if (r.identity.sha256 && r.identity.gguf_filename) canonicalByFile.set(r.identity.gguf_filename, { sha: r.identity.sha256, id: r.contract.id })
+  }
+  if (!canonicalByFile.size) { info('sha256 agreement: no ledger-anchored full sha256 to check'); return }
+  const knownShas = new Set([...canonicalByFile.values()].map((v) => v.sha))
+  let verified = 0
+  for (const rel of ['README.md', 'COMPATIBILITY.md', 'STATUS.md', join('src', 'api', 'mod.rs')]) {
+    const p = join(ROOT, rel)
+    if (!(await exists(p))) continue
+    const { verified: v, findings } = shaFindings(rel, await readFile(p, 'utf8'), canonicalByFile, knownShas)
+    verified += v
+    findings.forEach(fail)
+  }
+  info(`sha256 cross-surface agreement: ${verified} correct filename+sha co-occurrence(s) across surfaces, ${canonicalByFile.size} anchored file(s)`)
+}
+
 // ---------------------------------------------------------------------------
 async function main() {
   const ledgerPath = join(ROOT, 'ledger', 'camelid-ledger.json')
@@ -147,6 +204,8 @@ async function main() {
 
   await checkFreshness(committed)
   await checkSupportedTables(committed)
+  await checkFrontendCatalog(committed)
+  await checkSha256(committed)
 
   if (failures.length) {
     console.error(`\nledger drift check FAILED (${failures.length}):`)
@@ -156,7 +215,7 @@ async function main() {
   console.log('\nledger drift check passed: ledger == code contract, and no surface contradicts it')
 }
 
-export { firstDiff, canon, norm, fillerKey, parseTable, isSupported }
+export { firstDiff, canon, norm, fillerKey, parseTable, isSupported, shaFindings }
 
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
   main().catch((e) => { console.error(e); process.exit(1) })

--- a/scripts/test-check-ledger-drift.mjs
+++ b/scripts/test-check-ledger-drift.mjs
@@ -2,7 +2,7 @@
 // Self-test for check-ledger-drift.mjs (run in CI by the validation-scripts
 // test-*.mjs glob). Exercises the pure helpers that back the two drift checks.
 import assert from 'node:assert/strict'
-import { firstDiff, canon, norm, fillerKey, parseTable, isSupported } from './check-ledger-drift.mjs'
+import { firstDiff, canon, norm, fillerKey, parseTable, isSupported, shaFindings } from './check-ledger-drift.mjs'
 
 // --- firstDiff / canon (freshness engine) ---
 assert.equal(firstDiff({ a: 1, b: [1, 2] }, { b: [1, 2], a: 1 }), null, 'key order must not matter after canon-free deep compare')
@@ -41,5 +41,28 @@ assert.equal(rows.length, 2, 'parseTable stops at the blank line')
 assert.equal(rows[0][0], 'TinyLlama 1.1B Chat')
 assert.equal(rows[1][1], 'Q8_0')
 assert.equal(parseTable(md, /^\|\s*Nope\s*\|/), null, 'missing header returns null')
+
+// --- shaFindings (Phase 4 sha256 cross-surface agreement) ---
+const SHA_A = '6c1a2b411610'.padEnd(64, '0')
+const SHA_B = 'abcd'.padEnd(64, '0')
+const canonMap = new Map([['Model-A.gguf', { sha: SHA_A, id: 'model_a' }]])
+const known = new Set([SHA_A])
+// correct sha next to the file -> verified, no finding
+{
+  const r = shaFindings('X', `the Model-A.gguf row (sha256 ${SHA_A})`, canonMap, known)
+  assert.equal(r.verified, 1); assert.equal(r.findings.length, 0)
+}
+// a wrong/unknown sha next to the file -> one finding
+{
+  const r = shaFindings('DOC', `Model-A.gguf sha256 ${'dead'.padEnd(64, '0')}`, canonMap, known)
+  assert.equal(r.findings.length, 1, 'a stale/wrong sha for an anchored file must be caught')
+  assert.match(r.findings[0], /Model-A\.gguf/)
+}
+// another known file's sha co-occurring on the same line -> NOT flagged (no false positive)
+{
+  const two = new Map([...canonMap, ['Other.gguf', { sha: SHA_B, id: 'other' }]])
+  const r = shaFindings('Y', `Model-A.gguf mentioned near Other.gguf sha256 ${SHA_B}`, two, new Set([SHA_A, SHA_B]))
+  assert.equal(r.findings.length, 0, "another file's sha on the same line must not be flagged for the wrong file")
+}
 
 console.log('test-check-ledger-drift: all checks passed')


### PR DESCRIPTION
**CAIRN Phase 4.** Two robust, id-exact drift checks added to `check-ledger-drift.mjs` (already wired into `public-scrub`). Both fail **only on a confirmed contradiction** — no fuzzy mapping.

- **Frontend catalog consistency** — `frontend/src/lib/supportedModels.js` keys its download catalog by the exact contract id, so every `catalog_id` must resolve to a contract row. A catalog entry with no contract row is drift (the F6 class). **13/13** resolve today.
- **sha256 cross-surface agreement** — for each ledger-anchored `(gguf_filename → sha256)` (4 today), any surface line (README/COMPAT/STATUS/`mod.rs`) that names the file **and** states a full 64-hex sha must state the ledger's sha. A sha that is some *other* known file's hash co-occurring on the same line is ignored → fires only on a genuinely stale hash (the Phase-0 class). **5** correct co-occurrences verified today; this also locks in Phase 0's finding that the Q5_K_M sha is consistent between COMPATIBILITY.md and `mod.rs`.

Adversarially verified (self-test): correct sha passes, wrong sha is caught, another file's sha on the same line is **not** false-flagged.

Phase 5 (the diverged-anchor reconciliation) is the one remaining piece — it needs a content decision from the operator.