### PR TITLE
fix(desktop): inject the global Tauri API so the splash error pane can render

### DIFF
--- a/camelid-desktop/splash/index.html
+++ b/camelid-desktop/splash/index.html
@@ -83,6 +83,10 @@
           errDetailsEl.open = true;
         }
       }
+      // Requires `app.withGlobalTauri` in tauri.conf.json. This page has no bundler and no
+      // npm dependency, so the API has to arrive as a global; without that flag __TAURI__ is
+      // undefined, this guard is false, and every startup failure -- including a missing
+      // sidecar -- renders as a spinner that turns forever.
       if (window.__TAURI__ && window.__TAURI__.event && window.__TAURI__.core) {
         window.__TAURI__.event.listen("engine-status", (e) => {
           renderStartupState(e.payload);

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -7,6 +7,7 @@
     "frontendDist": "./splash"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "label": "main",


### PR DESCRIPTION
## The bug

`camelid-desktop/splash/index.html` reads `window.__TAURI__` directly — it has no bundler and no npm dependency, by design. But `app.withGlobalTauri` defaults to **false** in Tauri v2 and was never set, so that global is `undefined`.

Consequence: the guard is always false, so the `engine-status` listener and the `startup_snapshot` replay it gates are **dead code**. The Rust side emits errors correctly; nothing is listening. Every startup failure renders as a spinner turning forever on the hardcoded "Starting engine…" text — the exact fail-closed behaviour #509 set out to remove.

One line of config fixes it. The replay machinery added in #509 is correct and unchanged.

## Verified on Windows (this is a runtime-only bug — nothing catches it at compile time)

**Failure path** — sidecar removed so startup must fail:

| | Result |
|---|---|
| Before | spinner turns forever, "Starting engine…", no error pane |
| After | error pane renders |

After the fix the pane shows:

```
Engine could not start.
Camelid engine is missing
Reinstall Camelid Desktop or place camelid.exe beside camelid-desktop.exe, then retry.
▼ Technical details
failed to launch the camelid engine at camelid.exe: program not found
```

**Success path** — sidecar restored: the splash still hands off to the engine UI and reports "Camelid online". No regression.

## Note on diagnosis

The listener and replay were verified to be reached only after this flag is set. Instrumenting the page confirmed the mechanism directly: without the flag `typeof window.__TAURI__` is `undefined`; with it, `__TAURI__=object event=object` and the handshake proceeds.
