### PR TITLE
ci: guard Windows debug CLI startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,13 +234,28 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # Windows uses its default feature set here: build.rs enables CUDA for
+          # this target, matching the empty matrix.features value on this leg.
           cargo build --bin camelid
+          if ($LASTEXITCODE -ne 0) {
+            throw "cargo build --bin camelid exited with $LASTEXITCODE"
+          }
+
+          # These were the historical overflowing entrypoints. Each constructs
+          # the full Clap command tree before producing its respective output.
           $version = & .\target\debug\camelid.exe --version
           if ($LASTEXITCODE -ne 0) {
             throw "debug camelid --version exited with $LASTEXITCODE"
           }
           if ($version -notmatch '^camelid\s+\S+') {
             throw "unexpected debug version output: $version"
+          }
+          foreach ($arguments in @(@("--help"), @("serve", "--help"))) {
+            $display = $arguments -join " "
+            & .\target\debug\camelid.exe @arguments > $null
+            if ($LASTEXITCODE -ne 0) {
+              throw "debug camelid $display exited with $LASTEXITCODE"
+            }
           }
 
       # Report, in the log, whether this runner can actually execute the macOS Metal test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,23 @@ jobs:
           RUST_MIN_STACK: 8388608
         run: cargo test --all-targets ${{ matrix.features }}
 
+      # The Windows linker reserves an 8 MiB stack for camelid.exe because the
+      # debug Clap parser needs it. Unit tests exercise a libtest executable,
+      # so they cannot prove the shipped debug binary starts. Keep this direct
+      # check adjacent to the standard test gate to catch a lost linker setting.
+      - name: Debug CLI startup (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo build --bin camelid
+          $version = & .\target\debug\camelid.exe --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "debug camelid --version exited with $LASTEXITCODE"
+          }
+          if ($version -notmatch '^camelid\s+\S+') {
+            throw "unexpected debug version output: $version"
+          }
+
       # Report, in the log, whether this runner can actually execute the macOS Metal test
       # lane. 56 device-gated tests in src/metal.rs and the draft-rollback regression guard
       # in src/inference/tests.rs all self-skip on a host with no usable GPU session, and a

--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -55,24 +55,23 @@ On window close the sidecar is terminated cleanly; a Windows **job object** with
 ## Building (developers)
 
 ```sh
-# From the workspace root. Build the server in RELEASE so a working camelid.exe lands in
-# target/release/ (see the debug caveat below), then build + run the desktop app:
-cargo build --release --locked --bin camelid
+# From the workspace root. Build the debug server sidecar, then build and run
+# the desktop app. Both executables land in target/debug/:
+cargo build --locked --bin camelid
 cargo build -p camelid-desktop
-
-# Run the desktop app, pointing it at the release sidecar that sits beside it. In dev the
-# desktop exe is in target/debug/, so place (or symlink/copy) the release camelid.exe there:
-cp target/release/camelid.exe target/debug/camelid.exe   # one-time, for dev
 cargo run -p camelid-desktop
 ```
 
-> **Debug-server caveat (pre-existing, server-side).** The *debug* `camelid.exe` overflows
-> its main-thread stack on startup (it crashes even on `camelid --version`) — a large stack
-> frame in the server's `main.rs` that release optimization elides. This is unrelated to the
-> desktop app and out of scope here (the brief forbids modifying the server). Always pair the
-> desktop app with a **release** `camelid.exe`; the shipped artifact does exactly that. When
-> the sidecar fails to come up, the desktop surfaces the real error + engine stderr on the
-> splash rather than faking a ready state — which is the intended fail-closed behavior.
+For packaging, build the release sidecar explicitly:
+
+```sh
+cargo build --release --locked --bin camelid
+```
+
+The debug `camelid.exe` is supported for local desktop development. On Windows, the server's
+link configuration reserves sufficient stack for the large CLI parser; CI exercises its
+`--version` startup path directly. When the sidecar fails to come up, the desktop surfaces the
+real error and engine stderr on the splash rather than faking a ready state.
 
 The server build is unaffected by this crate: `cargo build --release --locked --bin camelid`
 does not pull `camelid-desktop` into its graph (workspace `resolver = "2"`,

--- a/docs/perf-deep-dive/PHASE6_CUDA_STREAMS_PLAN.md
+++ b/docs/perf-deep-dive/PHASE6_CUDA_STREAMS_PLAN.md
@@ -69,7 +69,7 @@ side_a:            wait ev_ffn ──► up gemv ──rec ev_up
 
 ## 6. Validation (token-identical)
 
-1. Existing device tests: `cargo test --release --all-features` cuda_resident suite (13/13 + ignored device tests run locally). `--release` (debug overflows Win main stack). Clippy `--all-targets --all-features -D warnings` + fmt before push.
+1. Existing device tests: `cargo test --release --all-features` cuda_resident suite (13/13 + ignored device tests run locally). Clippy `--all-targets --all-features -D warnings` + fmt before push.
 2. New `scripts/validate-cuda-streams.sh`, cloned from `scripts/validate-cuda-prefill-row.sh` (the established env-flag A/B pattern): sequential server restarts — **never two engines resident at once** (bench-memory-safety hard rule), free-RAM check (model+3GB) before each leg, kill orphans by PID after each leg. Byte-identical greedy diff, OFF vs ON, on:
    - Llama-3.2-3B Q8_0 GPU-resident (the gate model), low-ctx prompts + the long multi-chunk depth prompt from `scripts/qwen3-cuda-prefill-ab.mjs` (~1881 tok);
    - Qwen3-4B Q8_0 (second arch, QK-norm path exercises k-norm on side_a);

--- a/qa/capability/smoke.sh
+++ b/qa/capability/smoke.sh
@@ -3,7 +3,7 @@
 #
 # Usage:  qa/capability/smoke.sh <model.gguf> [port] [out-suffix]
 #   CAMELID_EXE        camelid binary (default: target/release/camelid.exe).
-#                      A RELEASE build is required — debug `serve` overflows the stack.
+#                      Set this to run the smoke test against another build.
 #   CAMELID_SMOKE_OUT  output dir (default: qa/capability/smoke_out<out-suffix>).
 #
 # Evidence captured: sampling lane (min_p/repeat_penalty accepted + seed


### PR DESCRIPTION
## Summary
- add a Windows CI guard that builds the debug server binary and verifies CLI startup paths
- fail explicitly if the debug build fails, then exercise `--version`, root `--help`, and `serve --help`; each constructs the full Clap command tree that historically exhausted the Windows main stack
- correct desktop development guidance: the debug sidecar is supported; release builds remain for packaging
- remove stale claims that debug `serve` overflows from the active CUDA streams plan and capability smoke harness; the harness still defaults to its existing release path and can be overridden with `CAMELID_EXE`

## Validation
- exact Windows CI PowerShell guard locally: `cargo build --bin camelid`, `--version`, root `--help`, and `serve --help` (passed)
- `cargo test --bin camelid -- --test-threads=1` (22 passed)
- debug `serve` loopback health probe (`/v1/health` returned `ok: true`)
- isolated `cargo test -p camelid-desktop --all-targets` (4 passed)
- `bash -n qa/capability/smoke.sh`
- `git diff --check`

## Notes
- The shared Cargo target hit the pre-existing Windows `LNK1104` locked-output condition while linking the desktop test executable; the same tests passed in a fresh isolated target directory.
- The cross-platform CI `RUST_MIN_STACK` setting is intentionally unchanged because this Windows validation does not establish it is unnecessary on Linux.