### PR TITLE
Correct the Phi-3 blocker: the engine is non-deterministic, not diverging

### DIFF
--- a/ledger/camelid-ledger.json
+++ b/ledger/camelid-ledger.json
@@ -1,7 +1,7 @@
 {
   "ledger_version": "camelid.ledger/v1",
   "provenance": {
-    "source_head": "e78dc0a",
+    "source_head": "26c6fe6",
     "note": "Derived from the static CapabilitiesResponse literal in src/api/mod.rs by scripts/extract-capabilities-to-ledger.mjs. Contract fields are byte-faithful (plain serde Serialize, no renames). Per CAIRN Amendment 1, the CODE is the contract source of truth; this ledger is its derived canonical form, and scripts/check-ledger-drift.mjs re-derives from code and fails CI if code and ledger disagree (provenance excluded)."
   },
   "capabilities": {
@@ -1636,7 +1636,7 @@
         "status": "active_validation_blocked_parity",
         "support_scope": "exact_row_validation_only",
         "full_support_status": "blocked_generation_parity",
-        "full_support_blockers": "the committed raw-generation parity receipt fails: the forward pass diverges from the reference (and disagrees with itself between fresh prefill and incremental decode); API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity no longer blocks",
+        "full_support_blockers": "the engine is NON-DETERMINISTIC on this architecture at temperature 0, so generation parity cannot be certified; API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity no longer blocks",
         "metadata_parses": "observed",
         "tokenizer_works": "validated_raw_8_of_8_and_chat_3_of_3_prompt_token_parity",
         "tensors_load": "observed",
@@ -1645,7 +1645,7 @@
         "performance_measured": "not_started",
         "frontend_load_path_verified": "fail_closed_blocked_parity",
         "frontend_readiness_gate": "fail-closed until generation parity passes for this exact artifact",
-        "tested_context": "prompt_token_parity_to_2180_tokens_generation_diverges_by_the_4th_token",
+        "tested_context": "prompt_token_parity_to_2180_tokens_generation_nondeterministic_at_temperature_zero",
         "chat_template_renderer": "phi3_metadata_template_prompt_tokens_reference_matched",
         "chat_template_shape_pack": "failed_reference_parity",
         "chat_template_shape_pack_id": "phi3-chat-template-pack-v1",
@@ -1667,8 +1667,8 @@
         "latest_checked_bucket": "phi3_hold_evidence",
         "latest_checked_result": "blocked_generation_parity",
         "latest_checked_output": "qa/muster/phi3-hold-evidence/README.md",
-        "evidence": "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. Generation parity still FAILS and blocks the row: on the 9-token prefix 'The capital of France is Paris.\\\\n' the reference is ~99.1% confident of <|assistant|> (logprob -0.0091) while camelid ranks it -4.944 and emits '===', and camelid disagrees with itself between fresh prefill and incremental decode at that position — qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json rules out the tokenizer, RoPE pairing, the padded vocab, sampling policy and detokenization. This row is intentionally not advertised as supported",
-        "next_step": "localize the forward-pass divergence by layer-level activation tracing against the reference (prefill and decode disagree, so the attention/KV-cache path is the open suspect), then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion"
+        "evidence": "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. Generation parity still blocks the row, but the cause is NON-DETERMINISM, not a fixed forward-pass error: six identical temperature-0 requests on the 9-token prefix 'The capital of France is Paris.\\\\n' returned two different tokens, flipping between the reference <|assistant|> (32001) and \\\\n (13), with the reference token winning a majority of runs — qa/muster/phi3-hold-evidence/nondeterminism-q8-20260727.json. That receipt scopes it to phi3 (Llama-3.2-3B on metal_resident and Mistral-7B on the SAME cpu_reference path are both bit-identical across runs) and rules out a parallel-reduction race (--threads 1) and lazy Q8 materialization (CAMELID_LAZY_Q8_0_LINEAR=0); phi3-only head_dim=96 and the fused attn_qkv/ffn_up sub-row expansion are the open suspects. It SUPERSEDES generation-divergence-q8-20260727.json, whose prefill-vs-decode reading was drawn from two samples of a noisy process and is wrong. This row is intentionally not advertised as supported",
+        "next_step": "make phi3 decode REPEATABLE first — identical temperature-0 requests must return identical logits. It survives --threads 1 and eager Q8, so hunt an uninitialized/stale read on the phi3-only paths: head_dim=96 tails (every other local row is 128) and the fused attn_qkv/ffn_up sub-row descriptor expansion in src/model.rs. Only then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion"
       }
     },
     {

--- a/qa/muster/phi3-hold-evidence/README.md
+++ b/qa/muster/phi3-hold-evidence/README.md
@@ -4,7 +4,7 @@ Why `phi3_mini_4k_instruct_q8_0` is NOT advertised as supported.
 
 ## Cleared 2026-07-27
 
-Prompt-token parity now PASSES on the pinned artifact `Phi-3-mini-4k-instruct-Q8_0.gguf`:
+Prompt-token parity PASSES on the pinned artifact `Phi-3-mini-4k-instruct-Q8_0.gguf`:
 
 - `prompt-token-parity-q8-20260727.json` - 8/8 raw prompts, `all_match=true`
 - `chat-prompt-token-parity-q8-20260727.json` - 3/3 rendered chat prompts, `all_match=true`
@@ -15,14 +15,31 @@ id instead of prepended as a character for SPM to merge; and raw text bypassing 
 algorithm entirely for a longest-match encoder. The superseded pre-fix captures
 (`prompt-token-parity.json`, `phi3-chat-parity.json`) are retained for history.
 
-## STILL BLOCKING
+## STILL BLOCKING: the engine does not repeat itself
 
-`generation-divergence-q8-20260727.json` - the forward pass diverges from the reference.
-On the 9-token prefix `The capital of France is Paris.\n` the reference is ~99.1%
-confident of `<|assistant|>` (32001) while camelid ranks it -4.944 and picks `===`.
-camelid also disagrees with ITSELF between fresh prefill and incremental decode at that
-position. Tokenizer, RoPE pairing, padded vocab, sampling policy and detokenization are
-all ruled out in that file; the attention / KV-cache path is the open suspect.
+`nondeterminism-q8-20260727.json` - camelid is NON-DETERMINISTIC on phi3 at temperature 0.
+Six identical requests on the 9-token prefix `The capital of France is Paris.\n` produced
+two different tokens, flipping between the reference `<|assistant|>` (32001) and `\n` (13).
+The reference token wins on a majority of runs, so this row is CLOSER than the superseded
+receipt implied - but generation parity cannot be certified while identical requests return
+different answers.
+
+Scoped by experiment: Llama-3.2-3B (metal resident) and Mistral-7B (the SAME
+`cpu_reference` path) are both bit-identical across runs, so this is phi3-specific rather
+than engine- or path-wide. It survives `--threads 1` (not a parallel-reduction race) and
+`CAMELID_LAZY_Q8_0_LINEAR=0` (not lazy weight materialization). Single-threaded,
+eager-weighted non-determinism is the signature of reading uninitialized or stale memory.
+Open suspects, both phi3-only: `head_dim=96` (every other local row is 128; 96 is a
+multiple of 32 but not 64, where a fixed-width kernel tail leaves a buffer partly
+unwritten), and the fused `attn_qkv`/`ffn_up` sub-row descriptor expansion in
+`src/model.rs`.
+
+### Correction
+
+`generation-divergence-q8-20260727.json` is SUPERSEDED and annotated in place. It read a
+fresh prefill disagreeing with incremental decode as a structural prefill/decode split and
+named the attention/KV path as the suspect. That was two samples of a noisy process with
+no repeatability check, and it is wrong. It is kept, marked, rather than deleted.
 
 Generation parity, the bounded-context packs, and API/WebUI evidence remain outstanding.
 The row stays `active_validation_blocked_parity` and fail-closed in the frontend.

--- a/qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json
+++ b/qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json
@@ -55,8 +55,10 @@
  },
  "findings": [
   "The reference assigns <|assistant|> ~99.1% (logprob -0.0091); camelid assigns it -4.944. Not a near-tie: ~4.9 nat apart on the reference's near-certain token.",
-  "camelid is INTERNALLY INCONSISTENT at this position: a fresh 9-token prefill yields 25512 while incremental decode to the same position yields 13. Identical prompt_token_ids in both cases.",
+  "camelid is INTERNALLY INCONSISTENT at this position: a fresh 9-token prefill yields 25512 while incremental decode to the same position yields 13. Identical prompt_token_ids in both cases.  [SUPERSEDED \u2014 see 'correction']",
   "Ruled out: tokenizer (prompt tokens byte-identical), RoPE pairing (dense_metadata reports rope_pairing=split_half, the pairing the committed rope probes show is correct for phi3), padded vocab (n_vocab=32064 and output.weight is [3072,32064], so 32001 is reachable), sampling policy (greedy_sample is a plain argmax with no special-token masking), and detokenization (this is a token-id comparison).",
-  "Remaining suspect: the attention / KV-cache path, given prefill and decode disagree with each other. Needs layer-level activation tracing against the reference to localize."
- ]
+  "Remaining suspect: the attention / KV-cache path, given prefill and decode disagree with each other. Needs layer-level activation tracing against the reference to localize.  [SUPERSEDED \u2014 see 'correction']"
+ ],
+ "SUPERSEDED": "This file's structural reading is WRONG. See nondeterminism-q8-20260727.json.",
+ "correction": "The 'fresh prefill (25512) vs incremental decode (13)' disagreement recorded below was two samples of a NON-DETERMINISTIC engine, not evidence of a prefill/decode split. Repeatability was not tested before concluding. camelid returns different logits for identical requests on phi3 at temperature 0, and produces the reference token 32001 on a majority of runs. The 'attention/KV path' suspect named below is not supported by this data."
 }

