### PR TITLE
fix(desktop): clarify sidecar startup failures

### DIFF
--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -46,6 +46,26 @@ camelid-desktop.exe ──spawns──▶ camelid.exe serve --addr 127.0.0.1:<ep
 On window close the sidecar is terminated cleanly; a Windows **job object** with
 `KILL_ON_JOB_CLOSE` is the backstop so a desktop crash cannot orphan a `camelid` process.
 
+## Startup failures
+
+The splash is fail-closed: it stays visible until the sidecar returns `200` from
+`/v1/health`. It polls every 350 ms for up to 40 seconds. Native startup state is retained and
+replayed after the splash listener registers, so a fast failure cannot be lost before the page
+loads. A failure shows an actionable title and next step first, followed by the engine's actual
+error and captured stderr under **Technical details**; it never navigates to a fake-ready UI.
+
+| Splash error | Meaning | Next step |
+| --- | --- | --- |
+| **Camelid engine is missing** | `camelid.exe` was not found beside the desktop executable, in the bundled sidecar resources, or on `PATH`. | Reinstall Camelid Desktop or restore `camelid.exe` beside `camelid-desktop.exe`, then retry. |
+| **Sidecar port unavailable** | The engine reported that it could not bind Camelid's selected ephemeral loopback port. This is not a fixed `8181` port conflict. | Close the conflicting local process and retry. |
+| **Engine startup timed out** | The sidecar did not pass the 40-second `/v1/health` gate. | Retry, then use the visible technical details to diagnose a persistent failure. |
+| **Engine startup failed** | The sidecar exited before it became healthy for another reason. | Review the visible technical details and retry. |
+
+Model readiness is separate from sidecar startup. Once `/v1/health` passes, Desktop navigates to
+the engine's existing UI; if no eligible model is loaded, that UI remains the authority and shows
+its normal model-required state. Desktop does not claim a ready model or manufacture a model error
+on the splash.
+
 ## Requirements
 
 - Windows 10/11 with the **WebView2 runtime** (preinstalled on current Windows 10/11; the

--- a/camelid-desktop/splash/index.html
+++ b/camelid-desktop/splash/index.html
@@ -26,8 +26,12 @@
       }
       .title { font-size: 20px; font-weight: 600; letter-spacing: 0.2px; }
       .status { color: #9aa6b2; min-height: 1.4em; }
-      .err { color: #f0a3a3; white-space: pre-wrap; text-align: left; max-width: 90%;
-             font-family: ui-monospace, "Cascadia Code", Consolas, monospace; font-size: 12.5px; }
+      .err { color: #f0a3a3; text-align: left; max-width: min(90%, 680px); }
+      .err-title { font-size: 16px; font-weight: 600; }
+      .err-guidance { color: #d8dee6; margin-top: 6px; }
+      .err-details { margin-top: 12px; }
+      .err-detail { margin: 8px 0 0; max-height: 15rem; overflow: auto; white-space: pre-wrap;
+            font-family: ui-monospace, "Cascadia Code", Consolas, monospace; font-size: 12.5px; }
       .spinner {
         width: 26px; height: 26px; border-radius: 50%;
         border: 3px solid #2a323c; border-top-color: #6ea8fe;
@@ -41,26 +45,51 @@
     <div class="wrap">
       <div id="spinner" class="spinner"></div>
       <div class="title">Camelid Desktop</div>
-      <!-- Updated by the Rust side via emit("engine-status", ...). Never shows a fake
-           "ready" state: it reflects real sidecar spawn + /v1/health progress only. -->
+       <!-- Updated by the Rust side via emit("engine-status", ...), then replayed from native
+         state after listener registration. Never shows a fake ready state. -->
       <div id="status" class="status">Starting engine&hellip;</div>
-      <div id="error" class="err hidden"></div>
+      <div id="error" class="err hidden" role="alert">
+        <div id="error-title" class="err-title"></div>
+        <div id="error-guidance" class="err-guidance"></div>
+        <details id="error-details" class="err-details" open>
+          <summary>Technical details</summary>
+          <pre id="error-detail" class="err-detail"></pre>
+        </details>
+      </div>
     </div>
     <script>
-      // Listen for real lifecycle events emitted by the Rust backend. This page does no
-      // IPC commands of its own; it only renders status the engine reports.
+      // Render real lifecycle events emitted by the Rust backend and the durable native
+      // snapshot that closes the gap before this page has installed its listener.
       const statusEl = document.getElementById("status");
       const errEl = document.getElementById("error");
+      const errTitleEl = document.getElementById("error-title");
+      const errGuidanceEl = document.getElementById("error-guidance");
+      const errDetailsEl = document.getElementById("error-details");
+      const errDetailEl = document.getElementById("error-detail");
       const spinnerEl = document.getElementById("spinner");
-      if (window.__TAURI__ && window.__TAURI__.event) {
+      function renderStartupState(payload) {
+        const p = payload || {};
+        if (p.message) statusEl.textContent = p.message;
+        if (p.error) {
+          const error = typeof p.error === "string"
+            ? { title: "Engine startup failed", detail: p.error }
+            : p.error;
+          spinnerEl.classList.add("hidden");
+          errEl.classList.remove("hidden");
+          statusEl.textContent = "Engine could not start.";
+          errTitleEl.textContent = error.title || "Engine startup failed";
+          errGuidanceEl.textContent = error.guidance || "Review the technical details and retry.";
+          errDetailEl.textContent = error.detail || "No additional diagnostics were available.";
+          errDetailsEl.open = true;
+        }
+      }
+      if (window.__TAURI__ && window.__TAURI__.event && window.__TAURI__.core) {
         window.__TAURI__.event.listen("engine-status", (e) => {
-          const p = e.payload || {};
-          if (p.message) statusEl.textContent = p.message;
-          if (p.error) {
-            spinnerEl.classList.add("hidden");
-            errEl.classList.remove("hidden");
-            errEl.textContent = p.error;
-          }
+          renderStartupState(e.payload);
+        }).then(() => {
+          window.__TAURI__.core.invoke("startup_snapshot")
+            .then(renderStartupState)
+            .catch(() => {});
         });
       }
     </script>

--- a/camelid-desktop/src/engine.rs
+++ b/camelid-desktop/src/engine.rs
@@ -31,27 +31,71 @@ const HEALTH_TIMEOUT: Duration = Duration::from_secs(40);
 /// Backoff between health polls (model load can dominate; keep polls cheap and patient).
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(350);
 
+/// Stable startup-failure classes rendered by the bundled splash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EngineErrorKind {
+    MissingBinary,
+    PortUnavailable,
+    StartupTimeout,
+    StartupFailed,
+}
+
 /// A fatal error during sidecar startup, carrying any captured engine stderr so the splash
 /// can surface the *real* failure rather than a fake "ready" state.
 #[derive(Debug)]
 pub struct EngineError {
+    kind: EngineErrorKind,
     pub message: String,
     pub stderr: Option<String>,
 }
 
 impl EngineError {
-    fn new(message: impl Into<String>) -> Self {
+    fn new(kind: EngineErrorKind, message: impl Into<String>) -> Self {
         Self {
+            kind,
             message: message.into(),
             stderr: None,
         }
     }
-    fn with_stderr(message: impl Into<String>, stderr: Option<String>) -> Self {
+    fn with_stderr(
+        kind: EngineErrorKind,
+        message: impl Into<String>,
+        stderr: Option<String>,
+    ) -> Self {
         Self {
+            kind,
             message: message.into(),
             stderr,
         }
     }
+    /// Stable summary rendered prominently on the splash after sidecar startup fails.
+    pub fn splash_title(&self) -> &'static str {
+        match self.kind {
+            EngineErrorKind::MissingBinary => "Camelid engine is missing",
+            EngineErrorKind::PortUnavailable => "Sidecar port unavailable",
+            EngineErrorKind::StartupTimeout => "Engine startup timed out",
+            EngineErrorKind::StartupFailed => "Engine startup failed",
+        }
+    }
+
+    /// Actionable next step paired with [`Self::splash_title`] on the splash.
+    pub fn splash_guidance(&self) -> &'static str {
+        match self.kind {
+            EngineErrorKind::MissingBinary => {
+                "Reinstall Camelid Desktop or place camelid.exe beside camelid-desktop.exe, then retry."
+            }
+            EngineErrorKind::PortUnavailable => {
+                "Another local process claimed Camelid's selected loopback port. Close it and retry."
+            }
+            EngineErrorKind::StartupTimeout => {
+                "The engine did not pass its 40-second health check. Retry, then review the technical details if it persists."
+            }
+            EngineErrorKind::StartupFailed => {
+                "The engine stopped before it became healthy. Review the technical details, then retry."
+            }
+        }
+    }
+
     /// Human-readable detail block for the splash error pane.
     pub fn detail(&self) -> String {
         match &self.stderr {
@@ -154,11 +198,20 @@ fn simplify_extended_path(p: PathBuf) -> PathBuf {
 /// release and the sidecar re-binding; this is the standard trade-off and is handled by the
 /// health gate failing loudly (never silently) if the bind races.
 pub fn pick_ephemeral_port() -> Result<u16, EngineError> {
-    let listener = TcpListener::bind("127.0.0.1:0")
-        .map_err(|e| EngineError::new(format!("could not reserve a loopback port: {e}")))?;
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| {
+        EngineError::new(
+            EngineErrorKind::PortUnavailable,
+            format!("could not reserve a loopback port: {e}"),
+        )
+    })?;
     let port = listener
         .local_addr()
-        .map_err(|e| EngineError::new(format!("could not read reserved port: {e}")))?
+        .map_err(|e| {
+            EngineError::new(
+                EngineErrorKind::PortUnavailable,
+                format!("could not read reserved port: {e}"),
+            )
+        })?
         .port();
     drop(listener);
     Ok(port)
@@ -167,8 +220,12 @@ pub fn pick_ephemeral_port() -> Result<u16, EngineError> {
 /// Spawn `camelid serve --addr 127.0.0.1:<port> --no-open --models-dir <abs>`, bound to
 /// loopback only, and health-gate it. Returns a running [`Engine`] or an [`EngineError`]
 /// carrying engine stderr.
-pub fn spawn(engine_path: &PathBuf) -> Result<Engine, EngineError> {
+pub fn spawn(engine_path: &Path) -> Result<Engine, EngineError> {
     let port = pick_ephemeral_port()?;
+    spawn_on_port(engine_path, port)
+}
+
+fn spawn_on_port(engine_path: &Path, port: u16) -> Result<Engine, EngineError> {
     let addr = format!("127.0.0.1:{port}");
 
     let mut command = Command::new(engine_path);
@@ -193,10 +250,18 @@ pub fn spawn(engine_path: &PathBuf) -> Result<Engine, EngineError> {
     no_console_window(&mut command);
 
     let mut child = command.spawn().map_err(|e| {
-        EngineError::new(format!(
-            "failed to launch the camelid engine at {}: {e}",
-            engine_path.display()
-        ))
+        let kind = if e.kind() == std::io::ErrorKind::NotFound {
+            EngineErrorKind::MissingBinary
+        } else {
+            EngineErrorKind::StartupFailed
+        };
+        EngineError::new(
+            kind,
+            format!(
+                "failed to launch the camelid engine at {}: {e}",
+                engine_path.display()
+            ),
+        )
     })?;
 
     // Tie the child's lifetime to ours: if the desktop process dies (even crashes), the OS
@@ -211,13 +276,7 @@ pub fn spawn(engine_path: &PathBuf) -> Result<Engine, EngineError> {
             #[cfg(windows)]
             _job: job,
         }),
-        Err(err) => {
-            // Capture whatever the engine printed before failing, then ensure it's dead.
-            let stderr = drain_stderr(&mut child);
-            let _ = child.kill();
-            let _ = child.wait();
-            Err(EngineError::with_stderr(err.message, stderr.or(err.stderr)))
-        }
+        Err(err) => Err(finish_startup_failure(&mut child, err)),
     }
 }
 
@@ -240,25 +299,54 @@ fn sidecar_models_dir(engine_path: &Path) -> Option<PathBuf> {
 
 /// Poll `/v1/health` until it returns 200, the engine exits, or the budget elapses.
 fn wait_for_health(port: u16, child: &mut Child) -> Result<(), EngineError> {
-    let deadline = Instant::now() + HEALTH_TIMEOUT;
+    wait_for_health_with_timeout(port, child, HEALTH_TIMEOUT, HEALTH_POLL_INTERVAL)
+}
+
+fn wait_for_health_with_timeout(
+    port: u16,
+    child: &mut Child,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<(), EngineError> {
+    let deadline = Instant::now() + timeout;
     loop {
         // If the engine already exited, fail immediately with its status (stderr added later).
         if let Ok(Some(status)) = child.try_wait() {
-            return Err(EngineError::new(format!(
-                "the camelid engine exited before becoming healthy (status: {status})"
-            )));
+            return Err(EngineError::new(
+                EngineErrorKind::StartupFailed,
+                format!("the camelid engine exited before becoming healthy (status: {status})"),
+            ));
         }
         if http_health_ok(port) {
             return Ok(());
         }
         if Instant::now() >= deadline {
-            return Err(EngineError::new(format!(
-                "the camelid engine did not report healthy on 127.0.0.1:{port} within {}s",
-                HEALTH_TIMEOUT.as_secs()
-            )));
+            return Err(EngineError::new(
+                EngineErrorKind::StartupTimeout,
+                format!(
+                    "the camelid engine did not report healthy on 127.0.0.1:{port} within {}s",
+                    HEALTH_TIMEOUT.as_secs()
+                ),
+            ));
         }
-        std::thread::sleep(HEALTH_POLL_INTERVAL);
+        std::thread::sleep(poll_interval);
     }
+}
+
+/// Recognize only explicit OS bind diagnostics captured from the sidecar.
+///
+/// The ephemeral reservation must be released before the sidecar binds. A listener observed
+/// *after* a generic sidecar exit is not proof that it caused the exit, so it must not control
+/// the user-facing diagnosis. The engine's own bind failure is the authority instead.
+fn stderr_is_bind_failure(stderr: Option<&str>) -> bool {
+    let Some(stderr) = stderr else {
+        return false;
+    };
+    let stderr = stderr.to_ascii_lowercase();
+    stderr.contains("address already in use")
+        || stderr.contains("only one usage of each socket address")
+        || stderr.contains("os error 98")
+        || stderr.contains("os error 10048")
 }
 
 /// Dependency-free loopback HTTP/1.1 GET of `/v1/health`; true iff the status line is 200.
@@ -287,17 +375,38 @@ fn http_health_ok(port: u16) -> bool {
     }
 }
 
-/// Best-effort read of any buffered engine stderr (used to enrich a startup failure).
+/// Best-effort read of engine stderr after the child has been reaped.
 fn drain_stderr(child: &mut Child) -> Option<String> {
     let mut stderr = child.stderr.take()?;
     let mut buf = String::new();
-    // The child has been (or is about to be) killed; this read returns what was buffered.
     let _ = stderr.read_to_string(&mut buf);
     if buf.trim().is_empty() {
         None
     } else {
         Some(buf)
     }
+}
+
+fn terminate_and_collect_stderr(child: &mut Child) -> Option<String> {
+    let _ = child.kill();
+    let _ = child.wait();
+    drain_stderr(child)
+}
+
+fn finish_startup_failure(child: &mut Child, error: EngineError) -> EngineError {
+    // A timed-out child still owns the stderr pipe. Reap it before a blocking read so the
+    // startup worker cannot get stuck and leave the splash spinner visible indefinitely.
+    let stderr = terminate_and_collect_stderr(child);
+    let EngineError {
+        mut kind,
+        message,
+        stderr: prior_stderr,
+    } = error;
+    let stderr = stderr.or(prior_stderr);
+    if kind == EngineErrorKind::StartupFailed && stderr_is_bind_failure(stderr.as_deref()) {
+        kind = EngineErrorKind::PortUnavailable;
+    }
+    EngineError::with_stderr(kind, message, stderr)
 }
 
 /// Suppress the spawned engine's console window on Windows (CREATE_NO_WINDOW).
@@ -375,8 +484,157 @@ impl Drop for JobObject {
 
 #[cfg(test)]
 mod tests {
-    use super::sidecar_models_dir;
+    use super::{
+        finish_startup_failure, sidecar_models_dir, spawn, stderr_is_bind_failure,
+        terminate_and_collect_stderr, wait_for_health_with_timeout, EngineError, EngineErrorKind,
+    };
+    use std::net::TcpListener;
     use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn splash_failure_contract_is_actionable() {
+        let cases = [
+            (
+                EngineErrorKind::MissingBinary,
+                "Camelid engine is missing",
+                "place camelid.exe beside camelid-desktop.exe",
+            ),
+            (
+                EngineErrorKind::PortUnavailable,
+                "Sidecar port unavailable",
+                "selected loopback port",
+            ),
+            (
+                EngineErrorKind::StartupTimeout,
+                "Engine startup timed out",
+                "40-second health check",
+            ),
+            (
+                EngineErrorKind::StartupFailed,
+                "Engine startup failed",
+                "stopped before it became healthy",
+            ),
+        ];
+
+        for (kind, title, guidance_fragment) in cases {
+            let error = EngineError::new(kind, "technical detail");
+            assert_eq!(error.splash_title(), title);
+            assert!(error.splash_guidance().contains(guidance_fragment));
+        }
+    }
+
+    #[test]
+    fn missing_sidecar_is_classified_at_spawn() {
+        let missing = std::env::temp_dir().join(format!(
+            "camelid-desktop-missing-sidecar-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&missing);
+
+        let error = match spawn(&missing) {
+            Ok(_) => panic!("a missing sidecar unexpectedly launched"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind, EngineErrorKind::MissingBinary);
+        assert_eq!(error.splash_title(), "Camelid engine is missing");
+    }
+
+    #[test]
+    fn captured_bind_diagnostic_is_required_for_port_classification() {
+        assert!(stderr_is_bind_failure(Some(
+            "failed to bind 127.0.0.1:1234: Address already in use (os error 98)"
+        )));
+        assert!(stderr_is_bind_failure(Some(
+            "Only one usage of each socket address is normally permitted. (os error 10048)"
+        )));
+        assert!(!stderr_is_bind_failure(Some(
+            "model metadata is invalid; sidecar stopped before binding"
+        )));
+        assert!(!stderr_is_bind_failure(None));
+    }
+
+    #[test]
+    fn unhealthy_live_child_is_reaped_before_stderr_is_drained() {
+        let mut command = long_lived_stderr_command("sidecar remains alive");
+        command.stdout(Stdio::null()).stderr(Stdio::piped());
+        let mut child = command.spawn().expect("start test sidecar");
+        assert!(child.try_wait().expect("query child state").is_none());
+
+        let started = Instant::now();
+        let error = wait_for_health_with_timeout(
+            unused_loopback_port(),
+            &mut child,
+            Duration::from_millis(100),
+            Duration::from_millis(5),
+        )
+        .expect_err("live child without health endpoint must time out");
+        assert_eq!(error.kind, EngineErrorKind::StartupTimeout);
+
+        let stderr = terminate_and_collect_stderr(&mut child).expect("captured test stderr");
+        assert!(started.elapsed() < Duration::from_secs(3));
+        assert!(stderr.contains("sidecar remains alive"));
+        assert!(child.try_wait().expect("query reaped child").is_some());
+    }
+
+    #[test]
+    fn only_captured_bind_diagnostics_change_the_final_error_kind() {
+        let mut bind_command = long_lived_stderr_command("address already in use");
+        bind_command.stdout(Stdio::null()).stderr(Stdio::piped());
+        let mut bind_child = bind_command.spawn().expect("start bind-failure test child");
+        std::thread::sleep(Duration::from_millis(100));
+
+        let bind_error = finish_startup_failure(
+            &mut bind_child,
+            EngineError::new(EngineErrorKind::StartupFailed, "sidecar exited"),
+        );
+        assert_eq!(
+            bind_error.kind,
+            EngineErrorKind::PortUnavailable,
+            "unexpected captured stderr: {:?}",
+            bind_error.stderr
+        );
+
+        let mut generic_command = long_lived_stderr_command("model metadata is invalid");
+        generic_command.stdout(Stdio::null()).stderr(Stdio::piped());
+        let mut generic_child = generic_command
+            .spawn()
+            .expect("start generic-failure test child");
+        std::thread::sleep(Duration::from_millis(100));
+
+        let generic_error = finish_startup_failure(
+            &mut generic_child,
+            EngineError::new(EngineErrorKind::StartupFailed, "sidecar exited"),
+        );
+        assert_eq!(generic_error.kind, EngineErrorKind::StartupFailed);
+    }
+
+    fn unused_loopback_port() -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve loopback port");
+        let port = listener.local_addr().expect("read reserved port").port();
+        drop(listener);
+        port
+    }
+
+    #[cfg(windows)]
+    fn long_lived_stderr_command(message: &str) -> Command {
+        let mut command = Command::new("cmd.exe");
+        let script = format!("echo {message} 1>&2 & ping -n 3 127.0.0.1 >nul 2>nul");
+        command.args(["/D", "/C", script.as_str()]);
+        command
+    }
+
+    #[cfg(not(windows))]
+    fn long_lived_stderr_command(message: &str) -> Command {
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!("printf '%s\\n' '{message}' >&2; exec sleep 30"),
+        ]);
+        command
+    }
 
     #[test]
     fn models_dir_sits_beside_an_absolute_engine_path() {

--- a/camelid-desktop/src/main.rs
+++ b/camelid-desktop/src/main.rs
@@ -12,7 +12,7 @@
 mod engine;
 
 use std::sync::Mutex;
-use tauri::{Emitter, Manager};
+use tauri::{Emitter, Manager, State};
 
 use engine::Engine;
 
@@ -20,20 +20,101 @@ use engine::Engine;
 #[derive(Default)]
 struct EngineState(Mutex<Option<Engine>>);
 
+/// A durable startup snapshot which the splash can replay after its JavaScript loads.
+#[derive(Clone, serde::Serialize)]
+struct StartupSnapshot {
+    message: Option<String>,
+    error: Option<StartupError>,
+}
+
+#[derive(Clone, serde::Serialize)]
+struct StartupError {
+    title: String,
+    guidance: String,
+    detail: String,
+}
+
+impl StartupSnapshot {
+    fn status(message: impl Into<String>) -> Self {
+        Self {
+            message: Some(message.into()),
+            error: None,
+        }
+    }
+
+    fn error(
+        title: impl Into<String>,
+        guidance: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            message: None,
+            error: Some(StartupError {
+                title: title.into(),
+                guidance: guidance.into(),
+                detail: detail.into(),
+            }),
+        }
+    }
+}
+
+impl Default for StartupSnapshot {
+    fn default() -> Self {
+        Self::status("Starting engine...")
+    }
+}
+
+/// Events improve responsiveness; this native state prevents early failures being lost before
+/// the splash listener has registered.
+#[derive(Default)]
+struct StartupState(Mutex<StartupSnapshot>);
+
+impl StartupState {
+    fn replace(&self, snapshot: StartupSnapshot) {
+        let mut guard = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = snapshot;
+    }
+
+    fn snapshot(&self) -> StartupSnapshot {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+#[tauri::command]
+fn startup_snapshot(state: State<'_, StartupState>) -> StartupSnapshot {
+    state.snapshot()
+}
+
 /// Report real startup progress to the splash. Never emits a "ready" state that isn't backed
 /// by a passing health check.
 fn emit_status(app: &tauri::AppHandle, message: &str) {
-    let _ = app.emit("engine-status", serde_json::json!({ "message": message }));
+    let snapshot = StartupSnapshot::status(message);
+    if let Some(state) = app.try_state::<StartupState>() {
+        state.replace(snapshot.clone());
+    }
+    let _ = app.emit("engine-status", snapshot);
 }
 
-/// Surface a real startup failure (with engine stderr) on the splash error pane.
-fn emit_error(app: &tauri::AppHandle, error: &str) {
-    let _ = app.emit("engine-status", serde_json::json!({ "error": error }));
+/// Surface a structured, actionable failure on the splash, with raw diagnostics retained.
+fn emit_error(app: &tauri::AppHandle, title: &str, guidance: &str, detail: &str) {
+    let snapshot = StartupSnapshot::error(title, guidance, detail);
+    if let Some(state) = app.try_state::<StartupState>() {
+        state.replace(snapshot.clone());
+    }
+    let _ = app.emit("engine-status", snapshot);
 }
 
 fn main() {
     tauri::Builder::default()
         .manage(EngineState::default())
+        .manage(StartupState::default())
+        .invoke_handler(tauri::generate_handler![startup_snapshot])
         .setup(|app| {
             let handle = app.handle().clone();
             // Start the sidecar off the UI thread so the splash paints immediately.
@@ -59,7 +140,7 @@ fn start_engine(app: tauri::AppHandle) {
     let engine_path = match engine::resolve_engine_path(resource_dir) {
         Ok(p) => p,
         Err(e) => {
-            emit_error(&app, &e.detail());
+            emit_error(&app, e.splash_title(), e.splash_guidance(), &e.detail());
             return;
         }
     };
@@ -78,16 +159,31 @@ fn start_engine(app: tauri::AppHandle) {
                 match tauri::Url::parse(&url) {
                     Ok(parsed) => {
                         if let Err(e) = window.navigate(parsed) {
-                            emit_error(&app, &format!("could not load the engine UI: {e}"));
+                            emit_error(
+                                &app,
+                                "Engine UI could not load",
+                                "Retry the desktop app. If it persists, review the technical details.",
+                                &format!("could not load the engine UI: {e}"),
+                            );
                         }
                     }
-                    Err(e) => emit_error(&app, &format!("invalid engine URL {url}: {e}")),
+                    Err(e) => emit_error(
+                        &app,
+                        "Engine UI could not load",
+                        "Retry the desktop app. If it persists, review the technical details.",
+                        &format!("invalid engine URL {url}: {e}"),
+                    ),
                 }
             } else {
-                emit_error(&app, "internal error: main window not found");
+                emit_error(
+                    &app,
+                    "Desktop window unavailable",
+                    "Close Camelid Desktop and try again.",
+                    "internal error: main window not found",
+                );
             }
         }
-        Err(e) => emit_error(&app, &e.detail()),
+        Err(e) => emit_error(&app, e.splash_title(), e.splash_guidance(), &e.detail()),
     }
 }
 
@@ -99,5 +195,26 @@ fn shutdown_engine(app_handle: &tauri::AppHandle) {
                 eng.shutdown();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StartupSnapshot, StartupState};
+
+    #[test]
+    fn startup_error_is_replayable_after_the_listener_would_register() {
+        let state = StartupState::default();
+        state.replace(StartupSnapshot::error(
+            "Camelid engine is missing",
+            "Restore camelid.exe and retry.",
+            "failed to launch camelid.exe",
+        ));
+
+        let snapshot = state.snapshot();
+        let error = snapshot.error.expect("early error remains available");
+        assert_eq!(error.title, "Camelid engine is missing");
+        assert_eq!(error.guidance, "Restore camelid.exe and retry.");
+        assert_eq!(error.detail, "failed to launch camelid.exe");
     }
 }


### PR DESCRIPTION
## Summary

Makes Camelid Desktop's sidecar-startup failure surface reliable rather than event-timing-dependent. The native shell remains additive: it owns only sidecar lifecycle and splash feedback; the engine remains the authority for health, models, inference, and the embedded UI after health succeeds.

## Why

The original splash could remain on an indefinite spinner when a healthy sidecar never appeared, because the startup worker tried to synchronously drain an alive child's stderr pipe. It could also lose a fast early error emitted before splash JavaScript registered its listener. Finally, a later TCP connection to the selected port was correlation, not proof that a bind conflict caused the engine exit.

## Review Fixes

### Terminate and reap before draining stderr

- All unsuccessful health-gate paths now converge through `finish_startup_failure`.
- It kills and waits for the sidecar before `read_to_string` drains stderr, guaranteeing EOF even when the 40-second health gate times out while the child remains alive.
- The original startup error and captured diagnostics remain available to the user-facing technical-details pane.

### Durable, replayable startup state

- The native shell maintains a serializable `StartupSnapshot` containing either current status or structured error information.
- Native state is updated before every `engine-status` event.
- The splash first registers its event listener, then invokes the `startup_snapshot` command and renders the returned authoritative state. A missing sidecar or other fast failure can no longer be lost before listener registration.
- Error detail continues to be rendered via `textContent`, not HTML injection.

### Confirmed bind diagnostics only

- Removed the post-exit loopback TCP probe.
- A generic early engine exit remains `Engine startup failed` even if some other process later listens on the chosen port.
- `Sidecar port unavailable` is now assigned only for loopback-reservation failures or explicit, captured OS bind diagnostics from the sidecar (`address already in use`, Windows 10048, or Unix 98).
- User documentation now describes an engine-reported bind failure, not an inferred bind race.

## User-facing Behavior

| Condition | Splash title | Guidance |
| --- | --- | --- |
| Sidecar binary missing | Camelid engine is missing | Reinstall or restore `camelid.exe`, then retry. |
| Confirmed sidecar bind failure | Sidecar port unavailable | Close the conflicting local process and retry. |
| Sidecar never becomes healthy | Engine startup timed out | Retry and use technical details for a persistent failure. |
| Other early sidecar exit | Engine startup failed | Review technical details and retry. |

The splash remains fail-closed until `/v1/health` returns `200`. Passing health only unlocks navigation to the existing engine UI; it does not claim that a model is ready.

## Tests

- `unhealthy_live_child_is_reaped_before_stderr_is_drained` covers a live child holding stderr open, verifies timeout classification, captured stderr, and reaping without a multi-second block.
- `only_captured_bind_diagnostics_change_the_final_error_kind` verifies that captured bind output maps to the port error while generic stderr stays generic.
- `startup_error_is_replayable_after_the_listener_would_register` verifies native state retains an early structured error for later splash retrieval.

## Validation

- `cargo test -p camelid-desktop --all-targets` - 10 passed
- `cargo clippy -p camelid-desktop --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/check-public-scrub.sh`
- `git diff --check`
- Editor diagnostics clean; touched files retain LF EOLs

## Scope

- No changes to engine inference, model support claims, readiness semantics, API behavior, or Web UI behavior after successful health gating.
- No fixed-port assumptions: Desktop continues using an ephemeral loopback address.

## Merge Checklist

- [x] Local focused tests and static gates pass
- [ ] Fresh PR CI matrix is green
- [ ] Review comments are resolved