### PR TITLE
docs(sirocco): open Phase P (prefill flash attention) — design + M0a traffic gate

### DIFF
--- a/SIROCCO_PHASE_P.md
+++ b/SIROCCO_PHASE_P.md
@@ -1,0 +1,57 @@
+# SIROCCO — Phase P (prefill)
+
+**Machine:** RTX 3060 Laptop (GA106, CC 8.6, 30 SM, ~3 MB L2), 6 GB, CUDA 12.9, **WDDM** · Win11
+**Status:** **OPEN — de-risking.** M0a (traffic) run: marginal-to-positive GO. Next decisive gate: **M0b (token-parity)**.
+
+> **Mandate.** The Lane K decode campaign optimized the wrong ~1%. Direct measurement (Llama-3.2-1B Q8_0, ctx 8802): **prefill = 152.8 s (99.2 % of wall)**, decode-64 = 1.2 s. Prefill is **94–96 % O(n²) attention** and was never on the decode roofline. Phase P attacks it. The first, byte-identical bite already shipped ([PR #443](https://github.com/timtoole02/Camelid/pull/443), uint4 prefill K-read, +17–19 %); the rest of the wall needs **flash-style tiling**, which reassociates the softmax and is therefore **token-parity** — gated like the rejected #8, not byte-identical.
+
+---
+
+## 1. The bottleneck — a 24–32× K/V re-read (code-confirmed)
+
+`attention_batched` launches `grid = (k_tokens × n_heads)` blocks, **one block per (query-token t, head)** (`cuda_resident.rs:1784-1789`, launch `:3636`). Each block re-streams the **entire** prefix K and V for its `kv_head`. So within one `MAX_VERIFY_K = 8`-token prefill chunk, each kv_head's K/V is read by `k_tokens(8) × GQA-repeats(4 for 1B / 3 for 3B) = 32× / 24×` independent blocks. With 8-token chunks the whole prompt's K/V is re-processed `n/8` times. At base≈8000, head_dim=128 (3B): current attention traffic ≈ **787 MB** vs a single-read minimum of ≈ **33 MB** = **24×**.
+
+Two stacked reuse axes a flash kernel can collapse: the **query-token** axis (8 tokens can share a K/V tile) and the **GQA** axis (4/3 q-heads share one kv_head's K/V).
+
+## 2. M0a — traffic reality (KILL gate: run, PASSED marginal)
+
+`qa/evidence-bundles/sirocco-phaseP-m0a-20260713/` — a standalone microbench lifting `attention_batched`'s read pattern, timing k=8 vs k=1 at base=8000:
+
+| model | t(k=1) | t(k=8) | ratio | k=8 naive-traffic BW |
+|---|---|---|---|---|
+| 1B (32/8, hd64) | 0.42 ms | 1.36 ms | 3.22 | 386 GB/s |
+| 3B (24/8, hd128) | 0.51 ms | 1.90 ms | 3.70 | 414 GB/s |
+
+**Read:** ratio 3.2–3.7 is between the strong-GO (≥5) and KILL (≤2) bars, but the **naive-traffic BW exceeds the 271 GB/s DRAM peak** — proof the kernel demands more read bandwidth than DRAM supplies, i.e. ~70 % of the re-reads hit DRAM (~30 % L2-absorbed by the small 3 MB L2). The re-read traffic is **real** (not KILL), but the realized win is **below the on-paper 24×** — plan for **~2–4× prefill**, not 5–6×. GO to M0b.
+
+## 3. Design (chosen)
+
+A **separate `launch_attention_flash` kernel, wired PREFILL-ONLY** — never on the verify path.
+- **Never touch verify.** Thread a `flash_prefill` flag through `run_batched_layer_stack`; `verify_batch` passes `false`, so verify + `attention_tree_batched` keep `attention_batched` and its **byte-identity contract** (`splitk_spec_verify_bit_identical`, `verify_batch_matches_sequential`) intact.
+- **Block = (kv_head, key-split)**, serving `Bq` query tokens × GQA-repeats q-heads — capturing **both** reuse axes. Grid = `n_kv_heads × n_key_splits` (flash-decoding-style key-split; 8 kv_heads alone underfill 30 SMs).
+- Stream `Bc`-key f16 K/V **tiles through shared** via the #443-proven uint4 (128-bit) load. **Online-softmax** running `(m, l, acc[head_dim])` per query row **within** a split; **reuse the existing `attn_sk_combine`** (already token-parity-proven for decode) to merge per-row partials across key-splits — so the **only new reassociation is the online rescale within a split**.
+- **Scores in GLOBAL** (attn_sk_scores-style), not shared → frees the O(prefix) shared-scores buffer that today caps context at ~11.2 k (a second win: raises the ctx ceiling).
+- `Bc` sized to fit **48 KB static** (no opt-in): Bc=32 @hd128, Bc=64 @hd64. Start `Bq=8`, enlarge to 64 (M3).
+- **Memory:** query-block size is bounded by the flash kernel's 48 KB static shared, **decoupled** from the 6 GB DRAM budget, from `MAX_VERIFY_K`, and from the batched-GEMM chunk (which must stay ≤32 — the down-proj `[warp][token][block]` scratch is an unguarded >48 KB cliff at k≈47). A vlogits-free prefill scratch makes Bq=64 cost ~9.6 MB (negligible).
+
+## 4. Parity — TOKEN-PARITY (byte-identity is capacity-blocked)
+
+Byte-identical reuse needs `Bq × repeats` full O(prefix) score rows in shared (`base×4` bytes each), busting the 99 KB opt-in max even at reuse-factor 2; and each query token's different `position_count` gives different split boundaries. So the traffic win **requires** O(head_dim) online-softmax state = reassociation = **token-parity**. Ship **opt-in / prefill-only** (`CAMELID_FLASH_PREFILL=1`), mirroring the existing `metal.rs` flash path.
+
+**Required gate** (the #8 bar, stricter — prefill perturbs the persisted KV cache so error compounds per-layer **and** per-position): a multi-prompt long-context oracle — **8–16 diverse / near-tie / repetitive prompts, real model, 4k–8k ctx, ≥64 greedy tokens, 100 % token match vs the byte-exact serial path across all 16 layers.** Run it TWICE: in the M0b probe (before any kernel) and against the real tiled kernel (M2). `prefill_then_decode_matches_sequential` must also pass; verify's byte-identity gates must stay green at every milestone.
+
+## 5. Milestones (biggest risk de-risked first, cheapest)
+
+- **M0a — traffic reality.** ✅ run (§2): marginal GO, re-reads are real DRAM traffic.
+- **M0b — parity reality (NEXT, decisive KILL gate, ~0.5 day, no tiling).** An env-gated `CAMELID_FLASH_PROBE` branch in the *existing* `attention_batched` that replaces the two-pass (global-max → exp → chunked-reduce) with a **single-pass online running-max rescale over the same p-order** — reproducing flash's exact float reassociation with zero tiling code. Run `prefill_then_decode_matches_sequential` + the multi-prompt oracle. **Cheapest precheck first:** keep the exact global max, swap only the chunked reduce for a flat sequential sum — if even that flips a token, **STOP** (parity is more fragile than #9 implied, flash prefill is dead here).
+- **M1 — flash kernel @Bq=8 (first shippable, opt-in).** The real `launch_attention_flash`. Gate: M0b oracle vs the real kernel + `prefill_then_decode`; `splitk_spec_verify` stays byte-identical (verify untouched). Target ~3.5–5× on attention (bounded by M0a's L2 absorption toward the lower end).
+- **M2 — enlarge Bq→64.** vlogits-free prefill scratch; GEMM chunk stays ≤32. Ceiling ~5–8× attention; hard Amdahl cap set by the pinned non-attention floor.
+- **M3 — (optional) >48 KB dynamic shared** via `cudaFuncSetAttribute` for occupancy — only if M1/M2 profiling shows occupancy, not traffic, as the new limit. New infra; deprioritized.
+
+## 6. Kill criteria
+
+- **M0b:** the online-softmax reassociation flips **any** token on **any** prompt → token-parity unachievable, and byte-identity is capacity-blocked → **NO shippable flash variant, abandon Phase P flash.** (The flat-sum precheck is the immediate stop.)
+- **M1/M2:** measured gated speedup < ~1.5× (re-read win eaten by online-rescale/tail/occupancy) → don't ship an opt-in kernel that carries token-parity maintenance risk; or a tiling-specific reassociation fails the oracle beyond M0b → fix or kill.
+- **Overriding:** ship only measured, oracle-gated numbers; verify's byte-identity gates green at every milestone or revert.
+
+_Design produced by a 6-scout + synthesis workflow (2026-07-13); all anchors code-verified. M0a evidence in the bundle above._

--- a/qa/evidence-bundles/sirocco-phaseP-m0a-20260713/m0a-result.txt
+++ b/qa/evidence-bundles/sirocco-phaseP-m0a-20260713/m0a-result.txt
@@ -1,0 +1,16 @@
+SIROCCO Phase P — M0a TRAFFIC-REALITY kill gate (RTX 3060 Laptop, CC 8.6, ~3MB L2, 271 GB/s peak)
+m0a-traffic.cu lifts attention_batched's read pattern (uint4 K-dot + scalar weighted-V), grid =
+(k_tokens * n_heads) blocks (one per query-token,head), each re-streaming the full prefix K+V.
+Times k=8 vs k=1 at base=8000. Ratio ~8 => re-reads miss to DRAM (flash win real); ~1 => L2 absorbs.
+
+M0a TRAFFIC-REALITY @ base=8000
+  Llama-3.2-1B (32/8, hd64)    t(k=1)=0.422ms t(k=8)=1.357ms  RATIO=3.22  | k=8 naive-traffic BW=386 GB/s (min-read 16.4 MB, naive 524 MB)
+  Llama-3.2-3B (24/8, hd128)   t(k=1)=0.514ms t(k=8)=1.901ms  RATIO=3.70  | k=8 naive-traffic BW=414 GB/s (min-read 32.8 MB, naive 786 MB)
+
+VERDICT: marginal-to-positive GO. Ratio 3.2-3.7 is between the strong-GO(>=5) and KILL(<=2) bars,
+but the naive-traffic BW (386-414 GB/s) EXCEEDS the 271 GB/s DRAM peak -> the kernel demands more
+read bandwidth than DRAM supplies, so ~70% of the re-reads hit DRAM (~30% absorbed by the 3MB L2).
+The re-read traffic is REAL (not a KILL); the realized flash win is BELOW the on-paper 24x -> plan
+for ~2-4x prefill, not 5-6x. Proceed to the decisive gate M0b (token-parity).
+Note: k=1 (32 blocks) underfills the 30 SMs, biasing the ratio toward KILL -> a 3.2-3.7 that already
+clears 2 despite that bias is a genuine (if not spectacular) traffic signal.

--- a/qa/evidence-bundles/sirocco-phaseP-m0a-20260713/m0a-traffic.cu
+++ b/qa/evidence-bundles/sirocco-phaseP-m0a-20260713/m0a-traffic.cu
@@ -1,0 +1,89 @@
+// SIROCCO Phase P — M0a TRAFFIC-REALITY kill gate.
+// Lifts attention_batched's read pattern (uint4 K-dot #443 + scalar weighted-V) VERBATIM: grid =
+// (k_tokens * n_heads) blocks, one block per (query-token t, head), each re-streaming the full
+// prefix K+V for its kv_head. Times k=8 vs k=1 at the SAME base. If the k-token re-reads miss to
+// DRAM (bandwidth-bound), t(k=8)/t(k=1) ~ 8; if L2 absorbs them, ~1. k=1 underfills the 30 SMs so
+// the ratio is biased toward KILL -> a high ratio is a STRONG go. GO >=5, KILL <=2.
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <algorithm>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#define CK(x) do{cudaError_t e=(x);if(e!=cudaSuccess){fprintf(stderr,"CUDA %s:%d %s\n",__FILE__,__LINE__,cudaGetErrorString(e));exit(1);}}while(0)
+__device__ __forceinline__ float f16b(unsigned short h){ return __half2float(__ushort_as_half(h)); }
+
+extern "C" __global__ void attn_bench(
+    const float* __restrict__ q, const unsigned short* __restrict__ cache_k,
+    const unsigned short* __restrict__ cache_v, float* __restrict__ out,
+    int n_heads, int n_kv_heads, int head_dim, int base_position, int max_pos, float scale,
+    int q_per_token, int k_tokens)
+{
+    int t = blockIdx.x / n_heads, head = blockIdx.x % n_heads;
+    if (t >= k_tokens) return;
+    int position_count = base_position + t + 1;
+    int repeats = n_heads / n_kv_heads, kv_head = head / repeats;
+    const float* qh = q + (long)t * q_per_token + (long)head * head_dim;
+    const unsigned short* kbase = cache_k + (long)kv_head * max_pos * head_dim;
+    const unsigned short* vbase = cache_v + (long)kv_head * max_pos * head_dim;
+    extern __shared__ float shared[];
+    float* qsh = shared; float* scores = shared + head_dim;
+    int tid = threadIdx.x;
+    for (int d = tid; d < head_dim; d += blockDim.x) qsh[d] = qh[d];
+    __syncthreads();
+    int kd8 = ((head_dim & 7) == 0) ? head_dim : 0;
+    for (int p = tid; p < position_count; p += blockDim.x) {         // K-read (uint4, #443)
+        const unsigned short* kp = kbase + (long)p * head_dim;
+        float dot = 0.0f; int d = 0;
+        for (; d < kd8; d += 8) {
+            uint4 kv = *reinterpret_cast<const uint4*>(kp + d);
+            const unsigned short* k8 = reinterpret_cast<const unsigned short*>(&kv);
+            dot += qsh[d+0]*f16b(k8[0]); dot += qsh[d+1]*f16b(k8[1]); dot += qsh[d+2]*f16b(k8[2]); dot += qsh[d+3]*f16b(k8[3]);
+            dot += qsh[d+4]*f16b(k8[4]); dot += qsh[d+5]*f16b(k8[5]); dot += qsh[d+6]*f16b(k8[6]); dot += qsh[d+7]*f16b(k8[7]);
+        }
+        for (; d < head_dim; d++) dot += qsh[d]*f16b(kp[d]);
+        scores[p] = dot * scale;
+    }
+    __syncthreads();
+    // weighted-V (scalar, head_dim threads active — as in attention_batched)
+    for (int did = tid; did < head_dim; did += blockDim.x) {
+        float acc = 0.0f;
+        for (int p = 0; p < position_count; p++) acc += scores[p] * f16b(vbase[(long)p*head_dim+did]);
+        out[(long)t*q_per_token + (long)head*head_dim + did] = acc;
+    }
+}
+
+double run(int k, int base, int n_heads, int n_kv, int hd, int iters){
+    int max_pos = base + 16; long qn=(long)k*n_heads*hd;
+    float *q,*out; unsigned short *ck,*cv;
+    CK(cudaMalloc(&q,qn*4)); CK(cudaMemset(q,1,qn*4)); CK(cudaMalloc(&out,qn*4));
+    CK(cudaMalloc(&ck,(long)n_kv*max_pos*hd*2)); CK(cudaMemset(ck,1,(long)n_kv*max_pos*hd*2));
+    CK(cudaMalloc(&cv,(long)n_kv*max_pos*hd*2)); CK(cudaMemset(cv,1,(long)n_kv*max_pos*hd*2));
+    dim3 grid(k*n_heads,1,1); int block=128; size_t sh=(hd+base+16)*4; float scale=0.125f;
+    for(int i=0;i<5;i++) attn_bench<<<grid,block,sh>>>(q,ck,cv,out,n_heads,n_kv,hd,base,max_pos,scale,n_heads*hd,k);
+    CK(cudaDeviceSynchronize());
+    cudaEvent_t a,b; CK(cudaEventCreate(&a)); CK(cudaEventCreate(&b)); std::vector<double> ts;
+    for(int i=0;i<iters;i++){ CK(cudaEventRecord(a));
+        attn_bench<<<grid,block,sh>>>(q,ck,cv,out,n_heads,n_kv,hd,base,max_pos,scale,n_heads*hd,k);
+        CK(cudaEventRecord(b)); CK(cudaEventSynchronize(b)); float ms; CK(cudaEventElapsedTime(&ms,a,b)); ts.push_back(ms); }
+    std::sort(ts.begin(),ts.end());
+    cudaFree(q);cudaFree(out);cudaFree(ck);cudaFree(cv);
+    return ts[ts.size()/2];
+}
+
+int main(int argc,char**argv){
+    int base = argc>1?atoi(argv[1]):8000;
+    struct Cfg{const char*name;int nh,nkv,hd;};
+    Cfg cfgs[] = {{"Llama-3.2-1B (32/8, hd64)",32,8,64},{"Llama-3.2-3B (24/8, hd128)",24,8,128}};
+    printf("M0a TRAFFIC-REALITY @ base=%d  (peak ~271 GB/s; single-read min bytes = n_kv*base*hd*2*2)\n",base);
+    for(auto c:cfgs){
+        double t1=run(1,base,c.nh,c.nkv,c.hd,60), t8=run(8,base,c.nh,c.nkv,c.hd,60);
+        double minB=(double)c.nkv*base*c.hd*2*2/1e9; // GB, single-read K+V
+        double naiveB8=(double)8*c.nh*base*c.hd*2*2/1e9; // naive: every (t,head) block reads full K+V
+        double bw8=naiveB8/(t8/1e3);
+        printf("  %-28s t(k=1)=%.3fms t(k=8)=%.3fms  RATIO=%.2f  | k=8 naive-traffic BW=%.0f GB/s (min-read %.1f MB, naive %.0f MB)\n",
+            c.name,t1,t8,t8/t1,bw8, minB*1e3, naiveB8*1e3);
+    }
+    printf("VERDICT: RATIO>=5 => re-reads miss to DRAM, flash win REAL (GO). RATIO<=2 => L2 absorbs, KILL.\n");
+    return 0;
+}


### PR DESCRIPTION
## Opens SIROCCO Phase P

The Lane K decode campaign optimized the wrong ~1%. **Prefill = 99% of long-context wall time** (ctx 8802: prefill 152.8 s vs decode-64 1.2 s), 94–96% O(n²) attention, never on the decode roofline. [#443](https://github.com/timtoole02/Camelid/pull/443) took the first byte-identical bite (uint4 prefill K-read, +17–19%); the rest needs **flash tiling**, which reassociates the softmax → **token-parity** (gated like the rejected #8, not byte-identical).

## Root cause (code-confirmed)

`attention_batched` runs **one block per (query-token, head)** (`cuda_resident.rs:1784`), each re-streaming the full prefix K/V → a **24–32× re-read** (`k_tokens × GQA-repeats`). At base≈8000/hd128: ~787 MB attention traffic vs a 33 MB single-read minimum.

## M0a — traffic reality (KILL gate, run)

Standalone microbench, k=8 vs k=1 at base=8000:

| model | ratio | k=8 naive-BW |
|---|---|---|
| 1B (32/8, hd64) | 3.22 | 386 GB/s |
| 3B (24/8, hd128) | 3.70 | 414 GB/s |

**Marginal-to-positive GO.** The naive-traffic BW exceeds the 271 GB/s DRAM peak → ~70% of re-reads hit DRAM (~30% L2-absorbed by the 3 MB L2). Re-reads are real (not a KILL); realized win ~2–4× prefill, below the on-paper 24×.

## What this PR contains (docs only)

`SIROCCO_PHASE_P.md` — the design (separate prefill-only `launch_attention_flash`: block per (kv_head, key-split) serving Bq queries × GQA heads, uint4 K/V tiles in shared, online softmax within a split, reuse the token-parity-proven `attn_sk_combine` across splits, scores in global), the token-parity strategy + #8-style multi-prompt oracle gate, and milestones M0–M4 with kill gates (biggest risk first).

**Next decisive gate: M0b (token-parity probe)** — a ~30-line env-gated online-softmax edit in the *existing* kernel + the multi-prompt oracle, before writing any tiling code. If the reassociation flips a token across the 16 layers, flash prefill is token-parity-dead here (byte-identity is capacity-blocked at 8k), and the phase stops.

Design produced by a 6-scout + synthesis workflow; all anchors code-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)