### PR TITLE
ci(release): verify shipped artifacts before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -529,11 +529,48 @@ jobs:
     needs: [build, build-windows]
     runs-on: ubuntu-latest
     steps:
-      - name: Download build artifacts
+      # Download BY NAME, one step per artifact this job is responsible for.
+      # `download-artifact` with neither `name` nor `pattern` fetches every
+      # artifact in the run, and `merge-multiple: true` flattens them all into
+      # one directory -- so a bare download would sweep the diagnostic
+      # verification receipts (and whatever the independent desktop job had
+      # finished uploading) into `dist`, and `files: dist/*` below would attach
+      # them to the public release. Naming each artifact keeps the published
+      # set exact and fails closed if one is missing.
+      - name: Download the macOS artifact
         uses: actions/download-artifact@v4
         with:
+          name: camelid-macos-arm64
           path: dist
-          merge-multiple: true
+
+      - name: Download the Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: camelid-linux-x86_64
+          path: dist
+
+      - name: Download the Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: camelid-windows-x64
+          path: dist
+
+      # Nothing but the three server archives and their sidecars may reach the
+      # release. This is a cheap standing assertion that the downloads above
+      # stayed scoped.
+      - name: Confirm only publishable files are staged
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          unexpected=$(find . -maxdepth 1 -type f \
+            ! -name '*.tar.gz' ! -name '*.tar.gz.sha256' \
+            ! -name '*.zip' ! -name '*.zip.sha256' -print)
+          if [ -n "$unexpected" ]; then
+            echo "refusing to publish unexpected files:" >&2
+            echo "$unexpected" >&2
+            exit 1
+          fi
+          ls -1
 
       # Each .sha256 was computed on its own build runner. The bytes then made
       # two more hops (upload-artifact, download-artifact) before this job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ permissions:
   contents: write
 
 env:
+  # The single release identity for this run. A tag push resolves to the pushed
+  # tag; a workflow_dispatch resolves to the tag the operator asked to publish.
+  # Every job checks THIS out and asserts the binary reports it, so a dispatch
+  # cannot build one ref and attach those bytes to a different tag.
+  RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
   # Any CUDA 12.x works: the NVRTC soname (nvrtc64_120_0.dll) is stable across the
   # 12.x series and cudarc is pinned to the 12.x ABI (`cuda-12090`). The matching
   # nvrtc-builtins ship in the same component, so the pair is always self-consistent.
@@ -37,8 +42,13 @@ jobs:
             label: linux-x86_64
     runs-on: ${{ matrix.os }}
     steps:
+      # Pinned to RELEASE_TAG, not the triggering ref: a workflow_dispatch must
+      # build the tag it is going to publish under, or the attached bytes are
+      # not the tag's bytes.
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       # The web UI is embedded into the binary at compile time, so it must be
       # built before cargo build.
@@ -125,20 +135,14 @@ jobs:
             $nvrtc_flag \
             --out "$dist-check-receipt.json"
 
-          # Only a tag push guarantees the checked-out commit IS the released
-          # commit. workflow_dispatch builds whatever ref it was started from,
-          # so pinning the binary to the input tag there would fail by design.
-          version_flag=""
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            version_flag="--expect-version ${{ github.ref_name }}"
-          else
-            echo "note: not a tag push; skipping the binary/tag version assertion"
-          fi
-
+          # Asserted unconditionally. The checkout above pinned this job to
+          # RELEASE_TAG, so the binary must report it whether this run came
+          # from a tag push or a manual dispatch -- the release is published
+          # under that same tag either way.
           node scripts/smoke-release-artifact.mjs \
             --dir "verify/$dist" \
             --label "${{ matrix.label }}" \
-            $version_flag \
+            --expect-version "${{ env.RELEASE_TAG }}" \
             --out "$dist-smoke-receipt.json"
 
       - name: Upload artifacts
@@ -178,6 +182,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -277,11 +283,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "check-release-artifact failed ($LASTEXITCODE)" }
 
           # Compress-Archive packs the CONTENTS, so the payload is at the root.
-          $versionArgs = @()
-          if ('${{ github.ref_type }}' -eq 'tag') { $versionArgs = @('--expect-version', '${{ github.ref_name }}') }
-          else { Write-Host 'note: not a tag push; skipping the binary/tag version assertion' }
-
-          node scripts/smoke-release-artifact.mjs --dir verify --label windows-x64 @versionArgs --out "$dist-smoke-receipt.json"
+          node scripts/smoke-release-artifact.mjs --dir verify --label windows-x64 --expect-version '${{ env.RELEASE_TAG }}' --out "$dist-smoke-receipt.json"
           if ($LASTEXITCODE -ne 0) { throw "smoke-release-artifact failed ($LASTEXITCODE)" }
 
       - name: Upload artifacts
@@ -331,6 +333,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -480,11 +484,7 @@ jobs:
             --out "$dist-check-receipt.json"
           if ($LASTEXITCODE -ne 0) { throw "check-release-artifact failed ($LASTEXITCODE)" }
 
-          $versionArgs = @()
-          if ('${{ github.ref_type }}' -eq 'tag') { $versionArgs = @('--expect-version', '${{ github.ref_name }}') }
-          else { Write-Host 'note: not a tag push; skipping the binary/tag version assertion' }
-
-          node scripts/smoke-release-artifact.mjs --dir verify-desktop --label desktop-windows-x64 @versionArgs --out "$dist-smoke-receipt.json"
+          node scripts/smoke-release-artifact.mjs --dir verify-desktop --label desktop-windows-x64 --expect-version '${{ env.RELEASE_TAG }}' --out "$dist-smoke-receipt.json"
           if ($LASTEXITCODE -ne 0) { throw "smoke-release-artifact failed ($LASTEXITCODE)" }
 
           # The installer is published separately and must exist as its own file.
@@ -518,7 +518,7 @@ jobs:
       - name: Publish signed desktop artifacts to the release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
           files: |
             camelid-desktop-windows-x64.zip
             camelid-desktop-windows-x64.zip.sha256
@@ -556,66 +556,31 @@ jobs:
           path: dist
 
       # Nothing but the three server archives and their sidecars may reach the
-      # release. This is a cheap standing assertion that the downloads above
-      # stayed scoped.
-      - name: Confirm only publishable files are staged
-        working-directory: dist
-        run: |
-          set -euo pipefail
-          unexpected=$(find . -maxdepth 1 -type f \
-            ! -name '*.tar.gz' ! -name '*.tar.gz.sha256' \
-            ! -name '*.zip' ! -name '*.zip.sha256' -print)
-          if [ -n "$unexpected" ]; then
-            echo "refusing to publish unexpected files:" >&2
-            echo "$unexpected" >&2
-            exit 1
-          fi
-          ls -1
+      # release, and every sidecar must be one record naming its own archive.
+      # This reuses the same parser the build-time check uses, so the two gates
+      # cannot drift and a `shasum -c` run by a user verifies what CI verified.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
-      # Each .sha256 was computed on its own build runner. The bytes then made
-      # two more hops (upload-artifact, download-artifact) before this job
-      # publishes them, and nothing re-checked them afterwards. Re-hashing here
-      # means the checksum published beside a file provably describes the file
-      # actually published.
-      - name: Re-verify checksums after the artifact round-trip
-        working-directory: dist
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Verify checksums after the artifact round-trip
         run: |
