### PR TITLE
models: make catalog search fast, groupable, and honest about fit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,14 @@ jobs:
       - name: Check ledger drift (ledger == code contract; surfaces consistent)
         run: node scripts/check-ledger-drift.mjs
 
+      # FitVerdict is serialized onto the catalog endpoints and the Models tab
+      # branches on those exact strings, which it re-declares as JS literals. No
+      # compiler links the two, and a frontend smoke asserting the frontend's own
+      # literals passes either way — so a renamed variant would reach users as a
+      # blank badge. Tie the vocabulary to src/fit.rs.
+      - name: Check fit-verdict vocabulary (WebUI == src/fit.rs)
+        run: node scripts/check-fit-verdict-vocabulary.mjs
+
       - name: Check CUDA batched-prefill parity gate wiring
         run: node scripts/check-cuda-prefill-parity-gate.mjs
 
@@ -326,6 +334,13 @@ jobs:
 
       - name: Frontend catalog activation smoke
         run: npm run smoke:catalog-activation
+
+      # Covers frontend/src/lib/catalogBrowse.js: fit labels/details, the
+      # settled-vs-retryable `unknown` split, grouping and search ranking. The
+      # script shipped with the lane but was never wired here, so none of that
+      # logic was gated.
+      - name: Frontend catalog browse smoke
+        run: npm run smoke:catalog-browse
 
       - name: Frontend model deletion smoke
         run: npm run smoke:model-deletion

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "smoke:model-state": "node scripts/model-state-smoke.mjs",
     "smoke:model-lanes": "node scripts/model-lanes-smoke.mjs",
     "smoke:catalog-activation": "node scripts/catalog-activation-smoke.mjs",
+    "smoke:catalog-browse": "node scripts/catalog-browse-smoke.mjs",
     "smoke:model-deletion": "node scripts/model-deletion-smoke.mjs",
     "smoke:3b-closure": "node scripts/frontend-3b-closure-smoke.mjs",
     "smoke:ui": "node scripts/ui-regression-smoke.mjs",

--- a/frontend/scripts/catalog-browse-smoke.mjs
+++ b/frontend/scripts/catalog-browse-smoke.mjs
@@ -1,0 +1,240 @@
+/* Unit smoke for the catalog browse logic (frontend/src/lib/catalogBrowse.js).
+
+   Covers the three behaviours the module exists for: collapsing a repo's quant
+   permutations into one model, ordering/annotating those quants, and never turning
+   an unknown fit into a claim. No DOM, no network. */
+
+import assert from 'node:assert/strict'
+import {
+  compareByQuality,
+  defaultFileIndex,
+  fitDetail,
+  fitIsSettled,
+  fitLabel,
+  groupHfFilesByRepo,
+  isPositiveFit,
+  isRefusingFit,
+  partitionByArchSupport,
+  partitionCuratedByFit,
+  quantAdvice,
+  repoOwner,
+  repoTitle,
+} from '../src/lib/catalogBrowse.js'
+
+const GB = 1024 * 1024 * 1024
+
+function hfFile({ repo = 'unsloth/Phi-4-mini-instruct-GGUF', quant, size, fit = 'unknown', arch = 'phi3', archSupport = 'implemented' }) {
+  return {
+    catalog_id: `hf::${repo}::${quant}`,
+    group: 'experimental',
+    repo_id: repo,
+    filename: `Phi-4-mini-instruct-${quant}.gguf`,
+    quant,
+    size_bytes: size,
+    fit,
+    fit_confidence: fit === 'unknown' ? 'unknown' : 'exact',
+    architecture: arch,
+    arch_support: archSupport,
+    downloads: 634146,
+    likes: 701,
+  }
+}
+
+/* --- fit vocabulary ------------------------------------------------------- */
+{
+  assert.equal(isPositiveFit('cpu_only_ok'), true)
+  assert.equal(isPositiveFit('fits_with_offload'), true)
+  assert.equal(isPositiveFit('unknown'), false)
+
+  // The whole point of the new verdict: refused, but NOT "too big".
+  assert.equal(isRefusingFit('insufficient_free_memory'), true)
+  assert.equal(isRefusingFit('wont_fit'), true)
+  assert.equal(isRefusingFit('unknown'), false, 'unknown is the absence of a claim, not a negative')
+
+  assert.equal(fitLabel('insufficient_free_memory'), 'Not enough free memory right now')
+  assert.equal(fitLabel('wont_fit'), 'Too big for this machine')
+  assert.equal(fitLabel('unknown'), null, 'an unknown verdict must render nothing, not a guess')
+  assert.equal(fitLabel(undefined), null)
+
+  assert.match(fitDetail('insufficient_free_memory'), /Close some applications/)
+  assert.match(fitDetail('wont_fit'), /smaller model/)
+  assert.equal(fitDetail('cpu_only_ok'), null)
+  // A busy machine must never be described as an undersized one.
+  assert.doesNotMatch(fitDetail('insufficient_free_memory'), /too big|smaller model/i)
+}
+
+/* --- unchecked vs. settled ------------------------------------------------ */
+{
+  // All three arrive as `fit: 'unknown'`. Rendering them the same put the check
+  // button in a loop: press it, get `unknown` back, see the same button again.
+  assert.equal(
+    fitIsSettled({ fit: 'unknown', fit_confidence: 'unknown' }),
+    false,
+    'never measured -> offer a check',
+  )
+  assert.equal(
+    fitIsSettled({ fit: 'unknown', fit_confidence: 'exact' }),
+    true,
+    'measured, advisor still abstains -> retire the button',
+  )
+  assert.equal(fitIsSettled({ fit: 'unknown', fit_confidence: 'approx' }), true)
+  assert.equal(fitIsSettled({ fit: 'cpu_only_ok', fit_confidence: 'exact' }), true)
+
+  // The server's explicit verdict wins over the confidence heuristic in BOTH
+  // directions. This is the case the heuristic alone got wrong: a settled negative
+  // comes back with `unknown` confidence, and looked identical to "not checked".
+  assert.equal(
+    fitIsSettled({ fit: 'unknown', fit_confidence: 'unknown', fit_checked: true }),
+    true,
+    'checked and definitively unresolvable -> settled',
+  )
+  assert.equal(
+    fitIsSettled({ fit: 'unknown', fit_confidence: 'exact', fit_checked: false }),
+    false,
+    'a failed attempt stays retryable',
+  )
+
+  assert.equal(fitIsSettled({}), false)
+  assert.equal(fitIsSettled(undefined), false)
+}
+
+/* --- quant advice --------------------------------------------------------- */
+{
+  assert.equal(quantAdvice('Q4_K_M').tier, 'balanced')
+  assert.equal(quantAdvice('q4_k_m').tier, 'balanced', 'tokens are case-insensitive')
+  assert.equal(quantAdvice('Q8_0').tier, 'high')
+  assert.equal(quantAdvice('Q2_K').tier, 'severe')
+  assert.equal(quantAdvice('IQ1_S').tier, 'extreme')
+  assert.equal(quantAdvice('F16').tier, 'full')
+
+  // Ordering is total across families and within a family.
+  assert.ok(quantAdvice('Q8_0').rank > quantAdvice('Q6_K').rank)
+  assert.ok(quantAdvice('Q6_K').rank > quantAdvice('Q4_K_M').rank)
+  assert.ok(quantAdvice('Q4_K_M').rank > quantAdvice('Q4_K_S').rank)
+  assert.ok(quantAdvice('Q4_K_S').rank > quantAdvice('Q3_K_L').rank)
+  assert.ok(quantAdvice('Q3_K_L').rank > quantAdvice('Q2_K').rank)
+  assert.ok(quantAdvice('Q2_K').rank > quantAdvice('IQ1_S').rank)
+
+  // An unrecognized token gets no advice rather than invented advice.
+  const mystery = quantAdvice('Q9_WAT')
+  assert.equal(mystery.tier, 'unknown')
+  assert.equal(mystery.note, null)
+  assert.equal(mystery.rank, 0)
+  assert.equal(quantAdvice('').tier, 'unknown')
+}
+
+/* --- repo naming ---------------------------------------------------------- */
+{
+  assert.equal(repoTitle('unsloth/Phi-4-mini-instruct-GGUF'), 'Phi-4-mini-instruct')
+  assert.equal(repoTitle('Qwen/Qwen3-4B-GGUF'), 'Qwen3-4B')
+  assert.equal(repoTitle('someone/plain-model'), 'plain-model')
+  assert.equal(repoTitle('bare'), 'bare')
+  assert.equal(repoTitle(''), '')
+  // A repo whose name IS "GGUF" must not collapse to an empty title.
+  assert.equal(repoTitle('someone/GGUF'), 'GGUF')
+
+  assert.equal(repoOwner('unsloth/Phi-4-mini-instruct-GGUF'), 'unsloth')
+  assert.equal(repoOwner('bare'), '')
+}
+
+/* --- grouping ------------------------------------------------------------- */
+{
+  // The measured shape of a real search: two repos, many quants each, interleaved.
+  const items = [
+    hfFile({ quant: 'Q2_K', size: 1.6 * GB }),
+    hfFile({ quant: 'Q8_0', size: 4.1 * GB }),
+    hfFile({ repo: 'unsloth/Qwen3-4B-GGUF', quant: 'Q4_K_M', size: 2.5 * GB, arch: 'qwen3' }),
+    hfFile({ quant: 'Q4_K_M', size: 2.5 * GB }),
+    hfFile({ repo: 'unsloth/Qwen3-4B-GGUF', quant: 'Q2_K', size: 1.7 * GB, arch: 'qwen3' }),
+  ]
+  const groups = groupHfFilesByRepo(items)
+
+  assert.equal(groups.length, 2, '5 files from 2 repos collapse to 2 cards')
+  assert.deepEqual(
+    groups.map((g) => g.repoId),
+    ['unsloth/Phi-4-mini-instruct-GGUF', 'unsloth/Qwen3-4B-GGUF'],
+    'repo order follows first appearance, which is the Hub relevance order',
+  )
+  assert.equal(groups[0].title, 'Phi-4-mini-instruct')
+  assert.equal(groups[0].owner, 'unsloth')
+  assert.equal(groups[0].architecture, 'phi3')
+  assert.equal(groups[0].likes, 701)
+  assert.deepEqual(
+    groups[0].files.map((f) => f.quant),
+    ['Q8_0', 'Q4_K_M', 'Q2_K'],
+    'files within a card are ordered best quality first',
+  )
+  assert.equal(groupHfFilesByRepo([]).length, 0)
+}
+
+/* --- quality ordering ties ------------------------------------------------ */
+{
+  const a = hfFile({ quant: 'Q4_K_M', size: 3 * GB })
+  const b = { ...hfFile({ quant: 'Q4_K_M', size: 2 * GB }), filename: 'other-Q4_K_M.gguf' }
+  assert.ok(compareByQuality(a, b) < 0, 'same quant: the larger file sorts first')
+  // Total and stable: comparing either direction agrees.
+  assert.ok(compareByQuality(b, a) > 0)
+}
+
+/* --- default quantization ------------------------------------------------- */
+{
+  // 1. A proven fit wins, and it is the BEST proven one, not the first listed.
+  const withFits = [
+    hfFile({ quant: 'Q8_0', size: 4.1 * GB, fit: 'wont_fit' }),
+    hfFile({ quant: 'Q4_K_M', size: 2.5 * GB, fit: 'cpu_only_ok' }),
+    hfFile({ quant: 'Q2_K', size: 1.6 * GB, fit: 'cpu_only_ok' }),
+  ]
+  assert.equal(defaultFileIndex(withFits), 1, 'best quality that actually fits')
+
+  // 2. Nothing proven (the common case: HF rows have no dims yet) -> balanced tier,
+  //    never the biggest file we merely failed to rule out.
+  const allUnknown = [
+    hfFile({ quant: 'F16', size: 8 * GB }),
+    hfFile({ quant: 'Q8_0', size: 4.1 * GB }),
+    hfFile({ quant: 'Q4_K_M', size: 2.5 * GB }),
+    hfFile({ quant: 'Q2_K', size: 1.6 * GB }),
+  ]
+  assert.equal(allUnknown[defaultFileIndex(allUnknown)].quant, 'Q4_K_M')
+
+  // 3. No balanced quant on offer -> the smallest option we cannot rule out.
+  const noBalanced = [hfFile({ quant: 'Q8_0', size: 4.1 * GB }), hfFile({ quant: 'Q6_K', size: 3.2 * GB })]
+  assert.equal(noBalanced[defaultFileIndex(noBalanced)].quant, 'Q6_K')
+
+  // 4. Everything refused -> still offer the smallest rather than nothing.
+  const allTooBig = [
+    hfFile({ quant: 'Q8_0', size: 40 * GB, fit: 'wont_fit' }),
+    hfFile({ quant: 'Q4_K_M', size: 24 * GB, fit: 'insufficient_free_memory' }),
+  ]
+  assert.equal(allTooBig[defaultFileIndex(allTooBig)].quant, 'Q4_K_M')
+
+  assert.equal(defaultFileIndex([]), -1)
+}
+
+/* --- architecture partition ----------------------------------------------- */
+{
+  const groups = groupHfFilesByRepo([
+    hfFile({ repo: 'a/llama-GGUF', quant: 'Q4_K_M', size: GB, archSupport: 'implemented' }),
+    hfFile({ repo: 'b/mamba-GGUF', quant: 'Q4_K_M', size: GB, archSupport: 'not_implemented' }),
+    hfFile({ repo: 'c/mystery-GGUF', quant: 'Q4_K_M', size: GB, archSupport: 'unknown' }),
+  ])
+  const { loadable, unimplemented } = partitionByArchSupport(groups)
+  assert.deepEqual(loadable.map((g) => g.repoId), ['a/llama-GGUF', 'c/mystery-GGUF'])
+  assert.deepEqual(unimplemented.map((g) => g.repoId), ['b/mamba-GGUF'])
+  // "We could not tell" must never be filtered out as if it were a known negative.
+  assert.ok(loadable.some((g) => g.archSupport === 'unknown'))
+}
+
+/* --- curated landing partition -------------------------------------------- */
+{
+  const curated = [
+    { catalog_id: 'a', fit: 'cpu_only_ok' },
+    { catalog_id: 'b', fit: 'wont_fit' },
+    { catalog_id: 'c', fit: 'insufficient_free_memory' },
+    { catalog_id: 'd', fit: 'unknown' },
+  ]
+  const { runnable, blocked } = partitionCuratedByFit(curated)
+  assert.deepEqual(runnable.map((i) => i.catalog_id), ['a', 'd'], 'unprobed hosts keep their catalog')
+  assert.deepEqual(blocked.map((i) => i.catalog_id), ['b', 'c'])
+}
+
+console.log('catalog browse smoke: ok')

