### PR TITLE
chore(release): bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump for the **v0.4.2** release.

Bumps `camelid` and `camelid-desktop` 0.4.1 → 0.4.2 across the four version-bearing files (`Cargo.toml`, `camelid-desktop/Cargo.toml`, `camelid-desktop/tauri.conf.json`, `Cargo.lock` ×2 workspace members).

## What ships in v0.4.2

**#501 — model swapping instead of a dead-end fit refusal.** Loading a model never evicted, so a second load kept the first model's RAM *and* VRAM and the fit preflight refused with "larger than this machine can hold in memory" — on hosts that hold the model comfortably once the previous one is released.

- `POST /api/models/load` accepts `replace` (defaults false; existing API clients unchanged). When set, other resident models are released first and the preflight re-probes live memory.
- Reclaim-awareness works by actually reclaiming and re-measuring, never by estimating — an over-credited estimate could manufacture a false "fits" and an OOM.
- New typed error `model_requires_unload` naming the blocking model, distinct from `model_too_large_for_host`.
- Unload teardown is shared between both paths, so a swap always runs `reset_resident_caches` (skipping it strands ~4.7 GB on the GPU and costs ~20× decode).
- The web UI sends `replace: true`, so choosing a model in the app is a swap.

Verified on a Windows RTX 3060 box with the real binary: 1B resident holding 4747 MiB VRAM → 3B load without `replace` returns `model_requires_unload` → with `replace` it swaps (VRAM 4747 → 107 MiB, proving the GPU released), reloads GPU-resident, and generates correctly.

Merging this, then tagging `v0.4.2`, triggers `release.yml` to publish the signed assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)