### PR TITLE
fix(release): actually assert the NVRTC soname, not just the family

### DIFF
--- a/scripts/check-release-artifact.mjs
+++ b/scripts/check-release-artifact.mjs
@@ -3,9 +3,14 @@
 // artifact, run BETWEEN packaging and publishing.
 //
 // Why this exists. release.yml already guards the STAGING DIRECTORY:
-// scripts/package-linux-cuda.sh fails on a missing `libnvrtc.so.<major>`
-// soname, a dangling symlink, and a duplicated payload (the v0.4.3 regression).
-// Those guards are good, but three things are still unverified:
+// scripts/package-linux-cuda.sh fails on a dangling symlink and a duplicated
+// payload (the v0.4.3 regression). Those guards are good, but three things are
+// still unverified:
+//
+// (Its soname guard is weaker than it reads: `compgen -G "$dist/libnvrtc.so.*"`
+// at package-linux-cuda.sh:72 also matches the three-component real file, so it
+// passes on a stage that lost the `libnvrtc.so.<major>` link. The compiler-role
+// check below asserts the soname for real, on the extracted archive.)
 //
 //   1. They run before `tar -czf` / `Compress-Archive`. Nothing has ever looked
 //      inside the archive users actually download.
@@ -60,9 +65,20 @@ import { pathToFileURL } from 'node:url'
 /** NVRTC redistributable shapes, per platform family. */
 const NVRTC = {
   unix: {
-    // The soname cudarc actually dlopen's. package-linux-cuda.sh globs
-    // `libnvrtc.so.*`; the staged set is normally the `libnvrtc.so.<major>`
-    // symlink plus its `libnvrtc.so.<major>.<minor>.<patch>` real file.
+    // SELECTOR vs VALIDATOR — these are deliberately different patterns, and
+    // collapsing them into one breaks the check in one direction or the other.
+    //
+    // `compilerSoname` is the name cudarc actually dlopen's: it builds a fixed
+    // candidate list (`libnvrtc.so`, `libnvrtc.so.<major>`, ...) and never asks
+    // for a three-component `libnvrtc.so.<major>.<minor>.<patch>`. So the
+    // ARTIFACT must contain the soname itself; that is what we search for.
+    //
+    // `compiler` is the looser family test applied to what the soname RESOLVES
+    // to, which legitimately IS the three-component real file. Anchoring the
+    // selector and reusing it as the validator would reject every correctly
+    // packaged tarball; leaving the validator loose and reusing it as the
+    // selector passes a tarball that lost the soname entirely.
+    compilerSoname: /^libnvrtc\.so\.\d+$/,
     compiler: /^libnvrtc\.so\.\d+/,
     builtins: /^libnvrtc-builtins\.so/,
     family: /^libnvrtc.*\.so/,
@@ -71,6 +87,11 @@ const NVRTC = {
     forbidden: /\.alt\.so/,
   },
   windows: {
+    // Same split as unix. On Windows the loadable name is already fully
+    // versioned (nvrtc64_120_0.dll) and is a real file rather than a symlink,
+    // so selector and validator coincide in practice — but keeping the shapes
+    // explicit stops `nvrtc64_120_0.alt.dll` from satisfying the role.
+    compilerSoname: /^nvrtc64_\d+_\d+\.dll$/i,
     compiler: /^nvrtc64_.*\.dll$/i,
     builtins: /^nvrtc-builtins64_.*\.dll$/i,
     family: /^nvrtc.*\.dll$/i,
@@ -306,11 +327,15 @@ export function resolveSymlinkChain(byPath, startPath, maxHops = MAX_SYMLINK_HOP
  * Require at least one entry named like `role` to RESOLVE to a regular file
  * that is also named like `role`.
  *
+ * `selector` is what the caller searched for and is reported when nothing
+ * matched; `pattern` validates the far end of the symlink chain. They differ
+ * for the NVRTC compiler — see the NVRTC table.
+ *
  * @returns {string[]} failure messages
  */
-function checkNvrtcRole(candidates, byPath, pattern, role, consequence) {
+function checkNvrtcRole(candidates, byPath, pattern, role, consequence, selector = pattern) {
   if (!candidates.length) {
-    return [`no NVRTC ${role} library matching ${pattern} — ${consequence}`]
+    return [`no NVRTC ${role} library matching ${selector} — ${consequence}`]
   }
   const diagnostics = []
   for (const candidate of candidates) {
@@ -380,11 +405,14 @@ export function checkManifest(entries, spec, options = {}) {
       // links, so the chain has to end at a real library of the right family.
       failures.push(
         ...checkNvrtcRole(
-          topLevel.filter((e) => spec.nvrtc.compiler.test(basename(e.path))),
+          // Search for the SONAME, not the family: a tarball holding only
+          // libnvrtc.so.<major>.<minor>.<patch> cannot be dlopen'd by cudarc.
+          topLevel.filter((e) => spec.nvrtc.compilerSoname.test(basename(e.path))),
           byPath,
           spec.nvrtc.compiler,
           'compiler',
           'the GPU path would silently fall back to CPU on a driver-only host',
+          spec.nvrtc.compilerSoname,
         ),
       )
       failures.push(

--- a/scripts/test-check-release-artifact.mjs
+++ b/scripts/test-check-release-artifact.mjs
@@ -233,7 +233,18 @@ assert.ok(
     await failuresFor('linux-no-compiler', omit(goodLinux, 'libnvrtc.so.12.9.86', 'libnvrtc.so.12'), LINUX, { requireNvrtc: true }),
     /no NVRTC compiler library/,
   ),
-  'a linux tarball without the libnvrtc soname would silently fall back to CPU and must fail',
+  'a linux tarball with no NVRTC compiler library at all would silently fall back to CPU and must fail',
+)
+// The soname is the whole point: cudarc's dlopen candidates are libnvrtc.so and
+// libnvrtc.so.<major>, never the three-component real name. A tarball that kept
+// libnvrtc.so.12.9.86 but lost the libnvrtc.so.12 link is a CPU-only artifact
+// that looks complete, so the compiler role must be searched for by soname.
+assert.ok(
+  has(
+    await failuresFor('linux-soname-only-missing', omit(goodLinux, 'libnvrtc.so.12'), LINUX, { requireNvrtc: true }),
+    /no NVRTC compiler library/,
+  ),
+  'the versioned real file WITHOUT its soname link cannot be dlopen’d and must fail',
 )
 assert.ok(
   has(await failuresFor('linux-no-builtins', omit(goodLinux, 'libnvrtc-builtins.so.12.9'), LINUX, { requireNvrtc: true }), /no NVRTC builtins/),
@@ -292,16 +303,27 @@ assert.deepEqual(
 // readTree's lstat/readlink handling wherever the OS permits it.
 // ---------------------------------------------------------------------------
 const entry = (path, over = {}) => ({ path, kind: 'file', size: 16, mode: 0o755, sha256: `hash-${path}`, ...over })
-const linuxEntries = (...extra) => [
-  entry('camelid'),
-  entry('README.md'),
-  entry('LICENSE'),
-  entry('THIRD_PARTY_NOTICES.md'),
-  entry('libnvrtc.so.12.9.86'),
-  entry('libnvrtc-builtins.so.12.9'),
-  ...extra,
-]
 const link = (path, linkTarget) => ({ path, kind: 'symlink', size: 0, mode: 0o777, linkTarget })
+/**
+ * A VALID linux payload. The `libnvrtc.so.<major>` soname belongs in the base
+ * fixture, not only in the tests that are about symlinks: it is the name cudarc
+ * dlopen's, so a payload without it is a CPU-only artifact rather than a
+ * release. Any `extra` entry REPLACES the base entry with the same path, which
+ * is how the variants below swap in a dangling or escaping link.
+ */
+const linuxEntries = (...extra) => {
+  const base = [
+    entry('camelid'),
+    entry('README.md'),
+    entry('LICENSE'),
+    entry('THIRD_PARTY_NOTICES.md'),
+    entry('libnvrtc.so.12.9.86'),
+    entry('libnvrtc-builtins.so.12.9'),
+    link('libnvrtc.so.12', 'libnvrtc.so.12.9.86'),
+  ]
+  const replaced = new Set(extra.map((e) => e.path))
+  return [...base.filter((e) => !replaced.has(e.path)), ...extra]
+}
 
 assert.deepEqual(
   checkManifest(linuxEntries(link('libnvrtc.so.12', 'libnvrtc.so.12.9.86')), LINUX, { requireNvrtc: true }),
@@ -322,7 +344,7 @@ assert.ok(
 )
 assert.ok(
   has(
-    checkManifest([...linuxEntries(), entry('libnvrtc.so.12', { sha256: 'hash-libnvrtc.so.12.9.86' })], LINUX, { requireNvrtc: true }),
+    checkManifest(linuxEntries(entry('libnvrtc.so.12', { sha256: 'hash-libnvrtc.so.12.9.86' })), LINUX, { requireNvrtc: true }),
     /duplicate payload/,
   ),
   'two byte-identical NVRTC real files mean a symlink was dereferenced',


### PR DESCRIPTION
Follow-up to #510, found while verifying its Windows legs on real hardware.

## The bug

`--require-nvrtc` did not actually assert the NVRTC soname, despite the file header saying it did.

`checkNvrtcRole` used **one** pattern for two different jobs: selecting candidate files, and validating what those candidates resolve to. That pattern, `/^libnvrtc\.so\.\d+/`, is unanchored — so it also matches `libnvrtc.so.12.9.86`.

Result: a Linux tarball that kept the versioned real file but lost its `libnvrtc.so.12` symlink **passed clean**. That artifact cannot reach the GPU — cudarc's dlopen candidates are `libnvrtc.so` and `libnvrtc.so.<major>`, never the three-component name — so it is exactly the silent-CPU-fallback this gate exists to prevent.

Reproduced against a real-shaped payload before changing anything:

```
SONAME MISSING (only the fully-versioned real file):
  failures: []
>>> CONFIRMED: soname-less payload PASSES --require-nvrtc (false pass)
```

## Why the obvious fix is wrong

Anchoring that regex to `$` looks like a one-character fix. It breaks **every** legitimate Linux release, because the same pattern validates what the symlink resolves to — and the link legitimately resolves to `libnvrtc.so.12.9.86`:

| Variant | Correct artifact | Soname absent | Dangling |
|---|---|---|---|
| Before | PASS ✓ | **PASS ✗** | FAIL ✓ |
| Anchored regex | **FAIL ✗** | FAIL ✓ | FAIL ✓ |
| This PR (split) | PASS ✓ | FAIL ✓ | FAIL ✓ |

So the fix splits the roles: `compilerSoname` selects by the name cudarc loads, `compiler` stays loose and validates the far end of the chain. Applied to Windows too, where it additionally stops `nvrtc64_120_0.alt.dll` satisfying the compiler role by itself.

## The test fixture had the same blind spot

`linuxEntries()` never contained the soname — the link only appeared in the tests specifically about symlinks. The base fixture was an invalid payload that the old check passed, which is why nothing caught this. The soname now lives in the fixture, with `extra` entries replacing by path so the dangling/escaping variants still work, plus the missing case: versioned real file present, soname absent, must fail.

The pre-existing `linux-no-compiler` case omitted *both* files, so it only ever proved "no NVRTC at all" fails; its assertion message claimed more than that and has been corrected.

## Verification

- All three release test suites pass.
- A real `windows-x64` artifact staged from CUDA 12.9 on an RTX 3060 box still passes `check-release-artifact --require-nvrtc` (6 files, 113.7 MiB).
- Seven-case matrix across both platforms correct in both directions — no false passes, no false failures.

## Not changed here

`scripts/package-linux-cuda.sh:72` has the identical hole (`compgen -G "$dist/libnvrtc.so.*"` matches the three-component file), so its soname guard is weaker than its comment reads. I left it alone deliberately: it fails a release loudly rather than shipping a bad one, this check now covers the case on the extracted archive, and I have no way to exercise the Linux packaging path here. The header comment that credited it with a soname guard is corrected. Worth a separate hardening PR.
