### PR TITLE
fix(metal): reset resident engine `filled` on rollback — macOS draft-model spec panic

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2076,11 +2076,11 @@ impl LlamaInferenceSession {
 
     /// Roll back a GPU-resident drafter session to `position`. Unlike
     /// [`rollback_to_position`], this does NOT require CPU-authoritative KV: it
-    /// resets the resident CUDA engine's `filled` to `position` so the next decode
-    /// trusts the (still-valid) GPU KV up to `position` instead of reseeding from the
-    /// CPU history. The GPU KV is position-major, so entries past `position` are
-    /// overwritten on the next append. For a CPU drafter (no resident engine in the
-    /// cache) this is just the plain kv_cache rollback.
+    /// resets the resident engine's `filled` to `position` (CUDA and Metal alike) so the
+    /// next decode trusts the (still-valid) GPU KV up to `position` instead of reseeding
+    /// from the CPU history. The GPU KV is position-indexed, so entries past `position`
+    /// are overwritten on the next append. For a CPU drafter (no resident engine) this is
+    /// just the plain kv_cache rollback.
     pub fn rollback_resident_to_position(&mut self, position: usize) -> Result<()> {
         self.kv_cache.rollback_to_position(position)?;
         #[cfg(feature = "cuda")]
@@ -2091,6 +2091,18 @@ impl LlamaInferenceSession {
                         slot.engine.set_filled(position);
                     }
                 }
+            }
+        }
+        // Metal analog of the CUDA branch. The Metal resident engine hangs off the session
+        // itself rather than a process-global cache, but the state it carries is the same:
+        // lowering only `kv_cache.position` leaves `filled()` stale, the next resident decode
+        // reads that as a new sequence (`filled() != position`) and tries to reseed the GPU
+        // cache from a CPU KV history a GPU-resident drafter never wrote — `keys` is empty
+        // until `ensure_position_capacity` grows it, so the seeding copy indexes out of range.
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(session) = self.resident_decode.as_mut() {
+                session.rollback_to_position(position);
             }
         }
         Ok(())

--- a/src/inference/kv_cache.rs
+++ b/src/inference/kv_cache.rs
@@ -374,6 +374,40 @@ impl LlamaKvCache {
         }
     }
 