--- a/qa/muster/phi3-hold-evidence/nondeterminism-q8-20260727.json
+++ b/qa/muster/phi3-hold-evidence/nondeterminism-q8-20260727.json
@@ -1,0 +1,122 @@
+{
+ "schema": "camelid.phi3.nondeterminism.v1",
+ "supersedes": "generation-divergence-q8-20260727.json (its prefill-vs-decode reading was WRONG \u2014 see corrects_prior_finding)",
+ "artifact": "Phi-3-mini-4k-instruct-Q8_0.gguf",
+ "comparator": "llama.cpp 9632 (acd79d603) CPU (llama-server, -ngl 0 -ctk f32 -ctv f32 -fa off --no-repack)",
+ "camelid_execution_plan": {
+  "selected_backend": "cpu_reference",
+  "decode_path": "safe_cpu_decode"
+ },
+ "finding": "camelid is NON-DETERMINISTIC on phi3 at temperature 0: identical requests return different logits, and the argmax flips between the reference token 32001 (<|assistant|>) and 13 (newline).",
+ "prefix_token_ids": [
+  1,
+  450,
+  7483,
+  310,
+  3444,
+  338,
+  3681,
+  29889,
+  13
+ ],
+ "prefix_text": "The capital of France is Paris.\n",
+ "reference_next_token": {
+  "id": 32001,
+  "token": "<|assistant|>",
+  "logprob": -0.009130490012466908
+ },
+ "identical_requests": [
+  {
+   "run": 0,
+   "generated_token_ids": [
+    13
+   ],
+   "top_logprobs": {
+    "\n": -0.18846,
+    "<|assistant|>": -2.00594,
+    "B": -3.98493
+   }
+  },
+  {
+   "run": 1,
+   "generated_token_ids": [
+    32001
+   ],
+   "top_logprobs": {
+    "<|assistant|>": -0.00597,
+    "*)": -6.22334,
+    "===": -6.4234
+   }
+  },
+  {
+   "run": 2,
+   "generated_token_ids": [
+    13
+   ],
+   "top_logprobs": {
+    "\n": -0.29317,
+    "===": -2.61782,
+    "B": -2.68714
+   }
+  },
+  {
+   "run": 3,
+   "generated_token_ids": [
+    13
+   ],
+   "top_logprobs": {
+    "\n": -0.08171,
+    "<|assistant|>": -3.02506,
+    "===": -3.98173
+   }
+  },
+  {
+   "run": 4,
+   "generated_token_ids": [
+    32001
+   ],
+   "top_logprobs": {
+    "<|assistant|>": -0.5115,
+    "===": -0.92457,
+    "*": -6.51456
+   }
+  },
+  {
+   "run": 5,
+   "generated_token_ids": [
+    13
+   ],
+   "top_logprobs": {
+    "\n": -0.0511,
+    "===": -3.62706,
+    "<|assistant|>": -4.499
+   }
+  }
+ ],
+ "distinct_outputs_across_6_identical_requests": 2,
+ "corrects_prior_finding": "generation-divergence-q8-20260727.json concluded the forward pass diverges structurally, citing a fresh prefill (25512) disagreeing with incremental decode (13) and naming the attention/KV path as the suspect. That was drawn from two samples of a noisy process WITHOUT testing repeatability, and is wrong: prefill and decode do not structurally disagree, the engine simply does not repeat itself. The reference token is produced on a majority of runs.",
+ "scoping_experiments": [
+  {
+   "test": "Llama-3.2-3B-Instruct-Q8_0 on metal_resident_q8_runtime, 4 identical requests",
+   "result": "bit-identical (-0.91886 every run)",
+   "conclusion": "not engine-wide"
+  },
+  {
+   "test": "Mistral-7B-Instruct-v0.3.Q8_0 on the SAME cpu_reference/safe_cpu_decode path, 4 identical requests",
+   "result": "bit-identical (-0.0096 every run)",
+   "conclusion": "not the cpu_reference path; phi3-specific"
+  },
+  {
+   "test": "phi3 with --threads 1",
+   "result": "still non-deterministic",
+   "conclusion": "not a rayon/parallel-reduction race"
+  },
+  {
+   "test": "phi3 with CAMELID_LAZY_Q8_0_LINEAR=0 (eager weights)",
+   "result": "still non-deterministic",
+   "conclusion": "not lazy Q8 linear materialization"
+  }
+ ],
+ "open_suspect": "Single-threaded and eager-weighted non-determinism is the signature of reading uninitialized or stale memory. Structural outlier: phi3 is the only local architecture with head_dim=96 (llama/mistral/qwen3 rows are all 128). 96 is a multiple of 32 but not 64, which is where a fixed-width kernel tail would leave part of a buffer unwritten. phi3 also ships FUSED attn_qkv [3072,9216] and ffn_up [3072,16384] expanded into sub-row descriptor slices (src/model.rs), a phi3-only code path.",
+ "consequence": "Generation parity cannot be certified while the engine does not repeat itself. Note the row is CLOSER than the superseded receipt implied: the reference token wins on a majority of runs."
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4255,7 +4255,7 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 status: "active_validation_blocked_parity",
                 support_scope: "exact_row_validation_only",
                 full_support_status: "blocked_generation_parity",
-                full_support_blockers: "the committed raw-generation parity receipt fails: the forward pass diverges from the reference (and disagrees with itself between fresh prefill and incremental decode); API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity no longer blocks",
+                full_support_blockers: "the engine is NON-DETERMINISTIC on this architecture at temperature 0, so generation parity cannot be certified; API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity no longer blocks",
                 metadata_parses: "observed",
                 tokenizer_works: "validated_raw_8_of_8_and_chat_3_of_3_prompt_token_parity",
                 tensors_load: "observed",
@@ -4264,7 +4264,7 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 performance_measured: "not_started",
                 frontend_load_path_verified: "fail_closed_blocked_parity",
                 frontend_readiness_gate: "fail-closed until generation parity passes for this exact artifact",
-                tested_context: "prompt_token_parity_to_2180_tokens_generation_diverges_by_the_4th_token",
+                tested_context: "prompt_token_parity_to_2180_tokens_generation_nondeterministic_at_temperature_zero",
                 chat_template_renderer: "phi3_metadata_template_prompt_tokens_reference_matched",
                 chat_template_shape_pack: "failed_reference_parity",
                 chat_template_shape_pack_id: "phi3-chat-template-pack-v1",
@@ -4286,8 +4286,8 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 latest_checked_bucket: "phi3_hold_evidence",
                 latest_checked_result: "blocked_generation_parity",
                 latest_checked_output: "qa/muster/phi3-hold-evidence/README.md",
-                evidence: "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. Generation parity still FAILS and blocks the row: on the 9-token prefix 'The capital of France is Paris.\\n' the reference is ~99.1% confident of <|assistant|> (logprob -0.0091) while camelid ranks it -4.944 and emits '===', and camelid disagrees with itself between fresh prefill and incremental decode at that position — qa/muster/phi3-hold-evidence/generation-divergence-q8-20260727.json rules out the tokenizer, RoPE pairing, the padded vocab, sampling policy and detokenization. This row is intentionally not advertised as supported",
-                next_step: "localize the forward-pass divergence by layer-level activation tracing against the reference (prefill and decode disagree, so the attention/KV-cache path is the open suspect), then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion",
+                evidence: "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. Generation parity still blocks the row, but the cause is NON-DETERMINISM, not a fixed forward-pass error: six identical temperature-0 requests on the 9-token prefix 'The capital of France is Paris.\\n' returned two different tokens, flipping between the reference <|assistant|> (32001) and \\n (13), with the reference token winning a majority of runs — qa/muster/phi3-hold-evidence/nondeterminism-q8-20260727.json. That receipt scopes it to phi3 (Llama-3.2-3B on metal_resident and Mistral-7B on the SAME cpu_reference path are both bit-identical across runs) and rules out a parallel-reduction race (--threads 1) and lazy Q8 materialization (CAMELID_LAZY_Q8_0_LINEAR=0); phi3-only head_dim=96 and the fused attn_qkv/ffn_up sub-row expansion are the open suspects. It SUPERSEDES generation-divergence-q8-20260727.json, whose prefill-vs-decode reading was drawn from two samples of a noisy process and is wrong. This row is intentionally not advertised as supported",
+                next_step: "make phi3 decode REPEATABLE first — identical temperature-0 requests must return identical logits. It survives --threads 1 and eager Q8, so hunt an uninitialized/stale read on the phi3-only paths: head_dim=96 tails (every other local row is 128) and the fused attn_qkv/ffn_up sub-row descriptor expansion in src/model.rs. Only then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion",
             },
             ModelCompatibilityTarget {
                 id: "deepseek_r1_distill_qwen_7b_q8_0",
@@ -15898,8 +15898,17 @@ mod tests {
         assert!(phi3.evidence.contains("prompt-token parity PASSES"));
         assert!(phi3.evidence.contains("all_match=true"));
         assert!(!phi3.tokenizer_works.starts_with("blocked"));
-        // ...while generation parity must still be stated as blocking.
-        assert!(phi3.evidence.contains("Generation parity still FAILS"));
+        // ...while generation parity must still be stated as blocking, and the
+        // stated CAUSE must be the non-determinism the receipts actually record,
+        // never the superseded prefill-vs-decode reading.
+        assert!(phi3
+            .evidence
+            .contains("Generation parity still blocks the row"));
+        assert!(phi3.evidence.contains("NON-DETERMINISM"));
+        assert!(phi3.evidence.contains("nondeterminism-q8-20260727.json"));
+        assert!(!phi3
+            .evidence
+            .contains("disagrees with itself between fresh prefill"));
         assert!(phi3
             .full_support_status
             .contains("blocked_generation_parity"));


### PR DESCRIPTION
The generation-divergence receipt merged in #518 read a fresh prefill (`25512`) disagreeing with an incremental decode (`13`) as a structural prefill/decode split, and named the attention/KV path as the suspect. **That conclusion was drawn from two samples without testing repeatability, and is wrong.**

## The actual blocker

**camelid is NON-DETERMINISTIC on phi3 at temperature 0.** Six identical requests on the 9-token prefix `The capital of France is Paris.\n` returned two different tokens, flipping between the reference `<|assistant|>` (32001) and `\n` (13) -- with the reference token winning a **majority** of runs. Prefill and decode do not structurally disagree; the engine simply does not repeat itself.

## Scoped by experiment

| test | result | rules out |
|---|---|---|
| Llama-3.2-3B Q8_0, metal resident, x4 | bit-identical (`-0.91886` every run) | engine-wide |
| Mistral-7B Q8_0, **same `cpu_reference` path**, x4 | bit-identical (`-0.0096` every run) | the CPU path |
| phi3, `--threads 1` | still varies | parallel-reduction race |
| phi3, `CAMELID_LAZY_Q8_0_LINEAR=0` | still varies | lazy Q8 materialization |

Single-threaded, eager-weighted non-determinism is the signature of reading uninitialized or stale memory. Open suspects, both phi3-only:

- **`head_dim = 96`** -- every other local row is 128. 96 is a multiple of 32 but not 64, exactly where a fixed-width kernel tail leaves part of a buffer unwritten.
- the fused **`attn_qkv` [3072,9216] / `ffn_up` [3072,16384]** sub-row descriptor expansion in `src/model.rs`, which is a phi3-only code path.

## Handling of the wrong receipt

`generation-divergence-q8-20260727.json` is **annotated in place**, not deleted -- it carries a `SUPERSEDED` marker, a `correction` field explaining exactly what was misread and why, and per-finding markers. The wrong reading and its correction both stay on the record.

The pinned test assertions move with it and now assert the *cause* is stated as non-determinism, including a negative assertion that the superseded prefill-vs-decode wording cannot come back.

## No support claim moves

The row stays `active_validation_blocked_parity`, `parity_audited=failed`, fail-closed in the frontend. It is however **closer** than the old evidence implied: the reference token already wins most runs, so the next step is repeatability, not a forward-pass rewrite.

## Verification

`cargo test --release --no-fail-fast`: only failure is `tensor::nvfp4_tests::encode_vectors_reproduce_pin_wire_bytes_and_dequant`, pre-existing on `main`. `cargo fmt --check`, `clippy --all-targets -D warnings`, `check-ledger-schema.mjs`, `check-ledger-drift.mjs` (ledger regenerated, not hand-edited) and `check-public-scrub.sh` all clean.