### PR TITLE
Accelerate Metal temperature sampling and Q8 views

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4920,6 +4920,7 @@ mod gemma4_template_tests {
         // reject them (falling through would reach the optimized engine, which
         // mis-binds gemma3), and must NOT touch the optimized-lane archs.
         assert!(completions_unsupported_for_arch("qwen35"));
+        assert!(completions_unsupported_for_arch("gemma2"));
         assert!(completions_unsupported_for_arch("gemma3"));
         assert!(!completions_unsupported_for_arch("llama"));
         assert!(!completions_unsupported_for_arch("qwen3"));
@@ -5707,7 +5708,7 @@ fn runnable_serve_enabled() -> bool {
 /// its chat requests get a typed 503 instead of falling through to the mis-bound
 /// optimized engine — fail-closed by design.
 fn is_runnable_serve_arch(arch: &str) -> bool {
-    matches!(arch, "qwen35" | "gemma3")
+    matches!(arch, "qwen35" | "gemma2" | "gemma3")
 }
 
 /// A runnable-lane model wrapped for the serve path: greedy generation + the GGUF
@@ -6097,12 +6098,12 @@ async fn runnable_chat_nonstreaming(
         .into_iter()
         .map(|t| t.get("function").cloned().unwrap_or(t))
         .collect();
-    let prompt_text = if runtime.architecture == "gemma3" {
+    let prompt_text = if runtime.architecture == "gemma2" || runtime.architecture == "gemma3" {
         if !tools.is_empty() {
             return api_error(
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "unsupported_tools",
-                "the gemma3 runnable serve lane does not support tools: the model's chat template has no tools branch and no tool-call grammar is certified for this row".to_string(),
+                "the gemma runnable serve lane does not support tools: the model's chat template has no tools branch and no tool-call grammar is certified for this row".to_string(),
                 None,
             );
         }
@@ -6114,7 +6115,7 @@ async fn runnable_chat_nonstreaming(
     };
     // gemma3 renders carry no BOS string (oracle /apply-template parity) — BOS is
     // added at token level (add_special=true), matching llama-server's chat path.
-    let add_special = runtime.architecture == "gemma3";
+    let add_special = runtime.architecture == "gemma2" || runtime.architecture == "gemma3";
     let prompt_ids = match runtime.tokenizer.encode(&prompt_text, add_special, true) {
         Ok(ids) => ids,
         Err(e) => {
@@ -6209,12 +6210,12 @@ async fn runnable_chat_streaming(
         .into_iter()
         .map(|t| t.get("function").cloned().unwrap_or(t))
         .collect();
-    let prompt_text = if runtime.architecture == "gemma3" {
+    let prompt_text = if runtime.architecture == "gemma2" || runtime.architecture == "gemma3" {
         if !tools.is_empty() {
             return api_error(
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "unsupported_tools",
-                "the gemma3 runnable serve lane does not support tools: the model's chat template has no tools branch and no tool-call grammar is certified for this row".to_string(),
+                "the gemma runnable serve lane does not support tools: the model's chat template has no tools branch and no tool-call grammar is certified for this row".to_string(),
                 None,
             );
         }
@@ -6226,7 +6227,7 @@ async fn runnable_chat_streaming(
     };
     // gemma3 renders carry no BOS string (oracle /apply-template parity) — BOS is
     // added at token level (add_special=true), matching llama-server's chat path.
-    let add_special = runtime.architecture == "gemma3";
+    let add_special = runtime.architecture == "gemma2" || runtime.architecture == "gemma3";
     let prompt_ids = match runtime.tokenizer.encode(&prompt_text, add_special, true) {
         Ok(ids) => ids,
         Err(e) => {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2689,30 +2689,28 @@ impl LlamaInferenceSession {
     }
 
     /// Temperature-sampling analog of the greedy resident fast lane: when the
-    /// sampler is plain temperature (no top-k / top-p / penalties / logit-bias),
-    /// draw the next token on the GPU via Gumbel-max ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â no 128K-logit host copy and
-    /// no CPU sort, which the profiler showed cost ~7 ms/token (more than the whole
-    /// forward). Returns `Ok(None)` when the config isn't GPU-eligible or CUDA
-    /// resident decode is off, so the caller uses the CPU logits path unchanged.
+    /// sampler is plain temperature (no filtering, penalties, or logit bias),
+    /// draw the next token on the GPU via Gumbel-max — no full-vocabulary host
+    /// copy and no CPU sort. Metal is enabled by default with an explicit escape
+    /// hatch; CUDA retains its opt-in gate until its older streaming-state issue
+    /// is separately resolved.
     pub fn generate_next_token_sampled_resident(
         &mut self,
         token_id: u32,
         config: &SamplingConfig,
     ) -> Result<Option<(u32, u128)>> {
-        // The resident GPU Gumbel-max temperature-sampling fast lane produces
-        // corrupted output in the streaming decode path (garbled, off-topic
-        // tokens for any temperature > 0; greedy/argmax and the CPU temperature
-        // sampler are unaffected). Disabled by default until the GPU
-        // sampling-state interaction is root-caused; opt back in with
-        // CAMELID_GPU_TEMP_SAMPLING. Declining here routes temperature sampling
-        // through the correct CPU sampler (one logits copy per token).
-        if !resident_gpu_temperature_sampling_enabled()
-            || !resident_decode_cuda_enabled()
+        let metal_sampling =
+            resident_decode_metal_enabled() && resident_metal_temperature_sampling_enabled();
+        let cuda_sampling =
+            resident_decode_cuda_enabled() && resident_gpu_temperature_sampling_enabled();
+        if (!metal_sampling && !cuda_sampling)
             || config.temperature <= 0.0
             || config.top_k.is_some()
             || config.top_p.is_some_and(|p| p < 1.0)
+            || config.min_p.is_some_and(|p| p > 0.0)
             || config.presence_penalty != 0.0
             || config.frequency_penalty != 0.0
+            || config.repeat_penalty != 1.0
             || !config.logit_bias.is_empty()
         {
             return Ok(None);
@@ -2729,16 +2727,15 @@ impl LlamaInferenceSession {
             .token_embedding
             .embedding_lookup(&[token_id], "token_embedding")?;
         let inv_temp = 1.0 / config.temperature;
-        // Per-token seed so the Gumbel draw differs each step (the CPU sampler's
-        // fixed seed=0 draw is replaced; temperature sampling is random regardless).
         let base = config.seed.unwrap_or(0);
-        let seed = base ^ 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(self.kv_cache.position as u64 + 1);
-        match self.try_resident_decode_forward_cuda(
-            &embedding,
-            true,
-            None,
-            Some((inv_temp, seed)),
-        )? {
+        let forward = if metal_sampling {
+            self.try_resident_decode_forward_metal_sample(&embedding, token_id, inv_temp, base)?
+        } else {
+            let seed =
+                base ^ 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(self.kv_cache.position as u64 + 1);
+            self.try_resident_decode_forward_cuda(&embedding, true, None, Some((inv_temp, seed)))?
+        };
+        match forward {
             Some(ResidentForward::Sampled(id)) => {
                 self.kv_cache.position += 1;
                 Ok(Some((id, started.elapsed().as_micros())))
@@ -6001,12 +5998,21 @@ fn sample_with_config(
     }
 
     let mut candidates: Vec<(usize, f32)> = adjusted.data.iter().copied().enumerate().collect();
+    if let Some(top_k) = config.top_k {
+        // Partition around K before ordering the survivors. The comparator is a
+        // total order (token id breaks equal-logit ties), so sorting the selected
+        // prefix below produces exactly the same candidates and deterministic
+        // sampling order as a full-vocabulary sort.
+        if top_k < candidates.len() {
+            candidates.select_nth_unstable_by(top_k, |(left_idx, left), (right_idx, right)| {
+                right.total_cmp(left).then_with(|| left_idx.cmp(right_idx))
+            });
+            candidates.truncate(top_k);
+        }
+    }
     candidates.sort_by(|(left_idx, left), (right_idx, right)| {
         right.total_cmp(left).then_with(|| left_idx.cmp(right_idx))
     });
-    if let Some(top_k) = config.top_k {
-        candidates.truncate(top_k.min(candidates.len()));
-    }
 
     let max_logit = candidates
         .iter()
@@ -6045,9 +6051,10 @@ fn sample_with_config(
     }
 
     if let Some(top_p) = config.top_p.filter(|top_p| *top_p < 1.0) {
-        weighted.sort_by(|(left_idx, left), (right_idx, right)| {
-            right.total_cmp(left).then_with(|| left_idx.cmp(right_idx))
-        });
+        // `weighted` still has the descending-logit order established above:
+        // exp/logit scaling and normalization are monotonic, and min-p retains
+        // elements without reordering them. Sorting by probability again was a
+        // redundant O(n log n) pass over the vocabulary.
         let mut cumulative = 0.0;
         let mut keep = 0usize;
         for (_, probability) in &weighted {
@@ -10477,8 +10484,7 @@ fn expert_matrix_view(
             TensorShape {
                 dims: vec![output_width, input_width],
             },
-            Q8_0FileBacking::new(
-                backing.path.clone(),
+            backing.clone_with_offset_and_blocks(
                 backing.absolute_offset + (block_offset * Q8BlockReader::BLOCK_SIZE_BYTES) as u64,
                 block_count,
             ),
@@ -11672,11 +11678,25 @@ fn build_resident_cuda_engine(
     Some(engine)
 }
 
-/// Opt-in gate for the resident GPU Gumbel-max temperature-sampling fast lane.
-/// Default OFF: the fast lane corrupts output in the streaming decode path, so
-/// temperature sampling falls back to the (correct) CPU sampler. Set
-/// `CAMELID_GPU_TEMP_SAMPLING=1/true/on/yes` to re-enable for debugging once the
-/// GPU sampling-state interaction is fixed.
+/// Metal's resident Gumbel-max sampling lane. Default ON after its device-level
+/// distribution/reproducibility gate; `CAMELID_METAL_TEMP_SAMPLING=0` keeps an
+/// escape hatch for driver diagnosis.
+fn resident_metal_temperature_sampling_enabled() -> bool {
+    match std::env::var_os("CAMELID_METAL_TEMP_SAMPLING") {
+        Some(value) => {
+            let value = value.to_string_lossy();
+            let value = value.trim();
+            !(value == "0"
+                || value.eq_ignore_ascii_case("false")
+                || value.eq_ignore_ascii_case("off")
+                || value.eq_ignore_ascii_case("no"))
+        }
+        None => true,
+    }
+}
+
+/// Opt-in gate for the CUDA Gumbel-max temperature-sampling lane. Its prior
+/// streaming-state corruption remains isolated behind this default-OFF switch.
 fn resident_gpu_temperature_sampling_enabled() -> bool {
     match std::env::var_os("CAMELID_GPU_TEMP_SAMPLING") {
         Some(value) => {

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -9,6 +9,40 @@ use crate::metal;
 
 pub(super) type ResidentDecodeState = metal::ResidentDecodeState;
 
+#[derive(Clone, Copy)]
+enum MetalSampleRequest {
+    Greedy {
+        input_token: u32,
+    },
+    Temperature {
+        input_token: u32,
+        inv_temperature: f32,
+        base_seed: u64,
+    },
+}
+
+impl MetalSampleRequest {
+    fn input_token(self) -> u32 {
+        match self {
+            Self::Greedy { input_token } | Self::Temperature { input_token, .. } => input_token,
+        }
+    }
+
+    fn mode(self) -> metal::SampleMode {
+        match self {
+            Self::Greedy { .. } => metal::SampleMode::Greedy,
+            Self::Temperature {
+                inv_temperature,
+                base_seed,
+                ..
+            } => metal::SampleMode::Temperature {
+                inv_temperature,
+                base_seed,
+            },
+        }
+    }
+}
+
 /// Maximum speculative-verify window (`[last_token, drafts...]`), mirroring the CUDA host's
 /// `MAX_VERIFY_K`. `k = drafts.len() + 1 <= MAX_VERIFY_K`.
 // Used only by the non-cuda Metal verify seam (verify_drafts_metal / verify_tree_metal), whose
@@ -272,6 +306,37 @@ impl super::LlamaInferenceSession {
         compute_logits: bool,
         gpu_sample_token: Option<u32>,
     ) -> Result<Option<ResidentForward>> {
+        self.try_resident_decode_forward_metal_inner(
+            embedding,
+            compute_logits,
+            gpu_sample_token.map(|input_token| MetalSampleRequest::Greedy { input_token }),
+        )
+    }
+
+    pub(super) fn try_resident_decode_forward_metal_sample(
+        &mut self,
+        embedding: &CpuTensor,
+        input_token: u32,
+        inv_temperature: f32,
+        base_seed: u64,
+    ) -> Result<Option<ResidentForward>> {
+        self.try_resident_decode_forward_metal_inner(
+            embedding,
+            true,
+            Some(MetalSampleRequest::Temperature {
+                input_token,
+                inv_temperature,
+                base_seed,
+            }),
+        )
+    }
+
+    fn try_resident_decode_forward_metal_inner(
+        &mut self,
+        embedding: &CpuTensor,
+        compute_logits: bool,
+        gpu_sample: Option<MetalSampleRequest>,
+    ) -> Result<Option<ResidentForward>> {
         if !self.resident_decode_eligible(compute_logits)? {
             return Ok(None);
         }
@@ -414,7 +479,7 @@ impl super::LlamaInferenceSession {
 
         // GPU-side greedy sampling stage: only when the caller asked for it, logits run on
         // the GPU, and the token embedding table is plain Q8_0 (the gather reads its rows).
-        let sample_stage = match gpu_sample_token {
+        let sample_stage = match gpu_sample {
             Some(_)
                 if compute_logits
                     && weights.token_embedding.source_type == Some(GgufTensorType::Q8_0)
@@ -422,11 +487,23 @@ impl super::LlamaInferenceSession {
                         || weights.token_embedding.q8_0_wire_pages.is_some()) =>
             {
                 let embedding_blocks = resident_weight_bytes(&weights.token_embedding);
-                (embedding_blocks.block_count() == vocab * (hidden / 32))
-                    .then_some(metal::SampleStage { embedding_blocks })
+                (embedding_blocks.block_count() == vocab * (hidden / 32)).then_some(
+                    metal::SampleStage {
+                        embedding_blocks,
+                        mode: gpu_sample.expect("sample request matched above").mode(),
+                    },
+                )
             }
             _ => None,
         };
+        // Temperature sampling must fail before advancing resident KV when the
+        // device-side tail cannot be built. Returning logits here would already
+        // have executed the position and make a caller fallback run it twice.
+        if matches!(gpu_sample, Some(MetalSampleRequest::Temperature { .. }))
+            && sample_stage.is_none()
+        {
+            return Ok(None);
+        }
 
         // Rope tables for position+1 feed the encode-ahead pipeline: the session encodes
         // the NEXT token's command buffer while this token executes on the GPU.
@@ -449,7 +526,9 @@ impl super::LlamaInferenceSession {
             scale,
             logits_stage,
             sample_stage,
-            gpu_sample_token.unwrap_or(u32::MAX),
+            gpu_sample
+                .map(MetalSampleRequest::input_token)
+                .unwrap_or(u32::MAX),
             next_tables
                 .as_ref()
                 .map(|t| (t.cos.as_slice(), t.sin.as_slice())),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2573,11 +2573,13 @@ async fn main() -> anyhow::Result<()> {
             warmup,
             threads,
             json: _,
-            // `apply_deterministic_mode` already set CAMELID_DETERMINISTIC + forced the
-            // Metal stack off before this match, so generation rides the CPU path; the
-            // engine reads the env directly.
-            deterministic: _,
+            deterministic,
         } => {
+            // Match `serve`'s fast-load plan so benchmark startup/RSS measures
+            // the production Metal path rather than eagerly materializing Q8.
+            if !deterministic {
+                apply_serve_nocopy_default();
+            }
             run_bench_generate(
                 model,
                 prompt_file,
@@ -5596,12 +5598,14 @@ fn apply_deterministic_mode() {
     );
 }
 
-/// Default the single-node `serve` path to fast-load (CAMELID_METAL_NOCOPY): Q8_0
+/// Default the single-node serve/benchmark path to fast-load
+/// (CAMELID_METAL_NOCOPY): Q8_0
 /// weights map straight into page-aligned wire pages the GPU reads in place — same
 /// decode speed, ~36% lower peak RSS, and warm reloads in seconds instead of the
 /// full disk pass. Gated to exactly the configuration that can consume wire pages:
 /// macOS, the resident decode path active, and the wire kernel stack on. This is
-/// why it lives in the serve arm and not `apply_default_fast_stack` — speculative
+/// why callers apply it after command-specific mode selection instead of from
+/// `apply_default_fast_stack` — speculative
 /// decoding disables resident decode (its CPU repack plan needs the materialized
 /// blocks), any wire-off override falls back to the block path, and the
 /// distributed nodes (whose CPU forward needs `q8_0_blocks`) never run this arm.

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -10835,6 +10835,7 @@ pub enum SampleMode {
     },
 }
 
+#[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SampleSignature {
     Greedy,
@@ -10845,6 +10846,7 @@ enum SampleSignature {
 }
 
 impl SampleMode {
+    #[cfg(target_os = "macos")]
     fn signature(self, position: usize) -> SampleSignature {
         match self {
             Self::Greedy => SampleSignature::Greedy,

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -82,6 +82,7 @@ struct MetalLinearKernel {
     rms_norm_quantize_pipeline: ComputePipelineState,
     silu_mul_quantize_pipeline: ComputePipelineState,
     argmax_f32_greedy_pipeline: ComputePipelineState,
+    sample_gumbel_f32_pipeline: ComputePipelineState,
     attention_decode_splitk_pipeline: ComputePipelineState,
     attention_decode_splitk_kv16_pipeline: ComputePipelineState,
     attention_decode_splitk_kv16_direct_pipeline: ComputePipelineState,
@@ -3991,6 +3992,60 @@ kernel void argmax_f32_greedy(
     }
 }
 
+// Temperature sampling via Gumbel-max. A categorical draw from
+// softmax(logits / temperature) is argmax(logit / temperature + Gumbel(0, 1)),
+// so one linear GPU pass replaces the full-logit host copy, softmax, and sort.
+// The stateless SplitMix64 hash makes the result reproducible for a given seed.
+inline float splitmix_uniform(ulong seed, uint idx) {
+    ulong z = seed + 0x9E3779B97F4A7C15ul * ulong(idx + 1u);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ul;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBul;
+    z ^= z >> 31;
+    uint mantissa = uint(z >> 40);
+    return (float(mantissa) + 0.5f) / 16777216.0f;
+}
+
+kernel void sample_gumbel_f32(
+    device const float* logits [[buffer(0)]],
+    device uint* out_id [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    constant float& inv_temperature [[buffer(3)]],
+    constant ulong& seed [[buffer(4)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tg_size [[threads_per_threadgroup]]
+) {
+    threadgroup float sh_val[1024];
+    threadgroup uint sh_idx[1024];
+    float best = -INFINITY;
+    uint best_i = 0xffffffffu;
+    for (uint i = tid; i < count; i += tg_size) {
+        float u = splitmix_uniform(seed, i);
+        float gumbel = -log(-log(u));
+        float value = logits[i] * inv_temperature + gumbel;
+        if (value > best) {
+            best = value;
+            best_i = i;
+        }
+    }
+    sh_val[tid] = best;
+    sh_idx[tid] = best_i;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint stride = tg_size / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            float other = sh_val[tid + stride];
+            uint other_i = sh_idx[tid + stride];
+            if (other > sh_val[tid] || (other == sh_val[tid] && other_i < sh_idx[tid])) {
+                sh_val[tid] = other;
+                sh_idx[tid] = other_i;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tid == 0) {
+        out_id[0] = sh_idx[0];
+    }
+}
+
 // Dequantize the sampled token's Q8_0 embedding row (wire 34-byte blocks) into the
 // f32 input buffer the next pre-encoded token graph reads. Same dequant math as the
 // CPU embedding_lookup (f16 scale -> f32, times the i8 quant), so the values are
@@ -4653,6 +4708,12 @@ fn metal_linear_kernel() -> Option<&'static MetalLinearKernel> {
             let argmax_f32_greedy_pipeline = device
                 .new_compute_pipeline_state_with_function(&argmax_f32_greedy_function)
                 .ok()?;
+            let sample_gumbel_f32_function = elementwise_library
+                .get_function("sample_gumbel_f32", None)
+                .ok()?;
+            let sample_gumbel_f32_pipeline = device
+                .new_compute_pipeline_state_with_function(&sample_gumbel_f32_function)
+                .ok()?;
             let embed_row_gather_q8_wire_function = elementwise_library
                 .get_function("embed_row_gather_q8_wire", None)
                 .ok()?;
@@ -4823,6 +4884,7 @@ fn metal_linear_kernel() -> Option<&'static MetalLinearKernel> {
                 rms_norm_quantize_pipeline,
                 silu_mul_quantize_pipeline,
                 argmax_f32_greedy_pipeline,
+                sample_gumbel_f32_pipeline,
                 attention_decode_splitk_pipeline,
                 attention_decode_splitk_kv16_pipeline,
                 attention_decode_splitk_kv16_direct_pipeline,
@@ -10763,13 +10825,48 @@ pub struct LogitsStage<'a> {
     pub vocab_size: usize,
 }
 
-/// GPU-side greedy sampling stage for the resident decode fast path: the token graph's
-/// tail argmaxes the logits and gathers the sampled token's embedding row into the next
-/// graph's input buffer, so the CPU never sits between two tokens on the critical path.
+/// GPU-side sampling operation attached to a resident token graph.
+#[derive(Clone, Copy)]
+pub enum SampleMode {
+    Greedy,
+    Temperature {
+        inv_temperature: f32,
+        base_seed: u64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SampleSignature {
+    Greedy,
+    Temperature {
+        inv_temperature_bits: u32,
+        token_seed: u64,
+    },
+}
+
+impl SampleMode {
+    fn signature(self, position: usize) -> SampleSignature {
+        match self {
+            Self::Greedy => SampleSignature::Greedy,
+            Self::Temperature {
+                inv_temperature,
+                base_seed,
+            } => SampleSignature::Temperature {
+                inv_temperature_bits: inv_temperature.to_bits(),
+                token_seed: base_seed ^ 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(position as u64 + 1),
+            },
+        }
+    }
+}
+
+/// GPU-side sampling stage for the resident decode fast path: the token graph's
+/// tail samples the logits and gathers the selected token's embedding row into
+/// the next graph's input buffer, so the CPU never sits between two tokens.
 pub struct SampleStage<'a> {
     /// Token-embedding Q8_0 bytes (36-byte CPU blocks wire-converted in the buffer
     /// cache, or page-aligned wire pages wrapped in place).
     pub embedding_blocks: ResidentWeightBytes<'a>,
+    pub mode: SampleMode,
 }
 
 /// What a resident forward_token call produced: the raw logits/hidden vector (CPU
@@ -10849,6 +10946,7 @@ struct PreparedToken {
     position: usize,
     has_logits: bool,
     has_sample: bool,
+    sample_signature: Option<SampleSignature>,
     event_value: u64,
     cb: metal::CommandBuffer,
     logits_buf: Option<Buffer>,
@@ -11181,6 +11279,9 @@ impl ResidentDecodeState {
             None
         };
         let want_sample = sample_stage.is_some() && logits_stage.is_some();
+        let requested_sample_signature = sample_stage
+            .as_ref()
+            .map(|stage| stage.mode.signature(position));
         let pending = self.pending.take();
         let pending_signaled = std::mem::take(&mut self.pending_signaled);
         let usable = matches!(
@@ -11188,6 +11289,7 @@ impl ResidentDecodeState {
             Some(p) if p.position == position
                 && p.has_logits == logits_stage.is_some()
                 && p.has_sample == want_sample
+                && p.sample_signature == requested_sample_signature
         );
         // Fast path: the pending graph was already signaled last call (its input embedding
         // comes from the previous graph's GPU-side gather). It only matches the caller's
@@ -11497,11 +11599,11 @@ impl ResidentDecodeState {
         } else {
             None
         };
-        // Greedy sampling tail: argmax the logits into a 4-byte id buffer, then gather the
-        // sampled token's embedding row into buf_a — the input the NEXT pre-encoded graph
-        // reads. Both are hazard-ordered after the logits matmul by Metal's tracking.
-        let sampled_buf = match (&logits_buf, &emb_buf, logits_stage) {
-            (Some(lb), Some(eb), Some(s)) => {
+        // Sampling tail: select an id from the logits, then gather that token's
+        // embedding row into buf_a — the input the NEXT pre-encoded graph reads.
+        // Both operations are hazard-ordered after the logits matmul by Metal.
+        let sampled_buf = match (&logits_buf, &emb_buf, logits_stage, sample_stage) {
+            (Some(lb), Some(eb), Some(s), Some(sample)) => {
                 let nb = |bytes: u64| pool_get(k, bytes);
                 let id_buf = nb(4);
                 let am_scalar = nb(4);
@@ -11510,10 +11612,34 @@ impl ResidentDecodeState {
                     *(am_scalar.contents() as *mut u32) = s.vocab_size as u32;
                     *(eg_scalar.contents() as *mut u32) = bpr_hidden as u32;
                 }
-                e.set_compute_pipeline_state(&k.argmax_f32_greedy_pipeline);
-                e.set_buffer(0, Some(lb), 0);
-                e.set_buffer(1, Some(&id_buf), 0);
-                e.set_buffer(2, Some(&am_scalar), 0);
+                match sample.mode {
+                    SampleMode::Greedy => {
+                        e.set_compute_pipeline_state(&k.argmax_f32_greedy_pipeline);
+                        e.set_buffer(0, Some(lb), 0);
+                        e.set_buffer(1, Some(&id_buf), 0);
+                        e.set_buffer(2, Some(&am_scalar), 0);
+                    }
+                    SampleMode::Temperature {
+                        inv_temperature,
+                        base_seed,
+                    } => {
+                        let temperature_scalar = nb(4);
+                        let seed_scalar = nb(8);
+                        let token_seed =
+                            base_seed ^ 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(position as u64 + 1);
+                        unsafe {
+                            *(temperature_scalar.contents() as *mut f32) = inv_temperature;
+                            *(seed_scalar.contents() as *mut u64) = token_seed;
+                        }
+                        e.set_compute_pipeline_state(&k.sample_gumbel_f32_pipeline);
+                        e.set_buffer(0, Some(lb), 0);
+                        e.set_buffer(1, Some(&id_buf), 0);
+                        e.set_buffer(2, Some(&am_scalar), 0);
+                        e.set_buffer(3, Some(&temperature_scalar), 0);
+                        e.set_buffer(4, Some(&seed_scalar), 0);
+                        keep.extend([temperature_scalar, seed_scalar]);
+                    }
+                }
                 e.dispatch_thread_groups(
                     metal::MTLSize {
                         width: 1,
@@ -11549,6 +11675,7 @@ impl ResidentDecodeState {
             position,
             has_logits: logits_stage.is_some(),
             has_sample: sampled_buf.is_some(),
+            sample_signature: sample_stage.map(|stage| stage.mode.signature(position)),
             event_value,
             cb: cb.to_owned(),
             logits_buf,
@@ -19987,6 +20114,98 @@ mod tests {
             let got = unsafe { *(ib.contents() as *const u32) };
             assert_eq!(got as usize, best_idx, "len {}", logits.len());
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn metal_gumbel_sampler_matches_stateless_reference() {
+        if !detect_metal_device().available {
+            return;
+        }
+        let k = metal_linear_kernel().expect("metal");
+        let logits = vec![0.0_f32; 4096];
+
+        let reference = |seed: u64| {
+            let mut best_uniform = f32::NEG_INFINITY;
+            let mut best_idx = 0_u32;
+            for idx in 0..logits.len() {
+                let mut z =
+                    seed.wrapping_add(0x9E37_79B9_7F4A_7C15u64.wrapping_mul(idx as u64 + 1));
+                z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+                z ^= z >> 31;
+                // Gumbel is monotonic in the uniform draw. Comparing the
+                // exact 24-bit uniforms avoids any CPU/GPU log approximation
+                // becoming part of this stateless-RNG and reduction test.
+                let uniform = ((z >> 40) as u32) as f32;
+                if uniform > best_uniform {
+                    best_uniform = uniform;
+                    best_idx = idx as u32;
+                }
+            }
+            best_idx
+        };
+
+        let logits_buf = k.device.new_buffer_with_data(
+            logits.as_ptr() as *const _,
+            (logits.len() * 4) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+        let out_buf = k
+            .device
+            .new_buffer(4, MTLResourceOptions::StorageModeShared);
+        let count_buf = k
+            .device
+            .new_buffer(4, MTLResourceOptions::StorageModeShared);
+        let temperature_buf = k
+            .device
+            .new_buffer(4, MTLResourceOptions::StorageModeShared);
+        let seed_buf = k
+            .device
+            .new_buffer(8, MTLResourceOptions::StorageModeShared);
+        unsafe {
+            *(count_buf.contents() as *mut u32) = logits.len() as u32;
+            *(temperature_buf.contents() as *mut f32) = 1.0;
+        }
+
+        let mut sampled = Vec::new();
+        for seed in [0_u64, 1, 7, 42, u32::MAX as u64, u64::MAX] {
+            unsafe {
+                *(seed_buf.contents() as *mut u64) = seed;
+            }
+            let cb = k.queue.new_command_buffer();
+            let e = cb.new_compute_command_encoder();
+            e.set_compute_pipeline_state(&k.sample_gumbel_f32_pipeline);
+            e.set_buffer(0, Some(&logits_buf), 0);
+            e.set_buffer(1, Some(&out_buf), 0);
+            e.set_buffer(2, Some(&count_buf), 0);
+            e.set_buffer(3, Some(&temperature_buf), 0);
+            e.set_buffer(4, Some(&seed_buf), 0);
+            e.dispatch_thread_groups(
+                metal::MTLSize {
+                    width: 1,
+                    height: 1,
+                    depth: 1,
+                },
+                metal::MTLSize {
+                    width: 1024,
+                    height: 1,
+                    depth: 1,
+                },
+            );
+            e.end_encoding();
+            cb.commit();
+            cb.wait_until_completed();
+            let got = unsafe { *(out_buf.contents() as *const u32) };
+            assert_eq!(got, reference(seed), "seed {seed}");
+            sampled.push(got);
+        }
+        sampled.sort_unstable();
+        sampled.dedup();
+        assert!(
+            sampled.len() > 1,
+            "different seeds should not collapse to one sampled token"
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -886,6 +886,15 @@ impl Q8_0FileBacking {
         }
     }
 
+    pub fn clone_with_offset_and_blocks(&self, absolute_offset: u64, num_blocks: usize) -> Self {
+        Self {
+            path: self.path.clone(),
+            absolute_offset,
+            num_blocks,
+            file_handle: self.file_handle.clone(),
+        }
+    }
+
     pub fn file(&self) -> Result<Arc<File>> {
         if let Some(file) = self.file_handle.get() {
             return Ok(file.clone());
@@ -6459,6 +6468,35 @@ mod tests {
         assert_eq!(stats.cache_capacity_bytes, 0);
         let _ = std::fs::remove_file(path);
         std::env::remove_var("CAMELID_Q8_0_FILE_CACHE_BYTES");
+    }
+
+    #[test]
+    fn q8_file_backing_subviews_share_one_cached_file_handle() {
+        let path = std::env::temp_dir().join(format!(
+            "camelid-q8-shared-backing-handle-{}",
+            std::process::id()
+        ));
+        let mut bytes = vec![0_u8; 3 * Q8_0_BLOCK_BYTES];
+        bytes[Q8_0_BLOCK_BYTES..2 * Q8_0_BLOCK_BYTES].fill(0x5a);
+        std::fs::write(&path, &bytes).unwrap();
+
+        let parent = Q8_0FileBacking::new(path.clone(), 0, 3);
+        let subview = parent.clone_with_offset_and_blocks(Q8_0_BLOCK_BYTES as u64, 1);
+        assert!(!parent.file_handle_cached());
+        assert!(!subview.file_handle_cached());
+
+        let subview_file = subview.file().unwrap();
+        assert!(parent.file_handle_cached());
+        let parent_file = parent.file().unwrap();
+        assert!(std::sync::Arc::ptr_eq(&parent_file, &subview_file));
+
+        let mut out = [0_u8; Q8_0_BLOCK_BYTES];
+        subview
+            .read_exact_at_cached(&mut out, Q8_0_BLOCK_BYTES as u64)
+            .unwrap();
+        assert_eq!(out, [0x5a; Q8_0_BLOCK_BYTES]);
+
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -285,11 +285,11 @@ impl Tokenizer {
             // Llama SPM — tokens, scores, and the bos/eos/unk ids are all read from
             // the GGUF below. (Gemma sets tokenizer.ggml.add_space_prefix=0; exact
             // leading-space parity is a follow-up, construction works on the SPM path.)
-            "llama" | "gemma4" => TokenizerModel::LlamaSpm,
+            "llama" | "gemma2" | "gemma3" | "gemma4" => TokenizerModel::LlamaSpm,
             "gpt2" => TokenizerModel::Gpt2Bpe,
             other => {
                 return Err(BackendError::UnsupportedTokenizer(format!(
-                    "unsupported tokenizer model {other:?}; currently supported: llama/SPM, gemma4/SPM, and GPT-2/BPE llama-bpe"
+                    "unsupported tokenizer model {other:?}; currently supported: llama/SPM, gemma2/SPM, gemma3/SPM, gemma4/SPM, and GPT-2/BPE llama-bpe"
                 )))
             }
         };
@@ -444,7 +444,7 @@ impl Tokenizer {
                 // (without this, the BOS is dropped and the whole forward
                 // diverges). E-series/12B already ship true, so this is a no-op
                 // for them.
-                add_bos: if model_name == "gemma4" {
+                add_bos: if model_name.starts_with("gemma") {
                     true
                 } else {
                     file.metadata_bool("tokenizer.ggml.add_bos_token")


### PR DESCRIPTION
## Summary

- add a Metal-resident Gumbel-max temperature sampler that avoids full-vocabulary logits readback, CPU softmax, and sorting on eligible plain-temperature requests
- optimize CPU top-k selection and remove a redundant top-p sort while preserving deterministic ordering
- make `bench-generate` use the production no-copy Q8 load plan
- preserve shared file handles for Q8 expert matrix subviews
- extend the experimental runnable/tokenizer plumbing for Gemma2/Gemma3 while keeping public unsupported rows fail-closed
- remove unsupported capability promotions and patch artifacts left by the earlier work

## Why

Profiling on Apple M4 showed plain temperature sampling spending substantial time copying and sorting the full vocabulary on the CPU even though resident Metal decode already had logits on-device. The new kernel samples and gathers the next embedding in the existing Metal graph.

## Impact

On Llama 3.2 1B Instruct Q8_0, 64-token temperature-0.7 generation improved from 50.58 tok/s with `CAMELID_METAL_TEMP_SAMPLING=0` to 70.88 tok/s enabled: a 40.2% same-binary improvement. Three measured runs produced identical seeded output. `CAMELID_METAL_TEMP_SAMPLING=0` remains an escape hatch.

A cross-request live-KV prototype was deliberately rejected and removed after lifecycle testing exposed Metal command-queue/output corruption; this PR contains no cross-request resident-session reuse.

## Validation

- `cargo test --lib -- --nocapture`: 1,199 passed, 20 ignored
- `cargo test --test api_vertical_slice --test inference_session -- --nocapture`: 119 passed
- `cargo test --bin camelid -- --nocapture`: 22 passed
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --all -- --check`
- release build and repeated HTTP greedy/seeded-temperature smoke tests
- same-binary enabled/disabled release benchmark on Apple M4
