### PR TITLE
perf(cuda): uint4 K-read in attention_batched — +17-19% long-context prefill

### DIFF
--- a/SIROCCO_LANEK.md
+++ b/SIROCCO_LANEK.md
@@ -1,9 +1,11 @@
 # SIROCCO — Lane K (kernel campaign)
 
 **Machine:** RTX 3060 Laptop GPU (GA106, CC 8.6, 30 SM), 6 GB GDDR6, driver 576.83, CUDA 12.9, **WDDM** · Win11
-**Target:** Llama-3.2-1B decode, Windows/CUDA · **Status:** two clean, correctness-preserving wins **shipped** (`uint4` attention K-read, [PR #440](https://github.com/timtoole02/Camelid/pull/440); `SPLITK_MAX` uncap, this PR). Remaining upside is gated behind a precision-policy decision, not more engineering.
+**Target:** Llama-3.2-1B decode, Windows/CUDA · **Status:** three clean, correctness-preserving wins **shipped** (`uint4` decode-attn K-read [PR #440]; `SPLITK_MAX` uncap [PR #442]; **`uint4` prefill-attn K-read, +17–19% prefill, this PR**). The decode budget is exhausted; the newly-measured **prefill** regime (99% of long-context wall time) is the open frontier.
 
-> **One-line result:** nine kernel experiments, **two shipped** (byte-identical `uint4` attention K-read, +~10% long-context; token-identical `SPLITK_MAX` uncap, +~6% e2e measured at ctx 8k, larger at longer ctx by the byte-share model), **seven rejected on measured evidence**. `main` only ever moved for a change that measurably earned it and cleared the bit-identical spec-verify gate.
+> **One-line result:** ten kernel experiments, **three shipped** (byte-identical `uint4` decode-attn K-read, +~10% long-ctx; token-identical `SPLITK_MAX` uncap, +~6% e2e @8k; **byte-identical `uint4` prefill-attn K-read, +17–19% prefill**), **seven rejected on measured evidence**. `main` only ever moved for a change that measurably earned it and cleared the bit-identical spec-verify gate.
+
+> **⚠ REFRAME (2026-07-13): the campaign optimized the wrong 1%.** Direct measurement — Llama-3.2-1B Q8_0, ctx 8802: **prefill = 152.8 s (99.2%)**, decode-64 = 1.2 s. The whole Lane K decode campaign (#1–#9) tuned the ~1% decode tail of a long-context request. **Prefill is the other 99%**, and its attention (`attention_batched`) was still doing the scalar f16 K read that win #1 replaced everywhere on the decode path — hence experiment #10 below (a verbatim transplant, +17–19% prefill, byte-identical). See [SIROCCO Phase P bundle](qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/README.md).
 
 ---
 
@@ -48,6 +50,7 @@ A follow-up decode-loop analysis (261 kernel launches/token; 148 non-GEMV moving
 | 7 | Bit-exact dp4a `q6k_gemv` | Q4 models | ❌ regresses 0.34–0.68× (2-lane cap) | microbench, byte-identical |
 | 8 | Token-parity (4-lane) dp4a `q6k` | Q4 models | ❌ fails token-parity (8/8 prompts diverge) | real-model verification |
 | **9** | **`SPLITK_MAX` uncap 16→32** | long-ctx Q8 | ✅ **SHIPPED** — +~6% e2e measured @8k (V-read +19% micro @32k; larger at longer ctx by byte-share, not A/B'd); token-identical to oracle **and** bit-identical spec-verify | [bundle](qa/evidence-bundles/sirocco-laneK-splitk-uncap-20260713/README.md) |
+| **10** | **`uint4` K-read → `attention_batched` (PREFILL)** | long-ctx **prefill** | ✅ **SHIPPED** — **+17–19% prefill** (2k/4k/6.6k interleaved), byte-identical (6 parity gates + 48/48 e2e). Win #1's read, applied to the prefill/verify attention it never reached — which is 99% of long-ctx wall | [bundle](qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/README.md) |
 
 > **#9 is the occupancy counterpart to the rejected #6.** #6 *vectorized* the split-K V read and lost by dropping threads to a quarter-warp; #9 keeps the kernel and adds split **blocks**, curing the same under-utilization from the other side. The V read at `attn_sk_partial` uses only `head_dim`=64 of 256 block threads, so it is occupancy- (not coalescing-) limited: 92→110 GB/s (+19%) going 16→32 splits. 32 is the knee — the K read is already optimal at 16 and regresses beyond it.
 
@@ -99,8 +102,9 @@ It **strictly dominates** the previously-shipped opt-in coalesced kernel — fas
 
 ## 7. Current state & what remains
 
-- **In `main`:** (1) the `uint4` attention K-read (PR #440) — byte-identical, lossless-spec-preserving, +~10% long-context decode; (2) the `SPLITK_MAX` uncap 16→32 (this PR) — token-identical (oracle + bit-identical spec-verify), +~6% e2e measured at ctx 8k (expected larger at longer ctx by the byte-share model, not A/B'd across contexts), no-op below ctx 512.
-- **Exhausted:** the clean, correctness-preserving Lane K gains on this GPU. ctx≈0 Q8 is at the wall; the attention **V-read via vectorization** is a proven dead end (but the **V-read via occupancy** — #9 — was the sleeper win that same analysis pointed at).
+- **In `main`:** (1) the `uint4` decode-attn K-read (PR #440) — byte-identical, lossless-spec-preserving, +~10% long-context decode; (2) the `SPLITK_MAX` uncap 16→32 (PR #442) — token-identical, +~6% e2e measured at ctx 8k; (3) the `uint4` **prefill**-attn K-read (this PR) — byte-identical, **+17–19% prefill**.
+- **Exhausted (decode):** the clean, correctness-preserving Lane K *decode* gains on this GPU. ctx≈0 Q8 is at the wall; the attention **V-read via vectorization** is a proven dead end (but the **V-read via occupancy** — #9 — was the sleeper win that same analysis pointed at).
+- **OPEN FRONTIER — prefill (SIROCCO Phase P):** prefill is **99% of long-context wall time** and was never on the decode roofline. Experiment #10 took the first, free, byte-identical bite (uint4 K-read, +17–19%). Remaining prefill levers (measured, not yet built): the prefill **V-read is also scalar**; the batch chunk is only `MAX_VERIFY_K`=8 tokens so weights are re-read ~n/8 times (a **larger prefill block** would amortize the linear term); and the O(n²) `attention_batched` is a **naive per-position kernel, not flash-tiled**. This is where the real long-context wall time lives.
 - **Gated (not blocked by engineering):** the K-quant lm_head dp4a is a real ~1.74× kernel win, but capturing it requires **retiring the K-quant byte-exact-vs-oracle Runnable invariant** (or restricting to a probabilistic lm_head-only variant). That is a **precision-policy decision**, not a kernel tweak — and having built and measured both, the recommendation is that it is not worth trading greedy determinism for.
 
 ---
@@ -110,6 +114,7 @@ It **strictly dominates** the previously-shipped opt-in coalesced kernel — fas
 - **Phase 0 / G0:** [`qa/evidence-bundles/sirocco-phase0-roofline-20260712/`](qa/evidence-bundles/sirocco-phase0-roofline-20260712/README.md) — `roofline-receipt.json`, `triad.cu`, all three sweeps.
 - **Shipped win #1 (`uint4` K-read):** [`qa/evidence-bundles/sirocco-laneK-attn-kvec-uint4-20260712/`](qa/evidence-bundles/sirocco-laneK-attn-kvec-uint4-20260712/README.md) — diff, `splitk_spec_verify` log, A/B, the design workflow.
 - **Shipped win #2 (`SPLITK_MAX` uncap):** [`qa/evidence-bundles/sirocco-laneK-splitk-uncap-20260713/`](qa/evidence-bundles/sirocco-laneK-splitk-uncap-20260713/README.md) — `micro-splitk.cu` n_splits sweep, the three correctness gates, the interleaved A/B (+5.96%).
+- **Shipped win #3 (`uint4` prefill K-read, Phase P):** [`qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/`](qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/README.md) — the prefill-vs-decode wall-time reframe, the interleaved prefill A/B (+17–19%), the six parity gates + 48/48 e2e.
 - **Coalesced investigation:** [`qa/evidence-bundles/sirocco-laneK-coalesced-attn-20260712/`](qa/evidence-bundles/sirocco-laneK-coalesced-attn-20260712/README.md).
 - **Kernels:** `src/cuda_resident.rs` — `q8_gemv` @230, `q4k_gemv` @455, `q6k_gemv` @779, `attention_decode` @1371, `attn_sk_scores` @2089 (`attn_sk_partial` @2207). Correctness gate: `splitk_spec_verify_bit_identical` (`src/cuda_resident/tests.rs`), `--ignored`, requires a CUDA device (does **not** run in CI).
 

--- a/qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/README.md
+++ b/qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/README.md
@@ -1,0 +1,45 @@
+# SIROCCO Phase P — uint4 K-read in `attention_batched` (prefill)
+
+**Machine:** RTX 3060 Laptop (GA106, CC 8.6, 30 SM), 6 GB, CUDA 12.9, WDDM, Win11
+**Change:** apply the shipped byte-identical uint4 (128-bit, 8 keys/load) f16 K-cache read to `attention_batched` and `attention_tree_batched` — the resident-**prefill** and spec-verify attention kernels, which were still doing a scalar per-element f16 K read. `src/cuda_resident.rs`.
+**Result:** **+17–19% prefill** wall time, **byte-identical** (bit-exact KV/output; greedy tokens unchanged).
+
+## The reframe: prefill is 99% of long-context wall time
+
+The Lane K campaign optimized **decode**. Direct measurement (`bench-generate`, Llama-3.2-1B Q8_0) shows decode is a rounding error of a long-context request:
+
+| prompt ctx | prefill | decode (64 tok) | prefill share |
+|---|---|---|---|
+| 8802 | **152.8 s** | 1.2 s | **99.2%** |
+
+Fitting `prefill_ms ≈ a·n + b·n²` over ctx {552, 2092, 4072, 8802} gives a ≈ 3.3 ms/token (per-chunk weight re-reads — prefill batches only in `MAX_VERIFY_K`=8-token chunks) + b ≈ 0.0016 ms/token² (the O(n²) attention). The quadratic dominates at high ctx, and within it `attention_batched` read the f16 KV cache **scalar** — the exact read win #1 replaced everywhere on the decode path but never on the prefill path.
+
+## The change
+
+Verbatim transplant of the #1 uint4 K-dot (from `attn_sk_scores`) into the two prefill/verify attention kernels' score loops. `--fmad=false` + identical d-order accumulation ⇒ **byte-identical**; head_dim=64 ⇒ every K row (incl. the tree's `slots[i]*head_dim` gather) is 16-byte-aligned; a `(head_dim & 7)==0` guard falls back to scalar otherwise. V-read left scalar on purpose (vectorizing it loses on occupancy — rejected experiments #5/#6).
+
+## Measured (`prefill-ab.txt`) — interleaved OLD(scalar)/NEW(uint4), thermal-robust
+
+| ctx | OLD prefill | NEW prefill | faster |
+|---|---|---|---|
+| 2092 | 9365 ms | 7546 ms | **+19.4%** |
+| 4072 | 28306 ms | 22935 ms | **+19.0%** |
+| 6602 | 76315 ms | 63606 ms | **+16.7%** |
+
+Because prefill is ~99% of long-ctx wall time, this ≈ the whole-request speedup. No-op at ctx≈0 (no prefill).
+
+## Correctness — byte-identical (`gate-results.txt`)
+
+All existing device parity gates stay green with the kernels changed:
+- `splitk_spec_verify_bit_identical` — decode ≡ the now-uint4 `attention_batched`/`attention_tree_batched` bit-identical.
+- `prefill_then_decode_matches_sequential` — the batched (uint4) prefill's output matches the sequential reference.
+- `verify_batch_matches_sequential`, `tree_linear_matches_verify_batch`, `tree_verify_multiround_lossless`, `tree_verify_forced_compaction_lossless`.
+- End-to-end: NEW prefill greedy tokens == OLD prefill, 48/48 @ ctx 8802.
+
+Byte-identity holds by the same argument as #1: a uint4 load returns the same 8 f16 values as 8 scalar loads, accumulated in the same order.
+
+## Files
+- `prefill-ab.txt` — the interleaved prefill A/B.
+- `gate-results.txt` — the parity gate log.
+
+_Same measurement protocol as the earlier wins: monitored-boost, mem clock stable at 6000 MHz; A/B interleaved OLD/NEW per ctx to cancel SM-clock drift._

--- a/qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/gate-results.txt
+++ b/qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/gate-results.txt
@@ -1,0 +1,26 @@
+SIROCCO Phase P — uint4 K-read in attention_batched / attention_tree_batched (prefill)
+RTX 3060 Laptop, CUDA 12.9, WDDM. Model: Llama-3.2-1B-Instruct-Q8_0. greedy (temp 0).
+
+Change: attention_batched (src/cuda_resident.rs, score loop) and attention_tree_batched
+(score loop, slots[]-gathered rows) now read the f16 K cache as uint4 (8 keys/load) in the
+SAME d-order as the scalar loop -> byte-identical (--fmad=false). These are the resident-prefill
+and spec-verify attention kernels; the scalar read never got win #1's uint4 treatment.
+
+=== DEVICE PARITY GATES (cargo test --release --lib -- --ignored, needs CUDA) ===
+  splitk_spec_verify_bit_identical .............. ok   (decode == uint4 attention_batched == tree, bit-identical)
+  prefill_then_decode_matches_sequential ........ ok   (batched uint4 prefill output == sequential reference)
+  verify_batch_matches_sequential ............... ok
+  tree_linear_matches_verify_batch .............. ok
+  tree_verify_multiround_lossless ............... ok   (40 tokens / 37 rounds)
+  tree_verify_forced_compaction_lossless ........ ok   (32 tokens / 16 compacting rounds)
+
+=== END-TO-END TOKEN PARITY ===
+  NEW (uint4 prefill) vs OLD (scalar prefill), ctx=8802, 48 tokens:
+    48/48 greedy tokens identical  -> byte-identical prefill confirmed end-to-end.
+
+=== WHY BYTE-IDENTICAL ===
+A uint4 load returns the same 8 consecutive f16 values as 8 scalar loads; accumulated in the
+same textual order with --fmad=false, the dot product is bit-for-bit identical (the exact
+argument that made win #1 byte-identical). head_dim=64 -> every K row (incl. the tree gather
+slots[i]*head_dim) is 16-byte aligned; (head_dim & 7)==0 guard else scalar tail. So the KV
+cache written by prefill and every verify/decode output is unchanged bit-for-bit.

--- a/qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/prefill-ab.txt
+++ b/qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/prefill-ab.txt
@@ -1,0 +1,4 @@
+=== Prefill A/B: OLD scalar K-read vs NEW uint4 K-read in attention_batched ===
+  ctx=2092  OLD_prefill=9365.1ms  NEW_prefill=7546.5ms  faster=+19.42%
+  ctx=4072  OLD_prefill=28306.3ms  NEW_prefill=22935.3ms  faster=+18.97%
+  ctx=6602  OLD_prefill=76314.7ms  NEW_prefill=63606.3ms  faster=+16.65%

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -1798,10 +1798,25 @@ extern "C" __global__ void attention_batched(
     int tid = threadIdx.x;
     for (int d = tid; d < head_dim; d += blockDim.x) qsh[d] = qh[d];
     __syncthreads();
+    // SIROCCO prefill lever: uint4 (128-bit, 8 keys/load) f16 K read, same d-order accumulation ->
+    // BYTE-IDENTICAL (fmad=false), mirroring attention_decode / attn_sk_scores (win #1). This is the
+    // resident-prefill + spec-verify attention (the O(n^2) dominant term of long-context prompt
+    // processing); the scalar read never got #1's treatment. splitk_spec_verify_bit_identical still
+    // passes (uint4 == scalar bitwise, already proven by #1). Non-mult-of-8 head_dim -> scalar tail.
+    int kd8 = ((head_dim & 7) == 0) ? head_dim : 0;
     for (int p = tid; p < position_count; p += blockDim.x) {
         const unsigned short* kp = kbase + (long)p * head_dim;
         float dot = 0.0f;
-        for (int d = 0; d < head_dim; d++) dot += qsh[d] * f16_bits_to_f32(kp[d]);
+        int d = 0;
+        for (; d < kd8; d += 8) {
+            uint4 kv = *reinterpret_cast<const uint4*>(kp + d);
+            const unsigned short* k8 = reinterpret_cast<const unsigned short*>(&kv);
+            dot += qsh[d + 0] * f16_bits_to_f32(k8[0]); dot += qsh[d + 1] * f16_bits_to_f32(k8[1]);
+            dot += qsh[d + 2] * f16_bits_to_f32(k8[2]); dot += qsh[d + 3] * f16_bits_to_f32(k8[3]);
+            dot += qsh[d + 4] * f16_bits_to_f32(k8[4]); dot += qsh[d + 5] * f16_bits_to_f32(k8[5]);
+            dot += qsh[d + 6] * f16_bits_to_f32(k8[6]); dot += qsh[d + 7] * f16_bits_to_f32(k8[7]);
+        }
+        for (; d < head_dim; d++) dot += qsh[d] * f16_bits_to_f32(kp[d]);
         scores[p] = dot * scale;
     }
     __syncthreads();
@@ -1964,10 +1979,22 @@ extern "C" __global__ void attention_tree_batched(
     }
     __syncthreads();
     int count = s_count;
+    // SIROCCO prefill lever: uint4 f16 K read, same d-order accumulation -> BYTE-IDENTICAL (mirrors
+    // attention_batched above and win #1). Gathered row slots[i]*head_dim stays 16B-aligned (head_dim=64).
+    int kd8 = ((head_dim & 7) == 0) ? head_dim : 0;
     for (int i = tid; i < count; i += blockDim.x) {
         const unsigned short* kp = kbase + (long)slots[i] * head_dim;
         float dot = 0.0f;
-        for (int d = 0; d < head_dim; d++) dot += qsh[d] * f16_bits_to_f32(kp[d]);
+        int d = 0;
+        for (; d < kd8; d += 8) {
+            uint4 kv = *reinterpret_cast<const uint4*>(kp + d);
+            const unsigned short* k8 = reinterpret_cast<const unsigned short*>(&kv);
+            dot += qsh[d + 0] * f16_bits_to_f32(k8[0]); dot += qsh[d + 1] * f16_bits_to_f32(k8[1]);
+            dot += qsh[d + 2] * f16_bits_to_f32(k8[2]); dot += qsh[d + 3] * f16_bits_to_f32(k8[3]);
+            dot += qsh[d + 4] * f16_bits_to_f32(k8[4]); dot += qsh[d + 5] * f16_bits_to_f32(k8[5]);
+            dot += qsh[d + 6] * f16_bits_to_f32(k8[6]); dot += qsh[d + 7] * f16_bits_to_f32(k8[7]);
+        }
+        for (; d < head_dim; d++) dot += qsh[d] * f16_bits_to_f32(kp[d]);
         scores[i] = dot * scale;
     }
     __syncthreads();


### PR DESCRIPTION
## The reframe: prefill is 99% of long-context wall time

The Lane K campaign optimized **decode**. Direct measurement (`bench-generate`, Llama-3.2-1B Q8_0) shows decode is a rounding error of a long-context request:

| prompt ctx | prefill | decode (64 tok) | prefill share |
|---|---|---|---|
| 8802 | **152.8 s** | 1.2 s | **99.2%** |

Within prefill, `attention_batched` (the resident-prefill + spec-verify attention, O(n²) in ctx) still did a **scalar** per-element f16 K read — the exact read that win #1 ([PR #440](https://github.com/timtoole02/Camelid/pull/440)) replaced everywhere on the *decode* path but never on the *prefill* path.

## The change

Verbatim transplant of #1's byte-identical uint4 (128-bit, 8 keys/load) K-dot into the score loops of `attention_batched` and `attention_tree_batched`. Same d-order accumulation + `--fmad=false` ⇒ **byte-identical**; head_dim=64 ⇒ every K row (incl. the tree's `slots[i]*head_dim` gather) is 16-byte-aligned; `(head_dim & 7)==0` guard falls back to scalar. V-read left scalar on purpose (vectorizing it loses on occupancy — rejected experiments #5/#6).

## Performance — interleaved OLD(scalar)/NEW(uint4), thermal-robust

| ctx | OLD prefill | NEW prefill | faster |
|---|---|---|---|
| 2092 | 9365 ms | 7546 ms | **+19.4%** |
| 4072 | 28306 ms | 22935 ms | **+19.0%** |
| 6602 | 76315 ms | 63606 ms | **+16.7%** |

Since prefill is ~99% of long-ctx wall time, this ≈ the whole-request speedup. No-op at ctx≈0.

## Correctness — byte-identical

All existing device parity gates stay green with the kernels changed:
- `splitk_spec_verify_bit_identical` — decode ≡ the now-uint4 `attention_batched`/`attention_tree_batched`, bit-identical.
- `prefill_then_decode_matches_sequential` — the batched (uint4) prefill output matches the sequential reference.
- `verify_batch_matches_sequential`, `tree_linear_matches_verify_batch`, `tree_verify_multiround_lossless`, `tree_verify_forced_compaction_lossless`.
- End-to-end: NEW prefill greedy tokens == OLD prefill, **48/48** @ ctx 8802.

Byte-identity holds by the same argument as #1: a uint4 load returns the same 8 f16 values as 8 scalar loads, accumulated in the same order.

## Evidence

`qa/evidence-bundles/sirocco-prefill-attn-kread-20260713/` — the prefill-vs-decode reframe, the interleaved A/B, the six gates + e2e. Campaign writeup: `SIROCCO_LANEK.md` (scorecard #10, Phase P reframe).

This is the first bite of the prefill frontier; remaining levers (measured, unbuilt): scalar prefill V-read, the 8-token `MAX_VERIFY_K` chunk (weights re-read ~n/8×), and the non-flash O(n²) `attention_batched`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)