### PR TITLE
Match the reference SPM tokenizer, and unblock Phi-3's tokenizer gate

### DIFF
--- a/ledger/camelid-ledger.json
+++ b/ledger/camelid-ledger.json
@@ -1,7 +1,7 @@
 {
   "ledger_version": "camelid.ledger/v1",
   "provenance": {
-    "source_head": "7d0098f7",
+    "source_head": "e78dc0a",
     "note": "Derived from the static CapabilitiesResponse literal in src/api/mod.rs by scripts/extract-capabilities-to-ledger.mjs. Contract fields are byte-faithful (plain serde Serialize, no renames). Per CAIRN Amendment 1, the CODE is the contract source of truth; this ledger is its derived canonical form, and scripts/check-ledger-drift.mjs re-derives from code and fails CI if code and ledger disagree (provenance excluded)."
   },
   "capabilities": {
@@ -1625,7 +1625,8 @@
       "identity": {
         "id": "phi3_mini_4k_instruct_q8_0",
         "family": "phi3",
-        "quantization": "Q8_0"
+        "quantization": "Q8_0",
+        "gguf_filename": "Phi-3-mini-4k-instruct-Q8_0.gguf"
       },
       "contract": {
         "id": "phi3_mini_4k_instruct_q8_0",
@@ -1634,18 +1635,18 @@
         "quantization": "Q8_0",
         "status": "active_validation_blocked_parity",
         "support_scope": "exact_row_validation_only",
-        "full_support_status": "blocked_prompt_and_generation_parity",
-        "full_support_blockers": "committed prompt-token and raw-generation parity receipts fail; API/WebUI readiness, context, performance, and portability evidence are also missing",
+        "full_support_status": "blocked_generation_parity",
+        "full_support_blockers": "the committed raw-generation parity receipt fails: the forward pass diverges from the reference (and disagrees with itself between fresh prefill and incremental decode); API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity no longer blocks",
         "metadata_parses": "observed",
-        "tokenizer_works": "blocked_prompt_token_parity",
+        "tokenizer_works": "validated_raw_8_of_8_and_chat_3_of_3_prompt_token_parity",
         "tensors_load": "observed",
         "generation_runs": "observed_but_not_parity_certified",
         "parity_audited": "failed",
         "performance_measured": "not_started",
         "frontend_load_path_verified": "fail_closed_blocked_parity",
-        "frontend_readiness_gate": "fail-closed until prompt-token and generation parity pass for this exact artifact",
-        "tested_context": "short_prompt_failed_parity_probe",
-        "chat_template_renderer": "phi3_metadata_template_under_validation",
+        "frontend_readiness_gate": "fail-closed until generation parity passes for this exact artifact",
+        "tested_context": "prompt_token_parity_to_2180_tokens_generation_diverges_by_the_4th_token",
+        "chat_template_renderer": "phi3_metadata_template_prompt_tokens_reference_matched",
         "chat_template_shape_pack": "failed_reference_parity",
         "chat_template_shape_pack_id": "phi3-chat-template-pack-v1",
         "bounded_context_512_pack": "not_started",
@@ -1664,10 +1665,10 @@
         "bounded_context_8192_pack_id": "not_selected",
         "bounded_context_8192_window": 8192,
         "latest_checked_bucket": "phi3_hold_evidence",
-        "latest_checked_result": "blocked_prompt_and_generation_parity",
+        "latest_checked_result": "blocked_generation_parity",
         "latest_checked_output": "qa/muster/phi3-hold-evidence/README.md",
-        "evidence": "exact-row work exists, but qa/muster/phi3-hold-evidence records all_match=false for prompt-token parity and all_pass=false for raw/chat generation parity; this row is intentionally not advertised as supported",
-        "next_step": "fix Phi-3 tokenizer/template and generation parity, then capture exact-row API/WebUI and bounded-context evidence before promotion"
+        "evidence": "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. Generation parity still FAILS and blocks the row: on the 9-token prefix 'The capital of France is Paris.\\\\n' the reference is ~99.1% confident of <|assistant|> (logprob -0.0091) while camelid ranks it -4.944 and emits '===', and camelid disagrees with itself between fresh prefill and incremental decode at that position — qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json rules out the tokenizer, RoPE pairing, the padded vocab, sampling policy and detokenization. This row is intentionally not advertised as supported",
+        "next_step": "localize the forward-pass divergence by layer-level activation tracing against the reference (prefill and decode disagree, so the attention/KV-cache path is the open suspect), then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion"
       }
     },
     {

--- a/ledger/camelid-ledger.schema.json
+++ b/ledger/camelid-ledger.schema.json
@@ -73,25 +73,12 @@
     "fullSupportStatusVocabulary": {
       "type": "string",
       "$comment": "Code-derived from `full_support_status:` literals in src/api/mod.rs (checked ⊇ by check-ledger-schema.mjs).",
-      "enum": [
-        "blocked_later_generation_divergence",
-        "blocked_pending_normalized_full_support",
-        "blocked_prompt_and_generation_parity",
-        "current_gate_refresh_under_stricter_bar",
-        "not_applicable_until_certified_row",
-        "not_applicable_until_runtime_support"
-      ]
+      "enum": ["blocked_generation_parity", "blocked_later_generation_divergence", "blocked_pending_normalized_full_support", "blocked_prompt_and_generation_parity", "current_gate_refresh_under_stricter_bar", "not_applicable_until_certified_row", "not_applicable_until_runtime_support"]
     },
     "latestCheckedResultVocabulary": {
       "type": "string",
       "$comment": "Code-derived from `latest_checked_result:` literals in src/api/mod.rs (checked ⊇ by check-ledger-schema.mjs).",
-      "enum": [
-        "blocked_later_generation_divergence",
-        "blocked_prompt_and_generation_parity",
-        "not_started",
-        "pass",
-        "planning_only"
-      ]
+      "enum": ["blocked_generation_parity", "blocked_later_generation_divergence", "blocked_prompt_and_generation_parity", "not_started", "pass", "planning_only"]
     },
     "supportItem": {
       "type": "object",

--- a/qa/muster/phi3-hold-evidence/README.md
+++ b/qa/muster/phi3-hold-evidence/README.md
@@ -1,0 +1,28 @@
+# Phi-3 hold evidence
+
+Why `phi3_mini_4k_instruct_q8_0` is NOT advertised as supported.
+
+## Cleared 2026-07-27
+
+Prompt-token parity now PASSES on the pinned artifact `Phi-3-mini-4k-instruct-Q8_0.gguf`:
+
+- `prompt-token-parity-q8-20260727.json` - 8/8 raw prompts, `all_match=true`
+- `chat-prompt-token-parity-q8-20260727.json` - 3/3 rendered chat prompts, `all_match=true`
+
+This closed the tokenizer half of the hold. Three defects were fixed: no rstrip of the
+whitespace following `<|...|>` markers; the SPM dummy prefix emitted as a standalone token
+id instead of prepended as a character for SPM to merge; and raw text bypassing the SPM
+algorithm entirely for a longest-match encoder. The superseded pre-fix captures
+(`prompt-token-parity.json`, `phi3-chat-parity.json`) are retained for history.
+
+## STILL BLOCKING
+
+`generation-divergence-q8-20260727.json` - the forward pass diverges from the reference.
+On the 9-token prefix `The capital of France is Paris.\n` the reference is ~99.1%
+confident of `<|assistant|>` (32001) while camelid ranks it -4.944 and picks `===`.
+camelid also disagrees with ITSELF between fresh prefill and incremental decode at that
+position. Tokenizer, RoPE pairing, padded vocab, sampling policy and detokenization are
+all ruled out in that file; the attention / KV-cache path is the open suspect.
+
+Generation parity, the bounded-context packs, and API/WebUI evidence remain outstanding.
+The row stays `active_validation_blocked_parity` and fail-closed in the frontend.

--- a/qa/muster/phi3-hold-evidence/chat-prompt-token-parity-q8-20260727.json
+++ b/qa/muster/phi3-hold-evidence/chat-prompt-token-parity-q8-20260727.json
@@ -1,0 +1,91 @@
+{
+ "schema": "camelid.phi3.chat_prompt_token_parity.v1",
+ "all_match": true,
+ "cases": [
+  {
+   "prompt": "What is the capital of France?",
+   "rendered": "<|user|>\nWhat is the capital of France?<|end|>\n<|assistant|>\n",
+   "camelid_prompt_tokens": [
+    1,
+    32010,
+    1724,
+    338,
+    278,
+    7483,
+    310,
+    3444,
+    29973,
+    32007,
+    32001
+   ],
+   "reference_prompt_tokens": [
+    1,
+    32010,
+    1724,
+    338,
+    278,
+    7483,
+    310,
+    3444,
+    29973,
+    32007,
+    32001
+   ],
+   "prompt_token_match": true
+  },
+  {
+   "prompt": "Say hello.",
+   "rendered": "<|user|>\nSay hello.<|end|>\n<|assistant|>\n",
+   "camelid_prompt_tokens": [
+    1,
+    32010,
+    14891,
+    22172,
+    29889,
+    32007,
+    32001
+   ],
+   "reference_prompt_tokens": [
+    1,
+    32010,
+    14891,
+    22172,
+    29889,
+    32007,
+    32001
+   ],
+   "prompt_token_match": true
+  },
+  {
+   "prompt": "What is 2+2?",
+   "rendered": "<|user|>\nWhat is 2+2?<|end|>\n<|assistant|>\n",
+   "camelid_prompt_tokens": [
+    1,
+    32010,
+    1724,
+    338,
+    29871,
+    29906,
+    29974,
+    29906,
+    29973,
+    32007,
+    32001
+   ],
+   "reference_prompt_tokens": [
+    1,
+    32010,
+    1724,
+    338,
+    29871,
+    29906,
+    29974,
+    29906,
+    29973,
+    32007,
+    32001
+   ],
+   "prompt_token_match": true
+  }
+ ]
+}

--- a/qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json
+++ b/qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json
@@ -1,0 +1,62 @@
+{
+ "schema": "camelid.phi3.generation_divergence.v1",
+ "artifact": "Phi-3-mini-4k-instruct-Q8_0.gguf",
+ "comparator": "llama.cpp 9632 (acd79d603) CPU (llama-server, -ngl 0 -ctk f32 -ctv f32 -fa off --no-repack)",
+ "camelid_execution_plan": {
+  "selected_backend": "cpu_reference",
+  "decode_path": "safe_cpu_decode"
+ },
+ "all_pass": false,
+ "note": "Prompt tokens are byte-identical (see prompt-token-parity-q8-20260727.json); the divergence is in the forward pass, not the tokenizer.",
+ "prefix_token_ids": [
+  1,
+  450,
+  7483,
+  310,
+  3444,
+  338,
+  3681,
+  29889,
+  13
+ ],
+ "prefix_text": "The capital of France is Paris.\n",
+ "reference_next_token": {
+  "id": 32001,
+  "token": "<|assistant|>",
+  "logprob": -0.009130490012466908
+ },
+ "reference_top_alternatives": [
+  {
+   "id": 28400,
+   "token": "----------",
+   "logprob": -5.87416934967041
+  },
+  {
+   "id": 25512,
+   "token": "===",
+   "logprob": -6.402482032775879
+  }
+ ],
+ "camelid_fresh_prefill_next_token": {
+  "id": 25512,
+  "token": "===",
+  "logprob": -0.4914248
+ },
+ "camelid_fresh_prefill_top_logprobs": {
+  "===": -0.4914248,
+  "\n": -1.2467997,
+  "B": -3.0508215,
+  "-": -4.525173,
+  "<|assistant|>": -4.9440594
+ },
+ "camelid_incremental_decode_next_token": {
+  "id": 13,
+  "token": "\\n"
+ },
+ "findings": [
+  "The reference assigns <|assistant|> ~99.1% (logprob -0.0091); camelid assigns it -4.944. Not a near-tie: ~4.9 nat apart on the reference's near-certain token.",
+  "camelid is INTERNALLY INCONSISTENT at this position: a fresh 9-token prefill yields 25512 while incremental decode to the same position yields 13. Identical prompt_token_ids in both cases.",
+  "Ruled out: tokenizer (prompt tokens byte-identical), RoPE pairing (dense_metadata reports rope_pairing=split_half, the pairing the committed rope probes show is correct for phi3), padded vocab (n_vocab=32064 and output.weight is [3072,32064], so 32001 is reachable), sampling policy (greedy_sample is a plain argmax with no special-token masking), and detokenization (this is a token-id comparison).",
+  "Remaining suspect: the attention / KV-cache path, given prefill and decode disagree with each other. Needs layer-level activation tracing against the reference to localize."
+ ]
+}

--- a/qa/muster/phi3-hold-evidence/prompt-token-parity-q8-20260727.json
+++ b/qa/muster/phi3-hold-evidence/prompt-token-parity-q8-20260727.json
@@ -1,0 +1,65 @@
+{
+ "schema": "camelid.muster_prompt_token_parity/v1",
+ "method": "camelid tokenize --file (add_special=true, parse_special=false) vs pinned llama-server /tokenize add_special=true, raw text (no chat specials), same committed 8-prompt pack",
+ "artifact": "Phi-3-mini-4k-instruct-Q8_0.gguf",
+ "comparator": "llama.cpp 9632 (acd79d603) CPU (llama-server, -ngl 0 -ctk f32 -ctv f32 -fa off --no-repack)",
+ "all_match": true,
+ "prompts": [
+  {
+   "i": 0,
+   "camelid_n": 6,
+   "oracle_n": 6,
+   "match": true,
+   "first_diff": null
+  },
+  {
+   "i": 1,
+   "camelid_n": 71,
+   "oracle_n": 71,
+   "match": true,
+   "first_diff": null
+  },
+  {
+   "i": 2,
+   "camelid_n": 97,
+   "oracle_n": 97,
+   "match": true,
+   "first_diff": null
+  },
+  {
+   "i": 3,
+   "camelid_n": 119,
+   "oracle_n": 119,
+   "match": true,
+   "first_diff": null
+  },
+  {
+   "i": 4,
+   "camelid_n": 29,
+   "oracle_n": 29,
+   "match": true,
+   "first_diff": null
+  },
+  {
+   "i": 5,
+   "camelid_n": 38,
+   "oracle_n": 38,
+   "match": true,
+   "first_diff": null
+  },
+  {
+   "i": 6,
+   "camelid_n": 54,
+   "oracle_n": 54,
+   "match": true,
+   "first_diff": null
+  },
+  {
+   "i": 7,
+   "camelid_n": 2180,
+   "oracle_n": 2180,
+   "match": true,
+   "first_diff": null
+  }
+ ]
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4254,18 +4254,18 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 quantization: "Q8_0",
                 status: "active_validation_blocked_parity",
                 support_scope: "exact_row_validation_only",
-                full_support_status: "blocked_prompt_and_generation_parity",
-                full_support_blockers: "committed prompt-token and raw-generation parity receipts fail; API/WebUI readiness, context, performance, and portability evidence are also missing",
+                full_support_status: "blocked_generation_parity",
+                full_support_blockers: "the committed raw-generation parity receipt fails: the forward pass diverges from the reference (and disagrees with itself between fresh prefill and incremental decode); API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity no longer blocks",
                 metadata_parses: "observed",
-                tokenizer_works: "blocked_prompt_token_parity",
+                tokenizer_works: "validated_raw_8_of_8_and_chat_3_of_3_prompt_token_parity",
                 tensors_load: "observed",
                 generation_runs: "observed_but_not_parity_certified",
                 parity_audited: "failed",
                 performance_measured: "not_started",
                 frontend_load_path_verified: "fail_closed_blocked_parity",
-                frontend_readiness_gate: "fail-closed until prompt-token and generation parity pass for this exact artifact",
-                tested_context: "short_prompt_failed_parity_probe",
-                chat_template_renderer: "phi3_metadata_template_under_validation",
+                frontend_readiness_gate: "fail-closed until generation parity passes for this exact artifact",
+                tested_context: "prompt_token_parity_to_2180_tokens_generation_diverges_by_the_4th_token",
+                chat_template_renderer: "phi3_metadata_template_prompt_tokens_reference_matched",
                 chat_template_shape_pack: "failed_reference_parity",
                 chat_template_shape_pack_id: "phi3-chat-template-pack-v1",
                 bounded_context_512_pack: "not_started",
@@ -4284,10 +4284,10 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 bounded_context_8192_pack_id: "not_selected",
                 bounded_context_8192_window: 8192,
                 latest_checked_bucket: "phi3_hold_evidence",
-                latest_checked_result: "blocked_prompt_and_generation_parity",
+                latest_checked_result: "blocked_generation_parity",
                 latest_checked_output: "qa/muster/phi3-hold-evidence/README.md",
-                evidence: "exact-row work exists, but qa/muster/phi3-hold-evidence records all_match=false for prompt-token parity and all_pass=false for raw/chat generation parity; this row is intentionally not advertised as supported",
-                next_step: "fix Phi-3 tokenizer/template and generation parity, then capture exact-row API/WebUI and bounded-context evidence before promotion",
+                evidence: "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. Generation parity still FAILS and blocks the row: on the 9-token prefix 'The capital of France is Paris.\\n' the reference is ~99.1% confident of <|assistant|> (logprob -0.0091) while camelid ranks it -4.944 and emits '===', and camelid disagrees with itself between fresh prefill and incremental decode at that position — qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json rules out the tokenizer, RoPE pairing, the padded vocab, sampling policy and detokenization. This row is intentionally not advertised as supported",
+                next_step: "localize the forward-pass divergence by layer-level activation tracing against the reference (prefill and decode disagree, so the attention/KV-cache path is the open suspect), then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion",
             },
             ModelCompatibilityTarget {
                 id: "deepseek_r1_distill_qwen_7b_q8_0",
@@ -15887,15 +15887,22 @@ mod tests {
             .iter()
             .find(|target| target.id == "phi3_mini_4k_instruct_q8_0")
             .expect("Phi-3 exact-row validation lane should stay visible");
+        // The row stays blocked and fail-closed: prompt-token parity was cleared
+        // 2026-07-27, but the forward pass still diverges from the reference, so
+        // nothing about the support claim moves.
         assert_eq!(phi3.status, "active_validation_blocked_parity");
         assert_eq!(phi3.parity_audited, "failed");
-        assert_eq!(
-            phi3.latest_checked_result,
-            "blocked_prompt_and_generation_parity"
-        );
+        assert_eq!(phi3.latest_checked_result, "blocked_generation_parity");
         assert!(phi3.frontend_readiness_gate.contains("fail-closed"));
-        assert!(phi3.evidence.contains("all_match=false"));
-        assert!(phi3.evidence.contains("all_pass=false"));
+        // Prompt-token parity now passes and must be stated as passing...
+        assert!(phi3.evidence.contains("prompt-token parity PASSES"));
+        assert!(phi3.evidence.contains("all_match=true"));
+        assert!(!phi3.tokenizer_works.starts_with("blocked"));
+        // ...while generation parity must still be stated as blocking.
+        assert!(phi3.evidence.contains("Generation parity still FAILS"));
+        assert!(phi3
+            .full_support_status
+            .contains("blocked_generation_parity"));
     }
 
     #[test]

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -333,10 +333,24 @@ impl Tokenizer {
             )));
         }
 
-        let bpe_registry = BpeRegistry::from_merges(
+        // `tokenizer.ggml.model = "llama"` is SPM proper: the reference segments it
+        // by token SCORE and ignores any merge list the converter happened to embed.
+        // Some Llama-family GGUFs ship merges anyway (TinyLlama carries 61k), and
+        // honouring them silently switched that model to rank-based BPE, segmenting
+        // ordinary words differently from the reference (`thunderstorm` -> `st|orm`
+        // instead of `stor|m`). Drop merges for this model only.
+        //
+        // Scoped to the raw metadata string, NOT `TokenizerModel::LlamaSpm`: gemma2/
+        // gemma3/gemma4 also map onto that enum but genuinely are merge-driven here
+        // (the DiffusionGemma tokenizer-parity gate pins gemma4's merge behaviour),
+        // and they declare their own tokenizer model names.
+        let spm_ignores_merges = model_name == "llama";
+        let bpe_registry = BpeRegistry::from_merges(if spm_ignores_merges {
+            Vec::new()
+        } else {
             file.metadata_array_strings_optional("tokenizer.ggml.merges")?
-                .unwrap_or_default(),
-        );
+                .unwrap_or_default()
+        });
         let bpe_ranks = bpe_registry.ranks().clone();
 
         let mut tokens = Vec::with_capacity(token_texts.len());
@@ -729,6 +743,17 @@ impl Tokenizer {
         normalized
     }
 
+    /// True when `token_text` is a `<|…|>` chat-control marker whose trailing
+    /// whitespace the reference strips. Deliberately narrow: SPM models whose turn
+    /// scaffolding is `[INST]`/`<s>` (TinyLlama, Llama 2, Mistral) do not match the
+    /// `<|…|>` shape, and BPE families (Qwen3, Llama 3) never reach this SPM path,
+    /// so their committed tokenizations are untouched.
+    fn chat_control_marker_rstrips(&self, token_text: &str) -> bool {
+        self.tokens
+            .iter()
+            .any(|token| token.text == token_text && is_chat_control_marker(token))
+    }
+
     fn should_insert_dummy_after_control(
         &self,
         token_text: &str,
@@ -792,12 +817,21 @@ impl Tokenizer {
     }
 
     fn encode_piece(&self, piece: &str, parse_special: bool) -> Result<Vec<TokenId>> {
-        if self.bpe_ranks.is_empty() && !parse_special {
-            return self.encode_piece_greedy(piece);
-        }
+        // SPM used to short-circuit to `encode_piece_greedy` here whenever specials
+        // were not being parsed. That encoder is longest-match-first, which is a
+        // different algorithm from the reference's score-ordered bigram merge and
+        // segments ordinary words differently (`thunderstorm` -> `stor|m` instead of
+        // `st|orm`). Fall through so every SPM segment reaches the ported session.
 
         let mut out = Vec::new();
         let mut byte_start = 0;
+        // Set when a control token asked for the SPM dummy prefix. It is applied by
+        // PREPENDING `▁` to the next raw segment, never by pushing the bare `▁` id:
+        // the reference merges the prefix into the following word (`▁What` = one
+        // token), whereas emitting the standalone id splits it into `▁` + `What` and
+        // diverges on every fragment that follows a special. `normalize_spm_text`'s
+        // non-special path already prepends the character; this keeps both in step.
+        let mut pending_dummy_prefix = false;
         while byte_start < piece.len() {
             if parse_special {
                 if let Some((token_text, token_len)) =
@@ -806,6 +840,18 @@ impl Tokenizer {
                     if let Some(id) = self.token_to_id.get(token_text) {
                         out.push(*id);
                         byte_start += token_len;
+                        // `<|...|>` chat-control markers carry rstrip semantics: the
+                        // reference drops the whitespace run that follows the marker
+                        // (Phi-3 renders `<|user|>\n…`, and the reference tokenizes
+                        // that as `<|user|>` + `▁What`, with no `<0x0A>`). Consume it
+                        // before deciding on the dummy prefix, so the prefix attaches
+                        // to the first real character of the fragment.
+                        if self.chat_control_marker_rstrips(token_text) {
+                            let trimmed = piece[byte_start..].trim_start_matches(|c: char| {
+                                c == SPM_SPACE || c.is_ascii_whitespace()
+                            });
+                            byte_start = piece.len() - trimmed.len();
+                        }
                         let rest = &piece[byte_start..];
                         let next_is_control = self
                             .longest_control_token_at(piece, byte_start, true)
@@ -817,10 +863,7 @@ impl Tokenizer {
                                 next_is_control,
                             )
                         {
-                            if let Some(dummy_prefix) = self.token_to_id.get(&SPM_SPACE.to_string())
-                            {
-                                out.push(*dummy_prefix);
-                            }
+                            pending_dummy_prefix = true;
                         }
                         continue;
                     }
@@ -833,15 +876,16 @@ impl Tokenizer {
             } else {
                 piece.len()
             };
-            if self.bpe_ranks.is_empty() {
-                if parse_special {
-                    self.encode_spm_segment(&piece[byte_start..byte_end], &mut out)?;
-                } else {
-                    out.extend(self.encode_piece_greedy(&piece[byte_start..byte_end])?);
-                }
+            let segment = &piece[byte_start..byte_end];
+            let prefixed;
+            let segment = if pending_dummy_prefix {
+                pending_dummy_prefix = false;
+                prefixed = format!("{SPM_SPACE}{segment}");
+                prefixed.as_str()
             } else {
-                self.encode_spm_segment(&piece[byte_start..byte_end], &mut out)?;
-            }
+                segment
+            };
+            self.encode_spm_segment(segment, &mut out)?;
             byte_start = byte_end;
         }
         Ok(out)
@@ -867,12 +911,15 @@ impl Tokenizer {
             return Ok(());
         }
 
-        let symbols = if self.bpe_ranks.is_empty() {
-            self.merge_spm_symbols_by_score(segment)
-        } else {
-            self.bpe_registry
-                .merge_symbols(segment.chars().map(|ch| ch.to_string()).collect())
-        };
+        // SPM (no merge ranks) follows the reference session verbatim; only the
+        // rank-based BPE families (gemma4 et al) use the symbol-merge path below.
+        if self.bpe_ranks.is_empty() {
+            return self.encode_spm_segment_reference(segment, out);
+        }
+
+        let symbols = self
+            .bpe_registry
+            .merge_symbols(segment.chars().map(|ch| ch.to_string()).collect());
 
         let mut unresolved = String::new();
         for symbol in symbols {
@@ -903,33 +950,177 @@ impl Tokenizer {
         Ok(())
     }
 
-    fn merge_spm_symbols_by_score(&self, segment: &str) -> Vec<String> {
-        let mut symbols: Vec<String> = segment.chars().map(|ch| ch.to_string()).collect();
-
-        loop {
-            let mut best: Option<(f32, usize)> = None;
-            for idx in 0..symbols.len().saturating_sub(1) {
-                let candidate = format!("{}{}", symbols[idx], symbols[idx + 1]);
-                if candidate.contains("▁▁") {
-                    continue;
-                }
-                let Some(id) = self.token_to_id.get(&candidate).copied() else {
-                    continue;
-                };
-                let score = self.tokens[id as usize].score;
-                match best {
-                    Some((best_score, best_idx))
-                        if score < best_score || (score == best_score && idx >= best_idx) => {}
-                    _ => best = Some((score, idx)),
-                }
-            }
-
-            let Some((_, idx)) = best else { break };
-            symbols[idx] = format!("{}{}", symbols[idx], symbols[idx + 1]);
-            symbols.remove(idx + 1);
+    /// SPM segmentation, ported from the reference `llm_tokenizer_spm_session`.
+    ///
+    /// A global "merge the best-scoring adjacent pair, recompute everything" loop is
+    /// NOT equivalent to the reference and diverges on ordinary words (`thunderstorm`
+    /// segmented `stor|m` instead of `st|orm`, `LRUCache` as `LR|UC|ache` instead of
+    /// `L|RU|Cache`). Four properties have to hold together:
+    ///
+    /// 1. Symbols are a doubly-linked list merged IN PLACE (`left.n += right.n`,
+    ///    `right.n = 0`), so indices stay stable and `rev_merge` can address them.
+    /// 2. The queue is seeded ONCE with every adjacent pair; after a merge only
+    ///    `(prev, left)` and `(left, next)` are offered. Re-deriving all pairs each
+    ///    pass invents merges the reference never queued.
+    /// 3. Popped entries are validated against the CURRENT symbol widths
+    ///    (`left.n + right.n != size` -> stale, skip), so a pair whose operands were
+    ///    already consumed cannot fire late.
+    /// 4. Output goes through `resegment`: a merged span that is not itself a vocab
+    ///    token is split back into the two operands that formed it via `rev_merge`,
+    ///    recursively, and only a span with no recorded merge falls back to bytes.
+    ///
+    /// Tie-break matches the reference comparator: highest score wins; on equal
+    /// scores the smaller left index wins.
+    fn encode_spm_segment_reference(&self, segment: &str, out: &mut Vec<TokenId>) -> Result<()> {
+        #[derive(Clone, Copy)]
+        struct Symbol {
+            start: usize,
+            n: usize,
+            prev: i64,
+            next: i64,
         }
 
-        symbols
+        #[derive(Clone, Copy)]
+        struct Bigram {
+            left: usize,
+            right: usize,
+            score: f32,
+            size: usize,
+        }
+        impl PartialEq for Bigram {
+            fn eq(&self, other: &Self) -> bool {
+                self.score == other.score && self.left == other.left
+            }
+        }
+        impl Eq for Bigram {}
+        impl Ord for Bigram {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                // Max-heap: greatest score pops first; equal scores favour the
+                // SMALLER left index, so reverse that half of the comparison.
+                self.score
+                    .partial_cmp(&other.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| other.left.cmp(&self.left))
+            }
+        }
+        impl PartialOrd for Bigram {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        let mut symbols: Vec<Symbol> = Vec::new();
+        for (offset, ch) in segment.char_indices() {
+            let index = symbols.len() as i64;
+            let n = ch.len_utf8();
+            symbols.push(Symbol {
+                start: offset,
+                n,
+                prev: index - 1,
+                next: if offset + n == segment.len() {
+                    -1
+                } else {
+                    index + 1
+                },
+            });
+        }
+        if symbols.is_empty() {
+            return Ok(());
+        }
+
+        let mut rev_merge: HashMap<String, (usize, usize)> = HashMap::new();
+        let mut work: BinaryHeap<Bigram> = BinaryHeap::new();
+
+        let try_add_bigram = |symbols: &Vec<Symbol>,
+                              work: &mut BinaryHeap<Bigram>,
+                              rev_merge: &mut HashMap<String, (usize, usize)>,
+                              left: i64,
+                              right: i64| {
+            if left == -1 || right == -1 {
+                return;
+            }
+            let (left, right) = (left as usize, right as usize);
+            let start = symbols[left].start;
+            let end = start + symbols[left].n + symbols[right].n;
+            let Some(text) = segment.get(start..end) else {
+                return;
+            };
+            let Some(id) = self.token_to_id.get(text).copied() else {
+                return;
+            };
+            let Some(token) = self.tokens.get(id as usize) else {
+                return;
+            };
+            work.push(Bigram {
+                left,
+                right,
+                score: token.score,
+                size: text.len(),
+            });
+            rev_merge.insert(text.to_string(), (left, right));
+        };
+
+        for i in 1..symbols.len() {
+            try_add_bigram(&symbols, &mut work, &mut rev_merge, i as i64 - 1, i as i64);
+        }
+
+        while let Some(bigram) = work.pop() {
+            let (left, right) = (bigram.left, bigram.right);
+            // Stale: an operand was already absorbed, or the pair no longer spans
+            // the width this entry was queued for.
+            if symbols[left].n == 0
+                || symbols[right].n == 0
+                || symbols[left].n + symbols[right].n != bigram.size
+            {
+                continue;
+            }
+
+            symbols[left].n += symbols[right].n;
+            symbols[right].n = 0;
+            symbols[left].next = symbols[right].next;
+            if symbols[right].next >= 0 {
+                let next = symbols[right].next as usize;
+                symbols[next].prev = left as i64;
+            }
+
+            let (prev, next) = (symbols[left].prev, symbols[left].next);
+            try_add_bigram(&symbols, &mut work, &mut rev_merge, prev, left as i64);
+            try_add_bigram(&symbols, &mut work, &mut rev_merge, left as i64, next);
+        }
+
+        // Walk the surviving chain, resegmenting each span. Iterative rather than
+        // recursive (the reference recurses) so a pathological merge tree cannot
+        // overflow the stack; the explicit stack reproduces the same left-then-right
+        // pre-order.
+        let mut index = 0_i64;
+        while index != -1 {
+            let symbol = symbols[index as usize];
+            let mut pending = vec![(symbol.start, symbol.n)];
+            while let Some((start, n)) = pending.pop() {
+                let Some(text) = segment.get(start..start + n) else {
+                    continue;
+                };
+                if let Some(id) = self.token_to_id.get(text).copied() {
+                    out.push(id);
+                    continue;
+                }
+                match rev_merge.get(text) {
+                    // A recorded merge whose left operand still spans the whole
+                    // parent would re-expand to itself forever. Unreachable for a
+                    // well-formed vocab (a merge is only queued when the joined text
+                    // IS a token, so the branch above already took it), but fail to
+                    // bytes rather than hang if a vocab ever violates that.
+                    Some(&(left, right)) if symbols[left].n < n => {
+                        // Push right first so left is popped (emitted) first.
+                        pending.push((symbols[right].start, symbols[right].n));
+                        pending.push((symbols[left].start, symbols[left].n));
+                    }
+                    _ => self.encode_unknown_symbol_bytes(text, out)?,
+                }
+            }
+            index = symbol.next;
+        }
+        Ok(())
     }
 
     fn encode_unknown_symbol_bytes(&self, symbol: &str, out: &mut Vec<TokenId>) -> Result<()> {

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -2365,7 +2365,7 @@ async fn load_model_reports_tokenizer_summary() {
         serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
     assert_eq!(body["tokenizer"]["status"], "available");
     assert_eq!(body["tokenizer"]["model"], "llama_spm");
-    assert_eq!(body["tokenizer"]["token_count"], 7);
+    assert_eq!(body["tokenizer"]["token_count"], 14);
     assert_eq!(body["tokenizer"]["byte_token_count"], 1);
     assert_eq!(body["tokenizer"]["special"]["bos"], 1);
     assert_eq!(body["tokenizer"]["special"]["eos"], 2);
@@ -2628,7 +2628,7 @@ async fn tokenizer_endpoint_returns_current_model_tokenizer_summary() {
     let body: Value =
         serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
     assert_eq!(body["model"], "llama_spm");
-    assert_eq!(body["token_count"], 7);
+    assert_eq!(body["token_count"], 14);
     assert_eq!(
         body["special"]["eog"].as_array().unwrap(),
         &[serde_json::json!(2)]
@@ -2791,13 +2791,16 @@ async fn llama_server_tokenize_detokenize_aliases_use_loaded_tokenizer() {
     let body: Value =
         serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
     // `add_space_prefix=true` unconditionally prepends a space, so the already
-    // space-led " hello!" tokenizes with a leading double-space (id 6 twice).
+    // space-led " hello!" normalizes to `▁▁hello!`. `▁▁` is not in this vocab, so
+    // the first `▁` stands alone (6) and the second merges into `▁hello` (3) —
+    // the reference merges the dummy prefix into the following word rather than
+    // leaving it as a bare piece. The previous `6,6,4,5` came from the old
+    // longest-match encoder plus its `▁▁` deferral, not from the reference.
     assert_eq!(
         body["tokens"].as_array().unwrap(),
         &[
             serde_json::json!(6),
-            serde_json::json!(6),
-            serde_json::json!(4),
+            serde_json::json!(3),
             serde_json::json!(5)
         ]
     );
@@ -2820,9 +2823,9 @@ async fn llama_server_tokenize_detokenize_aliases_use_loaded_tokenizer() {
     assert_eq!(
         body["tokens"].as_array().unwrap(),
         &[
+            // Same `▁▁hello!` segmentation as the id-only assertion above.
             serde_json::json!({"id":6,"piece":" "}),
-            serde_json::json!({"id":6,"piece":" "}),
-            serde_json::json!({"id":4,"piece":"hello"}),
+            serde_json::json!({"id":3,"piece":" hello"}),
             serde_json::json!({"id":5,"piece":"!"})
         ]
     );
@@ -4088,7 +4091,14 @@ async fn streaming_completion_accepts_advanced_sampling_controls() {
     assert_eq!(status, StatusCode::OK, "{body}");
     assert!(content_type.starts_with("text/event-stream"));
     assert!(body.contains("\"object\":\"text_completion\""));
-    assert!(body.contains("\"text\":\"<unk>\""));
+    // What this test is for is that presence_penalty / frequency_penalty /
+    // logit_bias are ACCEPTED and still stream a well-formed completion. The
+    // emitted token is incidental and fixture-specific: this vocab cannot build
+    // `▁hello` by pairwise merge, so the prompt is a run of byte-fallback <unk>s,
+    // and penalising that repeat (plus the logit_bias) makes the sampler pick EOS
+    // immediately — hence an empty delta and finish_reason=stop. The sibling
+    // `streaming_completion_*` test covers the unpenalised <unk> emission.
+    assert!(body.contains("\"finish_reason\":\"stop\""), "{body}");
     assert!(body.contains("data: [DONE]"));
 }
 
@@ -4156,7 +4166,13 @@ async fn completion_clamps_over_limit_max_tokens_to_context() {
     write_generation_gguf_with_options(
         &path,
         GenerationFixtureOptions {
-            context_length: 8,
+            // 16, not 8: this fixture's 4-token vocab holds `▁hello` but none of the
+            // single-step pieces SPM needs to build it, so `"hello"` byte-falls-back
+            // (and `▁` is 3 UTF-8 bytes) to a 9-token prompt. A longest-match encoder
+            // could jump straight to `▁hello`; the reference algorithm cannot. The
+            // clamp path under test needs a context with room left over, which is
+            // what this widens — the assertion below is unchanged.
+            context_length: 16,
             include_tokenizer: true,
             truncate_payload: false,
         },
@@ -4203,10 +4219,11 @@ async fn completion_clamps_over_limit_max_tokens_to_context() {
         StatusCode::OK,
         "an over-limit max_tokens must clamp and generate, not reject: {body}"
     );
+    // 9-token prompt in a 16-token context leaves room for 7.
     let completion_tokens = body["usage"]["completion_tokens"].as_u64().unwrap_or(0);
     assert!(
-        (1..=6).contains(&completion_tokens),
-        "generation must be clamped to the room left in the context (<=6), got {completion_tokens}: {body}"
+        (1..=7).contains(&completion_tokens),
+        "generation must be clamped to the room left in the context (<=7), got {completion_tokens}: {body}"
     );
 }
 
@@ -4440,9 +4457,18 @@ fn write_tokenizer_gguf_with_optional_chat_template(
     add_space_prefix: bool,
     chat_template: Option<&str>,
 ) {
-    let tokens = ["<unk>", "<s>", "</s>", "▁hello", "hello", "<0x21>", "▁"];
-    let scores = [0.0, 0.0, 0.0, 10.0, 2.0, 0.0, 1.0];
-    let token_types = [2, 3, 3, 1, 1, 6, 1];
+    // SPM reaches a token only through successive pairwise merges whose every
+    // intermediate is itself in the vocab, so the single-step pieces are required
+    // for `▁hello`/`hello` to be reachable at all. Appended (never reordered) so
+    // the ids these tests assert stay put. Mirrors tests/tokenizer.rs.
+    let tokens = [
+        "<unk>", "<s>", "</s>", "▁hello", "hello", "<0x21>", "▁", "▁h", "▁he", "▁hel", "▁hell",
+        "he", "hel", "hell",
+    ];
+    let scores = [
+        0.0, 0.0, 0.0, 10.0, 2.0, 0.0, 1.0, 3.0, 4.0, 5.0, 6.0, 2.5, 2.6, 2.7,
+    ];
+    let token_types = [2, 3, 3, 1, 1, 6, 1, 1, 1, 1, 1, 1, 1, 1];
 
     let mut b = Vec::new();
     b.extend_from_slice(b"GGUF");

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -15,7 +15,7 @@ fn loads_llama_spm_tokenizer_metadata() {
     assert_eq!(tokenizer.special.eos, Some(2));
     assert!(tokenizer.config.add_bos);
     assert!(!tokenizer.config.add_eos);
-    assert_eq!(tokenizer.tokens.len(), 7);
+    assert_eq!(tokenizer.tokens.len(), 14);
 }
 
 #[test]
@@ -475,12 +475,17 @@ fn encodes_known_piece_with_space_prefix() {
 }
 
 #[test]
-fn parse_special_spm_uses_vocab_piece_after_control_dummy_prefix() {
+fn parse_special_spm_merges_dummy_prefix_into_the_following_piece() {
     let tokenizer = load_fixture(false, false, true);
 
+    // The dummy prefix after a control token belongs to the NEXT fragment, not to
+    // a token of its own: the reference prepends a space to the fragment and lets
+    // SPM merge it, yielding `▁hello` (3). Emitting the bare `▁` (6) followed by
+    // `hello` (4) is the divergence this asserts against — it split `▁What` into
+    // `▁` + `What` on every real prompt that followed a special.
     assert_eq!(
         tokenizer.encode("<s>hello", false, true).unwrap(),
-        vec![1, 6, 4]
+        vec![1, 3]
     );
 }
 
@@ -494,10 +499,14 @@ fn falls_back_to_byte_tokens() {
 fn applies_tokenizer_merges_when_present() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("tokenizer-merges.gguf");
+    // A merge-driven tokenizer model. `llama` is SPM proper: the reference
+    // segments it by token score and ignores any merge list the converter
+    // embedded, so asserting merge behaviour under `llama` asserted the bug that
+    // switched TinyLlama (which ships 61k merges) onto rank-based BPE.
     write_tokenizer_gguf_with_overrides(
         &path,
         TokenizerFixtureOverrides {
-            model: "llama",
+            model: "gemma4",
             merges: &["h e", "he l", "hel l", "hell o"],
             ..TokenizerFixtureOverrides::default()
         },
@@ -512,8 +521,12 @@ fn applies_tokenizer_merges_when_present() {
 #[test]
 fn adds_dummy_prefix_after_control_token_before_newline() {
     let tokenizer = load_fixture(false, false, true);
+    // parse_special=true: a control token is only recognised as a token when
+    // specials are being parsed. This previously passed with parse_special=false
+    // because longest-match happened to swallow the literal text `</s>` as its own
+    // id — something the reference never does with specials off.
     assert_eq!(
-        tokenizer.encode("hello</s>\nhello", false, false).unwrap(),
+        tokenizer.encode("hello</s>\nhello", false, true).unwrap(),
         vec![3, 2, 6, 0, 4]
     );
 }
@@ -521,8 +534,9 @@ fn adds_dummy_prefix_after_control_token_before_newline() {
 #[test]
 fn does_not_duplicate_dummy_prefix_after_control_token_before_space() {
     let tokenizer = load_fixture(false, false, true);
+    // parse_special=true for the same reason as the newline case above.
     assert_eq!(
-        tokenizer.encode("hello</s> hello", false, false).unwrap(),
+        tokenizer.encode("hello</s> hello", false, true).unwrap(),
         vec![3, 2, 3]
     );
 }
@@ -552,7 +566,7 @@ fn rejects_special_token_id_outside_vocab() {
     let err = Tokenizer::from_gguf(&gguf).unwrap_err().to_string();
 
     assert!(err.contains("bos token id 99"));
-    assert!(err.contains("out of range for vocab size 7"));
+    assert!(err.contains("out of range for vocab size 14"));
 }
 
 #[test]
@@ -574,7 +588,7 @@ fn rejects_score_array_shorter_than_tokens() {
     let err = Tokenizer::from_gguf(&gguf).unwrap_err().to_string();
 
     assert!(err.contains("tokenizer.ggml.scores length 3"));
-    assert!(err.contains("shorter than token count 7"));
+    assert!(err.contains("shorter than token count 14"));
 }
 
 #[test]
@@ -801,9 +815,22 @@ struct TokenizerFixtureOverrides<'a> {
 }
 
 fn write_tokenizer_gguf_with_overrides(path: &Path, overrides: TokenizerFixtureOverrides<'_>) {
-    let tokens = ["<unk>", "<s>", "</s>", "▁hello", "hello", "<0x21>", "▁"];
-    let all_scores = [0.0, 0.0, 0.0, 10.0, 2.0, 0.0, 1.0];
-    let mut token_types = [2, 3, 3, 1, 1, 6, 1];
+    // SPM reaches a token only through successive pairwise merges in which every
+    // intermediate is ITSELF in the vocab. Without the single-step pieces below,
+    // `▁hello` and `hello` are unreachable and every character falls back to
+    // <unk> — the original 7-entry vocab was only tokenizable by a longest-match
+    // encoder, not by the reference algorithm. Appended (never reordered) so the
+    // ids every other test asserts stay put.
+    let tokens = [
+        "<unk>", "<s>", "</s>", "▁hello", "hello", "<0x21>", "▁", "▁h", "▁he", "▁hel", "▁hell",
+        "he", "hel", "hell",
+    ];
+    // The `▁`-prefixed chain outscores the bare chain so each step has a single
+    // best candidate and the merge order is deterministic.
+    let all_scores = [
+        0.0, 0.0, 0.0, 10.0, 2.0, 0.0, 1.0, 3.0, 4.0, 5.0, 6.0, 2.5, 2.6, 2.7,
+    ];
+    let mut token_types = [2, 3, 3, 1, 1, 6, 1, 1, 1, 1, 1, 1, 1, 1];
     if let Some(token_type) = overrides.token_type {
         token_types[3] = token_type;
     }


### PR DESCRIPTION
Camelid's SPM tokenization diverged from the reference on ordinary text. Against pinned llama.cpp `acd79d603`, prompt-token parity over the committed 8-prompt pack:

| artifact | before | after |
|---|---|---|
| `Phi-3-mini-4k-instruct-Q8_0.gguf` | 2/8 | **8/8** |
| `tinyllama-1.1b-chat-v1.0.Q8_0.gguf` | 2/8 | **8/8** |
| Phi-3 rendered chat prompts | `prompt_token_match: false` | **3/3** |

**TinyLlama is a supported row that was silently mis-tokenizing English** -- `thunderstorm` as `stor|m` instead of `st|orm`. Its committed packs never contained a word that exposed it.

## Three independent defects

**1. Raw text never reached the SPM algorithm.** `encode_piece` short-circuited to `encode_piece_greedy` whenever specials were not being parsed. That encoder is longest-match-first -- a different algorithm from the reference's score-ordered bigram merge. Ported `llm_tokenizer_spm_session` faithfully: symbols merged in place through a doubly-linked list; the queue seeded once and thereafter offered only `(prev,left)` and `(left,next)`; popped entries validated against current symbol widths so a stale pair cannot fire late; `rev_merge` resegmentation on output. A global "merge-best-pair, recompute-everything" loop is **not** equivalent to this.

**2. Specials handling.** `<|...|>` chat-control markers carry rstrip semantics that were not applied, and the SPM dummy prefix was emitted as a standalone token id rather than prepended as a `U+2581` character for SPM to merge -- splitting `_What` (1724) into `_` + `What` (29871, 5618) after every special.

**3. SPM models honouring embedded merges.** `tokenizer.ggml.model = "llama"` is SPM proper, and the reference ignores any merge list the converter embedded. TinyLlama ships 61k merges, which silently switched it to rank-based BPE. Gated on the raw metadata string rather than `TokenizerModel::LlamaSpm`, because gemma2/gemma3/gemma4 map onto that same enum but genuinely are merge-driven (the DiffusionGemma tokenizer-parity gate pins gemma4's behaviour) and declare their own model names.

## Why the fixtures had to change

SPM reaches a token only through pairwise merges whose **every intermediate is itself in the vocab**. A 7-entry fixture holding `_hello` but not `_h`/`_he`/`_hel`/`_hell` is tokenizable *only* by a longest-match encoder. Appended the single-step pieces (existing ids unchanged) and re-derived each affected expectation from reference semantics rather than from the new output:

- The two control-token tests were passing only because longest-match happened to swallow the literal text `</s>` with `parse_special=false` -- something the reference never does. With `parse_special=true` their **original expectations hold unchanged**, which is good evidence the new path is right.
- `parse_special_spm_uses_vocab_piece_after_control_dummy_prefix` asserted `[1,6,4]` -- that *was* defect 2. Now `[1,3]`, and renamed accordingly.
- `applies_tokenizer_merges_when_present` asserted merge behaviour under `model: "llama"`, i.e. defect 3. Moved to `gemma4`; expectation unchanged.
- The API-slice fixture needed the same treatment; its `" hello!"` expectation `6,6,4,5` came from the old encoder plus its `..` deferral, and is now `6,3,5`.

## Phi-3 ledger: tokenizer gate cleared, row stays blocked

`tokenizer_works` and the `all_match=false` evidence claim are no longer true, so they are corrected. **The row stays `active_validation_blocked_parity` and fail-closed** -- generation parity still fails, and nothing about the support claim moves.

On the 9-token prefix `The capital of France is Paris.\n` the reference is ~99.1% confident of `<|assistant|>` (logprob -0.0091) while camelid ranks it -4.944 and emits `===`. Camelid also disagrees with **itself** between fresh prefill and incremental decode at that position. `qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json` rules out the tokenizer, RoPE pairing (already `split_half`), the padded vocab (32064 end to end, so 32001 is reachable), sampling policy (plain argmax, no masking) and detokenization. The attention/KV path is the open suspect; the pinned assertions move with the row so they cannot disagree.

## Verification

`cargo test --release --no-fail-fast`: the only failure is `tensor::nvfp4_tests::encode_vectors_reproduce_pin_wire_bytes_and_dequant`, confirmed identical on pristine `c780eda` via `git stash` -- pre-existing and unrelated. `cargo fmt --check`, `clippy --all-targets -D warnings`, and `scripts/check-public-scrub.sh` all clean.

Not claimed: Phi-3 generation parity, any bounded-context or API/WebUI evidence, or any support-level change for any row.