### PR TITLE
Stop demoting supported models out of the Models lane

### DIFF
--- a/frontend/scripts/model-lanes-smoke.mjs
+++ b/frontend/scripts/model-lanes-smoke.mjs
@@ -24,11 +24,15 @@ const CAPABILITIES = {
       quantization: 'Q8_0',
       status: 'supported_exact_row_smoke',
     },
+    // Real /api/capabilities row id: it carries the model's `general.finetune`
+    // token ("Instruct"), which the canonical release filename
+    // (Qwen3-4B-Q8_0.gguf) does NOT. The fixture must mirror the shipped row id,
+    // or this file silently tests an identity match that production never makes.
     {
-      id: 'qwen3_4b_q8_0',
-      family: 'qwen_decoder',
+      id: 'qwen3_4b_instruct_q8_0',
+      family: 'qwen3',
       quantization: 'Q8_0',
-      status: 'supported',
+      status: 'supported_exact_row_smoke',
     },
     {
       id: 'gemma2_9b_it_q8_0',
@@ -55,11 +59,30 @@ check(
   'supported',
 )
 
-// Exact row id match without family heuristics (row id == normalized filename).
+// The shipped row id carries a `general.finetune` token the canonical release
+// filename omits (qwen3_4b_instruct_q8_0 vs Qwen3-4B-Q8_0.gguf), so the
+// identity match cannot resolve it from the filename alone. The backend's
+// exact-artifact verdict must still place it in the supported lane — otherwise
+// a loadable, generation-ready model is demoted to Experimental and the UI
+// offers no "Use for chat".
 check(
-  'supported: exact row id identity match',
-  laneOf(entry('Qwen3-4B-Q8_0.gguf'), CAPABILITIES),
+  'supported: backend exact-artifact verdict when the row id carries a finetune token',
+  laneOf(entry('Qwen3-4B-Q8_0.gguf', { lane_class: 'supported' }), CAPABILITIES),
   'supported',
+)
+
+// The backend verdict only ever promotes on an exact `supported`. An
+// implemented-but-uncertified artifact keeps its evidence-derived lane.
+check(
+  'compatible: backend experimental verdict never promotes',
+  laneOf(
+    entry('Qwen3-4B-Q4_K_M.gguf', {
+      lane_class: 'experimental_implemented',
+      runnable_receipt_present: true,
+    }),
+    CAPABILITIES,
+  ),
+  'compatible',
 )
 
 // The artifact gate must hold: same model row, wrong GGUF filename punctuation

--- a/frontend/scripts/model-state-smoke.mjs
+++ b/frontend/scripts/model-state-smoke.mjs
@@ -599,4 +599,43 @@ assert.doesNotMatch(LLAMA32_3B_ACCEPTANCE_AVAILABILITY, /not present locally yet
 assert.match(LLAMA32_3B_ACCEPTANCE_GATING_NOTE, /loaded_now=true and generation_ready=true/)
 assert.match(LLAMA32_3B_ACCEPTANCE_GATING_NOTE, /exact supported Llama 3\.2 3B Q8_0 compatibility row/)
 
+/* A family fallback must never name a row of a different model size. Several Qwen3
+   sizes are certified under one family, and the fallback used to take the FIRST row
+   whose id merely contains "qwen" — so a 4B file inherited the 0.6B row's id, status
+   and evidence copy purely from array order. */
+const multiSizeQwenFixture = {
+  model_compatibility: [
+    { id: 'qwen3_0_6b_instruct_q8_0', family: 'qwen3', quantization: 'Q8_0', status: 'supported_exact_row_smoke' },
+    { id: 'qwen3_4b_instruct_q8_0', family: 'qwen3', quantization: 'Q8_0', status: 'supported_exact_row_smoke' },
+    { id: 'qwen3_8b_instruct_q8_0', family: 'qwen3', quantization: 'Q8_0', status: 'supported_exact_row_smoke' },
+  ],
+}
+const qwen4bFamilyHint = findCompatibilityHint(multiSizeQwenFixture, {
+  id: 'Qwen3-4B-Q8_0.gguf',
+  name: 'Qwen3-4B-Q8_0.gguf',
+  model_path: 'Qwen3-4B-Q8_0.gguf',
+  quant: 'Q8_0',
+})
+assert.equal(qwen4bFamilyHint.kind, 'family', 'a row id carrying a finetune token the filename omits stays a non-exact family hint')
+assert.equal(
+  qwen4bFamilyHint.target.id,
+  'qwen3_4b_instruct_q8_0',
+  'the family fallback must select the row matching the subject size, not the first same-family row in array order',
+)
+assert.equal(
+  isCompatibilitySupportedForModel(multiSizeQwenFixture, { id: 'Qwen3-4B-Q8_0.gguf', quant: 'Q8_0' }),
+  false,
+  'a size-matched family hint is still advisory and must never unlock chat on its own',
+)
+
+/* When the subject states a size that no row covers, decline the row-specific hint
+   rather than naming a confidently wrong neighbour. */
+const qwen32bFamilyHint = findCompatibilityHint(multiSizeQwenFixture, {
+  id: 'Qwen3-32B-Q8_0.gguf',
+  name: 'Qwen3-32B-Q8_0.gguf',
+  model_path: 'Qwen3-32B-Q8_0.gguf',
+  quant: 'Q8_0',
+})
+assert.equal(qwen32bFamilyHint, null, 'an uncertified model size must not inherit a different size row as evidence')
+
 console.log('✓ model-state smoke passed')

--- a/frontend/src/components/models/LaneRows.jsx
+++ b/frontend/src/components/models/LaneRows.jsx
@@ -107,7 +107,7 @@ export function SupportedRow({ entry, active, busy, deleteBusy, blockedReason, o
   )
 }
 
-export function CompatibleRow({ entry, receipt, deleteBusy, blockedReason, onDelete }) {
+export function CompatibleRow({ entry, receipt, busy, deleteBusy, blockedReason, onUse, onDelete }) {
   return (
     <article className="lane-row lane-row--runnable" aria-label={`Compatible model ${entry.filename}`}>
       <div className="lane-row-head">
@@ -124,12 +124,16 @@ export function CompatibleRow({ entry, receipt, deleteBusy, blockedReason, onDel
         <p className="lane-row-faint">Loading runnable receipt…</p>
       )}
       <p className="lane-row-faint">
-        Runnable execution is the generic f32 lane — run it with the CLI
-        (<code>camelid runnable-smoke</code>). No HTTP serve endpoint yet, so there is no
-        in-app “Use for chat” for the runnable lane.
+        The receipt above attests one deterministic CLI run on the generic f32 lane
+        (<code>camelid runnable-smoke</code>) — it is not a parity contract. Loading it for
+        chat serves it the same way any implemented-but-unanchored model is served, so its
+        chat output carries no parity claim and is not cross-validated against the reference.
       </p>
       <div className="lane-row-actions">
-        <DeleteModelButton entry={entry} busy={deleteBusy} blockedReason={blockedReason} onDelete={onDelete} />
+        <button type="button" className="lane-row-action" onClick={onUse} disabled={busy || deleteBusy}>
+          {busy ? 'Loading…' : 'Use for chat (experimental)'}
+        </button>
+        <DeleteModelButton entry={entry} busy={busy || deleteBusy} blockedReason={blockedReason} onDelete={onDelete} />
       </div>
     </article>
   )

--- a/frontend/src/lib/capabilities.js
+++ b/frontend/src/lib/capabilities.js
@@ -180,6 +180,32 @@ function quantAwareCompatibilityHint(target, quantKey, confidence, { exact = fal
   return { kind: 'quant_mismatch', target, observedQuant: quantKey, confidence: `${confidence} with different quant`, exact }
 }
 
+/* Parameter-count token ("4b", "0.6b", "9b") normalized to a bare number string.
+   Underscores and dots are equivalent so a row id (`qwen3_0_6b_instruct_q8_0`) and a
+   filename ("Qwen3-0.6B-Q8_0.gguf") reduce to the same key. */
+function modelSizeKey(text) {
+  const match = String(text || '')
+    .toLowerCase()
+    .match(/(?:^|[^a-z0-9])(\d+(?:[._]\d+)?)\s*b(?:[^a-z0-9]|$)/)
+  return match ? match[1].replace(/[._]/g, '.') : null
+}
+
+/* The generic family fallbacks below scan for the FIRST row whose id merely contains
+   the family name. With several sizes certified under one family that returns an
+   arbitrary neighbour — a 4B file inherited the 0.6B row's id, status and evidence
+   copy purely from array order. A family hint is advisory and never unlocks chat, but
+   it must not name a row of a different size. When the subject states a size, keep only
+   rows of that size; if none match, decline the row-specific hint so the caller falls
+   through to the planned-family entry (or to "no matching compatibility row"), which is
+   honest rather than confidently wrong. Subjects with no size token are unchanged. */
+function findFamilyRowOfMatchingSize(rows, subject, predicate) {
+  const candidates = rows.filter(predicate)
+  if (!candidates.length) return null
+  const subjectSize = modelSizeKey(subject)
+  if (!subjectSize) return candidates[0]
+  return candidates.find((row) => modelSizeKey(row.id) === subjectSize) || null
+}
+
 function futureExactRowHint(rows, subject, quantKey) {
   const matchers = [
     {
@@ -672,7 +698,7 @@ export function findCompatibilityHint(capabilities, model, catalogItem) {
   if (subject.includes('mistral')) {
     const hint = futureExactRowHint(rows, subject, quantKey)
     if (hint) return hint
-    const target = findRow((row) => row.family === 'mistral' || row.id.includes('mistral'))
+    const target = findFamilyRowOfMatchingSize(rows, subject, (row) => row.family === 'mistral' || row.id.includes('mistral'))
     if (target) return { kind: 'family', target, confidence: 'Mistral family name match without exact row match' }
     const family = findFamily((item) => item.id.includes('mistral'))
     if (family) return { kind: 'family', target: family, confidence: 'family name match' }
@@ -681,7 +707,7 @@ export function findCompatibilityHint(capabilities, model, catalogItem) {
   if (subject.includes('mixtral')) {
     const hint = futureExactRowHint(rows, subject, quantKey)
     if (hint) return hint
-    const target = findRow((row) => row.family === 'mixtral_moe' || row.family === 'mixtral' || row.id.includes('mixtral'))
+    const target = findFamilyRowOfMatchingSize(rows, subject, (row) => row.family === 'mixtral_moe' || row.family === 'mixtral' || row.id.includes('mixtral'))
     if (target) return { kind: 'family', target, confidence: 'Mixtral family name match without exact row match' }
     const family = findFamily((item) => item.id.includes('mixtral'))
     if (family) return { kind: 'family', target: family, confidence: 'family name match' }
@@ -690,7 +716,7 @@ export function findCompatibilityHint(capabilities, model, catalogItem) {
   if (subject.includes('qwen')) {
     const hint = futureExactRowHint(rows, subject, quantKey)
     if (hint) return hint
-    const target = findRow((row) => row.family === 'qwen_decoder' || row.family === 'qwen2' || row.id.includes('qwen'))
+    const target = findFamilyRowOfMatchingSize(rows, subject, (row) => row.family === 'qwen_decoder' || row.family === 'qwen2' || row.id.includes('qwen'))
     if (target) return { kind: 'family', target, confidence: 'Qwen family name match without exact row match' }
     const family = findFamily((item) => item.id.includes('qwen'))
     if (family) return { kind: 'family', target: family, confidence: 'family name match' }
@@ -699,7 +725,7 @@ export function findCompatibilityHint(capabilities, model, catalogItem) {
   if (subject.includes('gemma')) {
     const hint = futureExactRowHint(rows, subject, quantKey)
     if (hint) return hint
-    const target = findRow((row) => row.family === 'gemma2_decoder' || row.family === 'gemma2' || row.id.includes('gemma'))
+    const target = findFamilyRowOfMatchingSize(rows, subject, (row) => row.family === 'gemma2_decoder' || row.family === 'gemma2' || row.id.includes('gemma'))
     if (target) return { kind: 'family', target, confidence: 'Gemma family name match without exact row match' }
     const family = findFamily((item) => item.id.includes('gemma'))
     if (family) return { kind: 'family', target: family, confidence: 'family name match' }

--- a/frontend/src/lib/modelLanes.js
+++ b/frontend/src/lib/modelLanes.js
@@ -19,7 +19,27 @@ export function matchModel(entry) {
   }
 }
 
+/* The backend's own exact-artifact verdict for this local file. `lane_class`
+   comes from /api/models/local, where classify_model_lane() requires BOTH an
+   implemented `general.architecture` (parsed from the real header, never a
+   filename guess) AND filename_is_supported_exact_row() — an exact filename
+   equality against the curated catalog whose row id must also be in
+   supported_compatibility_row_ids(). That conjunction is strictly stronger
+   evidence than the frontend's subject-string matching, and it is the same
+   support contract resolved where the curated catalog actually lives.
+
+   It is needed because a compatibility row id concatenates the model's
+   `general.finetune` token, which the canonical release filename may omit:
+   `qwen3_4b_instruct_q8_0` vs `Qwen3-4B-Q8_0.gguf`. The local-lane record
+   carries only the filename, so the identity match cannot see "instruct" and
+   the file falls to a non-exact family match — demoting a genuinely supported,
+   loadable model into Experimental, where no "Use for chat" is offered. */
+function backendMarksSupported(entry) {
+  return entry?.lane_class === 'supported'
+}
+
 export function laneOf(entry, capabilities) {
+  if (backendMarksSupported(entry)) return 'supported'
   if (isCompatibilitySupportedForModel(capabilities, matchModel(entry))) return 'supported'
   if (entry.runnable_receipt_present) return 'compatible'
   if (entry.admitted && entry.oracle_qualified) return 'eligible'

--- a/frontend/src/views/ModelsView.jsx
+++ b/frontend/src/views/ModelsView.jsx
@@ -437,8 +437,10 @@ export default function ModelsView({
                 key={m.filename}
                 entry={m}
                 receipt={receipts[m.filename]}
+                busy={usingFilename === m.filename}
                 deleteBusy={deletingFilename === m.filename}
                 blockedReason={deleteBlockedReason}
+                onUse={() => loadModelForChat(m.filename)}
                 onDelete={requestDeleteModel}
               />
             ))}


### PR DESCRIPTION
A supported, loadable model could land in the **Experimental** lane with no `Use for chat` button. `Qwen3-4B-Q8_0.gguf` reproduced all three defects below; it loads in ~9s and reports `generation_ready=true` throughout, so only the UI was wrong.

## 1. Trust the backend's exact-artifact verdict for lane membership

`laneOf()` ignored `lane_class` from `/api/models/local` and re-derived the supported gate by matching the filename against `/api/capabilities` row ids. The two authorities disagreed, because a row id concatenates the model's `general.finetune` token, which the canonical release filename may omit:

| | |
|---|---|
| row id | `qwen3_4b_instruct_q8_0` |
| filename | `Qwen3-4B-Q8_0.gguf` -> `qwen3_4b_q8_0` |

The local-lane record carries only the filename, so the identity match missed, fell to a non-exact family match, and dropped the file into the runnable lane.

`classify_model_lane()` already requires an implemented `general.architecture` parsed from the real header **and** `filename_is_supported_exact_row()` — exact filename equality against the curated catalog whose row id must also be in `supported_compatibility_row_ids()`. That conjunction cannot over-promote and is strictly stronger than subject-string matching, so it now wins. The capabilities check stays as a fallback, so nothing currently supported regresses.

## 2. Select family-fallback rows by model size

The generic family fallbacks took the **first** row whose id merely contains the family name. With several sizes certified under one family, a 4B file inherited the 0.6B row's id, status and evidence copy purely from array order. When the subject states a size, only same-size rows are candidates; when none match, the row-specific hint is declined so the caller falls through to the planned family (or to "no matching compatibility row") rather than naming a confidently wrong neighbour. All four family branches (mistral, mixtral, qwen, gemma) had the identical bug.

A family hint is advisory and never unlocks chat, so this changes displayed evidence, not the gate.

## 3. Offer the runnable lane the same load affordance as the unanchored lane

`CompatibleRow` claimed "No HTTP serve endpoint yet", while the *less*-evidenced `NotAnchoredRow` already called `loadModelForChat` — an inverted ladder where more evidence bought fewer capabilities.

The claim was verified stale before being changed: a non-supported implemented model (`Llama-3.2-1B-Instruct-Q4_K_M.gguf`, `lane_class=experimental_implemented`) loads over HTTP `200` and reports `generation_ready=true`. The copy now states what the receipt actually attests — one deterministic CLI run on the generic f32 lane, not a parity contract — and the row carries no parity claim.

## The fixture had drifted from production

`model-lanes-smoke.mjs` already asserted this exact filename lands in `supported`, **and passed** — because its hand-written fixture used row id `qwen3_4b_q8_0`, which the backend never emits. Corrected to the shipped id, it reproduced the demotion (`got "not_anchored", want "supported"`). These fixtures must mirror a live `/api/capabilities` payload or they prove nothing.

## Verification

Every CI frontend gate run locally on macOS: `build`, `smoke:model-state`, `smoke:model-lanes`, `smoke:catalog-activation`, `smoke:model-deletion`, `smoke:3b-closure`, `smoke:integration`, `smoke:workspace`, `smoke:workspace-visual`, `smoke:ui` — all pass, plus `scripts/check-public-scrub.sh` (exit 0).

New coverage: backend-verdict promotion, a guard that `lane_class=experimental_implemented` never promotes, right-size family selection, and decline-on-no-size-match.

End-to-end in the running web UI: the model now renders under **Supported 1** / **Experimental 0**, and its `Use for chat` button drives a real load to `active_model_id=Qwen3-4B-Q8_0.gguf`, `generation_ready=true`.

Not covered: `CompatibleRow` is not rendered live, because no local model occupies that lane once Qwen3-4B is correctly supported, and no genuine runnable receipt exists for a non-oracle-qualified file. Its `loadModelForChat` wiring is verified through the identical path in `NotAnchoredRow`.

Unrelated pre-existing failure, not touched: `smoke:observatory` ("view: honest no-traffic state renders with no requests — title missing") fails identically on pristine `c780eda`. It is not part of the CI frontend job.

Frontend only; no Rust changed.