### PR TITLE
docs: clarify experimental Windows CUDA boundary

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -147,6 +147,10 @@ The Windows port is implementation-level only and behind `#[cfg(...)]` guards: f
 - Direct Windows-vs-llama.cpp parity artifacts for the Llama 3.2 1B/3B and other exact rows. TinyLlama and the four Qwen3 dense Q8_0 rows (0.6B/1.7B/4B/8B) carry Windows parity bundles today; the Llama 3.2 1B/3B Windows CPU lanes generate correctly and agree with the GPU lane, but their Windows parity bundles are still follow-up.
 - Performance, throughput, or packaging on Windows. (The Qwen3 rows run on the AVX2 x86_q8 path, but no Windows throughput number is claimed.)
 
+**Windows CUDA status.** Windows CUDA is experimental. Any evidence is limited to the named exact
+rows and the recorded GPU, driver, and CUDA version; it does not establish general Windows-CUDA
+token parity or a throughput claim.
+
 **Windows CUDA — dense Qwen3 Q8_0 rows validated (GPU-specific); experimental beyond the recorded GPU.** The CUDA backend is compiled into the DEFAULT build on Windows and x86_64 Linux (other targets keep it opt-in via `cargo build --features cuda`; macOS uses Metal). Compiling the path in is a build-wiring fact, not a support claim: every validated row below was recorded on the Windows GPU named with it, and running the same path on Linux does not extend those parity claims to that host. It runs the whole decode forward on an NVIDIA GPU via from-scratch NVRTC kernels (no vendored llama.cpp): a GPU-resident decode engine that uploads weights once and caches them across requests, single-shot GPU prefill, on-device greedy/temperature sampling, and a lossless n-gram speculative-decode path. The per-kernel GPU tests are bit-identical to the CPU dot, and the resident prefill / batched-verify / full-forward paths carry GPU device tests.
 
 - **TinyLlama** on an RTX 3060: token-identical to the CPU/llama.cpp reference (direct parity audit, prompt + generated text + 50-token stream match, `first_divergent_token_index=-1`), including when dense per-token diagnostics force the decode onto the CPU path — the GPU prefill mirrors its KV cache back to host so the CPU and GPU KV histories stay in lockstep.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ready to use.
 - **Local by default.** Models and inference stay on your machine unless you choose to expose the server.
 - **One engine, several interfaces.** Desktop app, browser chat, terminal chat, or HTTP API — all the same runtime.
 - **Nothing else to install.** The engine and web UI ship together as one binary.
-- **Hardware acceleration.** Native Metal on Apple Silicon and CUDA on validated NVIDIA paths, with a CPU fallback everywhere.
+- **Hardware acceleration.** Native Metal on Apple Silicon and experimental Windows CUDA for exact, recorded NVIDIA paths, with a CPU fallback everywhere.
 - **Evidence-backed compatibility.** Support is tied to an exact GGUF row and published validation artifacts, never a broad claim.
 
 ## Quick start
@@ -48,8 +48,11 @@ ready to use.
    - `Camelid.Desktop_<version>_x64-setup.exe` — signed installer; installs per-user, no admin rights.
    - `camelid-desktop-windows-x64.zip` — portable desktop app, no installation required.
 2. Run it. The app installs per-user under `%LOCALAPPDATA%\Camelid Desktop`.
-3. It bundles the CUDA runtime, so GPU acceleration works with just the normal NVIDIA driver (CPU
-   otherwise), and it embeds the same engine as everything below.
+3. It bundles the CUDA runtime, so no separate CUDA Toolkit is required. Its experimental Windows
+  CUDA path still requires a compatible NVIDIA driver (CPU otherwise), and it embeds the same
+  engine as everything below. Windows CUDA evidence is limited to the exact rows and recorded GPU,
+  driver, and CUDA versions in [COMPATIBILITY.md](COMPATIBILITY.md); it makes no general
+  token-parity or throughput claim.
 
 ### Option B — Prebuilt engine (Windows, macOS, or Linux)
 
@@ -260,17 +263,19 @@ Camelid ships for three platforms today.
 
 | Platform | Distribution | Acceleration |
 |---|---|---|
