### PR TITLE
feat(verify): seal and verify the agent_eval promotion receipt

### DIFF
--- a/src/chat/agent_eval.rs
+++ b/src/chat/agent_eval.rs
@@ -387,7 +387,7 @@ fn finish(
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let receipt = json!({
+    let mut receipt = json!({
         "schema": "camelid.agent_eval/v1",
         "outcome": outcome.label(),
         "model_id": model_id,
@@ -400,6 +400,14 @@ fn finish(
         "timestamp_unix": ts,
         "promotion_eligible": outcome == EvalOutcome::Pass,
     });
+    // Seal the receipt with the shared tamper-evident digest so `camelid
+    // verify-receipt` can prove it intact. `receipt_id_over` hashes the canonical
+    // body with any `receipt_id` field removed, so inserting it afterwards yields
+    // the same digest the verifier recomputes.
+    let receipt_id = crate::receipt::receipt_id_over(&receipt);
+    if let Some(obj) = receipt.as_object_mut() {
+        obj.insert("receipt_id".to_string(), Value::from(receipt_id.clone()));
+    }
     std::fs::create_dir_all(&cfg.receipt_dir)?;
     let stem = gguf
         .file_stem()
@@ -414,7 +422,7 @@ fn finish(
 
     eprintln!();
     eprintln!("{} — {note}", outcome.label());
-    eprintln!("receipt → {}", path.display());
+    eprintln!("receipt → {} ({receipt_id})", path.display());
     if outcome == EvalOutcome::Inconclusive {
         eprintln!("(inconclusive does NOT change any tool_capable flag — re-run on a quiet box)");
     }

--- a/src/chat/agent_eval.rs
+++ b/src/chat/agent_eval.rs
@@ -405,9 +405,10 @@ fn finish(
     // body with any `receipt_id` field removed, so inserting it afterwards yields
     // the same digest the verifier recomputes.
     let receipt_id = crate::receipt::receipt_id_over(&receipt);
-    if let Some(obj) = receipt.as_object_mut() {
-        obj.insert("receipt_id".to_string(), Value::from(receipt_id.clone()));
-    }
+    receipt
+        .as_object_mut()
+        .expect("a json! object is always an object")
+        .insert("receipt_id".to_string(), Value::from(receipt_id.clone()));
     std::fs::create_dir_all(&cfg.receipt_dir)?;
     let stem = gguf
         .file_stem()

--- a/src/chat/agent_syscap.rs
+++ b/src/chat/agent_syscap.rs
@@ -4,7 +4,7 @@
 //! `inspect_system`) directly against a controlled temp sandbox and emits a
 //! **tamper-evident** receipt (`camelid.agent-syscap-receipt/v1`): a sealed
 //! SHA-256 digest over the canonical body, mirroring the parity-receipt family
-//! (NOT the digest-less `agent_eval/v1` shape).
+//! (as every agent-family receipt now does, including `agent_eval/v1`).
 //!
 //! Scope discipline (the claims ladder): this is a *rung-1* artifact. It attests
 //! that the syscap tools behave under the gate/sandbox on this box. It promotes

--- a/src/receipt/agent.rs
+++ b/src/receipt/agent.rs
@@ -26,6 +26,15 @@
 //! honest; it changes no support-ledger row. Agent-eval receipts minted before
 //! sealing carry no `receipt_id`; those are reported as unsealed legacy receipts
 //! (their tamper-evidence cannot be established), never as verified.
+//!
+//! *What the seal does and does not prove.* The `receipt_id` is an **unkeyed**
+//! SHA-256, not a signature. It makes accidental corruption and naive hand-edits
+//! of a committed receipt evident — the digest stops matching — and honest-scope
+//! catches a casual field flip the digest alone would miss (e.g. editing
+//! `outcome` without resealing). It is **not** forgery-resistant: anyone who can
+//! run `camelid` can mint a fresh, fully-consistent sealed receipt, so a
+//! determined forger who reseals is not detected here. Git history and review
+//! remain the integrity anchor for what a receipt attests.
 
 use std::path::Path;
 
@@ -522,6 +531,36 @@ mod tests {
         assert_eq!(err.phase, "self-digest");
         assert!(err.reason.contains("unsealed legacy"));
         assert_eq!(verify_value(&legacy), AgentVerifyOutcome::NotVerified);
+    }
+
+    #[test]
+    fn verifies_a_sealed_inconclusive_eval_receipt() {
+        // The noisy-box path: INCONCLUSIVE is not promotion-eligible, and a
+        // consistent receipt (eligible=false) must verify.
+        let mut body = eval_body();
+        body["outcome"] = json!("INCONCLUSIVE");
+        body["promotion_eligible"] = json!(false);
+        let receipt = seal(body);
+        let summary = check(&receipt).expect("verifies");
+        assert_eq!(summary.result, "INCONCLUSIVE");
+        assert_eq!(
+            summary.scope_note,
+            "promotion_eligible=false (consistent with outcome=\"INCONCLUSIVE\")"
+        );
+        assert_eq!(verify_value(&receipt), AgentVerifyOutcome::Verified);
+    }
+
+    #[test]
+    fn a_sealed_eval_with_a_float_loadavg_round_trips() {
+        // POSIX hosts record `host_loadavg_1m` as a float. Confirm the digest is
+        // stable across the f64 serialize/parse round-trip the on-disk path takes.
+        let mut body = eval_body();
+        body["host_loadavg_1m"] = json!(0.42);
+        let receipt = seal(body);
+        assert_eq!(check(&receipt).expect("verifies").result, "PASS");
+        let text = serde_json::to_string_pretty(&receipt).unwrap();
+        let reparsed: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(verify_value(&reparsed), AgentVerifyOutcome::Verified);
     }
 
     #[test]

--- a/src/receipt/agent.rs
+++ b/src/receipt/agent.rs
@@ -7,6 +7,7 @@
 //! - `agent-syscap-eval` → `camelid.agent-syscap-receipt/v1`
 //! - `agent-orchestration-eval` → `camelid.agent-orchestration-receipt/v1`
 //! - `agent-orchestration-bench` → `camelid.agent-orchestration-bench/v1`
+//! - `agent-eval` → `camelid.agent_eval/v1` (the tool-capable promotion gate)
 //!
 //! Unlike a parity receipt there is no model to re-run: verification is a
 //! self-contained **tamper-evidence + honest-scope** check.
@@ -14,14 +15,17 @@
 //! 1. *Tamper-evidence* — the document's canonical body (every field except
 //!    `receipt_id`, recursively key-sorted and compact) must hash to the stored
 //!    `receipt_id`. Any added, removed, or altered field breaks the match.
-//! 2. *Honest-scope* — a well-formed but over-claiming receipt is rejected. These
-//!    gates promote no capability and (for orchestration) claim no speedup; a
-//!    receipt whose own scope fields say otherwise is not a valid artifact of the
-//!    gate that supposedly produced it.
+//! 2. *Honest-scope* — a well-formed but over-claiming receipt is rejected. The
+//!    syscap / orchestration / bench gates promote no capability (and
+//!    orchestration claims no speedup); the eval gate is the one
+//!    promotion-bearing receipt, so its scope check is internal consistency —
+//!    `promotion_eligible` must equal `outcome == "PASS"`. A receipt whose scope
+//!    fields say otherwise is not a valid artifact of the gate that produced it.
 //!
-//! A verified agent receipt attests that the document is intact and claims
-//! nothing it should not. Like every receipt in this crate, it promotes no
-//! support claim.
+//! Verifying a receipt attests only that the document is intact and internally
+//! honest; it changes no support-ledger row. Agent-eval receipts minted before
+//! sealing carry no `receipt_id`; those are reported as unsealed legacy receipts
+//! (their tamper-evidence cannot be established), never as verified.
 
 use std::path::Path;
 
@@ -35,12 +39,15 @@ pub const SYSCAP_RECEIPT_SCHEMA_V1: &str = "camelid.agent-syscap-receipt/v1";
 pub const ORCHESTRATION_RECEIPT_SCHEMA_V1: &str = "camelid.agent-orchestration-receipt/v1";
 /// Schema stamped into an `agent-orchestration-bench` receipt.
 pub const ORCHESTRATION_BENCH_SCHEMA_V1: &str = "camelid.agent-orchestration-bench/v1";
+/// Schema stamped into an `agent-eval` receipt (the tool-capable promotion gate).
+pub const EVAL_RECEIPT_SCHEMA_V1: &str = "camelid.agent_eval/v1";
 
 /// Every agent-family schema this verifier understands.
-pub const RECOGNIZED_SCHEMAS: [&str; 3] = [
+pub const RECOGNIZED_SCHEMAS: [&str; 4] = [
     SYSCAP_RECEIPT_SCHEMA_V1,
     ORCHESTRATION_RECEIPT_SCHEMA_V1,
     ORCHESTRATION_BENCH_SCHEMA_V1,
+    EVAL_RECEIPT_SCHEMA_V1,
 ];
 
 /// True when `schema` names an agent-family receipt this module can verify.
@@ -60,6 +67,8 @@ pub enum AgentReceiptClass {
     Orchestration,
     /// `camelid.agent-orchestration-bench/v1`.
     OrchestrationBench,
+    /// `camelid.agent_eval/v1` — the tool-capable promotion gate.
+    Eval,
 }
 
 impl AgentReceiptClass {
@@ -68,6 +77,7 @@ impl AgentReceiptClass {
             SYSCAP_RECEIPT_SCHEMA_V1 => Some(Self::Syscap),
             ORCHESTRATION_RECEIPT_SCHEMA_V1 => Some(Self::Orchestration),
             ORCHESTRATION_BENCH_SCHEMA_V1 => Some(Self::OrchestrationBench),
+            EVAL_RECEIPT_SCHEMA_V1 => Some(Self::Eval),
             _ => None,
         }
     }
@@ -76,7 +86,7 @@ impl AgentReceiptClass {
     /// eval gates (PASS/FAIL/INCONCLUSIVE), `verdict` for the wall-clock bench.
     fn result_field(self) -> &'static str {
         match self {
-            Self::Syscap | Self::Orchestration => "outcome",
+            Self::Syscap | Self::Orchestration | Self::Eval => "outcome",
             Self::OrchestrationBench => "verdict",
         }
     }
@@ -111,6 +121,42 @@ impl AgentReceiptClass {
                             .to_string(),
                     })?;
                 Ok(format!("speedup_claimed_for={claimed:?}"))
+            }
+            Self::Eval => {
+                // The eval gate is the ONE agent receipt that may justify a
+                // promotion: a PASS is `promotion_eligible`. Honest-scope here is
+                // internal consistency — `promotion_eligible` must equal
+                // `outcome == "PASS"`. A receipt claiming eligibility without a
+                // PASS (or denying it after one) is dishonest.
+                let outcome =
+                    obj.get("outcome")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| AgentVerifyError {
+                            phase: "honest-scope",
+                            reason: "agent_eval receipt is missing the string `outcome` field"
+                                .to_string(),
+                        })?;
+                let eligible = obj
+                    .get("promotion_eligible")
+                    .and_then(Value::as_bool)
+                    .ok_or_else(|| AgentVerifyError {
+                        phase: "honest-scope",
+                        reason: "agent_eval receipt is missing the boolean \
+                                 `promotion_eligible` field"
+                            .to_string(),
+                    })?;
+                if eligible != (outcome == "PASS") {
+                    return Err(AgentVerifyError {
+                        phase: "honest-scope",
+                        reason: format!(
+                            "promotion_eligible={eligible} is inconsistent with \
+                             outcome={outcome:?} (only a PASS is promotion-eligible)"
+                        ),
+                    });
+                }
+                Ok(format!(
+                    "promotion_eligible={eligible} (consistent with outcome={outcome:?})"
+                ))
             }
         }
     }
@@ -174,8 +220,9 @@ pub struct AgentReceiptSummary {
     pub result: String,
     /// Human-readable summary of the honest-scope fields that were checked.
     pub scope_note: String,
-    /// `os/arch` or `os/arch (hostname)` from the receipt's `host` block.
-    pub host: String,
+    /// `os/arch` (optionally with `(hostname)`) from the receipt's `host` block,
+    /// or `None` when the receipt has no host block (e.g. `agent_eval`).
+    pub host: Option<String>,
 }
 
 /// Pure verification: no I/O, no printing. Returns what the receipt attests, or
@@ -201,14 +248,26 @@ pub fn check(value: &Value) -> Result<AgentReceiptSummary, AgentVerifyError> {
         ),
     })?;
 
