### PR TITLE
fix(release): stop shipping the alternate NVRTC JIT backend on Windows

### DIFF
--- a/scripts/package-windows-cuda.ps1
+++ b/scripts/package-windows-cuda.ps1
@@ -73,15 +73,21 @@ if (-not $CudaBin -or -not (Test-Path $CudaBin)) {
 Write-Host "CUDA bin:  $CudaBin"
 
 # --- Resolve the NVRTC redistributable DLLs -----------------------------------
-# nvrtc64_*.dll      -> the runtime compiler (e.g. nvrtc64_120_0.dll [+ .alt])
+# nvrtc64_*.dll      -> the runtime compiler (e.g. nvrtc64_120_0.dll)
 # nvrtc-builtins64_* -> its required builtins (e.g. nvrtc-builtins64_129.dll)
+#
+# `.alt.` variants are an alternate JIT backend cudarc never asks for; skipping
+# them keeps ~86 MB out of every download. Mirrors the same skip in
+# scripts/package-linux-cuda.sh -- without it the staged set trips the
+# `.alt.dll` forbidden rule in scripts/check-release-artifact.mjs.
 $patterns = @('nvrtc64_*.dll', 'nvrtc-builtins64_*.dll')
 $dlls = foreach ($p in $patterns) {
-    $matches = Get-ChildItem -Path (Join-Path $CudaBin $p) -ErrorAction SilentlyContinue
-    if (-not $matches) {
+    $found = Get-ChildItem -Path (Join-Path $CudaBin $p) -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -notlike '*.alt.dll' }
+    if (-not $found) {
         Write-Warning "No files matched '$p' in $CudaBin"
     }
-    $matches
+    $found
 }
 $dlls = $dlls | Where-Object { $_ } | Sort-Object FullName -Unique
 if (-not $dlls) {


### PR DESCRIPTION
## What

`scripts/package-windows-cuda.ps1` globs `nvrtc64_*.dll`, which also matches **`nvrtc64_120_0.alt.dll`** — the alternate JIT backend cudarc never asks for. `scripts/package-linux-cuda.sh:58` has skipped `.alt.` variants since it was written (keeps ~90 MB out of every download); the Windows script never did.

Both Windows packaging jobs call this script (`build-windows` and `desktop-windows`), so every Windows download has been carrying an extra **85.7 MB** of dead weight.

## Verification (Windows, RTX 3060, CUDA 12.9)

Staged set goes from 3 DLLs to the 2 that are actually loaded:

```
  + nvrtc64_120_0.dll                  85.7 MB
  + nvrtc-builtins64_129.dll            6.9 MB
```

`camelid-windows-x64.zip` drops **80.82 MB → 45.19 MB**. Rebuilt and re-verified both Windows artifacts end to end after the change. The incomplete-pair warning still fires, because the `.alt` filter runs before the emptiness check.

## Why this should land before #510

The release-artifact contract check proposed in #510 forbids `.alt.dll` outright. Running that checker against a real Windows ZIP staged by the current script fails:

```
FAIL: nvrtc64_120_0.alt.dll is the alternate JIT backend cudarc never loads and must not be shipped
FAIL: unexpected entry in the artifact: nvrtc64_120_0.alt.dll (file) is not part of the camelid-windows-x64.zip payload
```

`release.yml` only runs on a tag push, so no PR CI has ever exercised that path. Landing this first means `main` is never in a state where the gate exists and packaging violates it.

This change stands on its own regardless of #510.