-| Windows x86_64 | Desktop installer, portable desktop ZIP, engine ZIP | NVIDIA CUDA on validated paths; CPU fallback |
+| Windows x86_64 | Desktop installer, portable desktop ZIP, engine ZIP | Experimental CUDA on named exact rows and recorded NVIDIA configurations; CPU fallback |
 | macOS Apple Silicon | Engine archive (`.tar.gz`) | Metal and CPU |
 | Linux x86_64 | Engine archive (`.tar.gz`) | NVIDIA CUDA compiled in by default; CPU fallback |
 
-CUDA is compiled into the default build on Windows and x86_64 Linux, so a machine with the normal
-NVIDIA driver gets the GPU path with no build flags and no CUDA SDK (the driver and NVRTC load
-dynamically at runtime; without a GPU the build still runs CPU-only). `camelid serve --gpu
-auto|on|off` (or `CAMELID_GPU`) overrides the automatic choice. Other Linux targets — aarch64, the
-Raspberry Pi — stay CPU-only, with CUDA opt-in via `--features cuda`. Note the validated GPU parity
-rows in [COMPATIBILITY.md](COMPATIBILITY.md) were recorded on Windows; compiling the path in on
-Linux does not by itself extend those row-level parity claims.
+CUDA is compiled into the default build on Windows and x86_64 Linux. On Windows, the GPU path is
+experimental: it needs a compatible NVIDIA driver, but no separate CUDA Toolkit or build flag. Its
+evidence is limited to the named exact rows and recorded GPU, driver, and CUDA configuration in
+[COMPATIBILITY.md](COMPATIBILITY.md); other configurations are not covered by those parity or
+throughput claims. The driver and NVRTC load dynamically at runtime; without a usable GPU the build
+still runs CPU-only. `camelid serve --gpu auto|on|off` (or `CAMELID_GPU`) overrides the automatic
+choice. Other Linux targets — aarch64, the Raspberry Pi — stay CPU-only, with CUDA opt-in via
+`--features cuda`. Compiling the path in on Linux does not by itself extend the Windows row-level
+parity claims.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Clarifies the public support boundary for Windows CUDA without changing CUDA code, packaging, model support, inference behavior, or performance characteristics.

Windows CUDA remains **experimental**. The public documentation now consistently limits evidence to named exact compatibility rows and the recorded GPU, NVIDIA driver, and CUDA versions. It does not claim general Windows-CUDA token parity or throughput.

## Problem

The public README and compatibility contract needed the same narrow framing. In particular, bundled CUDA runtime support could be misread as removing all NVIDIA driver requirements, and high-level platform wording risked sounding broader than the recorded evidence.

## Changes

### README

- States that the bundled runtime removes the need to install a separate CUDA Toolkit, not the need for a compatible NVIDIA driver.
- Marks Windows acceleration as experimental CUDA limited to named exact rows and recorded NVIDIA configurations.
- Aligns the Windows CUDA explanation with the detailed compatibility contract and links readers to `COMPATIBILITY.md`.

### COMPATIBILITY.md

- Adds an explicit release-contract boundary for Windows CUDA.
- Limits evidence to the named exact rows and recorded GPU, driver, and CUDA version.
- Explicitly rules out a general Windows-CUDA token-parity or throughput claim.

## Review Follow-up

The wording review was incorporated in `f2e42c1`:

- Corrected the Toolkit/driver distinction.
- Synchronized the README platform table and explanatory text with the exact-evidence boundary.

## Validation

Local checks:

- `scripts/check-public-scrub.sh`
- Public evidence-claim checks
- Ledger schema and drift checks
- CUDA gate-wiring check
- README screenshot guard
- `git diff --check`

CI on `f2e42c1` is fully green:

- setup
- public-scrub
- Rust on Ubuntu, macOS, and Windows
- desktop
- validation-scripts
- frontend
- ci-gate

The evidence checksum script was not run locally because existing CRLF `SHA256SUMS` entries are incompatible with Git Bash `sha256sum` on Windows; the authoritative Ubuntu CI leg runs that validation successfully.

## Scope and Non-Goals

- Documentation-only change: no runtime, CUDA kernel, build, package, model, or API changes.
- Does not promote Windows CUDA to a supported lane.
- Does not claim general hardware coverage, token parity, or throughput.