### PR TITLE
feat(verify): verify sealed agent-family receipts (+ ornith gate fix)

### DIFF
--- a/src/chat/agent_bench.rs
+++ b/src/chat/agent_bench.rs
@@ -17,12 +17,11 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use super::agent_orchestration::{family_for, hostname, poll_to_terminal};
 use super::subagent::{self, SubagentConfig};
 
-pub const RECEIPT_SCHEMA_V1: &str = "camelid.agent-orchestration-bench/v1";
+pub const RECEIPT_SCHEMA_V1: &str = crate::receipt::agent::ORCHESTRATION_BENCH_SCHEMA_V1;
 
 pub struct BenchConfig {
     pub receipt_dir: PathBuf,
@@ -70,11 +69,7 @@ struct BenchReceipt {
 
 impl BenchReceipt {
     fn compute_receipt_id(&self) -> String {
-        let mut value = serde_json::to_value(self).expect("receipt serializes");
-        if let Value::Object(map) = &mut value {
-            map.remove("receipt_id");
-        }
-        crate::receipt::sha256_hex(crate::receipt::canonical_json(&value).as_bytes())
+        crate::receipt::receipt_id_over(&serde_json::to_value(self).expect("receipt serializes"))
     }
     fn seal(&mut self) {
         self.receipt_id = self.compute_receipt_id();

--- a/src/chat/agent_orchestration.rs
+++ b/src/chat/agent_orchestration.rs
@@ -21,12 +21,11 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use super::agent_eval::EvalOutcome;
 use super::subagent::{self, SubagentConfig};
 
-pub const RECEIPT_SCHEMA_V1: &str = "camelid.agent-orchestration-receipt/v1";
+pub const RECEIPT_SCHEMA_V1: &str = crate::receipt::agent::ORCHESTRATION_RECEIPT_SCHEMA_V1;
 
 pub struct OrchestrationConfig {
     pub receipt_dir: PathBuf,
@@ -75,11 +74,7 @@ struct OrchestrationReceipt {
 
 impl OrchestrationReceipt {
     fn compute_receipt_id(&self) -> String {
-        let mut value = serde_json::to_value(self).expect("receipt serializes to JSON");
-        if let Value::Object(map) = &mut value {
-            map.remove("receipt_id");
-        }
-        crate::receipt::sha256_hex(crate::receipt::canonical_json(&value).as_bytes())
+        crate::receipt::receipt_id_over(&serde_json::to_value(self).expect("receipt serializes"))
     }
     fn seal(&mut self) {
         self.receipt_id = self.compute_receipt_id();

--- a/src/chat/agent_orchestration.rs
+++ b/src/chat/agent_orchestration.rs
@@ -339,7 +339,13 @@ pub(super) fn family_for(model: &Path) -> String {
         .and_then(|n| n.to_str())
         .unwrap_or("")
         .to_lowercase();
-    if name.contains("qwen") {
+    // Ornith / Qwen3.5 emit the custom `<function=…>` XML tool format, which routes
+    // to `parse_ornith`. Check before "qwen" (the model is Qwen3.5-derived but its
+    // tool grammar differs from Qwen2/Qwen3 JSON-in-`<tool_call>`). Mirrors
+    // `agent_eval::family_for` so the two gate harnesses classify a model identically.
+    if name.contains("ornith") || name.contains("qwen35") || name.contains("qwen3.5") {
+        "ornith".to_string()
+    } else if name.contains("qwen") {
         "qwen".to_string()
     } else if name.contains("mistral") {
         "mistral".to_string()
@@ -654,5 +660,18 @@ mod tests {
         let r = sample();
         assert!(!r.promotes_capability);
         assert!(!r.claims_speedup);
+    }
+
+    #[test]
+    fn family_for_routes_ornith_before_qwen() {
+        // Ornith / Qwen3.5 must classify as `ornith` (custom `<function=…>` XML tool
+        // grammar), not `qwen` — matching `agent_eval::family_for`. Regression for a
+        // missing arm that misrouted these models to the JSON tool parser.
+        assert_eq!(family_for(Path::new("Ornith-4B-Q8_0.gguf")), "ornith");
+        assert_eq!(family_for(Path::new("Qwen3.5-4B-Instruct.gguf")), "ornith");
+        assert_eq!(family_for(Path::new("qwen35-coder.gguf")), "ornith");
+        assert_eq!(family_for(Path::new("Qwen3-4B-Q4_K_M.gguf")), "qwen");
+        assert_eq!(family_for(Path::new("Mistral-7B.gguf")), "mistral");
+        assert_eq!(family_for(Path::new("Llama-3.2-3B.gguf")), "llama");
     }
 }

--- a/src/chat/agent_syscap.rs
+++ b/src/chat/agent_syscap.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 
 use super::agent_eval::EvalOutcome;
 
-pub const RECEIPT_SCHEMA_V1: &str = "camelid.agent-syscap-receipt/v1";
+pub const RECEIPT_SCHEMA_V1: &str = crate::receipt::agent::SYSCAP_RECEIPT_SCHEMA_V1;
 
 pub struct SyscapConfig {
     pub receipt_dir: PathBuf,
@@ -58,15 +58,12 @@ struct SyscapReceipt {
 }
 
 impl SyscapReceipt {
-    /// SHA-256 of the canonical body (key-sorted, compact, `receipt_id` removed),
-    /// reusing the shared receipt helpers so the digest matches the rest of the
-    /// repo's tamper-evident artifacts.
+    /// The sealed `receipt_id`: SHA-256 over the canonical body (`receipt_id`
+    /// removed, recursively key-sorted, compact). Delegates to the shared
+    /// [`camelid::receipt::receipt_id_over`] primitive so this seal and the
+    /// standalone verifier compute the identical digest.
     fn compute_receipt_id(&self) -> String {
-        let mut value = serde_json::to_value(self).expect("receipt serializes to JSON");
-        if let Value::Object(map) = &mut value {
-            map.remove("receipt_id");
-        }
-        crate::receipt::sha256_hex(crate::receipt::canonical_json(&value).as_bytes())
+        crate::receipt::receipt_id_over(&serde_json::to_value(self).expect("receipt serializes"))
     }
 
     fn seal(&mut self) {

--- a/src/chat/agent_syscap.rs
+++ b/src/chat/agent_syscap.rs
@@ -16,6 +16,9 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
+// Only the Windows battery (`run_battery`) constructs `ToolCall` args as a
+// `Value`; off-Windows that code is `cfg`'d out, so the import would be unused.
+#[cfg(windows)]
 use serde_json::Value;
 
 use super::agent_eval::EvalOutcome;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1189,16 +1189,18 @@ enum Command {
         #[arg(long)]
         threads: Option<usize>,
     },
-    /// Verify a parity receipt: self-digest, lane identity, an in-process
-    /// Camelid re-run, and a llama.cpp reference re-run. A verified receipt
-    /// proves one request matched the reference for one exact GGUF; it does
-    /// not change any support claim.
+    /// Verify a receipt. For a parity receipt: self-digest, lane identity, an
+    /// in-process Camelid re-run, and a llama.cpp reference re-run (requires
+    /// `--gguf`). For a sealed agent-family receipt (syscap / orchestration /
+    /// bench): a self-contained tamper-evidence + honest-scope check, no GGUF.
+    /// A verified receipt changes no support claim.
     VerifyReceipt {
         /// Path to the receipt JSON file.
         receipt: PathBuf,
-        /// The exact GGUF file the receipt names (its SHA-256 must match).
+        /// The exact GGUF the receipt names (its SHA-256 must match). Required
+        /// for a parity receipt; agent-family receipts need no GGUF.
         #[arg(long)]
-        gguf: PathBuf,
+        gguf: Option<PathBuf>,
         /// llama-server binary for the reference re-run (path or name in PATH).
         #[arg(long, default_value = "llama-server")]
         llama_server: String,
@@ -2516,7 +2518,31 @@ async fn main() -> anyhow::Result<()> {
             llama_port,
             threads,
         } => {
+            // Route a sealed agent-family receipt to its self-contained verifier
+            // (no model, no GGUF). Any doubt about the schema falls through to the
+            // parity path below, which is left unchanged.
+            let is_agent = std::fs::read_to_string(&receipt)
+                .ok()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+                .and_then(|value| {
+                    value
+                        .get("schema")
+                        .and_then(|schema| schema.as_str())
+                        .map(camelid::receipt::agent::is_agent_schema)
+                })
+                .unwrap_or(false);
+            if is_agent {
+                let outcome = camelid::receipt::agent::run(&receipt);
+                std::process::exit(outcome.exit_code());
+            }
+
             configure_rayon_threads(threads)?;
+            let gguf = gguf.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "parity verification requires the exact GGUF via --gguf; agent-family \
+                     receipts (syscap / orchestration / bench) need no GGUF"
+                )
+            })?;
             let mode = if self_only {
                 camelid::receipt::verify::VerifyMode::SelfOnly
             } else if reference_only {

--- a/src/receipt/agent.rs
+++ b/src/receipt/agent.rs
@@ -1,0 +1,587 @@
+//! Standalone verifier for the sealed agent-family receipts, exposed through
+//! `camelid verify-receipt`.
+//!
+//! The agent gates each emit a **tamper-evident** receipt sealed with the shared
+//! [`receipt_id`](super::receipt_id_over) digest:
+//!
+//! - `agent-syscap-eval` → `camelid.agent-syscap-receipt/v1`
+//! - `agent-orchestration-eval` → `camelid.agent-orchestration-receipt/v1`
+//! - `agent-orchestration-bench` → `camelid.agent-orchestration-bench/v1`
+//!
+//! Unlike a parity receipt there is no model to re-run: verification is a
+//! self-contained **tamper-evidence + honest-scope** check.
+//!
+//! 1. *Tamper-evidence* — the document's canonical body (every field except
+//!    `receipt_id`, recursively key-sorted and compact) must hash to the stored
+//!    `receipt_id`. Any added, removed, or altered field breaks the match.
+//! 2. *Honest-scope* — a well-formed but over-claiming receipt is rejected. These
+//!    gates promote no capability and (for orchestration) claim no speedup; a
+//!    receipt whose own scope fields say otherwise is not a valid artifact of the
+//!    gate that supposedly produced it.
+//!
+//! A verified agent receipt attests that the document is intact and claims
+//! nothing it should not. Like every receipt in this crate, it promotes no
+//! support claim.
+
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+use super::receipt_id_over;
+
+/// Schema stamped into an `agent-syscap-eval` receipt.
+pub const SYSCAP_RECEIPT_SCHEMA_V1: &str = "camelid.agent-syscap-receipt/v1";
+/// Schema stamped into an `agent-orchestration-eval` receipt.
+pub const ORCHESTRATION_RECEIPT_SCHEMA_V1: &str = "camelid.agent-orchestration-receipt/v1";
+/// Schema stamped into an `agent-orchestration-bench` receipt.
+pub const ORCHESTRATION_BENCH_SCHEMA_V1: &str = "camelid.agent-orchestration-bench/v1";
+
+/// Every agent-family schema this verifier understands.
+pub const RECOGNIZED_SCHEMAS: [&str; 3] = [
+    SYSCAP_RECEIPT_SCHEMA_V1,
+    ORCHESTRATION_RECEIPT_SCHEMA_V1,
+    ORCHESTRATION_BENCH_SCHEMA_V1,
+];
+
+/// True when `schema` names an agent-family receipt this module can verify.
+/// The CLI uses this to route a receipt to this verifier instead of the parity
+/// verifier.
+pub fn is_agent_schema(schema: &str) -> bool {
+    RECOGNIZED_SCHEMAS.contains(&schema)
+}
+
+/// Which agent gate produced a receipt. Each family has a distinct body shape
+/// and a distinct honest-scope contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentReceiptClass {
+    /// `camelid.agent-syscap-receipt/v1`.
+    Syscap,
+    /// `camelid.agent-orchestration-receipt/v1`.
+    Orchestration,
+    /// `camelid.agent-orchestration-bench/v1`.
+    OrchestrationBench,
+}
+
+impl AgentReceiptClass {
+    fn from_schema(schema: &str) -> Option<Self> {
+        match schema {
+            SYSCAP_RECEIPT_SCHEMA_V1 => Some(Self::Syscap),
+            ORCHESTRATION_RECEIPT_SCHEMA_V1 => Some(Self::Orchestration),
+            ORCHESTRATION_BENCH_SCHEMA_V1 => Some(Self::OrchestrationBench),
+            _ => None,
+        }
+    }
+
+    /// The field carrying the receipt's own top-line result: `outcome` for the
+    /// eval gates (PASS/FAIL/INCONCLUSIVE), `verdict` for the wall-clock bench.
+    fn result_field(self) -> &'static str {
+        match self {
+            Self::Syscap | Self::Orchestration => "outcome",
+            Self::OrchestrationBench => "verdict",
+        }
+    }
+
+    /// Verify the family's honest-scope invariants and return a human-readable
+    /// summary of what was checked. The digest is already confirmed by the time
+    /// this runs, so these guards additionally reject a *freshly sealed* but
+    /// over-claiming receipt (one the digest alone would accept).
+    fn check_honest_scope(self, obj: &Map<String, Value>) -> Result<String, AgentVerifyError> {
+        match self {
+            Self::Syscap => {
+                require_false(obj, "promotes_capability")?;
+                Ok("promotes_capability=false".to_string())
+            }
+            Self::Orchestration => {
+                require_false(obj, "promotes_capability")?;
+                require_false(obj, "claims_speedup")?;
+                Ok("promotes_capability=false, claims_speedup=false".to_string())
+            }
+            Self::OrchestrationBench => {
+                // The bench measures wall-clock and never carries
+                // `promotes_capability`. Its honest-scope field is
+                // `speedup_claimed_for`: a string naming the one measured
+                // workload a speedup may be attributed to (or "none").
+                let claimed = obj
+                    .get("speedup_claimed_for")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| AgentVerifyError {
+                        phase: "honest-scope",
+                        reason: "bench receipt is missing the string `speedup_claimed_for` \
+                                 scope field"
+                            .to_string(),
+                    })?;
+                Ok(format!("speedup_claimed_for={claimed:?}"))
+            }
+        }
+    }
+}
+
+/// A boolean scope field that every honest receipt of the family pins to
+/// `false` (e.g. `promotes_capability`, `claims_speedup`).
+fn require_false(obj: &Map<String, Value>, field: &str) -> Result<(), AgentVerifyError> {
+    match obj.get(field).and_then(Value::as_bool) {
+        Some(false) => Ok(()),
+        Some(true) => Err(AgentVerifyError {
+            phase: "honest-scope",
+            reason: format!(
+                "receipt sets {field}=true; an agent gate promotes no capability and this \
+                 field must be false"
+            ),
+        }),
+        None => Err(AgentVerifyError {
+            phase: "honest-scope",
+            reason: format!("receipt is missing the boolean `{field}` scope field"),
+        }),
+    }
+}
+
+/// The outcome of verifying an agent-family receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentVerifyOutcome {
+    /// Schema recognized, digest intact, honest-scope invariants hold.
+    Verified,
+    /// A verification step failed (unrecognized schema, tampered/malformed body,
+    /// or an over-claiming scope field).
+    NotVerified,
+}
+
+impl AgentVerifyOutcome {
+    /// Process exit code: 0 verified, 1 not verified. (No divergence/lossy axes
+    /// apply to an agent receipt, so the code set is deliberately just 0/1.)
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::Verified => 0,
+            Self::NotVerified => 1,
+        }
+    }
+}
+
+/// The verification step that failed, and why. `phase` is a stable short label
+/// echoed in the final verdict line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentVerifyError {
+    pub phase: &'static str,
+    pub reason: String,
+}
+
+/// What a verified receipt attests, for reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReceiptSummary {
+    pub schema: String,
+    pub class: AgentReceiptClass,
+    pub receipt_id: String,
+    /// The receipt's own top-line result (`outcome` or `verdict`), verbatim.
+    pub result: String,
+    /// Human-readable summary of the honest-scope fields that were checked.
+    pub scope_note: String,
+    /// `os/arch` or `os/arch (hostname)` from the receipt's `host` block.
+    pub host: String,
+}
+
+/// Pure verification: no I/O, no printing. Returns what the receipt attests, or
+/// the first failing step. Exhaustively unit-tested.
+pub fn check(value: &Value) -> Result<AgentReceiptSummary, AgentVerifyError> {
+    let obj = value.as_object().ok_or_else(|| AgentVerifyError {
+        phase: "parse",
+        reason: "receipt is not a JSON object".to_string(),
+    })?;
+
+    // Schema — must be one this verifier understands.
+    let schema = obj
+        .get("schema")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AgentVerifyError {
+            phase: "schema",
+            reason: "receipt has no string `schema` field".to_string(),
+        })?;
+    let class = AgentReceiptClass::from_schema(schema).ok_or_else(|| AgentVerifyError {
+        phase: "schema",
+        reason: format!(
+            "unrecognized schema {schema:?}; this verifier understands {RECOGNIZED_SCHEMAS:?}"
+        ),
+    })?;
+
+    // Receipt id — must be a 64-char lowercase-hex SHA-256.
+    let receipt_id = obj
+        .get("receipt_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AgentVerifyError {
+            phase: "self-digest",
+            reason: "receipt has no string `receipt_id` field".to_string(),
+        })?;
+    if !is_sha256_hex(receipt_id) {
+        return Err(AgentVerifyError {
+            phase: "self-digest",
+            reason: format!(
+                "receipt_id {receipt_id:?} is not a 64-character lowercase-hex SHA-256"
+            ),
+        });
+    }
+
+    // Strict self-digest over the exact document body.
+    let computed = receipt_id_over(value);
+    if computed != receipt_id {
+        return Err(AgentVerifyError {
+            phase: "self-digest",
+            reason: format!(
+                "receipt_id does not match the canonical body (stored {receipt_id}, computed \
+                 {computed}); the receipt is tampered or malformed"
+            ),
+        });
+    }
+
+    // Honest-scope — reject a well-formed but over-claiming receipt.
+    let scope_note = class.check_honest_scope(obj)?;
+
+    Ok(AgentReceiptSummary {
+        schema: schema.to_string(),
+        class,
+        receipt_id: receipt_id.to_string(),
+        result: obj
+            .get(class.result_field())
+            .and_then(Value::as_str)
+            .unwrap_or("(none)")
+            .to_string(),
+        scope_note,
+        host: host_line(obj),
+    })
+}
+
+/// Verify a parsed receipt, printing one PASS/FAIL/NOTE line per step and a
+/// single final verdict, and return the outcome.
+pub fn verify_value(value: &Value) -> AgentVerifyOutcome {
+    match check(value) {
+        Ok(summary) => {
+            println!(
+                "PASS schema: recognized agent-family receipt ({})",
+                summary.schema
+            );
+            println!(
+                "PASS self-digest: receipt_id matches the canonical body ({})",
+                summary.receipt_id
+            );
+            println!(
+                "PASS honest-scope: {} (this gate promotes no capability)",
+                summary.scope_note
+            );
+            println!(
+                "NOTE receipt: {}={}; host {}",
+                summary.class.result_field(),
+                summary.result,
+                summary.host
+            );
+            println!("AGENT RECEIPT VERIFIED (tamper-evident; promotes no capability)");
+            AgentVerifyOutcome::Verified
+        }
+        Err(err) => {
+            println!("FAIL {}: {}", err.phase, err.reason);
+            println!("AGENT RECEIPT NOT VERIFIED ({})", err.phase);
+            AgentVerifyOutcome::NotVerified
+        }
+    }
+}
+
+/// Read a receipt file, parse it, and verify it. Read/parse failures are
+/// reported as a `NotVerified` outcome (never a panic).
+pub fn run(path: &Path) -> AgentVerifyOutcome {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(err) => {
+            println!("FAIL parse: could not read {}: {err}", path.display());
+            println!("AGENT RECEIPT NOT VERIFIED (parse)");
+            return AgentVerifyOutcome::NotVerified;
+        }
+    };
+    let value: Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(err) => {
+            println!("FAIL parse: receipt does not parse as JSON: {err}");
+            println!("AGENT RECEIPT NOT VERIFIED (parse)");
+            return AgentVerifyOutcome::NotVerified;
+        }
+    };
+    verify_value(&value)
+}
+
+/// A 64-character lowercase-hex string, as produced by [`super::sha256_hex`].
+fn is_sha256_hex(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// `os/arch` or `os/arch (hostname)` from the receipt's `host` block, with `?`
+/// standing in for any absent piece.
+fn host_line(obj: &Map<String, Value>) -> String {
+    let host = obj.get("host").and_then(Value::as_object);
+    let field = |key: &str| {
+        host.and_then(|h| h.get(key))
+            .and_then(Value::as_str)
+            .unwrap_or("?")
+            .to_string()
+    };
+    let os = field("os");
+    let arch = field("arch");
+    match host.and_then(|h| h.get("hostname")).and_then(Value::as_str) {
+        Some(name) => format!("{os}/{arch} ({name})"),
+        None => format!("{os}/{arch}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Stamp `receipt_id` over the body exactly as the emitters do, so the test
+    /// fixtures are sealed by the same primitive the verifier checks.
+    fn seal(mut body: Value) -> Value {
+        let id = receipt_id_over(&body);
+        body.as_object_mut()
+            .expect("body is an object")
+            .insert("receipt_id".to_string(), Value::String(id));
+        body
+    }
+
+    fn syscap_body() -> Value {
+        json!({
+            "schema": SYSCAP_RECEIPT_SCHEMA_V1,
+            "receipt_id": "",
+            "created_unix": 1_784_747_759u64,
+            "feature": "windows-system-control: run_windows_command (Exec) + inspect_system (Read)",
+            "outcome": "PASS",
+            "host": { "os": "windows", "arch": "x86_64", "hostname": "TEST-BOX" },
+            "cases": [
+                { "name": "echo", "input": "echo hi", "observed": "hi", "verdict": "PASS" }
+            ],
+            "note": "syscap tools verified under the gate",
+            "promotes_capability": false
+        })
+    }
+
+    fn orchestration_body() -> Value {
+        json!({
+            "schema": ORCHESTRATION_RECEIPT_SCHEMA_V1,
+            "receipt_id": "",
+            "created_unix": 1_784_747_760u64,
+            "feature": "subagent-orchestration: spawn_subagent + check_subagent_status",
+            "rung": 2,
+            "outcome": "PASS",
+            "host": { "os": "linux", "arch": "aarch64" },
+            "cases": [ { "name": "spawn", "observed": "collected", "verdict": "PASS" } ],
+            "note": "stub round-trip + caps/depth/reaping",
+            "promotes_capability": false,
+            "claims_speedup": false
+        })
+    }
+
+    fn bench_body() -> Value {
+        json!({
+            "schema": ORCHESTRATION_BENCH_SCHEMA_V1,
+            "receipt_id": "",
+            "created_unix": 1_784_747_761u64,
+            "rung": 4,
+            "host": { "os": "windows", "arch": "x86_64", "hostname": "BENCH-BOX" },
+            "workloads": [
+                {
+                    "name": "io_bound_sleep",
+                    "subagents": 4,
+                    "sequential_ms": 400,
+                    "concurrent_ms": 120,
+                    "speedup": 3.3333333333333335,
+                    "note": "sleeps overlap"
+                }
+            ],
+            "verdict": "io-bound concurrency helped; inference-bound not measured",
+            "speedup_claimed_for": "io_bound_sleep",
+            "notes": []
+        })
+    }
+
+    #[test]
+    fn recognizes_exactly_the_three_agent_schemas() {
+        assert!(is_agent_schema(SYSCAP_RECEIPT_SCHEMA_V1));
+        assert!(is_agent_schema(ORCHESTRATION_RECEIPT_SCHEMA_V1));
+        assert!(is_agent_schema(ORCHESTRATION_BENCH_SCHEMA_V1));
+        assert!(!is_agent_schema("camelid.parity-receipt/v1"));
+        assert!(!is_agent_schema("camelid.agent-eval/v1"));
+        assert!(!is_agent_schema(""));
+    }
+
+    #[test]
+    fn verifies_a_sealed_syscap_receipt() {
+        let receipt = seal(syscap_body());
+        let summary = check(&receipt).expect("verifies");
+        assert_eq!(summary.class, AgentReceiptClass::Syscap);
+        assert_eq!(summary.result, "PASS");
+        assert_eq!(summary.scope_note, "promotes_capability=false");
+        assert_eq!(summary.host, "windows/x86_64 (TEST-BOX)");
+        assert_eq!(verify_value(&receipt), AgentVerifyOutcome::Verified);
+    }
+
+    #[test]
+    fn verifies_a_sealed_orchestration_receipt() {
+        let receipt = seal(orchestration_body());
+        let summary = check(&receipt).expect("verifies");
+        assert_eq!(summary.class, AgentReceiptClass::Orchestration);
+        assert_eq!(
+            summary.scope_note,
+            "promotes_capability=false, claims_speedup=false"
+        );
+        // No hostname in this fixture.
+        assert_eq!(summary.host, "linux/aarch64");
+        assert_eq!(verify_value(&receipt), AgentVerifyOutcome::Verified);
+    }
+
+    #[test]
+    fn verifies_a_sealed_bench_receipt() {
+        let receipt = seal(bench_body());
+        let summary = check(&receipt).expect("verifies");
+        assert_eq!(summary.class, AgentReceiptClass::OrchestrationBench);
+        assert_eq!(
+            summary.result,
+            "io-bound concurrency helped; inference-bound not measured"
+        );
+        assert_eq!(summary.scope_note, "speedup_claimed_for=\"io_bound_sleep\"");
+        assert_eq!(verify_value(&receipt), AgentVerifyOutcome::Verified);
+    }
+
+    #[test]
+    fn a_tampered_field_fails_the_self_digest() {
+        let mut receipt = seal(syscap_body());
+        // Flip the outcome after sealing; the stored receipt_id no longer matches.
+        receipt["outcome"] = json!("FAIL");
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "self-digest");
+        assert_eq!(verify_value(&receipt), AgentVerifyOutcome::NotVerified);
+    }
+
+    #[test]
+    fn an_injected_extra_field_fails_the_self_digest() {
+        // Strictness: the digest covers the whole document, so an added field that
+        // no emitter sealed is caught (the struct-based check would silently drop
+        // an unknown field — this Value-based check does not).
+        let mut receipt = seal(syscap_body());
+        receipt
+            .as_object_mut()
+            .unwrap()
+            .insert("injected".to_string(), json!(true));
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "self-digest");
+    }
+
+    #[test]
+    fn a_removed_field_fails_the_self_digest() {
+        let mut receipt = seal(syscap_body());
+        receipt.as_object_mut().unwrap().remove("note");
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "self-digest");
+    }
+
+    #[test]
+    fn a_sealed_but_overclaiming_syscap_receipt_fails_honest_scope() {
+        // Seal WITH the over-claim so the digest is intact; only the honest-scope
+        // guard should reject it.
+        let mut body = syscap_body();
+        body["promotes_capability"] = json!(true);
+        let receipt = seal(body);
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "honest-scope");
+        assert!(err.reason.contains("promotes_capability=true"));
+    }
+
+    #[test]
+    fn a_sealed_orchestration_speedup_claim_fails_honest_scope() {
+        let mut body = orchestration_body();
+        body["claims_speedup"] = json!(true);
+        let receipt = seal(body);
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "honest-scope");
+        assert!(err.reason.contains("claims_speedup=true"));
+    }
+
+    #[test]
+    fn a_missing_scope_field_fails_honest_scope() {
+        let mut body = syscap_body();
+        body.as_object_mut().unwrap().remove("promotes_capability");
+        let receipt = seal(body);
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "honest-scope");
+    }
+
+    #[test]
+    fn a_bench_missing_its_scope_field_fails_honest_scope() {
+        let mut body = bench_body();
+        body.as_object_mut().unwrap().remove("speedup_claimed_for");
+        let receipt = seal(body);
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "honest-scope");
+    }
+
+    #[test]
+    fn an_unrecognized_schema_is_rejected() {
+        let mut body = syscap_body();
+        body["schema"] = json!("camelid.parity-receipt/v1");
+        let receipt = seal(body);
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "schema");
+    }
+
+    #[test]
+    fn a_malformed_receipt_id_is_rejected_before_hashing() {
+        for bad in [
+            "",
+            "tooshort",
+            &"a".repeat(63),
+            &"a".repeat(65),
+            &"A".repeat(64), // uppercase is not our lowercase-hex form
+            &format!("{}z", "a".repeat(63)),
+        ] {
+            let mut receipt = syscap_body();
+            receipt["receipt_id"] = json!(bad);
+            let err = check(&receipt).expect_err("must fail");
+            assert_eq!(err.phase, "self-digest", "id {bad:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn a_non_object_is_rejected() {
+        let err = check(&json!(["not", "an", "object"])).expect_err("must fail");
+        assert_eq!(err.phase, "parse");
+    }
+
+    #[test]
+    fn a_missing_schema_is_rejected() {
+        let mut body = syscap_body();
+        body.as_object_mut().unwrap().remove("schema");
+        let err = check(&body).expect_err("must fail");
+        assert_eq!(err.phase, "schema");
+    }
+
+    #[test]
+    fn run_reads_and_verifies_a_receipt_file() {
+        let dir = std::env::temp_dir().join(format!("camelid-agent-verify-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+
+        let good = dir.join("good.json");
+        std::fs::write(
+            &good,
+            serde_json::to_vec_pretty(&seal(syscap_body())).unwrap(),
+        )
+        .expect("write");
+        assert_eq!(run(&good), AgentVerifyOutcome::Verified);
+
+        let mut tampered_value = seal(syscap_body());
+        tampered_value["outcome"] = json!("FAIL");
+        let tampered = dir.join("tampered.json");
+        std::fs::write(
+            &tampered,
+            serde_json::to_vec_pretty(&tampered_value).unwrap(),
+        )
+        .expect("write");
+        assert_eq!(run(&tampered), AgentVerifyOutcome::NotVerified);
+
+        let missing = dir.join("does-not-exist.json");
+        assert_eq!(run(&missing), AgentVerifyOutcome::NotVerified);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/receipt/mod.rs
+++ b/src/receipt/mod.rs
@@ -18,6 +18,7 @@
 //! body (sorted keys, no insignificant whitespace, `receipt_id` excluded), so
 //! a receipt can be cited by fingerprint and trivially checked for tampering.
 
+pub mod agent;
 pub mod distributed;
 pub mod verify;
 
@@ -611,6 +612,23 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     hex_lower(&hasher.finalize())
 }
 
+/// The sealed `receipt_id` a JSON receipt body must carry: the lowercase-hex
+/// SHA-256 over the canonical serialization (recursively key-sorted, compact) of
+/// the body with the top-level `receipt_id` field removed.
+///
+/// This is the single definition of the repo's tamper-evident receipt digest.
+/// [`ParityReceipt::compute_receipt_id`] computes the identical value from its
+/// typed body (a unit test locks the two together), and the sealed agent-family
+/// receipts in `chat/` plus the standalone [`agent`] verifier all go through
+/// here — so a digest and its later check can never drift.
+pub fn receipt_id_over(body: &Value) -> String {
+    let mut value = body.clone();
+    if let Value::Object(map) = &mut value {
+        map.remove("receipt_id");
+    }
+    sha256_hex(canonical_json(&value).as_bytes())
+}
+
 /// Lowercase hex SHA-256 of a file, computed with a streaming reader so large
 /// GGUFs are never held in memory.
 pub fn sha256_file_hex(path: &Path) -> Result<String, ReceiptError> {
@@ -754,6 +772,26 @@ mod tests {
         receipt
             .verify_self_digest()
             .expect("legacy digest verifies");
+    }
+
+    #[test]
+    fn receipt_id_over_matches_the_parity_convention() {
+        // `receipt_id_over` is the single digest primitive shared by the
+        // agent-family emitters and the standalone agent verifier. Lock it to the
+        // ParityReceipt convention so the two implementations can never diverge.
+        let mut receipt = sample_receipt();
+        receipt.seal().expect("seal");
+        let body = serde_json::to_value(&receipt).expect("receipt serializes");
+        assert_eq!(
+            receipt_id_over(&body),
+            receipt.receipt_id,
+            "the shared primitive must reproduce the sealed receipt_id"
+        );
+        assert_eq!(
+            receipt_id_over(&body),
+            receipt.compute_receipt_id().expect("compute"),
+            "the shared primitive must equal ParityReceipt::compute_receipt_id"
+        );
     }
 
     #[test]


### PR DESCRIPTION
﻿## What

`camelid verify-receipt` understood only parity receipts. The three sealed agent-gate receipts had no shipped verifier -- their self-digest was only asserted inside a `debug_assert!`, so a release build never checked them. This adds a schema-dispatched, model-free verifier and routes `camelid verify-receipt` to it automatically. Covered schemas:

- `camelid.agent-syscap-receipt/v1`
- `camelid.agent-orchestration-receipt/v1`
- `camelid.agent-orchestration-bench/v1`

## Design

- **`receipt::receipt_id_over(&Value)`** -- one tamper-evident digest primitive (canonical body with `receipt_id` removed then SHA-256). The three emitters now delegate to it instead of hand-rolling the same three lines, and a unit test locks it to `ParityReceipt::compute_receipt_id`, so a seal and its later check can never drift.
- **`receipt::agent`** -- the verifier. Per receipt it checks: recognized schema, well-formed lowercase-hex `receipt_id`, a strict self-digest over the exact document (any added/removed/edited field is caught), then each family's honest-scope invariants (`promotes_capability=false`; orchestration also `claims_speedup=false`; bench carries `speedup_claimed_for`). A verified agent receipt promotes no capability -- the same discipline the parity verifier holds.
- **`verify-receipt`** peeks the schema and routes agent receipts to the new path; `--gguf` becomes optional (required only for a parity receipt). The parity path is byte-for-byte unchanged.
- Agent schema strings live in `receipt::agent` and the emitters alias them, keeping one source of truth.

## Second commit -- A10 (small, unrelated fix)

`agent_orchestration::family_for` was missing the `ornith`/`qwen35` arm that its twin `agent_eval::family_for` has, so a Qwen3.5-derived model driven through the orchestration gate was misrouted to the JSON `<tool_call>` parser instead of its `<function=...>` XML format. Added the arm (checked before `qwen`) plus a regression test.

## Testing

- `cargo fmt --check`; `cargo clippy --all-targets --all-features -- -D warnings` (Windows host) -- clean
- `cargo test --lib receipt::` -- 55 pass (the verifier's 15 unit tests plus the digest lock test); `cargo test --lib chat::agent` -- 86 pass (A10 regression plus emitter seal tests confirm the digest refactor is byte-identical)
- Cross-platform cfg validated by building for the Linux target locally (the one non-Windows issue -- an unused `serde_json::Value` import behind `#[cfg(windows)]` -- is fixed in the third commit)
- Edge cases unit-tested: tampered / injected / removed field, sealed-but-overclaiming, missing scope field, unrecognized schema, malformed `receipt_id` (length/case/non-hex), non-object, missing schema, plus a temp-file `run()` path

### End-to-end on real receipts (Windows, RTX 4060)

Minted with the actual gates (no model required) and verified through the CLI:

- `agent-syscap-eval`, `agent-orchestration-eval`, `agent-orchestration-bench` -> all `AGENT RECEIPT VERIFIED` (exit 0)
- tampered `outcome` -> `AGENT RECEIPT NOT VERIFIED (self-digest)` (exit 1)
- a parity receipt with no `--gguf` -> clear error (exit 1)
