### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump for the **v0.4.0** release — 262 commits since v0.3.1.

Bumps `camelid` and `camelid-desktop` from 0.3.1 → 0.4.0 across the four version-bearing files:
- `Cargo.toml`
- `camelid-desktop/Cargo.toml`
- `camelid-desktop/tauri.conf.json`
- `Cargo.lock` (both workspace members)

Highlights landing in this release:
- **Agent mode** promoted to Supported (experimental): `camelid agent exec`, agent TUI, plan/checkpoint/session commands
- **MCP client** — tool set is no longer just what was compiled in; web search tool
- **HARDPAN**: Windows terminal parity fixes (drain, job-object teardown, base64 stdin/exit codes, system32 resolution, paste, AltGr)
- **verify**: sealed agent-family receipts + a CI gate for committed-receipt integrity
- Workspace authenticated CLI client; `pull` catalog fixes (qwen3_4b_q4_k_m, column alignment)

Merging this, then tagging `v0.4.0`, triggers `release.yml` to build and publish the signed macOS/Linux/Windows-server/Windows-desktop assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)