-    // Receipt id — must be a 64-char lowercase-hex SHA-256.
-    let receipt_id = obj
-        .get("receipt_id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| AgentVerifyError {
-            phase: "self-digest",
-            reason: "receipt has no string `receipt_id` field".to_string(),
-        })?;
+    // Receipt id — must be a 64-char lowercase-hex SHA-256. Agent-eval receipts
+    // minted before sealing carry none; report those as unsealed legacy receipts
+    // rather than as a malformed body.
+    let receipt_id = match obj.get("receipt_id").and_then(Value::as_str) {
+        Some(id) => id,
+        None => {
+            let reason = if class == AgentReceiptClass::Eval {
+                "unsealed legacy agent_eval receipt (no `receipt_id`): it predates receipt \
+                 sealing, so its tamper-evidence cannot be established — re-run agent-eval \
+                 to mint a sealed receipt"
+                    .to_string()
+            } else {
+                "receipt has no string `receipt_id` field".to_string()
+            };
+            return Err(AgentVerifyError {
+                phase: "self-digest",
+                reason,
+            });
+        }
+    };
     if !is_sha256_hex(receipt_id) {
         return Err(AgentVerifyError {
             phase: "self-digest",
@@ -260,17 +319,20 @@ pub fn verify_value(value: &Value) -> AgentVerifyOutcome {
                 "PASS self-digest: receipt_id matches the canonical body ({})",
                 summary.receipt_id
             );
-            println!(
-                "PASS honest-scope: {} (this gate promotes no capability)",
-                summary.scope_note
-            );
-            println!(
-                "NOTE receipt: {}={}; host {}",
-                summary.class.result_field(),
-                summary.result,
-                summary.host
-            );
-            println!("AGENT RECEIPT VERIFIED (tamper-evident; promotes no capability)");
+            println!("PASS honest-scope: {}", summary.scope_note);
+            match &summary.host {
+                Some(host) => println!(
+                    "NOTE receipt: {}={}; host {host}",
+                    summary.class.result_field(),
+                    summary.result,
+                ),
+                None => println!(
+                    "NOTE receipt: {}={}",
+                    summary.class.result_field(),
+                    summary.result,
+                ),
+            }
+            println!("AGENT RECEIPT VERIFIED (tamper-evident; changes no support-ledger row)");
             AgentVerifyOutcome::Verified
         }
         Err(err) => {
@@ -308,22 +370,18 @@ fn is_sha256_hex(s: &str) -> bool {
     s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
 }
 
-/// `os/arch` or `os/arch (hostname)` from the receipt's `host` block, with `?`
-/// standing in for any absent piece.
-fn host_line(obj: &Map<String, Value>) -> String {
-    let host = obj.get("host").and_then(Value::as_object);
-    let field = |key: &str| {
-        host.and_then(|h| h.get(key))
-            .and_then(Value::as_str)
-            .unwrap_or("?")
-            .to_string()
-    };
+/// `os/arch` (optionally with `(hostname)`) from the receipt's `host` block, or
+/// `None` when the receipt carries no host block. A present-but-partial block
+/// renders `?` for the missing piece.
+fn host_line(obj: &Map<String, Value>) -> Option<String> {
+    let host = obj.get("host").and_then(Value::as_object)?;
+    let field = |key: &str| host.get(key).and_then(Value::as_str).unwrap_or("?");
     let os = field("os");
     let arch = field("arch");
-    match host.and_then(|h| h.get("hostname")).and_then(Value::as_str) {
+    Some(match host.get("hostname").and_then(Value::as_str) {
         Some(name) => format!("{os}/{arch} ({name})"),
         None => format!("{os}/{arch}"),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -396,14 +454,74 @@ mod tests {
         })
     }
 
+    /// Mirrors the fields `agent_eval::finish` emits (a PASS is promotion-eligible).
+    fn eval_body() -> Value {
+        json!({
+            "schema": EVAL_RECEIPT_SCHEMA_V1,
+            "receipt_id": "",
+            "outcome": "PASS",
+            "model_id": "qwen3-4b",
+            "gguf": "C:\\models\\Qwen3-4B-Q8_0.gguf",
+            "gguf_bytes": 4_000_000_000u64,
+            "quantization": "Q8_0",
+            "note": "full 3-case battery",
+            "cases": [ { "name": "read_notes", "tool": "read_file", "pass": true } ],
+            "host_loadavg_1m": null,
+            "timestamp_unix": 1_784_747_762u64,
+            "promotion_eligible": true
+        })
+    }
+
     #[test]
-    fn recognizes_exactly_the_three_agent_schemas() {
+    fn recognizes_exactly_the_four_agent_schemas() {
         assert!(is_agent_schema(SYSCAP_RECEIPT_SCHEMA_V1));
         assert!(is_agent_schema(ORCHESTRATION_RECEIPT_SCHEMA_V1));
         assert!(is_agent_schema(ORCHESTRATION_BENCH_SCHEMA_V1));
+        assert!(is_agent_schema(EVAL_RECEIPT_SCHEMA_V1));
         assert!(!is_agent_schema("camelid.parity-receipt/v1"));
+        // The eval schema uses an underscore; the hyphenated spelling is not it.
         assert!(!is_agent_schema("camelid.agent-eval/v1"));
         assert!(!is_agent_schema(""));
+    }
+
+    #[test]
+    fn verifies_a_sealed_eval_receipt() {
+        let receipt = seal(eval_body());
+        let summary = check(&receipt).expect("verifies");
+        assert_eq!(summary.class, AgentReceiptClass::Eval);
+        assert_eq!(summary.result, "PASS");
+        assert_eq!(
+            summary.scope_note,
+            "promotion_eligible=true (consistent with outcome=\"PASS\")"
+        );
+        assert_eq!(summary.host, None);
+        assert_eq!(verify_value(&receipt), AgentVerifyOutcome::Verified);
+    }
+
+    #[test]
+    fn a_sealed_eval_claiming_eligibility_without_pass_fails_honest_scope() {
+        // Seal WITH the inconsistency so the digest is intact; only the
+        // honest-scope guard should reject it.
+        let mut body = eval_body();
+        body["outcome"] = json!("FAIL");
+        // promotion_eligible stays true — inconsistent with a non-PASS outcome.
+        let receipt = seal(body);
+        let err = check(&receipt).expect_err("must fail");
+        assert_eq!(err.phase, "honest-scope");
+        assert!(err.reason.contains("promotion_eligible=true"));
+        assert!(err.reason.contains("outcome=\"FAIL\""));
+    }
+
+    #[test]
+    fn an_unsealed_legacy_eval_receipt_is_reported_as_such() {
+        // The 9 committed agent_eval receipts predate sealing: no `receipt_id`.
+        // They must be reported as unsealed legacy, not as a malformed body.
+        let mut legacy = eval_body();
+        legacy.as_object_mut().unwrap().remove("receipt_id");
+        let err = check(&legacy).expect_err("must fail");
+        assert_eq!(err.phase, "self-digest");
+        assert!(err.reason.contains("unsealed legacy"));
+        assert_eq!(verify_value(&legacy), AgentVerifyOutcome::NotVerified);
     }
 
     #[test]
@@ -413,7 +531,7 @@ mod tests {
         assert_eq!(summary.class, AgentReceiptClass::Syscap);
         assert_eq!(summary.result, "PASS");
         assert_eq!(summary.scope_note, "promotes_capability=false");
-        assert_eq!(summary.host, "windows/x86_64 (TEST-BOX)");
+        assert_eq!(summary.host.as_deref(), Some("windows/x86_64 (TEST-BOX)"));
         assert_eq!(verify_value(&receipt), AgentVerifyOutcome::Verified);
     }
 
@@ -427,7 +545,7 @@ mod tests {
             "promotes_capability=false, claims_speedup=false"
         );
         // No hostname in this fixture.
-        assert_eq!(summary.host, "linux/aarch64");
+        assert_eq!(summary.host.as_deref(), Some("linux/aarch64"));
         assert_eq!(verify_value(&receipt), AgentVerifyOutcome::Verified);
     }
 


### PR DESCRIPTION
﻿## What

The `agent-eval` gate mints the receipt that justifies flipping `tool_capable` true (its own docs: "the receipt that justifies flipping `tool_capable` true"). Yet it was the **only** agent receipt emitted with **no digest** -- unlike syscap / orchestration / bench, nothing could prove it intact, and `camelid verify-receipt` could not check it. This seals it and teaches the verifier to verify it, so the one promotion-bearing receipt is now tamper-evident.

## Changes

- **Seal** ([src/chat/agent_eval.rs](../blob/main/src/chat/agent_eval.rs) `finish`): stamps `receipt_id` via the shared `receipt::receipt_id_over` primitive. Additive to `camelid.agent_eval/v1`; the 9 committed pre-seal receipts are untouched.
- **Verify** ([src/receipt/agent.rs](../blob/main/src/receipt/agent.rs)): adds `AgentReceiptClass::Eval` + `EVAL_RECEIPT_SCHEMA_V1`. Its honest-scope invariant is internal consistency -- `promotion_eligible` must equal `outcome == "PASS"`; a receipt claiming eligibility without a PASS is rejected.
- **Legacy tolerance**: an unsealed receipt (no `receipt_id`) is reported as an *unsealed legacy* receipt, not as a malformed body.
- **Accuracy**: the reported `host` is now `Option` (agent_eval carries no host block, so no more `host ?/?`), and the verdict lines no longer claim "promotes no capability" for the one gate that *is* promotion-bearing.

## Testing

- `cargo fmt --check`; `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- `cargo test --lib receipt::agent` -- 19 pass (new: sealed-eval verifies, eligibility inconsistency rejected, unsealed-legacy reported)
- **End-to-end on Windows + Qwen3-4B-Q4_K_M** (real `agent-eval` battery, PASS): the freshly minted receipt verifies (`AGENT RECEIPT VERIFIED`), a committed legacy `qa/agent-eval/*.json` is reported unsealed, and a tampered copy fails (`self-digest`).

Follows up #490 (which sealed/verified the other three agent receipts); no schema/ledger consumer parses these receipts, so the added field is safe.


---

## Behavioral notes (per review)

- **Output-contract change to all four classes.** `verify_value` verdict wording changed for syscap/orchestration/bench too: the final line is now `(tamper-evident; changes no support-ledger row)`, the honest-scope line dropped its blanket `(this gate promotes no capability)` suffix, and `NOTE receipt:` omits `host` when absent. This corrects the old blanket "promotes no capability" (wrong for the promotion-bearing eval gate). Nothing in `src/`, `scripts/`, or `.github/` greps these strings; sibling tests assert on `summary` fields, not stdout.
- **API churn (intentional).** `AgentReceiptSummary.host: String` -> `Option<String>` (agent_eval has no host block). Only consumers are `verify_value` and unit tests.
- **Threat model.** The seal is an unkeyed SHA-256, not a signature: it is corruption-/naive-edit-evident, not forgery-resistant. Git history + review remain the integrity anchor. Documented in the `receipt::agent` module docs.
- **Evidentiary gap (prospective value).** The 9 committed `agent_eval` receipts predate sealing and now verify as "unsealed legacy"; they are reported (never silently accepted) with an actionable re-mint message. Sealing coverage of the in-tree promotion evidence is prospective.

Review fixes in `08cc7e32` (stale syscap doc, fail-loud seal, honest threat-model note, +2 eval tests: INCONCLUSIVE consistency and float-loadavg round-trip).
