### PR TITLE
ci(metal): measure whether the macOS runner can run the Metal test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,17 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets ${{ matrix.features }} -- -D warnings
 
+      # CAMELID_REQUIRE_METAL_TESTS=1 makes the macOS Metal lane fail-closed: the
+      # device-gated skips (56 in src/metal.rs, plus the draft-rollback regression guard
+      # in src/inference/tests.rs) become hard failures instead of silent passes. Enabled
+      # because the capability probe below MEASURED this runner as capable:
+      #   available=true resident_kernels=true device="Apple Paravirtual device"
+      # If GitHub ever withdraws the paravirtual Metal device, this leg goes red with an
+      # explicit message rather than quietly reverting to proving nothing — which is the
+      # entire point.
       - name: Tests
+        env:
+          CAMELID_REQUIRE_METAL_TESTS: ${{ runner.os == 'macOS' && '1' || '' }}
         run: cargo test --all-targets ${{ matrix.features }}
 
       # Report, in the log, whether this runner can actually execute the macOS Metal test
@@ -214,10 +224,12 @@ jobs:
       # in src/inference/tests.rs all self-skip on a host with no usable GPU session, and a
       # skip is indistinguishable from a pass in the summary above. This step prints the two
       # capabilities that decide it (`available`, `resident_kernels`) so the assumption is
-      # measured rather than asserted. It does NOT gate the build: once a runner is known to
-      # be capable, set CAMELID_REQUIRE_METAL_TESTS=1 here to make those skips fail-closed.
+      # measured rather than asserted, and keeps reporting them on every run so a change in
+      # the runner image is visible in the log rather than inferred from a red build.
       - name: Metal lane capability probe (macOS)
         if: runner.os == 'macOS'
+        env:
+          CAMELID_REQUIRE_METAL_TESTS: '1'
         run: cargo test --all-targets ${{ matrix.features }} metal_lane_capability_probe -- --nocapture
 
       - name: Docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,11 @@ jobs:
       #
       # macos-latest is Apple Silicon, so it compiles and lints the
       # cfg(target_os = "macos") Metal path that ubuntu never sees. The Metal
-      # tests self-skip when no GPU device is reported by the runner.
+      # tests self-skip when no GPU device is reported by the runner — which
+      # means a green macOS leg proves the Metal path COMPILES, not that any of
+      # it RAN. The "Metal lane capability probe" step below prints whether this
+      # runner has a usable device and can build the resident pipelines, so that
+      # is measured rather than assumed.
       # windows-latest (MSVC) is a first-class CPU target: it builds the
       # Windows file-I/O / mmap path (src/platform_fs.rs, the memmap2 wire
       # mapping) and runs the same exact-row gates as the other hosts.
@@ -204,6 +208,17 @@ jobs:
 
       - name: Tests
         run: cargo test --all-targets ${{ matrix.features }}
