### PR TITLE
feat(release): ship NVRTC in the Linux tarball + quiet cudarc's handled panics

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,3 +13,23 @@
 # target feature`). aarch64 keeps its defaults (NEON is baseline there).
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-C", "target-cpu=x86-64-v3"]
+
+# x86_64 Linux additionally gets `$ORIGIN` on the run-time search path, so a
+# release tarball can ship the NVRTC pair BESIDE the binary and have it found with
+# no LD_LIBRARY_PATH from the user. Windows solves the same problem in code
+# (`ensure_cuda_runtime_on_path` prepends the exe dir to PATH), but that cannot
+# work here: glibc fixes the loader search path at process start, so mutating the
+# environment in-process has no effect on later dlopen calls. RUNPATH of the
+# calling object IS consulted for dlopen, so this is the working equivalent.
+#
+# `$ORIGIN` is passed through literally — Cargo spawns rustc without a shell, so
+# there is nothing to expand it prematurely. The `-C target-cpu` flag is repeated
+# here deliberately: if Cargo ever stops merging rustflags across matching
+# `target.cfg` tables, this section must not silently drop the AVX2 baseline.
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))']
+rustflags = [
+    "-C",
+    "target-cpu=x86-64-v3",
+    "-C",
+    "link-arg=-Wl,-rpath,$ORIGIN",
+]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,21 @@ jobs:
       - name: Build release binary
         run: cargo build --release --locked --bin camelid
 
+      # Linux x86_64 only: CUDA is compiled into this target's DEFAULT build, and the
+      # resident engine compiles its kernels through NVRTC at runtime. NVRTC ships with
+      # the CUDA *Toolkit*, not the driver, so without this the downloaded tarball
+      # detects the GPU and then falls back to CPU on every ordinary driver-only host.
+      # Mirrors what build-windows already does for the Windows ZIP. Only the NVRTC
+      # component is installed — the driver itself is the user's and is not
+      # redistributable.
+      - name: Install CUDA NVRTC (packaging source)
+        if: matrix.label == 'linux-x86_64'
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: ${{ env.CUDA_VERSION }}
+          method: network
+          sub-packages: '["nvrtc"]'
+
       - name: Package
         run: |
           set -euo pipefail
@@ -72,6 +87,17 @@ jobs:
           strip target/release/camelid || true
           cp target/release/camelid "$dist/"
           cp README.md LICENSE THIRD_PARTY_NOTICES.md "$dist/"
+          # Stage the NVRTC redistributables beside the binary. The binary is linked
+          # with `-Wl,-rpath,$ORIGIN` (.cargo/config.toml), so its own directory is on
+          # the run-time search path and dlopen finds this pair with no LD_LIBRARY_PATH
+          # from the user. Fail loudly rather than shipping a tarball that silently
+          # cannot reach the GPU.
+          # Invoked through `bash` rather than as ./script, matching how ci.yml runs
+          # its shell gates: that does not depend on the executable bit surviving in
+          # the index (it does not, when the file is authored on Windows).
+          if [ "${{ matrix.label }}" = "linux-x86_64" ]; then
+            bash scripts/package-linux-cuda.sh "$dist"
+          fi
           tar -czf "$dist.tar.gz" "$dist"
           shasum -a 256 "$dist.tar.gz" > "$dist.tar.gz.sha256"
 

