### PR TITLE
fix(resident): guard the speculative verify chunk against a hollow KV history

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -3780,6 +3780,16 @@ impl LlamaInferenceSession {
             )));
         }
 
+        // Guard the third CPU KV-history reader, exactly as the other two CPU forward paths do
+        // (`forward_layer_range_from_hidden`, `forward_single_token_timed_internal`). The layer
+        // loop below attends over `[0, chunk_base_position)`; on a sequence that has been running
+        // on a GPU-resident lane, those rows live only on the device and the CPU buffers are
+        // hollow, so reading them zero-filled corrupts the greedy argmax that decides accepted
+        // drafts — and the batch write then advances the materialized-through watermark ACROSS the
+        // unwritten gap, so a later resident reseed launders the zeros onto the GPU permanently.
+        // Mirror the resident KV back first; a no-op once the cache is already materialized.
+        self.ensure_cpu_kv_materialized()?;
+
         let runtime_plan = ResolvedRuntimePlan::from_env()?;
         let chunk_base_position = self.kv_cache.position;
         let total_started = Instant::now();

--- a/tests/resident_kv_cpu_fallback.rs
+++ b/tests/resident_kv_cpu_fallback.rs
@@ -213,3 +213,98 @@ fn cpu_fallback_mid_sequence_preserves_the_resident_kv_history() {
         );
     }
 }
+
+/// Greedy generation on the GPU-resident lane, but at `FALLBACK_AT` the next token is produced by
+/// the SPECULATIVE CPU verify path (`forward_greedy_verify_chunk`, a one-token batch) instead of a
+/// resident decode step. Returns `None` if the resident lane was never actually taken.
+///
+/// That path is the THIRD CPU KV-history reader (alongside `forward_layer_range_from_hidden` and
+/// `forward_single_token_timed_internal`). Before its guard it attended over `[0, position)`
+/// without mirroring the resident KV back, so on a hollow CPU cache it read a zero-filled prefix —
+/// and its batch write then advanced the materialized-through watermark ACROSS the unwritten gap,
+/// so the NEXT resident step's reseed (which trusts the watermark) copied those zeros onto the GPU
+/// and made the corruption permanent. In production this path is reached under `CAMELID_SPEC_GPU=1`
+/// when `verify_drafts_gpu` declines (an offloaded engine, or a multi-session same-model collision);
+/// the test drives it directly, which covers the recovery the same way regardless of how it is
+/// reached.
+fn resident_run_verify_chunk(model: &Model, force_verify_chunk: bool) -> Option<Vec<u32>> {
+    let mut s = session(model);
+
+    // Produce the whole history on the resident lane so the CPU KV buffers stay empty — the state
+    // the bug needs.
+    let (&first, rest) = model.prompt.split_first().expect("non-empty prompt");
+    let mut next = s.generate_next_token_greedy_resident(first).ok()??.0;
+    for &tok in rest {
+        next = s.generate_next_token_greedy_resident(tok).ok()??.0;
+    }
+
+    // Same load-bearing precondition as the single-token regression: a hollow CPU history is what
+    // makes the verify chunk's read observable. If the prompt materialized the CPU buffers this
+    // run would pass even with the guard reverted.
+    assert!(
+        !s.cpu_kv_authoritative(),
+        "the resident prompt left the CPU KV cache authoritative, so this run cannot prove \
+         anything about a hollow GPU-only history"
+    );
+
+    let mut out = Vec::with_capacity(GENERATE);
+    for i in 0..GENERATE {
+        out.push(next);
+        let fed = next;
+        next = if force_verify_chunk && i == FALLBACK_AT {
+            // One token off the resident lane, through the speculative CPU verify chunk. A batch of
+            // exactly the fed token appends one position and predicts the token after it — the same
+            // net effect as a decode step, but computed on the CPU path that reads `[0, position)`.
+            let (predictions, _timings) = s
+                .forward_greedy_verify_chunk(&[fed])
+                .expect("verify chunk forward");
+            assert_eq!(
+                predictions.len(),
+                1,
+                "a one-token chunk yields one prediction"
+            );
+            predictions[0]
+        } else {
+            match s.generate_next_token_greedy_resident(fed) {
+                Ok(Some((id, _))) => id,
+                Ok(None) => panic!("resident lane declined unexpectedly at generated token {i}"),
+                Err(e) => panic!("resident generation step {i} failed: {e}"),
+            }
+        };
+    }
+    Some(out)
+}
+
+#[test]
+fn speculative_verify_chunk_preserves_the_resident_kv_history() {
+    let Some(model) = load() else {
+        eprintln!(
+            "SKIP verify-chunk resident KV regression: set CAMELID_RESIDENT_KV_FALLBACK_GGUF"
+        );
+        return;
+    };
+    // Same lane opt-in as the sibling test: inert on a CUDA host (default-on), required on Metal.
+    std::env::set_var("CAMELID_METAL_RESIDENT_DECODE", "1");
+
+    let Some(clean) = resident_run_verify_chunk(&model, false) else {
+        eprintln!(
+            "SKIP verify-chunk resident KV regression: resident lane unavailable on this host"
+        );
+        return;
+    };
+    eprintln!("resident, no verify-chunk : {clean:?}");
+
+    let with_chunk = resident_run_verify_chunk(&model, true)
+        .expect("the resident lane was available for the control run, so it must be here too");
+    eprintln!("resident, one verify-chunk: {with_chunk:?}");
+
+    // THE assertion. One speculative CPU verify chunk in the middle of a resident sequence must be
+    // transparent. Pre-guard this fails hard: the chunk attends over a zeroed prefix, then the next
+    // resident reseed copies those zeros onto the GPU, so the tail is unrelated text.
+    assert_eq!(
+        with_chunk, clean,
+        "one speculative CPU verify chunk changed the output — forward_greedy_verify_chunk read a \
+         hollow GPU-only KV history (the CPU cache holds no history for GPU-produced positions), so \
+         it attended over a zeroed prefix and the next resident reseed made it stick"
+    );
+}