+
+      # Report, in the log, whether this runner can actually execute the macOS Metal test
+      # lane. 56 device-gated tests in src/metal.rs and the draft-rollback regression guard
+      # in src/inference/tests.rs all self-skip on a host with no usable GPU session, and a
+      # skip is indistinguishable from a pass in the summary above. This step prints the two
+      # capabilities that decide it (`available`, `resident_kernels`) so the assumption is
+      # measured rather than asserted. It does NOT gate the build: once a runner is known to
+      # be capable, set CAMELID_REQUIRE_METAL_TESTS=1 here to make those skips fail-closed.
+      - name: Metal lane capability probe (macOS)
+        if: runner.os == 'macOS'
+        run: cargo test --all-targets ${{ matrix.features }} metal_lane_capability_probe -- --nocapture
 
       - name: Docs
         run: cargo doc --no-deps ${{ matrix.features }}

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -13581,6 +13581,16 @@ fn metal_resident_rollback_moves_filled_with_the_kv_position() {
     let Some(mut state) =
         crate::metal::ResidentDecodeState::new(1, 1, 1, 32, 32, 32, 16, 64, 1.0e-5, false)
     else {
+        // No usable Metal lane. This is the ONLY guard for the draft-rollback regression that
+        // needs no model file, so a silent skip here means the regression is unguarded — and
+        // indistinguishable from a pass. Under CAMELID_REQUIRE_METAL_TESTS=1 (set by CI on the
+        // macOS leg once the runner is known to be capable) that is a failure, not a skip.
+        // `metal_lane_capability_probe` in src/metal.rs reports which capability is missing.
+        assert!(
+            std::env::var("CAMELID_REQUIRE_METAL_TESTS").as_deref() != Ok("1"),
+            "CAMELID_REQUIRE_METAL_TESTS=1 but ResidentDecodeState::new returned None — the \
+             draft-rollback regression is UNGUARDED on this runner"
+        );
         return; // no Metal device on this host — nothing to exercise
     };
 

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -14294,6 +14294,63 @@ pub fn detect_metal_device() -> MetalDeviceInfo {
 #[cfg(test)]
 mod tests {
 
+    /// Capability gate for the whole macOS Metal test lane.
+    ///
+    /// 56 device-gated tests in this file open with `if !detect_metal_device().available {
+    /// return; }`, and `metal_resident_rollback_moves_filled_with_the_kv_position`
+    /// (`src/inference/tests.rs`) — the only guard for the draft-rollback regression that needs
+    /// no model file — skips the same way on `ResidentDecodeState::new(..) -> None`. If the host
+    /// reports no device, or reports one whose driver cannot build the resident pipelines, every
+    /// one of them prints `ok` while proving nothing. CI has never measured which case it is on
+    /// `macos-latest`; the workflow comment merely *asserts* the tests self-skip.
+    ///
+    /// This test always PRINTS what the host can do (visible with `--nocapture`; CI runs it as a
+    /// dedicated step) and, under `CAMELID_REQUIRE_METAL_TESTS=1`, turns "no lane" into a hard
+    /// failure. Contributors never set that variable, so a Mac without a usable GPU session — or
+    /// a non-macOS host, where this test does not exist — still passes locally.
+    ///
+    /// Two distinct capabilities are reported, because they fail independently:
+    ///   `available`         — a Metal device exists.
+    ///   `resident_kernels`  — `ResidentDecodeState::new` built its shaders and pipelines, i.e.
+    ///                         the GPU-resident decode lane can actually run here.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn metal_lane_capability_probe() {
+        let info = super::detect_metal_device();
+        // Same shape as `tiny_kv_budget_session` (1 layer / 1 head / 1 kv head, dims 32,
+        // kv budget 64), so this reaches the kernel build with every dimension guard
+        // satisfied: `Some(..)` proves device + shader libraries + compute pipelines.
+        let resident = super::ResidentDecodeState::new(1, 1, 1, 32, 32, 32, 16, 64, 1.0e-5, false);
+        let resident_kernels = resident.is_some();
+        eprintln!(
+            "CAMELID_METAL_CAPABILITY available={} resident_kernels={} device={:?} \
+             headless={:?} unified={:?} low_power={:?} note={:?}",
+            info.available,
+            resident_kernels,
+            info.device_name,
+            info.headless,
+            info.has_unified_memory,
+            info.low_power,
+            info.note
+        );
+
+        if std::env::var("CAMELID_REQUIRE_METAL_TESTS").as_deref() != Ok("1") {
+            return;
+        }
+        assert!(
+            info.available,
+            "CAMELID_REQUIRE_METAL_TESTS=1 but no Metal device is reported — every \
+             device-gated Metal test on this host is a silent no-op"
+        );
+        assert!(
+            resident_kernels,
+            "CAMELID_REQUIRE_METAL_TESTS=1 and a Metal device is present ({:?}), but \
+             ResidentDecodeState::new returned None — the shaders/pipelines could not be \
+             built here, so the GPU-resident lane and its regression tests cannot run",
+            info.device_name
+        );
+    }
+
     /// End-to-end proof for the instant-start lane: Metal can wrap a page-aligned
     /// window of an mmap'd GGUF with newBufferWithBytesNoCopy and the GPU reads the
     /// file's own bytes at per-tensor offsets — no read loop, no conversion, no

--- a/tests/spec_draft_rollback.rs
+++ b/tests/spec_draft_rollback.rs
@@ -31,6 +31,15 @@ use std::sync::Arc;
 #[test]
 fn draft_model_rollback_after_rejection_keeps_the_resident_engine_in_sync() {
     let Some(model) = std::env::var_os("CAMELID_DRAFT_ROLLBACK_GGUF").map(PathBuf::from) else {
+        // Skipping is correct for contributors and for CI legs that carry no model files, but a
+        // skip that reports "ok" is indistinguishable from coverage. A job that is CONFIGURED to
+        // prove this fix opts in with CAMELID_REQUIRE_MODEL_TESTS=1 and then cannot silently
+        // degrade to a no-op.
+        assert!(
+            std::env::var("CAMELID_REQUIRE_MODEL_TESTS").as_deref() != Ok("1"),
+            "CAMELID_REQUIRE_MODEL_TESTS=1 but CAMELID_DRAFT_ROLLBACK_GGUF is unset — this job \
+             is configured to prove the draft-rollback fix and cannot"
+        );
         eprintln!("SKIP draft rollback regression: set CAMELID_DRAFT_ROLLBACK_GGUF");
         return;
     };
@@ -65,6 +74,17 @@ fn draft_model_rollback_after_rejection_keeps_the_resident_engine_in_sync() {
     let (_, resident_steps, cpu_steps) = drafter.take_forward_stats();
     let resident_lane = resident_steps > 0;
     eprintln!("round 1: drafts={first:?} resident_steps={resident_steps} cpu_steps={cpu_steps}");
+    // A model WAS supplied, so the caller asked for the resident lane. Falling back to CPU is
+    // not a softer pass — the panic this file guards lives in the resident reseed, so a CPU-only
+    // run proves nothing and every assertion below also holds with the fix reverted. Opt out
+    // explicitly (CAMELID_ALLOW_CPU_LANE=1) if you are deliberately smoke-testing the CPU path.
+    if !resident_lane && std::env::var("CAMELID_ALLOW_CPU_LANE").as_deref() != Ok("1") {
+        panic!(
+            "a model was supplied but the resident lane never engaged (resident_steps=0, \
+             cpu_steps={cpu_steps}) — this run cannot reproduce the pre-fix panic, which lives \
+             in the resident reseed. Set CAMELID_ALLOW_CPU_LANE=1 to accept a CPU-only run."
+        );
+    }
     // LOAD-BEARING PRECONDITION, not a nicety. The pre-fix failure mode is the panic in the
     // round-2 reseed, and that panic needs `kv_cache.keys` to still be EMPTY — i.e. round 1
     // must have stayed entirely on the resident lane. A single CPU-fallback step here calls


### PR DESCRIPTION
A green macOS CI leg proves the `cfg(target_os = "macos")` Metal path **compiles**. It did not prove any of it **ran**. This measures that, then acts on the answer.

## The gap

- **56** device-gated tests in `src/metal.rs` open with `if !detect_metal_device().available { return; }`.
- `metal_resident_rollback_moves_filled_with_the_kv_position` (`src/inference/tests.rs`) — the guard for the draft-rollback regression fixed in #485, which needs **no model file** — skips the same way when `ResidentDecodeState::new(..)` returns `None`.
- All of them then report `ok`.

`ci.yml` asserted *"The Metal tests self-skip when no GPU device is reported by the runner."* Nobody had measured which case CI was actually in. That assumption was load-bearing for a whole platform's coverage.

This began as "make `spec_draft_rollback` run in CI." Investigating it found something more useful: that test is **not** the only guard — the unit test above also fails on pre-fix source and needs no GGUF. The regression was guarded; the guard was just sitting behind an unmeasured skip, alongside 55 others.

## What the probe measured

`metal_lane_capability_probe` reports two capabilities that fail **independently**: `available` (a device exists) and `resident_kernels` (`ResidentDecodeState::new` built its shaders and compute pipelines). On GitHub's `macos-latest`:

```
CAMELID_METAL_CAPABILITY available=true resident_kernels=true
  device=Some("Apple Paravirtual device") headless=Some(false) unified=Some(true)
```

**`resident_kernels=true` on a paravirtual device.** The concern that the runner would advertise a GPU while failing to build the simdgroup-matrix MSL is refuted by measurement — it can compile and run the resident kernels.

## What that enables (second commit)

`CAMELID_REQUIRE_METAL_TESTS=1` is now set on the macOS test leg. Scope, precisely:

- It does **not** change the other 55 device-gated tests in `src/metal.rs`. They still open with `if !available { return; }` and run only because a device is present.
- It **does** convert the two skips that would hide a missing lane into hard failures: the probe itself, and the draft-rollback regression guard.

Confirmed on the runner, in fail-closed mode:

```
test inference::tests::metal_resident_rollback_moves_filled_with_the_kv_position ... ok
test result: ok. 881 passed; 0 failed; 19 ignored
```

So the regression fixed in #485 is now genuinely enforced by CI, on hardware proven able to execute it, with **no GGUF required**. If GitHub withdraws the paravirtual Metal device, this leg goes red naming what disappeared, instead of quietly reverting to proving nothing.

## Two vacuous passes closed

- **`tests/spec_draft_rollback.rs` now FAILS when a model was supplied but the resident lane never engaged** (`resident_steps == 0`). The panic it guards lives in the *resident reseed*; a CPU-only run proves nothing, and every assertion in the file also holds with the fix reverted. Handing the test a model on a machine without a working GPU session would have looked like coverage. Opt out deliberately with `CAMELID_ALLOW_CPU_LANE=1`.
- Its **missing-model skip** stays a skip for contributors and model-less CI legs, but a job setting `CAMELID_REQUIRE_MODEL_TESTS=1` can no longer degrade into a silent no-op.

## What this still does NOT cover

`spec_draft_rollback` itself **still skips in CI** — it needs a real GGUF, and CI carries none. Its end-to-end draft-model path is therefore still unexercised there. What changed is that the regression it guards is now covered by a model-free test that CI provably runs, and that `spec_draft_rollback` can no longer *claim* coverage it did not deliver.

Closing that last gap means a synthetic loadable model (tokenizer + weights). `write_llama_gguf` in `tests/model_binding.rs` is metadata-shaped, not runnable, so this is days of work — now worth considering only because the probe proved the runner could actually execute it.

## Safety

No engine math, kernel, reduction order, or default-on path changed. The probe is `#[cfg(target_os = "macos")]`, so the Linux and Windows legs are untouched. Every new assertion is behind an env var; the only leg that sets one is macOS, and it passes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