--- a/scripts/package-linux-cuda.sh
+++ b/scripts/package-linux-cuda.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Stage the NVRTC redistributables next to the `camelid` binary so a downloaded
+# x86_64 Linux release runs on the GPU with only the NVIDIA *driver* installed
+# (no CUDA Toolkit required on the end user's machine).
+#
+# Why this is needed at all: camelid links cudarc with `fallback-dynamic-loading`,
+# so it dlopen's the CUDA driver (libcuda.so.1, shipped with the GPU driver) and
+# the NVRTC runtime compiler at startup. The resident decode engine compiles its
+# kernels through NVRTC — and NVRTC ships with the CUDA *Toolkit*, not the driver.
+# Since CUDA is compiled into the DEFAULT x86_64 Linux build, without this pair the
+# common driver-only host detects the GPU and then quietly runs on the CPU.
+#
+# How the binary finds them: it is linked with `-Wl,-rpath,$ORIGIN`
+# (.cargo/config.toml), so its own directory is on the run-time search path and
+# dlopen resolves these without the user setting LD_LIBRARY_PATH. The Windows
+# equivalent (`ensure_cuda_runtime_on_path`, which prepends the exe directory to
+# PATH) cannot work here: glibc fixes the loader search path at process start, so
+# changing the environment in-process has no effect on later dlopen calls.
+#
+# The CUDA driver (libcuda.so.1) is NOT redistributable and is NOT copied — it
+# comes from the user's NVIDIA driver install.
+#
+# Usage: scripts/package-linux-cuda.sh <dist-dir> [cuda-lib-dir]
+set -euo pipefail
+
+dist="${1:?usage: package-linux-cuda.sh <dist-dir> [cuda-lib-dir]}"
+[ -d "$dist" ] || { echo "package-linux-cuda: '$dist' is not a directory" >&2; exit 1; }
+
+# Prefer an explicit dir, then the toolkit CUDA_PATH the installer action exports,
+# then the usual system locations.
+candidates=()
+[ "${2:-}" != "" ] && candidates+=("$2")
+[ "${CUDA_PATH:-}" != "" ] && candidates+=("$CUDA_PATH/lib64" "$CUDA_PATH/lib")
+candidates+=(/usr/local/cuda/lib64 /usr/lib/x86_64-linux-gnu)
+
+src=""
+for dir in "${candidates[@]}"; do
+  if [ -d "$dir" ] && compgen -G "$dir/libnvrtc.so*" > /dev/null; then
+    src="$dir"
+    break
+  fi
+done
+
+if [ -z "$src" ]; then
+  echo "package-linux-cuda: no libnvrtc.so* found in: ${candidates[*]}" >&2
+  echo "package-linux-cuda: install the CUDA nvrtc component before packaging." >&2
+  exit 1
+fi
+
+echo "package-linux-cuda: staging NVRTC from $src"
+copied=0
+for pattern in 'libnvrtc.so*' 'libnvrtc-builtins.so*'; do
+  for lib in "$src"/$pattern; do
+    [ -e "$lib" ] || continue
+    # `.alt.` variants are an alternate JIT backend cudarc never asks for; skipping
+    # them keeps ~90 MB out of every download.
+    case "$(basename "$lib")" in *.alt.so*) continue ;; esac
+    cp -L "$lib" "$dist/"
+    echo "  + $(basename "$lib")"
+    copied=$((copied + 1))
+  done
+done
+
+# libnvrtc.so.<major> is the soname cudarc actually dlopen's; a stage that missed it
+# would produce a tarball that still cannot reach the GPU, so fail rather than ship.
+if ! compgen -G "$dist/libnvrtc.so.*" > /dev/null; then
+  echo "package-linux-cuda: staged $copied file(s) but no libnvrtc.so.<major> soname" >&2
+  exit 1
+fi
+
+echo "package-linux-cuda: staged $copied NVRTC file(s) into $dist"

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,38 @@ fn dir_has_nvrtc(dir: &std::path::Path) -> bool {
 #[cfg(not(all(windows, feature = "cuda")))]
 fn ensure_cuda_runtime_on_path() {}
 
+/// Stop cudarc's missing-library panics from printing, without silencing anything
+/// else.
+///
+/// cudarc's lazy loaders panic when a CUDA library cannot be dlopen'd. We already
+/// catch those and fall back to the CPU path, so on a host with an NVIDIA driver
+/// but no CUDA toolkit the fallback is *working as designed* — but the default
+/// panic hook still prints the panic plus a `RUST_BACKTRACE` hint on the way
+/// through, so a healthy CPU-only start reads like a crash. That population is
+/// now large: CUDA is compiled into the default x86_64 Linux build, and NVRTC
+/// ships with the toolkit rather than the driver.
+///
+/// Installed ONCE, and it filters by panic origin rather than swapping the hook
+/// around each call: a scoped swap would be process-global for its duration and
+/// could swallow an unrelated thread's panic message (model loads run while the
+/// server handles other requests). Every non-cudarc panic reaches the previous
+/// hook untouched.
+fn quiet_cudarc_loader_panics() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let from_cudarc = info
+                .location()
+                .is_some_and(|loc| loc.file().replace('\\', "/").contains("/cudarc-"));
+            if !from_cudarc {
+                previous(info);
+            }
+        }));
+    });
+}
+
 // Optimus / Enduro hint variables, exported from the exe via build.rs. A laptop's
 // hybrid-graphics driver reads these at process start and routes the process to
 // the discrete NVIDIA / AMD GPU rather than the integrated Intel one. Without this