### PR DESCRIPTION
## The gap

[PR #487](https://github.com/timtoole02/Camelid/pull/487) mirrored the GPU-resident KV back into the CPU cache before any CPU forward reads it (`ensure_cpu_kv_materialized`), closing the "a CPU fallback silently zeroes a GPU KV history" bug for **two** of the three CPU KV-history readers:

- `forward_layer_range_from_hidden` (`src/inference.rs:3555`)
- `forward_single_token_timed_internal` (`src/inference.rs:4176`)

It missed the **third**: `forward_greedy_verify_chunk` (`src/inference.rs:3761`), the speculative-decode CPU verify path.

Under `CAMELID_SPEC_GPU=1` the resident single-token lane stays enabled, so plain steps advance `kv_cache.position` while writing nothing to the CPU buffers — the CPU history goes hollow. When `verify_drafts_gpu` then **declines** (an offloaded engine in a constrained-VRAM run, or a multi-session same-model collision), control falls to `forward_greedy_verify_chunk` (`src/api/mod.rs:11133`). It attends over `[0, chunk_base_position)` — zero-filled for every GPU-produced position — so the greedy argmax that decides accepted drafts is computed over a corrupted context, **and** the batch write then advances the materialized-through watermark *across* the unwritten gap, so the next resident reseed (which trusts the watermark) copies those zeros onto the GPU and makes it permanent. Exactly the bug class #487 set out to eliminate, reached through the one reader it didn't guard.

This is **pre-existing** (the spec loop and `resident_paths_disabled` gating live in `src/api/mod.rs`, untouched by #487 — it reproduces at that PR's base) and **config-gated** (needs the `CAMELID_SPEC_GPU=1` opt-in plus a declined GPU verify), which is why it wasn't a merge blocker for #487.

## The fix

The same guard the other two readers already use — `self.ensure_cpu_kv_materialized()?;` at the top of `forward_greedy_verify_chunk`, before the layer loop reads history. It mirrors the resident KV back (Metal then CUDA, with the CUDA identity checks), never `Err`s on the CPU path, restores the watermark on a partial recovery, and is a no-op once the cache is already materialized. No kernel math, reduction order, or default-on path changes.

## Verification (M4 / CUDA RTX 3060 Laptop, `Llama-3.2-1B-Instruct-Q8_0`)

New backend-agnostic regression `speculative_verify_chunk_preserves_the_resident_kv_history` in `tests/resident_kv_cpu_fallback.rs`: produces the whole history on the resident lane (CPU cache hollow, asserted via `!cpu_kv_authoritative()`), then at one mid-sequence step takes the next token through a single-token `forward_greedy_verify_chunk` instead of a resident decode step. Binding assertion is resident-with-chunk == resident-clean — the forced chunk is the only variable.

**Reverting only the guard makes it FAIL, and it passes with the guard** (CUDA lane engaged, 16 layers resident):

```
# guard reverted:
resident, no verify-chunk : [22463, 13, 578, 6864, 315, 18157, 374, 25048]
resident, one verify-chunk: [22463, 13, 578, 1888, 893, 374, 578, 893]   <-- derails one token after the chunk
test speculative_verify_chunk_preserves_the_resident_kv_history ... FAILED
test cpu_fallback_mid_sequence_preserves_the_resident_kv_history ... ok    <-- #487's readers unaffected

# guard applied:
resident, no verify-chunk : [22463, 13, 578, 6864, 315, 18157, 374, 25048]
resident, one verify-chunk: [22463, 13, 578, 6864, 315, 18157, 374, 25048]
test result: ok. 2 passed; 0 failed
```

- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --release --all-targets --no-fail-fast` — 0 failed on Windows (the release-only `nvfp4` `encode_vectors…` row that is red on M4 passes on x86, as established in #487).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
