### PR TITLE
chore(release): bump version to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump for **v0.4.3**. Bumps `camelid` and `camelid-desktop` 0.4.2 → 0.4.3 across the four version-bearing files.

## What ships

**#489 (MESA) — CUDA in the default x86_64 Linux build + `serve --gpu auto|on|off`.** Open since 2026-07-22 and excluded from three releases; closed out by finally running the Linux GPU gate it was missing. That gate found **two independent startup crashes**, both made reachable by compiling CUDA in by default, and neither catchable by the guards already present:
- **Missing NVRTC panicked the process** — including under `--gpu off`. NVRTC ships with the CUDA Toolkit, not the driver, so the ordinary driver-only Linux host could not start camelid at all. Now guarded at all three NVRTC entry points.
- **`CUDA_VISIBLE_DEVICES=-1` aborted with a heap double-free** — a SIGABRT that `catch_unwind` cannot intercept, breaking this repo's own documented CPU-pinning idiom. The mask is now honored before the driver is touched.

**#503 — the Linux GPU story actually works.** The tarball now ships NVRTC (with `-Wl,-rpath,$ORIGIN` so it is found without any `LD_LIBRARY_PATH`), matching what the Windows ZIP has always done; and cudarc's handled missing-library panics no longer print, so a healthy CPU-only start stops looking like a crash.

**Heads-up on artifact size:** `camelid-linux-x86_64.tar.gz` grows from ~7.5 MB to ~127 MB, because libnvrtc.so.12 is 106 MB. Unavoidable for GPU-out-of-the-box; the Windows ZIP already pays the same cost at ~87 MB. The `.alt.` JIT variants are skipped, saving ~90 MB more.

Verified on WSL2 Ubuntu + RTX 3060 with the real binaries: GPU decode token-identical to the CPU reference, all four failure scenarios start clean, and a bundled-vs-not A/B shows GPU vs CPU fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)