### PR TITLE
Fix pull for qwen3_4b_q4_k_m by adding it to the curated catalog (#469)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18007,6 +18007,31 @@ pub fn curated_catalog() -> Vec<CatalogItem> {
             task_tags: &["reasoning", "coding"],
         },
         CatalogItem {
+            // First non-Q8_0 curated row. `qwen3_4b_q4_k_m` is a
+            // `supported_exact_row_smoke` contract row (tool_capable), but it was
+            // absent from this catalog, so `camelid pull qwen3_4b_q4_k_m`, the TUI
+            // picker, and the Web UI browse all saw it as supported yet could not
+            // fetch it (upstream #469). The certified GGUF (sha256 7485fe6f...) is
+            // the official Qwen upload, so it downloads from the same repo as the
+            // Q8_0 row above. catalog_id MUST equal the ledger row id
+            // `qwen3_4b_q4_k_m`: the picker joins the two by exact id, and the
+            // server's supported-row check anchors on the exact filename.
+            catalog_id: "qwen3_4b_q4_k_m",
+            name: "Qwen3 4B Q4_K_M",
+            repo_id: "Qwen/Qwen3-4B-GGUF",
+            filename: "Qwen3-4B-Q4_K_M.gguf",
+            // HuggingFace resolve Content-Length (verified 2026-07-23); matches the
+            // certified parity bundle's recorded size. Must stay exact or pull's
+            // skip-if-complete/resume check misfires.
+            size_bytes: 2497280256,
+            downloads: 0,
+            likes: 0,
+            quant: "Q4_K_M",
+            architecture: "qwen3",
+            license: "apache-2.0",
+            task_tags: &["reasoning", "coding"],
+        },
+        CatalogItem {
             catalog_id: "qwen3_8b_instruct_q8_0",
             name: "Qwen3 8B Q8_0",
             repo_id: "Qwen/Qwen3-8B-GGUF",
@@ -18980,7 +19005,9 @@ const NON_CATALOG_SUPPORTED_ARTIFACTS: &[(&str, &str)] = &[
     ("ornith-1.0-9b-Q8_0.gguf", "Ornith 1.0 9B"),
     ("ornith-1.0-9b-Q4_K_M.gguf", "ornith_1_0_9b_q4_k_m"),
     ("ornith-1.0-9b-Q3_K_M.gguf", "ornith_1_0_9b_q3_k_m"),
-    ("Qwen3-4B-Q4_K_M.gguf", "qwen3_4b_q4_k_m"),
+    // NB: Qwen3-4B-Q4_K_M.gguf is intentionally NOT here -- it is an official
+    // Qwen/Qwen3-4B-GGUF upload, so it lives in curated_catalog() and is covered
+    // by the curated-catalog branch of filename_is_supported_exact_row.
 ];
 
 /// True when `filename` is the exact GGUF artifact of a curated row whose

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -233,4 +233,19 @@ mod tests {
         let entries = curated_catalog();
         assert!(resolve(&entries, "gpt-9-turbo").is_err());
     }
+
+    #[test]
+    fn qwen3_4b_q4_k_m_is_pullable_by_its_ledger_id() {
+        // Regression for upstream #469: the supported `qwen3_4b_q4_k_m` exact row
+        // appeared in the ledger, the TUI picker, and the Web UI browse but was
+        // missing from the pull catalog, so `camelid pull qwen3_4b_q4_k_m` failed
+        // with "no supported model matches". Its catalog id must equal the ledger
+        // row id (the picker joins on it) and point at the official Qwen upload.
+        let entries = curated_catalog();
+        let item = resolve(&entries, "qwen3_4b_q4_k_m").expect("row must resolve");
+        assert_eq!(item.catalog_id, "qwen3_4b_q4_k_m");
+        assert_eq!(item.repo_id, "Qwen/Qwen3-4B-GGUF");
+        assert_eq!(item.filename, "Qwen3-4B-Q4_K_M.gguf");
+        assert_eq!(item.quant, "Q4_K_M");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #469 — `qwen3_4b_q4_k_m` shows up as a supported model but can't be pulled.

`qwen3_4b_q4_k_m` is a supported exact-row (`supported_exact_row_smoke`, `tool_capable`). It appeared in the ledger, the TUI model picker, and the Web UI model browser, **but it was missing from `curated_catalog()`**. Since the pull CLI (`src/catalog.rs::resolve`), the TUI/inline picker (`src/chat/models.rs::supported_rows`), and the catalog browse all join supported rows to the curated catalog by exact id, the row surfaced as supported yet had no way to be fetched:

- `camelid pull qwen3_4b_q4_k_m` → `Error: no supported model matches "qwen3_4b_q4_k_m"`
- TUI/CLI picker → `Availability::NoPullAlias` ("has no pull alias")

This matches the reporter's symptom exactly: the model is visible/supported in the browser but every pull path refuses it.

## Root cause

The row was mislabeled as a "non-catalog" artifact in `NON_CATALOG_SUPPORTED_ARTIFACTS` (with a comment claiming "no HF catalog source"), so it never got a curated catalog entry — the single source the pull/picker join keys on. In reality `Qwen3-4B-Q4_K_M.gguf` (sha256 `7485fe6f...`, size `2497280256`) is the official `Qwen/Qwen3-4B-GGUF` upload, i.e. the same repo as the already-catalogued Q8_0 row.

## Fix

- Add a curated `CatalogItem` for `qwen3_4b_q4_k_m` in `curated_catalog()` (`catalog_id` equals the ledger row id — the picker joins on it — with the exact filename and HuggingFace-verified `size_bytes`, pointing at `Qwen/Qwen3-4B-GGUF`).
- Remove the now-redundant `NON_CATALOG_SUPPORTED_ARTIFACTS` entry; it's covered by the curated-catalog branch of `filename_is_supported_exact_row`. Removing it also avoids a double-listing, since `workspace_model_options` iterates the curated and non-catalog lists in separate loops.
- Add a regression test `qwen3_4b_q4_k_m_is_pullable_by_its_ledger_id` asserting the row resolves via `pull` to the official Qwen upload.

**No support claims change** — the row was already supported; this only makes its already-earned support fetchable.

## Behavior note

`catalog::resolve()` matches queries by substring and errors when more than one row matches. With a second Qwen3-4B row now in the catalog, a partial query like `camelid pull qwen3_4b` (which previously auto-resolved to the only Qwen3-4B row, Q8_0) now returns *"matches several models — be more specific"* and the user must disambiguate (`qwen3_4b_q4_k_m` or `qwen3_4b_instruct_q8_0`). This is intentional and arguably more correct — the fully-qualified ids still resolve uniquely — but it is a user-visible change worth calling out.

## Validation (built the binary on Windows, before/after)

**Before** (fix stashed):
```
> camelid pull                       # only Q8_0 present
  qwen3_4b_instruct_q8_0   Q8_0   4.3 GB   Qwen3 4B Q8_0
> camelid pull qwen3_4b_q4_k_m
Error: no supported model matches "qwen3_4b_q4_k_m"    (exit 1)
```

**After**:
```
> camelid pull
  qwen3_4b_instruct_q8_0   Q8_0     4.3 GB   Qwen3 4B Q8_0
  qwen3_4b_q4_k_m          Q4_K_M   2.5 GB   Qwen3 4B Q4_K_M   ← now present
> camelid pull qwen3_4b_q4_k_m
Downloading Qwen3 4B Q4_K_M (2.5 GB) from Qwen/Qwen3-4B-GGUF    ← resolves + downloads
```

The bug is OS-independent (pure catalog-resolution logic, no platform/GPU/model-load code on the `pull` path), so although #469 was reported on macOS it reproduces identically on Windows.

- `cargo check --lib` — clean
- `cargo test --lib` — passes, including the new regression test and the existing consistency tests (`compatible_models_expose_only_exact_earned_artifacts_and_installed_state`, `every_curated_row_is_tagged_within_the_allowed_set`, `unknown_host_never_reports_wont_fit_for_any_curated_row`, `picker_is_ledger_derived_supported_only_and_joins_catalog`)
- `cargo fmt --check` — clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>