### PR TITLE
Bound the PV pass's row tile by `rows`, fixing phi3 non-determinism

### DIFF
--- a/ledger/camelid-ledger.json
+++ b/ledger/camelid-ledger.json
@@ -1,7 +1,7 @@
 {
   "ledger_version": "camelid.ledger/v1",
   "provenance": {
-    "source_head": "5500b294",
+    "source_head": "3348dc4",
     "note": "Derived from the static CapabilitiesResponse literal in src/api/mod.rs by scripts/extract-capabilities-to-ledger.mjs. Contract fields are byte-faithful (plain serde Serialize, no renames). Per CAIRN Amendment 1, the CODE is the contract source of truth; this ledger is its derived canonical form, and scripts/check-ledger-drift.mjs re-derives from code and fails CI if code and ledger disagree (provenance excluded)."
   },
   "capabilities": {
@@ -1636,7 +1636,7 @@
         "status": "active_validation_blocked_parity",
         "support_scope": "exact_row_validation_only",
         "full_support_status": "blocked_generation_parity",
-        "full_support_blockers": "the engine is NON-DETERMINISTIC on this architecture at temperature 0, so generation parity cannot be certified; API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity no longer blocks",
+        "full_support_blockers": "generation parity is not certified: prefill and incremental decode disagree from the 3rd generated token (deterministically, since the Metal PV row-tail fix); API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity and the temperature-0 non-determinism no longer block",
         "metadata_parses": "observed",
         "tokenizer_works": "validated_raw_8_of_8_and_chat_3_of_3_prompt_token_parity",
         "tensors_load": "observed",
@@ -1645,7 +1645,7 @@
         "performance_measured": "not_started",
         "frontend_load_path_verified": "fail_closed_blocked_parity",
         "frontend_readiness_gate": "fail-closed until generation parity passes for this exact artifact",
-        "tested_context": "prompt_token_parity_to_2180_tokens_generation_nondeterministic_at_temperature_zero",
+        "tested_context": "prompt_token_parity_to_2180_tokens_single_token_decode_reference_matched_multi_token_diverges_at_index_2",
         "chat_template_renderer": "phi3_metadata_template_prompt_tokens_reference_matched",
         "chat_template_shape_pack": "failed_reference_parity",
         "chat_template_shape_pack_id": "phi3-chat-template-pack-v1",
@@ -1667,8 +1667,8 @@
         "latest_checked_bucket": "phi3_hold_evidence",
         "latest_checked_result": "blocked_generation_parity",
         "latest_checked_output": "qa/muster/phi3-hold-evidence/README.md",
-        "evidence": "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. Generation parity still blocks the row, but the cause is NON-DETERMINISM, not a fixed forward-pass error: six identical temperature-0 requests on the 9-token prefix 'The capital of France is Paris.\\\\n' returned two different tokens, flipping between the reference <|assistant|> (32001) and \\\\n (13), with the reference token winning a majority of runs — qa/muster/phi3-hold-evidence/nondeterminism-q8-20260727.json. That receipt scopes it to phi3 (Llama-3.2-3B on metal_resident and Mistral-7B on the SAME cpu_reference path are both bit-identical across runs) and rules out a parallel-reduction race (--threads 1) and lazy Q8 materialization (CAMELID_LAZY_Q8_0_LINEAR=0); phi3-only head_dim=96 and the fused attn_qkv/ffn_up sub-row expansion are the open suspects. It SUPERSEDES generation-divergence-q8-20260727.json, whose prefill-vs-decode reading was drawn from two samples of a noisy process and is wrong. This row is intentionally not advertised as supported",
-        "next_step": "make phi3 decode REPEATABLE first — identical temperature-0 requests must return identical logits. It survives --threads 1 and eager Q8, so hunt an uninitialized/stale read on the phi3-only paths: head_dim=96 tails (every other local row is 128) and the fused attn_qkv/ffn_up sub-row descriptor expansion in src/model.rs. Only then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion"
+        "evidence": "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. The temperature-0 NON-DETERMINISM that previously blocked this row is FIXED: half_mm_batched_f16o ignored its `rows` argument, so at head_dim=96 the prefill PV pass's partial 64-row tile read past each head V slab and wrote into the next head's columns, racing it; bounding the three unguarded sites by `rows` makes the default path bit-stable (6/6 identical single-token, 3/3 identical multi-token) and returns the reference token 32001 — qa/muster/phi3-hold-evidence/nondeterminism-fixed-q8-20260728.json, which also records Llama-3.2-3B and Mistral-7B bit-identical pre/post patch. Generation parity STILL blocks the row for a separate and now-DETERMINISTIC reason: on 'The capital of France is' the reference emits [3681,29889,13,32001,3869] while camelid emits [3681,29889,3681,338,2998], diverging at index 2, and a fresh prefill of the 8-token prefix returns the reference 13 where incremental decode returns 3681. This row is intentionally not advertised as supported",
+        "next_step": "reconcile phi3 incremental decode with prefill — a fresh prefill of the same prefix matches the reference while decode does not, so compare the decode KV-cache read against the prefill path for head_dim=96 (the same non-multiple-of-64 shape that broke the PV row tile). Then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion"
       }
     },
     {

--- a/qa/muster/phi3-hold-evidence/nondeterminism-fixed-q8-20260728.json
+++ b/qa/muster/phi3-hold-evidence/nondeterminism-fixed-q8-20260728.json
@@ -1,0 +1,68 @@
+{
+ "schema": "camelid.phi3.nondeterminism_fixed.v1",
+ "supersedes": "nondeterminism-q8-20260727.json (the non-determinism it records is FIXED; its scoping experiments remain valid)",
+ "artifact": "Phi-3-mini-4k-instruct-Q8_0.gguf",
+ "comparator": "llama.cpp 9632 (acd79d603) CPU (llama-server, -ngl 0 -ctk f32 -ctv f32 -fa off --no-repack)",
+ "root_cause": "half_mm_batched_f16o (src/metal.rs) tiles its A-row dimension in fixed 64-row blocks and ignored its `rows` argument entirely -- the parameter was declared at buffer(4) and never read. The prefill attention-as-matmul PV pass drives it with rows = head_dim. At head_dim=96 the host dispatches ceil(96/64)=2 row tiles, so the second tile's 32-row overhang (a) READ past each head's V-transpose slab, which transpose_v16 only ever fills for d < head_dim, and off the end of vt_scratch entirely for the last head, and (b) WROTE into the next head's columns 0..31, racing that head's own legitimate write from a different threadgroup with no ordering. Every other local architecture has head_dim=128, which tiles evenly, so nothing else was affected.",
+ "fix": "Bound all three unguarded sites by the `rows` argument that was already being passed: zero-pad A rows past `rows` exactly as the k tail was already zero-padded; add `quad_r0 < rows` to sg_active; route a partial row tile to the guarded ragged store by requiring r0 + NR0 <= rows; and bound the ragged store's row index (r_oct + fr < rows). Applied to both the f16-output kernel and its f32 twin, which carried the identical latent defect.",
+ "fixed_non_determinism": {
+  "single_token_6_identical_requests": {
+   "all_runs": "(32001,) logprob -0.009686",
+   "distinct": 1,
+   "stable": true
+  },
+  "multi_token_3_identical_requests": {
+   "all_runs": [
+    3681,
+    29889,
+    3681,
+    338,
+    2998
+   ],
+   "distinct": 1,
+   "stable": true
+  },
+  "reference_single_token": {
+   "id": 32001,
+   "token": "<|assistant|>",
+   "logprob": -0.00913
+  },
+  "note": "camelid now returns the reference token 32001 on the 9-token prefix, deterministically, on the DEFAULT path with no flags."
+ },
+ "no_regression": {
+  "Llama-3.2-3B-Instruct-Q8_0.gguf": {
+   "pre_patch": "'The' -0.91886",
+   "post_patch": "'The' -0.91886",
+   "bit_identical": true
+  },
+  "Mistral-7B-Instruct-v0.3.Q8_0.gguf": {
+   "pre_patch": "'\\n' -0.0096",
+   "post_patch": "'\\n' -0.0096",
+   "bit_identical": true
+  },
+  "note": "head_dim=128 rows tile evenly, so both row tiles still take the fast store path and the guards are a no-op."
+ },
+ "STILL_BLOCKING": {
+  "finding": "A SEPARATE, now-DETERMINISTIC correctness bug remains in phi3 multi-token decode.",
+  "prompt": "The capital of France is",
+  "reference_tokens": [
+   3681,
+   29889,
+   13,
+   32001,
+   3869
+  ],
+  "camelid_tokens": [
+   3681,
+   29889,
+   3681,
+   338,
+   2998
+  ],
+  "first_divergence_index": 2,
+  "repeatability": "3/3 identical runs -- deterministic, unlike before the kernel fix",
+  "detail": "A FRESH prefill of the 8-token prefix 'The capital of France is Paris.' returns 13, matching the reference; incremental decode to the same position returns 3681. So prefill and decode genuinely disagree. NOTE: an earlier receipt asserted this same prefill-vs-decode split from two samples of a then-non-deterministic engine and was rightly retracted; it is now measurable and repeatable, which is what makes it assertable.",
+  "next": "Compare the decode path's KV-cache read against the prefill path's for phi3 (head_dim=96) -- the same non-multiple-of-64 shape that broke the PV tile is the obvious place to look next."
+ },
+ "consequence": "The row stays active_validation_blocked_parity. Generation parity is still not certified. But the engine now produces the same answer twice, and phi3 is usable on the default path with no flags."
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4256,7 +4256,7 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 status: "active_validation_blocked_parity",
                 support_scope: "exact_row_validation_only",
                 full_support_status: "blocked_generation_parity",
-                full_support_blockers: "the engine is NON-DETERMINISTIC on this architecture at temperature 0, so generation parity cannot be certified; API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity no longer blocks",
+                full_support_blockers: "generation parity is not certified: prefill and incremental decode disagree from the 3rd generated token (deterministically, since the Metal PV row-tail fix); API/WebUI readiness, context, performance, and portability evidence are also missing. Prompt-token parity and the temperature-0 non-determinism no longer block",
                 metadata_parses: "observed",
                 tokenizer_works: "validated_raw_8_of_8_and_chat_3_of_3_prompt_token_parity",
                 tensors_load: "observed",
@@ -4265,7 +4265,7 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 performance_measured: "not_started",
                 frontend_load_path_verified: "fail_closed_blocked_parity",
                 frontend_readiness_gate: "fail-closed until generation parity passes for this exact artifact",
-                tested_context: "prompt_token_parity_to_2180_tokens_generation_nondeterministic_at_temperature_zero",
+                tested_context: "prompt_token_parity_to_2180_tokens_single_token_decode_reference_matched_multi_token_diverges_at_index_2",
                 chat_template_renderer: "phi3_metadata_template_prompt_tokens_reference_matched",
                 chat_template_shape_pack: "failed_reference_parity",
                 chat_template_shape_pack_id: "phi3-chat-template-pack-v1",
@@ -4287,8 +4287,8 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 latest_checked_bucket: "phi3_hold_evidence",
                 latest_checked_result: "blocked_generation_parity",
                 latest_checked_output: "qa/muster/phi3-hold-evidence/README.md",
-                evidence: "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. Generation parity still blocks the row, but the cause is NON-DETERMINISM, not a fixed forward-pass error: six identical temperature-0 requests on the 9-token prefix 'The capital of France is Paris.\\n' returned two different tokens, flipping between the reference <|assistant|> (32001) and \\n (13), with the reference token winning a majority of runs — qa/muster/phi3-hold-evidence/nondeterminism-q8-20260727.json. That receipt scopes it to phi3 (Llama-3.2-3B on metal_resident and Mistral-7B on the SAME cpu_reference path are both bit-identical across runs) and rules out a parallel-reduction race (--threads 1) and lazy Q8 materialization (CAMELID_LAZY_Q8_0_LINEAR=0); phi3-only head_dim=96 and the fused attn_qkv/ffn_up sub-row expansion are the open suspects. It SUPERSEDES generation-divergence-q8-20260727.json, whose prefill-vs-decode reading was drawn from two samples of a noisy process and is wrong. This row is intentionally not advertised as supported",
-                next_step: "make phi3 decode REPEATABLE first — identical temperature-0 requests must return identical logits. It survives --threads 1 and eager Q8, so hunt an uninitialized/stale read on the phi3-only paths: head_dim=96 tails (every other local row is 128) and the fused attn_qkv/ffn_up sub-row descriptor expansion in src/model.rs. Only then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion",
+                evidence: "prompt-token parity PASSES on the exact artifact Phi-3-mini-4k-instruct-Q8_0.gguf: all_match=true over the committed 8-prompt pack (to a 2180-token prompt) and over the 3 rendered chat prompts, against pinned llama.cpp acd79d603 — qa/muster/phi3-hold-evidence/{prompt-token-parity-q8-20260727.json,chat-prompt-token-parity-q8-20260727.json}. The temperature-0 NON-DETERMINISM that previously blocked this row is FIXED: half_mm_batched_f16o ignored its `rows` argument, so at head_dim=96 the prefill PV pass's partial 64-row tile read past each head V slab and wrote into the next head's columns, racing it; bounding the three unguarded sites by `rows` makes the default path bit-stable (6/6 identical single-token, 3/3 identical multi-token) and returns the reference token 32001 — qa/muster/phi3-hold-evidence/nondeterminism-fixed-q8-20260728.json, which also records Llama-3.2-3B and Mistral-7B bit-identical pre/post patch. Generation parity STILL blocks the row for a separate and now-DETERMINISTIC reason: on 'The capital of France is' the reference emits [3681,29889,13,32001,3869] while camelid emits [3681,29889,3681,338,2998], diverging at index 2, and a fresh prefill of the 8-token prefix returns the reference 13 where incremental decode returns 3681. This row is intentionally not advertised as supported",
+                next_step: "reconcile phi3 incremental decode with prefill — a fresh prefill of the same prefix matches the reference while decode does not, so compare the decode KV-cache read against the prefill path for head_dim=96 (the same non-multiple-of-64 shape that broke the PV row tile). Then re-run generation parity and capture exact-row API/WebUI and bounded-context evidence before promotion",
             },
             ModelCompatibilityTarget {
                 id: "phi4_mini_instruct_q4_k_m",
@@ -16119,17 +16119,23 @@ mod tests {
         assert!(phi3.evidence.contains("prompt-token parity PASSES"));
         assert!(phi3.evidence.contains("all_match=true"));
         assert!(!phi3.tokenizer_works.starts_with("blocked"));
-        // ...while generation parity must still be stated as blocking, and the
-        // stated CAUSE must be the non-determinism the receipts actually record,
-        // never the superseded prefill-vs-decode reading.
+        // ...the temperature-0 non-determinism must be stated as FIXED (the Metal PV
+        // row-tail guard landed)...
         assert!(phi3
             .evidence
-            .contains("Generation parity still blocks the row"));
-        assert!(phi3.evidence.contains("NON-DETERMINISM"));
-        assert!(phi3.evidence.contains("nondeterminism-q8-20260727.json"));
-        assert!(!phi3
+            .contains("NON-DETERMINISM that previously blocked this row is"));
+        assert!(phi3
             .evidence
-            .contains("disagrees with itself between fresh prefill"));
+            .contains("nondeterminism-fixed-q8-20260728.json"));
+        // ...and generation parity must still be stated as blocking, for the separate
+        // DETERMINISTIC prefill-vs-decode divergence. This is the same claim an earlier
+        // receipt made and had to retract -- it was then inferred from two samples of a
+        // non-deterministic engine. It is assertable here only because it is now
+        // repeatable (3/3 identical runs), which is what makes it evidence.
+        assert!(phi3
+            .evidence
+            .contains("Generation parity STILL blocks the row"));
+        assert!(phi3.evidence.contains("diverging at index 2"));
         assert!(phi3
             .full_support_status
             .contains("blocked_generation_parity"));

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -3210,20 +3210,28 @@ kernel void half_mm_batched(
     const uint quad_t0 = t0 + 8 * sg_tok_oct;
     const uint quad_r0 = r0 + 32 * (sg % 2);
     const bool sg_active = quad_t0 < cols
+        && quad_r0 < rows
         && !(causal_mode == 1 && quad_r0 > quad_t0 + q_offset + 31);
 
     for (uint kk0 = 0; kk0 < k_end; kk0 += NK) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         // A: 64 rows x 32 k staged TRANSPOSED (k-major in-block); zero-pad past kdim.
+        // ROW TAIL: `rows` need not be a multiple of NR0, so the last row tile is
+        // partial. A row past `rows` does not exist in A -- the attention PV pass hands
+        // this kernel rows = head_dim over a slab allocated to exactly head_dim rows --
+        // so reading it walks into the NEXT head's slab, or off the end of the buffer
+        // for the last head. Zero-pad it, exactly as the k tail is already zero-padded.
         {
-            device const half* arow =
-                ab + (r0 + lr0) * a_row_stride + (kk0 + k0) * a_elem_stride;
+            const bool a_row_valid = (r0 + lr0) < rows;
+            device const half* arow = a_row_valid
+                ? ab + (r0 + lr0) * a_row_stride + (kk0 + k0) * a_elem_stride
+                : ab;
             const uint sy = lr0 / 8;
             const uint lx = lr0 % 8;
             for (uint i = 0; i < 16; ++i) {
                 const uint kg = k0 + i;
                 sa[64 * (8 * (kg / 8) + sy) + 8 * (kg % 8) + lx] =
-                    (kk0 + kg < kdim) ? arow[i * a_elem_stride] : half(0.0f);
+                    (a_row_valid && kk0 + kg < kdim) ? arow[i * a_elem_stride] : half(0.0f);
             }
         }
         // B: 64 rows x 32 k, token-major vector stores (B is padded past cols).
@@ -3258,7 +3266,7 @@ kernel void half_mm_batched(
         }
     }
 
-    if (t0 + NR1 <= cols) {
+    if (t0 + NR1 <= cols && r0 + NR0 <= rows) {
         device float* cq = cb + (r0 + 32 * (sg % 2)) + (t0 + 32 * (sg / 2)) * c_row_stride;
         for (uint i = 0; i < 16; ++i) {
             simdgroup_store(mc[i], cq + 8 * (i % 4) + 8 * c_row_stride * (i / 4),
@@ -3276,7 +3284,7 @@ kernel void half_mm_batched(
             for (uint e2 = lane; e2 < 64; e2 += 32) {
                 const uint ft = e2 / 8;
                 const uint fr = e2 % 8;
-                if (t_oct + ft < cols) {
+                if (t_oct + ft < cols && r_oct + fr < rows) {
                     cb[(t_oct + ft) * c_row_stride + r_oct + fr] =
                         scratch[sg * 64 + ft * 8 + fr];
                 }
@@ -3343,20 +3351,28 @@ kernel void half_mm_batched_f16o(
     const uint quad_t0 = t0 + 8 * sg_tok_oct;
     const uint quad_r0 = r0 + 32 * (sg % 2);
     const bool sg_active = quad_t0 < cols
+        && quad_r0 < rows
         && !(causal_mode == 1 && quad_r0 > quad_t0 + q_offset + 31);
 
     for (uint kk0 = 0; kk0 < k_end; kk0 += NK) {
         threadgroup_barrier(mem_flags::mem_threadgroup);
         // A: 64 rows x 32 k staged TRANSPOSED (k-major in-block); zero-pad past kdim.
+        // ROW TAIL: `rows` need not be a multiple of NR0, so the last row tile is
+        // partial. A row past `rows` does not exist in A -- the attention PV pass hands
+        // this kernel rows = head_dim over a slab allocated to exactly head_dim rows --
+        // so reading it walks into the NEXT head's slab, or off the end of the buffer
+        // for the last head. Zero-pad it, exactly as the k tail is already zero-padded.
         {
-            device const half* arow =
-                ab + (r0 + lr0) * a_row_stride + (kk0 + k0) * a_elem_stride;
+            const bool a_row_valid = (r0 + lr0) < rows;
+            device const half* arow = a_row_valid
+                ? ab + (r0 + lr0) * a_row_stride + (kk0 + k0) * a_elem_stride
+                : ab;
             const uint sy = lr0 / 8;
             const uint lx = lr0 % 8;
             for (uint i = 0; i < 16; ++i) {
                 const uint kg = k0 + i;
                 sa[64 * (8 * (kg / 8) + sy) + 8 * (kg % 8) + lx] =
-                    (kk0 + kg < kdim) ? arow[i * a_elem_stride] : half(0.0f);
+                    (a_row_valid && kk0 + kg < kdim) ? arow[i * a_elem_stride] : half(0.0f);
             }
         }
         // B: 64 rows x 32 k, token-major vector stores (B is padded past cols).
@@ -3391,7 +3407,7 @@ kernel void half_mm_batched_f16o(
         }
     }
 
-    if (t0 + NR1 <= cols) {
+    if (t0 + NR1 <= cols && r0 + NR0 <= rows) {
         // Half output: per-lane element stores from the accumulator fragments.
         device half* cq = cb + (r0 + 32 * (sg % 2)) + (t0 + 32 * (sg / 2)) * c_row_stride;
         const short qid = (short)(lane / 4);
@@ -3415,7 +3431,7 @@ kernel void half_mm_batched_f16o(
             for (uint e2 = lane; e2 < 64; e2 += 32) {
                 const uint ft = e2 / 8;
                 const uint fr = e2 % 8;
-                if (t_oct + ft < cols) {
+                if (t_oct + ft < cols && r_oct + fr < rows) {
                     cb[(t_oct + ft) * c_row_stride + r_oct + fr] =
                         half(scratch[sg * 64 + ft * 8 + fr]);
                 }


### PR DESCRIPTION
`half_mm_batched_f16o` tiles its A-row dimension in fixed 64-row blocks and **ignored its `rows` argument entirely** — the parameter is declared at `buffer(4)` and never read anywhere in the body. The prefill attention-as-matmul PV pass drives it with `rows = head_dim`.

At **head_dim = 96** the host dispatches `ceil(96/64) = 2` row tiles, so the second tile carries a 32-row overhang that:

- **reads** past each head's V-transpose slab (`transpose_v16` only ever writes `d < head_dim`, and `vt_scratch` has no row padding) — and off the end of the buffer entirely for the last head;
- **writes** output columns 96..127 of a 96-wide-per-head slot, which are physically the **next head's** columns 0..31 — racing that head's own legitimate write, from a different threadgroup, with no ordering.

That race is why camelid returned different logits for byte-identical temperature-0 requests on phi3: six identical requests flipped between the reference token `32001` (`<|assistant|>`) and `13`.

Every other local architecture has `head_dim = 128`, which tiles evenly — so only phi3 was hit. Note also that `use_attn_mm` admits on `head_dim % 8 == 0`, while its sibling `use_mm` correctly demands multiples of 128 for every row count it feeds this same guardless kernel family.

## Fix

Bound all three unguarded sites by the `rows` value that was already being passed:

| site | guard |
|---|---|
| A-row stage | zero-pad rows past `rows`, exactly as the k tail already was |
| `sg_active` | `quad_r0 < rows` |
| fast store | require `r0 + NR0 <= rows`, so a partial tile routes to the ragged path |
| ragged store | bound the row index: `r_oct + fr < rows` |

Applied to both the f16-output kernel and its **f32 twin**, which carried the identical latent defect (its only caller today is a test, so it was a trap rather than a live bug).

## Verification — default path, no flags

| | result |
|---|---|
| phi3 single-token, 6 identical requests | **6/6 bit-identical**, token `32001`, logprob `-0.009686` (oracle: `-0.009130`) |
| phi3 multi-token, 3 identical requests | **3/3 bit-identical** |
| Llama-3.2-3B Q8_0 pre/post patch | `'The' -0.91886` -> `'The' -0.91886` — **bit-identical** |
| Mistral-7B Q8_0 pre/post patch | `'\n' -0.0096` -> `'\n' -0.0096` — **bit-identical** |

`head_dim=128` tiles evenly, so both row tiles still take the fast store path and the guards are a no-op there.

`cargo test --release --no-fail-fast`: only failure is `tensor::nvfp4_tests::encode_vectors_reproduce_pin_wire_bytes_and_dequant`, pre-existing on main. `cargo fmt --check`, `clippy --all-targets -D warnings`, `check-ledger-schema.mjs`, `check-ledger-drift.mjs` (ledger regenerated, not hand-edited) and `check-public-scrub.sh` all clean.

## Phi-3 does NOT move to supported

Generation parity still fails, now for a **separate and deterministic** reason: on `"The capital of France is"` the reference emits `[3681,29889,13,32001,3869]` and camelid emits `[3681,29889,3681,338,2998]`, diverging at index 2. A fresh prefill of the 8-token prefix returns the reference `13` where incremental decode returns `3681`.

An earlier receipt asserted that same prefill-vs-decode split from two samples of the then-non-deterministic engine and was retracted in #519. It is asserted now **only because it is repeatable** (3/3 identical runs). The row stays `active_validation_blocked_parity` and fail-closed; the pinned assertions move with it.

## Also recorded, not fixed here

`attn_mm_small_parity` is `#[ignore]`d **and already failing on pristine main** (identical `max_err` at `hd=64`), so it could not serve as the regression harness for this bug — which is part of why nothing caught it. Its `hd = 64usize; // PV rows must be 64-aligned` line documents the very assumption that hid the defect. Repairing that harness and adding an `hd=96` case is the natural follow-up.