### PR TITLE
Redact operator home paths from the stream-options bundle proxy.log

### DIFF
--- a/qa/evidence-bundles/stream-options-include-usage-20260623/phase3/REDACTION_NOTE.md
+++ b/qa/evidence-bundles/stream-options-include-usage-20260623/phase3/REDACTION_NOTE.md
@@ -1,0 +1,39 @@
+# Redaction note — phase3/proxy.log (2026-07-15)
+
+`proxy.log` (the logging-proxy capture of the opencode end-to-end run described in
+`e2e-validation.md`) contained operator home-directory paths inside one logged
+request body (line 40, a `REQ_BODY` JSON line embedding the client's system prompt
+and tool descriptions). `scripts/audit-evidence-bundle-privacy.mjs` flagged the
+forward-slash occurrences as `mac_home_path` findings.
+
+## What was redacted
+
+Six occurrences on that single line, all replaced with the placeholder
+`REDACTED_HOME` substituted for the home-directory path component (the `Users`
+segment plus the account name):
+
+- 1 × a `file:///` URL embedding the operator's forward-slash Windows home path
+  (a tool `<location>` pointing back into this repo checkout) — now
+  `file:///C:/REDACTED_HOME/Camelid/…`
+- 3 × JSON-escaped backslash Windows home paths (an AppData temp path and two
+  repo-checkout paths) — now the `C:\\REDACTED_HOME\\…` form
+- 2 × generic "My Documents" documentation-example home paths quoted inside the
+  client's embedded system-prompt text (not a real leak; redacted uniformly so
+  the privacy audit's home-path pattern stays quiet)
+
+Every other byte of the file is unchanged. No parity/evidence semantics were
+altered: the SSE frames, usage fields, token counts, and response bodies the
+bundle's conclusions rest on are untouched, and no checksum manifest in this
+bundle covers `proxy.log`.
+
+## Git status of the log (why there is no history concern)
+
+`proxy.log` has never been tracked or committed — it is ignored by the repo-root
+`.gitignore` (`*.log`) and exists only on the capture host's disk. The leak was
+therefore local-only, not public, and no git-history rewriting is needed. This
+note is the tracked record of the redaction. (Related pre-existing quirk, left
+as-is: the tracked `e2e-validation.md` cites `proxy.log` as evidence even though
+the log is untracked; whether to commit a scrubbed copy is a maintainer decision.)
+
+After redaction, `node scripts/audit-evidence-bundle-privacy.mjs` reports
+`finding_count: 0`.


### PR DESCRIPTION
## What

`qa/evidence-bundles/stream-options-include-usage-20260623/phase3/proxy.log` carried six home-directory path occurrences inside one logged request body (line 40, a `REQ_BODY` JSON line embedding the opencode client's system prompt): one `file:///` URL with the operator's Windows home path, three JSON-escaped backslash Windows home paths, and two generic "My Documents" doc-example paths from the client's embedded prompt text. All six are now the uniform `REDACTED_HOME` placeholder; every other byte of the log is unchanged, and no checksum manifest covers the file, so no evidence semantics move.

## Premise correction (important)

The task as filed said the file was tracked and "already public in git history." **It is not:** `proxy.log` has never been tracked or committed — it matches the repo-root `.gitignore` `*.log` rule and exists only on the capture host's disk. The leak was local-only, so **no history rewriting is needed at all.** This PR therefore commits only the tracked `REDACTION_NOTE.md` recording what was redacted and why; the log edit itself lives on the capture host.

## Verification

- `node scripts/audit-evidence-bundle-privacy.mjs`: **finding_count 0** (was 3 — the repo's only privacy findings)
- `bash scripts/check-public-scrub.sh`: green (the note deliberately avoids reproducing any scrub-matchable path shape)

## Left as-is (maintainer's call)

The tracked `e2e-validation.md` cites `proxy.log` as evidence while the log is untracked on this host — a pre-existing bundle-completeness quirk. Committing a scrubbed copy of the log would make the bundle self-contained; not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)