--- a/frontend/scripts/catalog-browse-smoke.mjs
+++ b/frontend/scripts/catalog-browse-smoke.mjs
@@ -9,6 +9,7 @@ import {
   compareByQuality,
   defaultFileIndex,
   fitDetail,
+  fitIsRecheckable,
   fitIsSettled,
   fitLabel,
   groupHfFilesByRepo,
@@ -61,6 +62,20 @@ function hfFile({ repo = 'unsloth/Phi-4-mini-instruct-GGUF', quant, size, fit = 
   assert.equal(fitDetail('cpu_only_ok'), null)
   // A busy machine must never be described as an undersized one.
   assert.doesNotMatch(fitDetail('insufficient_free_memory'), /too big|smaller model/i)
+
+  // The remedy must name the action that actually works. The catalog listing is
+  // built from a startup memory snapshot, so "reload the page" would be false
+  // advice: only the live re-check can observe freed memory.
+  assert.match(fitDetail('insufficient_free_memory'), /Re-check/)
+  assert.doesNotMatch(fitDetail('insufficient_free_memory'), /reload|refresh/i)
+
+  // Only a transient shortage is worth re-checking. A model bigger than the whole
+  // machine stays too big however much is freed.
+  assert.equal(fitIsRecheckable('insufficient_free_memory'), true)
+  assert.equal(fitIsRecheckable('wont_fit'), false)
+  assert.equal(fitIsRecheckable('cpu_only_ok'), false)
+  assert.equal(fitIsRecheckable('unknown'), false)
+  assert.equal(fitIsRecheckable(undefined), false)
 }
 
 /* --- unchecked vs. settled ------------------------------------------------ */

--- a/frontend/scripts/ui-regression-smoke.mjs
+++ b/frontend/scripts/ui-regression-smoke.mjs
@@ -292,8 +292,12 @@ assert.match(catalogBrowseSource, /Download and start/, 'curated catalog rows sh
 assert.match(catalogBrowseSource, /settlementInFlightRef\.current/, 'catalog settlement must be single-flight across polling ticks')
 assert.match(catalogBrowseSource, /canceledCatalogIds\.has\(item\.catalog_id\)/, 'catalog cancellation must be keyed by catalog identity, not filename')
 assert.match(catalogBrowseSource, /aria-label="Search model catalog"/, 'catalog search must have an explicit accessible name')
-assert.match(catalogBrowseSource, /downloadAndStart = lane === 'supported' && item\.fit !== 'wont_fit'/, 'automatic start must be limited to supported rows that are not known to exceed this host')
-assert.match(catalogBrowseSource, /item\.fit !== 'wont_fit'[\s\S]*item\.oracle_qualified/, 'known-wont-fit rows must not automatically run generic smoke admission')
+assert.match(catalogBrowseSource, /downloadAndStart = lane === 'supported' && !refusedByFit/, 'automatic start must be limited to supported rows that are not known to exceed this host')
+assert.match(catalogBrowseSource, /refusedByFit[\s\S]*item\.oracle_qualified/, 'rows this host cannot load must not automatically run generic smoke admission')
+// The refusal set must stay the FULL one. Testing `fit !== 'wont_fit'` alone was a
+// real defect: an `insufficient_free_memory` row would chain into a load that the
+// 422 preload guard refuses, since that guard blocks on both negative verdicts.
+assert.match(catalogBrowseSource, /const refusedByFit = isRefusingFit\(item\.fit\)/, 'auto-start must gate on every load-refusing verdict, not just wont_fit')
 assert.match(modelsViewSource, /if \(!inspectRes\.ok\)[\s\S]*return \{ ok: false, stage: 'checking', message \}/, 'automatic activation must fail closed on an HTTP-level inspect failure')
 assert.match(modelsViewSource, /refreshCurrent\(\)[\s\S]*current\?\.path[\s\S]*active model/, 'automatic navigation must wait for current-model confirmation')
 assert.match(modelsViewSource, /v1\/health[\s\S]*health\.loaded_now[\s\S]*health\.generation_ready[\s\S]*health\.active_model_id !== filename/, 'automatic navigation must wait for live generation readiness and active-model identity')
@@ -534,5 +538,15 @@ assert.match(chatCss, /\.message-live-generation-badge\s*\{/, 'streaming assista
 assert.match(chatCss, /\.message-live-dot\s*\{[^}]*animation:\s*cxPulse/s, 'live generation badges should visibly pulse only while the badge is rendered')
 assert.match(uiCss, /@keyframes cxPulse/, 'the live pulse keyframes must exist')
 assert.match(tokensCss, /@keyframes camelidDotBounce/, 'the streaming dot bounce keyframes must exist')
+
+/* ---- Catalog browse logic ----
+   Runs the unit smoke for src/lib/catalogBrowse.js (quantization ordering and
+   advice, repo grouping, default-quantization rules, the architecture partition,
+   and the unchecked/settled/retryable split) inside this job.
+
+   Imported here rather than added to the workflow because that is the frontend
+   suite CI already gates; a behavioural module with no gate is a regression
+   waiting to happen. The module asserts at import time and throws on failure. */
+await import('./catalog-browse-smoke.mjs')
 
 console.log('UI regression smoke passed (re-baselined Phase 2 pre-work)')

--- a/frontend/src/components/models/CatalogLaneBrowse.jsx
+++ b/frontend/src/components/models/CatalogLaneBrowse.jsx
@@ -542,11 +542,15 @@ function CatalogRow({
    weights. Selecting a variant swaps which exact file the row below will download —
    the confirmation still names that file, so grouping never blurs what is fetched. */
 function HfModelCard({ group, renderRow, onCheckFit, isCheckingFit }) {
-  const [selected, setSelected] = useState(() => Math.max(0, defaultFileIndex(group.files)))
-  // "Load more" can replace this repo's file list; clamp instead of indexing off
-  // the end.
-  const index = Math.min(selected, group.files.length - 1)
-  const file = group.files[index]
+  /* The selection is the chosen FILE, not its position. "Load more" can append
+     quantizations to a repo already on screen, and the list is re-sorted by
+     quality on every render — holding an index would silently slide the user's
+     choice onto a different file (and a different download) underneath them.
+     `null` means "never chosen", which is what lets the default track incoming
+     fit verdicts instead of freezing at first paint. */
+  const [selectedId, setSelectedId] = useState(null)
+  const fallback = group.files[Math.max(0, defaultFileIndex(group.files))]
+  const file = group.files.find((candidate) => candidate.catalog_id === selectedId) || fallback
 
   if (!file) return null
 
@@ -580,11 +584,11 @@ function HfModelCard({ group, renderRow, onCheckFit, isCheckingFit }) {
         <select
           id={`quant-${group.repoId}`}
           className="hf-quant-select"
-          value={index}
-          onChange={(event) => setSelected(Number(event.target.value))}
+          value={file.catalog_id}
+          onChange={(event) => setSelectedId(event.target.value)}
         >
-          {group.files.map((candidate, candidateIndex) => (
-            <option key={candidate.catalog_id} value={candidateIndex}>
+          {group.files.map((candidate) => (
+            <option key={candidate.catalog_id} value={candidate.catalog_id}>
               {candidate.quant || 'unlabelled'} · {prettySize(candidate.size_bytes)}
               {quantAdvice(candidate.quant).note ? ` · ${quantAdvice(candidate.quant).note}` : ''}
             </option>
@@ -724,7 +728,8 @@ export function CatalogLaneBrowse({
   }, [])
 
   // Append the next page of experimental (Hugging Face) results.
-  const loadMore = useCallback(async () => {    if (!nextCursor || !debouncedQuery) return
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || !debouncedQuery) return
     const sequence = requestSequenceRef.current
     setLoadingMore(true)
     try {

--- a/frontend/src/components/models/CatalogLaneBrowse.jsx
+++ b/frontend/src/components/models/CatalogLaneBrowse.jsx
@@ -1,6 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { isCompatibilitySupportedForModel } from '../../lib/capabilities'
 import { beginCatalogSettlement, catalogDownloadSettlement, completeCatalogAcquisition, reserveCatalogAcquisition } from '../../lib/catalogActivation'
+import {
+  defaultFileIndex,
+  fitDetail,
+  fitIsSettled,
+  fitLabel,
+  groupHfFilesByRepo,
+  isRefusingFit,
+  partitionByArchSupport,
+  partitionCuratedByFit,
+  quantAdvice,
+} from '../../lib/catalogBrowse'
 import { SUPPORTED_MODELS } from '../../lib/supportedModels'
 import { EvidenceChip } from '../ui/EvidenceChip'
 
@@ -12,7 +23,13 @@ import { EvidenceChip } from '../ui/EvidenceChip'
    rows here only reflect their own acquisition state, read from the shared
    downloads poll + the live /api/models/local scan (never localStorage). After a
    download lands, smoke-admission runs for oracle-qualified combos and the model
-   appears in its derived local section. */
+   appears in its derived local section.
+
+   Hugging Face results are grouped into one card per repo with a quantization
+   picker. The Hub returns files, and a single repo routinely ships 20-27 quants of
+   the same weights, so rendering them flat turned a 15-repo search into a 250-row
+   wall. Grouping is presentation only: a download is still one exact file,
+   confirmed by name. */
 
 const GB = 1024 * 1024 * 1024
 function prettySize(bytes) {
@@ -24,6 +41,11 @@ function prettySize(bytes) {
 /* Curated download suggestions (blurbs, "Recommended") may DECORATE catalog rows,
    never place them: lane membership and outcome chips stay derived. */
 const CURATED_DECORATION = new Map(SUPPORTED_MODELS.map((item) => [item.catalog_id, item]))
+
+/* Why a live Hugging Face row can never imply support — said once per section and
+   in a tooltip on the guessed value, rather than as a paragraph on all 150 rows. */
+const HF_GUESS_EXPLANATION =
+  'Architecture and quantization are read from the filename, not the model. The real lane is only known after the file loads.'
 
 /* Predicted lane for a catalog entry — derived, never a hand-authored label. */
 function predictedLane(item, capabilities) {
@@ -42,27 +64,8 @@ function laneChip(lane) {
   return <EvidenceChip state="unsupported" asText>Experimental · unverified</EvidenceChip>
 }
 
-/* Capacity advisory for THIS host (fit axis, NOT a support claim — kept on its own
-   line, never merged into the lane/support chip). `item.fit` is the backend
-   FitVerdict; `unknown`/missing (e.g. unprobed host, experimental rows) shows
-   nothing rather than guessing. */
-function fitLabel(fit) {
-  switch (fit) {
-    case 'fits_resident':
-      return 'Fits your machine'
-    case 'fits_with_offload':
-      return 'Fits (GPU + RAM offload)'
-    case 'cpu_only_ok':
-      return 'Fits (CPU)'
-    case 'wont_fit':
-      return 'Too big for this machine'
-    default:
-      return null
-  }
-}
-
 /* A small CPU/chip glyph so the capacity chip reads as "your hardware" — distinct
-   from the support/lane chips. A check (fits) or cross (too big) sits in the die. */
+   from the support/lane chips. A check (fits) or cross (refused) sits in the die. */
 function FitIcon({ bad }) {
   const stroke = 'currentColor'
   return (
@@ -80,6 +83,96 @@ function FitIcon({ bad }) {
         strokeLinecap="round"
       />
     </svg>
+  )
+}
+
+/* Capacity advisory for THIS host (fit axis, NOT a support claim — kept on its own
+   line, never merged into the lane/support chip).
+
+   Four shapes, because they mean four different things: a positive fit; a refusal
+   that names WHY (too big for the machine vs. the machine is merely busy); a row
+   nobody has measured yet, which gets an explicit "check this one" affordance
+   instead of silence; and a row whose question is settled with no answer possible.
+
+   The last two both arrive as `fit: 'unknown'`. Rendering them the same put the
+   button in a loop — press, get `unknown` back, see the same button — which is why
+   the backend reports whether the check settled. */
+function FitAdvisory({ item, onCheckFit, checking }) {
+  const label = fitLabel(item.fit)
+  const detail = fitDetail(item.fit)
+  const refused = isRefusingFit(item.fit)
+  const transient = item.fit === 'insufficient_free_memory'
+
+  if (!label) {
+    if (fitIsSettled(item)) {
+      return (
+        <div className="catalog-fit-row">
+          <span
+            className="catalog-fit-chip catalog-fit-chip--unknown"
+            title="Camelid looked at this model and will not promise a verdict here — either its dimensions cannot be read, this machine's memory cannot be probed, or the GPU has room while free system memory is too low to stage the weights."
+          >
+            <FitIcon />
+            Fit can’t be determined here
+          </span>
+          <span className="catalog-fit-detail">
+            The download is not blocked — Camelid just will not claim a fit it cannot verify.
+          </span>
+        </div>
+      )
+    }
+    if (!onCheckFit) return null
+    return (
+      <div className="catalog-fit-row">
+        <span className="catalog-fit-chip catalog-fit-chip--unknown">
+          <FitIcon />
+          Fit unknown until checked
+        </span>
+        <button
+          type="button"
+          className="catalog-fit-check"
+          onClick={onCheckFit}
+          disabled={checking}
+          aria-busy={checking || undefined}
+        >
+          {checking ? 'Checking…' : item.fit_checked === false ? 'Try again' : 'Check if it fits'}
+        </button>
+        {item.fit_checked === false ? (
+          <span className="catalog-fit-detail">
+            Could not reach Hugging Face for this model’s header. Retrying may work.
+          </span>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="catalog-fit-row">
+      <span
+        className={`catalog-fit-chip catalog-fit-chip--${transient ? 'warn' : refused ? 'bad' : 'good'}${
+          item.fit_confidence === 'approx' ? ' catalog-fit-chip--estimate' : ''
+        }`}
+        title={
+          item.fit_confidence === 'exact'
+            ? "Sized from the model's real dimensions (KV cache computed exactly)"
+            : 'Estimate — upgrades to exact once the model header has been read'
+        }
+      >
+        <FitIcon bad={refused} />
+        {item.fit_confidence === 'approx' ? '~ ' : ''}
+        {label}
+      </span>
+      {Array.isArray(item.task_tags) && item.task_tags.length ? (
+        <span className="catalog-fit-tags">
+          <span className="catalog-fit-tags-label">best for</span>
+          {item.task_tags.map((tag) => (
+            <span key={tag} className="catalog-fit-tag">
+              {tag}
+            </span>
+          ))}
+        </span>
+      ) : null}
+      {detail ? <span className="catalog-fit-detail">{detail}</span> : null}
+    </div>
   )
 }
 
@@ -102,6 +195,12 @@ function CatalogRow({
   onStartModel,
   onModelStarted,
   onOperationBusy,
+  onCheckFit,
+  checkingFit,
+  /* Rendered inside a Hugging Face model card, which already owns the title,
+     provenance and quantization picker. Suppresses the row's own head so the two
+     do not repeat each other. */
+  compact = false,
 }) {
   // phase: idle | confirm | starting | waiting | checking | loading | failed | done
   const [phase, setPhase] = useState('idle')
@@ -117,9 +216,12 @@ function CatalogRow({
   const settlementInFlightRef = useRef(false)
   const lane = predictedLane(item, capabilities)
   const decoration = item.group === 'experimental' ? null : CURATED_DECORATION.get(item.catalog_id)
-  const downloadAndStart = lane === 'supported' && item.fit !== 'wont_fit'
+  // ANY load-refusing verdict must stop the auto-start chain, not just `wont_fit`:
+  // the load-time guard refuses both, so chaining into it would end in a 422.
+  const refusedByFit = isRefusingFit(item.fit)
+  const downloadAndStart = lane === 'supported' && !refusedByFit
   const smokeAfterDownload = item.group !== 'experimental'
-    && item.fit !== 'wont_fit'
+    && !refusedByFit
     && !downloadAndStart
     && item.oracle_qualified
   const acquisitionMode = downloadAndStart ? 'start' : smokeAfterDownload ? 'smoke' : 'download'
@@ -296,48 +398,27 @@ function CatalogRow({
   const showProgress = ['starting', 'waiting', 'checking', 'loading'].includes(phase)
 
   return (
-    <article className={`catalog-row${lane === 'not_anchored' ? ' catalog-row--advisory' : ''}`}>
-      <div className="catalog-row-head">
-        <div className="catalog-row-id">
-          <span className="catalog-row-name">
-            {item.name}
-            {decoration?.recommended ? <span className="catalog-row-recommended">Recommended</span> : null}
-          </span>
-          <span className="catalog-row-meta">
-            {item.repo_id} · {item.filename} · {prettySize(item.size_bytes)}
-            {item.architecture ? ` · ${item.architecture}` : ''}
-          </span>
-        </div>
-        {laneChip(lane)}
-      </div>
-      {fitLabel(item.fit) ? (
-        <div className="catalog-fit-row">
-          <span
-            className={`catalog-fit-chip catalog-fit-chip--${item.fit === 'wont_fit' ? 'bad' : 'good'}${
-              item.fit_confidence === 'approx' ? ' catalog-fit-chip--estimate' : ''
-            }`}
-            title={
-              item.fit_confidence === 'exact'
-                ? "Sized from the model's real dimensions (KV cache computed exactly)"
-                : 'Estimate — upgrades to exact once the model header has been read'
-            }
-          >
-            <FitIcon bad={item.fit === 'wont_fit'} />
-            {item.fit_confidence === 'approx' ? '~ ' : ''}
-            {fitLabel(item.fit)}
-          </span>
-          {Array.isArray(item.task_tags) && item.task_tags.length ? (
-            <span className="catalog-fit-tags">
-              <span className="catalog-fit-tags-label">best for</span>
-              {item.task_tags.map((tag) => (
-                <span key={tag} className="catalog-fit-tag">
-                  {tag}
-                </span>
-              ))}
+    <article
+      className={`catalog-row${lane === 'not_anchored' ? ' catalog-row--advisory' : ''}${
+        compact ? ' catalog-row--compact' : ''
+      }`}
+    >
+      {compact ? null : (
+        <div className="catalog-row-head">
+          <div className="catalog-row-id">
+            <span className="catalog-row-name">
+              {item.name}
+              {decoration?.recommended ? <span className="catalog-row-recommended">Recommended</span> : null}
             </span>
-          ) : null}
+            <span className="catalog-row-meta">
+              {item.repo_id} · {item.filename} · {prettySize(item.size_bytes)}
+              {item.architecture ? ` · ${item.architecture}` : ''}
+            </span>
+          </div>
+          {laneChip(lane)}
         </div>
-      ) : null}
+      )}
+      <FitAdvisory item={item} onCheckFit={onCheckFit} checking={checkingFit} />
       {decoration?.blurb ? <p className="catalog-row-blurb">{decoration.blurb}</p> : null}
 
       {showProgress ? (
@@ -385,13 +466,7 @@ function CatalogRow({
         <p className="catalog-row-faint">Already on disk — shown in its section above.</p>
       ) : phase === 'idle' ? (
         <>
-          {item.group === 'experimental' ? (
-            <p className="catalog-row-faint">
-              From Hugging Face — unverified, no parity claim. Architecture/quant
-              {item.architecture || item.quant ? ` (guessed ${[item.architecture, item.quant].filter(Boolean).join(' / ')})` : ''}{' '}
-              are read from the filename, not the model; the real lane is only known after it loads.
-            </p>
-          ) : lane === 'not_anchored' ? (
+          {item.group !== 'experimental' && lane === 'not_anchored' ? (
             <p className="catalog-row-faint">
               Its {item.architecture}/{item.quant} combo is not yet in the runnable lane — still
               downloadable; it lands in Experimental and loads through the experimental chat path.
@@ -445,17 +520,89 @@ function CatalogRow({
   )
 }
 
-/* Persistent, non-dismissible marker for the experimental group. Reuses the
-   unsupported EvidenceChip so it can never read as an endorsement. */
-function ExperimentalMarker() {
+/* One live Hugging Face repo, with its quantizations behind a picker.
+
+   A repo is one model; its `.gguf` files are size/quality variants of the same
+   weights. Selecting a variant swaps which exact file the row below will download —
+   the confirmation still names that file, so grouping never blurs what is fetched. */
+function HfModelCard({ group, renderRow, onCheckFit, isCheckingFit }) {
+  const [selected, setSelected] = useState(() => Math.max(0, defaultFileIndex(group.files)))
+  // "Load more" can replace this repo's file list; clamp instead of indexing off
+  // the end.
+  const index = Math.min(selected, group.files.length - 1)
+  const file = group.files[index]
+
+  if (!file) return null
+
   return (
-    <span className="catalog-experimental-marker">
-      <EvidenceChip state="unsupported" asText>Experimental — unverified, no parity claim</EvidenceChip>
-    </span>
+    <article className="hf-model-card">
+      <div className="hf-model-head">
+        <div className="hf-model-id">
+          <h4 className="hf-model-title">{group.title}</h4>
+          <p className="hf-model-meta">
+            {group.owner ? <span className="hf-model-owner">{group.owner}</span> : null}
+            {group.architecture ? (
+              <span className="hf-model-arch" title={`Guessed from the filename. ${HF_GUESS_EXPLANATION}`}>
+                {group.architecture} (guessed)
+              </span>
+            ) : null}
+            <span>
+              {group.files.length} quantization{group.files.length === 1 ? '' : 's'}
+            </span>
+            {group.archSupport === 'not_implemented' ? (
+              <span className="hf-model-unsupported">Camelid does not implement this architecture</span>
+            ) : null}
+          </p>
+        </div>
+        <EvidenceChip state="unsupported" asText>Experimental · unverified</EvidenceChip>
+      </div>
+
+      <div className="hf-quant-picker">
+        <label className="hf-quant-label" htmlFor={`quant-${group.repoId}`}>
+          Quantization
+        </label>
+        <select
+          id={`quant-${group.repoId}`}
+          className="hf-quant-select"
+          value={index}
+          onChange={(event) => setSelected(Number(event.target.value))}
+        >
+          {group.files.map((candidate, candidateIndex) => (
+            <option key={candidate.catalog_id} value={candidateIndex}>
+              {candidate.quant || 'unlabelled'} · {prettySize(candidate.size_bytes)}
+              {quantAdvice(candidate.quant).note ? ` · ${quantAdvice(candidate.quant).note}` : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {renderRow(file, {
+        compact: true,
+        onCheckFit: () => onCheckFit(file),
+        checkingFit: isCheckingFit(file),
+      })}
+    </article>
   )
 }
 
-function CatalogGroup({ title, marker, items, emptyText, renderRow }) {
+/* Placeholder rows while a live Hugging Face search is in flight. A search costs
+   real network round-trips; leaving the previous results on screen with no
+   indicator is what made it read as a hang rather than as work in progress. */
+function SearchSkeleton() {
+  return (
+    <div className="catalog-skeleton" role="status" aria-live="polite" aria-busy="true">
+      <p className="lane-empty">Searching Hugging Face…</p>
+      {[0, 1, 2].map((row) => (
+        <div key={row} className="catalog-skeleton-row" aria-hidden="true">
+          <span className="catalog-skeleton-bar catalog-skeleton-bar--title" />
+          <span className="catalog-skeleton-bar catalog-skeleton-bar--meta" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function CatalogGroup({ title, marker, count, emptyText, children }) {
   return (
     <section className="catalog-group">
       <div className="catalog-group-head">
@@ -463,8 +610,7 @@ function CatalogGroup({ title, marker, items, emptyText, renderRow }) {
         {marker}
       </div>
       <div className="catalog-list">
-        {items.map(renderRow)}
-        {items.length === 0 ? <p className="lane-empty">{emptyText}</p> : null}
+        {count === 0 ? <p className="lane-empty">{emptyText}</p> : children}
       </div>
     </section>
   )
@@ -491,39 +637,58 @@ export function CatalogLaneBrowse({
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [nextCursor, setNextCursor] = useState(null)
+  const [loading, setLoading] = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState('')
   const [pendingCatalogId, setPendingCatalogId] = useState('')
   const [pendingItem, setPendingItem] = useState(null)
+  const [checkingFitIds, setCheckingFitIds] = useState(() => new Set())
   const pendingCatalogIdRef = useRef('')
   const requestSequenceRef = useRef(0)
+  const inFlightRef = useRef(null)
 
   // Debounce the query so each keystroke doesn't fire a live Hugging Face search.
+  // A search is one Hub round-trip plus one per repo, so it costs a noticeable
+  // fraction of a second even warm; a shorter debounce only queues work that the
+  // next keystroke throws away.
   useEffect(() => {
-    const t = setTimeout(() => setDebouncedQuery(query.trim()), 350)
+    const t = setTimeout(() => setDebouncedQuery(query.trim()), 500)
     return () => clearTimeout(t)
   }, [query])
 
   const load = useCallback(async () => {
     const sequence = ++requestSequenceRef.current
+    // Abort the previous search instead of letting it run to completion and be
+    // discarded: it holds a Hub connection and a server-side fetch worker.
+    inFlightRef.current?.abort()
+    const controller = new AbortController()
+    inFlightRef.current = controller
     setError('')
+    setLoading(true)
     try {
       const params = debouncedQuery ? `?query=${encodeURIComponent(debouncedQuery)}` : ''
-      const res = await fetch(`${base}/api/models/catalog${params}`)
+      const res = await fetch(`${base}/api/models/catalog${params}`, { signal: controller.signal })
       if (!res.ok) throw new Error(`catalog HTTP ${res.status}`)
       const body = await res.json()
       if (sequence !== requestSequenceRef.current) return
       setItems(body.items || [])
       setNextCursor(body.next_cursor || null)
     } catch (err) {
+      if (err?.name === 'AbortError') return
       if (sequence !== requestSequenceRef.current) return
       setError(String(err?.message || err))
+    } finally {
+      if (sequence === requestSequenceRef.current) setLoading(false)
     }
   }, [base, debouncedQuery])
 
   useEffect(() => {
     load()
   }, [load])
+
+  // Unmounting mid-search must not leave the request (and its server-side work)
+  // running.
+  useEffect(() => () => inFlightRef.current?.abort(), [])
 
   const reserveAcquisition = useCallback((item) => {
     const catalogId = item.catalog_id
@@ -543,8 +708,7 @@ export function CatalogLaneBrowse({
   }, [])
 
   // Append the next page of experimental (Hugging Face) results.
-  const loadMore = useCallback(async () => {
-    if (!nextCursor || !debouncedQuery) return
+  const loadMore = useCallback(async () => {    if (!nextCursor || !debouncedQuery) return
     const sequence = requestSequenceRef.current
     setLoadingMore(true)
     try {
@@ -567,7 +731,52 @@ export function CatalogLaneBrowse({
     }
   }, [base, debouncedQuery, nextCursor])
 
-  const renderRow = (item) => (
+  /* Resolve one model's real GGUF dimensions on demand and fold the verdict back
+     into its row. Explicit and per-row on purpose: the background warm is capped
+     precisely to avoid a header-fetch storm, so the fix for "most rows say unknown"
+     is a user-driven check, not a bigger fan-out. */
+  const checkFit = useCallback(async (item) => {
+    setCheckingFitIds((prev) => new Set(prev).add(item.catalog_id))
+    try {
+      const res = await fetch(`${base}/api/models/catalog/fit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repo_id: item.repo_id,
+          filename: item.filename,
+          size_bytes: item.size_bytes,
+        }),
+      })
+      if (!res.ok) throw new Error(`fit check HTTP ${res.status}`)
+      const body = await res.json()
+      setItems((prev) =>
+        (prev || []).map((row) =>
+          row.catalog_id === item.catalog_id
+            ? {
+                ...row,
+                fit: body.fit,
+                fit_confidence: body.fit_confidence,
+                // Whether the question is settled. Without it an unresolvable model
+                // keeps offering a check that can never change anything.
+                fit_checked: body.checked,
+              }
+            : row,
+        ),
+      )
+    } catch (err) {
+      setError(String(err?.message || err))
+    } finally {
+      setCheckingFitIds((prev) => {
+        const next = new Set(prev)
+        next.delete(item.catalog_id)
+        return next
+      })
+    }
+  }, [base])
+
+  const isCheckingFit = useCallback((item) => checkingFitIds.has(item.catalog_id), [checkingFitIds])
+
+  const renderRow = useCallback((item, extra) => (
     <CatalogRow
       key={item.catalog_id}
       item={item}
@@ -588,15 +797,51 @@ export function CatalogLaneBrowse({
       onStartModel={onStartModel}
       onModelStarted={onModelStarted}
       onOperationBusy={onOperationBusy}
+      {...extra}
     />
+  ), [
+    base, canceledCatalogIds, capabilities, downloads, installAvailable, installBlockedReason,
+    localFilenames, onAcquired, onDownloadAcknowledged, onDownloadRetry, onInstallStarted,
+    onModelStarted, onOperationBusy, onStartModel, pendingCatalogId, reserveAcquisition,
+    settleAcquisition,
+  ])
+
+  // A row whose acquisition is in flight must keep rendering even if a newer
+  // search no longer returns it, or the user loses sight of their own download.
+  const visibleItems = useMemo(() => {
+    const rows = items || []
+    return pendingItem && !rows.some((item) => item.catalog_id === pendingItem.catalog_id)
+      ? [pendingItem, ...rows]
+      : rows
+  }, [items, pendingItem])
+  const curated = useMemo(
+    () => visibleItems.filter((it) => it.group !== 'experimental'),
+    [visibleItems],
+  )
+  const experimental = useMemo(
+    () => visibleItems.filter((it) => it.group === 'experimental'),
+    [visibleItems],
+  )
+  const searching = debouncedQuery.length >= 2
+
+  const hfGroups = useMemo(() => groupHfFilesByRepo(experimental), [experimental])
+  const { loadable, unimplemented } = useMemo(() => partitionByArchSupport(hfGroups), [hfGroups])
+  // Landing state only: with no query, lead with what this machine can actually
+  // run rather than a wall of rows the user cannot use.
+  const { runnable: curatedRunnable, blocked: curatedBlocked } = useMemo(
+    () => partitionCuratedByFit(curated),
+    [curated],
   )
 
-  const visibleItems = pendingItem && !(items || []).some((item) => item.catalog_id === pendingItem.catalog_id)
-    ? [pendingItem, ...(items || [])]
-    : (items || [])
-  const curated = visibleItems.filter((it) => it.group !== 'experimental')
-  const experimental = visibleItems.filter((it) => it.group === 'experimental')
-  const searching = debouncedQuery.length >= 2
+  const renderHfCard = (group) => (
+    <HfModelCard
+      key={group.repoId}
+      group={group}
+      renderRow={renderRow}
+      onCheckFit={checkFit}
+      isCheckingFit={isCheckingFit}
+    />
+  )
 
   return (
     <div className="catalog-lane-browse">
@@ -624,26 +869,69 @@ export function CatalogLaneBrowse({
       ) : null}
       {items === null && !error ? <p className="lane-empty">Loading catalog…</p> : null}
 
-      {items !== null || error ? (
+      {items === null && !error ? null : searching ? (
         <CatalogGroup
           title="Curated"
           marker={null}
-          items={curated}
-          emptyText={debouncedQuery ? 'No curated entries match.' : 'No curated entries available.'}
-          renderRow={renderRow}
-        />
-      ) : null}
+          count={curated.length}
+          emptyText="No curated entries match."
+        >
+          {curated.map((item) => renderRow(item))}
+        </CatalogGroup>
+      ) : (
+        <>
+          <CatalogGroup
+            title="Curated — runs on this machine"
+            marker={null}
+            count={curatedRunnable.length}
+            emptyText="No curated model fits the memory free right now. Close some applications and reload, or search Hugging Face for a smaller one."
+          >
+            {curatedRunnable.map((item) => renderRow(item))}
+          </CatalogGroup>
+          {curatedBlocked.length ? (
+            <details className="catalog-collapsed">
+              <summary>
+                {curatedBlocked.length} more curated model{curatedBlocked.length === 1 ? '' : 's'} this
+                machine cannot load right now
+              </summary>
+              <div className="catalog-list">{curatedBlocked.map((item) => renderRow(item))}</div>
+            </details>
+          ) : null}
+        </>
+      )}
 
       {searching && items !== null ? (
         <>
           <CatalogGroup
             title="Experimental (Hugging Face)"
-            marker={<ExperimentalMarker />}
-            items={experimental}
-            emptyText="No live Hugging Face GGUFs match (or the Hub is unreachable)."
-            renderRow={renderRow}
-          />
-          {nextCursor ? (
+            marker={
+              <span className="catalog-experimental-marker">
+                <EvidenceChip state="unsupported" asText>Experimental — unverified, no parity claim</EvidenceChip>
+              </span>
+            }
+            count={loading ? 1 : loadable.length}
+            emptyText={
+              // Saying "nothing matched" when results DID match and were merely
+              // folded into the section below would be false, and it hides the one
+              // place the user should look next.
+              unimplemented.length
+                ? `Every match (${unimplemented.length}) uses an architecture Camelid does not implement — see below.`
+                : 'No live Hugging Face GGUFs match (or the Hub is unreachable).'
+            }
+          >
+            {loading ? <SearchSkeleton /> : loadable.map(renderHfCard)}
+          </CatalogGroup>
+          {!loading && unimplemented.length ? (
+            <details className="catalog-collapsed">
+              <summary>
+                {unimplemented.length} result{unimplemented.length === 1 ? '' : 's'} whose architecture
+                Camelid does not implement
+              </summary>
+              <p className="catalog-row-faint">{HF_GUESS_EXPLANATION}</p>
+              <div className="catalog-list">{unimplemented.map(renderHfCard)}</div>
+            </details>
+          ) : null}
+          {nextCursor && !loading ? (
             <button
               type="button"
               className="catalog-row-action"

--- a/frontend/src/components/models/CatalogLaneBrowse.jsx
+++ b/frontend/src/components/models/CatalogLaneBrowse.jsx
@@ -4,6 +4,7 @@ import { beginCatalogSettlement, catalogDownloadSettlement, completeCatalogAcqui
 import {
   defaultFileIndex,
   fitDetail,
+  fitIsRecheckable,
   fitIsSettled,
   fitLabel,
   groupHfFilesByRepo,
@@ -161,6 +162,21 @@ function FitAdvisory({ item, onCheckFit, checking }) {
         {item.fit_confidence === 'approx' ? '~ ' : ''}
         {label}
       </span>
+      {/* Memory pressure is the one refusal a user can act on, and acting on it
+          needs a live re-probe: the listing's verdicts come from a startup
+          snapshot, so reloading the page cannot pick up freed memory. */}
+      {transient && onCheckFit ? (
+        <button
+          type="button"
+          className="catalog-fit-check"
+          onClick={onCheckFit}
+          disabled={checking}
+          aria-busy={checking || undefined}
+          title="Re-read this machine's free memory and this model's size, right now"
+        >
+          {checking ? 'Re-checking…' : 'Re-check'}
+        </button>
+      ) : null}
       {Array.isArray(item.task_tags) && item.task_tags.length ? (
         <span className="catalog-fit-tags">
           <span className="catalog-fit-tags-label">best for</span>
@@ -797,13 +813,19 @@ export function CatalogLaneBrowse({
       onStartModel={onStartModel}
       onModelStarted={onModelStarted}
       onOperationBusy={onOperationBusy}
+      // Curated rows get the re-check path too, and it matters more for them:
+      // the landing view now FOLDS AWAY rows the catalog thinks cannot load, so a
+      // stale "not enough memory" would hide a model that has since become
+      // runnable, with no way to bring it back.
+      onCheckFit={fitIsRecheckable(item.fit) ? () => checkFit(item) : undefined}
+      checkingFit={isCheckingFit(item)}
       {...extra}
     />
   ), [
-    base, canceledCatalogIds, capabilities, downloads, installAvailable, installBlockedReason,
-    localFilenames, onAcquired, onDownloadAcknowledged, onDownloadRetry, onInstallStarted,
-    onModelStarted, onOperationBusy, onStartModel, pendingCatalogId, reserveAcquisition,
-    settleAcquisition,
+    base, canceledCatalogIds, capabilities, checkFit, downloads, installAvailable,
+    installBlockedReason, isCheckingFit, localFilenames, onAcquired, onDownloadAcknowledged,
+    onDownloadRetry, onInstallStarted, onModelStarted, onOperationBusy, onStartModel,
+    pendingCatalogId, reserveAcquisition, settleAcquisition,
   ])
 
   // A row whose acquisition is in flight must keep rendering even if a newer
@@ -884,7 +906,7 @@ export function CatalogLaneBrowse({
             title="Curated — runs on this machine"
             marker={null}
             count={curatedRunnable.length}
-            emptyText="No curated model fits the memory free right now. Close some applications and reload, or search Hugging Face for a smaller one."
+            emptyText="No curated model fits the memory free right now. Close some applications, then use Re-check on one of the rows below."
           >
             {curatedRunnable.map((item) => renderRow(item))}
           </CatalogGroup>

--- a/frontend/src/lib/catalogBrowse.js
+++ b/frontend/src/lib/catalogBrowse.js
@@ -70,16 +70,30 @@ export function fitIsSettled(item) {
 }
 
 /* Why the row is refused or unresolved, and what the user can actually do about
-   it. A machine that is merely busy must never be described as too small. */
+   it. A machine that is merely busy must never be described as too small.
+
+   The wording is tied to a real mechanism: a refusal caused by memory pressure is
+   re-checkable, because the check endpoint probes memory live. Telling the user to
+   free memory would be empty advice otherwise — the catalog listing reads a
+   startup snapshot, so a page reload alone changes nothing. */
 export function fitDetail(fit) {
   switch (fit) {
     case 'insufficient_free_memory':
-      return 'This machine is big enough — the memory is in use. Close some applications and check again.'
+      return 'This machine is big enough — the memory is in use. Close some applications, then use Re-check.'
     case 'wont_fit':
       return 'Freeing memory will not help; pick a smaller model or a smaller quantization.'
     default:
       return null
   }
+}
+
+/* Whether re-checking this row could ever change its answer.
+
+   Only memory pressure is transient. A model larger than the whole machine stays
+   too large however much is freed, so offering a re-check there would be busywork
+   dressed as a remedy. */
+export function fitIsRecheckable(fit) {
+  return fit === 'insufficient_free_memory'
 }
 
 /* --- quantization --------------------------------------------------------- */

--- a/frontend/src/lib/catalogBrowse.js
+++ b/frontend/src/lib/catalogBrowse.js
@@ -1,0 +1,251 @@
+/* Pure presentation logic for the "Get models" catalog browse.
+
+   It lives outside the component so the three rules that actually decide what the
+   user sees are unit-testable and have exactly one definition each:
+
+   1. A Hugging Face *repo* is one model; its many `.gguf` files are quantizations
+      OF that model. The browse API returns files, because a file is what you
+      download — but rendering one card per file is what made the list feel
+      endless (15 repos routinely expand to 250+ rows, e.g. `Q2_K`, `Q2_K_L`,
+      `IQ3_M`, `IQ4_XS`, ... of the same weights). Grouping happens here.
+   2. Quantization is a quality/size tradeoff the user is currently given no help
+      with. The ordering and the plain-language note come from one table.
+   3. Fit is never guessed. Every helper here distinguishes "does not fit",
+      "does not fit right now", and "we do not know" — collapsing them is what made
+      the advisory read as "nothing works on this machine". */
+
+/* --- fit ------------------------------------------------------------------ */
+
+/* Verdicts that mean the model can run somehow on this host. */
+const POSITIVE_FITS = new Set(['fits_resident', 'fits_with_offload', 'cpu_only_ok'])
+
+/* Verdicts that mean the model cannot be loaded as things stand. `unknown` is
+   deliberately absent: it is the absence of a claim, not a negative one. */
+const REFUSING_FITS = new Set(['wont_fit', 'insufficient_free_memory'])
+
+export function isPositiveFit(fit) {
+  return POSITIVE_FITS.has(fit)
+}
+
+export function isRefusingFit(fit) {
+  return REFUSING_FITS.has(fit)
+}
+
+/* Capacity advisory for THIS host (fit axis, NOT a support claim). `unknown` and
+   anything unrecognized render nothing rather than a guess. */
+export function fitLabel(fit) {
+  switch (fit) {
+    case 'fits_resident':
+      return 'Fits your machine'
+    case 'fits_with_offload':
+      return 'Fits (GPU + RAM offload)'
+    case 'cpu_only_ok':
+      return 'Fits (CPU)'
+    case 'insufficient_free_memory':
+      return 'Not enough free memory right now'
+    case 'wont_fit':
+      return 'Too big for this machine'
+    default:
+      return null
+  }
+}
+
+/* Whether this row's capacity question is settled — i.e. asking again cannot teach
+   us anything new.
+
+   `fit: 'unknown'` has THREE causes and they need different UI. Either nothing has
+   been resolved yet (offer a check); or the footprint WAS resolved and the advisor
+   still abstained (`fit_confidence: 'exact'`/`'approx'` — happens when host memory
+   cannot be probed, or when the GPU has room while free system memory is too low to
+   stage the weights); or a check ran and did not settle (offline, rate-limited —
+   `fit_checked: false`, worth retrying).
+
+   Treating the middle case as "not checked yet" left the check button in a loop:
+   press it, get `unknown` back, see the same button. The backend reports `checked`
+   precisely so this is decidable client-side. */
+export function fitIsSettled(item) {
+  if (item?.fit_checked === true) return true
+  if (item?.fit_checked === false) return false
+  return item?.fit_confidence === 'exact' || item?.fit_confidence === 'approx'
+}
+
+/* Why the row is refused or unresolved, and what the user can actually do about
+   it. A machine that is merely busy must never be described as too small. */
+export function fitDetail(fit) {
+  switch (fit) {
+    case 'insufficient_free_memory':
+      return 'This machine is big enough — the memory is in use. Close some applications and check again.'
+    case 'wont_fit':
+      return 'Freeing memory will not help; pick a smaller model or a smaller quantization.'
+    default:
+      return null
+  }
+}
+
+/* --- quantization --------------------------------------------------------- */
+
+/* Ordered from highest to lowest fidelity. Rank is ordinal only — it encodes the
+   established ordering of the GGUF quant families (wider integer types keep more
+   of the original weights; within a family `_L` > `_M` > `_S`) and is never
+   presented as a measured quality score.
+
+   `note` is what the user needs to decide, in their words, not ours. */
+const QUANT_TABLE = [
+  ['F32', 'full', 'Unquantized — largest file, no quantization loss'],
+  ['BF16', 'full', 'Unquantized — largest file, no quantization loss'],
+  ['F16', 'full', 'Unquantized — largest file, no quantization loss'],
+  ['Q8_K', 'high', 'Near-lossless — big, closest to the original weights'],
+  ['Q8_0', 'high', 'Near-lossless — big, closest to the original weights'],
+  ['Q6_K', 'high', 'Very close to the original weights'],
+  ['Q5_K_M', 'good', 'High quality'],
+  ['Q5_K_S', 'good', 'High quality'],
+  ['Q5_K', 'good', 'High quality'],
+  ['Q5_1', 'good', 'High quality'],
+  ['Q5_0', 'good', 'High quality'],
+  ['Q4_K_M', 'balanced', 'Balanced — the usual default'],
+  ['Q4_K_S', 'balanced', 'Balanced, slightly smaller than Q4_K_M'],
+  ['Q4_K', 'balanced', 'Balanced'],
+  ['Q4_1', 'balanced', 'Balanced'],
+  ['Q4_0', 'balanced', 'Balanced'],
+  ['IQ4_NL', 'balanced', 'Balanced (imatrix) — needs an imatrix-aware runtime'],
+  ['IQ4_XS', 'balanced', 'Balanced (imatrix) — needs an imatrix-aware runtime'],
+  ['Q3_K_L', 'reduced', 'Smaller, noticeably lower quality'],
+  ['Q3_K_M', 'reduced', 'Smaller, noticeably lower quality'],
+  ['Q3_K_S', 'reduced', 'Smaller, noticeably lower quality'],
+  ['Q3_K', 'reduced', 'Smaller, noticeably lower quality'],
+  ['IQ3_M', 'reduced', 'Smaller, noticeably lower quality (imatrix)'],
+  ['IQ3_S', 'reduced', 'Smaller, noticeably lower quality (imatrix)'],
+  ['IQ3_XS', 'reduced', 'Smaller, noticeably lower quality (imatrix)'],
+  ['IQ3_XXS', 'reduced', 'Smaller, noticeably lower quality (imatrix)'],
+  ['Q2_K_S', 'severe', 'Heavy quality loss — a last resort for tight memory'],
+  ['Q2_K', 'severe', 'Heavy quality loss — a last resort for tight memory'],
+  ['IQ2_M', 'severe', 'Heavy quality loss (imatrix)'],
+  ['IQ2_S', 'severe', 'Heavy quality loss (imatrix)'],
+  ['IQ2_XS', 'severe', 'Heavy quality loss (imatrix)'],
+  ['IQ2_XXS', 'severe', 'Heavy quality loss (imatrix)'],
+  ['IQ1_M', 'extreme', 'Extreme compression — output is often incoherent'],
+  ['IQ1_S', 'extreme', 'Extreme compression — output is often incoherent'],
+]
+
+const QUANT_BY_TOKEN = new Map(
+  QUANT_TABLE.map(([token, tier, note], index) => [
+    token,
+    { token, tier, note, rank: QUANT_TABLE.length - index },
+  ]),
+)
+
+/* What we can say about a quantization token. An unrecognized token gets a rank of
+   0 and no note: the browse layer guesses quants from filenames, so "we do not
+   recognize this" must not be dressed up as advice. */
+export function quantAdvice(quant) {
+  return (
+    QUANT_BY_TOKEN.get(String(quant || '').toUpperCase()) || {
+      token: quant || '',
+      tier: 'unknown',
+      note: null,
+      rank: 0,
+    }
+  )
+}
+
+/* Highest fidelity first; ties broken by size then filename so the order is total
+   and stable across renders (two files can share a quant token when a repo ships
+   variants the filename guesser cannot tell apart). */
+export function compareByQuality(a, b) {
+  const byRank = quantAdvice(b.quant).rank - quantAdvice(a.quant).rank
+  if (byRank !== 0) return byRank
+  const bySize = (b.size_bytes || 0) - (a.size_bytes || 0)
+  if (bySize !== 0) return bySize
+  return String(a.filename).localeCompare(String(b.filename))
+}
+
+/* --- repo grouping -------------------------------------------------------- */
+
+/* `owner/Model-Name-GGUF` → `Model-Name`. The `-GGUF` suffix is a packaging
+   convention, not part of the model's name, and repeating the owner in the title
+   wastes the widest line in the card. */
+export function repoTitle(repoId) {
+  const withoutOwner = String(repoId || '').split('/').pop() || ''
+  return withoutOwner.replace(/[-_. ]?GGUF$/i, '') || withoutOwner
+}
+
+export function repoOwner(repoId) {
+  const parts = String(repoId || '').split('/')
+  return parts.length > 1 ? parts[0] : ''
+}
+
+/* Collapse flat file rows into one entry per repo, preserving the order the repos
+   first appeared in.
+
+   That order is the ranking: the Hub returns repos by search relevance and the
+   server preserves it, so re-sorting here (by downloads, say) would discard
+   relevance for a number that is identical across every file of a repo and
+   therefore cannot discriminate within one. */
+export function groupHfFilesByRepo(items) {
+  const order = []
+  const byRepo = new Map()
+  for (const item of items) {
+    const key = item.repo_id
+    if (!byRepo.has(key)) {
+      byRepo.set(key, [])
+      order.push(key)
+    }
+    byRepo.get(key).push(item)
+  }
+  return order.map((repoId) => {
+    const files = byRepo.get(repoId).slice().sort(compareByQuality)
+    return {
+      repoId,
+      owner: repoOwner(repoId),
+      title: repoTitle(repoId),
+      files,
+      // Repo-level facts: identical on every file, so read them off the first.
+      downloads: files[0]?.downloads || 0,
+      likes: files[0]?.likes || 0,
+      architecture: files[0]?.architecture || '',
+      archSupport: files[0]?.arch_support || 'unknown',
+    }
+  })
+}
+
+/* Which quantization to preselect, as an index into a quality-sorted `files`.
+
+   Order of preference:
+   1. The highest-fidelity file with a PROVEN fit — the best thing this machine can
+      actually run.
+   2. Nothing proven: the balanced tier, which is what a person picks when they do
+      not know their memory budget. Defaulting to the largest file we merely failed
+      to rule out would preselect a 24 GB download on an unknown host.
+   3. Everything is refused: the smallest file, so the card still shows the closest
+      thing to viable. */
+export function defaultFileIndex(files) {
+  if (!files.length) return -1
+  const proven = files.findIndex((file) => isPositiveFit(file.fit))
+  if (proven >= 0) return proven
+  const candidates = files.filter((file) => !isRefusingFit(file.fit))
+  if (!candidates.length) return files.length - 1
+  const balanced = candidates.find((file) => quantAdvice(file.quant).tier === 'balanced')
+  return files.indexOf(balanced || candidates[candidates.length - 1])
+}
+
+/* Split repo groups by whether Camelid implements the architecture at all.
+
+   `unknown` groups with the runnable ones on purpose: the architecture came from a
+   filename guess, so "we could not tell" must not hide a model that would load.
+   Only a recognized-and-unimplemented architecture is filtered out. */
+export function partitionByArchSupport(groups) {
+  return {
+    loadable: groups.filter((group) => group.archSupport !== 'not_implemented'),
+    unimplemented: groups.filter((group) => group.archSupport === 'not_implemented'),
+  }
+}
+
+/* Split curated rows into what this machine can run and what it cannot, for the
+   no-search landing state. Rows with an `unknown` verdict count as runnable: an
+   unprobed host must not have its whole catalog folded away. */
+export function partitionCuratedByFit(items) {
+  return {
+    runnable: items.filter((item) => !isRefusingFit(item.fit)),
+    blocked: items.filter((item) => isRefusingFit(item.fit)),
+  }
+}

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -1311,6 +1311,50 @@
 .catalog-start-steps li.is-done { color: var(--color-text-muted); }
 .catalog-start-steps li.is-done span { border-color: var(--color-ready); color: var(--color-ready); }
 .catalog-start-failure { margin-top: var(--space-2); padding: var(--space-2) var(--space-3); border-left: 3px solid var(--color-warning); background: var(--color-surface-strong); }
+
+/* Fit advisory: three tones for three remedies. `--bad` (error) means the machine
+   is too small; `--warn` means it is merely busy, which is a different sentence and
+   must not borrow the error colour; `--unknown` is the absence of a claim and is
+   deliberately quiet so it never competes with a real verdict. */
+.catalog-fit-chip--warn { color: var(--color-warning); background: color-mix(in srgb, var(--color-warning) 12%, transparent); border-color: color-mix(in srgb, var(--color-warning) 40%, transparent); }
+.catalog-fit-chip--unknown { color: var(--color-text-muted); background: var(--color-surface-strong); border-color: var(--color-border-soft); font-weight: 600; }
+.catalog-fit-detail { font-size: var(--text-xs); color: var(--color-text-faint); flex: 1 1 100%; }
+.catalog-fit-check { padding: 2px 10px; border-radius: 999px; border: 1px solid var(--color-border-soft); background: var(--color-bg-elevated); color: var(--color-text); font-size: var(--text-xs); font-weight: 700; }
+.catalog-fit-check:hover:not(:disabled) { background: var(--color-surface-hover); }
+.catalog-fit-check:disabled { color: var(--color-text-faint); }
+
+/* One Hugging Face repo = one card. The nested row keeps the download machinery
+   but drops its own head, so the card owns the identity and the row owns the act. */
+.hf-model-card { border: 1px solid var(--color-border-soft); border-radius: var(--radius-md); padding: var(--space-3); background: var(--color-surface); }
+.hf-model-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-2); }
+.hf-model-id { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.hf-model-title { margin: 0; font-size: var(--text-sm); font-weight: 700; overflow-wrap: anywhere; }
+.hf-model-meta { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); margin: 0; font-size: var(--text-xs); color: var(--color-text-muted); }
+.hf-model-owner { font-family: var(--font-mono); }
+.hf-model-arch { border-bottom: 1px dotted var(--color-border-soft); cursor: help; }
+.hf-model-unsupported { color: var(--color-warning); }
+.hf-quant-picker { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); margin-top: var(--space-2); }
+.hf-quant-label { font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.04em; color: var(--color-text-faint); }
+.hf-quant-select { flex: 1 1 260px; min-width: 0; max-width: 100%; padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); border: 1px solid var(--color-border-soft); background: var(--color-bg-elevated); color: var(--color-text); font-size: var(--text-xs); font-family: var(--font-mono); }
+/* Nested inside a card: no second border or background box. */
+.catalog-row--compact { border: 0; border-radius: 0; padding: 0; background: transparent; }
+.catalog-row--compact.catalog-row--advisory { border-left: 0; }
+
+/* Search feedback. A live Hub search is several network round-trips; leaving the
+   previous results frozen with no indicator is what made it read as a hang. */
+.catalog-skeleton { display: flex; flex-direction: column; gap: var(--space-2); }
+.catalog-skeleton-row { border: 1px solid var(--color-border-soft); border-radius: var(--radius-md); padding: var(--space-3); background: var(--color-surface); display: flex; flex-direction: column; gap: var(--space-2); }
+.catalog-skeleton-bar { height: 10px; border-radius: 999px; background: linear-gradient(90deg, var(--color-surface-strong) 25%, var(--color-surface-hover) 37%, var(--color-surface-strong) 63%); background-size: 400% 100%; animation: catalogSkeleton 1.4s ease-in-out infinite; }
+.catalog-skeleton-bar--title { width: 42%; }
+.catalog-skeleton-bar--meta { width: 68%; height: 8px; }
+@keyframes catalogSkeleton { 0% { background-position: 100% 50%; } 100% { background-position: 0 50%; } }
+@media (prefers-reduced-motion: reduce) { .catalog-skeleton-bar { animation: none; } }
+
+/* Dead ends stay reachable but stop competing for the first screen. */
+.catalog-collapsed { margin-top: var(--space-3); border: 1px solid var(--color-border-soft); border-radius: var(--radius-md); background: var(--color-surface); }
+.catalog-collapsed > summary { padding: var(--space-2) var(--space-3); font-size: var(--text-xs); font-weight: 600; color: var(--color-text-muted); cursor: pointer; }
+.catalog-collapsed > summary:hover { color: var(--color-text); }
+.catalog-collapsed > .catalog-list, .catalog-collapsed > .catalog-row-faint { padding: 0 var(--space-3) var(--space-3); }
 /* Download button doubles as the progress bar: a fill grows left→right with the
    percentage (smooth transition); before the first byte lands it shows an
    indeterminate shimmer so the click feels acknowledged immediately. */

--- a/scripts/check-fit-verdict-vocabulary.mjs
+++ b/scripts/check-fit-verdict-vocabulary.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// check-fit-verdict-vocabulary.mjs — keeps the WebUI's fit vocabulary tied to the code.
+//
+// `FitVerdict` in src/fit.rs is serialized straight onto /api/models/catalog and
+// /api/models/catalog/fit, and the Models tab branches on those exact strings. The
+// JS side re-declares them as literals, so a renamed or added variant silently
+// stops matching: no compiler sees it, and a frontend smoke that asserts the
+// frontend's own literals against each other passes either way. That is the
+// lane-gate class of bug — the UI re-deciding something the backend already said,
+// against a vocabulary that has drifted.
+//
+// Rust is the source of truth. Three declarations there define the whole partition:
+//   as_str()          — the complete vocabulary
+//   is_positive_fit() — the verdicts that mean "can run somehow"
+//   refuses_load()    — the verdicts a pre-load guard refuses on
+// This asserts the JS sets agree EXACTLY (not merely as a superset — an extra JS
+// entry is drift too, e.g. a verdict deleted in Rust but still special-cased in the
+// UI), and that every verdict string is actually handled somewhere in the lib.
+//
+// Usage: node scripts/check-fit-verdict-vocabulary.mjs
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const ROOT = resolve('.')
+const FIT_RS = resolve(ROOT, 'src/fit.rs')
+const BROWSE_JS = resolve(ROOT, 'frontend/src/lib/catalogBrowse.js')
+
+let failures = 0
+function fail(msg) {
+  console.error(`  FAIL ${msg}`)
+  failures++
+}
+
+/** Body of `fn <name>` up to the closing brace at its own indentation.
+ *
+ * The indent must come from the START of the declaring line, not from just before
+ * the `fn` token: `    pub fn as_str(` would otherwise yield a one-space indent, no
+ * `\n }` would ever match, and the "body" would run to end-of-file and pick up
+ * later functions' match arms (`cli_label`'s "fits" was exactly that). */
+export function fnBody(src, name) {
+  const decl = new RegExp(`^([ \\t]*)(?:pub(?:\\([^)]*\\))?[ \\t]+)?fn ${name}\\(`, 'm')
+  const m = src.match(decl)
+  if (!m) return null
+  const rest = src.slice(m.index)
+  const end = rest.indexOf(`\n${m[1]}}`)
+  return end === -1 ? rest : rest.slice(0, end)
+}
+
+/** variant -> wire string, from as_str()'s match arms. */
+export function variantStrings(src) {
+  const body = fnBody(src, 'as_str')
+  if (!body) return new Map()
+  const map = new Map()
+  for (const m of body.matchAll(/FitVerdict::(\w+)\s*=>\s*"([a-z0-9_]+)"/g)) {
+    map.set(m[1], m[2])
+  }
+  return map
+}
+
+/** Variants named inside `matches!(self, ...)` in is_positive_fit(). */
+export function positiveVariants(src) {
+  const body = fnBody(src, 'is_positive_fit')
+  if (!body) return null
+  return new Set([...body.matchAll(/FitVerdict::(\w+)/g)].map((m) => m[1]))
+}
+
+/** Variants on the `=> true` arm of refuses_load(). */
+export function refusingVariants(src) {
+  const body = fnBody(src, 'refuses_load')
+  if (!body) return null
+  // Take the arm text preceding `=> true`; `|`-joined patterns may span lines.
+  const arm = body.match(/((?:\s*FitVerdict::\w+\s*\|?)+)=>\s*true/)
+  if (!arm) return null
+  return new Set([...arm[1].matchAll(/FitVerdict::(\w+)/g)].map((m) => m[1]))
+}
+
+/** A `new Set([...])` literal's string members, by const name. */
+export function jsSet(src, constName) {
+  const m = src.match(new RegExp(`const\\s+${constName}\\s*=\\s*new Set\\(\\[([^\\]]*)\\]`))
+  if (!m) return null
+  return new Set([...m[1].matchAll(/['"]([a-z0-9_]+)['"]/g)].map((x) => x[1]))
+}
+
+function compare(label, expected, actual) {
+  if (!actual) {
+    fail(`${label}: could not parse the JS set (has it been renamed or reshaped?)`)
+    return
+  }
+  const missing = [...expected].filter((v) => !actual.has(v)).sort()
+  const extra = [...actual].filter((v) => !expected.has(v)).sort()
+  if (missing.length) fail(`${label} is missing verdict(s) the code emits: ${missing.join(', ')}`)
+  if (extra.length) fail(`${label} has verdict(s) the code no longer emits: ${extra.join(', ')}`)
+  if (!missing.length && !extra.length) {
+    console.log(`  ${label} matches src/fit.rs exactly (${[...expected].sort().join(', ')})`)
+  }
+}
+
+async function main() {
+  const rust = await readFile(FIT_RS, 'utf8')
+  const js = await readFile(BROWSE_JS, 'utf8')
+
+  const strings = variantStrings(rust)
+  if (!strings.size) {
+    fail('no FitVerdict::X => "y" arms found in src/fit.rs as_str() (check cannot run)')
+    process.exit(1)
+  }
+  console.log(`  vocabulary: ${strings.size} verdict(s) declared by FitVerdict::as_str()`)
+
+  const toWire = (variants, what) => {
+    if (!variants) {
+      fail(`could not parse ${what} in src/fit.rs (check cannot run)`)
+      return null
+    }
+    const wire = new Set()
+    for (const v of variants) {
+      const s = strings.get(v)
+      if (!s) fail(`${what} names FitVerdict::${v}, which has no as_str() arm`)
+      else wire.add(s)
+    }
+    return wire
+  }
+
+  const positive = toWire(positiveVariants(rust), 'is_positive_fit()')
+  const refusing = toWire(refusingVariants(rust), 'refuses_load()')
+
+  if (positive) compare('POSITIVE_FITS', positive, jsSet(js, 'POSITIVE_FITS'))
+  if (refusing) compare('REFUSING_FITS', refusing, jsSet(js, 'REFUSING_FITS'))
+
+  // Every verdict must be mentioned somewhere in the lib, so a new variant cannot
+  // fall through the label/detail switches into a blank UI string.
+  const unhandled = [...strings.values()].filter((s) => !js.includes(`'${s}'`)).sort()
+  if (unhandled.length) {
+    fail(`frontend/src/lib/catalogBrowse.js never mentions: ${unhandled.join(', ')}`)
+  } else {
+    console.log(`  all ${strings.size} verdict(s) are referenced in catalogBrowse.js`)
+  }
+
+  if (failures) {
+    console.error(`\nfit-verdict vocabulary check FAILED (${failures} problem(s))`)
+    process.exit(1)
+  }
+  console.log('\nfit-verdict vocabulary check passed: WebUI vocabulary == src/fit.rs')
+}
+
+// Importable for scripts/test-check-fit-verdict-vocabulary.mjs; runs when invoked.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}

--- a/scripts/test-check-fit-verdict-vocabulary.mjs
+++ b/scripts/test-check-fit-verdict-vocabulary.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// Self-test for check-fit-verdict-vocabulary.mjs (run in CI by the
+// validation-scripts job's test-*.mjs glob). A drift guard that cannot fail is
+// worse than no guard — it reads as coverage. So this asserts the parsers both
+// agree with the real src/fit.rs AND reject each way the two sides can diverge.
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  fnBody,
+  variantStrings,
+  positiveVariants,
+  refusingVariants,
+  jsSet,
+} from './check-fit-verdict-vocabulary.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const realRust = await readFile(join(repoRoot, 'src', 'fit.rs'), 'utf8')
+const realJs = await readFile(join(repoRoot, 'frontend', 'src', 'lib', 'catalogBrowse.js'), 'utf8')
+
+// --- baseline: the real sources parse, and agree -----------------------------
+const strings = variantStrings(realRust)
+assert.ok(strings.size >= 6, `expected >=6 verdicts, got ${strings.size}`)
+assert.equal(strings.get('FitsResident'), 'fits_resident')
+assert.equal(strings.get('InsufficientFreeMemory'), 'insufficient_free_memory')
+assert.equal(strings.get('Unknown'), 'unknown')
+
+const wire = (vs) => new Set([...vs].map((v) => strings.get(v)))
+assert.deepEqual(
+  wire(positiveVariants(realRust)),
+  jsSet(realJs, 'POSITIVE_FITS'),
+  'real POSITIVE_FITS must match is_positive_fit()',
+)
+assert.deepEqual(
+  wire(refusingVariants(realRust)),
+  jsSet(realJs, 'REFUSING_FITS'),
+  'real REFUSING_FITS must match refuses_load()',
+)
+
+// --- regression guard for the indent bug ------------------------------------
+// fnBody once derived indentation from just before the `fn` token, so `pub fn`
+// yielded a 1-space indent, no closing brace matched, and the body ran to EOF —
+// swallowing later functions. That made cli_label's `"fits"` look like as_str's
+// wire string for FitsResident. Assert the body stops at its own function.
+const asStrBody = fnBody(realRust, 'as_str')
+assert.ok(asStrBody, 'as_str() body must be found')
+assert.ok(!asStrBody.includes('cli_label'), 'as_str() body must not run past its own closing brace')
+assert.ok(!/=>\s*"fits"/.test(asStrBody), 'as_str() body must not include cli_label arms')
+
+// --- synthetic drift: each divergence must be detectable --------------------
+const rustFor = (arms, positive, refusing) => `
+impl FitVerdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+${arms.map(([v, s]) => `            FitVerdict::${v} => "${s}",`).join('\n')}
+        }
+    }
+
+    pub fn is_positive_fit(self) -> bool {
+        matches!(
+            self,
+            ${positive.map((v) => `FitVerdict::${v}`).join(' | ')}
+        )
+    }
+
+    pub fn refuses_load(self) -> bool {
+        match self {
+            ${refusing.map((v) => `FitVerdict::${v}`).join(' | ')} => true,
+            _ => false,
+        }
+    }
+
+    pub fn cli_label(self) -> &'static str {
+        match self {
+            FitVerdict::FitsResident => "fits",
+        }
+    }
+}
+`
+
+// A RENAMED wire string is visible: as_str changes, the JS literal does not.
+const renamed = rustFor(
+  [['FitsResident', 'fits_vram_resident'], ['WontFit', 'wont_fit']],
+  ['FitsResident'],
+  ['WontFit'],
+)
+assert.equal(variantStrings(renamed).get('FitsResident'), 'fits_vram_resident')
+assert.ok(
+  !jsSet(realJs, 'POSITIVE_FITS').has('fits_vram_resident'),
+  'a renamed verdict must not already be in the JS set (else the guard proves nothing)',
+)
+
+// An ADDED verdict that Rust calls positive but JS never lists.
+const added = rustFor(
+  [['FitsResident', 'fits_resident'], ['FitsPartly', 'fits_partly'], ['WontFit', 'wont_fit']],
+  ['FitsResident', 'FitsPartly'],
+  ['WontFit'],
+)
+const addedWire = new Set([...positiveVariants(added)].map((v) => variantStrings(added).get(v)))
+assert.ok(addedWire.has('fits_partly'))
+assert.ok(!jsSet(realJs, 'POSITIVE_FITS').has('fits_partly'), 'added verdict must be missing from JS')
+
+// A verdict REMOVED from Rust but still special-cased in JS (extra-side drift).
+const shrunk = rustFor([['FitsResident', 'fits_resident'], ['WontFit', 'wont_fit']], ['FitsResident'], ['WontFit'])
+const shrunkRefusing = new Set([...refusingVariants(shrunk)].map((v) => variantStrings(shrunk).get(v)))
+assert.deepEqual(shrunkRefusing, new Set(['wont_fit']))
+assert.ok(
+  jsSet(realJs, 'REFUSING_FITS').has('insufficient_free_memory'),
+  'JS still lists insufficient_free_memory, so a Rust-side removal would be caught as extra',
+)
+
+// refuses_load()'s `|`-joined arm may span lines; the parser must gather all of it.
+const multiline = `
+impl FitVerdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FitVerdict::WontFit => "wont_fit",
+            FitVerdict::InsufficientFreeMemory => "insufficient_free_memory",
+            FitVerdict::Unknown => "unknown",
+        }
+    }
+
+    pub fn refuses_load(self) -> bool {
+        match self {
+            FitVerdict::WontFit
+            | FitVerdict::InsufficientFreeMemory => true,
+            FitVerdict::Unknown => false,
+        }
+    }
+}
+`
+assert.deepEqual(
+  refusingVariants(multiline),
+  new Set(['WontFit', 'InsufficientFreeMemory']),
+  'multi-line `|` arms must all be collected',
+)
+
+// A reshaped/renamed JS set is reported rather than silently passing.
+assert.equal(jsSet('const SOMETHING_ELSE = new Set([])', 'POSITIVE_FITS'), null)
+
+console.log('check-fit-verdict-vocabulary self-test: ok')

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18470,10 +18470,27 @@ pub struct CatalogItemView {
     pub arch_support: &'static str,
 }
 
+/// The `general.architecture` a GGUF guessed as `token` will actually declare.
+///
+/// The browse guesser names model *families*; the loader allowlist names GGUF
+/// architectures, and those are not the same vocabulary — the same mismatch that
+/// made curated labels unusable for this axis. Mixtral is the case that bites:
+/// its GGUFs declare `llama` (the MoE tensors ride the llama architecture, which
+/// is why [`crate::model::MixtralMoeMetadata`] reads `llama.expert_count`), and
+/// Camelid ships an evidence-backed `mixtral_8x7b_instruct_v0_1_q8_0` row. Testing
+/// the family token directly stamped every Mixtral repo `not_implemented`, which
+/// folded a family we vouch for into the "cannot run this" drawer.
+fn loader_architecture_for_guess(token: &str) -> &str {
+    match token {
+        "mixtral" => "llama",
+        other => other,
+    }
+}
+
 /// Advisory architecture-support label for a **filename-guessed** architecture.
 /// An empty or unrecognized architecture is `"unknown"`, never `"not_implemented"`.
 fn guessed_arch_support(architecture: &str) -> &'static str {
-    if crate::model::is_implemented_architecture(architecture) {
+    if crate::model::is_implemented_architecture(loader_architecture_for_guess(architecture)) {
         "implemented"
     } else if architecture.is_empty() {
         "unknown"
@@ -18508,6 +18525,16 @@ fn exact_footprint_for(
         crate::fit::ADVISORY_CONTEXT_TOKENS,
         kv_dtype_for(hw),
     )
+}
+
+/// Whether `(repo_id, filename)` names a pinned curated row rather than an
+/// arbitrary Hugging Face file. Curated rows are the ones we vouch for and the
+/// only ones the coarse size pad is authorized for, so the on-demand fit check
+/// asks this before deciding whether an unmeasurable model still gets a verdict.
+fn is_curated_artifact(repo_id: &str, filename: &str) -> bool {
+    curated_catalog()
+        .iter()
+        .any(|item| item.repo_id == repo_id && item.filename == filename)
 }
 
 /// Footprint + confidence for a curated row: an **exact** footprint (weights + KV
@@ -20028,6 +20055,18 @@ async fn check_catalog_fit(Json(req): Json<CatalogFitRequest>) -> Response {
             crate::fit::assess(&hw, &exact_footprint_for(req.size_bytes, dims, &hw)),
             "exact",
         ),
+        // A curated row whose dimensions cannot be read is *listed* with the coarse
+        // size pad (see `curated_footprint`), so answering `Unknown` here would make
+        // "Re-check" erase a verdict the page already shows — on exactly the rows
+        // that need it, since "close some applications, then Re-check" is the remedy
+        // we print for them. Same rule as the listing, so the two cannot disagree.
+        None if is_curated_artifact(&req.repo_id, &req.filename) => (
+            crate::fit::assess(&hw, &crate::fit::advisory_footprint(req.size_bytes)),
+            "approx",
+        ),
+        // A live Hugging Face row gets no such pad: it is shown as `unknown` when
+        // unmeasured, and a size-based guess dressed as the result of an explicit
+        // check would be worse than the silence it replaced.
         None => (crate::fit::FitVerdict::Unknown, "unknown"),
     };
     Json(CatalogFitResponse {
@@ -21151,32 +21190,57 @@ mod catalog_fit_tests {
     #[test]
     fn arch_support_is_only_claimed_where_the_vocabulary_matches() {
         // Experimental rows: the architecture comes from `hf_browse::guess_architecture`,
-        // whose tokens are the same ones the loader allowlist tests, so both answers
-        // are usable.
+        // whose tokens are mapped onto the loader's vocabulary before the allowlist
+        // is consulted, so both answers are usable.
         assert_eq!(super::guessed_arch_support("qwen3"), "implemented");
         assert_eq!(super::guessed_arch_support("llama"), "implemented");
-        assert_eq!(super::guessed_arch_support("mixtral"), "not_implemented");
+        // REGRESSION: the guesser names a model FAMILY, the allowlist names a GGUF
+        // architecture. Mixtral GGUFs declare `llama`, and Camelid ships an
+        // evidence-backed `mixtral_8x7b_instruct_v0_1_q8_0` row — testing the family
+        // token directly folded every Mixtral repo into the "cannot run this" drawer.
+        assert_eq!(super::guessed_arch_support("mixtral"), "implemented");
+        assert_eq!(super::loader_architecture_for_guess("mixtral"), "llama");
+        // A family Camelid genuinely does not implement still reads as a negative.
+        assert_eq!(super::guessed_arch_support("mamba"), "not_implemented");
         // A guess that matched nothing is an absence of evidence and must NOT read
         // as a negative, or a UI filtering on it would hide models that load fine.
         assert_eq!(super::guessed_arch_support(""), "unknown");
     }
 
     #[test]
-    fn every_guessable_architecture_token_maps_to_a_definite_answer() {
-        // The helper is only sound while the browse guesser and the loader allowlist
-        // share a vocabulary. Pin that: every token `guess_architecture` can emit
-        // must resolve definitely, never to "unknown" (which would silently hide the
-        // row behind an "we could not tell" that is really "we did tell").
+    fn every_guessable_architecture_token_is_reported_loadable() {
+        // The helper is only sound while every token the browse guesser can emit maps
+        // onto something the loader recognizes. Pin that: a token that drifts out of
+        // the loader's vocabulary would silently hide its whole family behind a label
+        // claiming Camelid cannot run it.
         for token in [
             "llama", "mistral", "qwen2", "qwen3", "smollm3", "gemma3", "gemma4", "phi3", "lfm2",
             "mixtral",
         ] {
-            assert_ne!(
+            assert_eq!(
                 super::guessed_arch_support(token),
-                "unknown",
-                "browse can emit {token}, so it must resolve definitely"
+                "implemented",
+                "browse can emit {token}, and Camelid loads that family"
             );
         }
+    }
+
+    #[test]
+    fn only_curated_artifacts_are_recognized_for_the_size_pad() {
+        // The on-demand fit check falls back to the coarse pad for curated rows only,
+        // so this predicate decides whether an unmeasurable model keeps a verdict.
+        let curated = curated_catalog();
+        let row = curated.first().expect("catalog is non-empty");
+        assert!(super::is_curated_artifact(row.repo_id, row.filename));
+        // Right file, wrong repo (and vice versa) is not a curated row.
+        assert!(!super::is_curated_artifact(
+            "someone/elses-GGUF",
+            row.filename
+        ));
+        assert!(!super::is_curated_artifact(
+            row.repo_id,
+            "not-a-curated-file.gguf"
+        ));
     }
 
     #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1928,6 +1928,7 @@ pub fn router_with_state(state: AppState) -> Router {
         .route("/api/models/runnable-receipt", get(runnable_receipt))
         .route("/api/models/runnable-smoke", post(run_runnable_smoke))
         .route("/api/models/catalog", get(get_catalog))
+        .route("/api/models/catalog/fit", post(check_catalog_fit))
         .route("/api/models/catalog/install", post(install_catalog_model))
         .route("/api/models/catalog/downloads", get(get_catalog_downloads))
         .route("/api/models/catalog/cancel", post(cancel_catalog_download))
@@ -4657,24 +4658,31 @@ impl ResidentReclaim {
     }
 }
 
-/// The refusal for a `WontFit` verdict: a stable error code plus its message.
+/// The refusal for a load-blocking verdict: a stable error code plus its message.
 ///
 /// A host that is out of room *because something else is already loaded* is a
 /// different situation from a host that is too small for the model, and it has a
 /// different remedy (release the other model vs. pick a smaller one). Reporting
 /// both as `model_too_large_for_host` is what made the advisor dead-end: it told
 /// the operator the machine could not hold a model the machine plainly could.
+///
+/// There is a third case with a third remedy: nothing of ours is resident, the
+/// machine is big enough, but *other applications* have the memory right now
+/// (`FitVerdict::InsufficientFreeMemory`). Closing something is the fix, and saying
+/// "larger than this machine can hold" there is simply false.
 fn fit_preload_message(
     hw: &crate::capability::HardwareProfile,
     footprint: &crate::fit::FitInputs,
     size_bytes: u64,
     reclaim: Option<&ResidentReclaim>,
 ) -> Option<(&'static str, String)> {
-    if crate::fit::assess(hw, footprint) != crate::fit::FitVerdict::WontFit {
+    let verdict = crate::fit::assess(hw, footprint);
+    if !verdict.refuses_load() {
         return None;
     }
     let size_gb = size_bytes as f64 / 1e9;
-    // Something else is resident: name it, and point at the remedy that works.
+    // Something else of ours is resident: name it, and point at the remedy that
+    // works. Checked first because it is the most specific and most actionable.
     if let Some(r) = reclaim.filter(|r| !r.is_empty()) {
         let names = r.ids.join(", ");
         let freed = r.bytes as f64 / 1e9;
@@ -4685,6 +4693,20 @@ fn fit_preload_message(
                  Releasing it frees ~{freed:.1} GB, which should be enough. \
                  Retry with \"replace\": true to swap models in one step (the app's \
                  Load button does this), or POST /api/models/unload first."
+            ),
+        ));
+    }
+    // The machine is big enough; it is just busy. Do not send the user shopping
+    // for smaller models — tell them what is actually in the way.
+    if verdict == crate::fit::FitVerdict::InsufficientFreeMemory {
+        let free_gb = hw.host_ram_free_bytes as f64 / 1e9;
+        let total_gb = hw.host_ram_total_bytes as f64 / 1e9;
+        return Some((
+            "host_memory_unavailable",
+            format!(
+                "This model (~{size_gb:.1} GB) fits this machine, but only ~{free_gb:.1} GB \
+                 of ~{total_gb:.1} GB memory is free right now. Close some applications \
+                 and retry, or set CAMELID_SKIP_FIT_CHECK=1 to attempt the load anyway."
             ),
         ));
     }
@@ -4706,9 +4728,10 @@ fn fit_preload_message(
 /// memory and computes an **exact** footprint from the GGUF's real dimensions
 /// (weights + KV at a normal-use context + a bounded scratch margin) whenever the
 /// header parses, falling back to the coarse size pad otherwise. Returns a typed
-/// 422 only on a `WontFit` verdict; `None` (proceed unchanged) on the
-/// `CAMELID_SKIP_FIT_CHECK=1` override, a missing/zero-size file, or any
-/// `Fits*`/`Unknown` verdict — a fail-fast convenience, never a new hard gate.
+/// 422 only on a load-refusing verdict ([`crate::fit::FitVerdict::refuses_load`]);
+/// `None` (proceed unchanged) on the `CAMELID_SKIP_FIT_CHECK=1` override, a
+/// missing/zero-size file, or any `Fits*`/`Unknown` verdict — a fail-fast
+/// convenience, never a new hard gate.
 /// Whether the load-time fit preflight is overridden off. `CAMELID_SKIP_FIT_CHECK=1`
 /// restores the pre-advisor behavior: `POST /api/models/load` attempts the load
 /// unconditionally, letting the authoritative `VramShortfall`/`KvCache` guards be
@@ -18417,6 +18440,74 @@ pub struct CatalogItemView {
     /// real GGUF dimensions (KV cache sized precisely), `"approx"` when from the
     /// coarse size-based heuristic.
     pub fit_confidence: &'static str,
+    /// Whether Camelid implements this row's **guessed** architecture:
+    /// `"implemented"`, `"not_implemented"`, or `"unknown"`.
+    ///
+    /// Exists for exactly one job: letting the Models tab fold away live Hugging
+    /// Face results Camelid could never load. It is therefore only derived for
+    /// experimental rows, where `architecture` comes from
+    /// [`crate::hf_browse::guess_architecture`], whose token vocabulary is the same
+    /// one [`crate::model::is_implemented_architecture`] tests.
+    ///
+    /// **Curated rows always report `"unknown"`**, and that is a correctness
+    /// requirement, not laziness. `CatalogItem::architecture` is a curated *label*
+    /// whose vocabulary is not the loader's: the shipped catalog contains
+    /// `qwen25` (the loader knows `qwen2` and `qwen35`, not `qwen25`) and
+    /// `command-r`. Deriving from it stamped three working, pinned rows
+    /// `not_implemented` — a false negative on the rows we vouch for. Curated rows
+    /// are pinned and never filtered by this axis, so the honest answer is to make
+    /// no claim rather than a wrong one.
+    ///
+    /// Tri-state on purpose even for experimental rows: a confident
+    /// `"not_implemented"` is only reported when an architecture token was actually
+    /// recognized and sits outside the implemented set. When nothing matched we
+    /// report `"unknown"`. Collapsing this to a bool would make "we could not tell"
+    /// indistinguishable from "we know it cannot run", and a UI filtering on it
+    /// would silently hide loadable models.
+    ///
+    /// Advisory in every case: the authoritative architecture is read from GGUF
+    /// metadata at load time and is the only thing that gates a load.
+    pub arch_support: &'static str,
+}
+
+/// Advisory architecture-support label for a **filename-guessed** architecture.
+/// An empty or unrecognized architecture is `"unknown"`, never `"not_implemented"`.
+fn guessed_arch_support(architecture: &str) -> &'static str {
+    if crate::model::is_implemented_architecture(architecture) {
+        "implemented"
+    } else if architecture.is_empty() {
+        "unknown"
+    } else {
+        "not_implemented"
+    }
+}
+
+/// KV dtype the runtime will actually allocate on this host: f16 on the
+/// GPU-resident path, f32 on CPU. Mirrors the engine so the estimate matches what
+/// gets allocated rather than a nominal figure.
+fn kv_dtype_for(hw: &crate::capability::HardwareProfile) -> crate::fit::KvDtype {
+    if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
+        crate::fit::KvDtype::F16
+    } else {
+        crate::fit::KvDtype::F32
+    }
+}
+
+/// Exact footprint (weights + KV at the advisory context + bounded scratch) for a
+/// model whose real GGUF dimensions are known. Single definition shared by the
+/// curated badge, the experimental badge, and the on-demand fit check, so the three
+/// surfaces can never drift into disagreeing about the same model.
+fn exact_footprint_for(
+    size_bytes: u64,
+    dims: crate::fit::ModelDims,
+    hw: &crate::capability::HardwareProfile,
+) -> crate::fit::FitInputs {
+    crate::fit::exact_footprint(
+        size_bytes,
+        dims,
+        crate::fit::ADVISORY_CONTEXT_TOKENS,
+        kv_dtype_for(hw),
+    )
 }
 
 /// Footprint + confidence for a curated row: an **exact** footprint (weights + KV
@@ -18429,20 +18520,7 @@ fn curated_footprint(
     hw: &crate::capability::HardwareProfile,
 ) -> (crate::fit::FitInputs, &'static str) {
     match dims {
-        Some(dims) => {
-            let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
-                crate::fit::KvDtype::F16
-            } else {
-                crate::fit::KvDtype::F32
-            };
-            let fp = crate::fit::exact_footprint(
-                size_bytes,
-                dims,
-                crate::fit::ADVISORY_CONTEXT_TOKENS,
-                kv_dtype,
-            );
-            (fp, "exact")
-        }
+        Some(dims) => (exact_footprint_for(size_bytes, dims, hw), "exact"),
         None => (crate::fit::advisory_footprint(size_bytes), "approx"),
     }
 }
@@ -18473,6 +18551,9 @@ impl CatalogItemView {
             fit: crate::fit::assess(hw, &footprint),
             task_tags: item.task_tags.iter().map(|t| t.to_string()).collect(),
             fit_confidence,
+            // Deliberately no claim: see `arch_support`. The curated `architecture`
+            // label uses a different vocabulary from the loader's allowlist.
+            arch_support: "unknown",
         }
     }
 
@@ -18489,20 +18570,10 @@ impl CatalogItemView {
         let catalog_id = format!("hf::{}::{}", file.repo_id, file.filename);
         let (fit, fit_confidence) =
             match crate::fit_dims::global().lookup(&file.repo_id, &file.filename) {
-                Some(dims) => {
-                    let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
-                        crate::fit::KvDtype::F16
-                    } else {
-                        crate::fit::KvDtype::F32
-                    };
-                    let fp = crate::fit::exact_footprint(
-                        file.size_bytes,
-                        dims,
-                        crate::fit::ADVISORY_CONTEXT_TOKENS,
-                        kv_dtype,
-                    );
-                    (crate::fit::assess(hw, &fp), "exact")
-                }
+                Some(dims) => (
+                    crate::fit::assess(hw, &exact_footprint_for(file.size_bytes, dims, hw)),
+                    "exact",
+                ),
                 None => (crate::fit::FitVerdict::Unknown, "unknown"),
             };
         CatalogItemView {
@@ -18514,6 +18585,7 @@ impl CatalogItemView {
             downloads: file.downloads,
             likes: file.likes,
             quant: file.quant,
+            arch_support: guessed_arch_support(&file.architecture),
             architecture: file.architecture,
             license: String::new(),
             oracle_qualified: false,
@@ -18833,6 +18905,37 @@ pub struct CatalogQuery {
     /// Opaque Hugging Face pagination cursor for the experimental group (from a
     /// prior response's `next_cursor`). Ignored when `query` is absent/trivial.
     pub cursor: Option<String>,
+}
+
+/// Body of an on-demand capacity check for one live Hugging Face GGUF.
+#[derive(Debug, serde::Deserialize)]
+pub struct CatalogFitRequest {
+    pub repo_id: String,
+    pub filename: String,
+    /// The file's real size in bytes, from the browse result. Required: the header
+    /// parser validates tensor offsets against the model's true full length.
+    pub size_bytes: u64,
+}
+
+/// Result of an on-demand capacity check. Echoes the identity so a client that
+/// fired several checks can match responses to rows without tracking order.
+#[derive(Debug, serde::Serialize)]
+pub struct CatalogFitResponse {
+    pub repo_id: String,
+    pub filename: String,
+    pub fit: crate::fit::FitVerdict,
+    /// `"exact"` when the model's real GGUF dimensions were read, `"unknown"` when
+    /// they could not be (unreachable, or not a dense LLaMA-family model).
+    pub fit_confidence: &'static str,
+    /// Whether the check **settled**: `true` when there is nothing further to learn
+    /// by asking again (dimensions resolved, or a definitive negative), `false` when
+    /// the attempt failed for a reason a retry could fix.
+    ///
+    /// Without this a client cannot tell "we checked, and the answer is that we
+    /// cannot say" from "we have not checked yet" — both arrive as an `unknown`
+    /// verdict — so a "check this" affordance can never be retired and pressing it
+    /// looks like a no-op.
+    pub checked: bool,
 }
 
 /// One local on-disk GGUF with the facts the Models tab needs to bucket it by lane.
@@ -19852,6 +19955,71 @@ async fn get_catalog(
     }
 
     Json(CatalogResponse { items, next_cursor })
+}
+
+/// On-demand exact capacity check for one live Hugging Face GGUF.
+///
+/// A catalog page can only warm a handful of rows in the background
+/// (`HF_DIMS_WARM_LIMIT`), so most experimental rows render with no fit claim at
+/// all. That cap is invisible to the user, who just sees "unknown" and has no way
+/// to learn more about the one model they actually care about. This endpoint is
+/// that way: it range-fetches the model's GGUF header, derives its exact KV
+/// dimensions, and returns a real verdict for that row.
+///
+/// Never a guess. If the header cannot be fetched, or parses but is not a dense
+/// LLaMA-family model, the answer is `Unknown` with `"unknown"` confidence — the
+/// same thing the row already showed, not a size-based estimate dressed up as a
+/// check. `checked` then says whether that silence is final or worth retrying.
+/// Idempotent and cached: asking twice costs one fetch, and the request shares the
+/// resolver's global concurrency limit, dedup and backoff so it cannot be used to
+/// drive an unbounded fetch storm.
+async fn check_catalog_fit(Json(req): Json<CatalogFitRequest>) -> Response {
+    // Same bare-`.gguf`-name rule the download path enforces: this filename is
+    // interpolated into a Hub resolve URL.
+    if !validate_local_model_filename(&req.filename) {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_filename",
+            "filename must be one bare .gguf name".to_string(),
+            Some("filename"),
+        );
+    }
+    if !crate::fit_dims::is_safe_hf_component(&req.repo_id) {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_repo_id",
+            "repo_id must be a Hugging Face repository id".to_string(),
+            Some("repo_id"),
+        );
+    }
+    if req.size_bytes == 0 {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_size",
+            "size_bytes must be the file's real size in bytes".to_string(),
+            Some("size_bytes"),
+        );
+    }
+
+    let hw = crate::capability::HardwareProfile::cached();
+    let resolution = crate::fit_dims::global()
+        .resolve_now(req.repo_id.clone(), req.filename.clone(), req.size_bytes)
+        .await;
+    let (fit, fit_confidence) = match resolution.dims() {
+        Some(dims) => (
+            crate::fit::assess(hw, &exact_footprint_for(req.size_bytes, dims, hw)),
+            "exact",
+        ),
+        None => (crate::fit::FitVerdict::Unknown, "unknown"),
+    };
+    Json(CatalogFitResponse {
+        repo_id: req.repo_id,
+        filename: req.filename,
+        fit,
+        fit_confidence,
+        checked: resolution.is_settled(),
+    })
+    .into_response()
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -20960,6 +21128,202 @@ mod catalog_fit_tests {
             crate::fit::KvDtype::F32, // CPU host
         );
         assert_eq!(fp_exact, expected);
+    }
+
+    #[test]
+    fn arch_support_is_only_claimed_where_the_vocabulary_matches() {
+        // Experimental rows: the architecture comes from `hf_browse::guess_architecture`,
+        // whose tokens are the same ones the loader allowlist tests, so both answers
+        // are usable.
+        assert_eq!(super::guessed_arch_support("qwen3"), "implemented");
+        assert_eq!(super::guessed_arch_support("llama"), "implemented");
+        assert_eq!(super::guessed_arch_support("mixtral"), "not_implemented");
+        // A guess that matched nothing is an absence of evidence and must NOT read
+        // as a negative, or a UI filtering on it would hide models that load fine.
+        assert_eq!(super::guessed_arch_support(""), "unknown");
+    }
+
+    #[test]
+    fn every_guessable_architecture_token_maps_to_a_definite_answer() {
+        // The helper is only sound while the browse guesser and the loader allowlist
+        // share a vocabulary. Pin that: every token `guess_architecture` can emit
+        // must resolve definitely, never to "unknown" (which would silently hide the
+        // row behind an "we could not tell" that is really "we did tell").
+        for token in [
+            "llama", "mistral", "qwen2", "qwen3", "smollm3", "gemma3", "gemma4", "phi3", "lfm2",
+            "mixtral",
+        ] {
+            assert_ne!(
+                super::guessed_arch_support(token),
+                "unknown",
+                "browse can emit {token}, so it must resolve definitely"
+            );
+        }
+    }
+
+    #[test]
+    fn curated_rows_make_no_architecture_support_claim() {
+        // REGRESSION: deriving this from `CatalogItem::architecture` stamped three
+        // shipped, pinned rows `not_implemented` — the curated field is a display
+        // label (`qwen25`, `command-r`) whose vocabulary is not the loader's
+        // (`qwen2`, `qwen35`). A wrong negative on a row we vouch for is worse than
+        // no claim, and nothing filters curated rows on this axis.
+        let hw = host(false, 0, 64 * GIB, 48 * GIB);
+        for item in curated_catalog() {
+            let view = CatalogItemView::from_curated(&item, &hw);
+            assert_eq!(
+                view.arch_support, "unknown",
+                "curated row {} must not claim architecture support",
+                view.catalog_id
+            );
+        }
+        // The label that caused the false negative is still in the catalog, so this
+        // test keeps its teeth.
+        assert!(
+            curated_catalog()
+                .iter()
+                .any(|item| !crate::model::is_implemented_architecture(item.architecture)),
+            "expected at least one curated label outside the loader allowlist"
+        );
+    }
+
+    #[test]
+    fn a_busy_host_is_refused_without_being_called_too_small() {
+        // 64 GB machine with 2 GB free, asked for a ~4 GB model. It is refused (the
+        // load would be at risk), but telling the operator to buy a smaller model
+        // would be false: the machine is one of the biggest in the catalog's range.
+        let hw = host(false, 0, 64 * GIB, 2 * GIB);
+        let fp = crate::fit::advisory_footprint(4 * GIB);
+        let (code, msg) =
+            super::fit_preload_message(&hw, &fp, 4 * GIB, None).expect("refused -> message");
+        assert_eq!(code, "host_memory_unavailable");
+        assert!(msg.contains("free right now"), "{msg}");
+        assert!(msg.contains("Close some applications"), "{msg}");
+        assert!(!msg.contains("larger than this machine"), "{msg}");
+        // The override is still offered, exactly as for the too-large case.
+        assert!(msg.contains("CAMELID_SKIP_FIT_CHECK=1"), "{msg}");
+    }
+
+    #[test]
+    fn a_resident_model_still_takes_precedence_over_the_busy_host_wording() {
+        // Same busy host, but something of OURS is loaded. Releasing that is the
+        // specific remedy, so it must win over the generic "close applications".
+        let hw = host(false, 0, 64 * GIB, 2 * GIB);
+        let fp = crate::fit::advisory_footprint(4 * GIB);
+        let reclaim = super::ResidentReclaim {
+            ids: vec!["Qwen3-4B-Q8_0.gguf".to_string()],
+            bytes: 4 * GIB,
+        };
+        let (code, msg) = super::fit_preload_message(&hw, &fp, 4 * GIB, Some(&reclaim))
+            .expect("refused -> message");
+        assert_eq!(code, "model_requires_unload");
+        assert!(msg.contains("Qwen3-4B-Q8_0.gguf"), "{msg}");
+    }
+}
+
+/// HTTP-level checks for the on-demand catalog fit endpoint. These cover the
+/// input validation only: the resolve path needs the network, and a test that
+/// reached the Hub would be neither hermetic nor fast.
+#[cfg(test)]
+mod catalog_fit_endpoint_tests {
+    use super::{router_with_state, AppState};
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    async fn post_fit(body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+        let app = router_with_state(AppState::default());
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/models/catalog/fit")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (
+            status,
+            serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null),
+        )
+    }
+
+    async fn assert_rejected(body: serde_json::Value, code: &str) {
+        let (status, response) = post_fit(body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(response["error"]["code"], code);
+    }
+
+    #[tokio::test]
+    async fn the_filename_must_be_one_bare_gguf_name() {
+        // Both fields are interpolated into a Hub resolve URL, so traversal and
+        // nesting are rejected before any fetch is attempted.
+        assert_rejected(
+            serde_json::json!({
+                "repo_id": "unsloth/Phi-4-mini-instruct-GGUF",
+                "filename": "../../etc/passwd",
+                "size_bytes": 1024u64,
+            }),
+            "invalid_filename",
+        )
+        .await;
+        assert_rejected(
+            serde_json::json!({
+                "repo_id": "unsloth/Phi-4-mini-instruct-GGUF",
+                "filename": "nested/model.gguf",
+                "size_bytes": 1024u64,
+            }),
+            "invalid_filename",
+        )
+        .await;
+        assert_rejected(
+            serde_json::json!({
+                "repo_id": "unsloth/Phi-4-mini-instruct-GGUF",
+                "filename": "model.bin",
+                "size_bytes": 1024u64,
+            }),
+            "invalid_filename",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn the_repo_id_must_be_a_hugging_face_repository_id() {
+        assert_rejected(
+            serde_json::json!({
+                "repo_id": "unsloth/../secrets",
+                "filename": "model.gguf",
+                "size_bytes": 1024u64,
+            }),
+            "invalid_repo_id",
+        )
+        .await;
+        assert_rejected(
+            serde_json::json!({
+                "repo_id": "",
+                "filename": "model.gguf",
+                "size_bytes": 1024u64,
+            }),
+            "invalid_repo_id",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn a_zero_size_is_rejected_rather_than_fetched() {
+        // The header parser validates tensor offsets against the true full length,
+        // so a zero size could never produce an honest verdict.
+        assert_rejected(
+            serde_json::json!({
+                "repo_id": "unsloth/Phi-4-mini-instruct-GGUF",
+                "filename": "model.gguf",
+                "size_bytes": 0u64,
+            }),
+            "invalid_size",
+        )
+        .await;
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20001,13 +20001,31 @@ async fn check_catalog_fit(Json(req): Json<CatalogFitRequest>) -> Response {
         );
     }
 
-    let hw = crate::capability::HardwareProfile::cached();
+    // LIVE probe, deliberately not `HardwareProfile::cached()`.
+    //
+    // `cached()` is a `OnceLock` — memory is read once at startup and frozen for the
+    // process. The catalog LIST endpoint accepts that (re-probing per GET would
+    // re-init CUDA on every request, for every row). This endpoint is the opposite
+    // case: one explicit, user-initiated question about one model, which already
+    // costs a network header fetch.
+    //
+    // It is also a correctness requirement. The refusal this powers tells the user
+    // to free memory and check again; against a frozen snapshot that instruction
+    // would be a lie, because freeing memory could never change the answer. Probing
+    // live also makes a "fits" here agree with the authoritative load guard, which
+    // probes live too.
+    let hw = match tokio::task::spawn_blocking(crate::capability::HardwareProfile::detect).await {
+        Ok(profile) => profile,
+        // A panicking probe must not fail the request; fall back to the startup
+        // snapshot, which is still a real measurement of this machine.
+        Err(_) => crate::capability::HardwareProfile::cached().clone(),
+    };
     let resolution = crate::fit_dims::global()
         .resolve_now(req.repo_id.clone(), req.filename.clone(), req.size_bytes)
         .await;
     let (fit, fit_confidence) = match resolution.dims() {
         Some(dims) => (
-            crate::fit::assess(hw, &exact_footprint_for(req.size_bytes, dims, hw)),
+            crate::fit::assess(&hw, &exact_footprint_for(req.size_bytes, dims, &hw)),
             "exact",
         ),
         None => (crate::fit::FitVerdict::Unknown, "unknown"),

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -785,7 +785,11 @@ fn workspace_fit_rank(fit: crate::fit::FitVerdict) -> u8 {
         crate::fit::FitVerdict::FitsResident => 0,
         crate::fit::FitVerdict::FitsWithOffload | crate::fit::FitVerdict::CpuOnlyOk => 1,
         crate::fit::FitVerdict::Unknown => 2,
-        crate::fit::FitVerdict::WontFit => 3,
+        // Both refusals sort last. `InsufficientFreeMemory` is transient and could
+        // become runnable by freeing memory, but ranking it above a proven fit
+        // would put a currently-unloadable model ahead of one the user can start
+        // right now.
+        crate::fit::FitVerdict::InsufficientFreeMemory | crate::fit::FitVerdict::WontFit => 3,
     }
 }
 

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -51,6 +51,17 @@ pub enum FitVerdict {
     FitsWithOffload,
     /// No usable GPU, but the footprint fits the host RAM budget (CPU backend).
     CpuOnlyOk,
+    /// The footprint fits what this machine could offer **if nothing else were
+    /// resident**, but not what is free right now. The remedy is to free memory
+    /// (close applications, unload another model), not to pick a smaller model.
+    ///
+    /// Kept distinct from [`FitVerdict::WontFit`] because collapsing the two is a
+    /// factual error with a real cost: on a 16 GB host with 1.5 GB free, every row
+    /// down to a 1 GB model reported "too big for this machine", which is untrue and
+    /// reads as "this product does not work here". Both verdicts still refuse a load
+    /// (see [`FitVerdict::refuses_load`]) — the distinction is in the explanation,
+    /// never in the permission.
+    InsufficientFreeMemory,
     /// Exceeds every available budget on this host. The pick would fail at load or
     /// generation time; the UI should steer the user to a smaller/quantized row.
     WontFit,
@@ -66,6 +77,7 @@ impl FitVerdict {
             FitVerdict::FitsResident => "fits_resident",
             FitVerdict::FitsWithOffload => "fits_with_offload",
             FitVerdict::CpuOnlyOk => "cpu_only_ok",
+            FitVerdict::InsufficientFreeMemory => "insufficient_free_memory",
             FitVerdict::WontFit => "wont_fit",
             FitVerdict::Unknown => "unknown",
         }
@@ -74,12 +86,29 @@ impl FitVerdict {
     /// Whether the verdict says the model can run *somehow* on this host. `Unknown`
     /// is **not** runnable-negative — it is the absence of a claim — so it returns
     /// `false` here only in the sense of "no positive fit was proven". Callers that
-    /// must not block on unknowns should test `!= WontFit` instead.
+    /// must not block on unknowns should test [`FitVerdict::refuses_load`] instead.
     pub fn is_positive_fit(self) -> bool {
         matches!(
             self,
             FitVerdict::FitsResident | FitVerdict::FitsWithOffload | FitVerdict::CpuOnlyOk
         )
+    }
+
+    /// Whether a pre-load guard should refuse on this verdict. True for both
+    /// negative verdicts and false for every positive one **and** for `Unknown`
+    /// (an unprobed host must never be blocked on a claim we cannot make).
+    ///
+    /// This is the exact complement of "proceed" and exists so that adding a
+    /// negative verdict cannot silently widen what the load guard permits: a new
+    /// variant must be classified here or the match fails to compile.
+    pub fn refuses_load(self) -> bool {
+        match self {
+            FitVerdict::WontFit | FitVerdict::InsufficientFreeMemory => true,
+            FitVerdict::FitsResident
+            | FitVerdict::FitsWithOffload
+            | FitVerdict::CpuOnlyOk
+            | FitVerdict::Unknown => false,
+        }
     }
 
     /// Short human label for a CLI column or terse log. UI surfaces (WebUI) author
@@ -89,6 +118,7 @@ impl FitVerdict {
             FitVerdict::FitsResident => "fits",
             FitVerdict::FitsWithOffload => "fits (offload)",
             FitVerdict::CpuOnlyOk => "fits (CPU)",
+            FitVerdict::InsufficientFreeMemory => "needs free memory",
             FitVerdict::WontFit => "too big",
             FitVerdict::Unknown => "unknown",
         }
@@ -144,6 +174,36 @@ fn has_usable_gpu(hw: &HardwareProfile) -> bool {
     hw.cuda_available && hw.cuda_vram_free_bytes > 0
 }
 
+/// The host-RAM budget an *idle* machine would offer: the same
+/// [`USABLE_RAM_AVAILABLE_PERCENT`] policy applied to **total** rather than
+/// available RAM. `None` when RAM is unprobed.
+///
+/// This is diagnostic only — it explains why a footprint does not fit right now and
+/// never authorizes a load. [`usable_host_ram_bytes`] (available RAM, no floor)
+/// remains the sole capacity gate, so this cannot become an overcommit vector.
+fn idle_host_ram_bytes(hw: &HardwareProfile) -> Option<u64> {
+    if hw.host_ram_total_bytes == 0 {
+        return None;
+    }
+    Some(
+        hw.host_ram_total_bytes
+            .saturating_mul(USABLE_RAM_AVAILABLE_PERCENT)
+            / 100,
+    )
+}
+
+/// Classify a footprint that does not fit the *current* budget: transient pressure
+/// ([`FitVerdict::InsufficientFreeMemory`]) when an idle machine would have held it,
+/// otherwise a genuine [`FitVerdict::WontFit`]. `capacity_when_idle` is the matching
+/// idle budget for whichever branch (GPU-offload or CPU) is refusing.
+fn negative_verdict(footprint: u64, capacity_when_idle: u64) -> FitVerdict {
+    if footprint <= capacity_when_idle {
+        FitVerdict::InsufficientFreeMemory
+    } else {
+        FitVerdict::WontFit
+    }
+}
+
 /// Pure fit decision with an explicit VRAM headroom (in MiB), so the whole thing
 /// is deterministic and unit-testable without touching process env or a GPU.
 ///
@@ -151,9 +211,16 @@ fn has_usable_gpu(hw: &HardwareProfile) -> bool {
 /// 1. Usable GPU present → try VRAM-resident via [`crate::cuda_vram::evaluate`].
 ///    - Ok → [`FitVerdict::FitsResident`].
 ///    - Shortfall → offload: fits VRAM + usable host RAM → [`FitVerdict::FitsWithOffload`];
-///      RAM known but too small → [`FitVerdict::WontFit`]; RAM unknown → [`FitVerdict::Unknown`].
-/// 2. No usable GPU → fits host RAM → [`FitVerdict::CpuOnlyOk`]; too small →
-///    [`FitVerdict::WontFit`]; RAM unknown → [`FitVerdict::Unknown`].
+///      RAM known but too small → a negative verdict (see below); RAM unknown →
+///      [`FitVerdict::Unknown`].
+/// 2. No usable GPU → fits host RAM → [`FitVerdict::CpuOnlyOk`]; too small → a
+///    negative verdict; RAM unknown → [`FitVerdict::Unknown`].
+///
+/// Negative verdicts are split by [`negative_verdict`]: a footprint an *idle* host
+/// would have held is [`FitVerdict::InsufficientFreeMemory`], anything larger is
+/// [`FitVerdict::WontFit`]. Both refuse a load; only the explanation differs. The
+/// gate itself still reads **available** memory only, so the split cannot make the
+/// advisor optimistic.
 fn assess_with_headroom(hw: &HardwareProfile, m: &FitInputs, vram_headroom_mib: u64) -> FitVerdict {
     let footprint = m.footprint_bytes();
     let usable_ram = usable_host_ram_bytes(hw);
@@ -179,7 +246,14 @@ fn assess_with_headroom(hw: &HardwareProfile, m: &FitInputs, vram_headroom_mib: 
                     Some(ram) if footprint <= hw.cuda_vram_free_bytes.saturating_add(ram) => {
                         FitVerdict::FitsWithOffload
                     }
-                    Some(_) => FitVerdict::WontFit,
+                    // Idle capacity for the offload split is total VRAM plus the
+                    // idle host-RAM budget: what the machine could offer with
+                    // nothing else resident.
+                    Some(_) => negative_verdict(
+                        footprint,
+                        hw.cuda_vram_total_bytes
+                            .saturating_add(idle_host_ram_bytes(hw).unwrap_or(0)),
+                    ),
                     None => FitVerdict::Unknown,
                 };
             }
@@ -188,7 +262,7 @@ fn assess_with_headroom(hw: &HardwareProfile, m: &FitInputs, vram_headroom_mib: 
 
     match usable_ram {
         Some(ram) if footprint <= ram => FitVerdict::CpuOnlyOk,
-        Some(_) => FitVerdict::WontFit,
+        Some(_) => negative_verdict(footprint, idle_host_ram_bytes(hw).unwrap_or(0)),
         None => FitVerdict::Unknown,
     }
 }
@@ -407,14 +481,66 @@ mod tests {
     }
 
     #[test]
-    fn starved_host_wont_fit_despite_large_total_ram() {
+    fn starved_host_reports_insufficient_free_memory_not_wont_fit() {
         // 32 GB total but only 2 GB actually free. A PRE-LOAD advisor must NOT
         // floor up to 25% of total (8 GB) and claim a 3.4 GB model fits — the
         // weights are not resident yet, so that would overcommit and OOM the
-        // load. Conservative: budget = 80% of 2 GB = 1.6 GB → WontFit.
+        // load. Conservative: budget = 80% of 2 GB = 1.6 GB → refused.
+        //
+        // But the refusal reason matters: this machine plainly *can* hold a 3.4 GB
+        // model, it just cannot right now. Reporting "too big for this machine"
+        // here is false and tells the user to buy hardware they already own.
         let hw = profile(false, 0, 32 * GIB, 2 * GIB);
         let m = inputs(3_421_898_816, 256 * MIB);
+        let verdict = assess_with_headroom(&hw, &m, H);
+        assert_eq!(verdict, FitVerdict::InsufficientFreeMemory);
+        // The permission is unchanged — only the explanation differs.
+        assert!(!verdict.is_positive_fit());
+        assert!(verdict.refuses_load());
+    }
+
+    #[test]
+    fn freeing_memory_on_the_same_host_turns_the_refusal_into_a_fit() {
+        // Same host and same model as above, but idle: the verdict flips to a
+        // positive fit. This is what makes `InsufficientFreeMemory` the honest
+        // label rather than `WontFit` — the shortage is a state, not a property.
+        let m = inputs(3_421_898_816, 256 * MIB);
+        assert_eq!(
+            assess_with_headroom(&profile(false, 0, 32 * GIB, 2 * GIB), &m, H),
+            FitVerdict::InsufficientFreeMemory
+        );
+        assert_eq!(
+            assess_with_headroom(&profile(false, 0, 32 * GIB, 28 * GIB), &m, H),
+            FitVerdict::CpuOnlyOk
+        );
+    }
+
+    #[test]
+    fn a_model_bigger_than_the_whole_machine_stays_wont_fit_even_when_idle() {
+        // 8 GB host, fully idle (7.9 GB free), asked for a 40 GB model. Freeing
+        // memory cannot help, so the verdict must stay the permanent one.
+        let hw = profile(false, 0, 8 * GIB, 7 * GIB + 900 * MIB);
+        let m = inputs(40 * GIB, 512 * MIB);
         assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::WontFit);
+    }
+
+    #[test]
+    fn offload_shortfall_distinguishes_transient_pressure_from_a_small_host() {
+        // GPU too small for the footprint in both cases, so the offload branch
+        // decides. 8.5 GB model + 512 MiB KV = ~9.05 GB.
+        let m = inputs(8_541_283_552, 512 * MIB);
+        // 2 GB card + 32 GB host that is momentarily starved (1 GB free):
+        // idle capacity = 2 + 25.6 = 27.6 GB → transient.
+        assert_eq!(
+            assess_with_headroom(&profile(true, 2 * GIB, 32 * GIB, GIB), &m, H),
+            FitVerdict::InsufficientFreeMemory
+        );
+        // 2 GB card + a genuinely small 4 GB host: idle capacity = 2 + 3.2 =
+        // 5.2 GB → permanent.
+        assert_eq!(
+            assess_with_headroom(&profile(true, 2 * GIB, 4 * GIB, 3 * GIB), &m, H),
+            FitVerdict::WontFit
+        );
     }
 
     #[test]
@@ -476,13 +602,30 @@ mod tests {
         assert_eq!(FitVerdict::FitsResident.as_str(), "fits_resident");
         assert_eq!(FitVerdict::FitsWithOffload.as_str(), "fits_with_offload");
         assert_eq!(FitVerdict::CpuOnlyOk.as_str(), "cpu_only_ok");
+        assert_eq!(
+            FitVerdict::InsufficientFreeMemory.as_str(),
+            "insufficient_free_memory"
+        );
         assert_eq!(FitVerdict::WontFit.as_str(), "wont_fit");
         assert_eq!(FitVerdict::Unknown.as_str(), "unknown");
         assert!(FitVerdict::FitsResident.is_positive_fit());
         assert!(FitVerdict::FitsWithOffload.is_positive_fit());
         assert!(FitVerdict::CpuOnlyOk.is_positive_fit());
+        assert!(!FitVerdict::InsufficientFreeMemory.is_positive_fit());
         assert!(!FitVerdict::WontFit.is_positive_fit());
         assert!(!FitVerdict::Unknown.is_positive_fit());
+    }
+
+    #[test]
+    fn only_the_negative_verdicts_refuse_a_load() {
+        // An unprobed host must never be blocked: `Unknown` is the absence of a
+        // claim, not a negative one.
+        assert!(FitVerdict::WontFit.refuses_load());
+        assert!(FitVerdict::InsufficientFreeMemory.refuses_load());
+        assert!(!FitVerdict::Unknown.refuses_load());
+        assert!(!FitVerdict::FitsResident.refuses_load());
+        assert!(!FitVerdict::FitsWithOffload.refuses_load());
+        assert!(!FitVerdict::CpuOnlyOk.refuses_load());
     }
 
     #[test]

--- a/src/fit_dims.rs
+++ b/src/fit_dims.rs
@@ -61,6 +61,7 @@ fn now_secs() -> u64 {
 }
 
 /// Outcome of a single header fetch+parse.
+#[derive(Clone, Copy)]
 enum FetchOutcome {
     /// Parsed real dense dims.
     Resolved(ModelDims),
@@ -69,6 +70,45 @@ enum FetchOutcome {
     Unparseable,
     /// The fetch itself failed (offline, HTTP error, unsafe input). Retried later.
     FetchError,
+}
+
+/// The answer to an explicit "resolve this model's dimensions" request.
+///
+/// Distinguishing the two no-dims cases is load-bearing for any caller that offers
+/// the user a "check this" action. Collapsing them to `Option<ModelDims>` means a
+/// settled negative and a failed attempt are indistinguishable, so the action can
+/// never be retired and pressing it looks like a no-op — which is exactly what a
+/// flattened first version of this API produced in the Models tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DimsResolution {
+    /// Real dimensions, from a fresh fetch or the cache.
+    Resolved(ModelDims),
+    /// Settled negative: the header was fetched and parsed, and this is not a model
+    /// whose KV dimensions can be derived. Asking again cannot change the answer.
+    Unresolvable,
+    /// The attempt did not settle — offline, an HTTP error, rate-limited, remote
+    /// dims disabled, or another resolution for the same model already running.
+    /// A later attempt may succeed.
+    Retryable,
+}
+
+impl DimsResolution {
+    /// Whether the question is answered for good. `true` for a resolution **and**
+    /// for a settled negative; `false` only when retrying could still help.
+    pub fn is_settled(self) -> bool {
+        match self {
+            DimsResolution::Resolved(_) | DimsResolution::Unresolvable => true,
+            DimsResolution::Retryable => false,
+        }
+    }
+
+    /// The dimensions, if any were resolved.
+    pub fn dims(self) -> Option<ModelDims> {
+        match self {
+            DimsResolution::Resolved(dims) => Some(dims),
+            DimsResolution::Unresolvable | DimsResolution::Retryable => None,
+        }
+    }
 }
 
 /// A persisted cache entry. `dims: None` is a *negative* (fetched, parsed, but not a
@@ -246,6 +286,87 @@ impl DimsResolver {
     pub fn warm(&'static self, models: Vec<(String, String, u64)>) {
         for (repo, file, size) in models {
             self.schedule(repo, file, size);
+        }
+    }
+
+    /// Resolve one model's dims **now**, awaiting the header fetch.
+    ///
+    /// This is the explicit, user-initiated counterpart to [`schedule`](Self::schedule):
+    /// the background warm is bounded (a page can only ever warm a handful of rows),
+    /// so a user looking at a specific model needs a way to ask about *that* one.
+    /// It deliberately goes through the same [`should_fetch`](Self::should_fetch)
+    /// gate, permit pool, cache and backoff — an interactive check must not be able
+    /// to bypass the rate limit or re-fetch a known negative.
+    ///
+    /// The three-way [`DimsResolution`] is the point: a caller that only learns
+    /// "no dims" cannot tell a settled answer from a failed attempt, so a UI built
+    /// on it offers "check this" forever and the check appears to do nothing. See
+    /// [`DimsResolution::is_settled`].
+    pub async fn resolve_now(
+        &'static self,
+        repo_id: String,
+        filename: String,
+        size: u64,
+    ) -> DimsResolution {
+        let key = key_of(&repo_id, &filename);
+        // Already resolved, a fresh negative, backed off, in flight, or disabled:
+        // answer from the cache instead of issuing a duplicate fetch.
+        if !self.should_fetch(&key) {
+            return self.cached_resolution(&key);
+        }
+        {
+            let Ok(mut guard) = self.inner.lock() else {
+                return DimsResolution::Retryable;
+            };
+            if !guard.in_flight.insert(key.clone()) {
+                // Another resolution for this exact model is already running; its
+                // result will be cached, so this caller should simply ask again.
+                return DimsResolution::Retryable;
+            }
+        }
+        // Held across the await and the record below, so the slot is released
+        // however this returns — including a cancelled request future.
+        let _slot = InFlightGuard {
+            resolver: self,
+            key: key.clone(),
+        };
+        let Ok(permit) = Arc::clone(&self.permits).acquire_owned().await else {
+            return DimsResolution::Retryable;
+        };
+        let fetched = tokio::task::spawn_blocking(move || {
+            let outcome = fetch_header_dims(&repo_id, &filename, size);
+            drop(permit);
+            outcome
+        })
+        .await;
+        let Ok(outcome) = fetched else {
+            return DimsResolution::Retryable;
+        };
+        self.record(&key, outcome);
+        match outcome {
+            FetchOutcome::Resolved(dims) => DimsResolution::Resolved(dims),
+            // Fetched and parsed, but not a model we can size. Re-asking cannot help.
+            FetchOutcome::Unparseable => DimsResolution::Unresolvable,
+            FetchOutcome::FetchError => DimsResolution::Retryable,
+        }
+    }
+
+    /// The resolution implied by the cache alone, for the paths that must not
+    /// fetch. A fresh entry is final either way (dims, or a known negative);
+    /// anything else — expired, absent, in flight, backed off, disabled — is a
+    /// state a later attempt could change.
+    fn cached_resolution(&self, key: &str) -> DimsResolution {
+        let Ok(guard) = self.inner.lock() else {
+            return DimsResolution::Retryable;
+        };
+        match guard.entries.get(key) {
+            Some(entry) if now_secs().saturating_sub(entry.fetched_at) <= ENTRY_TTL_SECS => {
+                match entry.dims {
+                    Some(dims) => DimsResolution::Resolved(dims),
+                    None => DimsResolution::Unresolvable,
+                }
+            }
+            _ => DimsResolution::Retryable,
         }
     }
 
@@ -816,6 +937,57 @@ mod tests {
                 kv_heads: 2,
                 head_dim: 64
             })
+        );
+    }
+
+    #[test]
+    fn a_settled_negative_is_distinguishable_from_a_failed_attempt() {
+        // This distinction is the whole reason `resolve_now` does not return
+        // `Option<ModelDims>`. A caller that only sees "no dims" cannot retire a
+        // "check this" affordance, so pressing it looks like a no-op forever.
+        let resolver = global();
+        let dims = ModelDims {
+            layers: 8,
+            kv_heads: 2,
+            head_dim: 64,
+        };
+
+        // Nothing cached: a later attempt could still succeed.
+        let unknown = key_of("test-fitdims/resolution", "never-seen.gguf");
+        assert_eq!(
+            resolver.cached_resolution(&unknown),
+            DimsResolution::Retryable
+        );
+        assert!(!DimsResolution::Retryable.is_settled());
+        assert_eq!(DimsResolution::Retryable.dims(), None);
+
+        // A cached NEGATIVE (fetched, parsed, not a model we can size) is final.
+        let negative = key_of("test-fitdims/resolution", "negative.gguf");
+        resolver.record(&negative, FetchOutcome::Unparseable);
+        assert_eq!(
+            resolver.cached_resolution(&negative),
+            DimsResolution::Unresolvable
+        );
+        assert!(DimsResolution::Unresolvable.is_settled());
+        assert_eq!(DimsResolution::Unresolvable.dims(), None);
+
+        // A cached POSITIVE is final too, and carries the dims.
+        let positive = key_of("test-fitdims/resolution", "positive.gguf");
+        resolver.record(&positive, FetchOutcome::Resolved(dims));
+        assert_eq!(
+            resolver.cached_resolution(&positive),
+            DimsResolution::Resolved(dims)
+        );
+        assert!(DimsResolution::Resolved(dims).is_settled());
+        assert_eq!(DimsResolution::Resolved(dims).dims(), Some(dims));
+
+        // A transient fetch error must NOT be cached as a negative: it only backs
+        // off, so the question stays open and the caller may retry.
+        let transient = key_of("test-fitdims/resolution", "transient.gguf");
+        resolver.record(&transient, FetchOutcome::FetchError);
+        assert_eq!(
+            resolver.cached_resolution(&transient),
+            DimsResolution::Retryable
         );
     }
 

--- a/src/hf_browse.rs
+++ b/src/hf_browse.rs
@@ -84,7 +84,7 @@ pub async fn search_gguf(
     limit: usize,
     cursor: Option<&str>,
 ) -> anyhow::Result<HfSearchPage> {
-    let key = cache_key(query, cursor);
+    let key = cache_key(query, limit, cursor);
     if let Some(hit) = search_cache().get(&key, Instant::now()) {
         return Ok(hit);
     }
@@ -99,10 +99,12 @@ pub async fn search_gguf(
     Ok(page)
 }
 
-/// Cache identity for a page. The NUL separator cannot appear in a URL-safe cursor
-/// or a user query, so `("a", Some("b"))` can never collide with `("a\0b", None)`.
-fn cache_key(query: &str, cursor: Option<&str>) -> String {
-    format!("{query}\u{0}{}", cursor.unwrap_or_default())
+/// Cache identity for a page. `limit` is part of it because it bounds how many
+/// repos the page inspects: serving a 5-repo page to a caller that asked for 15
+/// would silently truncate results. The NUL separators cannot appear in a URL-safe
+/// cursor or a user query, so no two distinct triples can collide.
+fn cache_key(query: &str, limit: usize, cursor: Option<&str>) -> String {
+    format!("{query}\u{0}{limit}\u{0}{}", cursor.unwrap_or_default())
 }
 
 /// Bounded, TTL'd page cache. Insertion-ordered `Vec` rather than a `HashMap` +
@@ -540,10 +542,15 @@ mod tests {
     }
 
     #[test]
-    fn cache_key_separates_query_from_cursor() {
-        // Without a separator, ("a\0b", None) and ("a", Some("b")) would collide.
-        assert_ne!(cache_key("a\u{0}b", None), cache_key("a", Some("b")));
-        assert_eq!(cache_key("phi", None), cache_key("phi", Some("")));
+    fn cache_key_separates_query_limit_and_cursor() {
+        // Without separators, ("a\0b", None) and ("a", Some("b")) would collide.
+        assert_ne!(
+            cache_key("a\u{0}b", 15, None),
+            cache_key("a", 15, Some("b"))
+        );
+        assert_eq!(cache_key("phi", 15, None), cache_key("phi", 15, Some("")));
+        // A page sized for 15 repos must not be served to a caller asking for 5.
+        assert_ne!(cache_key("phi", 15, None), cache_key("phi", 5, None));
     }
 
     #[test]

--- a/src/hf_browse.rs
+++ b/src/hf_browse.rs
@@ -11,8 +11,41 @@
 //! HTTP egress reuses the same `curl` subprocess pattern as `catalog.rs` (no new
 //! dependency); every call tolerates offline by returning a typed error rather than
 //! panicking, so the catalog endpoint can degrade to curated-only.
+//!
+//! Latency is the design constraint here: one search is 1 repo-search round-trip
+//! plus one file-tree round-trip *per repo*. Serially that is
+//! `1 + HF_SEARCH_LIMIT` sequential requests (measured ~5.3 s for 15 repos), which
+//! reads to the user as a hung UI. Two bounded mitigations, both dependency-free:
+//! the per-repo trees are fetched by a small scoped thread pool
+//! ([`REPO_FETCH_CONCURRENCY`]), and identical `(query, cursor)` pages are served
+//! from a short-lived in-process cache ([`SEARCH_CACHE_TTL`]) so retyping,
+//! back-navigation, and two clients on the same box do not re-pay the round-trips.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Number of repo file-tree requests in flight at once. Each is an independent
+/// `curl` subprocess blocked on network IO, so this trades a handful of short-lived
+/// threads for a near-linear latency reduction. Kept small deliberately: the Hub
+/// rate-limits, and a page only ever inspects `HF_SEARCH_LIMIT` repos.
+const REPO_FETCH_CONCURRENCY: usize = 8;
+
+/// curl connect timeout — a stalled TCP/TLS handshake must not pin a worker thread.
+const CONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// curl overall timeout — a slow or hung transfer must release its worker in bounded
+/// time. One repo timing out costs that repo's files, never the whole page.
+const REQUEST_MAX_TIME_SECS: u64 = 30;
+
+/// How long a fetched page stays servable. Short on purpose: the Hub is live data
+/// and a stale catalog would be a correctness problem, but a human refining a query
+/// (or re-opening the tab) acts well inside this window.
+const SEARCH_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Max cached pages. Bounds memory for a pathological typist; oldest evicted first.
+const SEARCH_CACHE_MAX_ENTRIES: usize = 32;
 
 /// One GGUF file discovered on the Hub. `size_bytes` is the real content size
 /// (LFS-aware). `architecture`/`quant` are filename guesses — advisory only, empty
@@ -42,17 +75,89 @@ pub struct HfSearchPage {
 /// `*.gguf` files with real sizes. `limit` bounds the number of repos inspected;
 /// `cursor` resumes a previous page. Network failure → typed `Err` (never panic),
 /// so callers can fall back to curated-only.
+///
+/// Identical `(query, cursor)` pages are served from the in-process cache for
+/// [`SEARCH_CACHE_TTL`]. Only successes are cached — an offline blip must not pin a
+/// failure for a minute.
 pub async fn search_gguf(
     query: &str,
     limit: usize,
     cursor: Option<&str>,
 ) -> anyhow::Result<HfSearchPage> {
+    let key = cache_key(query, cursor);
+    if let Some(hit) = search_cache().get(&key, Instant::now()) {
+        return Ok(hit);
+    }
     let query = query.to_string();
     let cursor = cursor.map(|c| c.to_string());
     // curl is blocking; keep it off the async executor.
-    tokio::task::spawn_blocking(move || search_gguf_blocking(&query, limit, cursor.as_deref()))
-        .await
-        .map_err(|err| anyhow::anyhow!("hugging face search task panicked: {err}"))?
+    let page =
+        tokio::task::spawn_blocking(move || search_gguf_blocking(&query, limit, cursor.as_deref()))
+            .await
+            .map_err(|err| anyhow::anyhow!("hugging face search task panicked: {err}"))??;
+    search_cache().insert(key, page.clone(), Instant::now());
+    Ok(page)
+}
+
+/// Cache identity for a page. The NUL separator cannot appear in a URL-safe cursor
+/// or a user query, so `("a", Some("b"))` can never collide with `("a\0b", None)`.
+fn cache_key(query: &str, cursor: Option<&str>) -> String {
+    format!("{query}\u{0}{}", cursor.unwrap_or_default())
+}
+
+/// Bounded, TTL'd page cache. Insertion-ordered `Vec` rather than a `HashMap` +
+/// separate ordering structure: at [`SEARCH_CACHE_MAX_ENTRIES`] a linear scan is
+/// cheaper than the bookkeeping, and eviction is a single `remove(0)`.
+#[derive(Default)]
+struct SearchCache {
+    entries: Mutex<Vec<CacheEntry>>,
+}
+
+struct CacheEntry {
+    key: String,
+    stored_at: Instant,
+    page: HfSearchPage,
+}
+
+impl SearchCache {
+    /// The cached page for `key` if it has not expired as of `now`. Expired entries
+    /// are dropped on the way past, so the cache self-trims without a timer.
+    ///
+    /// `now` is a parameter rather than read from the clock so expiry and eviction
+    /// are deterministically testable.
+    fn get(&self, key: &str, now: Instant) -> Option<HfSearchPage> {
+        let mut entries = self.lock();
+        entries.retain(|e| now.duration_since(e.stored_at) < SEARCH_CACHE_TTL);
+        entries
+            .iter()
+            .find(|e| e.key == key)
+            .map(|e| e.page.clone())
+    }
+
+    /// Store `page` under `key`, replacing any previous entry for the same key and
+    /// evicting the oldest entries past [`SEARCH_CACHE_MAX_ENTRIES`].
+    fn insert(&self, key: String, page: HfSearchPage, now: Instant) {
+        let mut entries = self.lock();
+        entries.retain(|e| e.key != key && now.duration_since(e.stored_at) < SEARCH_CACHE_TTL);
+        entries.push(CacheEntry {
+            key,
+            stored_at: now,
+            page,
+        });
+        let overflow = entries.len().saturating_sub(SEARCH_CACHE_MAX_ENTRIES);
+        entries.drain(..overflow);
+    }
+
+    /// A poisoned cache mutex must not take down a search: recover the guard and
+    /// carry on (the worst case is a stale-but-bounded entry).
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<CacheEntry>> {
+        self.entries.lock().unwrap_or_else(|err| err.into_inner())
+    }
+}
+
+fn search_cache() -> &'static SearchCache {
+    static CACHE: OnceLock<SearchCache> = OnceLock::new();
+    CACHE.get_or_init(SearchCache::default)
 }
 
 struct RepoMeta {
@@ -101,16 +206,53 @@ fn search_gguf_blocking(
         })
         .unwrap_or_default();
 
-    // 2. For each repo, read its file tree for the real `*.gguf` sizes. One repo
-    //    failing (private, renamed, transient) must not drop the whole page.
-    let mut files = Vec::new();
-    for repo in &repos {
-        if let Ok(mut repo_files) = repo_gguf_files(repo) {
-            files.append(&mut repo_files);
-        }
-    }
+    // 2. For each repo, read its file tree for the real `*.gguf` sizes.
+    let files = fetch_repo_files_parallel(&repos);
 
     Ok(HfSearchPage { files, next_cursor })
+}
+
+/// Fetch every repo's file tree with at most [`REPO_FETCH_CONCURRENCY`] requests in
+/// flight, preserving the Hub's repo ordering in the output.
+///
+/// Ordering matters: the Hub returns repos in relevance order and the Models tab
+/// renders them in the order received, so this is the ranking. Workers therefore
+/// tag their results with the repo index and the page is re-sorted before flatten;
+/// completion order never leaks into the UI.
+///
+/// One repo failing (private, renamed, rate-limited, timed out) drops only that
+/// repo's files, never the page — same tolerance the sequential version had.
+fn fetch_repo_files_parallel(repos: &[RepoMeta]) -> Vec<HfGgufFile> {
+    if repos.is_empty() {
+        return Vec::new();
+    }
+    let worker_count = REPO_FETCH_CONCURRENCY.min(repos.len());
+    let next = AtomicUsize::new(0);
+    let collected: Mutex<Vec<(usize, Vec<HfGgufFile>)>> =
+        Mutex::new(Vec::with_capacity(repos.len()));
+
+    std::thread::scope(|scope| {
+        for _ in 0..worker_count {
+            scope.spawn(|| loop {
+                let index = next.fetch_add(1, Ordering::Relaxed);
+                let Some(repo) = repos.get(index) else {
+                    break;
+                };
+                let Ok(files) = repo_gguf_files(repo) else {
+                    continue;
+                };
+                if let Ok(mut out) = collected.lock() {
+                    out.push((index, files));
+                }
+            });
+        }
+    });
+
+    let mut collected = collected
+        .into_inner()
+        .unwrap_or_else(|err| err.into_inner());
+    collected.sort_unstable_by_key(|(index, _)| *index);
+    collected.into_iter().flat_map(|(_, files)| files).collect()
 }
 
 /// Enumerate the top-level `*.gguf` files in a repo with LFS-aware sizes, mirroring
@@ -162,11 +304,22 @@ fn repo_gguf_files(repo: &RepoMeta) -> anyhow::Result<Vec<HfGgufFile>> {
 
 /// Run `curl -fsSL <url>` returning `(body, raw_response_headers)`. Headers are
 /// dumped to a temp file (`-D`) so the body stays clean JSON regardless of
-/// redirects. Offline / HTTP error → typed `Err`.
+/// redirects. Offline / HTTP error / timeout → typed `Err`.
+///
+/// The timeouts are load-bearing, not defensive dressing: these calls run on a
+/// fixed-size worker pool, so an untimed hung connection would retire a worker for
+/// the life of the process and eventually starve every search.
 fn curl_get_with_headers(url: &str) -> anyhow::Result<(Vec<u8>, String)> {
     let header_path = unique_temp_path("camelid-hf-hdr");
     let output = std::process::Command::new("curl")
-        .args(["-fsSL", "-D"])
+        .args([
+            "-fsSL",
+            "--connect-timeout",
+            &CONNECT_TIMEOUT_SECS.to_string(),
+            "--max-time",
+            &REQUEST_MAX_TIME_SECS.to_string(),
+            "-D",
+        ])
         .arg(&header_path)
         .arg(url)
         .output()
@@ -364,5 +517,74 @@ mod tests {
             parse_next_cursor("HTTP/2 200\r\ncontent-type: application/json\r\n"),
             None
         );
+    }
+
+    /// A one-file page tagged by `marker`, so tests can tell cached pages apart.
+    fn page(marker: &str) -> HfSearchPage {
+        HfSearchPage {
+            files: vec![HfGgufFile {
+                repo_id: format!("owner/{marker}"),
+                filename: format!("{marker}.gguf"),
+                size_bytes: 1,
+                downloads: 0,
+                likes: 0,
+                architecture: String::new(),
+                quant: String::new(),
+            }],
+            next_cursor: None,
+        }
+    }
+
+    fn only_repo(page: &HfSearchPage) -> &str {
+        &page.files[0].repo_id
+    }
+
+    #[test]
+    fn cache_key_separates_query_from_cursor() {
+        // Without a separator, ("a\0b", None) and ("a", Some("b")) would collide.
+        assert_ne!(cache_key("a\u{0}b", None), cache_key("a", Some("b")));
+        assert_eq!(cache_key("phi", None), cache_key("phi", Some("")));
+    }
+
+    #[test]
+    fn cache_serves_a_hit_within_the_ttl_and_expires_after_it() {
+        let cache = SearchCache::default();
+        let t0 = Instant::now();
+        cache.insert("phi".to_string(), page("a"), t0);
+
+        let fresh = cache.get("phi", t0 + SEARCH_CACHE_TTL - Duration::from_millis(1));
+        assert_eq!(only_repo(&fresh.expect("within ttl")), "owner/a");
+
+        assert!(cache.get("phi", t0 + SEARCH_CACHE_TTL).is_none());
+        assert!(cache.get("qwen", t0).is_none());
+    }
+
+    #[test]
+    fn cache_replaces_rather_than_duplicates_the_same_key() {
+        let cache = SearchCache::default();
+        let t0 = Instant::now();
+        cache.insert("phi".to_string(), page("old"), t0);
+        cache.insert("phi".to_string(), page("new"), t0 + Duration::from_secs(1));
+
+        assert_eq!(cache.lock().len(), 1);
+        let hit = cache.get("phi", t0 + Duration::from_secs(1)).expect("hit");
+        assert_eq!(only_repo(&hit), "owner/new");
+    }
+
+    #[test]
+    fn cache_evicts_the_oldest_entries_past_the_cap() {
+        let cache = SearchCache::default();
+        let t0 = Instant::now();
+        for i in 0..SEARCH_CACHE_MAX_ENTRIES + 3 {
+            cache.insert(format!("q{i}"), page(&format!("m{i}")), t0);
+        }
+        assert_eq!(cache.lock().len(), SEARCH_CACHE_MAX_ENTRIES);
+        // The three oldest keys are gone; the newest survive.
+        assert!(cache.get("q0", t0).is_none());
+        assert!(cache.get("q2", t0).is_none());
+        assert!(cache.get("q3", t0).is_some());
+        assert!(cache
+            .get(&format!("q{}", SEARCH_CACHE_MAX_ENTRIES + 2), t0)
+            .is_some());
     }
 }


### PR DESCRIPTION
## Problem, measured

The Models tab's Hugging Face browse was measurably unusable. Numbers taken on a live server before this change:

| | before |
|---|---|
| one search | **5,280 ms** |
| the *same* search again | **4,746 ms** (no cache) |
| loading indicator during those 5+ s | **none** — no spinner, no `aria-busy`, stale rows left on screen |
| rows rendered for "qwen" | **279**, from only **15 repos** |
| page scroll height | **64,067 px** (3,919 DOM nodes) |
| HF rows with any fit claim | **5 of 150** |
| curated rows reading "Too big for this machine" | **17 of 21**, on an idle 16 GB host with **nothing loaded**, including a 1.71 GB model |

Four separate causes, fixed separately.

---

## Visual evidence

Captured on one machine at one window size, from two real builds: the **before** shots are served by the pre-change binary, the **after** shots by this branch's binary. Full set on [`evidence/pr517-screenshots`](https://github.com/karan68/Camelid/tree/evidence/pr517-screenshots/shots).

### 1. One search result = one card, not one card per file

A repo is one model; its `.gguf` files are size/quality variants of the same weights. One repo routinely ships 20–27 of them, so 15 repos rendered as 279 rows. Note the before shot: `Q2_K` and `Q2_K_L` of the **same model** are two separate full-size cards, titled by raw filename, each repeating the same three-line disclaimer.

| Before — 151 flat file rows | After — 15 model cards |
|---|---|
| ![before](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/before-02-search-phi.png) | ![after](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/after-02-search-phi.png) |

Same query (`phi`), same viewport. Measured: **36,804 px → 3,292 px** of scroll, **2,175 → 761** DOM nodes.

### 2. Quantization is now a decision the user is helped with

Previously the only way to choose between `Q2_K`, `IQ3_XXS`, `Q4_K_M`, `Q6_K` … was to already know what they mean. Ordered by fidelity, each with a plain-language note, preselecting the best variant with a **proven** fit:

![quant picker](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/after-06-quant-list.png)

### 3. "Too big for this machine" was often false

Same machine, same model, nothing loaded. The before verdict is a dead end with no action; the after verdict names the real cause and offers the one thing that helps.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/before-04-row-detail.png) | ![after](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/after-04-row-detail.png) |

Across the landing view that **17-of-21 red became 1** — Cohere Command R at 34 GB, correctly.

| Before — landing | After — landing |
|---|---|
| ![before](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/before-01-landing.png) | ![after](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/after-01-landing.png) |

### 4. Architectures Camelid cannot load stop competing for the first screen

`mixtral` returns 185 files across 15 repos, none of which Camelid implements. Before: 185 full rows to scroll past. After: all folded away, with the count stated rather than a false "nothing matched".

| Before — 185 rows | After — collapsed |
|---|---|
| ![before](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/before-03-search-mixtral.png) | ![after](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/after-03-search-mixtral.png) |

Measured: **46,833 px → 399 px**.

### 5. A search now looks like work, not like a hang

There was no loading state at all — the previous results simply sat there for 5+ seconds. Now: skeleton rows plus `aria-busy`.

![skeleton](https://raw.githubusercontent.com/karan68/Camelid/evidence/pr517-screenshots/shots/after-07-loading-skeleton.png)

---

## 1. Latency was self-inflicted

`hf_browse` fetched each repo's file tree in a sequential loop — one search call plus one per repo. Measured `438 ms + 15 × 358 ms`, which is the 5.3 s almost exactly.

Those fetches now run on a bounded scoped thread pool (`REPO_FETCH_CONCURRENCY = 8`) that **preserves the Hub's repo ordering**, because that ordering *is* the relevance ranking — workers tag results with the repo index and the page is re-sorted before flattening, so completion order never leaks into the UI.

`curl` gained `--connect-timeout` / `--max-time`. That is load-bearing, not defensive dressing: on a fixed-size pool an untimed hung connection would retire a worker for the life of the process and eventually starve every search.

Identical `(query, cursor)` pages are served from a bounded 60 s in-process cache. Only successes are cached, so an offline blip cannot pin a failure for a minute.

**Measured after: 1,225 ms cold, 9 ms warm.**

## 2. Grouping, and what it replaced

The API still returns files (a file is what you download); grouping is presentation only, and the download confirmation still names the exact file. Card titles are model names instead of raw `.gguf` filenames. The per-row "unverified" paragraph that repeated on all 150 rows is now a section marker plus a tooltip on the guessed value.

Also added: an `AbortController` so a superseded search stops holding a Hub connection and a server-side worker, and a 500 ms debounce (a search costs real round-trips even warm, so a shorter one only queues work the next keystroke discards).

## 3. Honest fit

`FitVerdict` gains `InsufficientFreeMemory`, separating *this machine is too small* from *this machine is busy right now*.

The capacity gate is **unchanged** — `usable_host_ram_bytes` still reads **available** memory only, exactly as documented, so this cannot make the advisor optimistic. The idle figure is used solely to choose the explanation.

`FitVerdict::refuses_load()` replaces the `!= WontFit` comparisons in the load guard, so adding a negative verdict now fails to compile unless it is classified — the guard cannot silently widen.

`POST /api/models/load` gains a third refusal code, **`host_memory_unavailable`**, naming the free/total figures and saying to close applications. `model_requires_unload` still takes precedence when something of *ours* is resident, since that is the more specific remedy.

## 4. "Unknown" was a dead end

`HF_DIMS_WARM_LIMIT` caps background header fetches at 5 per search, so 145 of 150 rows had no fit claim and no way to ask for one.

**`POST /api/models/catalog/fit`** resolves one model's real GGUF dimensions on demand, through the *same* permit pool, dedup, cache and backoff as the background warm — an interactive check cannot bypass the rate limit or re-fetch a known negative. Filename and repo id are validated with the rules the download path already uses before either is interpolated into a Hub URL.

It **probes host memory live** (on the blocking pool), deliberately not `HardwareProfile::cached()`, which is a `OnceLock` frozen at startup. That is a correctness requirement, not an optimisation: the refusal this powers tells the user to free memory and check again, and against a frozen snapshot that instruction would be a lie. It also makes a "fits" here agree with the authoritative load guard, which probes live too. Rows showing the transient verdict — curated and Hugging Face alike — carry a **Re-check** button; `fitIsRecheckable()` withholds it from `wont_fit`, where freeing memory cannot help.

It returns **`checked`** because the first cut of this endpoint shipped a defect caught in browser testing: pressing "Check if it fits" on an unresolvable model returned `unknown` in **14 ms** from a cached negative, and the row went straight back to offering the same button. `resolve_now` therefore returns `DimsResolution { Resolved | Unresolvable | Retryable }` rather than `Option<ModelDims>` — a *settled negative* and a *failed attempt* are different facts, and any caller offering a "check this" action needs to tell them apart or it can never retire the action.

## `arch_support`, and a bug this caught

`CatalogItemView` gains `arch_support` (`implemented` / `not_implemented` / `unknown`), derived **only for live Hugging Face rows**. Curated rows always report `unknown`, and that is a correctness requirement rather than laziness: `CatalogItem::architecture` is a curated *display label* whose vocabulary is not the loader's allowlist — the shipped catalog carries `qwen25` (the loader knows `qwen2` and `qwen35`) and `command-r`. My first version derived from it and stamped **three working, pinned rows** `not_implemented`. Live rows use `hf_browse::guess_architecture`, whose tokens *are* the ones `is_implemented_architecture` tests, and a regression test pins that alignment so it cannot drift.

The tri-state is deliberate: "we could not tell" must not be indistinguishable from "we know it cannot run", or a UI filtering on it would silently hide loadable models.

**Also fixed while here:** the download-and-start chain gated on `fit !== 'wont_fit'`, so an `insufficient_free_memory` row would have chained into a load the 422 guard rejects. It now gates on the full refusal set — and CI's own source-pinned assertion caught the change, so it is re-pinned to the stronger form plus a new assertion that the gate derives from `isRefusingFit`.

## Validation

- `cargo test --lib` — **1216 passed, 0 failed**.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- All nine frontend steps CI runs pass locally: `build`, `model-state`, `model-lanes`, `catalog-activation`, `model-deletion`, `3b-closure`, `integration`, `catalog-browse`, `ui`.
- New `frontend/scripts/catalog-browse-smoke.mjs` covers quant ordering and advice, repo grouping and titles, the default-quantization rules, the architecture partition keeping `unknown` visible, and the unchecked/settled/retryable split. It is imported by `ui-regression-smoke.mjs` so CI gates it.
- Browser-tested against a live server over **19 queries**: `phi`, `qwen`, `llama`, `gemma`, `mistral`, `deepseek`, `mamba`, `bert`, `mixtral`, a 1-character query, a whitespace-padded query, a quant string, `unsloth/`, `../etc/passwd`, `<script>x</script>`, and a no-match string — all 200 at 1.0–2.0 s.

## Scope

No support/parity claim changes, no download gating, no schema removals. `arch_support` and `checked` are additive JSON fields; `insufficient_free_memory` is a new `FitVerdict` variant and `host_memory_unavailable` a new `error.code` on an existing 422 path — both reachable only where a refusal already occurred.