+    /// Whether the f32 `keys`/`values` buffers are ADDRESSABLE over `[0, position)` for every
+    /// layer through `last_layer` — i.e. whether a reader may index them with
+    /// [`offset`](Self::offset) over that range without going out of bounds.
+    ///
+    /// `position` alone does NOT imply the buffers exist: only `ensure_position_capacity`
+    /// grows them, so a session whose positions were all produced by a GPU-resident engine
+    /// carries a high `position` over empty buffers, and in `F16` dtype the entries live in
+    /// `keys_f16`/`values_f16` instead. Both layouts put the maximum offset at the last
+    /// layer's last kv head at `position - 1`, so one probe bounds the whole range.
+    ///
+    /// SCOPE — read this before relying on it. This is a BOUNDS check, not a validity check.
+    /// It says the bytes are safe to index; it does NOT say they hold the sequence's real
+    /// K/V. Once `ensure_position_capacity` has grown the buffers for ANY position, this
+    /// returns true for every position `<= allocated_sequence_length` regardless of what was
+    /// actually written — so a range this accepts may still be zero-filled for positions the
+    /// GPU produced and the CPU never wrote. Seeding from such a range is silently wrong, not
+    /// unsafe. Distinguishing that needs a materialized-through watermark, which the cache
+    /// does not currently carry. Same weakness as the pre-existing `cpu_kv_authoritative`.
+    pub(super) fn f32_history_addressable(&self, last_layer: usize, position: usize) -> bool {
+        if position == 0 {
+            return true;
+        }
+        if self.dtype != KvDtype::F32
+            || position > self.allocated_sequence_length
+            || last_layer >= self.plan.layer_count
+            || self.plan.kv_head_count == 0
+        {
+            return false;
+        }
+        let end =
+            self.offset(last_layer, position - 1, self.plan.kv_head_count - 1) + self.plan.head_dim;
+        self.keys.len() >= end && self.values.len() >= end
+    }
+
     pub(super) fn offset(&self, layer_idx: usize, position: usize, kv_head: usize) -> usize {
         match self.layout {
             KvLayout::PositionMajor => {

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -209,6 +209,28 @@ impl super::LlamaInferenceSession {
                 None => return Ok(None),
             };
             if position > 0 {
+                // Seeding reads the CPU KV history [0, position) out of `kv_cache.keys` /
+                // `.values`. Those buffers are grown only by `ensure_position_capacity`, so a
+                // session whose positions were all produced by this resident engine carries a
+                // non-zero `position` over empty buffers (and an F16 cache keeps its entries
+                // elsewhere entirely). Decline instead of indexing out of range. With the
+                // rollback state reset in `rollback_resident_to_position` this is unreachable
+                // on the drafter path, and it must stay that way — a CPU fallback per draft
+                // token would cost far more than it saves.
+                //
+                // LIMIT OF THIS GUARD: it is a bounds probe (see `f32_history_addressable`),
+                // so it only catches the case where the buffers were NEVER grown. Once any
+                // CPU fallback has grown them, this passes even though positions the GPU
+                // produced are still zero-filled, and the seed below copies those zeros —
+                // silently wrong output rather than a panic. That path predates this guard
+                // and is not fixed by it; closing it needs a materialized-through watermark
+                // on the cache.
+                if !self
+                    .kv_cache
+                    .f32_history_addressable(range.end.saturating_sub(1), position)
+                {
+                    return Ok(None);
+                }
                 let kv_dim = n_kv * head_dim;
                 for layer in 0..n_layers {
                     let mut ck = vec![0.0f32; kv_dim * position];

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -13538,3 +13538,77 @@ fn nvfp4_wire_row_dot_matches_pin_order_reference_on_pilot_fixture() {
          64-superblock rows bitwise-identical to the pin-order reference"
     );
 }
+
+/// A session whose positions were all produced by a GPU-resident engine carries a
+/// non-zero `kv_cache.position` over CPU K/V buffers that were never grown — the
+/// state the resident reseed path used to index blindly.
+#[test]
+fn f32_history_addressable_declines_kv_buffers_a_resident_session_never_grew() {
+    let (mut session, _temp_file) = tiny_kv_budget_session(64);
+
+    // Position 0 needs no history, so seeding from it is always safe.
+    assert!(session.kv_cache.f32_history_addressable(0, 0));
+
+    // The resident lane advances `position` without touching the CPU buffers.
+    session.kv_cache.position = 5;
+    assert!(session.kv_cache.keys.is_empty());
+    assert!(
+        !session.kv_cache.f32_history_addressable(0, 5),
+        "an unallocated CPU KV history must never be reported as readable"
+    );
+
+    // Once the CPU path has grown the buffers the same range is readable...
+    session.kv_cache.ensure_position_capacity(5).unwrap();
+    assert!(session.kv_cache.f32_history_addressable(0, 5));
+    // ...but only up to what was actually allocated.
+    let past_end = session.kv_cache.allocated_sequence_length + 1;
+    assert!(!session.kv_cache.f32_history_addressable(0, past_end));
+    // A layer index past the plan is out of range for the offset math.
+    assert!(!session
+        .kv_cache
+        .f32_history_addressable(session.kv_cache.plan.layer_count, 5));
+}
+
+/// Rejected-draft rollback must move the Metal resident engine's `filled` with the KV
+/// position. Leaving it stale is what made the next resident decode treat the session as
+/// a new sequence and reseed from a CPU KV history the GPU-resident drafter never wrote
+/// (`range end index <head_dim> out of range for slice of length 0`).
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn metal_resident_rollback_moves_filled_with_the_kv_position() {
+    let (mut session, _temp_file) = tiny_kv_budget_session(64);
+    // tiny_kv_budget_session: 1 layer, 1 head, 1 kv head, head_dim 32, hidden 32, ffn 32.
+    let Some(mut state) =
+        crate::metal::ResidentDecodeState::new(1, 1, 1, 32, 32, 32, 16, 64, 1.0e-5, false)
+    else {
+        return; // no Metal device on this host — nothing to exercise
+    };
+
+    // Six positions decoded on the GPU: `filled` and `position` advance together, and the
+    // CPU K/V buffers stay empty (only `ensure_position_capacity` grows them).
+    state.set_filled(6);
+    session.resident_decode = Some(state);
+    session.kv_cache.position = 6;
+    assert!(session.kv_cache.keys.is_empty());
+
+    // The target accepted four of those positions and rejected the tail.
+    session.rollback_resident_to_position(4).unwrap();
+
+    let filled = session
+        .resident_decode
+        .as_ref()
+        .expect("rollback must not drop the resident session")
+        .filled();
+    assert_eq!(session.kv_cache.position, 4);
+    assert_eq!(
+        filled, session.kv_cache.position,
+        "a stale `filled` sends the next decode into the reseed path"
+    );
+
+    // Rolling back to the current position is a no-op, and rolling forward is not a
+    // rollback: neither may raise `filled` past what the GPU cache holds.
+    session.rollback_resident_to_position(4).unwrap();
+    assert_eq!(session.resident_decode.as_ref().unwrap().filled(), 4);
+    session.rollback_resident_to_position(0).unwrap();
+    assert_eq!(session.resident_decode.as_ref().unwrap().filled(), 0);
+}

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -11046,6 +11046,26 @@ impl ResidentDecodeState {
         self.filled = n;
     }
 
+    /// Discard the KV positions at and after `position` (speculative rollback of rejected
+    /// draft tokens). The cache is position-indexed and the next append overwrites the
+    /// dropped slots, so nothing but the materialized count moves — no buffer work, and the
+    /// still-valid history `[0, position)` stays on the GPU instead of being reseeded from
+    /// the CPU. A no-op when the cache holds no more than `position` positions. The
+    /// encode-ahead graph was built for the abandoned position, so it is released here
+    /// rather than left for `forward_token` to discover (releasing is mandatory: it sits
+    /// committed and gated on the serial queue).
+    pub fn rollback_to_position(&mut self, position: usize) {
+        if position >= self.filled {
+            return;
+        }
+        if let Some(stale) = self.pending.take() {
+            self.release_stale(stale);
+        }
+        self.pending_signaled = false;
+        self.last_sampled = None;
+        self.filled = position;
+    }
+
     /// Decode one token at sequence position `position` (0-based): append this token's K/V to
     /// the persistent GPU cache and attend over positions `0..=position`, all layers in one
     /// command buffer. `cos_t`/`sin_t` are the RoPE tables for `position`; `scale` is the
@@ -13859,6 +13879,8 @@ impl ResidentDecodeState {
     }
 
     pub fn set_filled(&mut self, _n: usize) {}
+
+    pub fn rollback_to_position(&mut self, _position: usize) {}
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/tests/spec_draft_rollback.rs
+++ b/tests/spec_draft_rollback.rs
@@ -1,0 +1,130 @@
+//! Regression: rejected-draft rollback on the GPU-resident draft-model path.
+//!
+//! `ModelDrafter::draft` rolls its session back to the accepted prefix before each
+//! round (`rollback_resident_to_position`). That lowers `kv_cache.position`, so the
+//! resident engine's own `filled` must move with it — otherwise the next resident
+//! decode reads `filled() != position` as a new sequence and reseeds the GPU cache
+//! from a CPU KV history a GPU-resident drafter never wrote (`keys` is grown only by
+//! `ensure_position_capacity`), indexing an empty buffer:
+//!
+//!   thread 'main' panicked at src/inference/metal_resident.rs:
+//!   range end index 64 out of range for slice of length 0
+//!
+//! On macOS that reset existed only under `#[cfg(feature = "cuda")]`, so every
+//! `--drafter draft` run without `--cpu-draft` panicked at the first partially
+//! rejected round. This test drives exactly that sequence: draft a round, then draft
+//! again from a history that diverges inside the drafted tail.
+//!
+//! Skips cleanly when the env var is unset (CI carries no model files); run locally:
+//!   CAMELID_DRAFT_ROLLBACK_GGUF=/path/Llama-3.2-1B-Instruct-Q8_0.gguf \
+//!     cargo test --release --test spec_draft_rollback -- --nocapture
+
+use camelid::gguf::read_metadata;
+use camelid::inference::speculative::ModelDrafter;
+use camelid::inference::{LlamaInferenceSession, LlamaLoadedWeights};
+use camelid::model::{LlamaModelConfig, LlamaTensorBinding};
+use camelid::tensor::TensorStore;
+use camelid::tokenizer::Tokenizer;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+#[test]
+fn draft_model_rollback_after_rejection_keeps_the_resident_engine_in_sync() {
+    let Some(model) = std::env::var_os("CAMELID_DRAFT_ROLLBACK_GGUF").map(PathBuf::from) else {
+        eprintln!("SKIP draft rollback regression: set CAMELID_DRAFT_ROLLBACK_GGUF");
+        return;
+    };
+    // The defect lives on the GPU-resident lane; the CLI turns this on via the execution
+    // planner, so a bare test process must ask for it explicitly.
+    std::env::set_var("CAMELID_METAL_RESIDENT_DECODE", "1");
+
+    let gguf = read_metadata(&model).expect("read gguf metadata");
+    let config = LlamaModelConfig::from_gguf(&gguf).expect("model config");
+    let binding = LlamaTensorBinding::bind(&gguf, &config).expect("tensor binding");
+    let store = TensorStore::open(&model, &gguf);
+    let tokenizer = Tokenizer::from_gguf(&gguf).expect("tokenizer");
+    let weights = Arc::new(LlamaLoadedWeights::load(&store, &binding, None).expect("load weights"));
+    let session = LlamaInferenceSession::new(config, weights).expect("session");
+    let mut drafter = ModelDrafter::new(session);
+
+    let prompt: Vec<u32> = tokenizer
+        .encode(
+            "The capital of France is Paris, and the capital of Italy is",
+            true,
+            false,
+        )
+        .expect("encode prompt");
+    assert!(
+        prompt.len() > 4,
+        "prompt must give the drafter real history"
+    );
+
+    let gamma = 5;
+    let first = drafter.draft(&prompt, gamma).expect("first draft round");
+    assert_eq!(first.len(), gamma, "drafter should fill the window");
+    let (_, resident_steps, cpu_steps) = drafter.take_forward_stats();
+    let resident_lane = resident_steps > 0;
+    eprintln!("round 1: drafts={first:?} resident_steps={resident_steps} cpu_steps={cpu_steps}");
+    // LOAD-BEARING PRECONDITION, not a nicety. The pre-fix failure mode is the panic in the
+    // round-2 reseed, and that panic needs `kv_cache.keys` to still be EMPTY — i.e. round 1
+    // must have stayed entirely on the resident lane. A single CPU-fallback step here calls
+    // `ensure_position_capacity`, which grows the buffers; the round-2 reseed then finds them
+    // addressable, does NOT panic, and silently seeds zeros instead. Since this test asserts
+    // nothing about draft CONTENT, that outcome would pass on a build with the fix reverted —
+    // the regression test would quietly stop being one. Assert the precondition so the test
+    // fails loudly rather than passing for the wrong reason.
+    if resident_lane {
+        assert_eq!(
+            cpu_steps, 0,
+            "round 1 fell back to the CPU ({cpu_steps} steps), which grows kv_cache.keys and \
+             masks the pre-fix panic — this run cannot prove the rollback fix"
+        );
+    }
+
+    // The target accepts the first draft and then emits something else — the classic
+    // partial rejection. `history` therefore keeps drafts[0] and diverges after it, so the
+    // next round must roll the draft KV back past the speculative tail it fed last round.
+    let rejected = (first[1] + 1) % tokenizer.tokens.len().max(2) as u32;
+    assert_ne!(rejected, first[1], "the second history token must diverge");
+    let mut history = prompt.clone();
+    history.push(first[0]);
+    history.push(rejected);
+
+    // Pre-fix this call panicked inside the resident reseed.
+    let second = drafter.draft(&history, gamma).expect("second draft round");
+    assert_eq!(second.len(), gamma, "drafter should fill the window again");
+    let (_, resident_steps_2, cpu_steps_2) = drafter.take_forward_stats();
+    eprintln!(
+        "round 2: drafts={second:?} resident_steps={resident_steps_2} cpu_steps={cpu_steps_2}"
+    );
+
+    // A round that quietly fell back to the CPU forward would also "not panic", so assert
+    // the rolled-back session stayed on the resident lane it was on before the rollback.
+    if resident_lane {
+        assert_eq!(
+            cpu_steps_2, 0,
+            "rollback pushed the draft session off the resident lane \
+             ({resident_steps_2} resident vs {cpu_steps_2} CPU steps)"
+        );
+    }
+
+    // A third round where the target accepted the whole fed tail must keep working too:
+    // the rollback target equals the current position, so it is a no-op that must leave the
+    // engine (and its encode-ahead graph) alone. History grows by the accepted drafts plus
+    // the target's bonus token, which the draft session has not consumed yet.
+    let mut history = history.clone();
+    history.extend_from_slice(&second[..gamma - 1]);
+    history.push(rejected);
+    let third = drafter.draft(&history, gamma).expect("third draft round");
+    assert_eq!(third.len(), gamma);
+    let (_, resident_steps_3, cpu_steps_3) = drafter.take_forward_stats();
+    eprintln!(
+        "round 3: drafts={third:?} resident_steps={resident_steps_3} cpu_steps={cpu_steps_3}"
+    );
+    if resident_lane {
+        assert_eq!(
+            cpu_steps_3, 0,
+            "a no-op rollback must not disturb the engine"
+        );
+    }
+}


### PR DESCRIPTION
Fixes a hard panic on the macOS/Metal draft-model speculative decode path, and verifies the fix by reproducing the crash first.

## The bug

`rollback_resident_to_position` reset the resident engine's `filled` under `#[cfg(feature = "cuda")]` **only** — there was no Metal branch. On macOS it lowered `kv_cache.position` but left `filled()` stale, so the next resident decode read `filled() != position` as a *new sequence* and tried to reseed the GPU cache from the CPU KV history — which a GPU-resident drafter never wrote (`keys` is grown only by `ensure_position_capacity`). The seeding copy then indexed a zero-length slice:

```
thread 'main' panicked at src/inference/metal_resident.rs:
range end index 64 out of range for slice of length 0
```

The index is the model's `head_dim`, so it identifies the *model*, not the mechanism (1B draft = 64, 3B/Qwen3 = 128). An earlier report of this crash showing `128` sent the diagnosis toward model size; it is not size-dependent.

Sole caller is `ModelDrafter::draft`, reachable only via `--drafter draft` **without** `--cpu-draft`. It is **config-dependent** — the `ngram` drafter cannot reach it, which is why the default speculative lane never hit it.

## The fix

Mirrors the existing CUDA branch:

- **`rollback_resident_to_position`** (`src/inference.rs`) gains a `#[cfg(target_os = "macos")]` branch that rolls the resident session back.
- **`ResidentDecodeState::rollback_to_position`** (`src/metal.rs`) lowers `filled` and **releases the encode-ahead graph** built for the abandoned position — that release is mandatory, it sits committed and gated on the serial queue. No buffer work: the cache is position-indexed, so the next append overwrites the dropped slots and the still-valid history `[0, position)` stays on the GPU instead of being reseeded from the CPU. Non-macOS gets a no-op stub.
- **Defence in depth:** the seeding path declines (falling back to the CPU forward) when the f32 KV buffers were never grown, via the new `f32_history_addressable`.

## Verification

On Apple M4 / macOS 26.5 / Metal, `Llama-3.2-3B-Instruct-Q8_0` target with a `Llama-3.2-1B-Instruct-Q8_0` draft:

| check | result |
|---|---|
| Panic reproduces on pre-fix binary | ✅ exit **101**, `metal_resident.rs:221` |
| Panic gone post-fix, same command/models | ✅ exit **0**, record captured |
| `tests/spec_draft_rollback.rs` on **pre-fix source** | ✅ **FAILS** with the exact panic at round 2 |
| Same test on this branch | ✅ passes, `resident_steps` 18/5/5, `cpu_steps=0` |
| `qa/speed/spec-verify-parity.sh` | ✅ **PASS** |
| Generated token SHA-256, all 4 gate columns | ✅ **byte-identical** to a pre-fix baseline |
| fmt / clippy `-D warnings` / new unit tests | ✅ |

The pre-fix reproduction is the point: a fix for a crash that was never reproduced isn't verified. And because the token SHAs are unchanged, this **removes a crash and changes no output**.

The bounds arithmetic in `f32_history_addressable` was independently re-derived for **both** `KvLayout` variants: `offset` is monotone in position, layer and kv_head in each, so the single max-offset probe really does bound the whole accessed range. The `position > allocated_sequence_length` early-out is load-bearing specifically for `HeadMajor`, where `alloc` is the stride and an over-large position would wrap into the next head's stream (in-bounds but wrong data). The call site's `range.end.saturating_sub(1)` is correct including for pipeline-sharded layer subranges.

## Known gaps — stated, not implied

- **`f32_history_addressable` is a BOUNDS probe, not a validity probe.** It catches the never-grown case only. Once any CPU fallback has grown the buffers, positions the GPU produced are still zero-filled, the probe passes, and the reseed copies zeros — *silently wrong output instead of a panic*. That path **predates this change and is not fixed by it**; the helper's doc and the call-site comment now say so explicitly. Closing it needs a materialized-through watermark on the cache, tracked separately.
- **Verified on macOS only.** Windows/Linux/CUDA rest on CI.
- **CI does not run the one test that catches this crash.** `tests/spec_draft_rollback.rs` skips without `CAMELID_DRAFT_ROLLBACK_GGUF` and still reports `ok`. The skip is reasonable (CI carries no model files), but as it stands this crash could regress with CI green. Run locally with:
  ```
  CAMELID_DRAFT_ROLLBACK_GGUF=/path/Llama-3.2-1B-Instruct-Q8_0.gguf \
    cargo test --release --test spec_draft_rollback -- --nocapture
  ```

The regression test also now asserts `cpu_steps == 0` for round 1. That is load-bearing rather than decorative: the pre-fix failure mode *requires* round 1 to stay entirely on the resident lane, because a single CPU-fallback step grows `kv_cache.keys` and makes the round-2 reseed find the buffers addressable — no panic, just silent zeros. Since the test asserts nothing about draft content, that outcome would have passed on a reverted build. The assertion stops the test from quietly ceasing to be a regression test.

No engine math, kernel, reduction order, or default-on path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