@@ -1470,6 +1502,9 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
+    // Both before ANY CUDA probe: the hook must be in place before cudarc's lazy
+    // loaders can panic, or the first (caught, handled) miss still prints.
+    quiet_cudarc_loader_panics();
     // Make the GPU runtime discoverable before anything probes for a device, so
     // the shipped app needs no PATH setup (no-op off Windows / without CUDA).
     ensure_cuda_runtime_on_path();


### PR DESCRIPTION
The two follow-ups from #489.

## 1. The Linux tarball now ships NVRTC

MESA compiles CUDA into the default x86_64 Linux build, but `camelid-linux-x86_64.tar.gz` carried no NVRTC — and **NVRTC ships with the CUDA Toolkit, not the driver**. So the ordinary driver-only host detected the GPU and then ran on the CPU: MESA's headline benefit reached only users who already had the toolkit, who could already build with `--features cuda`. The Windows ZIP has always staged its NVRTC DLLs; Linux now matches.

- **`scripts/package-linux-cuda.sh`** stages `libnvrtc.so.<major>` + `libnvrtc-builtins` beside the binary. It skips the `.alt.` JIT variants cudarc never asks for (~90 MB off every download) and **fails** if the soname cudarc actually `dlopen`s is missing, rather than shipping a tarball that silently cannot reach the GPU.
- **`release.yml`** installs only the `nvrtc` component on the Linux leg, via the same action `build-windows` already uses.
- **`.cargo/config.toml`** links x86_64 Linux with `-Wl,-rpath,$ORIGIN`. This is the load-bearing part. Windows solves discovery in code (`ensure_cuda_runtime_on_path` prepends the exe dir to `PATH`), but that **cannot** work on Linux: glibc fixes the loader search path at process start, so changing the environment in-process has no effect on later `dlopen` calls. RUNPATH of the calling object *is* consulted for `dlopen`, so it is the working equivalent. `readelf -d` confirms `RUNPATH [$ORIGIN]`.

### Proof (WSL2 + RTX 3060, `LD_LIBRARY_PATH` scrubbed, same binary both legs)

| leg | result |
|---|---|
| **with** bundled libnvrtc | `cuda_resident_active: true`, `q8_0_cuda_resident_decode` |
| **without** bundled libnvrtc | `cuda_resident_active: false`, `q8_0_decode_packed_rows4_avx2` |

The control leg still served (`load=200 gen=200`), so a host without the bundle degrades rather than failing. Note the A/B was necessary precisely *because* fix 2 below makes the failure silent — "it started" no longer proves NVRTC was found, so both legs load a model to force the kernel compile.

## 2. Handled cudarc panics no longer print

On a driver-only host the CPU fallback is working as designed, but the default panic hook still printed the panic plus a `RUST_BACKTRACE` hint on the way through, so a healthy CPU-only start read like a crash.

One hook is installed at startup that drops panics originating inside cudarc and delegates everything else to the previous hook. Deliberately **not** a scoped `take_hook`/`set_hook` around each call: the hook is process-global, so a scoped swap could swallow an unrelated thread's panic message — model loads run while the server handles other requests. Filtering by origin keeps every other panic's diagnostics intact.

## Also

`package-linux-cuda.sh` is invoked as `bash scripts/...` and carries mode `100755`. Authored on Windows, the executable bit does not survive into the index on its own, and the release job would otherwise have died on `Permission denied` — caught by running the packaging step for real rather than only reading it.

Local gates: fmt, `clippy --all-targets --all-features -D warnings`, public-scrub, ledger-drift all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)