-          set -euo pipefail
-          shopt -s nullglob
-          sidecars=(*.sha256)
-          if [ ${#sidecars[@]} -eq 0 ]; then
-            echo "no .sha256 sidecars found in dist/ — refusing to publish unverifiable artifacts" >&2
-            exit 1
-          fi
-          for sidecar in "${sidecars[@]}"; do
-            archive="${sidecar%.sha256}"
-            if [ ! -f "$archive" ]; then
-              echo "$sidecar has no matching archive $archive" >&2
-              exit 1
-            fi
-            # awk (not read) so a sidecar written without a trailing newline —
-            # which is exactly what the PowerShell packaging steps produce —
-            # still yields its hash.
-            expected=$(awk '{print $1; exit}' "$sidecar")
-            actual=$(shasum -a 256 "$archive" | awk '{print $1}')
-            if [ "$expected" != "$actual" ]; then
-              echo "checksum mismatch for $archive: sidecar $expected, actual $actual" >&2
-              exit 1
-            fi
-            echo "  verified $archive"
-          done
-          # Every publishable archive must carry a sidecar, not just the reverse.
-          for archive in *.tar.gz *.zip; do
-            if [ ! -f "$archive.sha256" ]; then
-              echo "$archive has no .sha256 sidecar" >&2
-              exit 1
-            fi
-          done
+          node scripts/verify-release-checksums.mjs \
+            --dir dist \
+            --expect camelid-macos-arm64.tar.gz \
+            --expect camelid-linux-x86_64.tar.gz \
+            --expect camelid-windows-x64.zip
 
       - name: Publish to the GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
           files: dist/*
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,46 @@ jobs:
           tar -czf "$dist.tar.gz" "$dist"
           shasum -a 256 "$dist.tar.gz" > "$dist.tar.gz.sha256"
 
+      # Open the box that actually ships. Everything above this point verifies
+      # the STAGING directory (scripts/package-linux-cuda.sh) or the source tree
+      # (ci.yml); nothing has ever inspected or executed the archive itself.
+      # Extracting with the same tar a user runs also proves the archive is
+      # readable and that symlinks survived packaging.
+      - name: Verify the packaged artifact
+        run: |
+          set -euo pipefail
+          dist="camelid-${{ matrix.label }}"
+          rm -rf verify && mkdir -p verify
+          tar -xzf "$dist.tar.gz" -C verify
+
+          # NVRTC is staged into the Linux tarball only; macOS has no CUDA lane.
+          nvrtc_flag=""
+          if [ "${{ matrix.label }}" = "linux-x86_64" ]; then nvrtc_flag="--require-nvrtc"; fi
+
+          node scripts/check-release-artifact.mjs \
+            --dir verify \
+            --label "${{ matrix.label }}" \
+            --archive "$dist.tar.gz" \
+            --checksum "$dist.tar.gz.sha256" \
+            $nvrtc_flag \
+            --out "$dist-check-receipt.json"
+
+          # Only a tag push guarantees the checked-out commit IS the released
+          # commit. workflow_dispatch builds whatever ref it was started from,
+          # so pinning the binary to the input tag there would fail by design.
+          version_flag=""
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            version_flag="--expect-version ${{ github.ref_name }}"
+          else
+            echo "note: not a tag push; skipping the binary/tag version assertion"
+          fi
+
+          node scripts/smoke-release-artifact.mjs \
+            --dir "verify/$dist" \
+            --label "${{ matrix.label }}" \
+            $version_flag \
+            --out "$dist-smoke-receipt.json"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -108,6 +148,17 @@ jobs:
           path: |
             camelid-${{ matrix.label }}.tar.gz
             camelid-${{ matrix.label }}.tar.gz.sha256
+
+      # Receipts are diagnostic only: they are attached to the CI run, never to
+      # the release and never committed (qa/evidence-bundles is a scrubbed,
+      # checksum-audited tree and this is not one of its bundles).
+      - name: Upload verification receipts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verification-receipts-${{ matrix.label }}
+          path: camelid-${{ matrix.label }}-*-receipt.json
+          if-no-files-found: ignore
 
   # Windows is built separately: its packaging differs from the unix matrix above
   # because a self-contained Windows download must ship the NVRTC redistributable
@@ -206,6 +257,33 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 "$dist.zip").Hash.ToLower()
           "$hash  $dist.zip" | Out-File -Encoding ascii -NoNewline "$dist.zip.sha256"
 
+      # Verify the SIGNED, zipped artifact — after signing on purpose, so the
+      # smoke proves the exe users actually receive still boots.
+      - name: Verify the packaged artifact
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dist = 'camelid-windows-x64'
+          Remove-Item -Recurse -Force verify -ErrorAction SilentlyContinue
+          Expand-Archive -Path "$dist.zip" -DestinationPath verify -Force
+
+          node scripts/check-release-artifact.mjs `
+            --dir verify `
+            --label windows-x64 `
+            --archive "$dist.zip" `
+            --checksum "$dist.zip.sha256" `
+            --require-nvrtc `
+            --out "$dist-check-receipt.json"
+          if ($LASTEXITCODE -ne 0) { throw "check-release-artifact failed ($LASTEXITCODE)" }
+
+          # Compress-Archive packs the CONTENTS, so the payload is at the root.
+          $versionArgs = @()
+          if ('${{ github.ref_type }}' -eq 'tag') { $versionArgs = @('--expect-version', '${{ github.ref_name }}') }
+          else { Write-Host 'note: not a tag push; skipping the binary/tag version assertion' }
+
+          node scripts/smoke-release-artifact.mjs --dir verify --label windows-x64 @versionArgs --out "$dist-smoke-receipt.json"
+          if ($LASTEXITCODE -ne 0) { throw "smoke-release-artifact failed ($LASTEXITCODE)" }
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -213,6 +291,14 @@ jobs:
           path: |
             camelid-windows-x64.zip
             camelid-windows-x64.zip.sha256
+
+      - name: Upload verification receipts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verification-receipts-windows-x64
+          path: camelid-windows-x64-*-receipt.json
+          if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------------
   # ADDITIVE: native Windows desktop app (camelid-desktop). Fully independent of the
@@ -370,6 +456,43 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 "$dist.zip").Hash.ToLower()
           "$hash  $dist.zip" | Out-File -Encoding ascii -NoNewline "$dist.zip.sha256"
 
+      # The portable layout depends on beside-exe resolution, so the contract
+      # check also proves the sidecar and its NVRTC pair travelled with the
+      # desktop exe, and that the NSIS installer was moved OUT before zipping.
+      # The boot smoke drives the SIDECAR: launching a Tauri GUI headless on a
+      # runner proves nothing, whereas the engine it bundles is the thing that
+      # must serve. A failure here still cannot block the server release — this
+      # job is in no other job's `needs`.
+      - name: Verify the packaged desktop artifact
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dist = 'camelid-desktop-windows-x64'
+          Remove-Item -Recurse -Force verify-desktop -ErrorAction SilentlyContinue
+          Expand-Archive -Path "$dist.zip" -DestinationPath verify-desktop -Force
+
+          node scripts/check-release-artifact.mjs `
+            --dir verify-desktop `
+            --label desktop-windows-x64 `
+            --archive "$dist.zip" `
+            --checksum "$dist.zip.sha256" `
+            --require-nvrtc `
+            --out "$dist-check-receipt.json"
+          if ($LASTEXITCODE -ne 0) { throw "check-release-artifact failed ($LASTEXITCODE)" }
+
+          $versionArgs = @()
+          if ('${{ github.ref_type }}' -eq 'tag') { $versionArgs = @('--expect-version', '${{ github.ref_name }}') }
+          else { Write-Host 'note: not a tag push; skipping the binary/tag version assertion' }
+
+          node scripts/smoke-release-artifact.mjs --dir verify-desktop --label desktop-windows-x64 @versionArgs --out "$dist-smoke-receipt.json"
+          if ($LASTEXITCODE -ne 0) { throw "smoke-release-artifact failed ($LASTEXITCODE)" }
+
+          # The installer is published separately and must exist as its own file.
+          $setup = Get-ChildItem -Filter '*-setup.exe' | Select-Object -First 1
+          if (-not $setup) { throw 'no NSIS installer was produced' }
+          if ($setup.Length -le 0) { throw "installer $($setup.Name) is zero bytes" }
+          Write-Host "installer: $($setup.Name) ($([math]::Round($setup.Length / 1MB, 1)) MB)"
+
       - name: Upload desktop artifacts (CI)
         uses: actions/upload-artifact@v4
         with:
@@ -378,6 +501,14 @@ jobs:
             camelid-desktop-windows-x64.zip
             camelid-desktop-windows-x64.zip.sha256
             *-setup.exe
+
+      - name: Upload verification receipts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verification-receipts-desktop-windows-x64
+          path: camelid-desktop-windows-x64-*-receipt.json
+          if-no-files-found: ignore
 
       # Publish the SIGNED desktop artifacts to the SAME GitHub release, independently of the
       # server `release` job (which is left untouched and is in no way gated by this job).
@@ -403,6 +534,46 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      # Each .sha256 was computed on its own build runner. The bytes then made
+      # two more hops (upload-artifact, download-artifact) before this job
+      # publishes them, and nothing re-checked them afterwards. Re-hashing here
+      # means the checksum published beside a file provably describes the file
+      # actually published.
+      - name: Re-verify checksums after the artifact round-trip
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          sidecars=(*.sha256)
+          if [ ${#sidecars[@]} -eq 0 ]; then
+            echo "no .sha256 sidecars found in dist/ — refusing to publish unverifiable artifacts" >&2
+            exit 1
+          fi
+          for sidecar in "${sidecars[@]}"; do
+            archive="${sidecar%.sha256}"
+            if [ ! -f "$archive" ]; then
+              echo "$sidecar has no matching archive $archive" >&2
+              exit 1
+            fi
+            # awk (not read) so a sidecar written without a trailing newline —
+            # which is exactly what the PowerShell packaging steps produce —
+            # still yields its hash.
+            expected=$(awk '{print $1; exit}' "$sidecar")
+            actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+            if [ "$expected" != "$actual" ]; then
+              echo "checksum mismatch for $archive: sidecar $expected, actual $actual" >&2
+              exit 1
+            fi
+            echo "  verified $archive"
+          done
+          # Every publishable archive must carry a sidecar, not just the reverse.
+          for archive in *.tar.gz *.zip; do
+            if [ ! -f "$archive.sha256" ]; then
+              echo "$archive has no .sha256 sidecar" >&2
+              exit 1
+            fi
+          done
 
       - name: Publish to the GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -529,6 +529,23 @@ jobs:
     needs: [build, build-windows]
     runs-on: ubuntu-latest
     steps:
+      # Checkout FIRST, before anything is downloaded into the workspace.
+      # actions/checkout finds no .git here, so it takes its "Deleting the
+      # contents of ..." path and rmRF's the whole workspace -- which would
+      # remove a `dist` populated by earlier steps, leaving the verify step to
+      # fail on a missing directory and publishing nothing. The scripts this job
+      # runs live in the repo, so the checkout has to happen either way; it just
+      # has to happen before `dist` exists.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
       # Download BY NAME, one step per artifact this job is responsible for.
       # `download-artifact` with neither `name` nor `pattern` fetches every
       # artifact in the run, and `merge-multiple: true` flattens them all into
@@ -559,16 +576,6 @@ jobs:
       # release, and every sidecar must be one record naming its own archive.
       # This reuses the same parser the build-time check uses, so the two gates
       # cannot drift and a `shasum -c` run by a user verifies what CI verified.
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
       - name: Verify checksums after the artifact round-trip
         run: |
           node scripts/verify-release-checksums.mjs \

--- a/scripts/check-release-artifact.mjs
+++ b/scripts/check-release-artifact.mjs
@@ -91,6 +91,20 @@ const JUNK_PATTERNS = [
 
 const COMMON_DOCS = ['README.md', 'LICENSE', 'THIRD_PARTY_NOTICES.md']
 
+/**
+ * Allowlist patterns shared by every artifact. Anchored on purpose: the payload
+ * is a CLOSED set, so anything not named here fails rather than riding along.
+ */
+const DOC_PATTERNS = [/^README\.md$/, /^LICENSE$/, /^THIRD_PARTY_NOTICES\.md$/]
+
+/**
+ * Constrained NVRTC filename shapes. `libnvrtc.so.12`, `libnvrtc.so.12.9.86`
+ * and `libnvrtc-builtins.so.12.9` match; `libnvrtc.alt.so.12` and anything
+ * merely containing "nvrtc" do not.
+ */
+const NVRTC_UNIX_PATTERNS = [/^libnvrtc\.so(\.\d+)+$/, /^libnvrtc-builtins\.so(\.\d+)+$/]
+const NVRTC_WINDOWS_PATTERNS = [/^nvrtc64_\d+_\d+\.dll$/i, /^nvrtc-builtins64_\d+\.dll$/i]
+
 /** Depth bound for symlink resolution; real payloads use one hop. */
 const MAX_SYMLINK_HOPS = 8
 
@@ -102,6 +116,7 @@ const ARTIFACT_SPECS = {
     binary: 'camelid',
     executable: true,
     required: ['camelid', ...COMMON_DOCS],
+    allowed: [/^camelid$/, ...DOC_PATTERNS],
     nvrtc: null,
     forbidden: [],
   },
@@ -112,6 +127,7 @@ const ARTIFACT_SPECS = {
     binary: 'camelid',
     executable: true,
     required: ['camelid', ...COMMON_DOCS],
+    allowed: [/^camelid$/, ...DOC_PATTERNS, ...NVRTC_UNIX_PATTERNS],
     nvrtc: NVRTC.unix,
     forbidden: [],
   },
@@ -122,6 +138,7 @@ const ARTIFACT_SPECS = {
     binary: 'camelid.exe',
     executable: false,
     required: ['camelid.exe', ...COMMON_DOCS],
+    allowed: [/^camelid\.exe$/, ...DOC_PATTERNS, ...NVRTC_WINDOWS_PATTERNS],
     nvrtc: NVRTC.windows,
     forbidden: [],
   },
@@ -134,6 +151,7 @@ const ARTIFACT_SPECS = {
     // The portable layout is desktop exe + sidecar + NVRTC beside each other,
     // which is what `beside-exe` sidecar resolution depends on.
     required: ['camelid-desktop.exe', 'camelid.exe', 'DESKTOP_README.md', ...COMMON_DOCS],
+    allowed: [/^camelid-desktop\.exe$/, /^camelid\.exe$/, /^DESKTOP_README\.md$/, ...DOC_PATTERNS, ...NVRTC_WINDOWS_PATTERNS],
     nvrtc: NVRTC.windows,
     // The NSIS installer is `Move-Item`d OUT of the portable folder before it is
     // zipped, because it is published as its own artifact. If that move ever
@@ -159,14 +177,22 @@ const LABELS = Object.keys(ARTIFACT_SPECS)
  * coreutils emits in binary mode, CRLF, and a UTF-8 BOM so a future packaging
  * tweak does not fail for a cosmetic reason.
  *
+ * EXACTLY ONE record is required. A sidecar carrying a valid first line
+ * followed by anything else is rejected: `shasum -c` would consume every
+ * record, so accepting only the first would verify something different from
+ * what a user's own check does.
+ *
  * @returns {{hash: string, name: string}}
  */
 export function parseChecksumFile(text) {
   if (typeof text !== 'string') throw new TypeError('checksum content must be a string')
-  const line = text.replace(/^\uFEFF/, '').split(/\r?\n/).find((l) => l.trim().length > 0)
-  if (!line) throw new Error('checksum file is empty')
-  const match = /^([0-9a-fA-F]{64})\s+\*?(.+?)\s*$/.exec(line.trim())
-  if (!match) throw new Error(`checksum line is not "<64-hex>  <name>": ${JSON.stringify(line.trim())}`)
+  const lines = text.replace(/^\uFEFF/, '').split(/\r?\n/).filter((l) => l.trim().length > 0)
+  if (!lines.length) throw new Error('checksum file is empty')
+  if (lines.length > 1) {
+    throw new Error(`checksum file must contain exactly one record, found ${lines.length}`)
+  }
+  const match = /^([0-9a-fA-F]{64})\s+\*?(.+?)\s*$/.exec(lines[0].trim())
+  if (!match) throw new Error(`checksum line is not "<64-hex>  <name>": ${JSON.stringify(lines[0].trim())}`)
   return { hash: match[1].toLowerCase(), name: match[2] }
 }
 
@@ -424,6 +450,17 @@ export function checkManifest(entries, spec, options = {}) {
     } else if (resolution.kind === 'too-deep') {
       failures.push(`symlink ${entry.path} -> ${target} exceeds ${MAX_SYMLINK_HOPS} hops`)
     }
+  }
+
+  // --- closed payload contract ---------------------------------------------
+  // Required-plus-junk-patterns is an OPEN set: it accepts anything nobody
+  // thought to forbid. The shipped payloads are small and fully enumerable, so
+  // the allowlist is the honest shape: an accidental future glob, a staged
+  // credential, or a stray build output fails here instead of reaching a
+  // public download.
+  for (const entry of entries) {
+    if (spec.allowed.some((re) => re.test(entry.path))) continue
+    failures.push(`unexpected entry in the artifact: ${entry.path} (${entry.kind}) is not part of the ${spec.archive} payload`)
   }
 
   // --- junk and label-specific forbidden entries ---------------------------

--- a/scripts/check-release-artifact.mjs
+++ b/scripts/check-release-artifact.mjs
@@ -1,0 +1,578 @@
+#!/usr/bin/env node
+// check-release-artifact.mjs — static contract check for a packaged release
+// artifact, run BETWEEN packaging and publishing.
+//
+// Why this exists. release.yml already guards the STAGING DIRECTORY:
+// scripts/package-linux-cuda.sh fails on a missing `libnvrtc.so.<major>`
+// soname, a dangling symlink, and a duplicated payload (the v0.4.3 regression).
+// Those guards are good, but three things are still unverified:
+//
+//   1. They run before `tar -czf` / `Compress-Archive`. Nothing has ever looked
+//      inside the archive users actually download.
+//   2. They live INSIDE a conditional packaging step
+//      (`if [ "$label" = "linux-x86_64" ]`). A renamed matrix label silently
+//      skips them and still ships. A check that runs on the EXTRACTED archive
+//      cannot be skipped by a packaging branch that never ran.
+//   3. The `.sha256` sidecar is written once on the build runner and never
+//      re-verified after the artifact round-trips through
+//      upload-artifact / download-artifact into the publish job.
+//
+// This file is deliberately execution-free — booting the binary is
+// scripts/smoke-release-artifact.mjs. Keeping them apart lets the whole
+// contract here stay a pure function of a directory listing, which is what
+// makes it exhaustively unit-testable in scripts/test-check-release-artifact.mjs.
+//
+// One environmental requirement: an artifact must be extracted on a filesystem
+// that preserves what it ships. The Linux tarball carries an NVRTC symlink, so
+// extracting it somewhere symlinks collapse into copies (Windows without
+// developer mode) makes the duplicate-payload guard fire on a packaging job
+// that was actually correct. release.yml always verifies each artifact on the
+// runner that built it, which is the platform it ships to.
+//
+// Usage:
+//   node scripts/check-release-artifact.mjs --dir <extracted-dir> --label <label>
+//        [--archive <file>] [--checksum <file.sha256>]
+//        [--require-nvrtc] [--out <receipt.json>]
+//
+// Labels: macos-arm64 | linux-x86_64 | windows-x64 | desktop-windows-x64
+// Exit 0 = every check passed. Exit 1 = one or more FAIL lines were printed.
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { lstat, readdir, readlink, writeFile, readFile } from 'node:fs/promises'
+import { basename, join, posix, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+// ---------------------------------------------------------------------------
+// Artifact specifications
+//
+// One declarative row per shipped artifact, transcribed from release.yml. The
+// `layout` field is the subtle one and the most likely source of a wrong check:
+//
+//   nested — `tar -czf "$dist.tar.gz" "$dist"` archives the DIRECTORY, so the
+//            extracted tree is `<dest>/camelid-<label>/...`.
+//   flat   — `Compress-Archive -Path "$dist/*"` archives the CONTENTS, so the
+//            extracted tree is `<dest>/...` with no wrapper directory.
+//
+// Asserting the expected layout per label means a packaging change that flips
+// one into the other is caught here rather than by a user with a broken path.
+// ---------------------------------------------------------------------------
+
+/** NVRTC redistributable shapes, per platform family. */
+const NVRTC = {
+  unix: {
+    // The soname cudarc actually dlopen's. package-linux-cuda.sh globs
+    // `libnvrtc.so.*`; the staged set is normally the `libnvrtc.so.<major>`
+    // symlink plus its `libnvrtc.so.<major>.<minor>.<patch>` real file.
+    compiler: /^libnvrtc\.so\.\d+/,
+    builtins: /^libnvrtc-builtins\.so/,
+    family: /^libnvrtc.*\.so/,
+    // The alternate JIT backend cudarc never asks for; ~90 MB of dead weight
+    // that package-linux-cuda.sh deliberately skips.
+    forbidden: /\.alt\.so/,
+  },
+  windows: {
+    compiler: /^nvrtc64_.*\.dll$/i,
+    builtins: /^nvrtc-builtins64_.*\.dll$/i,
+    family: /^nvrtc.*\.dll$/i,
+    forbidden: /\.alt\.dll$/i,
+  },
+}
+
+/** Build outputs and source-tree leakage that must never reach a user download. */
+const JUNK_PATTERNS = [
+  { re: /\.pdb$/i, why: 'debug symbol database' },
+  { re: /\.(d|rlib|rmeta)$/i, why: 'cargo build intermediate' },
+  { re: /\.(exp|ilk)$/i, why: 'linker intermediate' },
+  { re: /^\.git(\/|$)/, why: 'version control metadata' },
+  { re: /(^|\/)node_modules(\/|$)/, why: 'javascript dependency tree' },
+  { re: /(^|\/)target(\/|$)/, why: 'cargo target directory' },
+  { re: /\.(env|pem|key)$/i, why: 'credential-shaped file' },
+]
+
+const COMMON_DOCS = ['README.md', 'LICENSE', 'THIRD_PARTY_NOTICES.md']
+
+const ARTIFACT_SPECS = {
+  'macos-arm64': {
+    archive: 'camelid-macos-arm64.tar.gz',
+    layout: 'nested',
+    payloadRoot: 'camelid-macos-arm64',
+    binary: 'camelid',
+    executable: true,
+    required: ['camelid', ...COMMON_DOCS],
+    nvrtc: null,
+    forbidden: [],
+  },
+  'linux-x86_64': {
+    archive: 'camelid-linux-x86_64.tar.gz',
+    layout: 'nested',
+    payloadRoot: 'camelid-linux-x86_64',
+    binary: 'camelid',
+    executable: true,
+    required: ['camelid', ...COMMON_DOCS],
+    nvrtc: NVRTC.unix,
+    forbidden: [],
+  },
+  'windows-x64': {
+    archive: 'camelid-windows-x64.zip',
+    layout: 'flat',
+    payloadRoot: null,
+    binary: 'camelid.exe',
+    executable: false,
+    required: ['camelid.exe', ...COMMON_DOCS],
+    nvrtc: NVRTC.windows,
+    forbidden: [],
+  },
+  'desktop-windows-x64': {
+    archive: 'camelid-desktop-windows-x64.zip',
+    layout: 'flat',
+    payloadRoot: null,
+    binary: 'camelid-desktop.exe',
+    executable: false,
+    // The portable layout is desktop exe + sidecar + NVRTC beside each other,
+    // which is what `beside-exe` sidecar resolution depends on.
+    required: ['camelid-desktop.exe', 'camelid.exe', 'DESKTOP_README.md', ...COMMON_DOCS],
+    nvrtc: NVRTC.windows,
+    // The NSIS installer is `Move-Item`d OUT of the portable folder before it is
+    // zipped, because it is published as its own artifact. If that move ever
+    // regresses, the portable download silently doubles in size and ships an
+    // installer inside a portable archive.
+    forbidden: [{ re: /-setup\.exe$/i, why: 'NSIS installer must be moved out of the portable zip' }],
+  },
+}
+
+const LABELS = Object.keys(ARTIFACT_SPECS)
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested directly)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a `.sha256` sidecar.
+ *
+ * Two producers write these and they do NOT agree on trailing bytes:
+ *   `shasum -a 256 f > f.sha256`            -> "<hash>  <name>\n"
+ *   PowerShell `Out-File -NoNewline`        -> "<hash>  <name>"   (no newline)
+ * Both use two spaces, but tolerate one-or-more, the `*` binary marker that
+ * coreutils emits in binary mode, CRLF, and a UTF-8 BOM so a future packaging
+ * tweak does not fail for a cosmetic reason.
+ *
+ * @returns {{hash: string, name: string}}
+ */
+export function parseChecksumFile(text) {
+  if (typeof text !== 'string') throw new TypeError('checksum content must be a string')
+  const line = text.replace(/^\uFEFF/, '').split(/\r?\n/).find((l) => l.trim().length > 0)
+  if (!line) throw new Error('checksum file is empty')
+  const match = /^([0-9a-fA-F]{64})\s+\*?(.+?)\s*$/.exec(line.trim())
+  if (!match) throw new Error(`checksum line is not "<64-hex>  <name>": ${JSON.stringify(line.trim())}`)
+  return { hash: match[1].toLowerCase(), name: match[2] }
+}
+
+/** Normalize a version string for tag comparison: drop a leading `v`, trim. */
+export function normalizeVersion(value) {
+  return String(value ?? '').trim().replace(/^v/i, '')
+}
+
+/**
+ * Compare a binary's self-reported version to the release tag.
+ *
+ * `VERSION` (src/main.rs) is `CAMELID_GIT_DESCRIBE` when git metadata is
+ * available, else `CARGO_PKG_VERSION`. At a clean tagged checkout git describe
+ * yields exactly the tag, so an exact match after normalization is the correct
+ * assertion. Anything else — a `-N-gsha` suffix, `-dirty`, or a stale
+ * Cargo.toml that was never bumped — means the published tag and the shipped
+ * bytes disagree, which is precisely what this guard exists to catch.
+ *
+ * @returns {string|null} a failure message, or null when they agree
+ */
+export function compareVersionToTag(reported, tag) {
+  const got = normalizeVersion(reported)
+  const want = normalizeVersion(tag)
+  if (!got) return `binary reported an empty version (expected ${want})`
+  if (got === want) return null
+  if (got.startsWith(`${want}-`)) {
+    return `binary version ${got} is ahead of tag ${want} (git describe suffix means the tag is not at this commit)`
+  }
+  return `binary version ${got} does not match release tag ${want}`
+}
+
+/**
+ * Extract the version token from `camelid --version` output.
+ * clap prints "<bin-name> <version>"; be liberal about the binary name so a
+ * rename does not break the parse.
+ */
+export function parseVersionOutput(text) {
+  const line = String(text ?? '').split(/\r?\n/).find((l) => l.trim().length > 0)
+  if (!line) return null
+  const match = /^\S+\s+(\S+)/.exec(line.trim())
+  return match ? match[1] : null
+}
+
+/**
+ * Decide which subdirectory of the extraction destination holds the payload,
+ * and verify the archive layout matches the spec.
+ *
+ * @param {string[]} topLevelNames entries directly under the extraction dir
+ * @returns {{root: string|null, failures: string[]}} `root` is the payload
+ *   subdirectory name, or null when the payload is the extraction dir itself
+ */
+export function resolvePayloadRoot(topLevelNames, spec) {
+  const failures = []
+  const names = [...topLevelNames].sort()
+  if (spec.layout === 'nested') {
+    if (names.length !== 1 || names[0] !== spec.payloadRoot) {
+      failures.push(
+        `layout: expected exactly one top-level directory "${spec.payloadRoot}/" ` +
+          `(tar archives the directory), found [${names.join(', ')}]`,
+      )
+      // Recover when the expected root is present alongside strays so the rest
+      // of the manifest still gets checked and reported in one run.
+      return { root: names.includes(spec.payloadRoot) ? spec.payloadRoot : null, failures }
+    }
+    return { root: spec.payloadRoot, failures }
+  }
+  // flat
+  if (names.length === 1 && names[0] === basename(spec.archive, '.zip')) {
+    failures.push(
+      `layout: expected archive contents at the root (Compress-Archive -Path "$dist/*"), ` +
+        `but found a single wrapper directory "${names[0]}/"`,
+    )
+    return { root: names[0], failures }
+  }
+  return { root: null, failures }
+}
+
+/**
+ * The whole manifest contract, as a pure function of a normalized entry list.
+ *
+ * @param {Array<{path: string, kind: 'file'|'dir'|'symlink', size: number,
+ *   mode: number, linkTarget?: string, sha256?: string}>} entries
+ *   paths are POSIX, relative to the payload root
+ * @param {object} spec one of ARTIFACT_SPECS
+ * @param {{requireNvrtc?: boolean, checkExecutableBit?: boolean}} options
+ * @returns {string[]} failure messages (empty = pass)
+ */
+export function checkManifest(entries, spec, options = {}) {
+  const { requireNvrtc = false, checkExecutableBit = false } = options
+  const failures = []
+  const files = entries.filter((e) => e.kind === 'file')
+  const byPath = new Map(entries.map((e) => [e.path, e]))
+  const topLevelFileNames = files.filter((e) => !e.path.includes('/')).map((e) => e.path)
+
+  // --- required payload -----------------------------------------------------
+  for (const required of spec.required) {
+    const entry = byPath.get(required)
+    if (!entry) {
+      failures.push(`missing required entry: ${required}`)
+      continue
+    }
+    if (entry.kind !== 'file') {
+      failures.push(`required entry ${required} is a ${entry.kind}, expected a file`)
+      continue
+    }
+    if (entry.size === 0) failures.push(`required entry ${required} is zero bytes`)
+  }
+
+  // --- the binary must be launchable ---------------------------------------
+  const binary = byPath.get(spec.binary)
+  if (binary && binary.kind === 'file' && spec.executable && checkExecutableBit) {
+    // A tarball whose binary lost its +x bit extracts fine and then cannot be
+    // run. Only meaningful on POSIX hosts; Windows has no mode bits to lose.
+    if ((binary.mode & 0o111) === 0) {
+      failures.push(`${spec.binary} is not executable (mode ${(binary.mode & 0o777).toString(8)})`)
+    }
+  }
+
+  // --- NVRTC redistributables ----------------------------------------------
+  if (spec.nvrtc) {
+    const family = topLevelFileNames.concat(
+      entries.filter((e) => e.kind === 'symlink' && !e.path.includes('/')).map((e) => e.path),
+    )
+    if (requireNvrtc) {
+      if (!family.some((n) => spec.nvrtc.compiler.test(n))) {
+        failures.push(
+          `no NVRTC compiler library matching ${spec.nvrtc.compiler} — the GPU path ` +
+            'would silently fall back to CPU on a driver-only host',
+        )
+      }
+      if (!family.some((n) => spec.nvrtc.builtins.test(n))) {
+        failures.push(`no NVRTC builtins library matching ${spec.nvrtc.builtins} — the NVRTC pair is incomplete`)
+      }
+    }
+    for (const name of family) {
+      if (spec.nvrtc.forbidden.test(name)) {
+        failures.push(`${name} is the alternate JIT backend cudarc never loads and must not be shipped`)
+      }
+    }
+  }
+
+  // --- duplicated payload (the v0.4.3 regression, checked post-archive) -----
+  // Scoped to the NVRTC family, mirroring package-linux-cuda.sh's `libnvrtc*`
+  // glob: those are the only entries where duplication is a known failure mode,
+  // and narrowing the scope means two benign identical files (say, a doc
+  // copied twice) can never block a release.
+  //
+  // Within that scope this is stronger than upstream, which compares SIZES.
+  // Comparing content hashes cannot false-positive on two genuinely different
+  // libraries that happen to match in size, and still catches a dereferenced
+  // symlink shipping the same 106 MB twice.
+  const hashed = spec.nvrtc
+    ? files.filter((e) => typeof e.sha256 === 'string' && e.sha256.length > 0 && spec.nvrtc.family.test(basename(e.path)))
+    : []
+  const byHash = new Map()
+  for (const entry of hashed) {
+    if (!byHash.has(entry.sha256)) byHash.set(entry.sha256, [])
+    byHash.get(entry.sha256).push(entry)
+  }
+  for (const [hash, group] of byHash) {
+    if (group.length < 2) continue
+    const paths = group.map((e) => e.path).sort()
+    failures.push(
+      `duplicate payload: ${paths.join(' and ')} are byte-identical (${group[0].size} bytes, sha256 ${hash.slice(0, 12)}…) — ` +
+        'symlinks must be preserved (cp -P), not dereferenced. If this artifact was extracted on a ' +
+        'filesystem that cannot represent symlinks (e.g. Windows without developer mode), extract and ' +
+        'verify it on the platform it ships to instead.',
+    )
+  }
+
+  // --- dangling symlinks ----------------------------------------------------
+  // A link that resolves nowhere is worse than no link: dlopen fails and the
+  // GPU silently never engages.
+  for (const entry of entries) {
+    if (entry.kind !== 'symlink') continue
+    const target = entry.linkTarget ?? ''
+    if (target.startsWith('/') || target.includes('..')) {
+      failures.push(`symlink ${entry.path} -> ${target} escapes the payload`)
+      continue
+    }
+    const resolved = posix.normalize(posix.join(posix.dirname(entry.path), target))
+    if (!byPath.has(resolved)) failures.push(`symlink ${entry.path} -> ${target} is dangling inside the archive`)
+  }
+
+  // --- junk and label-specific forbidden entries ---------------------------
+  for (const entry of entries) {
+    for (const { re, why } of JUNK_PATTERNS) {
+      if (re.test(entry.path)) failures.push(`unexpected ${why} in the artifact: ${entry.path}`)
+    }
+    for (const { re, why } of spec.forbidden) {
+      if (re.test(entry.path)) failures.push(`${entry.path} must not be present: ${why}`)
+    }
+  }
+
+  return failures
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem shell
+// ---------------------------------------------------------------------------
+
+async function sha256File(path) {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+/**
+ * Walk `root` into the normalized entry shape checkManifest expects.
+ * Symlinks are recorded, never followed — following them would hide exactly
+ * the duplication and escape cases we are looking for.
+ */
+export async function readTree(root, { hashFiles = true } = {}) {
+  const entries = []
+  const walk = async (dir, prefix) => {
+    const dirents = await readdir(dir, { withFileTypes: true })
+    for (const dirent of dirents.sort((a, b) => (a.name < b.name ? -1 : 1))) {
+      const absolute = join(dir, dirent.name)
+      const relative = prefix ? posix.join(prefix, dirent.name) : dirent.name
+      const stats = await lstat(absolute)
+      if (stats.isSymbolicLink()) {
+        entries.push({
+          path: relative,
+          kind: 'symlink',
+          size: 0,
+          mode: stats.mode,
+          linkTarget: (await readlink(absolute)).split('\\').join('/'),
+        })
+        continue
+      }
+      if (stats.isDirectory()) {
+        entries.push({ path: relative, kind: 'dir', size: 0, mode: stats.mode })
+        await walk(absolute, relative)
+        continue
+      }
+      entries.push({
+        path: relative,
+        kind: 'file',
+        size: stats.size,
+        mode: stats.mode,
+        sha256: hashFiles ? await sha256File(absolute) : undefined,
+      })
+    }
+  }
+  await walk(root, '')
+  return entries
+}
+
+function parseArgs(argv) {
+  const args = { requireNvrtc: false }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = () => {
+      const value = argv[i + 1]
+      if (value === undefined || value.startsWith('--')) throw new Error(`${arg} requires a value`)
+      i += 1
+      return value
+    }
+    switch (arg) {
+      case '--dir': args.dir = next(); break
+      case '--label': args.label = next(); break
+      case '--archive': args.archive = next(); break
+      case '--checksum': args.checksum = next(); break
+      case '--out': args.out = next(); break
+      case '--require-nvrtc': args.requireNvrtc = true; break
+      case '--help': case '-h': args.help = true; break
+      default: throw new Error(`unknown argument ${arg}`)
+    }
+  }
+  return args
+}
+
+const USAGE = `Usage:
+  node scripts/check-release-artifact.mjs --dir <extracted-dir> --label <label> [options]
+
+Options:
+  --dir <path>        directory the release archive was extracted into (required)
+  --label <label>     ${LABELS.join(' | ')}
+  --archive <path>    archive file to checksum-verify
+  --checksum <path>   .sha256 sidecar to verify --archive against
+  --require-nvrtc     fail when the NVRTC redistributables are absent
+  --out <path>        write a JSON receipt
+`
+
+async function main() {
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(`check-release-artifact: ${error.message}\n\n${USAGE}`)
+    process.exit(2)
+  }
+  if (args.help) {
+    console.log(USAGE)
+    return
+  }
+
+  const failures = []
+  const fail = (message) => failures.push(message)
+
+  if (!args.dir) fail('--dir is required')
+  if (!args.label) fail('--label is required')
+  if (args.label && !ARTIFACT_SPECS[args.label]) fail(`unknown --label ${args.label} (expected one of ${LABELS.join(', ')})`)
+  if (args.archive && !args.checksum) fail('--archive requires --checksum')
+  if (args.checksum && !args.archive) fail('--checksum requires --archive')
+  if (failures.length) {
+    console.error(`check-release-artifact FAILED (${failures.length}):`)
+    for (const failure of failures) console.error(`  FAIL: ${failure}`)
+    console.error(`\n${USAGE}`)
+    process.exit(2)
+  }
+
+  const spec = ARTIFACT_SPECS[args.label]
+  const extractDir = resolve(args.dir)
+  console.log(`check-release-artifact: label=${args.label} layout=${spec.layout}`)
+
+  // 1. checksum round-trip -------------------------------------------------
+  let archiveHash = null
+  if (args.archive) {
+    const archivePath = resolve(args.archive)
+    const archiveName = basename(archivePath)
+    if (archiveName !== spec.archive) {
+      fail(`archive is named ${archiveName}, but label ${args.label} ships ${spec.archive}`)
+    }
+    let expected
+    try {
+      expected = parseChecksumFile(await readFile(resolve(args.checksum), 'utf8'))
+    } catch (error) {
+      fail(`checksum sidecar unreadable: ${error.message}`)
+    }
+    if (expected) {
+      archiveHash = await sha256File(archivePath)
+      if (expected.name !== archiveName) {
+        fail(`checksum sidecar names ${expected.name}, but the archive is ${archiveName}`)
+      }
+      if (expected.hash !== archiveHash) {
+        fail(`sha256 mismatch for ${archiveName}: sidecar ${expected.hash}, actual ${archiveHash}`)
+      } else {
+        console.log(`  sha256 ok: ${archiveHash}`)
+      }
+    }
+  }
+
+  // 2. layout --------------------------------------------------------------
+  let topLevel
+  try {
+    topLevel = (await readdir(extractDir, { withFileTypes: true })).map((d) => d.name)
+  } catch (error) {
+    console.error(`check-release-artifact FAILED: cannot read --dir ${args.dir}: ${error.message}`)
+    process.exit(1)
+  }
+  const { root, failures: layoutFailures } = resolvePayloadRoot(topLevel, spec)
+  layoutFailures.forEach(fail)
+
+  // 3. manifest ------------------------------------------------------------
+  const payloadDir = root ? join(extractDir, root) : extractDir
+  const entries = await readTree(payloadDir)
+  const manifestFailures = checkManifest(entries, spec, {
+    requireNvrtc: args.requireNvrtc,
+    // Mode bits only survive on POSIX filesystems; asserting them on Windows
+    // would fail for a reason that has nothing to do with the artifact.
+    checkExecutableBit: process.platform !== 'win32',
+  })
+  manifestFailures.forEach(fail)
+
+  const fileCount = entries.filter((e) => e.kind === 'file').length
+  const totalBytes = entries.reduce((sum, e) => sum + e.size, 0)
+  console.log(`  payload: ${fileCount} file(s), ${(totalBytes / 1024 / 1024).toFixed(1)} MiB`)
+
+  // 4. receipt -------------------------------------------------------------
+  if (args.out) {
+    const receipt = {
+      schema: 'camelid.release-artifact-check/v1',
+      checked_at: new Date().toISOString(),
+      label: args.label,
+      // Basenames and payload-relative paths only: a receipt must never carry
+      // a runner or developer absolute path into an uploaded artifact.
+      archive: args.archive ? basename(args.archive) : null,
+      archive_sha256: archiveHash,
+      layout: spec.layout,
+      payload_root: root,
+      require_nvrtc: args.requireNvrtc,
+      entries: entries.map((e) => ({
+        path: e.path,
+        kind: e.kind,
+        size: e.size,
+        sha256: e.sha256 ?? null,
+        link_target: e.linkTarget ?? null,
+      })),
+      failures,
+      passed: failures.length === 0,
+    }
+    await writeFile(resolve(args.out), `${JSON.stringify(receipt, null, 2)}\n`, 'utf8')
+    console.log(`  receipt: ${basename(args.out)}`)
+  }
+
+  if (failures.length) {
+    console.error(`\ncheck-release-artifact FAILED (${failures.length}):`)
+    for (const failure of failures) console.error(`  FAIL: ${failure}`)
+    process.exit(1)
+  }
+  console.log(`\ncheck-release-artifact passed: ${args.label} is publishable`)
+}
+
+export { ARTIFACT_SPECS, JUNK_PATTERNS, LABELS, NVRTC, sha256File }
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/check-release-artifact.mjs
+++ b/scripts/check-release-artifact.mjs
@@ -91,6 +91,9 @@ const JUNK_PATTERNS = [
 
 const COMMON_DOCS = ['README.md', 'LICENSE', 'THIRD_PARTY_NOTICES.md']
 
+/** Depth bound for symlink resolution; real payloads use one hop. */
+const MAX_SYMLINK_HOPS = 8
+
 const ARTIFACT_SPECS = {
   'macos-arm64': {
     archive: 'camelid-macos-arm64.tar.gz',
@@ -242,6 +245,68 @@ export function resolvePayloadRoot(topLevelNames, spec) {
 }
 
 /**
+ * Follow a symlink chain to the regular file it ultimately names.
+ *
+ * dlopen resolves links, so verifying only that a link's immediate target
+ * exists is not enough: `libnvrtc.so.12 -> libnvrtc-builtins.so.12.9` points
+ * at a real staged file and still cannot serve as the compiler soname. Cycles
+ * must terminate too, or a self-referential link looks like a valid target of
+ * itself.
+ *
+ * @param {Map<string, object>} byPath payload entries keyed by POSIX path
+ * @param {string} startPath entry to resolve
+ * @returns {{kind: 'resolved'|'dangling'|'escape'|'cycle'|'too-deep', path: string,
+ *   entry?: object, target?: string}}
+ */
+export function resolveSymlinkChain(byPath, startPath, maxHops = MAX_SYMLINK_HOPS) {
+  const seen = new Set()
+  let current = startPath
+  for (let hop = 0; hop <= maxHops; hop += 1) {
+    if (seen.has(current)) return { kind: 'cycle', path: current }
+    seen.add(current)
+    const entry = byPath.get(current)
+    if (!entry) return { kind: 'dangling', path: current }
+    if (entry.kind !== 'symlink') return { kind: 'resolved', path: current, entry }
+    const target = entry.linkTarget ?? ''
+    if (target.startsWith('/')) return { kind: 'escape', path: current, target }
+    const next = posix.normalize(posix.join(posix.dirname(current), target))
+    if (next === '..' || next.startsWith('../')) return { kind: 'escape', path: current, target }
+    current = next
+  }
+  return { kind: 'too-deep', path: startPath }
+}
+
+/**
+ * Require at least one entry named like `role` to RESOLVE to a regular file
+ * that is also named like `role`.
+ *
+ * @returns {string[]} failure messages
+ */
+function checkNvrtcRole(candidates, byPath, pattern, role, consequence) {
+  if (!candidates.length) {
+    return [`no NVRTC ${role} library matching ${pattern} — ${consequence}`]
+  }
+  const diagnostics = []
+  for (const candidate of candidates) {
+    const resolution = resolveSymlinkChain(byPath, candidate.path)
+    if (resolution.kind !== 'resolved') {
+      diagnostics.push(`${candidate.path} does not resolve (${resolution.kind}${resolution.target ? ` -> ${resolution.target}` : ''})`)
+      continue
+    }
+    if (resolution.entry.kind !== 'file') {
+      diagnostics.push(`${candidate.path} resolves to a ${resolution.entry.kind} (${resolution.path})`)
+      continue
+    }
+    if (!pattern.test(basename(resolution.path))) {
+      diagnostics.push(`${candidate.path} resolves to ${resolution.path}, which is not an NVRTC ${role} library`)
+      continue
+    }
+    return []
+  }
+  return [`no usable NVRTC ${role} library — ${consequence}. Checked: ${diagnostics.join('; ')}`]
+}
+
+/**
  * The whole manifest contract, as a pure function of a normalized entry list.
  *
  * @param {Array<{path: string, kind: 'file'|'dir'|'symlink', size: number,
@@ -256,7 +321,6 @@ export function checkManifest(entries, spec, options = {}) {
   const failures = []
   const files = entries.filter((e) => e.kind === 'file')
   const byPath = new Map(entries.map((e) => [e.path, e]))
-  const topLevelFileNames = files.filter((e) => !e.path.includes('/')).map((e) => e.path)
 
   // --- required payload -----------------------------------------------------
   for (const required of spec.required) {
@@ -284,23 +348,32 @@ export function checkManifest(entries, spec, options = {}) {
 
   // --- NVRTC redistributables ----------------------------------------------
   if (spec.nvrtc) {
-    const family = topLevelFileNames.concat(
-      entries.filter((e) => e.kind === 'symlink' && !e.path.includes('/')).map((e) => e.path),
-    )
+    const topLevel = entries.filter((e) => !e.path.includes('/') && (e.kind === 'file' || e.kind === 'symlink'))
     if (requireNvrtc) {
-      if (!family.some((n) => spec.nvrtc.compiler.test(n))) {
-        failures.push(
-          `no NVRTC compiler library matching ${spec.nvrtc.compiler} — the GPU path ` +
-            'would silently fall back to CPU on a driver-only host',
-        )
-      }
-      if (!family.some((n) => spec.nvrtc.builtins.test(n))) {
-        failures.push(`no NVRTC builtins library matching ${spec.nvrtc.builtins} — the NVRTC pair is incomplete`)
-      }
+      // A NAME is not enough. cudarc dlopen's the soname, and dlopen follows
+      // links, so the chain has to end at a real library of the right family.
+      failures.push(
+        ...checkNvrtcRole(
+          topLevel.filter((e) => spec.nvrtc.compiler.test(basename(e.path))),
+          byPath,
+          spec.nvrtc.compiler,
+          'compiler',
+          'the GPU path would silently fall back to CPU on a driver-only host',
+        ),
+      )
+      failures.push(
+        ...checkNvrtcRole(
+          topLevel.filter((e) => spec.nvrtc.builtins.test(basename(e.path))),
+          byPath,
+          spec.nvrtc.builtins,
+          'builtins',
+          'the NVRTC pair is incomplete',
+        ),
+      )
     }
-    for (const name of family) {
-      if (spec.nvrtc.forbidden.test(name)) {
-        failures.push(`${name} is the alternate JIT backend cudarc never loads and must not be shipped`)
+    for (const entry of topLevel) {
+      if (spec.nvrtc.forbidden.test(entry.path)) {
+        failures.push(`${entry.path} is the alternate JIT backend cudarc never loads and must not be shipped`)
       }
     }
   }
@@ -334,18 +407,23 @@ export function checkManifest(entries, spec, options = {}) {
     )
   }
 
-  // --- dangling symlinks ----------------------------------------------------
+  // --- symlink integrity ----------------------------------------------------
   // A link that resolves nowhere is worse than no link: dlopen fails and the
-  // GPU silently never engages.
+  // GPU silently never engages. A link that never terminates is worse still,
+  // because a naive one-hop check reads a cycle as a satisfied target.
   for (const entry of entries) {
     if (entry.kind !== 'symlink') continue
+    const resolution = resolveSymlinkChain(byPath, entry.path)
     const target = entry.linkTarget ?? ''
-    if (target.startsWith('/') || target.includes('..')) {
-      failures.push(`symlink ${entry.path} -> ${target} escapes the payload`)
-      continue
+    if (resolution.kind === 'escape') {
+      failures.push(`symlink ${entry.path} -> ${resolution.target ?? target} escapes the payload`)
+    } else if (resolution.kind === 'dangling') {
+      failures.push(`symlink ${entry.path} -> ${target} is dangling inside the archive (no entry at ${resolution.path})`)
+    } else if (resolution.kind === 'cycle') {
+      failures.push(`symlink ${entry.path} -> ${target} never terminates (cycle at ${resolution.path})`)
+    } else if (resolution.kind === 'too-deep') {
+      failures.push(`symlink ${entry.path} -> ${target} exceeds ${MAX_SYMLINK_HOPS} hops`)
     }
-    const resolved = posix.normalize(posix.join(posix.dirname(entry.path), target))
-    if (!byPath.has(resolved)) failures.push(`symlink ${entry.path} -> ${target} is dangling inside the archive`)
   }
 
   // --- junk and label-specific forbidden entries ---------------------------

--- a/scripts/smoke-release-artifact.mjs
+++ b/scripts/smoke-release-artifact.mjs
@@ -52,6 +52,12 @@ export const HEALTH_POLL_INTERVAL_MS = 350
 /** Version probe budget. `--version` parses the clap tree and exits. */
 export const VERSION_TIMEOUT_MS = 30_000
 
+/** How long a terminated engine gets to close its stdio before SIGKILL. */
+export const TERMINATE_TIMEOUT_MS = 10_000
+
+/** Grace period after SIGKILL for the stdio pipes to drain. */
+export const SIGKILL_GRACE_MS = 5_000
+
 // ---------------------------------------------------------------------------
 // Pure assertions (unit-tested directly)
 // ---------------------------------------------------------------------------
@@ -230,23 +236,101 @@ export async function probeServer(port, get = httpGet) {
   return { failures, health: health.body }
 }
 
-/** Terminate a child and its tree, then wait for the exit to be observed. */
-async function terminate(child) {
-  if (child.exitCode !== null || child.signalCode !== null) return
-  if (process.platform === 'win32') {
-    // A bare kill() leaves the process tree behind on Windows and the runner
-    // then hangs waiting on inherited pipes.
-    await new Promise((done) => {
-      const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' })
-      killer.on('exit', done)
-      killer.on('error', done)
-    })
-  } else {
-    child.kill('SIGTERM')
+/**
+ * Terminate a child and its whole tree, then wait for its stdio to CLOSE.
+ *
+ * `close` rather than `exit`: exit fires when the process goes away, but the
+ * piped stdio streams can still be draining, so reading stderr after exit can
+ * miss the very tail — which is exactly where a panic or abort message lands.
+ * The caller passes a `closed` promise created at spawn time so the event
+ * cannot be missed if the child had already gone.
+ */
+async function terminate(child, closed) {
+  if (child.exitCode === null && child.signalCode === null) {
+    if (process.platform === 'win32') {
+      // A bare kill() leaves the process tree behind on Windows and the runner
+      // then hangs waiting on inherited pipes.
+      await new Promise((done) => {
+        const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' })
+        killer.on('exit', done)
+        killer.on('error', done)
+      })
+    } else {
+      child.kill('SIGTERM')
+    }
   }
-  const exited = new Promise((done) => child.once('exit', done))
-  const timedOut = await Promise.race([exited.then(() => false), sleep(10_000).then(() => true)])
-  if (timedOut) child.kill('SIGKILL')
+  const timedOut = await Promise.race([closed.then(() => false), sleep(TERMINATE_TIMEOUT_MS).then(() => true)])
+  if (!timedOut) return
+  child.kill('SIGKILL')
+  // Still wait after escalating: SIGKILL is not instantaneous, and returning
+  // here would hand the caller a half-drained stderr buffer.
+  await Promise.race([closed, sleep(SIGKILL_GRACE_MS)])
+}
+
+/**
+ * Boot a candidate engine, probe it, and shut it down.
+ *
+ * Split out of main() so the self-test can drive it against a fixture process
+ * that misbehaves in ways a healthy release binary never would.
+ *
+ * @returns {Promise<{failures: string[], healthBody: string|null, stdout: string, stderr: string}>}
+ */
+export async function bootAndProbe({ command, args, cwd, port, timeoutMs = HEALTH_TIMEOUT_MS, get = httpGet }) {
+  const failures = []
+  const child = spawn(command, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
+  // Created before anything can kill the child, so a fast exit cannot race us
+  // into awaiting an event that already fired. Deliberately NOT events.once():
+  // that rejects on the 'error' event a failed spawn emits, turning an
+  // unspawnable binary into an unhandled rejection instead of a clean failure.
+  const closed = new Promise((markClosed) => child.once('close', markClosed))
+  let stdout = ''
+  let stderr = ''
+  let spawnError = null
+  child.stdout.on('data', (d) => { stdout += d })
+  child.stderr.on('data', (d) => { stderr += d })
+  child.on('error', (error) => { spawnError = error })
+  const isAlive = () => spawnError === null && child.exitCode === null && child.signalCode === null
+
+  let healthBody = null
+  try {
+    const health = await waitForHealth({ port, timeoutMs, isAlive, get })
+    if (!health.ok) {
+      failures.push(health.reason)
+      if (spawnError) failures.push(`spawn failed: ${spawnError.message}`)
+    } else {
+      const probe = await probeServer(port, get)
+      failures.push(...probe.failures)
+      healthBody = probe.health
+      // Answering the probes and then falling over is not "serving". Without
+      // this the teardown below sees an already-dead child, returns happily,
+      // and the smoke reports success for a binary that cannot stay up. The
+      // transport re-check is the reliable half: a closed listener refuses
+      // immediately, whereas the process may take a moment to disappear.
+      try {
+        const after = await get(port, '/v1/health')
+        if (after.status !== 200) {
+          failures.push(`the engine stopped serving after the probes (/v1/health returned ${after.status})`)
+        }
+      } catch (error) {
+        failures.push(`the engine stopped serving after the probes (/v1/health: ${error.code || error.message})`)
+      }
+      if (!isAlive()) {
+        failures.push(
+          `the engine exited on its own after answering the probes ` +
+            `(exit code ${child.exitCode}, signal ${child.signalCode}) — a release binary must keep serving`,
+        )
+      }
+    }
+  } catch (error) {
+    // A transport error mid-probe means the engine died under us; report it as
+    // a failure rather than letting it escape as an unhandled rejection.
+    failures.push(`probing the engine failed: ${error.message}`)
+    if (!isAlive()) failures.push('the engine exited while it was being probed')
+  } finally {
+    await terminate(child, closed)
+  }
+
+  return { failures, healthBody, stdout, stderr }
 }
 
 /** Run `<binary> --version` and compare it to the expected tag. */
@@ -343,44 +427,31 @@ async function main() {
   // 2. boot, serve, shut down ---------------------------------------------
   const emptyModelsDir = await mkdtemp(join(tmpdir(), 'camelid-smoke-models-'))
   const port = await pickFreePort()
-  let stderr = ''
-  let stdout = ''
-  let child = null
-  let healthBody = null
+  let boot
   try {
-    child = spawn(binaryPath, buildServeArgs({ port, modelsDir: emptyModelsDir }), {
+    boot = await bootAndProbe({
+      command: binaryPath,
+      args: buildServeArgs({ port, modelsDir: emptyModelsDir }),
       cwd: args.dir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-    child.stdout.on('data', (d) => { stdout += d })
-    child.stderr.on('data', (d) => { stderr += d })
-    let spawnError = null
-    child.on('error', (error) => { spawnError = error })
-
-    const health = await waitForHealth({
       port,
       timeoutMs,
-      isAlive: () => spawnError === null && child.exitCode === null && child.signalCode === null,
     })
-    if (!health.ok) {
-      failures.push(health.reason)
-      if (spawnError) failures.push(`spawn failed: ${spawnError.message}`)
-    } else {
-      console.log(`  /v1/health answered on 127.0.0.1:${port}`)
-      const probe = await probeServer(port)
-      failures.push(...probe.failures)
-      healthBody = probe.health
-      if (!probe.failures.length) console.log('  /v1/health, /api/capabilities and the embedded web UI all served')
-    }
   } finally {
-    if (child) await terminate(child)
     await rm(emptyModelsDir, { recursive: true, force: true })
+  }
+  failures.push(...boot.failures)
+  const healthBody = boot.healthBody
+  if (!boot.failures.length) {
+    console.log(`  /v1/health answered on 127.0.0.1:${port}`)
+    console.log('  /v1/health, /api/capabilities and the embedded web UI all served')
   }
 
   // 3. crash markers -------------------------------------------------------
+  // Read only after bootAndProbe has awaited the child's stdio CLOSE, so this
+  // sees the complete buffer including anything written on the way down.
   // A driverless runner is exactly the missing-NVRTC environment, so a clean
   // stderr here is the standing guard for "fall back to CPU, do not abort".
-  failures.push(...assertNoCrashMarkers(stderr))
+  failures.push(...assertNoCrashMarkers(boot.stderr))
 
   if (args.out) {
     const receipt = {
@@ -402,8 +473,8 @@ async function main() {
   if (failures.length) {
     console.error(`\nsmoke-release-artifact FAILED (${failures.length}):`)
     for (const failure of failures) console.error(`  FAIL: ${failure}`)
-    if (stderr.trim()) console.error(`\n--- engine stderr ---\n${stderr.trim()}`)
-    if (stdout.trim()) console.error(`\n--- engine stdout ---\n${stdout.trim()}`)
+    if (boot.stderr.trim()) console.error(`\n--- engine stderr ---\n${boot.stderr.trim()}`)
+    if (boot.stdout.trim()) console.error(`\n--- engine stdout ---\n${boot.stdout.trim()}`)
     process.exit(1)
   }
   console.log(`\nsmoke-release-artifact passed: ${args.label} boots and serves`)

--- a/scripts/smoke-release-artifact.mjs
+++ b/scripts/smoke-release-artifact.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+// smoke-release-artifact.mjs — boot the SHIPPED binary out of an extracted
+// release archive and prove it actually serves.
+//
+// Why this exists. Nothing in release.yml has ever executed an artifact. Every
+// existing gate is either a source-tree test (`cargo test`) or a staging-
+// directory inspection (scripts/package-*), so an entire class of defect —
+// the kind that only appears once the bytes are packaged and unpacked
+// somewhere else — reaches users first. v0.4.1 through v0.4.4 were all that
+// class.
+//
+// What this specifically regression-guards, on a stock CI runner that has NO
+// NVIDIA driver and NO CUDA toolkit:
+//
+//   * `fix(cuda): a missing NVRTC must fall back to CPU, not abort the process`
+//     (02f6a8b04). A driverless host is exactly the environment that fix
+//     addresses, so booting the shipped artifact there exercises it directly.
+//   * The embedded web UI. If `npm run build` ever silently produces nothing,
+//     rust-embed happily bakes an empty UI into a binary that still compiles,
+//     still passes every test, and ships a blank app.
+//   * Tag/binary version agreement. `VERSION` (src/main.rs) comes from
+//     CAMELID_GIT_DESCRIBE, falling back to CARGO_PKG_VERSION, and Cargo.toml
+//     is bumped by a separate commit from the one that gets tagged.
+//
+// The run is deliberately MODEL-LESS. There is no GGUF on a CI runner, so this
+// proves boot, health, capability reporting, UI embedding and clean shutdown —
+// it makes no inference or parity claim whatsoever. Those stay with the
+// existing exact-row evidence lanes.
+//
+// Usage:
+//   node scripts/smoke-release-artifact.mjs --dir <extracted-payload> --label <label>
+//        [--expect-version <tag>] [--out <receipt.json>] [--timeout-ms <n>]
+//
+// Exit 0 = the artifact booted and served. Exit 1 = it did not.
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { request } from 'node:http'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { ARTIFACT_SPECS, LABELS, compareVersionToTag, parseVersionOutput } from './check-release-artifact.mjs'
+
+// Mirror camelid-desktop/src/engine.rs (HEALTH_TIMEOUT / HEALTH_POLL_INTERVAL)
+// on purpose: the desktop app and CI should agree on one definition of "this
+// engine failed to come up", so a regression that pushes startup past the
+// budget fails here instead of in a user's splash screen.
+export const HEALTH_TIMEOUT_MS = 40_000
+export const HEALTH_POLL_INTERVAL_MS = 350
+
+/** Version probe budget. `--version` parses the clap tree and exits. */
+export const VERSION_TIMEOUT_MS = 30_000
+
+// ---------------------------------------------------------------------------
+// Pure assertions (unit-tested directly)
+// ---------------------------------------------------------------------------
+
+/**
+ * Arguments for a deterministic, model-less `serve`.
+ *
+ * `--models-dir` is pointed at an empty directory on purpose. Without it,
+ * `auto_select_model` (src/main.rs) scans `<exe dir>/models`, the exe dir,
+ * `./models` and `.` for the first *.gguf and loads it — so a stray model
+ * anywhere near the runner's working directory would change what this smoke
+ * actually tested.
+ */
+export function buildServeArgs({ port, modelsDir }) {
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) throw new RangeError(`invalid port ${port}`)
+  if (!modelsDir) throw new Error('modelsDir is required so the boot stays model-less')
+  return ['serve', '--addr', `127.0.0.1:${port}`, '--no-open', '--models-dir', modelsDir]
+}
+
+function parseJson(bodyText, what, failures) {
+  try {
+    return JSON.parse(bodyText)
+  } catch (error) {
+    failures.push(`${what}: response is not valid JSON — ${error.message}`)
+    return null
+  }
+}
+
+/**
+ * `/v1/health` on a model-less engine.
+ * Field names are HealthResponse in src/api/mod.rs.
+ */
+export function assertHealthPayload(status, bodyText) {
+  const failures = []
+  if (status !== 200) failures.push(`/v1/health: expected 200, got ${status}`)
+  const body = parseJson(bodyText, '/v1/health', failures)
+  if (!body) return failures
+  if (body.ok !== true) failures.push(`/v1/health: ok=${JSON.stringify(body.ok)}, expected true`)
+  if (body.loaded_now !== false) {
+    failures.push(`/v1/health: loaded_now=${JSON.stringify(body.loaded_now)}, expected false for a model-less boot`)
+  }
+  if (body.generation_ready !== false) {
+    failures.push(
+      `/v1/health: generation_ready=${JSON.stringify(body.generation_ready)}, expected false for a model-less boot`,
+    )
+  }
+  if (body.active_model_id !== null && body.active_model_id !== undefined) {
+    failures.push(`/v1/health: active_model_id=${JSON.stringify(body.active_model_id)}, expected null`)
+  }
+  if (typeof body.backend !== 'string') failures.push('/v1/health: backend must be a string')
+  if (body.engine_queue_depth !== 0) {
+    failures.push(`/v1/health: engine_queue_depth=${JSON.stringify(body.engine_queue_depth)}, expected 0 at rest`)
+  }
+  return failures
+}
+
+/** `/api/capabilities` must be reachable and parse; its CONTENT is the ledger's business. */
+export function assertCapabilitiesPayload(status, bodyText) {
+  const failures = []
+  if (status !== 200) failures.push(`/api/capabilities: expected 200, got ${status}`)
+  const body = parseJson(bodyText, '/api/capabilities', failures)
+  if (!body) return failures
+  if (typeof body !== 'object' || Array.isArray(body)) failures.push('/api/capabilities: expected a JSON object')
+  return failures
+}
+
+/**
+ * `GET /` must serve the EMBEDDED web UI, not merely 200.
+ *
+ * Requiring both the app title and a hashed module asset means an empty or
+ * placeholder embed fails, which a bare status check would wave through.
+ */
+export function assertWebUi(status, headers, bodyText) {
+  const failures = []
+  if (status !== 200) failures.push(`GET /: expected 200, got ${status}`)
+  const contentType = String(headers?.['content-type'] ?? '')
+  if (!contentType.includes('text/html')) failures.push(`GET /: expected an HTML content-type, got ${JSON.stringify(contentType)}`)
+  const body = String(bodyText ?? '')
+  if (!/<title>\s*Camelid\s*<\/title>/i.test(body)) failures.push('GET /: embedded UI is missing the Camelid app shell title')
+  if (!/src="\/assets\/[^"]+\.js"/.test(body)) {
+    failures.push('GET /: embedded UI references no hashed /assets/*.js bundle — the web UI build did not make it into the binary')
+  }
+  return failures
+}
+
+/** Engine stderr must be free of crash markers even when the run succeeds. */
+export function assertNoCrashMarkers(stderr) {
+  const failures = []
+  const text = String(stderr ?? '')
+  const markers = [
+    { re: /panicked at/i, why: 'rust panic' },
+    { re: /stack overflow/i, why: 'stack overflow' },
+    { re: /segmentation fault|SIGSEGV/i, why: 'segfault' },
+    { re: /Aborted \(core dumped\)/i, why: 'abort' },
+  ]
+  for (const { re, why } of markers) {
+    if (re.test(text)) failures.push(`engine stderr contains a ${why} marker`)
+  }
+  return failures
+}
+
+// ---------------------------------------------------------------------------
+// I/O shell
+// ---------------------------------------------------------------------------
+
+/** Ask the OS for an unused loopback port. */
+export function pickFreePort() {
+  return new Promise((resolvePort, rejectPort) => {
+    const server = createServer()
+    server.on('error', rejectPort)
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      server.close((error) => (error ? rejectPort(error) : resolvePort(port)))
+    })
+  })
+}
+
+/** Dependency-free loopback GET. Resolves even on non-2xx; rejects on transport failure. */
+export function httpGet(port, path, { timeoutMs = 5000, host = '127.0.0.1' } = {}) {
+  return new Promise((resolveGet, rejectGet) => {
+    const req = request({ host, port, path, method: 'GET', timeout: timeoutMs }, (res) => {
+      const chunks = []
+      res.on('data', (chunk) => chunks.push(chunk))
+      res.on('end', () => resolveGet({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString('utf8') }))
+    })
+    req.on('timeout', () => req.destroy(new Error(`GET ${path} timed out after ${timeoutMs}ms`)))
+    req.on('error', rejectGet)
+    req.end()
+  })
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+/**
+ * Poll `/v1/health` until it answers, the process dies, or the budget elapses.
+ * Dependencies are injectable so the self-test can drive every branch without
+ * a real binary.
+ */
+export async function waitForHealth({
+  port,
+  isAlive = () => true,
+  timeoutMs = HEALTH_TIMEOUT_MS,
+  intervalMs = HEALTH_POLL_INTERVAL_MS,
+  get = httpGet,
+  now = () => Date.now(),
+  wait = sleep,
+} = {}) {
+  const deadline = now() + timeoutMs
+  let lastError = 'no attempt was made'
+  for (;;) {
+    if (!isAlive()) return { ok: false, reason: `the engine exited before /v1/health answered (last transport state: ${lastError})` }
+    try {
+      const response = await get(port, '/v1/health', { timeoutMs: Math.min(intervalMs * 4, 5000) })
+      if (response.status === 200) return { ok: true, response }
+      lastError = `HTTP ${response.status}`
+    } catch (error) {
+      // Connection refused is the normal pre-listen state, not a failure.
+      lastError = error.code || error.message
+    }
+    if (now() >= deadline) {
+      return { ok: false, reason: `/v1/health did not return 200 within ${timeoutMs}ms (last transport state: ${lastError})` }
+    }
+    await wait(intervalMs)
+  }
+}
+
+/** Run all three endpoint probes against a live server. */
+export async function probeServer(port, get = httpGet) {
+  const failures = []
+  const health = await get(port, '/v1/health')
+  failures.push(...assertHealthPayload(health.status, health.body))
+  const capabilities = await get(port, '/api/capabilities')
+  failures.push(...assertCapabilitiesPayload(capabilities.status, capabilities.body))
+  const index = await get(port, '/')
+  failures.push(...assertWebUi(index.status, index.headers, index.body))
+  return { failures, health: health.body }
+}
+
+/** Terminate a child and its tree, then wait for the exit to be observed. */
+async function terminate(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  if (process.platform === 'win32') {
+    // A bare kill() leaves the process tree behind on Windows and the runner
+    // then hangs waiting on inherited pipes.
+    await new Promise((done) => {
+      const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' })
+      killer.on('exit', done)
+      killer.on('error', done)
+    })
+  } else {
+    child.kill('SIGTERM')
+  }
+  const exited = new Promise((done) => child.once('exit', done))
+  const timedOut = await Promise.race([exited.then(() => false), sleep(10_000).then(() => true)])
+  if (timedOut) child.kill('SIGKILL')
+}
+
+/** Run `<binary> --version` and compare it to the expected tag. */
+async function checkVersion(binaryPath, expectedTag) {
+  const result = await new Promise((done) => {
+    const child = spawn(binaryPath, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => child.kill('SIGKILL'), VERSION_TIMEOUT_MS)
+    child.stdout.on('data', (d) => { stdout += d })
+    child.stderr.on('data', (d) => { stderr += d })
+    child.on('error', (error) => { clearTimeout(timer); done({ code: -1, stdout, stderr: `${stderr}${error.message}` }) })
+    child.on('exit', (code) => { clearTimeout(timer); done({ code, stdout, stderr }) })
+  })
+  const failures = []
+  if (result.code !== 0) failures.push(`--version exited ${result.code}: ${result.stderr.trim() || '(no stderr)'}`)
+  const reported = parseVersionOutput(result.stdout)
+  if (!reported) {
+    failures.push(`could not parse a version from --version output: ${JSON.stringify(result.stdout.trim())}`)
+  } else if (expectedTag) {
+    const mismatch = compareVersionToTag(reported, expectedTag)
+    if (mismatch) failures.push(mismatch)
+  }
+  return { failures, reported }
+}
+
+function parseArgs(argv) {
+  const args = {}
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = () => {
+      const value = argv[i + 1]
+      if (value === undefined || value.startsWith('--')) throw new Error(`${arg} requires a value`)
+      i += 1
+      return value
+    }
+    switch (arg) {
+      case '--dir': args.dir = next(); break
+      case '--label': args.label = next(); break
+      case '--expect-version': args.expectVersion = next(); break
+      case '--out': args.out = next(); break
+      case '--timeout-ms': args.timeoutMs = Number.parseInt(next(), 10); break
+      case '--help': case '-h': args.help = true; break
+      default: throw new Error(`unknown argument ${arg}`)
+    }
+  }
+  return args
+}
+
+const USAGE = `Usage:
+  node scripts/smoke-release-artifact.mjs --dir <extracted-payload> --label <label> [options]
+
+Options:
+  --dir <path>              payload directory (the one that holds the binary)
+  --label <label>           ${LABELS.join(' | ')}
+  --expect-version <tag>    release tag the binary must report (e.g. v0.4.4)
+  --timeout-ms <n>          health budget (default ${HEALTH_TIMEOUT_MS})
+  --out <path>              write a JSON receipt
+`
+
+async function main() {
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(`smoke-release-artifact: ${error.message}\n\n${USAGE}`)
+    process.exit(2)
+  }
+  if (args.help) {
+    console.log(USAGE)
+    return
+  }
+  if (!args.dir || !args.label || !ARTIFACT_SPECS[args.label]) {
+    console.error(`smoke-release-artifact: --dir and a valid --label are required\n\n${USAGE}`)
+    process.exit(2)
+  }
+
+  const spec = ARTIFACT_SPECS[args.label]
+  // The desktop portable layout ships the Tauri GUI as its primary binary, but
+  // the thing that must SERVE is the sidecar. Launching a GUI app headless on a
+  // CI runner proves nothing and hangs; boot the engine it bundles instead.
+  const serveBinary = args.label === 'desktop-windows-x64' ? 'camelid.exe' : spec.binary
+  const binaryPath = resolve(join(args.dir, serveBinary))
+  const failures = []
+  const timeoutMs = Number.isInteger(args.timeoutMs) && args.timeoutMs > 0 ? args.timeoutMs : HEALTH_TIMEOUT_MS
+
+  console.log(`smoke-release-artifact: label=${args.label} binary=${serveBinary}`)
+
+  // 1. version / tag agreement --------------------------------------------
+  const version = await checkVersion(binaryPath, args.expectVersion)
+  failures.push(...version.failures)
+  if (version.reported) console.log(`  version: ${version.reported}${args.expectVersion ? ` (tag ${args.expectVersion})` : ''}`)
+
+  // 2. boot, serve, shut down ---------------------------------------------
+  const emptyModelsDir = await mkdtemp(join(tmpdir(), 'camelid-smoke-models-'))
+  const port = await pickFreePort()
+  let stderr = ''
+  let stdout = ''
+  let child = null
+  let healthBody = null
+  try {
+    child = spawn(binaryPath, buildServeArgs({ port, modelsDir: emptyModelsDir }), {
+      cwd: args.dir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    child.stdout.on('data', (d) => { stdout += d })
+    child.stderr.on('data', (d) => { stderr += d })
+    let spawnError = null
+    child.on('error', (error) => { spawnError = error })
+
+    const health = await waitForHealth({
+      port,
+      timeoutMs,
+      isAlive: () => spawnError === null && child.exitCode === null && child.signalCode === null,
+    })
+    if (!health.ok) {
+      failures.push(health.reason)
+      if (spawnError) failures.push(`spawn failed: ${spawnError.message}`)
+    } else {
+      console.log(`  /v1/health answered on 127.0.0.1:${port}`)
+      const probe = await probeServer(port)
+      failures.push(...probe.failures)
+      healthBody = probe.health
+      if (!probe.failures.length) console.log('  /v1/health, /api/capabilities and the embedded web UI all served')
+    }
+  } finally {
+    if (child) await terminate(child)
+    await rm(emptyModelsDir, { recursive: true, force: true })
+  }
+
+  // 3. crash markers -------------------------------------------------------
+  // A driverless runner is exactly the missing-NVRTC environment, so a clean
+  // stderr here is the standing guard for "fall back to CPU, do not abort".
+  failures.push(...assertNoCrashMarkers(stderr))
+
+  if (args.out) {
+    const receipt = {
+      schema: 'camelid.release-artifact-smoke/v1',
+      checked_at: new Date().toISOString(),
+      label: args.label,
+      binary: basename(binaryPath),
+      reported_version: version.reported ?? null,
+      expected_version: args.expectVersion ?? null,
+      health_timeout_ms: timeoutMs,
+      health: healthBody ? JSON.parse(healthBody) : null,
+      failures,
+      passed: failures.length === 0,
+    }
+    await writeFile(resolve(args.out), `${JSON.stringify(receipt, null, 2)}\n`, 'utf8')
+    console.log(`  receipt: ${basename(args.out)}`)
+  }
+
+  if (failures.length) {
+    console.error(`\nsmoke-release-artifact FAILED (${failures.length}):`)
+    for (const failure of failures) console.error(`  FAIL: ${failure}`)
+    if (stderr.trim()) console.error(`\n--- engine stderr ---\n${stderr.trim()}`)
+    if (stdout.trim()) console.error(`\n--- engine stdout ---\n${stdout.trim()}`)
+    process.exit(1)
+  }
+  console.log(`\nsmoke-release-artifact passed: ${args.label} boots and serves`)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/smoke-release-artifact.mjs
+++ b/scripts/smoke-release-artifact.mjs
@@ -125,6 +125,19 @@ export function assertCapabilitiesPayload(status, bodyText) {
 }
 
 /**
+ * Pull the first hashed module URL out of the app shell.
+ *
+ * Matching the markup only proves the HTML mentions a bundle; the URL has to be
+ * fetched before the UI can be called embedded (see assertUiAsset).
+ *
+ * @returns {string|null}
+ */
+export function extractUiAssetUrl(bodyText) {
+  const match = /<script[^>]+src="(\/assets\/[^"]+\.js)"/i.exec(String(bodyText ?? ''))
+  return match ? match[1] : null
+}
+
+/**
  * `GET /` must serve the EMBEDDED web UI, not merely 200.
  *
  * Requiring both the app title and a hashed module asset means an empty or
@@ -137,9 +150,30 @@ export function assertWebUi(status, headers, bodyText) {
   if (!contentType.includes('text/html')) failures.push(`GET /: expected an HTML content-type, got ${JSON.stringify(contentType)}`)
   const body = String(bodyText ?? '')
   if (!/<title>\s*Camelid\s*<\/title>/i.test(body)) failures.push('GET /: embedded UI is missing the Camelid app shell title')
-  if (!/src="\/assets\/[^"]+\.js"/.test(body)) {
+  if (!extractUiAssetUrl(body)) {
     failures.push('GET /: embedded UI references no hashed /assets/*.js bundle — the web UI build did not make it into the binary')
   }
+  return failures
+}
+
+/**
+ * The referenced bundle must actually be served.
+ *
+ * An app shell that names `/assets/index-abc.js` while the binary embeds
+ * nothing at that path is a blank page for every browser client, and a
+ * markup-only assertion cannot tell the two apart.
+ */
+export function assertUiAsset(url, status, headers, bodyText) {
+  const failures = []
+  if (status !== 200) {
+    failures.push(`GET ${url}: expected 200, got ${status} — the app shell references a bundle the binary does not serve`)
+    return failures
+  }
+  const contentType = String(headers?.['content-type'] ?? '')
+  if (!/javascript|ecmascript/i.test(contentType)) {
+    failures.push(`GET ${url}: expected a JavaScript content-type, got ${JSON.stringify(contentType)}`)
+  }
+  if (String(bodyText ?? '').length === 0) failures.push(`GET ${url}: bundle is empty`)
   return failures
 }
 
@@ -233,6 +267,18 @@ export async function probeServer(port, get = httpGet) {
   failures.push(...assertCapabilitiesPayload(capabilities.status, capabilities.body))
   const index = await get(port, '/')
   failures.push(...assertWebUi(index.status, index.headers, index.body))
+
+  // Follow the reference. A shell that names a bundle the binary never embeds
+  // renders a blank app, and every markup-level assertion above still passes.
+  const assetUrl = extractUiAssetUrl(index.body)
+  if (assetUrl) {
+    try {
+      const asset = await get(port, assetUrl)
+      failures.push(...assertUiAsset(assetUrl, asset.status, asset.headers, asset.body))
+    } catch (error) {
+      failures.push(`GET ${assetUrl}: request failed — ${error.code || error.message}`)
+    }
+  }
   return { failures, health: health.body }
 }
 

--- a/scripts/test-check-release-artifact.mjs
+++ b/scripts/test-check-release-artifact.mjs
@@ -112,6 +112,18 @@ assert.equal(parseChecksumFile(`${'A'.repeat(64)}  a.zip`).hash, HASH, 'hashes m
 assert.throws(() => parseChecksumFile(''), /empty/, 'an empty sidecar must throw')
 assert.throws(() => parseChecksumFile('not-a-hash  a.zip'), /64-hex/, 'a malformed sidecar must throw')
 assert.throws(() => parseChecksumFile(`${'a'.repeat(63)}  a.zip`), /64-hex/, 'a short hash must throw')
+// `shasum -c` consumes every record, so honouring only the first would verify
+// something different from what a user's own check does.
+assert.throws(
+  () => parseChecksumFile(`${HASH}  a.zip\ngarbage garbage`),
+  /exactly one record/,
+  'a valid first record followed by garbage must throw',
+)
+assert.throws(
+  () => parseChecksumFile(`${HASH}  a.zip\n${'b'.repeat(64)}  b.zip`),
+  /exactly one record/,
+  'a multi-record sidecar must throw',
+)
 
 // ---------------------------------------------------------------------------
 // version comparison
@@ -490,6 +502,57 @@ assert.deepEqual(
   ),
   [],
   'the installer rule is desktop-specific and must not leak onto other labels',
+)
+
+// ---------------------------------------------------------------------------
+// closed payload contract
+//
+// Required-files-plus-junk-patterns is an OPEN set: it accepts anything nobody
+// thought to forbid. These assert the allowlist actually closes it, so an
+// accidental future glob or a staged credential cannot ride along into a
+// public download.
+// ---------------------------------------------------------------------------
+assert.ok(
+  has(await failuresFor('windows-credentials', { ...goodWindows, 'credentials.json': '{}' }, WINDOWS, { requireNvrtc: true }), /unexpected entry/),
+  'a staged credential file must fail even though it matches no junk pattern',
+)
+assert.ok(
+  has(await failuresFor('windows-extra-exe', { ...goodWindows, 'totally-unexpected.exe': 'PE' }, WINDOWS, { requireNvrtc: true }), /unexpected entry/),
+  'an unexpected executable must fail',
+)
+assert.ok(
+  has(await failuresFor('windows-nested-dir', { ...goodWindows, 'extra/inner.txt': 'x' }, WINDOWS, { requireNvrtc: true }), /unexpected entry/),
+  'an arbitrary nested directory must fail',
+)
+assert.ok(
+  has(await failuresFor('linux-extra-doc', { ...goodLinux, 'NOTES.md': 'notes' }, LINUX, { requireNvrtc: true }), /unexpected entry/),
+  'even an innocuous extra document must fail: the payload is a closed set',
+)
+// NVRTC names are constrained, not merely "contains nvrtc".
+assert.ok(
+  has(await failuresFor('windows-odd-nvrtc', { ...goodWindows, 'nvrtc64_evil.dll': 'x' }, WINDOWS, { requireNvrtc: true }), /unexpected entry/),
+  'an nvrtc-shaped name that does not match the versioned pattern must fail',
+)
+assert.ok(
+  has(await failuresFor('linux-odd-nvrtc', { ...goodLinux, 'libnvrtc.so': 'x' }, LINUX, { requireNvrtc: true }), /unexpected entry/),
+  'an unversioned libnvrtc.so must fail the constrained pattern',
+)
+assert.deepEqual(
+  checkManifest(
+    [
+      entry('camelid'),
+      entry('README.md'),
+      entry('LICENSE'),
+      entry('THIRD_PARTY_NOTICES.md'),
+      entry('libnvrtc.so.12.9.86'),
+      entry('libnvrtc-builtins.so.12.9'),
+      link('libnvrtc.so.12', 'libnvrtc.so.12.9.86'),
+    ],
+    LINUX,
+    { requireNvrtc: true },
+  ),
+  [],
+  'the real staged NVRTC filenames must all satisfy the allowlist',
 )
 
 // ---------------------------------------------------------------------------

--- a/scripts/test-check-release-artifact.mjs
+++ b/scripts/test-check-release-artifact.mjs
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+// Self-test for check-release-artifact.mjs (run in CI by the validation-scripts
+// job's test-*.mjs glob, so it gates every PR without touching ci.yml).
+//
+// Strategy: the pure functions are exercised directly, and the manifest
+// contract is exercised against REAL directory trees written to a temp dir —
+// including real symlinks — so readTree's lstat/readlink handling is covered
+// rather than mocked.
+import assert from 'node:assert/strict'
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import {
+  ARTIFACT_SPECS,
+  checkManifest,
+  compareVersionToTag,
+  normalizeVersion,
+  parseChecksumFile,
+  parseVersionOutput,
+  readTree,
+  resolvePayloadRoot,
+} from './check-release-artifact.mjs'
+
+const workspace = await mkdtemp(join(tmpdir(), 'camelid-artifact-test-'))
+let symlinksSupported = true
+
+/**
+ * Materialize a fixture tree.
+ * Values: string -> file content; {symlink} -> symbolic link; {dir:true} -> directory.
+ */
+async function makeTree(name, layout) {
+  const root = join(workspace, name)
+  await mkdir(root, { recursive: true })
+  // Two passes so a symlink may point at a file declared after it.
+  for (const [relative, value] of Object.entries(layout)) {
+    if (typeof value === 'object' && value !== null && value.symlink) continue
+    const target = join(root, relative)
+    await mkdir(dirname(target), { recursive: true })
+    if (typeof value === 'object' && value !== null && value.dir) await mkdir(target, { recursive: true })
+    else await writeFile(target, String(value))
+  }
+  for (const [relative, value] of Object.entries(layout)) {
+    if (!(typeof value === 'object' && value !== null && value.symlink)) continue
+    const target = join(root, relative)
+    await mkdir(dirname(target), { recursive: true })
+    try {
+      await symlink(value.symlink, target)
+    } catch (error) {
+      // Windows needs Developer Mode or elevation to create symlinks. Degrade
+      // to a regular file and let the caller skip link-specific assertions,
+      // rather than failing the whole suite for an unrelated OS restriction.
+      if (error.code === 'EPERM' || error.code === 'ENOSYS') {
+        symlinksSupported = false
+        await writeFile(target, `link->${value.symlink}`)
+      } else {
+        throw error
+      }
+    }
+  }
+  return root
+}
+
+const LINUX = ARTIFACT_SPECS['linux-x86_64']
+const WINDOWS = ARTIFACT_SPECS['windows-x64']
+const DESKTOP = ARTIFACT_SPECS['desktop-windows-x64']
+const MACOS = ARTIFACT_SPECS['macos-arm64']
+
+const goodLinux = {
+  camelid: 'ELF-ish payload',
+  'README.md': '# Camelid',
+  LICENSE: 'MIT',
+  'THIRD_PARTY_NOTICES.md': 'notices',
+  'libnvrtc.so.12.9.86': 'nvrtc real payload',
+  'libnvrtc.so.12': { symlink: 'libnvrtc.so.12.9.86' },
+  'libnvrtc-builtins.so.12.9': 'builtins payload',
+}
+const goodWindows = {
+  'camelid.exe': 'PE payload',
+  'README.md': '# Camelid',
+  LICENSE: 'MIT',
+  'THIRD_PARTY_NOTICES.md': 'notices',
+  'nvrtc64_120_0.dll': 'nvrtc payload',
+  'nvrtc-builtins64_129.dll': 'builtins payload',
+}
+
+const failuresFor = async (name, layout, spec, options = {}) =>
+  checkManifest(await readTree(await makeTree(name, layout)), spec, options)
+
+const has = (failures, pattern) => failures.some((f) => pattern.test(f))
+const omit = (layout, ...keys) => Object.fromEntries(Object.entries(layout).filter(([k]) => !keys.includes(k)))
+
+// ---------------------------------------------------------------------------
+// parseChecksumFile — two producers, two trailing-byte conventions
+// ---------------------------------------------------------------------------
+const HASH = 'a'.repeat(64)
+assert.deepEqual(
+  parseChecksumFile(`${HASH}  camelid-linux-x86_64.tar.gz\n`),
+  { hash: HASH, name: 'camelid-linux-x86_64.tar.gz' },
+  'shasum output (two spaces, trailing newline) must parse',
+)
+assert.deepEqual(
+  parseChecksumFile(`${HASH}  camelid-windows-x64.zip`),
+  { hash: HASH, name: 'camelid-windows-x64.zip' },
+  'PowerShell Out-File -NoNewline output must parse',
+)
+assert.deepEqual(parseChecksumFile(`${HASH}  a.zip\r\n`).name, 'a.zip', 'CRLF must parse')
+assert.deepEqual(parseChecksumFile(`\uFEFF${HASH}  a.zip`).name, 'a.zip', 'a UTF-8 BOM must not break the parse')
+assert.deepEqual(parseChecksumFile(`${HASH} *a.tar.gz`).name, 'a.tar.gz', "coreutils' binary-mode * marker must parse")
+assert.equal(parseChecksumFile(`${'A'.repeat(64)}  a.zip`).hash, HASH, 'hashes must normalize to lower case')
+assert.throws(() => parseChecksumFile(''), /empty/, 'an empty sidecar must throw')
+assert.throws(() => parseChecksumFile('not-a-hash  a.zip'), /64-hex/, 'a malformed sidecar must throw')
+assert.throws(() => parseChecksumFile(`${'a'.repeat(63)}  a.zip`), /64-hex/, 'a short hash must throw')
+
+// ---------------------------------------------------------------------------
+// version comparison
+// ---------------------------------------------------------------------------
+assert.equal(normalizeVersion('v0.4.4'), '0.4.4')
+assert.equal(normalizeVersion('  0.4.4 '), '0.4.4')
+assert.equal(compareVersionToTag('0.4.4', 'v0.4.4'), null, 'a bare version must match a v-prefixed tag')
+assert.equal(compareVersionToTag('v0.4.4', 'v0.4.4'), null, 'identical strings must match')
+assert.match(
+  compareVersionToTag('v0.4.4-3-gabcdef', 'v0.4.4'),
+  /ahead of tag/,
+  'a git-describe suffix means the tag is not at this commit and must fail',
+)
+assert.match(compareVersionToTag('0.4.3', 'v0.4.4'), /does not match/, 'a stale Cargo.toml version must fail')
+assert.match(compareVersionToTag('', 'v0.4.4'), /empty version/, 'an empty version must fail')
+assert.equal(parseVersionOutput('camelid 0.4.4\n'), '0.4.4')
+assert.equal(parseVersionOutput('camelid v0.4.4-3-gabcdef\n'), 'v0.4.4-3-gabcdef')
+assert.equal(parseVersionOutput('\n\ncamelid 0.4.4\n'), '0.4.4', 'leading blank lines must be skipped')
+assert.equal(parseVersionOutput(''), null)
+
+// ---------------------------------------------------------------------------
+// layout — the tar/zip asymmetry
+// ---------------------------------------------------------------------------
+assert.deepEqual(
+  resolvePayloadRoot(['camelid-linux-x86_64'], LINUX),
+  { root: 'camelid-linux-x86_64', failures: [] },
+  'a tarball extracts to exactly one wrapper directory',
+)
+assert.deepEqual(resolvePayloadRoot(['camelid.exe', 'README.md'], WINDOWS).failures, [], 'a zip extracts flat')
+{
+  const { root, failures } = resolvePayloadRoot(['camelid-linux-x86_64', 'stray.txt'], LINUX)
+  assert.equal(root, 'camelid-linux-x86_64', 'the payload root is still resolved so the manifest can be reported too')
+  assert.ok(has(failures, /expected exactly one top-level directory/), 'a stray top-level entry must be reported')
+}
+assert.ok(
+  has(resolvePayloadRoot(['nope'], LINUX).failures, /expected exactly one top-level directory/),
+  'a missing wrapper directory must be reported',
+)
+assert.ok(
+  has(resolvePayloadRoot(['camelid-windows-x64'], WINDOWS).failures, /found a single wrapper directory/),
+  'a zip that gained a wrapper directory must be reported',
+)
+
+// ---------------------------------------------------------------------------
+// manifest — happy paths
+// ---------------------------------------------------------------------------
+assert.deepEqual(
+  await failuresFor('linux-good', goodLinux, LINUX, { requireNvrtc: true }),
+  [],
+  'a correctly packaged linux payload must pass with NVRTC required',
+)
+assert.deepEqual(
+  await failuresFor('windows-good', goodWindows, WINDOWS, { requireNvrtc: true }),
+  [],
+  'a correctly packaged windows payload must pass',
+)
+assert.deepEqual(
+  await failuresFor(
+    'macos-good',
+    { camelid: 'macho', 'README.md': '#', LICENSE: 'MIT', 'THIRD_PARTY_NOTICES.md': 'n' },
+    MACOS,
+    { requireNvrtc: false },
+  ),
+  [],
+  'macOS ships no NVRTC and must pass without it',
+)
+assert.deepEqual(
+  await failuresFor('desktop-good', { ...goodWindows, 'camelid-desktop.exe': 'PE', 'DESKTOP_README.md': 'd' }, DESKTOP, {
+    requireNvrtc: true,
+  }),
+  [],
+  'a correctly packaged desktop portable payload must pass',
+)
+assert.deepEqual(
+  await failuresFor('linux-no-nvrtc-not-required', omit(goodLinux, 'libnvrtc.so.12.9.86', 'libnvrtc.so.12', 'libnvrtc-builtins.so.12.9'), LINUX, {
+    requireNvrtc: false,
+  }),
+  [],
+  'without --require-nvrtc a CPU-only payload is legitimate (local dry runs have no CUDA toolkit)',
+)
+
+// ---------------------------------------------------------------------------
+// manifest — required payload
+// ---------------------------------------------------------------------------
+assert.ok(
+  has(await failuresFor('linux-no-binary', omit(goodLinux, 'camelid'), LINUX, { requireNvrtc: true }), /missing required entry: camelid/),
+  'a missing binary must fail',
+)
+assert.ok(
+  has(await failuresFor('linux-no-license', omit(goodLinux, 'LICENSE'), LINUX, {}), /missing required entry: LICENSE/),
+  'a missing LICENSE must fail',
+)
+assert.ok(
+  has(await failuresFor('linux-empty-binary', { ...goodLinux, camelid: '' }, LINUX, {}), /camelid is zero bytes/),
+  'a zero-byte binary must fail',
+)
+assert.ok(
+  has(await failuresFor('linux-binary-is-dir', { ...omit(goodLinux, 'camelid'), camelid: { dir: true } }, LINUX, {}), /is a dir, expected a file/),
+  'a directory where the binary should be must fail',
+)
+
+// ---------------------------------------------------------------------------
+// manifest — NVRTC
+// ---------------------------------------------------------------------------
+assert.ok(
+  has(
+    await failuresFor('linux-no-compiler', omit(goodLinux, 'libnvrtc.so.12.9.86', 'libnvrtc.so.12'), LINUX, { requireNvrtc: true }),
+    /no NVRTC compiler library/,
+  ),
+  'a linux tarball without the libnvrtc soname would silently fall back to CPU and must fail',
+)
+assert.ok(
+  has(await failuresFor('linux-no-builtins', omit(goodLinux, 'libnvrtc-builtins.so.12.9'), LINUX, { requireNvrtc: true }), /no NVRTC builtins/),
+  'an incomplete NVRTC pair must fail',
+)
+assert.ok(
+  has(
+    await failuresFor('windows-no-builtins', omit(goodWindows, 'nvrtc-builtins64_129.dll'), WINDOWS, { requireNvrtc: true }),
+    /no NVRTC builtins/,
+  ),
+  'package-windows-cuda.ps1 only warns about an incomplete pair; this gate must fail',
+)
+assert.ok(
+  has(await failuresFor('linux-alt', { ...goodLinux, 'libnvrtc.alt.so.12.9.86': 'alt backend' }, LINUX, { requireNvrtc: true }), /alternate JIT backend/),
+  'the .alt backend is ~90 MB cudarc never loads and must not ship',
+)
+
+// ---------------------------------------------------------------------------
+// manifest — duplicated payload (the v0.4.3 regression, post-archive)
+// ---------------------------------------------------------------------------
+assert.ok(
+  has(
+    await failuresFor(
+      'linux-duplicated',
+      { ...omit(goodLinux, 'libnvrtc.so.12'), 'libnvrtc.so.12': 'nvrtc real payload' },
+      LINUX,
+      { requireNvrtc: true },
+    ),
+    /duplicate payload/,
+  ),
+  'a dereferenced symlink ships the same library twice and must fail',
+)
+// 'nvrtc real payload' and 'builtins payload!!' are both 18 bytes and differ in
+// content — upstream's size comparison would flag this pair, hashing must not.
+assert.equal('nvrtc real payload'.length, 'builtins payload!!'.length, 'the fixture pair must be the same size')
+assert.deepEqual(
+  (await failuresFor('linux-same-size-different-bytes', { ...goodLinux, 'libnvrtc-builtins.so.12.9': 'builtins payload!!' }, LINUX, {
+    requireNvrtc: true,
+  })).filter((f) => /duplicate payload/.test(f)),
+  [],
+  'hashing content (not comparing sizes) means same-size different libraries must NOT false-positive',
+)
+assert.deepEqual(
+  (await failuresFor('linux-identical-docs', { ...goodLinux, 'README.md': 'same', LICENSE: 'same' }, LINUX, { requireNvrtc: true })).filter((f) =>
+    /duplicate payload/.test(f),
+  ),
+  [],
+  'duplicate detection is scoped to the NVRTC family; two identical docs must not block a release',
+)
+
+// ---------------------------------------------------------------------------
+// manifest — symlink integrity and mode, as PURE entry lists
+//
+// checkManifest is a pure function of an entry list, so these run identically
+// on every host. The filesystem-backed variants below additionally cover
+// readTree's lstat/readlink handling wherever the OS permits it.
+// ---------------------------------------------------------------------------
+const entry = (path, over = {}) => ({ path, kind: 'file', size: 16, mode: 0o755, sha256: `hash-${path}`, ...over })
+const linuxEntries = (...extra) => [
+  entry('camelid'),
+  entry('README.md'),
+  entry('LICENSE'),
+  entry('THIRD_PARTY_NOTICES.md'),
+  entry('libnvrtc.so.12.9.86'),
+  entry('libnvrtc-builtins.so.12.9'),
+  ...extra,
+]
+const link = (path, linkTarget) => ({ path, kind: 'symlink', size: 0, mode: 0o777, linkTarget })
+
+assert.deepEqual(
+  checkManifest(linuxEntries(link('libnvrtc.so.12', 'libnvrtc.so.12.9.86')), LINUX, { requireNvrtc: true }),
+  [],
+  'a symlink resolving to a staged file is the correct packaging and must pass',
+)
+assert.ok(
+  has(checkManifest(linuxEntries(link('libnvrtc.so.12', 'libnvrtc.so.nope')), LINUX, { requireNvrtc: true }), /is dangling inside the archive/),
+  'a link that resolves nowhere means dlopen fails and the GPU never engages',
+)
+assert.ok(
+  has(checkManifest(linuxEntries(link('libnvrtc.so.12', '../../etc/passwd')), LINUX, { requireNvrtc: true }), /escapes the payload/),
+  'a relative link pointing outside the payload must fail',
+)
+assert.ok(
+  has(checkManifest(linuxEntries(link('libnvrtc.so.12', '/usr/lib/libnvrtc.so.12')), LINUX, { requireNvrtc: true }), /escapes the payload/),
+  'an absolute link target must fail',
+)
+assert.ok(
+  has(
+    checkManifest([...linuxEntries(), entry('libnvrtc.so.12', { sha256: 'hash-libnvrtc.so.12.9.86' })], LINUX, { requireNvrtc: true }),
+    /duplicate payload/,
+  ),
+  'two byte-identical NVRTC real files mean a symlink was dereferenced',
+)
+assert.ok(
+  has(checkManifest(linuxEntries().map((e) => (e.path === 'camelid' ? { ...e, mode: 0o644 } : e)), LINUX, { requireNvrtc: true, checkExecutableBit: true }), /is not executable/),
+  'a binary that lost +x extracts fine and then cannot be run',
+)
+assert.deepEqual(
+  checkManifest(linuxEntries().map((e) => (e.path === 'camelid' ? { ...e, mode: 0o644 } : e)), LINUX, {
+    requireNvrtc: true,
+    checkExecutableBit: false,
+  }),
+  [],
+  'the mode check must stay off where the filesystem has no mode bits to lose',
+)
+
+// ---------------------------------------------------------------------------
+// manifest — symlink integrity, filesystem-backed
+// ---------------------------------------------------------------------------
+if (symlinksSupported) {
+  assert.ok(
+    has(
+      await failuresFor('linux-dangling', { ...goodLinux, 'libnvrtc.so.12': { symlink: 'libnvrtc.so.does-not-exist' } }, LINUX, {
+        requireNvrtc: true,
+      }),
+      /is dangling inside the archive/,
+    ),
+    'a link that resolves nowhere means dlopen fails and the GPU never engages',
+  )
+  assert.ok(
+    has(await failuresFor('linux-escape', { ...goodLinux, 'libnvrtc.so.12': { symlink: '../../etc/passwd' } }, LINUX, {}), /escapes the payload/),
+    'a link pointing outside the payload must fail',
+  )
+  assert.ok(
+    has(await failuresFor('linux-absolute', { ...goodLinux, 'libnvrtc.so.12': { symlink: '/usr/lib/libnvrtc.so.12' } }, LINUX, {}), /escapes the payload/),
+    'an absolute link target must fail',
+  )
+} else {
+  console.log('test-check-release-artifact: symlink cases skipped (this host cannot create symlinks)')
+}
+
+// ---------------------------------------------------------------------------
+// manifest — junk and label-specific forbidden entries
+// ---------------------------------------------------------------------------
+assert.ok(
+  has(await failuresFor('windows-pdb', { ...goodWindows, 'camelid.pdb': 'symbols' }, WINDOWS, {}), /debug symbol database/),
+  'a stray .pdb must not ship',
+)
+assert.ok(
+  has(await failuresFor('linux-target-dir', { ...goodLinux, 'target/debug/leftover': 'x' }, LINUX, {}), /cargo target directory/),
+  'a leaked target/ tree must not ship',
+)
+assert.ok(
+  has(await failuresFor('linux-dotenv', { ...goodLinux, '.env': 'SECRET=1' }, LINUX, {}), /credential-shaped file/),
+  'a credential-shaped file must not ship',
+)
+assert.ok(
+  has(
+    await failuresFor(
+      'desktop-with-installer',
+      { ...goodWindows, 'camelid-desktop.exe': 'PE', 'DESKTOP_README.md': 'd', 'camelid-desktop_0.4.4_x64-setup.exe': 'installer' },
+      DESKTOP,
+      { requireNvrtc: true },
+    ),
+    /must be moved out of the portable zip/,
+  ),
+  'the NSIS installer is a separate artifact and must not be inside the portable zip',
+)
+assert.deepEqual(
+  (await failuresFor('windows-setup-allowed-elsewhere', { ...goodWindows, 'camelid_0.4.4_x64-setup.exe': 'installer' }, WINDOWS, {})).filter((f) =>
+    /moved out of the portable zip/.test(f),
+  ),
+  [],
+  'the installer rule is desktop-specific and must not leak onto other labels',
+)
+
+// ---------------------------------------------------------------------------
+// manifest — executable bit (POSIX only)
+// ---------------------------------------------------------------------------
+if (process.platform !== 'win32') {
+  const root = await makeTree('linux-nonexec', goodLinux)
+  await chmod(join(root, 'camelid'), 0o644)
+  assert.ok(
+    has(checkManifest(await readTree(root), LINUX, { requireNvrtc: true, checkExecutableBit: true }), /is not executable/),
+    'a tarball whose binary lost +x extracts fine and then cannot be run',
+  )
+  await chmod(join(root, 'camelid'), 0o755)
+  assert.deepEqual(
+    checkManifest(await readTree(root), LINUX, { requireNvrtc: true, checkExecutableBit: true }).filter((f) => /not executable/.test(f)),
+    [],
+    'a +x binary must pass the mode check',
+  )
+} else {
+  console.log('test-check-release-artifact: executable-bit case skipped (Windows has no mode bits)')
+}
+
+await rm(workspace, { recursive: true, force: true })
+console.log('test-check-release-artifact: all checks passed')

--- a/scripts/test-check-release-artifact.mjs
+++ b/scripts/test-check-release-artifact.mjs
@@ -20,6 +20,7 @@ import {
   parseVersionOutput,
   readTree,
   resolvePayloadRoot,
+  resolveSymlinkChain,
 } from './check-release-artifact.mjs'
 
 const workspace = await mkdtemp(join(tmpdir(), 'camelid-artifact-test-'))
@@ -325,6 +326,110 @@ assert.deepEqual(
   }),
   [],
   'the mode check must stay off where the filesystem has no mode bits to lose',
+)
+
+// ---------------------------------------------------------------------------
+// resolveSymlinkChain
+// ---------------------------------------------------------------------------
+{
+  const map = (...es) => new Map(es.map((e) => [e.path, e]))
+  const real = entry('libnvrtc.so.12.9.86')
+
+  assert.equal(resolveSymlinkChain(map(real), 'libnvrtc.so.12.9.86').kind, 'resolved', 'a regular file resolves to itself')
+  assert.equal(
+    resolveSymlinkChain(map(real, link('libnvrtc.so.12', 'libnvrtc.so.12.9.86')), 'libnvrtc.so.12').path,
+    'libnvrtc.so.12.9.86',
+    'a one-hop link resolves to its target',
+  )
+  assert.equal(
+    resolveSymlinkChain(map(real, link('a', 'b'), link('b', 'libnvrtc.so.12.9.86')), 'a').path,
+    'libnvrtc.so.12.9.86',
+    'a multi-hop chain resolves to the terminal file',
+  )
+  assert.equal(resolveSymlinkChain(map(link('a', 'missing')), 'a').kind, 'dangling')
+  assert.equal(resolveSymlinkChain(map(link('a', 'a')), 'a').kind, 'cycle', 'a self-referential link is a cycle, not a satisfied target')
+  assert.equal(resolveSymlinkChain(map(link('a', 'b'), link('b', 'a')), 'a').kind, 'cycle')
+  assert.equal(resolveSymlinkChain(map(link('a', '/usr/lib/x')), 'a').kind, 'escape')
+  assert.equal(resolveSymlinkChain(map(link('a', '../../etc/passwd')), 'a').kind, 'escape')
+  {
+    // A chain longer than the hop bound must terminate rather than spin.
+    const long = []
+    for (let i = 0; i < 12; i += 1) long.push(link(`l${i}`, `l${i + 1}`))
+    assert.equal(resolveSymlinkChain(map(...long), 'l0').kind, 'too-deep')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NVRTC sonames must RESOLVE to the right library, not merely be named like one
+//
+// cudarc dlopen's the soname and dlopen follows links, so a link whose name
+// matches while its target is the wrong library reproduces exactly the
+// silent CPU-fallback packaging failure this gate exists to catch. The
+// driverless boot smoke cannot catch it either, because it deliberately
+// exercises the CPU path.
+// ---------------------------------------------------------------------------
+const withoutCompiler = [
+  entry('camelid'),
+  entry('README.md'),
+  entry('LICENSE'),
+  entry('THIRD_PARTY_NOTICES.md'),
+  entry('libnvrtc-builtins.so.12.9'),
+]
+
+assert.deepEqual(
+  checkManifest([...withoutCompiler, entry('libnvrtc.so.12.9.86'), link('libnvrtc.so.12', 'libnvrtc.so.12.9.86')], LINUX, { requireNvrtc: true }),
+  [],
+  'the real packaging shape (soname symlink -> versioned real file) must still pass',
+)
+assert.ok(
+  has(checkManifest([...withoutCompiler, link('libnvrtc.so.12', 'libnvrtc-builtins.so.12.9')], LINUX, { requireNvrtc: true }), /not an NVRTC compiler library/),
+  'a compiler soname pointing at the BUILTINS library must fail',
+)
+assert.ok(
+  has(checkManifest([...withoutCompiler, link('libnvrtc.so.12', 'LICENSE')], LINUX, { requireNvrtc: true }), /not an NVRTC compiler library/),
+  'a compiler soname pointing at an unrelated file must fail',
+)
+assert.ok(
+  has(checkManifest([...withoutCompiler, link('libnvrtc.so.12', 'libnvrtc.so.12')], LINUX, { requireNvrtc: true }), /no usable NVRTC compiler/),
+  'a self-referential compiler soname must fail',
+)
+assert.ok(
+  has(
+    checkManifest([...withoutCompiler, link('libnvrtc.so.12', 'libnvrtc.so.13'), link('libnvrtc.so.13', 'libnvrtc.so.12')], LINUX, {
+      requireNvrtc: true,
+    }),
+    /no usable NVRTC compiler/,
+  ),
+  'a cyclic compiler soname must fail',
+)
+assert.ok(
+  has(
+    checkManifest(
+      [entry('camelid'), entry('README.md'), entry('LICENSE'), entry('THIRD_PARTY_NOTICES.md'), entry('libnvrtc.so.12.9.86'), link('libnvrtc-builtins.so.12.9', 'libnvrtc.so.12.9.86')],
+      LINUX,
+      { requireNvrtc: true },
+    ),
+    /not an NVRTC builtins library/,
+  ),
+  'a builtins soname pointing at the compiler must fail',
+)
+assert.ok(
+  has(
+    checkManifest(
+      [
+        entry('camelid.exe'),
+        entry('README.md'),
+        entry('LICENSE'),
+        entry('THIRD_PARTY_NOTICES.md'),
+        entry('nvrtc-builtins64_129.dll'),
+        link('nvrtc64_120_0.dll', 'nvrtc-builtins64_129.dll'),
+      ],
+      WINDOWS,
+      { requireNvrtc: true },
+    ),
+    /not an NVRTC compiler library/,
+  ),
+  'the same wrong-family check must apply on Windows',
 )
 
 // ---------------------------------------------------------------------------

--- a/scripts/test-smoke-release-artifact.mjs
+++ b/scripts/test-smoke-release-artifact.mjs
@@ -25,9 +25,11 @@ import {
   assertCapabilitiesPayload,
   assertHealthPayload,
   assertNoCrashMarkers,
+  assertUiAsset,
   assertWebUi,
   bootAndProbe,
   buildServeArgs,
+  extractUiAssetUrl,
   httpGet,
   pickFreePort,
   probeServer,
@@ -97,6 +99,8 @@ assert.ok(has(assertCapabilitiesPayload(200, '[]'), /expected a JSON object/), '
 // GET / — the embedded web UI must actually be embedded
 // ---------------------------------------------------------------------------
 const goodHtml = '<!doctype html><html><head><title>Camelid</title><script type="module" src="/assets/index-BwWMwyQo.js"></script></head><body></body></html>'
+const UI_ASSET_URL = '/assets/index-BwWMwyQo.js'
+const UI_ASSET_BODY = 'export const app = 1;\n'
 const htmlHeaders = { 'content-type': 'text/html' }
 assert.deepEqual(assertWebUi(200, htmlHeaders, goodHtml), [], 'the real app shell must pass')
 assert.ok(has(assertWebUi(404, htmlHeaders, goodHtml), /expected 200, got 404/), 'a missing root route must fail')
@@ -106,6 +110,37 @@ assert.ok(
   has(assertWebUi(200, htmlHeaders, '<html><head><title>Camelid</title></head><body>placeholder</body></html>'), /no hashed \/assets/),
   'a shell with no bundle means the web UI build never reached the binary',
 )
+
+// ---------------------------------------------------------------------------
+// The referenced bundle must be fetched, not just mentioned
+// ---------------------------------------------------------------------------
+assert.equal(extractUiAssetUrl(goodHtml), UI_ASSET_URL, 'the hashed module URL must be extracted from the shell')
+assert.equal(
+  extractUiAssetUrl('<script type="module" crossorigin src="/assets/index-Cz-PZZB3.js"></script>'),
+  '/assets/index-Cz-PZZB3.js',
+  'vite emits extra attributes before src; extraction must still work',
+)
+assert.equal(extractUiAssetUrl('<html><body>nothing</body></html>'), null, 'a shell with no bundle yields no URL')
+
+assert.deepEqual(
+  assertUiAsset(UI_ASSET_URL, 200, { 'content-type': 'text/javascript' }, UI_ASSET_BODY),
+  [],
+  'a served bundle must pass',
+)
+assert.deepEqual(
+  assertUiAsset(UI_ASSET_URL, 200, { 'content-type': 'application/javascript; charset=utf-8' }, UI_ASSET_BODY),
+  [],
+  'the other common JavaScript content-type must also pass',
+)
+assert.ok(
+  has(assertUiAsset(UI_ASSET_URL, 404, {}, ''), /does not serve/),
+  'a referenced-but-missing bundle is a blank app and must fail',
+)
+assert.ok(
+  has(assertUiAsset(UI_ASSET_URL, 200, { 'content-type': 'text/html' }, '<html>'), /expected a JavaScript content-type/),
+  'an HTML fallback served at an asset path must fail',
+)
+assert.ok(has(assertUiAsset(UI_ASSET_URL, 200, { 'content-type': 'text/javascript' }, ''), /bundle is empty/), 'an empty bundle must fail')
 
 // ---------------------------------------------------------------------------
 // crash markers
@@ -193,6 +228,7 @@ const engineLike = (overrides = {}) => (req, res) => {
     '/v1/health': () => res.writeHead(200, { 'content-type': 'application/json' }).end(healthyBody),
     '/api/capabilities': () => res.writeHead(200, { 'content-type': 'application/json' }).end('{"capabilities":[]}'),
     '/': () => res.writeHead(200, { 'content-type': 'text/html' }).end(goodHtml),
+    [UI_ASSET_URL]: () => res.writeHead(200, { 'content-type': 'text/javascript' }).end(UI_ASSET_BODY),
     ...overrides,
   }
   const route = routes[req.url]
@@ -223,6 +259,23 @@ await withServer(
 await withServer(engineLike({ '/api/capabilities': (res) => res.writeHead(500).end('boom') }), async (port) => {
   const probe = await probeServer(port)
   assert.ok(has(probe.failures, /expected 200, got 500/), 'a broken capabilities route must be caught end to end')
+})
+
+// The reviewer's case: a syntactically valid shell whose bundle 404s. Every
+// markup-level assertion passes; only fetching the URL catches it.
+await withServer(engineLike({ [UI_ASSET_URL]: (res) => res.writeHead(404).end('missing') }), async (port) => {
+  const probe = await probeServer(port)
+  assert.deepEqual(
+    assertWebUi(200, htmlHeaders, goodHtml),
+    [],
+    'the markup assertions alone must still pass — that is why the fetch is required',
+  )
+  assert.ok(has(probe.failures, /does not serve/), 'a referenced-but-missing bundle must be caught end to end')
+})
+
+await withServer(engineLike({ [UI_ASSET_URL]: (res) => res.writeHead(200, { 'content-type': 'text/html' }).end('<html>') }), async (port) => {
+  const probe = await probeServer(port)
+  assert.ok(has(probe.failures, /expected a JavaScript content-type/), 'an HTML body served at the bundle URL must be caught')
 })
 
 const closedPort = await pickFreePort()
@@ -260,16 +313,19 @@ const port = Number(process.argv[2])
 const mode = process.argv[3] ?? 'stay'
 const health = ${JSON.stringify(healthyBody)}
 const html = ${JSON.stringify(goodHtml)}
+const assetUrl = ${JSON.stringify(UI_ASSET_URL)}
+const assetBody = ${JSON.stringify(UI_ASSET_BODY)}
 
 const server = createServer((req, res) => {
   if (req.url === '/v1/health') res.writeHead(200, { 'content-type': 'application/json' }).end(health)
   else if (req.url === '/api/capabilities') res.writeHead(200, { 'content-type': 'application/json' }).end('{}')
   else if (req.url === '/') res.writeHead(200, { 'content-type': 'text/html' }).end(html)
+  else if (req.url === assetUrl) res.writeHead(200, { 'content-type': 'text/javascript' }).end(assetBody)
   else res.writeHead(404).end('nope')
 
-  // '/' is the last probe probeServer issues. Dying right after flushing it is
-  // the "served everything, then fell over" case.
-  if (mode === 'die-after-probes' && req.url === '/') {
+  // The bundle is the last probe probeServer issues. Dying right after
+  // flushing it is the "served everything, then fell over" case.
+  if (mode === 'die-after-probes' && req.url === assetUrl) {
     res.on('finish', () => {
       // writeSync, not process.stderr.write: an async pipe write can be
       // truncated by process.exit, and this message existing at all is the

--- a/scripts/test-smoke-release-artifact.mjs
+++ b/scripts/test-smoke-release-artifact.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+// Self-test for smoke-release-artifact.mjs (run in CI by the validation-scripts
+// job's test-*.mjs glob).
+//
+// The smoke script's job is to boot a real release binary, which does not exist
+// in the validation-scripts job. So this suite covers it two ways:
+//
+//   1. every assertion is a pure function and is driven directly, including the
+//      failure branches that a healthy binary would never produce;
+//   2. the polling and probing logic is driven against a REAL loopback HTTP
+//      server that impersonates the engine, so the transport path, retry
+//      behaviour and response handling are genuinely executed.
+//
+// What is deliberately NOT covered here: spawning camelid itself. That is what
+// the release workflow does with the actual artifact.
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+
+import {
+  HEALTH_POLL_INTERVAL_MS,
+  HEALTH_TIMEOUT_MS,
+  assertCapabilitiesPayload,
+  assertHealthPayload,
+  assertNoCrashMarkers,
+  assertWebUi,
+  buildServeArgs,
+  httpGet,
+  pickFreePort,
+  probeServer,
+  waitForHealth,
+} from './smoke-release-artifact.mjs'
+
+const has = (failures, pattern) => failures.some((f) => pattern.test(f))
+
+// ---------------------------------------------------------------------------
+// buildServeArgs — the boot must be model-less and deterministic
+// ---------------------------------------------------------------------------
+assert.deepEqual(
+  buildServeArgs({ port: 8181, modelsDir: '/tmp/empty' }),
+  ['serve', '--addr', '127.0.0.1:8181', '--no-open', '--models-dir', '/tmp/empty'],
+  'serve must bind loopback, skip the browser, and be pinned to an explicit models dir',
+)
+assert.throws(() => buildServeArgs({ port: 8181 }), /modelsDir is required/, 'an unpinned models dir would let auto_select_model load a stray GGUF')
+assert.throws(() => buildServeArgs({ port: 0, modelsDir: '/tmp' }), RangeError, 'port 0 must be rejected')
+assert.throws(() => buildServeArgs({ port: 70000, modelsDir: '/tmp' }), RangeError, 'an out-of-range port must be rejected')
+
+// ---------------------------------------------------------------------------
+// /v1/health — HealthResponse (src/api/mod.rs) on a model-less engine
+// ---------------------------------------------------------------------------
+const healthyBody = JSON.stringify({
+  ok: true,
+  engine: 'camelid',
+  loaded_now: false,
+  generation_ready: false,
+  active_model_id: null,
+  backend: 'none',
+  engine_queue_depth: 0,
+})
+assert.deepEqual(assertHealthPayload(200, healthyBody), [], 'a model-less engine at rest must pass')
+assert.ok(has(assertHealthPayload(503, healthyBody), /expected 200, got 503/), 'a non-200 health must fail')
+assert.ok(has(assertHealthPayload(200, 'not json'), /not valid JSON/), 'an unparseable health body must fail')
+assert.ok(has(assertHealthPayload(200, JSON.stringify({ ...JSON.parse(healthyBody), ok: false })), /ok=false/), 'ok=false must fail')
+assert.ok(
+  has(assertHealthPayload(200, JSON.stringify({ ...JSON.parse(healthyBody), loaded_now: true })), /loaded_now=true/),
+  'a model-less boot that reports a loaded model means the smoke did not test what it claims',
+)
+assert.ok(
+  has(assertHealthPayload(200, JSON.stringify({ ...JSON.parse(healthyBody), generation_ready: true })), /generation_ready=true/),
+  'generation_ready must be false without a model',
+)
+assert.ok(
+  has(assertHealthPayload(200, JSON.stringify({ ...JSON.parse(healthyBody), active_model_id: 'llama' })), /active_model_id/),
+  'an active model id without a model must fail',
+)
+assert.ok(
+  has(assertHealthPayload(200, JSON.stringify({ ...JSON.parse(healthyBody), engine_queue_depth: 3 })), /engine_queue_depth=3/),
+  'a non-zero queue depth at rest must fail',
+)
+assert.ok(
+  has(assertHealthPayload(200, JSON.stringify({ ...JSON.parse(healthyBody), backend: 7 })), /backend must be a string/),
+  'a malformed backend field must fail',
+)
+
+// ---------------------------------------------------------------------------
+// /api/capabilities
+// ---------------------------------------------------------------------------
+assert.deepEqual(assertCapabilitiesPayload(200, '{"capabilities":[]}'), [], 'a JSON object must pass')
+assert.ok(has(assertCapabilitiesPayload(404, '{}'), /expected 200, got 404/), 'a missing capabilities route must fail')
+assert.ok(has(assertCapabilitiesPayload(200, '<html>'), /not valid JSON/), 'an HTML fallback served at an API path must fail')
+assert.ok(has(assertCapabilitiesPayload(200, '[]'), /expected a JSON object/), 'a bare array must fail')
+
+// ---------------------------------------------------------------------------
+// GET / — the embedded web UI must actually be embedded
+// ---------------------------------------------------------------------------
+const goodHtml = '<!doctype html><html><head><title>Camelid</title><script type="module" src="/assets/index-BwWMwyQo.js"></script></head><body></body></html>'
+const htmlHeaders = { 'content-type': 'text/html' }
+assert.deepEqual(assertWebUi(200, htmlHeaders, goodHtml), [], 'the real app shell must pass')
+assert.ok(has(assertWebUi(404, htmlHeaders, goodHtml), /expected 200, got 404/), 'a missing root route must fail')
+assert.ok(has(assertWebUi(200, { 'content-type': 'application/json' }, goodHtml), /expected an HTML content-type/), 'a non-HTML root must fail')
+assert.ok(has(assertWebUi(200, htmlHeaders, '<html><head><title>Other</title></head></html>'), /Camelid app shell title/), 'a foreign page must fail')
+assert.ok(
+  has(assertWebUi(200, htmlHeaders, '<html><head><title>Camelid</title></head><body>placeholder</body></html>'), /no hashed \/assets/),
+  'a shell with no bundle means the web UI build never reached the binary',
+)
+
+// ---------------------------------------------------------------------------
+// crash markers
+// ---------------------------------------------------------------------------
+assert.deepEqual(assertNoCrashMarkers('listening on 127.0.0.1:8181\n'), [], 'ordinary startup logging must pass')
+assert.deepEqual(assertNoCrashMarkers(''), [], 'empty stderr must pass')
+assert.ok(has(assertNoCrashMarkers("thread 'main' panicked at src/main.rs:1:1"), /rust panic/), 'a panic must fail')
+assert.ok(has(assertNoCrashMarkers('\nthread ... has overflowed its stack\nstack overflow'), /stack overflow/), 'a stack overflow must fail')
+assert.ok(has(assertNoCrashMarkers('Segmentation fault'), /segfault/), 'a segfault must fail')
+assert.ok(has(assertNoCrashMarkers('Aborted (core dumped)'), /abort/), 'an abort must fail — a missing NVRTC must fall back to CPU, not abort')
+
+// ---------------------------------------------------------------------------
+// waitForHealth — injected clock/transport so every branch runs instantly
+// ---------------------------------------------------------------------------
+assert.equal(HEALTH_TIMEOUT_MS, 40_000, 'the health budget must stay aligned with camelid-desktop/src/engine.rs')
+assert.equal(HEALTH_POLL_INTERVAL_MS, 350, 'the poll interval must stay aligned with camelid-desktop/src/engine.rs')
+
+{
+  const result = await waitForHealth({ port: 1, get: async () => ({ status: 200, headers: {}, body: healthyBody }) })
+  assert.equal(result.ok, true, 'an immediately healthy engine must succeed')
+}
+{
+  let attempts = 0
+  const result = await waitForHealth({
+    port: 1,
+    get: async () => {
+      attempts += 1
+      if (attempts < 3) throw Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' })
+      return { status: 200, headers: {}, body: healthyBody }
+    },
+    wait: async () => {},
+  })
+  assert.equal(result.ok, true, 'connection-refused while the listener binds is normal and must be retried')
+  assert.equal(attempts, 3, 'polling must continue until the engine answers')
+}
+{
+  const result = await waitForHealth({ port: 1, isAlive: () => false, get: async () => ({ status: 200, headers: {}, body: '{}' }) })
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /exited before \/v1\/health answered/, 'a dead engine must be reported as death, not as a timeout')
+}
+{
+  let clock = 0
+  const result = await waitForHealth({
+    port: 1,
+    timeoutMs: 1000,
+    intervalMs: 350,
+    get: async () => { throw Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }) },
+    now: () => clock,
+    wait: async (ms) => { clock += ms },
+  })
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /did not return 200 within 1000ms/, 'the budget must be enforced')
+  assert.match(result.reason, /ECONNREFUSED/, 'the last transport state must be reported for diagnosis')
+}
+{
+  let clock = 0
+  const result = await waitForHealth({
+    port: 1,
+    timeoutMs: 1000,
+    intervalMs: 350,
+    get: async () => ({ status: 500, headers: {}, body: 'boom' }),
+    now: () => clock,
+    wait: async (ms) => { clock += ms },
+  })
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /HTTP 500/, 'a server that answers but never becomes healthy must report its status')
+}
+
+// ---------------------------------------------------------------------------
+// transport + probe, against a real loopback server impersonating the engine
+// ---------------------------------------------------------------------------
+async function withServer(handler, run) {
+  const server = createServer(handler)
+  const port = await pickFreePort()
+  await new Promise((done) => server.listen(port, '127.0.0.1', done))
+  try {
+    return await run(port)
+  } finally {
+    await new Promise((done) => server.close(done))
+  }
+}
+
+const engineLike = (overrides = {}) => (req, res) => {
+  const routes = {
+    '/v1/health': () => res.writeHead(200, { 'content-type': 'application/json' }).end(healthyBody),
+    '/api/capabilities': () => res.writeHead(200, { 'content-type': 'application/json' }).end('{"capabilities":[]}'),
+    '/': () => res.writeHead(200, { 'content-type': 'text/html' }).end(goodHtml),
+    ...overrides,
+  }
+  const route = routes[req.url]
+  if (route) route(res)
+  else res.writeHead(404).end('nope')
+}
+
+await withServer(engineLike(), async (port) => {
+  const response = await httpGet(port, '/v1/health')
+  assert.equal(response.status, 200, 'httpGet must reach a real server')
+  assert.deepEqual(JSON.parse(response.body).ok, true, 'httpGet must return the body verbatim')
+
+  const health = await waitForHealth({ port, timeoutMs: 5000 })
+  assert.equal(health.ok, true, 'waitForHealth must succeed against a real listener')
+
+  const probe = await probeServer(port)
+  assert.deepEqual(probe.failures, [], 'a fully healthy engine must produce zero probe failures')
+})
+
+await withServer(
+  engineLike({ '/': (res) => res.writeHead(200, { 'content-type': 'text/html' }).end('<html><head><title>Camelid</title></head></html>') }),
+  async (port) => {
+    const probe = await probeServer(port)
+    assert.ok(has(probe.failures, /no hashed \/assets/), 'an engine with an empty embedded UI must be caught end to end')
+  },
+)
+
+await withServer(engineLike({ '/api/capabilities': (res) => res.writeHead(500).end('boom') }), async (port) => {
+  const probe = await probeServer(port)
+  assert.ok(has(probe.failures, /expected 200, got 500/), 'a broken capabilities route must be caught end to end')
+})
+
+const closedPort = await pickFreePort()
+await assert.rejects(
+  () => httpGet(closedPort, '/v1/health', { timeoutMs: 250 }),
+  /ECONNREFUSED|timed out/,
+  'a transport failure must reject rather than resolve as a false pass',
+)
+
+// ---------------------------------------------------------------------------
+// pickFreePort
+// ---------------------------------------------------------------------------
+{
+  const port = await pickFreePort()
+  assert.ok(Number.isInteger(port) && port > 0 && port <= 65535, 'pickFreePort must return a usable TCP port')
+  const another = await pickFreePort()
+  assert.ok(Number.isInteger(another), 'pickFreePort must be repeatable')
+}
+
+console.log('test-smoke-release-artifact: all checks passed')

--- a/scripts/test-smoke-release-artifact.mjs
+++ b/scripts/test-smoke-release-artifact.mjs
@@ -14,7 +14,10 @@
 // What is deliberately NOT covered here: spawning camelid itself. That is what
 // the release workflow does with the actual artifact.
 import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import {
   HEALTH_POLL_INTERVAL_MS,
@@ -23,6 +26,7 @@ import {
   assertHealthPayload,
   assertNoCrashMarkers,
   assertWebUi,
+  bootAndProbe,
   buildServeArgs,
   httpGet,
   pickFreePort,
@@ -237,5 +241,91 @@ await assert.rejects(
   const another = await pickFreePort()
   assert.ok(Number.isInteger(another), 'pickFreePort must be repeatable')
 }
+
+// ---------------------------------------------------------------------------
+// bootAndProbe, against a real child process
+//
+// The release binary is not available in the validation-scripts job, so these
+// drive a fixture process that behaves like the engine and then misbehaves in
+// ways a healthy binary never would.
+// ---------------------------------------------------------------------------
+const fixtureDir = await mkdtemp(join(tmpdir(), 'camelid-smoke-fixture-'))
+const fixturePath = join(fixtureDir, 'engine-fixture.mjs')
+await writeFile(
+  fixturePath,
+  `import { createServer } from 'node:http'
+import { writeSync } from 'node:fs'
+
+const port = Number(process.argv[2])
+const mode = process.argv[3] ?? 'stay'
+const health = ${JSON.stringify(healthyBody)}
+const html = ${JSON.stringify(goodHtml)}
+
+const server = createServer((req, res) => {
+  if (req.url === '/v1/health') res.writeHead(200, { 'content-type': 'application/json' }).end(health)
+  else if (req.url === '/api/capabilities') res.writeHead(200, { 'content-type': 'application/json' }).end('{}')
+  else if (req.url === '/') res.writeHead(200, { 'content-type': 'text/html' }).end(html)
+  else res.writeHead(404).end('nope')
+
+  // '/' is the last probe probeServer issues. Dying right after flushing it is
+  // the "served everything, then fell over" case.
+  if (mode === 'die-after-probes' && req.url === '/') {
+    res.on('finish', () => {
+      // writeSync, not process.stderr.write: an async pipe write can be
+      // truncated by process.exit, and this message existing at all is the
+      // point of the test.
+      writeSync(2, "thread 'main' panicked at fixture: dying right after the last probe\\n")
+      server.close()
+      process.exit(0)
+    })
+  }
+})
+server.listen(port, '127.0.0.1')
+`,
+  'utf8',
+)
+
+{
+  const port = await pickFreePort()
+  const boot = await bootAndProbe({ command: process.execPath, args: [fixturePath, String(port), 'stay'], port, timeoutMs: 10_000 })
+  assert.deepEqual(boot.failures, [], 'a fixture that boots, serves and stays up must pass')
+}
+
+{
+  const port = await pickFreePort()
+  const boot = await bootAndProbe({
+    command: process.execPath,
+    args: [fixturePath, String(port), 'die-after-probes'],
+    port,
+    timeoutMs: 10_000,
+  })
+  assert.ok(
+    has(boot.failures, /stopped serving after the probes|exited on its own after answering the probes/),
+    `an engine that serves every probe and then exits must NOT pass; got ${JSON.stringify(boot.failures)}`,
+  )
+  // Proves the teardown waits for stdio 'close' rather than 'exit': this line
+  // is written while the process is on its way down, and would be missed by a
+  // buffer read at exit time.
+  assert.match(boot.stderr, /panicked at fixture/, 'stderr written on the way down must still be captured')
+  assert.ok(has(assertNoCrashMarkers(boot.stderr), /rust panic/), 'the captured tail must reach the crash-marker check')
+}
+
+{
+  const port = await pickFreePort()
+  const boot = await bootAndProbe({ command: process.execPath, args: ['--eval', 'process.exit(3)'], port, timeoutMs: 3000 })
+  assert.ok(has(boot.failures, /exited before \/v1\/health answered/), 'a process that never listens must fail, not hang')
+}
+
+{
+  const boot = await bootAndProbe({
+    command: join(fixtureDir, 'does-not-exist-anywhere'),
+    args: [],
+    port: await pickFreePort(),
+    timeoutMs: 3000,
+  })
+  assert.ok(boot.failures.length > 0, 'a binary that cannot be spawned must fail')
+}
+
+await rm(fixtureDir, { recursive: true, force: true })
 
 console.log('test-smoke-release-artifact: all checks passed')

--- a/scripts/test-verify-release-checksums.mjs
+++ b/scripts/test-verify-release-checksums.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Self-test for verify-release-checksums.mjs (run in CI by the
+// validation-scripts job's test-*.mjs glob).
+//
+// Covers the two cases the previous inline `awk '{print $1; exit}'` publish
+// gate accepted and a user's own `shasum -c` would not: a correct hash under
+// the wrong embedded filename, and a valid first record followed by garbage.
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { CHECKSUM_SUFFIX, checkChecksumRecord, checkStagedSet } from './verify-release-checksums.mjs'
+
+const has = (failures, pattern) => failures.some((f) => pattern.test(f))
+const HASH = 'a'.repeat(64)
+const OTHER = 'b'.repeat(64)
+const EXPECTED = ['camelid-macos-arm64.tar.gz', 'camelid-linux-x86_64.tar.gz', 'camelid-windows-x64.zip']
+const staged = (...extra) => [...EXPECTED, ...EXPECTED.map((a) => `${a}${CHECKSUM_SUFFIX}`), ...extra]
+
+// ---------------------------------------------------------------------------
+// staged set — only the three server archives and their sidecars
+// ---------------------------------------------------------------------------
+assert.deepEqual(checkStagedSet(staged(), EXPECTED), [], 'exactly the expected archives and sidecars must pass')
+assert.ok(
+  has(checkStagedSet(staged('camelid-linux-x86_64-check-receipt.json'), EXPECTED), /unexpected file: camelid-linux-x86_64-check-receipt\.json/),
+  'a diagnostic receipt must never be published',
+)
+assert.ok(
+  has(checkStagedSet(staged('camelid-desktop-windows-x64.zip'), EXPECTED), /unexpected file/),
+  'the independently published desktop artifact must not be swept in',
+)
+assert.ok(
+  has(checkStagedSet(staged('camelid_0.4.4_x64-setup.exe'), EXPECTED), /unexpected file/),
+  'a stray installer must not be published by the server release job',
+)
+assert.ok(
+  has(checkStagedSet(staged().filter((n) => n !== 'camelid-windows-x64.zip'), EXPECTED), /missing expected archive: camelid-windows-x64\.zip/),
+  'a missing archive must fail closed',
+)
+assert.ok(
+  has(
+    checkStagedSet(staged().filter((n) => n !== `camelid-windows-x64.zip${CHECKSUM_SUFFIX}`), EXPECTED),
+    /missing checksum sidecar: camelid-windows-x64\.zip\.sha256/,
+  ),
+  'an archive with no sidecar must fail closed',
+)
+assert.ok(has(checkStagedSet([], EXPECTED), /missing expected archive/), 'an empty staging directory must fail')
+
+// ---------------------------------------------------------------------------
+// checksum records
+// ---------------------------------------------------------------------------
+assert.deepEqual(
+  checkChecksumRecord('camelid-windows-x64.zip', `${HASH}  camelid-windows-x64.zip`, HASH),
+  [],
+  'a correct single record must pass (PowerShell writes no trailing newline)',
+)
+assert.deepEqual(
+  checkChecksumRecord('camelid-linux-x86_64.tar.gz', `${HASH}  camelid-linux-x86_64.tar.gz\n`, HASH),
+  [],
+  'the shasum convention must also pass',
+)
+assert.ok(
+  has(checkChecksumRecord('camelid-windows-x64.zip', `${HASH}  some-other-file.zip`, HASH), /names "some-other-file\.zip"/),
+  'a correct hash under the wrong embedded filename must fail',
+)
+assert.ok(
+  has(checkChecksumRecord('camelid-windows-x64.zip', `${HASH}  camelid-windows-x64.zip`, OTHER), /sha256 mismatch/),
+  'a hash that does not describe the archive must fail',
+)
+assert.ok(
+  has(checkChecksumRecord('camelid-windows-x64.zip', `${HASH}  camelid-windows-x64.zip\ngarbage`, HASH), /exactly one record/),
+  'a valid first record followed by garbage must fail',
+)
+assert.ok(
+  has(checkChecksumRecord('camelid-windows-x64.zip', `${HASH}  camelid-windows-x64.zip\n${OTHER}  extra.zip`, HASH), /exactly one record/),
+  'a multi-record sidecar must fail',
+)
+assert.ok(has(checkChecksumRecord('camelid-windows-x64.zip', '', HASH), /empty/), 'an empty sidecar must fail')
+assert.ok(has(checkChecksumRecord('camelid-windows-x64.zip', 'nonsense', HASH), /64-hex/), 'a malformed sidecar must fail')
+
+// ---------------------------------------------------------------------------
+// end to end against real files
+// ---------------------------------------------------------------------------
+const { createHash } = await import('node:crypto')
+const workspace = await mkdtemp(join(tmpdir(), 'camelid-checksums-test-'))
+const payload = 'archive bytes'
+const realHash = createHash('sha256').update(payload).digest('hex')
+await writeFile(join(workspace, 'camelid-windows-x64.zip'), payload)
+await writeFile(join(workspace, `camelid-windows-x64.zip${CHECKSUM_SUFFIX}`), `${realHash}  camelid-windows-x64.zip`)
+
+const { sha256File } = await import('./check-release-artifact.mjs')
+assert.equal(await sha256File(join(workspace, 'camelid-windows-x64.zip')), realHash, 'sha256File must agree with node:crypto')
+assert.deepEqual(
+  checkChecksumRecord('camelid-windows-x64.zip', `${realHash}  camelid-windows-x64.zip`, realHash),
+  [],
+  'a real archive and its real sidecar must verify',
+)
+
+await rm(workspace, { recursive: true, force: true })
+console.log('test-verify-release-checksums: all checks passed')

--- a/scripts/verify-release-checksums.mjs
+++ b/scripts/verify-release-checksums.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// verify-release-checksums.mjs — the last gate before artifacts become public.
+//
+// Why this is not inline shell. The build-time checker validates a sidecar's
+// embedded filename, but the publish step originally took only the first
+// whitespace field (`awk '{print $1; exit}'`). That accepts two things a user
+// running `shasum -c` would not:
+//
+//   * a sidecar whose hash is right but whose embedded filename names some
+//     other file, so the user's check verifies a different (or missing) path;
+//   * a valid first record followed by anything at all, because `shasum -c`
+//     consumes every record while the publish gate read one.
+//
+// Reusing parseChecksumFile from check-release-artifact.mjs means the two
+// gates cannot drift, and the tolerant-format handling (BOM, CRLF, the
+// coreutils `*` marker, PowerShell's missing trailing newline) is written once.
+//
+// It also closes the staging directory: only the expected archives and their
+// sidecars may be present, so diagnostic receipts or a stray desktop artifact
+// cannot be swept into `files: dist/*`.
+//
+// Usage:
+//   node scripts/verify-release-checksums.mjs --dir dist \
+//     --expect camelid-macos-arm64.tar.gz \
+//     --expect camelid-linux-x86_64.tar.gz \
+//     --expect camelid-windows-x64.zip
+//
+// Exit 0 = every expected archive is present, alone, and matches its sidecar.
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { parseChecksumFile, sha256File } from './check-release-artifact.mjs'
+
+/** Sidecar suffix produced by both packaging lanes. */
+export const CHECKSUM_SUFFIX = '.sha256'
+
+/**
+ * Compare what is staged against what may be published.
+ *
+ * Pure so the set logic is unit-testable without a filesystem.
+ *
+ * @param {string[]} presentNames every file name directly in the staging dir
+ * @param {string[]} expectedArchives archive names that must be published
+ * @returns {string[]} failure messages
+ */
+export function checkStagedSet(presentNames, expectedArchives) {
+  const failures = []
+  const present = new Set(presentNames)
+  const allowed = new Set()
+  for (const archive of expectedArchives) {
+    allowed.add(archive)
+    allowed.add(`${archive}${CHECKSUM_SUFFIX}`)
+  }
+
+  for (const archive of expectedArchives) {
+    if (!present.has(archive)) failures.push(`missing expected archive: ${archive}`)
+    if (!present.has(`${archive}${CHECKSUM_SUFFIX}`)) failures.push(`missing checksum sidecar: ${archive}${CHECKSUM_SUFFIX}`)
+  }
+  for (const name of [...present].sort()) {
+    if (!allowed.has(name)) failures.push(`refusing to publish unexpected file: ${name}`)
+  }
+  return failures
+}
+
+/**
+ * Validate one sidecar against the archive it names.
+ *
+ * @param {string} archiveName expected file name
+ * @param {string} sidecarText raw sidecar contents
+ * @param {string} actualHash sha256 of the archive on disk
+ * @returns {string[]} failure messages
+ */
+export function checkChecksumRecord(archiveName, sidecarText, actualHash) {
+  let record
+  try {
+    record = parseChecksumFile(sidecarText)
+  } catch (error) {
+    return [`${archiveName}${CHECKSUM_SUFFIX}: ${error.message}`]
+  }
+  const failures = []
+  if (record.name !== archiveName) {
+    failures.push(
+      `${archiveName}${CHECKSUM_SUFFIX} names ${JSON.stringify(record.name)}, not ${JSON.stringify(archiveName)} — ` +
+        'a user running `shasum -c` would check a different file',
+    )
+  }
+  if (record.hash !== actualHash) {
+    failures.push(`${archiveName}: sha256 mismatch — sidecar ${record.hash}, actual ${actualHash}`)
+  }
+  return failures
+}
+
+function parseArgs(argv) {
+  const args = { expect: [] }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = () => {
+      const value = argv[i + 1]
+      if (value === undefined || value.startsWith('--')) throw new Error(`${arg} requires a value`)
+      i += 1
+      return value
+    }
+    switch (arg) {
+      case '--dir': args.dir = next(); break
+      case '--expect': args.expect.push(next()); break
+      case '--help': case '-h': args.help = true; break
+      default: throw new Error(`unknown argument ${arg}`)
+    }
+  }
+  return args
+}
+
+const USAGE = `Usage:
+  node scripts/verify-release-checksums.mjs --dir <staging-dir> --expect <archive> [--expect <archive> ...]
+`
+
+async function main() {
+  let args
+  try {
+    args = parseArgs(process.argv.slice(2))
+  } catch (error) {
+    console.error(`verify-release-checksums: ${error.message}\n\n${USAGE}`)
+    process.exit(2)
+  }
+  if (args.help) {
+    console.log(USAGE)
+    return
+  }
+  if (!args.dir || !args.expect.length) {
+    console.error(`verify-release-checksums: --dir and at least one --expect are required\n\n${USAGE}`)
+    process.exit(2)
+  }
+
+  const dir = resolve(args.dir)
+  const failures = []
+
+  const dirents = await readdir(dir, { withFileTypes: true })
+  for (const dirent of dirents) {
+    if (!dirent.isFile()) failures.push(`refusing to publish non-file entry: ${dirent.name}`)
+  }
+  const names = dirents.filter((d) => d.isFile()).map((d) => d.name)
+  failures.push(...checkStagedSet(names, args.expect))
+
+  for (const archive of args.expect) {
+    const archivePath = join(dir, archive)
+    const sidecarPath = `${archivePath}${CHECKSUM_SUFFIX}`
+    let sidecarText
+    try {
+      sidecarText = await readFile(sidecarPath, 'utf8')
+    } catch {
+      continue // already reported as missing by checkStagedSet
+    }
+    let size
+    try {
+      size = (await stat(archivePath)).size
+    } catch {
+      continue
+    }
+    if (size === 0) {
+      failures.push(`${archive} is zero bytes`)
+      continue
+    }
+    const actualHash = await sha256File(archivePath)
+    const recordFailures = checkChecksumRecord(basename(archivePath), sidecarText, actualHash)
+    failures.push(...recordFailures)
+    if (!recordFailures.length) console.log(`  verified ${archive} (${(size / 1024 / 1024).toFixed(1)} MiB)`)
+  }
+
+  if (failures.length) {
+    console.error(`\nverify-release-checksums FAILED (${failures.length}):`)
+    for (const failure of failures) console.error(`  FAIL: ${failure}`)
+    process.exit(1)
+  }
+  console.log(`\nverify-release-checksums passed: ${args.expect.length} archive(s) ready to publish`)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Problem

`release.yml` builds, checksums and signs three archives, then publishes them without ever opening or running one. Every existing gate inspects either the source tree (`ci.yml`) or the staging directory (`scripts/package-linux-cuda.sh`, `scripts/package-windows-cuda.ps1`).

That leaves a class of defect that only appears once the bytes are packaged. v0.4.1 → v0.4.4 were all that class, tagged within about a day:

| Tag | PR | Fix |
|---|---|---|
| v0.4.1 | #500 | resolve GGUF loads under a Windows `\\?\` verbatim models-dir |
| v0.4.2 | #501 | swap models on load instead of dead-ending on the fit guard |
| v0.4.3 | #503 | ship NVRTC in the x86_64 Linux tarball |
| v0.4.4 | #505 | stop shipping NVRTC twice in the Linux tarball |

## What this does NOT claim

**The existing staging guards already work and are not duplicated here.** `scripts/package-linux-cuda.sh` fails on a missing `libnvrtc.so.<major>` soname, a dangling symlink, and a duplicated payload. This PR does not re-litigate #503/#505.

The gaps are what comes *after* those guards:

1. They run before `tar -czf` / `Compress-Archive`, so the archive itself was never inspected.
2. They live inside a conditional packaging step (`if [ "$label" = "linux-x86_64" ]`). A renamed matrix label silently skips them and still ships. A check on the extracted archive cannot be skipped by a packaging branch that never ran.
3. The `.sha256` sidecars are written once on the build runner and never re-verified after the artifacts round-trip through `upload-artifact` → `download-artifact` into the publish job.
4. No artifact was ever executed, on any platform.
5. Nothing asserted that the binary's self-reported version matches the release tag.

## What ships

Two dependency-free Node scripts, wired into `release.yml` between packaging and upload.

**`scripts/check-release-artifact.mjs`** — execution-free, verifies the extracted archive:

- checksum round-trip, parsing both sidecar conventions (`shasum` writes a trailing newline; PowerShell `Out-File -NoNewline` does not)
- per-label archive layout — `tar -czf "$dist.tar.gz" "$dist"` nests under a wrapper directory, `Compress-Archive -Path "$dist/*"` is flat at the zip root
- required payload, NVRTC pair, forbidden `.alt` backend
- byte-identical duplicate payloads, dangling or escaping symlinks
- build junk (`.pdb`, `target/`, credential-shaped files)
- POSIX executable bit on the binary
- that the NSIS installer was moved out of the desktop portable zip

**`scripts/smoke-release-artifact.mjs`** — boots the shipped binary out of the extracted archive, model-less:

- `/v1/health` (asserting `loaded_now`/`generation_ready` are false, so the run is provably model-less), `/api/capabilities`, and `GET /` requiring both the app-shell title and a hashed `/assets/*.js` bundle — that last one catches a web UI build that never made it into the binary
- asserts binary version == release tag
- tears the process tree down and checks stderr for crash markers

On a runner with no NVIDIA driver, this is a standing regression guard for `02f6a8b04` — *"a missing NVRTC must fall back to CPU, not abort the process"*.

**Publish job** re-hashes every artifact against its sidecar before uploading, and requires the archive/sidecar sets to match in both directions.

## Design notes

- **Verify the extracted archive rather than parsing archives.** Round-tripping through the same extraction tools users run is a stronger signal than a hand-rolled tar/zip reader, and it leaves the contract a pure function of a directory tree — which is what makes it exhaustively unit-testable.
- **Duplicate detection compares content hashes, scoped to the NVRTC family.** Stronger than a size comparison (cannot false-positive on same-size different libraries) and narrow enough that two benign identical files can never block a release.
- **The version assertion is applied on tag pushes only.** `workflow_dispatch` builds whatever ref it was started from, so pinning the binary to the input tag there would fail by design.
- **The desktop job boots the sidecar `camelid.exe`, not the Tauri GUI.** Launching a GUI headless on a runner proves nothing; the engine it bundles is the thing that must serve. A failure there still cannot block the server release — that job remains in no other job's `needs`.
- **Self-tests are named `test-*.mjs`** so the existing `ci.yml` validation-scripts glob picks them up. **No `ci.yml` change** (deliberate — #507 touches that file).
- **The publish-job re-verify is plain shell** (`shasum` + `awk`), so it needs no `checkout`/`setup-node` added to that job. `awk` rather than `read` so a sidecar with no trailing newline still yields its hash.
- Receipts are uploaded as CI run artifacts only — never attached to the release, never committed (`qa/evidence-bundles` is a scrubbed, checksum-audited tree and these are not one of its bundles).

## Scope

No Rust, no source, no `ci.yml`, no support-claim and no ledger changes.

The smoke is **model-less by design** — CI has no GGUF. It proves boot, health, capability reporting, UI embedding and clean shutdown. It makes **no inference or parity claim**; those stay with the existing exact-row evidence lanes.

## Validation

- Both self-tests pass, covering every failure branch, both sidecar conventions, the layout asymmetry in both directions, and a real loopback HTTP server standing in for the engine.
- Full `ci.yml` validation-scripts glob run locally: 22 pass, 3 fail. All three failures are pre-existing Windows-only path assumptions in untouched scripts (`test-audit-evidence-bundle-privacy.mjs` asserts a POSIX `/SHA256SUMS` separator; `test-bench-llama3-same-host.mjs` expects a `/tmp` path; `test-check-public-evidence-claims.mjs` trips its own private-path scanner on a `C:\Users` temp dir). That job runs on ubuntu in CI, which is why they are green upstream.
- Ran both gates against a **real release build**, staged, zipped, checksummed and extracted exactly as `release.yml` does it: `sha256 ok`, `version: v0.4.4 (tag v0.4.4)`, health + capabilities + embedded UI all served, clean teardown, no orphan processes. That host has an NVIDIA driver but the artifact shipped no NVRTC, so the CPU-fallback path was genuinely exercised.
- Real `tar` round-trip for the nested layout, including symlink preservation.
- Negative cases all exit 1 with precise messages: absent NVRTC under `--require-nvrtc`, corrupted sidecar, wrong label, version mismatch.
- Publish-job shell loop harness-tested: both sidecar conventions, tampered archive, sidecar without archive, archive without sidecar, empty `dist/`.
- Workflow YAML parses and every verify step lands after packaging/signing and before upload/publish.
- `check-public-scrub.sh` exits 0. All new files are LF (`i/lf w/lf`), `git diff --check` clean.

## Known limitations

- **The Windows legs are not dry-runnable on a fork.** `build-windows` and `desktop-windows` use `environment: release` with Azure OIDC signing; a fork lacks those secrets, so only the linux/macos `build` legs can be exercised via `workflow_dispatch`. The Windows path was validated locally instead, against a real staged artifact.
- **Verification runs on the runner that built each artifact**, which is the platform it ships to. Extracting the Linux tarball somewhere symlinks collapse into copies (Windows without developer mode) makes the duplicate-payload guard fire on a correct packaging job; the failure message says so explicitly.
- The smoke asserts nothing about inference, throughput or model behaviour.
