### PR TITLE
fix(release): stop shipping NVRTC twice in the Linux tarball (v0.4.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"

--- a/scripts/package-linux-cuda.sh
+++ b/scripts/package-linux-cuda.sh
@@ -56,7 +56,12 @@ for pattern in 'libnvrtc.so*' 'libnvrtc-builtins.so*'; do
     # `.alt.` variants are an alternate JIT backend cudarc never asks for; skipping
     # them keeps ~90 MB out of every download.
     case "$(basename "$lib")" in *.alt.so*) continue ;; esac
-    cp -L "$lib" "$dist/"
+    # -P, NOT -L. A toolkit ships libnvrtc.so.<major> as a SYMLINK to
+    # libnvrtc.so.<major>.<minor>.<patch>, and this glob matches both, so
+    # dereferencing copied the same 106 MB library twice — v0.4.3 shipped 113 MB of
+    # duplication that way. Preserving the link keeps one real file plus a cheap
+    # symlink beside it, which resolves identically under $ORIGIN.
+    cp -P "$lib" "$dist/"
     echo "  + $(basename "$lib")"
     copied=$((copied + 1))
   done
@@ -69,4 +74,26 @@ if ! compgen -G "$dist/libnvrtc.so.*" > /dev/null; then
   exit 1
 fi
 
+# A symlink that resolves nowhere is worse than no symlink: dlopen would fail and the
+# GPU would silently never engage. Every staged link must land on a staged file.
+for link in "$dist"/libnvrtc*.so*; do
+  [ -L "$link" ] || continue
+  if [ ! -e "$dist/$(basename "$(readlink "$link")")" ]; then
+    echo "package-linux-cuda: $(basename "$link") -> $(readlink "$link") is dangling" >&2
+    exit 1
+  fi
+done
+
+# Regression guard for the v0.4.3 duplication: two staged REAL files of identical size
+# means a symlink was dereferenced again. Cheap to check, and it fails the release
+# rather than quietly doubling every download.
+dupes=$(find "$dist" -maxdepth 1 -type f -name 'libnvrtc*.so*' -printf '%s\n' | sort | uniq -d | wc -l)
+if [ "$dupes" -ne 0 ]; then
+  echo "package-linux-cuda: staged duplicate NVRTC payloads (same-size real files);" >&2
+  echo "package-linux-cuda: symlinks must be preserved with cp -P, not followed." >&2
+  find "$dist" -maxdepth 1 -name 'libnvrtc*.so*' -printf '  %y %10s %f\n' >&2
+  exit 1
+fi
+
 echo "package-linux-cuda: staged $copied NVRTC file(s) into $dist"
+du -sh "$dist" | awk '{print "package-linux-cuda: dist is " $1}'


### PR DESCRIPTION
## The bug

v0.4.3's `camelid-linux-x86_64.tar.gz` shipped **113 MB of pure duplication** — verified by downloading the published artifact:

```
106237008  libnvrtc.so.12            sha256 c3430e8b6b0d8d3a...
106237008  libnvrtc.so.12.9.86       sha256 c3430e8b6b0d8d3a...   <- identical
  7202760  libnvrtc-builtins.so.12.9      6507cf33450cfb22...
  7202760  libnvrtc-builtins.so.12.9.86   6507cf33450cfb22...      <- identical
```

A CUDA toolkit ships the soname as a **symlink** to the versioned file; the glob matches both, and `cp -L` dereferenced each into its own full copy.

**Why local testing missed it:** the pip `nvidia-cuda-nvrtc-cu12` wheel used to verify the feature ships only `libnvrtc.so.12` with no versioned twin — there was no symlink to follow. The CI runner's toolkit layout has both. The verification environment differed from the release environment in exactly the way that mattered.

## The fix

`cp -P` preserves the link, so one real file plus a cheap symlink land side by side and resolve identically under `$ORIGIN`. Plus two guards that **fail the release** rather than quietly shipping bloat again:

- every staged symlink must resolve to a staged file — a dangling link would make `dlopen` fail and the GPU silently never engage
- no two staged real files may share a size — the duplication signature

Both directions tested against a simulated toolkit layout (real file + symlink), since the pip layout cannot reproduce the bug:

| case | result |
|---|---|
| correct source (real + symlink) | 1 real + 1 symlink per lib, `.alt.` skipped, 3.4M vs 6.9M on the fixture |
| duplicated source (two real files) | **script exits non-zero**, guard prints the offenders |

A guard that has never been shown to fail is not a guard, so the second row matters as much as the first.

## Effect

| | v0.4.3 | v0.4.4 |
|---|---|---|
| compressed | 97 MB | ~50 MB |
| unpacked | 234 MB | ~121 MB |

Functionally identical — v0.4.3 works, it just wastes half the bytes. Includes the 0.4.4 version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)