### PR TITLE
Add optimized KV cache quantization

### DIFF
--- a/docs/perf-deep-dive/PERF_RECEIPTS/same-host/kv-cache-quantization-ab-20260728.md
+++ b/docs/perf-deep-dive/PERF_RECEIPTS/same-host/kv-cache-quantization-ab-20260728.md
@@ -1,0 +1,171 @@
+# KV cache quantization before/after report
+
+Date: 2026-07-28
+
+Repository: `C:\Users\timto\Documents\GitHub\Camelid`
+
+Baseline: clean `origin/main` at `f8649c6294aac0ab742890328320e80cc0434085`
+
+After: the KV cache quantization implementation in this pull request
+
+## Verdict
+
+PASS.
+
+- Exact cache allocation tests pass for F32, F16, Q8_0, and Q4_0, including
+  dimensions that are not divisible by the 32-value quantization block.
+- Measured process RSS follows the predicted cache sizes.
+- The current F32 and F16 control paths show no material throughput regression.
+- Q8_0 and Q4_0 have no material short-context decode regression, improve
+  long-context CPU decode in the balanced final matrix, and are flat on the
+  fully resident CUDA path.
+- All measured deterministic generations produced the same token IDs in every
+  tested cache mode.
+- The complete all-target/all-feature test matrix passes.
+
+The quantized formats remain lossy. Token identity on this benchmark is a
+regression check, not a general model-quality certification.
+
+## Test host
+
+| Item | Value |
+| --- | --- |
+| OS | Windows 11 Home Insider Preview, 10.0.26220 |
+| CPU | Intel Core i7-11800H, 8 cores / 16 logical processors |
+| RAM | 15.74 GiB |
+| GPU | NVIDIA RTX 3060 Laptop GPU, compute capability 8.6, 6 GiB VRAM |
+| Model | `Llama-3.2-3B-Instruct-Q8_0.gguf`, 3.187 GiB |
+| Threads | 8 |
+| Sampling | Greedy, temperature 0 |
+| Build | Cargo release profile: opt-level 3, fat LTO, one codegen unit, x86-64-v3 |
+
+The clean baseline and current tree were built in separate source worktrees with
+the same Cargo target directory and identical release flags. The baseline
+working tree was not modified.
+
+## Benchmark method
+
+CPU measurements used `bench-generate --deterministic`, which disables the GPU
+stack and isolates host KV-cache behavior.
+
+- Short context: 5 prompt tokens, 65 generated tokens, 64 measured decode
+  steps, warmup enabled, two mirrored-order rounds, four samples per format.
+- Long context: 1,010 prompt tokens, 33 generated tokens, 32 measured decode
+  steps, two mirrored-order samples per format.
+- Memory: process peak RSS reported by `bench-generate`.
+- The long prompt crossed Camelid's 2,048-position allocation boundary, so the
+  expected memory deltas use a 2,048-position cache capacity.
+- CUDA control: 5 prompt tokens, 65 generated tokens, warmup plus three measured
+  iterations, all 28 layers resident.
+
+The laptop showed meaningful power/thermal variation, so the report uses
+balanced medians rather than individual fastest samples.
+
+## Theoretical KV memory
+
+The model has 28 layers, 8 KV heads, and a 128-value head dimension.
+
+| Cache format | Bytes/token | Bytes at 2,048 positions | Reduction vs F32 |
+| --- | ---: | ---: | ---: |
+| F32 baseline | 229,376 | 448 MiB | — |
+| F16 | 114,688 | 224 MiB | 50.0% |
+| Q8_0 | 60,928 | 119 MiB | 73.4% |
+| Q4_0 | 32,256 | 63 MiB | 85.9% |
+
+Q8_0 uses 34 bytes per 32-value block and Q4_0 uses 18 bytes per block.
+Per-row block rounding is included in allocation and budget calculations.
+
+## Measured host memory
+
+| Configuration | Median peak RSS | RSS saved vs F32 | Expected cache-only saving |
+| --- | ---: | ---: | ---: |
+| Before: F32 | 4.396 GiB | — | — |
+| After: Q8_0 | 4.069 GiB | 335 MiB | 329 MiB |
+| After: Q4_0 | 4.007 GiB | 399 MiB | 385 MiB |
+
+The 6–14 MiB difference between process-RSS deltas and cache-only predictions
+is normal process high-water variability. Dedicated allocator tests verify the
+exact block counts and byte totals independently of RSS.
+
+The existing opt-in F16 lane reduced the same 2,048-position cache by
+approximately 218–225 MiB in the mirrored control run, matching the theoretical
+224 MiB.
+
+## CPU decode throughput
+
+### Short context
+
+| Configuration | Median tok/s | Change vs before |
+| --- | ---: | ---: |
+| Before: F32 | 9.029 | — |
+| After: Q8_0 | 8.929 | -1.1% |
+| After: Q4_0 | 8.909 | -1.3% |
+
+The approximately 1% differences are inside the observed run-to-run noise.
+Every one of the 12 measured outputs was token-identical.
+
+The F16 before/after control was also stable: 6.521 versus 6.454 tok/s in its
+balanced short-context run (-1.0%).
+
+### Long context
+
+| Configuration | Median tok/s | Change vs before | Median prefill | Prefill change |
+| --- | ---: | ---: | ---: | ---: |
+| Before: F32 | 7.416 | — | 33.185 s | — |
+| After: Q8_0 | 8.288 | +11.8% | 34.442 s | +3.8% |
+| After: Q4_0 | 8.211 | +10.7% | 33.497 s | +0.9% |
+
+All long-context outputs were token-identical.
+
+The first implementation used scalar quantized dot and value-dequantization
+loops. That candidate measured 4.909 tok/s for Q8_0 and 4.269 tok/s for Q4_0,
+or -25.1% and -34.9% versus its paired baseline. The final implementation
+adds runtime-dispatched AVX2/FMA Q8_0 and Q4_0 attention kernels and fuses value
+dequantization with accumulation. The table above is the post-fix result.
+
+## CUDA resident control
+
+| Configuration | Median tok/s | Change vs before |
+| --- | ---: | ---: |
+| Before: F32 host cache | 54.386 | — |
+| After: Q8_0 host cache | 54.203 | -0.34% |
+| After: Q4_0 host cache | 54.197 | -0.35% |
+
+All 28 layers were resident in VRAM and every output was token-identical. The
+differences are below 0.4% and are not a material regression.
+
+Host KV quantization does not claim to reduce the resident engine's own VRAM
+cache; this control verifies that selecting a host-cache format does not slow
+the normal CUDA fast path.
+
+## Correctness and regression validation
+
+- `cargo build --release --bin camelid`
+- `cargo test --all-targets --all-features -- --test-threads=1`
+  - Library: 1,229 passed, 0 failed, 68 ignored.
+  - 59 test-result sections across library, integration, binary, and example
+    targets; no failure markers.
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo fmt --all -- --check`
+- Focused Q8_0/Q4_0 roundtrip, dot, fused AXPY, tail-row, layout, budget, and
+  attention-oracle tests.
+
+The final source includes:
+
+- row-padded quantized offsets and exact allocation accounting;
+- tail-safe Q8_0/Q4_0 storage and attention;
+- current ggml-compatible Q4_0 signed-max scaling;
+- IEEE-correct F16 scale conversion;
+- dtype-neutral resident-cache seeding;
+- AVX2/FMA quantized attention fast paths with portable scalar fallbacks;
+- strict CLI parsing and model-config propagation.
+
+## Binary provenance
+
+| Binary | SHA-256 |
+| --- | --- |
+| Clean baseline | `C0B31C017394B9BE812E08D597469041B8DA5BCF3C0F795F8BFA817444DB2252` |
+| Final rebuilt implementation | `094D0E54073EBA6F2DA6413C1202C1E5F62FE2345BB1916154B2AE0E0F451EFE` |
+
+Raw benchmark JSONL and full test logs are in the ignored local directory
+`target\kv-bench-results`.

--- a/docs/perf-deep-dive/PERF_RECEIPTS/same-host/kv-cache-quantization-ab-20260728.md
+++ b/docs/perf-deep-dive/PERF_RECEIPTS/same-host/kv-cache-quantization-ab-20260728.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-28
 
-Repository: `C:\Users\timto\Documents\GitHub\Camelid`
+Repository: Camelid repository root
 
 Baseline: clean `origin/main` at `f8649c6294aac0ab742890328320e80cc0434085`
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18523,6 +18523,7 @@ mod tests {
             feed_forward_length: 6,
             attention_head_count: 2,
             attention_head_count_kv: 1,
+            kv_quant: crate::model::KvCacheQuantization::F16,
             rope_dimension_count: Some(2),
             rope_freq_base: Some(10_000.0),
             rope_scaling_type: None,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -97,7 +97,11 @@ use crate::{
         LlamaMoeExpertTensors, LlamaTensorBinding,
     },
     tensor::{
-        dot_product, parse_byte_count_env, q8_0_file_read_stats, should_parallelize_linear_output,
+        dot_product,
+        kv_quant::{
+            axpy_row_q4_0, axpy_row_q8_0, vec_dot_row_q4_0, vec_dot_row_q8_0, KV_QUANT_BLOCK_VALUES,
+        },
+        parse_byte_count_env, q8_0_file_read_stats, should_parallelize_linear_output,
         with_q8_file_cache_capacity_override, CpuTensor, Q8_0Block, Q8_0FileBacking,
         Q8_0FileReadStats, Q8_0PackedRows4, Q8_0PackedRows4Block, Q8_0PackedRows4Interleave,
         Q8_0RuntimeStorage, Q8_0VnniPacked, Q8_0VnniTile16, TensorShape, TensorStore,
@@ -2186,6 +2190,10 @@ impl LlamaInferenceSession {
                     values: Vec::new(),
                     keys_f16: Vec::new(),
                     values_f16: Vec::new(),
+                    keys_q8_0: Vec::new(),
+                    values_q8_0: Vec::new(),
+                    keys_q4_0: Vec::new(),
+                    values_q4_0: Vec::new(),
                     allocated_sequence_length: 0,
                     position: 0,
                     materialized_through: 0,
@@ -2317,10 +2325,11 @@ impl LlamaInferenceSession {
         let weights = weights.into();
         weights.validate_dense_shapes(&config)?;
         let plan = LlamaKvCachePlan::from_config(&config)?;
+        let kv_quant = config.kv_quant;
         Ok(Self {
             config,
             weights,
-            kv_cache: LlamaKvCache::new(plan)?,
+            kv_cache: LlamaKvCache::new(plan, kv_quant)?,
             resident_decode: None,
             resident_paths_disabled: false,
             execution_trace: None,
@@ -3574,9 +3583,8 @@ impl LlamaInferenceSession {
                 // (engine evicted or rebuilt for another model); declining routes to the CPU
                 // path, which warns, instead of laundering zeros through the GPU cache.
                 //
-                // The watermark alone, not `f32_history_materialized`: the loop below reads via
-                // `copy_key_row_into`, which serves an F16 cache too, so pairing it with a probe
-                // over the (legitimately empty) f32 buffers would decline a readable history.
+                // The watermark is sufficient because the loop below reads via the
+                // dtype-neutral `copy_key_row_into` / `copy_value_row_into` accessors.
                 if !self.kv_cache.history_materialized(position) {
                     if trace {
                         eprintln!(
@@ -24964,6 +24972,15 @@ fn attention_context_for_head_into_with_kernels(
         .kv_cache
         .head_base_offset(params.layer_idx, params.kv_head);
     let position_stride = params.kv_cache.head_position_stride();
+    let key_blocks_per_row = k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+    let mut key_block_start = params.kv_cache.quantized_head_base_offset(
+        params.layer_idx,
+        params.kv_head,
+        key_blocks_per_row,
+    );
+    let key_block_position_stride = params
+        .kv_cache
+        .quantized_head_position_stride(key_blocks_per_row);
 
     let mut key_start = head_base;
     for position in 0..params.position_count {
@@ -24984,10 +25001,21 @@ fn attention_context_for_head_into_with_kernels(
                 let key_slice = &params.kv_cache.keys_f16[key_start..key_start + k_head_dim];
                 attn_f32_dot::dot_blocked_f16(params.query_slice, key_slice) * params.scale
             }
+            KvDtype::Q8_0 => {
+                let key_blocks = &params.kv_cache.keys_q8_0
+                    [key_block_start..key_block_start + key_blocks_per_row];
+                vec_dot_row_q8_0(params.query_slice, key_blocks) * params.scale
+            }
+            KvDtype::Q4_0 => {
+                let key_blocks = &params.kv_cache.keys_q4_0
+                    [key_block_start..key_block_start + key_blocks_per_row];
+                vec_dot_row_q4_0(params.query_slice, key_blocks) * params.scale
+            }
         };
         scores.push(score);
         if position + 1 < params.position_count {
             key_start += position_stride;
+            key_block_start += key_block_position_stride;
         }
     }
 
@@ -25006,6 +25034,23 @@ fn attention_context_for_head_into_with_kernels(
     let inv_score_sum = 1.0 / score_sum;
     let mut value_start = head_base;
     let is_mla = params.kv_cache.plan.value_shape[3] == 0;
+    let value_blocks_per_row = v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+    let mut quantized_key_value_start = params.kv_cache.quantized_head_base_offset(
+        params.layer_idx,
+        params.kv_head,
+        key_blocks_per_row,
+    );
+    let quantized_key_value_stride = params
+        .kv_cache
+        .quantized_head_position_stride(key_blocks_per_row);
+    let mut quantized_value_start = params.kv_cache.quantized_head_base_offset(
+        params.layer_idx,
+        params.kv_head,
+        value_blocks_per_row,
+    );
+    let quantized_value_stride = params
+        .kv_cache
+        .quantized_head_position_stride(value_blocks_per_row);
     for (position, score) in scores.iter().copied().enumerate() {
         let probability = score * inv_score_sum;
         match params.kv_cache.dtype {
@@ -25031,9 +25076,31 @@ fn attention_context_for_head_into_with_kernels(
                 };
                 attn_f32_dot::axpy_blocked_f16(out_slice, probability, value_slice);
             }
+            KvDtype::Q8_0 => {
+                let value_blocks = if is_mla {
+                    &params.kv_cache.keys_q8_0[quantized_key_value_start
+                        ..quantized_key_value_start + value_blocks_per_row]
+                } else {
+                    &params.kv_cache.values_q8_0
+                        [quantized_value_start..quantized_value_start + value_blocks_per_row]
+                };
+                axpy_row_q8_0(out_slice, probability, value_blocks);
+            }
+            KvDtype::Q4_0 => {
+                let value_blocks = if is_mla {
+                    &params.kv_cache.keys_q4_0[quantized_key_value_start
+                        ..quantized_key_value_start + value_blocks_per_row]
+                } else {
+                    &params.kv_cache.values_q4_0
+                        [quantized_value_start..quantized_value_start + value_blocks_per_row]
+                };
+                axpy_row_q4_0(out_slice, probability, value_blocks);
+            }
         }
         if position + 1 < params.position_count {
             value_start += position_stride;
+            quantized_key_value_start += quantized_key_value_stride;
+            quantized_value_start += quantized_value_stride;
         }
     }
 

--- a/src/inference/kv_cache.rs
+++ b/src/inference/kv_cache.rs
@@ -4,6 +4,10 @@ use serde::Serialize;
 
 use crate::{
     model::{DenseLlamaDims, LlamaModelConfig},
+    tensor::kv_quant::{
+        dequantize_row_q4_0, dequantize_row_q8_0, quantize_row_q4_0, quantize_row_q8_0, BlockQ4_0,
+        BlockQ8_0, KV_QUANT_BLOCK_VALUES,
+    },
     BackendError, Result,
 };
 
@@ -118,6 +122,10 @@ pub struct LlamaKvCache {
     /// f16 storage (bit patterns), live only when `dtype == KvDtype::F16`.
     pub keys_f16: Vec<u16>,
     pub values_f16: Vec<u16>,
+    pub keys_q8_0: Vec<BlockQ8_0>,
+    pub values_q8_0: Vec<BlockQ8_0>,
+    pub keys_q4_0: Vec<BlockQ4_0>,
+    pub values_q4_0: Vec<BlockQ4_0>,
     pub allocated_sequence_length: usize,
     pub position: usize,
     /// Materialized-through watermark: positions `[0, materialized_through)` have had
@@ -157,6 +165,10 @@ impl PartialEq for LlamaKvCache {
             && self.values == other.values
             && self.keys_f16 == other.keys_f16
             && self.values_f16 == other.values_f16
+            && self.keys_q8_0 == other.keys_q8_0
+            && self.values_q8_0 == other.values_q8_0
+            && self.keys_q4_0 == other.keys_q4_0
+            && self.values_q4_0 == other.values_q4_0
             && self.allocated_sequence_length == other.allocated_sequence_length
             && self.position == other.position
             && self.materialized_through == other.materialized_through
@@ -204,6 +216,8 @@ fn kv_layout_head_major_enabled() -> bool {
 pub enum KvDtype {
     F32,
     F16,
+    Q8_0,
+    Q4_0,
 }
 
 /// Env gate for f16 storage, read once per cache construction. Requires the
@@ -228,7 +242,7 @@ fn kv_f16_enabled() -> bool {
 }
 
 impl LlamaKvCache {
-    pub fn new(plan: LlamaKvCachePlan) -> Result<Self> {
+    pub fn new(plan: LlamaKvCachePlan, quant: crate::model::KvCacheQuantization) -> Result<Self> {
         #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
         let (layout, dtype) = (
             if kv_layout_head_major_enabled() {
@@ -236,14 +250,27 @@ impl LlamaKvCache {
             } else {
                 KvLayout::PositionMajor
             },
-            if kv_f16_enabled() {
-                KvDtype::F16
-            } else {
-                KvDtype::F32
+            match quant {
+                crate::model::KvCacheQuantization::Q8_0 => KvDtype::Q8_0,
+                crate::model::KvCacheQuantization::Q4_0 => KvDtype::Q4_0,
+                crate::model::KvCacheQuantization::F16 => {
+                    if kv_f16_enabled() {
+                        KvDtype::F16
+                    } else {
+                        KvDtype::F32
+                    }
+                }
             },
         );
         #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
-        let (layout, dtype) = (KvLayout::PositionMajor, KvDtype::F32);
+        let (layout, dtype) = (
+            KvLayout::PositionMajor,
+            match quant {
+                crate::model::KvCacheQuantization::Q8_0 => KvDtype::Q8_0,
+                crate::model::KvCacheQuantization::Q4_0 => KvDtype::Q4_0,
+                _ => KvDtype::F32,
+            },
+        );
         Self::new_with_layout_and_dtype(plan, layout, dtype)
     }
 
@@ -267,6 +294,10 @@ impl LlamaKvCache {
             values: Vec::new(),
             keys_f16: Vec::new(),
             values_f16: Vec::new(),
+            keys_q8_0: Vec::new(),
+            values_q8_0: Vec::new(),
+            keys_q4_0: Vec::new(),
+            values_q4_0: Vec::new(),
             allocated_sequence_length: 0,
             position: 0,
             materialized_through: 0,
@@ -328,19 +359,25 @@ impl LlamaKvCache {
                 budget_bytes: self.kv_budget_bytes,
             });
         }
-        let k_elements = target_sequence_length
+        let row_count = target_sequence_length
             .checked_mul(self.plan.layer_count)
             .and_then(|value| value.checked_mul(self.plan.kv_head_count))
-            .and_then(|value| value.checked_mul(self.plan.key_shape[3]))
             .ok_or_else(|| {
-                BackendError::RuntimeShapeMismatch("KV cache element count overflow".to_string())
+                BackendError::RuntimeShapeMismatch("KV cache row count overflow".to_string())
             })?;
-        let v_elements = target_sequence_length
-            .checked_mul(self.plan.layer_count)
-            .and_then(|value| value.checked_mul(self.plan.kv_head_count))
-            .and_then(|value| value.checked_mul(self.plan.value_shape[3]))
+        let k_elements = row_count
+            .checked_mul(self.plan.key_shape[3])
             .ok_or_else(|| {
-                BackendError::RuntimeShapeMismatch("KV cache element count overflow".to_string())
+                BackendError::RuntimeShapeMismatch(
+                    "KV cache key element count overflow".to_string(),
+                )
+            })?;
+        let v_elements = row_count
+            .checked_mul(self.plan.value_shape[3])
+            .ok_or_else(|| {
+                BackendError::RuntimeShapeMismatch(
+                    "KV cache value element count overflow".to_string(),
+                )
             })?;
 
         #[allow(clippy::too_many_arguments)]
@@ -423,6 +460,30 @@ impl LlamaKvCache {
                 v_head_dim,
                 streams,
             ),
+            KvDtype::Q8_0 => grow_buffers(
+                &mut self.keys_q8_0,
+                &mut self.values_q8_0,
+                self.layout,
+                row_count * k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES),
+                row_count * v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES),
+                self.allocated_sequence_length,
+                target_sequence_length,
+                k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES),
+                v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES),
+                streams,
+            ),
+            KvDtype::Q4_0 => grow_buffers(
+                &mut self.keys_q4_0,
+                &mut self.values_q4_0,
+                self.layout,
+                row_count * k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES),
+                row_count * v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES),
+                self.allocated_sequence_length,
+                target_sequence_length,
+                k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES),
+                v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES),
+                streams,
+            ),
         }
         self.allocated_sequence_length = target_sequence_length;
         Ok(())
@@ -440,17 +501,26 @@ impl LlamaKvCache {
     }
 
     pub fn allocated_elements(&self) -> usize {
-        self.keys.len() + self.values.len() + self.keys_f16.len() + self.values_f16.len()
+        self.allocated_sequence_length
+            .saturating_mul(self.position_stride() + self.value_position_stride())
     }
 
     pub fn allocated_bytes(&self) -> u64 {
-        (self.allocated_elements() as u64) * self.element_bytes()
-    }
-
-    fn element_bytes(&self) -> u64 {
         match self.dtype {
-            KvDtype::F32 => std::mem::size_of::<f32>() as u64,
-            KvDtype::F16 => std::mem::size_of::<u16>() as u64,
+            KvDtype::F32 => {
+                ((self.keys.len() + self.values.len()) * std::mem::size_of::<f32>()) as u64
+            }
+            KvDtype::F16 => {
+                ((self.keys_f16.len() + self.values_f16.len()) * std::mem::size_of::<u16>()) as u64
+            }
+            KvDtype::Q8_0 => {
+                ((self.keys_q8_0.len() + self.values_q8_0.len()) * std::mem::size_of::<BlockQ8_0>())
+                    as u64
+            }
+            KvDtype::Q4_0 => {
+                ((self.keys_q4_0.len() + self.values_q4_0.len()) * std::mem::size_of::<BlockQ4_0>())
+                    as u64
+            }
         }
     }
 
@@ -471,8 +541,8 @@ impl LlamaKvCache {
     /// actually written — so a range this accepts may still be zero-filled for positions the
     /// GPU produced and the CPU never wrote.
     ///
-    /// Anything that READS the history (rather than merely indexing it) must therefore use
-    /// [`f32_history_materialized`](Self::f32_history_materialized) instead.
+    /// This remains as a regression-test probe for hollow resident-session buffers.
+    #[cfg(test)]
     pub(super) fn f32_history_addressable(&self, last_layer: usize, position: usize) -> bool {
         if position == 0 {
             return true;
@@ -489,29 +559,12 @@ impl LlamaKvCache {
         self.keys.len() >= end && self.values.len() >= end
     }
 
-    /// Whether `[0, position)` is both addressable AND actually written — the check any
-    /// consumer that READS the f32 history needs (GPU reseeding, resumption from CPU state).
+    /// Has `[0, position)` actually been written?
     ///
-    /// This is the strict form of [`f32_history_addressable`](Self::f32_history_addressable).
-    /// The bounds probe alone cannot tell "grown and written" from "grown and zero", and the
-    /// two become indistinguishable the moment a single CPU fallback fires mid-sequence on a
-    /// GPU-resident run: that one step grows the buffers for its own position and leaves every
-    /// earlier position zero-filled, after which the probe passes and a reseed copies a zeroed
-    /// prompt onto the GPU. The watermark is what separates them.
-    pub(super) fn f32_history_materialized(&self, last_layer: usize, position: usize) -> bool {
-        self.materialized_through >= position && self.f32_history_addressable(last_layer, position)
-    }
-
-    /// Dtype-neutral form of the same question: has `[0, position)` actually been written?
-    ///
-    /// [`f32_history_materialized`](Self::f32_history_materialized) pairs the watermark with a
-    /// bounds probe over the f32 buffers, which is right for a reader that indexes `keys` /
-    /// `values` directly (the Metal seed does) but wrong for one that goes through
-    /// [`copy_key_row_into`](Self::copy_key_row_into) / `copy_value_row_into` (the CUDA seed
-    /// does): those serve both dtypes, so on an F16 cache — where the f32 buffers are empty by
-    /// design — the probe would decline a history that is perfectly readable. The watermark
-    /// alone is the correct predicate there, and it is not weaker: it only ever advances from
-    /// `store_kv_head_row`, which cannot have written a position without capacity for it.
+    /// GPU seed paths read through [`copy_key_row_into`](Self::copy_key_row_into) and
+    /// [`copy_value_row_into`](Self::copy_value_row_into), which serve every cache dtype.
+    /// The watermark is therefore the correct predicate, and it only advances from
+    /// [`store_kv_head_row`](Self::store_kv_head_row), which cannot write without capacity.
     #[cfg_attr(not(feature = "cuda"), allow(dead_code))]
     pub(super) fn history_materialized(&self, position: usize) -> bool {
         self.materialized_through >= position
@@ -605,8 +658,41 @@ impl LlamaKvCache {
         }
     }
 
+    /// Block offset for a quantized row. Quantized rows are padded independently
+    /// to a block boundary, so deriving this from the logical element offset is
+    /// incorrect when a head dimension is not a multiple of 32.
+    pub(super) fn quantized_offset(
+        &self,
+        layer_idx: usize,
+        position: usize,
+        kv_head: usize,
+        blocks_per_row: usize,
+    ) -> usize {
+        match self.layout {
+            KvLayout::PositionMajor => {
+                (((position * self.plan.layer_count) + layer_idx) * self.plan.kv_head_count
+                    + kv_head)
+                    * blocks_per_row
+            }
+            KvLayout::HeadMajor => {
+                (((layer_idx * self.plan.kv_head_count) + kv_head) * self.allocated_sequence_length
+                    + position)
+                    * blocks_per_row
+            }
+        }
+    }
+
     pub(super) fn head_base_offset(&self, layer_idx: usize, kv_head: usize) -> usize {
         self.offset(layer_idx, 0, kv_head)
+    }
+
+    pub(super) fn quantized_head_base_offset(
+        &self,
+        layer_idx: usize,
+        kv_head: usize,
+        blocks_per_row: usize,
+    ) -> usize {
+        self.quantized_offset(layer_idx, 0, kv_head, blocks_per_row)
     }
 
     /// Element step between one head's consecutive positions — the stride the
@@ -616,6 +702,15 @@ impl LlamaKvCache {
         match self.layout {
             KvLayout::PositionMajor => self.position_stride(),
             KvLayout::HeadMajor => self.plan.k_head_dim,
+        }
+    }
+
+    pub(super) fn quantized_head_position_stride(&self, blocks_per_row: usize) -> usize {
+        match self.layout {
+            KvLayout::PositionMajor => {
+                self.plan.layer_count * self.plan.kv_head_count * blocks_per_row
+            }
+            KvLayout::HeadMajor => blocks_per_row,
         }
     }
 
@@ -634,8 +729,27 @@ impl LlamaKvCache {
     /// dtype, counting both the K and V buffers — the per-token cost the
     /// predict-and-abort guard projects.
     fn kv_bytes_per_token(&self) -> u64 {
-        ((self.position_stride() + self.value_position_stride()) as u64)
-            .saturating_mul(self.element_bytes())
+        let total_elements = (self.position_stride() + self.value_position_stride()) as u64;
+        match self.dtype {
+            KvDtype::F32 => total_elements * 4,
+            KvDtype::F16 => total_elements * 2,
+            KvDtype::Q8_0 => {
+                let blocks_per_stream = self.plan.k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES)
+                    + self.plan.v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                (self.plan.layer_count
+                    * self.plan.kv_head_count
+                    * blocks_per_stream
+                    * std::mem::size_of::<BlockQ8_0>()) as u64
+            }
+            KvDtype::Q4_0 => {
+                let blocks_per_stream = self.plan.k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES)
+                    + self.plan.v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                (self.plan.layer_count
+                    * self.plan.kv_head_count
+                    * blocks_per_stream
+                    * std::mem::size_of::<BlockQ4_0>()) as u64
+            }
+        }
     }
 
     /// THE canonical KV store: one (layer, position, kv_head) row of K and V,
@@ -688,6 +802,34 @@ impl LlamaKvCache {
                     );
                 }
             }
+            KvDtype::Q8_0 => {
+                let key_blocks = k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                let key_dst = self.quantized_offset(layer_idx, position, kv_head, key_blocks);
+                quantize_row_q8_0(key_row, &mut self.keys_q8_0[key_dst..key_dst + key_blocks]);
+                if v_dim > 0 {
+                    let value_blocks = v_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                    let value_dst =
+                        self.quantized_offset(layer_idx, position, kv_head, value_blocks);
+                    quantize_row_q8_0(
+                        value_row,
+                        &mut self.values_q8_0[value_dst..value_dst + value_blocks],
+                    );
+                }
+            }
+            KvDtype::Q4_0 => {
+                let key_blocks = k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                let key_dst = self.quantized_offset(layer_idx, position, kv_head, key_blocks);
+                quantize_row_q4_0(key_row, &mut self.keys_q4_0[key_dst..key_dst + key_blocks]);
+                if v_dim > 0 {
+                    let value_blocks = v_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                    let value_dst =
+                        self.quantized_offset(layer_idx, position, kv_head, value_blocks);
+                    quantize_row_q4_0(
+                        value_row,
+                        &mut self.values_q4_0[value_dst..value_dst + value_blocks],
+                    );
+                }
+            }
         }
     }
 
@@ -710,6 +852,16 @@ impl LlamaKvCache {
                 for (slot, &bits) in out.iter_mut().zip(&self.keys_f16[src..src + k_head_dim]) {
                     *slot = super::kv_f16::f16_to_f32_kv(bits);
                 }
+            }
+            KvDtype::Q8_0 => {
+                let block_count = k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                let block_src = self.quantized_offset(layer_idx, position, kv_head, block_count);
+                dequantize_row_q8_0(&self.keys_q8_0[block_src..block_src + block_count], out);
+            }
+            KvDtype::Q4_0 => {
+                let block_count = k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                let block_src = self.quantized_offset(layer_idx, position, kv_head, block_count);
+                dequantize_row_q4_0(&self.keys_q4_0[block_src..block_src + block_count], out);
             }
         }
     }
@@ -747,6 +899,36 @@ impl LlamaKvCache {
                 for (slot, &bits) in out.iter_mut().zip(src_slice) {
                     *slot = super::kv_f16::f16_to_f32_kv(bits);
                 }
+            }
+            KvDtype::Q8_0 => {
+                let blocks = if is_mla {
+                    let key_block_count = k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                    let block_src =
+                        self.quantized_offset(layer_idx, position, kv_head, key_block_count);
+                    &self.keys_q8_0
+                        [block_src..block_src + v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES)]
+                } else {
+                    let block_count = v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                    let block_src =
+                        self.quantized_offset(layer_idx, position, kv_head, block_count);
+                    &self.values_q8_0[block_src..block_src + block_count]
+                };
+                dequantize_row_q8_0(blocks, out);
+            }
+            KvDtype::Q4_0 => {
+                let blocks = if is_mla {
+                    let key_block_count = k_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                    let block_src =
+                        self.quantized_offset(layer_idx, position, kv_head, key_block_count);
+                    &self.keys_q4_0
+                        [block_src..block_src + v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES)]
+                } else {
+                    let block_count = v_head_dim.div_ceil(KV_QUANT_BLOCK_VALUES);
+                    let block_src =
+                        self.quantized_offset(layer_idx, position, kv_head, block_count);
+                    &self.values_q4_0[block_src..block_src + block_count]
+                };
+                dequantize_row_q4_0(blocks, out);
             }
         }
     }
@@ -838,10 +1020,18 @@ mod tests {
     fn kv_bytes_per_token_counts_k_and_v_f32() {
         // Llama 3.2 3B shape: 28 layers * 8 kv-heads * 128 head_dim = 28672 stride;
         // *2 (K+V) *4 (f32) = 229376 bytes/token.
-        let cache = LlamaKvCache::new(plan_with(131072, 28, 8, 128)).unwrap();
+        let cache = LlamaKvCache::new(
+            plan_with(131072, 28, 8, 128),
+            crate::model::KvCacheQuantization::F16,
+        )
+        .unwrap();
         assert_eq!(cache.kv_bytes_per_token(), 229_376);
         // TinyLlama shape: 22 * 4 * 64 = 5632 stride; *8 = 45056 bytes/token.
-        let cache = LlamaKvCache::new(plan_with(2048, 22, 4, 64)).unwrap();
+        let cache = LlamaKvCache::new(
+            plan_with(2048, 22, 4, 64),
+            crate::model::KvCacheQuantization::F16,
+        )
+        .unwrap();
         assert_eq!(cache.kv_bytes_per_token(), 45_056);
     }
 
@@ -849,7 +1039,11 @@ mod tests {
     fn predict_and_abort_refuses_over_budget_before_allocating() {
         // max_seq < 512 => grow_tokens == 1, so target == required (no chunk rounding) —
         // deterministic regardless of CAMELID_KV_CACHE_GROW_TOKENS.
-        let mut cache = LlamaKvCache::new(plan_with(400, 16, 8, 64)).unwrap();
+        let mut cache = LlamaKvCache::new(
+            plan_with(400, 16, 8, 64),
+            crate::model::KvCacheQuantization::F16,
+        )
+        .unwrap();
         let per_token = cache.kv_bytes_per_token(); // 16*8*64*8 = 65536
         cache.kv_budget_bytes = 100 * per_token; // budget for exactly 100 tokens
                                                  // At budget: allowed, allocates exactly 100.
@@ -875,7 +1069,11 @@ mod tests {
 
     #[test]
     fn unbounded_budget_allows_normal_growth() {
-        let mut cache = LlamaKvCache::new(plan_with(4096, 16, 8, 64)).unwrap();
+        let mut cache = LlamaKvCache::new(
+            plan_with(4096, 16, 8, 64),
+            crate::model::KvCacheQuantization::F16,
+        )
+        .unwrap();
         cache.kv_budget_bytes = u64::MAX;
         assert!(cache.ensure_position_capacity(2048).is_ok());
         assert!(cache.allocated_sequence_length >= 2048);
@@ -959,11 +1157,101 @@ mod tests {
 
     #[test]
     fn budget_excluded_from_state_equality() {
-        let mut a = LlamaKvCache::new(plan_with(2048, 22, 4, 64)).unwrap();
-        let mut b = LlamaKvCache::new(plan_with(2048, 22, 4, 64)).unwrap();
+        let mut a = LlamaKvCache::new(
+            plan_with(2048, 22, 4, 64),
+            crate::model::KvCacheQuantization::F16,
+        )
+        .unwrap();
+        let mut b = LlamaKvCache::new(
+            plan_with(2048, 22, 4, 64),
+            crate::model::KvCacheQuantization::F16,
+        )
+        .unwrap();
         a.kv_budget_bytes = 1 << 20;
         b.kv_budget_bytes = 1 << 40;
         // Different host budgets, identical state -> still equal.
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn quantized_cache_byte_accounting_includes_per_row_padding() {
+        let plan = plan_with(100, 2, 3, 33);
+        for (dtype, expected_per_token) in [(KvDtype::Q8_0, 816), (KvDtype::Q4_0, 432)] {
+            let mut cache = LlamaKvCache::new_with_layout_and_dtype(
+                plan.clone(),
+                KvLayout::PositionMajor,
+                dtype,
+            )
+            .unwrap();
+            assert_eq!(cache.kv_bytes_per_token(), expected_per_token);
+            cache.kv_budget_bytes = expected_per_token;
+            cache.ensure_position_capacity(1).unwrap();
+            assert_eq!(cache.allocated_bytes(), expected_per_token);
+            assert_eq!(cache.allocated_elements(), 2 * 3 * 33 * 2);
+
+            let error = cache.ensure_position_capacity(2).unwrap_err();
+            assert!(matches!(error, BackendError::KvCacheBudgetExceeded { .. }));
+            assert_eq!(cache.allocated_sequence_length, 1);
+        }
+    }
+
+    #[test]
+    fn quantized_cache_preserves_tail_rows_across_layout_growth() {
+        let plan = plan_with(600, 2, 2, 40);
+        for dtype in [KvDtype::Q8_0, KvDtype::Q4_0] {
+            for layout in [KvLayout::PositionMajor, KvLayout::HeadMajor] {
+                let mut cache =
+                    LlamaKvCache::new_with_layout_and_dtype(plan.clone(), layout, dtype).unwrap();
+                cache.kv_budget_bytes = u64::MAX;
+                cache.ensure_position_capacity(1).unwrap();
+
+                let key: Vec<f32> = (0..40).map(|i| (i as f32 - 17.0) * 0.125).collect();
+                let value: Vec<f32> = (0..40).map(|i| (11.0 - i as f32) * 0.0625).collect();
+                cache.store_kv_head_row(1, 0, 1, &key, &value);
+
+                // Crossing the 256-position growth boundary re-lays head-major
+                // storage and must preserve every padded quantized row.
+                cache.ensure_position_capacity(257).unwrap();
+                let mut actual_key = vec![0.0; 40];
+                let mut actual_value = vec![0.0; 40];
+                cache.copy_key_row_into(1, 0, 1, &mut actual_key);
+                cache.copy_value_row_into(1, 0, 1, &mut actual_value);
+
+                let tolerance = if dtype == KvDtype::Q8_0 { 0.02 } else { 0.2 };
+                for (index, (actual, expected)) in actual_key.iter().zip(&key).enumerate() {
+                    assert!(
+                        (actual - expected).abs() <= tolerance,
+                        "{dtype:?}/{layout:?} key tail mismatch at {index}: {actual} vs {expected}"
+                    );
+                }
+                for (index, (actual, expected)) in actual_value.iter().zip(&value).enumerate() {
+                    assert!(
+                        (actual - expected).abs() <= tolerance,
+                        "{dtype:?}/{layout:?} value tail mismatch at {index}: {actual} vs {expected}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn quantized_storage_participates_in_cache_equality() {
+        for dtype in [KvDtype::Q8_0, KvDtype::Q4_0] {
+            let mut cache = LlamaKvCache::new_with_layout_and_dtype(
+                plan_with(1, 1, 1, 32),
+                KvLayout::PositionMajor,
+                dtype,
+            )
+            .unwrap();
+            cache.ensure_position_capacity(1).unwrap();
+            cache.store_kv_head_row(0, 0, 0, &[1.0; 32], &[2.0; 32]);
+            let mut different = cache.clone();
+            match dtype {
+                KvDtype::Q8_0 => different.keys_q8_0[0].qs[0] ^= 1,
+                KvDtype::Q4_0 => different.keys_q4_0[0].qs[0] ^= 1,
+                _ => unreachable!(),
+            }
+            assert_ne!(cache, different);
+        }
     }
 }

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -401,28 +401,19 @@ impl super::LlamaInferenceSession {
                 None => return Ok(None),
             };
             if position > 0 {
-                // Seeding reads the CPU KV history [0, position) out of `kv_cache.keys` /
-                // `.values`, so that range must be both addressable AND actually written.
+                // Seeding reads the CPU KV history [0, position) through the
+                // dtype-neutral row accessors, so that range must actually be written.
                 //
-                // Addressability alone is not enough, and the difference is the whole bug this
-                // guard exists for. Those buffers are grown only by `ensure_position_capacity`,
-                // so a session whose positions were all produced by this resident engine
-                // carries a non-zero `position` over empty buffers (and an F16 cache keeps its
-                // entries elsewhere entirely) — a bounds probe catches that and declines. But
-                // ONE CPU fallback mid-sequence grows the buffers for its own position and
-                // leaves every earlier position zero-filled; from then on a bounds probe passes
-                // and this loop would copy a zeroed prompt onto the GPU, so the model attends
-                // over nothing for the rest of the generation. Wrong output, no error.
+                // Capacity alone is not enough: one CPU fallback can grow buffers for its own
+                // position while earlier GPU-produced positions remain zero-filled. Seeding
+                // from that hollow history would silently erase the prompt context.
                 //
-                // `f32_history_materialized` adds the materialized-through watermark, which
-                // distinguishes the two. Reaching it with a hollow history should now be
-                // impossible — `ensure_cpu_kv_materialized` mirrors the GPU history back before
+                // The materialized-through watermark distinguishes the two. Reaching this
+                // point with a hollow history should now be impossible —
+                // `ensure_cpu_kv_materialized` mirrors the GPU history back before
                 // any CPU fallback runs — so this is the backstop, not the fix; declining is
                 // lossless and the caller takes the CPU path.
-                if !self
-                    .kv_cache
-                    .f32_history_materialized(range.end.saturating_sub(1), position)
-                {
+                if !self.kv_cache.history_materialized(position) {
                     return Ok(None);
                 }
                 let kv_dim = n_kv * head_dim;
@@ -431,12 +422,19 @@ impl super::LlamaInferenceSession {
                     let mut cv = vec![0.0f32; kv_dim * position];
                     for p in 0..position {
                         for h in 0..n_kv {
-                            let src = self.kv_cache.offset(range.start + layer, p, h);
                             let dst = (h * position + p) * head_dim;
-                            ck[dst..dst + head_dim]
-                                .copy_from_slice(&self.kv_cache.keys[src..src + head_dim]);
-                            cv[dst..dst + head_dim]
-                                .copy_from_slice(&self.kv_cache.values[src..src + head_dim]);
+                            self.kv_cache.copy_key_row_into(
+                                range.start + layer,
+                                p,
+                                h,
+                                &mut ck[dst..dst + head_dim],
+                            );
+                            self.kv_cache.copy_value_row_into(
+                                range.start + layer,
+                                p,
+                                h,
+                                &mut cv[dst..dst + head_dim],
+                            );
                         }
                     }
                     if !session.seed_layer(layer, &ck, &cv, position) {

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -1358,6 +1358,7 @@ fn prefill_layer_major_scoped_q8_cache_reuses_file_reads_across_chunks() {
         feed_forward_length: 32,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(32),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -1467,6 +1468,7 @@ fn tiny_kv_budget_session(context_length: u32) -> (LlamaInferenceSession, tempfi
         feed_forward_length: 32,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(32),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -8533,6 +8535,7 @@ fn applies_rope_to_each_attention_head() {
         feed_forward_length: 8,
         attention_head_count: 2,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -8575,6 +8578,7 @@ fn apply_rope_uses_configured_frequency_base() {
         feed_forward_length: 8,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(4),
         rope_freq_base: Some(500_000.0),
         rope_scaling_type: None,
@@ -8627,6 +8631,7 @@ fn apply_rope_uses_llama3_frequency_scaling_metadata() {
         feed_forward_length: 8,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(4),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: Some("llama3".to_string()),
@@ -8683,6 +8688,7 @@ fn apply_rope_uses_gguf_rope_frequency_factors() {
         feed_forward_length: 8,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(4),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -8746,6 +8752,7 @@ fn rope_diagnostics_reconstruct_reported_rotation() {
         feed_forward_length: 8,
         attention_head_count: 2,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -8814,6 +8821,7 @@ fn split_half_rope_pairing_is_available_for_diagnostics() {
         feed_forward_length: 8,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(4),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -8896,6 +8904,7 @@ fn inverse_rope_direction_is_available_for_diagnostics() {
         feed_forward_length: 8,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -8977,6 +8986,7 @@ fn one_based_rope_position_mode_is_available_for_diagnostics() {
         feed_forward_length: 8,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -10594,6 +10604,7 @@ fn single_token_forward_diagnostics_follow_llama_stage_order() {
         feed_forward_length: 2,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -10883,6 +10894,7 @@ fn chunked_prefill_matches_sequential_prefill_outputs_and_cache() {
         feed_forward_length: 2,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -11112,6 +11124,7 @@ fn prefill_layer_rejects_misaligned_kv_cache_cursor() {
         feed_forward_length: 2,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -11189,7 +11202,7 @@ fn prefill_layer_rejects_misaligned_kv_cache_cursor() {
     };
     let hidden = CpuTensor::from_f32("hidden", vec![2, 2], vec![0.1, 0.2, 0.3, 0.4]).unwrap();
     let plan = LlamaKvCachePlan::from_config(&config).unwrap();
-    let mut kv_cache = LlamaKvCache::new(plan).unwrap();
+    let mut kv_cache = LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).unwrap();
     kv_cache.position = 1;
 
     let err = forward_prefill_layer_chunk_timed(
@@ -11225,6 +11238,7 @@ fn batch_attention_rejects_reads_beyond_allocated_kv_cache() {
         feed_forward_length: 2,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -11243,7 +11257,11 @@ fn batch_attention_rejects_reads_beyond_allocated_kv_cache() {
         qwen35: None,
         mla: None,
     };
-    let kv_cache = LlamaKvCache::new(LlamaKvCachePlan::from_config(&config).unwrap()).unwrap();
+    let kv_cache = LlamaKvCache::new(
+        LlamaKvCachePlan::from_config(&config).unwrap(),
+        crate::model::KvCacheQuantization::F16,
+    )
+    .unwrap();
     let query = CpuTensor::from_f32("query", vec![1, 2], vec![0.1, 0.2]).unwrap();
 
     let err = causal_attention_context_batch(&kv_cache, 0, 0, &query, 1, 1, "context").unwrap_err();
@@ -11274,7 +11292,8 @@ fn batch_attention_parallel_context_matches_serial() {
         key_shape: vec![1, rows, kv_heads, head_dim],
         value_shape: vec![1, rows, kv_heads, head_dim],
     };
-    let mut kv_cache = LlamaKvCache::new(plan).expect("KV cache");
+    let mut kv_cache =
+        LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).expect("KV cache");
     let key_data: Vec<f32> = (0..rows * kv_width)
         .map(|idx| ((idx % 11) as f32 - 5.0) * 0.125)
         .collect();
@@ -11372,6 +11391,7 @@ fn zero_prefill_chunk_env_falls_back_without_panicking() {
         feed_forward_length: 2,
         attention_head_count: 1,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(2),
         rope_freq_base: Some(10_000.0),
         rope_scaling_type: None,
@@ -11503,7 +11523,8 @@ fn kv_cache_allocates_positions_lazily_without_losing_prior_layers() {
         key_shape: vec![2, 10, 1, 2],
         value_shape: vec![2, 10, 1, 2],
     };
-    let mut kv_cache = LlamaKvCache::new(plan).expect("KV cache");
+    let mut kv_cache =
+        LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).expect("KV cache");
     assert_eq!(kv_cache.allocated_sequence_length, 0);
     assert!(kv_cache.keys.is_empty());
     assert!(kv_cache.values.is_empty());
@@ -11552,7 +11573,8 @@ fn kv_cache_uses_paged_growth_for_model_sized_contexts() {
         key_shape: vec![2, 1024, 1, 2],
         value_shape: vec![2, 1024, 1, 2],
     };
-    let mut kv_cache = LlamaKvCache::new(plan).expect("KV cache");
+    let mut kv_cache =
+        LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).expect("KV cache");
     let key = CpuTensor::from_f32("key", vec![1, 2], vec![1.0, 2.0]).unwrap();
     let value = CpuTensor::from_f32("value", vec![1, 2], vec![3.0, 4.0]).unwrap();
 
@@ -11575,7 +11597,8 @@ fn kv_cache_storage_matches_llama_cpp_f16_rounding() {
         key_shape: vec![1, 1, 1, 2],
         value_shape: vec![1, 1, 1, 2],
     };
-    let mut kv_cache = LlamaKvCache::new(plan).expect("KV cache");
+    let mut kv_cache =
+        LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).expect("KV cache");
     let key = CpuTensor::from_f32("key", vec![1, 2], vec![1.0001, -2.0003]).unwrap();
     let value = CpuTensor::from_f32("value", vec![1, 2], vec![3.0007, -4.0009]).unwrap();
 
@@ -11603,6 +11626,79 @@ fn kv_cache_storage_matches_llama_cpp_f16_rounding() {
 }
 
 #[test]
+fn quantized_attention_matches_its_dequantized_cache_for_tail_rows() {
+    let _env_guard = env_lock();
+    std::env::remove_var("CAMELID_ATTENTION_SCORE_SCALE");
+    std::env::remove_var("CAMELID_GQA_HEAD_MAPPING");
+
+    let head_dim = 40;
+    let plan = LlamaKvCachePlan {
+        max_sequence_length: 3,
+        layer_count: 1,
+        kv_head_count: 1,
+        head_dim,
+        k_head_dim: head_dim,
+        v_head_dim: head_dim,
+        key_shape: vec![1, 3, 1, head_dim],
+        value_shape: vec![1, 3, 1, head_dim],
+    };
+    let query_data: Vec<f32> = (0..head_dim)
+        .map(|index| (index as f32 - 13.0) * 0.03125)
+        .collect();
+    let query = CpuTensor::from_f32("query", vec![1, head_dim], query_data.clone()).unwrap();
+
+    for dtype in [KvDtype::Q8_0, KvDtype::Q4_0] {
+        for layout in [KvLayout::PositionMajor, KvLayout::HeadMajor] {
+            let mut cache =
+                LlamaKvCache::new_with_layout_and_dtype(plan.clone(), layout, dtype).unwrap();
+            cache.ensure_position_capacity(3).unwrap();
+            for position in 0..3 {
+                let key: Vec<f32> = (0..head_dim)
+                    .map(|index| (index as f32 - 17.0) * 0.025 + position as f32 * 0.0625)
+                    .collect();
+                let value: Vec<f32> = (0..head_dim)
+                    .map(|index| (9.0 - index as f32) * 0.04 + position as f32 * 0.125)
+                    .collect();
+                cache.store_kv_head_row(0, position, 0, &key, &value);
+            }
+            cache.position = 2;
+
+            let actual = causal_attention_context(&cache, 0, &query, 1, 1, "context", false)
+                .unwrap()
+                .tensor;
+
+            let scale = 1.0 / (head_dim as f32).sqrt();
+            let mut scores = Vec::new();
+            let mut values = Vec::new();
+            for position in 0..3 {
+                let mut key = vec![0.0; head_dim];
+                let mut value = vec![0.0; head_dim];
+                cache.copy_key_row_into(0, position, 0, &mut key);
+                cache.copy_value_row_into(0, position, 0, &mut value);
+                scores.push(dot_product(&query_data, &key) * scale);
+                values.push(value);
+            }
+            let max_score = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let denominator: f32 = scores.iter().map(|score| (score - max_score).exp()).sum();
+            let mut expected = vec![0.0; head_dim];
+            for (score, value) in scores.iter().zip(values) {
+                let probability = (*score - max_score).exp() / denominator;
+                for (out, value) in expected.iter_mut().zip(value) {
+                    *out += probability * value;
+                }
+            }
+
+            for (index, (actual, expected)) in actual.data.iter().zip(expected.iter()).enumerate() {
+                assert!(
+                    (actual - expected).abs() < 1e-5,
+                    "{dtype:?}/{layout:?} attention mismatch at {index}: {actual} vs {expected}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn causal_attention_context_attends_over_prior_and_current_positions() {
     let _env_guard = env_lock();
     std::env::remove_var("CAMELID_ATTENTION_SCORE_SCALE");
@@ -11618,7 +11714,8 @@ fn causal_attention_context_attends_over_prior_and_current_positions() {
         key_shape: vec![1, 3, 1, 2],
         value_shape: vec![1, 3, 1, 2],
     };
-    let mut kv_cache = LlamaKvCache::new(plan).expect("KV cache");
+    let mut kv_cache =
+        LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).expect("KV cache");
 
     let prior_key = CpuTensor::from_f32("prior_key", vec![1, 2], vec![1.0, 0.0]).unwrap();
     let prior_value = CpuTensor::from_f32("prior_value", vec![1, 2], vec![10.0, 0.0]).unwrap();
@@ -11716,7 +11813,8 @@ fn causal_attention_context_repeats_grouped_kv_heads_for_single_position() {
         key_shape: vec![1, 1, 2, 2],
         value_shape: vec![1, 1, 2, 2],
     };
-    let mut kv_cache = LlamaKvCache::new(plan).expect("KV cache");
+    let mut kv_cache =
+        LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).expect("KV cache");
 
     let key = CpuTensor::from_f32("key", vec![1, 4], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
     let value = CpuTensor::from_f32("value", vec![1, 4], vec![10.0, 11.0, 20.0, 21.0]).unwrap();
@@ -11776,7 +11874,8 @@ fn causal_attention_context_repeats_grouped_kv_heads_across_positions() {
         key_shape: vec![1, 2, 2, 2],
         value_shape: vec![1, 2, 2, 2],
     };
-    let mut kv_cache = LlamaKvCache::new(plan).expect("KV cache");
+    let mut kv_cache =
+        LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).expect("KV cache");
 
     let prior_key = CpuTensor::from_f32("prior_key", vec![1, 4], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
     let prior_value =
@@ -11860,7 +11959,8 @@ fn attention_trace_reports_top_probability_positions_outside_edge_samples() {
         key_shape: vec![1, 10, 1, 2],
         value_shape: vec![1, 10, 1, 2],
     };
-    let mut kv_cache = LlamaKvCache::new(plan).expect("KV cache");
+    let mut kv_cache =
+        LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16).expect("KV cache");
 
     for position in 0..10 {
         kv_cache.position = position;
@@ -12162,6 +12262,7 @@ fn resident_prefill_rope_tables_match_per_position_builder() {
         feed_forward_length: 16,
         attention_head_count: 2,
         attention_head_count_kv: 1,
+        kv_quant: crate::model::KvCacheQuantization::F16,
         rope_dimension_count: Some(8),
         rope_freq_base: Some(500_000.0),
         rope_scaling_type: Some("llama3".to_string()),
@@ -13044,7 +13145,8 @@ fn decode_attention_parallel_lane_is_bitwise_identical_to_serial() {
                     key_shape: vec![1, position_count, kv_heads, head_dim],
                     value_shape: vec![1, position_count, kv_heads, head_dim],
                 };
-                let mut kv_cache = LlamaKvCache::new(plan).expect("kv cache");
+                let mut kv_cache = LlamaKvCache::new(plan, crate::model::KvCacheQuantization::F16)
+                    .expect("kv cache");
                 let kv_len = position_count * kv_heads * head_dim;
                 kv_cache.keys = rng.fill(kv_len);
                 kv_cache.values = rng.fill(kv_len);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use camelid::{
         LlamaSampler, Q8ResidencyReport, SamplingConfig,
     },
     metal::detect_metal_device,
-    model::{LlamaModelConfig, LlamaTensorBinding},
+    model::{KvCacheQuantization, LlamaModelConfig, LlamaTensorBinding},
     tensor::{CpuTensor, Q8_0TensorBlocks, TensorStore},
     tokenizer::Tokenizer,
 };
@@ -83,6 +83,10 @@ fn default_launch_command() -> Command {
         // arg does not apply here; read CAMELID_GPU explicitly, like the sibling
         // env-backed fields above. Default (and any unrecognised value) is Auto.
         gpu: GpuMode::from_env(),
+        kv_quant: std::env::var("CAMELID_KV_QUANT")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or_default(),
     }
 }
 
@@ -604,6 +608,10 @@ enum Command {
         /// env seed, and the Settings toggle can still flip state live after startup.
         #[arg(long = "gpu", value_enum, default_value_t = GpuMode::Auto, env = "CAMELID_GPU")]
         gpu: GpuMode,
+        /// KV cache quantization format: "f16" (default, unquantized), "q8_0"
+        /// (50% memory savings), or "q4_0" (75% memory savings).
+        #[arg(long, env = "CAMELID_KV_QUANT", default_value_t = KvCacheQuantization::F16)]
+        kv_quant: KvCacheQuantization,
     },
     /// Interactive terminal chat REPL over the local Camelid API.
     ///
@@ -1550,7 +1558,9 @@ async fn main() -> anyhow::Result<()> {
             enable_thinking,
             models_dir,
             gpu,
+            kv_quant,
         } => {
+            std::env::set_var("CAMELID_KV_QUANT", kv_quant.to_string());
             configure_rayon_threads(threads)?;
             camelid::capability::HardwareProfile::detect().log();
             // In deterministic mode the engine fails every Metal gate closed (see
@@ -4302,6 +4312,7 @@ fn known_arch_config(arch: &str) -> anyhow::Result<LlamaModelConfig> {
         feed_forward_length,
         attention_head_count: heads,
         attention_head_count_kv: kv_heads,
+        kv_quant: camelid::model::KvCacheQuantization::F16,
         rope_dimension_count: None,
         rope_freq_base: None,
         rope_scaling_type: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
 
+pub use crate::tensor::kv_quant::KvCacheQuantization;
+
 use crate::{
     gguf::{GgufFile, GgufTensorDescriptor},
     BackendError, Result,
@@ -13,6 +15,7 @@ pub struct LlamaModelConfig {
     pub feed_forward_length: u32,
     pub attention_head_count: u32,
     pub attention_head_count_kv: u32,
+    pub kv_quant: KvCacheQuantization,
     pub rope_dimension_count: Option<u32>,
     pub rope_freq_base: Option<f32>,
     pub rope_scaling_type: Option<String>,
@@ -166,6 +169,10 @@ impl LlamaModelConfig {
             feed_forward_length,
             attention_head_count,
             attention_head_count_kv,
+            kv_quant: std::env::var("CAMELID_KV_QUANT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_default(),
             rope_dimension_count: gguf
                 .metadata_u32(&architecture_key(architecture, "rope.dimension_count")),
             rope_freq_base: gguf.metadata_f32(&architecture_key(architecture, "rope.freq_base")),

--- a/src/model_source.rs
+++ b/src/model_source.rs
@@ -94,6 +94,10 @@ impl HfLlamaConfigSummary {
             feed_forward_length: self.intermediate_size,
             attention_head_count: self.num_attention_heads,
             attention_head_count_kv: self.num_key_value_heads,
+            kv_quant: std::env::var("CAMELID_KV_QUANT")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or_default(),
             // LLaMA rotates the full per-head dimension.
             rope_dimension_count: Some(head_dim),
             rope_freq_base: Some(self.rope_theta),

--- a/src/tensor/kv_quant.rs
+++ b/src/tensor/kv_quant.rs
@@ -1,0 +1,575 @@
+//! Quantized KV-cache block structures and attention helpers.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+#[cfg(target_arch = "x86_64")]
+use std::sync::OnceLock;
+
+pub const KV_QUANT_BLOCK_VALUES: usize = 32;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KvCacheQuantization {
+    #[default]
+    F16,
+    Q8_0,
+    Q4_0,
+}
+
+impl fmt::Display for KvCacheQuantization {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::F16 => write!(f, "f16"),
+            Self::Q8_0 => write!(f, "q8_0"),
+            Self::Q4_0 => write!(f, "q4_0"),
+        }
+    }
+}
+
+impl std::str::FromStr for KvCacheQuantization {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "f16" | "fp16" | "none" | "off" => Ok(Self::F16),
+            "q8_0" | "q80" | "q8" => Ok(Self::Q8_0),
+            "q4_0" | "q40" | "q4" => Ok(Self::Q4_0),
+            _ => Err(format!(
+                "unknown kv cache quantization format '{s}'; supported: f16, q8_0, q4_0"
+            )),
+        }
+    }
+}
+
+/// Block of 32 FP16/FP32 elements quantized to 8-bit Q8_0.
+/// Storage per 32 elements: 1 f16 scale (2 bytes) + 32 i8 values (32 bytes) = 34 bytes.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockQ8_0 {
+    pub scale: u16, // f16 bits
+    pub qs: [i8; KV_QUANT_BLOCK_VALUES],
+}
+
+impl Default for BlockQ8_0 {
+    fn default() -> Self {
+        Self {
+            scale: 0,
+            qs: [0; KV_QUANT_BLOCK_VALUES],
+        }
+    }
+}
+
+/// Block of 32 FP16/FP32 elements quantized to 4-bit Q4_0.
+/// Storage per 32 elements: 1 f16 scale (2 bytes) + 16 u8 packed nibbles (16 bytes) = 18 bytes.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockQ4_0 {
+    pub scale: u16, // f16 bits
+    pub qs: [u8; KV_QUANT_BLOCK_VALUES / 2],
+}
+
+impl Default for BlockQ4_0 {
+    fn default() -> Self {
+        Self {
+            scale: 0,
+            qs: [0; KV_QUANT_BLOCK_VALUES / 2],
+        }
+    }
+}
+
+/// Quantize a slice of 32 f32 values into a `BlockQ8_0`.
+pub fn quantize_block_q8_0(src: &[f32; KV_QUANT_BLOCK_VALUES]) -> BlockQ8_0 {
+    let mut amax = 0.0f32;
+    for &v in src {
+        let abs_v = v.abs();
+        if abs_v > amax {
+            amax = abs_v;
+        }
+    }
+    let d = amax / 127.0;
+    let id = if d != 0.0 { 1.0 / d } else { 0.0 };
+    let mut qs = [0i8; KV_QUANT_BLOCK_VALUES];
+    for i in 0..KV_QUANT_BLOCK_VALUES {
+        let val = (src[i] * id).round();
+        qs[i] = val.clamp(-127.0, 127.0) as i8;
+    }
+    BlockQ8_0 {
+        scale: super::f32_to_f16_bits(d),
+        qs,
+    }
+}
+
+/// Dequantize a `BlockQ8_0` into a full block or a final partial row.
+pub fn dequantize_block_q8_0(block: &BlockQ8_0, dst: &mut [f32]) {
+    debug_assert!(dst.len() <= KV_QUANT_BLOCK_VALUES);
+    let d = super::f16_bits_to_f32(block.scale);
+    for (i, value) in dst.iter_mut().enumerate() {
+        *value = block.qs[i] as f32 * d;
+    }
+}
+
+/// Compute a dot product against a full block or a final partial row.
+pub fn vec_dot_q8_0(query: &[f32], key_block: &BlockQ8_0) -> f32 {
+    debug_assert!(query.len() <= KV_QUANT_BLOCK_VALUES);
+    let d = super::f16_bits_to_f32(key_block.scale);
+    let mut sum = 0.0f32;
+    for (i, &query_value) in query.iter().enumerate() {
+        sum += query_value * (key_block.qs[i] as f32);
+    }
+    sum * d
+}
+
+pub fn quantize_row_q8_0(src: &[f32], dst: &mut [BlockQ8_0]) {
+    debug_assert_eq!(dst.len(), src.len().div_ceil(KV_QUANT_BLOCK_VALUES));
+    for (block, chunk) in dst.iter_mut().zip(src.chunks(KV_QUANT_BLOCK_VALUES)) {
+        let mut values = [0.0f32; KV_QUANT_BLOCK_VALUES];
+        values[..chunk.len()].copy_from_slice(chunk);
+        *block = quantize_block_q8_0(&values);
+    }
+}
+
+pub fn dequantize_row_q8_0(src: &[BlockQ8_0], dst: &mut [f32]) {
+    debug_assert_eq!(src.len(), dst.len().div_ceil(KV_QUANT_BLOCK_VALUES));
+    for (block, chunk) in src.iter().zip(dst.chunks_mut(KV_QUANT_BLOCK_VALUES)) {
+        dequantize_block_q8_0(block, chunk);
+    }
+}
+
+pub fn vec_dot_row_q8_0(query: &[f32], key_blocks: &[BlockQ8_0]) -> f32 {
+    debug_assert_eq!(
+        key_blocks.len(),
+        query.len().div_ceil(KV_QUANT_BLOCK_VALUES)
+    );
+    #[cfg(target_arch = "x86_64")]
+    if kv_quant_avx2_fma_available() {
+        // SAFETY: guarded by the runtime AVX2+FMA check. The implementation
+        // handles a final partial block with the scalar helper.
+        return unsafe { vec_dot_row_q8_0_avx2(query, key_blocks) };
+    }
+    query
+        .chunks(KV_QUANT_BLOCK_VALUES)
+        .zip(key_blocks)
+        .map(|(chunk, block)| vec_dot_q8_0(chunk, block))
+        .sum()
+}
+
+/// Fused `out += probability * dequant(blocks)` for one Q8_0 row.
+///
+/// Keeping dequantization inside the accumulation avoids a temporary f32
+/// block and lets the x86 path expand eight i8 values directly into an AVX2
+/// register. The scalar fallback preserves support on every other target.
+pub fn axpy_row_q8_0(out: &mut [f32], probability: f32, value_blocks: &[BlockQ8_0]) {
+    debug_assert_eq!(
+        value_blocks.len(),
+        out.len().div_ceil(KV_QUANT_BLOCK_VALUES)
+    );
+    #[cfg(target_arch = "x86_64")]
+    if kv_quant_avx2_fma_available() {
+        // SAFETY: guarded by the runtime AVX2+FMA check.
+        unsafe { axpy_row_q8_0_avx2(out, probability, value_blocks) };
+        return;
+    }
+    for (out_chunk, block) in out.chunks_mut(KV_QUANT_BLOCK_VALUES).zip(value_blocks) {
+        let d = super::f16_bits_to_f32(block.scale);
+        for (i, out_value) in out_chunk.iter_mut().enumerate() {
+            *out_value = (probability * d).mul_add(block.qs[i] as f32, *out_value);
+        }
+    }
+}
+
+/// Quantize a slice of 32 f32 values into a `BlockQ4_0`.
+pub fn quantize_block_q4_0(src: &[f32; KV_QUANT_BLOCK_VALUES]) -> BlockQ4_0 {
+    let mut amax = 0.0f32;
+    let mut signed_max = 0.0f32;
+    for &v in src {
+        let abs_v = v.abs();
+        if abs_v > amax {
+            amax = abs_v;
+            signed_max = v;
+        }
+    }
+    // Match ggml's Q4_0 reference quantizer: the sign of the first
+    // max-magnitude value chooses which side receives the -8 code.
+    let d = signed_max / -8.0;
+    let id = if d != 0.0 { 1.0 / d } else { 0.0 };
+    let mut qs = [0u8; KV_QUANT_BLOCK_VALUES / 2];
+    for i in 0..KV_QUANT_BLOCK_VALUES / 2 {
+        let x0 = (src[i] * id + 8.5).floor().clamp(0.0, 15.0) as u8;
+        let x1 = (src[i + KV_QUANT_BLOCK_VALUES / 2] * id + 8.5)
+            .floor()
+            .clamp(0.0, 15.0) as u8;
+        qs[i] = (x0 & 0x0F) | ((x1 & 0x0F) << 4);
+    }
+    BlockQ4_0 {
+        scale: super::f32_to_f16_bits(d),
+        qs,
+    }
+}
+
+/// Dequantize a `BlockQ4_0` into a full block or a final partial row.
+pub fn dequantize_block_q4_0(block: &BlockQ4_0, dst: &mut [f32]) {
+    debug_assert!(dst.len() <= KV_QUANT_BLOCK_VALUES);
+    let d = super::f16_bits_to_f32(block.scale);
+    for (i, value) in dst.iter_mut().enumerate() {
+        let packed = block.qs[i % (KV_QUANT_BLOCK_VALUES / 2)];
+        let quant = if i < KV_QUANT_BLOCK_VALUES / 2 {
+            packed & 0x0f
+        } else {
+            packed >> 4
+        };
+        *value = (quant as f32 - 8.0) * d;
+    }
+}
+
+/// Compute a dot product against a full block or a final partial row.
+pub fn vec_dot_q4_0(query: &[f32], key_block: &BlockQ4_0) -> f32 {
+    debug_assert!(query.len() <= KV_QUANT_BLOCK_VALUES);
+    let d = super::f16_bits_to_f32(key_block.scale);
+    let mut sum = 0.0f32;
+    for (i, &query_value) in query.iter().enumerate() {
+        let packed = key_block.qs[i % (KV_QUANT_BLOCK_VALUES / 2)];
+        let quant = if i < KV_QUANT_BLOCK_VALUES / 2 {
+            packed & 0x0f
+        } else {
+            packed >> 4
+        };
+        sum += query_value * (quant as f32 - 8.0);
+    }
+    sum * d
+}
+
+pub fn quantize_row_q4_0(src: &[f32], dst: &mut [BlockQ4_0]) {
+    debug_assert_eq!(dst.len(), src.len().div_ceil(KV_QUANT_BLOCK_VALUES));
+    for (block, chunk) in dst.iter_mut().zip(src.chunks(KV_QUANT_BLOCK_VALUES)) {
+        let mut values = [0.0f32; KV_QUANT_BLOCK_VALUES];
+        values[..chunk.len()].copy_from_slice(chunk);
+        *block = quantize_block_q4_0(&values);
+    }
+}
+
+pub fn dequantize_row_q4_0(src: &[BlockQ4_0], dst: &mut [f32]) {
+    debug_assert_eq!(src.len(), dst.len().div_ceil(KV_QUANT_BLOCK_VALUES));
+    for (block, chunk) in src.iter().zip(dst.chunks_mut(KV_QUANT_BLOCK_VALUES)) {
+        dequantize_block_q4_0(block, chunk);
+    }
+}
+
+pub fn vec_dot_row_q4_0(query: &[f32], key_blocks: &[BlockQ4_0]) -> f32 {
+    debug_assert_eq!(
+        key_blocks.len(),
+        query.len().div_ceil(KV_QUANT_BLOCK_VALUES)
+    );
+    #[cfg(target_arch = "x86_64")]
+    if kv_quant_avx2_fma_available() {
+        // SAFETY: guarded by the runtime AVX2+FMA check. The implementation
+        // handles a final partial block with the scalar helper.
+        return unsafe { vec_dot_row_q4_0_avx2(query, key_blocks) };
+    }
+    query
+        .chunks(KV_QUANT_BLOCK_VALUES)
+        .zip(key_blocks)
+        .map(|(chunk, block)| vec_dot_q4_0(chunk, block))
+        .sum()
+}
+
+/// Fused `out += probability * dequant(blocks)` for one Q4_0 row.
+pub fn axpy_row_q4_0(out: &mut [f32], probability: f32, value_blocks: &[BlockQ4_0]) {
+    debug_assert_eq!(
+        value_blocks.len(),
+        out.len().div_ceil(KV_QUANT_BLOCK_VALUES)
+    );
+    #[cfg(target_arch = "x86_64")]
+    if kv_quant_avx2_fma_available() {
+        // SAFETY: guarded by the runtime AVX2+FMA check.
+        unsafe { axpy_row_q4_0_avx2(out, probability, value_blocks) };
+        return;
+    }
+    for (out_chunk, block) in out.chunks_mut(KV_QUANT_BLOCK_VALUES).zip(value_blocks) {
+        let d = super::f16_bits_to_f32(block.scale);
+        for (i, out_value) in out_chunk.iter_mut().enumerate() {
+            let packed = block.qs[i % (KV_QUANT_BLOCK_VALUES / 2)];
+            let quant = if i < KV_QUANT_BLOCK_VALUES / 2 {
+                packed & 0x0f
+            } else {
+                packed >> 4
+            };
+            *out_value = (probability * d).mul_add(quant as f32 - 8.0, *out_value);
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn kv_quant_avx2_fma_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma")
+    })
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn horizontal_sum_f32x8(value: std::arch::x86_64::__m256) -> f32 {
+    use std::arch::x86_64::_mm256_storeu_ps;
+    let mut lanes = [0.0f32; 8];
+    // SAFETY: `lanes` holds exactly one 256-bit vector.
+    unsafe { _mm256_storeu_ps(lanes.as_mut_ptr(), value) };
+    let t0 = lanes[0] + lanes[4];
+    let t1 = lanes[1] + lanes[5];
+    let t2 = lanes[2] + lanes[6];
+    let t3 = lanes[3] + lanes[7];
+    (t0 + t2) + (t1 + t3)
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn vec_dot_row_q8_0_avx2(query: &[f32], key_blocks: &[BlockQ8_0]) -> f32 {
+    use std::arch::x86_64::{
+        __m128i, _mm256_cvtepi32_ps, _mm256_cvtepi8_epi32, _mm256_fmadd_ps, _mm256_loadu_ps,
+        _mm256_setzero_ps, _mm_loadl_epi64,
+    };
+
+    let mut total = 0.0f32;
+    for (query_chunk, block) in query.chunks(KV_QUANT_BLOCK_VALUES).zip(key_blocks) {
+        if query_chunk.len() != KV_QUANT_BLOCK_VALUES {
+            total += vec_dot_q8_0(query_chunk, block);
+            continue;
+        }
+        let mut acc = _mm256_setzero_ps();
+        for offset in [0usize, 8, 16, 24] {
+            // SAFETY: a full block has 32 query/i8 values and every load is
+            // within one of its four eight-element groups.
+            let packed =
+                unsafe { _mm_loadl_epi64(block.qs.as_ptr().add(offset) as *const __m128i) };
+            let quant = _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(packed));
+            let input = unsafe { _mm256_loadu_ps(query_chunk.as_ptr().add(offset)) };
+            acc = _mm256_fmadd_ps(input, quant, acc);
+        }
+        total += unsafe { horizontal_sum_f32x8(acc) } * super::f16_bits_to_f32(block.scale);
+    }
+    total
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn vec_dot_row_q4_0_avx2(query: &[f32], key_blocks: &[BlockQ4_0]) -> f32 {
+    use std::arch::x86_64::{
+        __m128i, _mm256_cvtepi32_ps, _mm256_cvtepu8_epi32, _mm256_fmadd_ps, _mm256_loadu_ps,
+        _mm256_set1_epi32, _mm256_setzero_ps, _mm256_sub_epi32, _mm_and_si128, _mm_loadl_epi64,
+        _mm_set1_epi8, _mm_srli_epi16,
+    };
+
+    let mask = _mm_set1_epi8(0x0f);
+    let bias = _mm256_set1_epi32(8);
+    let mut total = 0.0f32;
+    for (query_chunk, block) in query.chunks(KV_QUANT_BLOCK_VALUES).zip(key_blocks) {
+        if query_chunk.len() != KV_QUANT_BLOCK_VALUES {
+            total += vec_dot_q4_0(query_chunk, block);
+            continue;
+        }
+        let mut acc = _mm256_setzero_ps();
+        for byte_offset in [0usize, 8] {
+            // SAFETY: each iteration loads eight of the block's 16 packed bytes.
+            let packed =
+                unsafe { _mm_loadl_epi64(block.qs.as_ptr().add(byte_offset) as *const __m128i) };
+            let low = _mm256_sub_epi32(_mm256_cvtepu8_epi32(_mm_and_si128(packed, mask)), bias);
+            let high = _mm256_sub_epi32(
+                _mm256_cvtepu8_epi32(_mm_and_si128(_mm_srli_epi16(packed, 4), mask)),
+                bias,
+            );
+            let query_low = unsafe { _mm256_loadu_ps(query_chunk.as_ptr().add(byte_offset)) };
+            let query_high = unsafe { _mm256_loadu_ps(query_chunk.as_ptr().add(16 + byte_offset)) };
+            acc = _mm256_fmadd_ps(query_low, _mm256_cvtepi32_ps(low), acc);
+            acc = _mm256_fmadd_ps(query_high, _mm256_cvtepi32_ps(high), acc);
+        }
+        total += unsafe { horizontal_sum_f32x8(acc) } * super::f16_bits_to_f32(block.scale);
+    }
+    total
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn axpy_row_q8_0_avx2(out: &mut [f32], probability: f32, value_blocks: &[BlockQ8_0]) {
+    use std::arch::x86_64::{
+        __m128i, _mm256_cvtepi32_ps, _mm256_cvtepi8_epi32, _mm256_fmadd_ps, _mm256_loadu_ps,
+        _mm256_set1_ps, _mm256_storeu_ps, _mm_loadl_epi64,
+    };
+
+    for (out_chunk, block) in out.chunks_mut(KV_QUANT_BLOCK_VALUES).zip(value_blocks) {
+        if out_chunk.len() != KV_QUANT_BLOCK_VALUES {
+            let d = super::f16_bits_to_f32(block.scale);
+            for (i, out_value) in out_chunk.iter_mut().enumerate() {
+                *out_value = (probability * d).mul_add(block.qs[i] as f32, *out_value);
+            }
+            continue;
+        }
+        let factor = _mm256_set1_ps(probability * super::f16_bits_to_f32(block.scale));
+        for offset in [0usize, 8, 16, 24] {
+            // SAFETY: full chunks and blocks hold all four eight-element groups.
+            unsafe {
+                let packed = _mm_loadl_epi64(block.qs.as_ptr().add(offset) as *const __m128i);
+                let quant = _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(packed));
+                let current = _mm256_loadu_ps(out_chunk.as_ptr().add(offset));
+                _mm256_storeu_ps(
+                    out_chunk.as_mut_ptr().add(offset),
+                    _mm256_fmadd_ps(factor, quant, current),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn axpy_row_q4_0_avx2(out: &mut [f32], probability: f32, value_blocks: &[BlockQ4_0]) {
+    use std::arch::x86_64::{
+        __m128i, _mm256_cvtepi32_ps, _mm256_cvtepu8_epi32, _mm256_fmadd_ps, _mm256_loadu_ps,
+        _mm256_set1_epi32, _mm256_set1_ps, _mm256_storeu_ps, _mm256_sub_epi32, _mm_and_si128,
+        _mm_loadl_epi64, _mm_set1_epi8, _mm_srli_epi16,
+    };
+
+    let mask = _mm_set1_epi8(0x0f);
+    let bias = _mm256_set1_epi32(8);
+    for (out_chunk, block) in out.chunks_mut(KV_QUANT_BLOCK_VALUES).zip(value_blocks) {
+        if out_chunk.len() != KV_QUANT_BLOCK_VALUES {
+            let d = super::f16_bits_to_f32(block.scale);
+            for (i, out_value) in out_chunk.iter_mut().enumerate() {
+                let packed = block.qs[i % (KV_QUANT_BLOCK_VALUES / 2)];
+                let quant = if i < KV_QUANT_BLOCK_VALUES / 2 {
+                    packed & 0x0f
+                } else {
+                    packed >> 4
+                };
+                *out_value = (probability * d).mul_add(quant as f32 - 8.0, *out_value);
+            }
+            continue;
+        }
+        let factor = _mm256_set1_ps(probability * super::f16_bits_to_f32(block.scale));
+        for byte_offset in [0usize, 8] {
+            // SAFETY: full chunks and blocks hold the referenced eight-byte
+            // packed group and both corresponding eight-f32 output groups.
+            unsafe {
+                let packed = _mm_loadl_epi64(block.qs.as_ptr().add(byte_offset) as *const __m128i);
+                let low = _mm256_cvtepi32_ps(_mm256_sub_epi32(
+                    _mm256_cvtepu8_epi32(_mm_and_si128(packed, mask)),
+                    bias,
+                ));
+                let high = _mm256_cvtepi32_ps(_mm256_sub_epi32(
+                    _mm256_cvtepu8_epi32(_mm_and_si128(_mm_srli_epi16(packed, 4), mask)),
+                    bias,
+                ));
+                let low_offset = byte_offset;
+                let high_offset = 16 + byte_offset;
+                let current_low = _mm256_loadu_ps(out_chunk.as_ptr().add(low_offset));
+                let current_high = _mm256_loadu_ps(out_chunk.as_ptr().add(high_offset));
+                _mm256_storeu_ps(
+                    out_chunk.as_mut_ptr().add(low_offset),
+                    _mm256_fmadd_ps(factor, low, current_low),
+                );
+                _mm256_storeu_ps(
+                    out_chunk.as_mut_ptr().add(high_offset),
+                    _mm256_fmadd_ps(factor, high, current_high),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn q8_0_roundtrip_and_dot_match_dequantized_values() {
+        let mut original = [0.0f32; KV_QUANT_BLOCK_VALUES];
+        for (i, value) in original.iter_mut().enumerate() {
+            *value = (i as f32 - 16.0) * 0.25;
+        }
+        let block = quantize_block_q8_0(&original);
+        let mut reconstructed = [0.0f32; KV_QUANT_BLOCK_VALUES];
+        dequantize_block_q8_0(&block, &mut reconstructed);
+
+        for i in 0..KV_QUANT_BLOCK_VALUES {
+            let diff = (original[i] - reconstructed[i]).abs();
+            assert!(
+                diff < 0.05,
+                "Q8_0 roundtrip diff too high at index {i}: {diff}"
+            );
+        }
+        let query: [f32; KV_QUANT_BLOCK_VALUES] = std::array::from_fn(|i| (i as f32 - 7.0) * 0.125);
+        let expected: f32 = query.iter().zip(reconstructed).map(|(q, k)| q * k).sum();
+        assert!((vec_dot_q8_0(&query, &block) - expected).abs() < 1e-5);
+
+        let mut accumulated: [f32; KV_QUANT_BLOCK_VALUES] =
+            std::array::from_fn(|i| i as f32 * 0.01);
+        let expected_accumulated: [f32; KV_QUANT_BLOCK_VALUES] =
+            std::array::from_fn(|i| 0.375f32.mul_add(reconstructed[i], i as f32 * 0.01));
+        axpy_row_q8_0(&mut accumulated, 0.375, &[block]);
+        for (actual, expected) in accumulated.iter().zip(expected_accumulated) {
+            assert!((actual - expected).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn q4_0_roundtrip_and_dot_match_dequantized_values() {
+        let mut original = [0.0f32; KV_QUANT_BLOCK_VALUES];
+        for (i, value) in original.iter_mut().enumerate() {
+            *value = (i as f32 - 16.0) * 0.25;
+        }
+        let block = quantize_block_q4_0(&original);
+        let mut reconstructed = [0.0f32; KV_QUANT_BLOCK_VALUES];
+        dequantize_block_q4_0(&block, &mut reconstructed);
+
+        for i in 0..KV_QUANT_BLOCK_VALUES {
+            let diff = (original[i] - reconstructed[i]).abs();
+            assert!(
+                diff < 0.30,
+                "Q4_0 roundtrip diff too high at index {i}: {diff}"
+            );
+        }
+        let query: [f32; KV_QUANT_BLOCK_VALUES] = std::array::from_fn(|i| (i as f32 - 7.0) * 0.125);
+        let expected: f32 = query.iter().zip(reconstructed).map(|(q, k)| q * k).sum();
+        assert!((vec_dot_q4_0(&query, &block) - expected).abs() < 1e-5);
+
+        let mut accumulated: [f32; KV_QUANT_BLOCK_VALUES] =
+            std::array::from_fn(|i| i as f32 * 0.01);
+        let expected_accumulated: [f32; KV_QUANT_BLOCK_VALUES] =
+            std::array::from_fn(|i| 0.375f32.mul_add(reconstructed[i], i as f32 * 0.01));
+        axpy_row_q4_0(&mut accumulated, 0.375, &[block]);
+        for (actual, expected) in accumulated.iter().zip(expected_accumulated) {
+            assert!((actual - expected).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn quantized_blocks_have_wire_compatible_sizes() {
+        assert_eq!(size_of::<BlockQ8_0>(), 34);
+        assert_eq!(size_of::<BlockQ4_0>(), 18);
+    }
+
+    #[test]
+    fn q4_0_uses_reference_signed_max_scale() {
+        let mut negative_max = [0.0; KV_QUANT_BLOCK_VALUES];
+        negative_max[0] = -8.0;
+        negative_max[KV_QUANT_BLOCK_VALUES / 2] = 7.0;
+        let negative_block = quantize_block_q4_0(&negative_max);
+        assert_eq!(negative_block.scale, super::super::f32_to_f16_bits(1.0));
+        assert_eq!(negative_block.qs[0], 0xf0);
+
+        let mut positive_max = [0.0; KV_QUANT_BLOCK_VALUES];
+        positive_max[0] = 8.0;
+        positive_max[KV_QUANT_BLOCK_VALUES / 2] = -7.0;
+        let positive_block = quantize_block_q4_0(&positive_max);
+        assert_eq!(positive_block.scale, super::super::f32_to_f16_bits(-1.0));
+        assert_eq!(positive_block.qs[0], 0xf0);
+    }
+
+    #[test]
+    fn scale_conversion_preserves_small_nonzero_values() {
+        let value = 5.960_464_5e-8;
+        assert_eq!(
+            super::super::f16_bits_to_f32(super::super::f32_to_f16_bits(value)),
+            value
+        );
+    }
+}

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -29,6 +29,7 @@ use crate::{
     BackendError, Result,
 };
 
+pub mod kv_quant;
 pub mod wire_dequant;
 
 #[cfg(target_os = "macos")]

--- a/tests/inference_session.rs
+++ b/tests/inference_session.rs
@@ -558,6 +558,7 @@ fn tiny_config() -> LlamaModelConfig {
         rope_scaling_low_freq_factor: None,
         rope_scaling_high_freq_factor: None,
         rms_norm_epsilon: 1e-6,
+        kv_quant: camelid::model::KvCacheQuantization::F16,
         vocab_size: Some(3),
         file_type: Some(0),
         rope_neox_pairing: false,


### PR DESCRIPTION
## Summary

- add selectable F16, Q8_0, and Q4_0 KV-cache storage with exact per-row padding, allocation, and budget accounting
- add tail-safe quantized attention with runtime-dispatched AVX2/FMA kernels and portable scalar fallbacks
- propagate cache format selection through the CLI, model configuration, inference sessions, and resident Metal cache handling
- add allocation, conversion, attention-oracle, tail-row, layout, budget, equality, and CLI regression coverage
- add a reproducible same-host before/after performance and memory report

## Why

KV-cache memory grows with context length and can become a major inference constraint. Quantized cache formats reduce that footprint while retaining the existing F32/F16 paths.

The first scalar Q8_0/Q4_0 attention implementation exposed a 25-35% long-context CPU decode regression. This version fixes that root cause by operating directly on quantized rows with AVX2/FMA dot and fused accumulation kernels.

## Results

- 2,048-position peak RSS: Q8_0 saves 335 MiB; Q4_0 saves 399 MiB versus F32
- short-context CPU decode: Q8_0 -1.1%; Q4_0 -1.3% (within measured noise)
- approximately 1K-context CPU decode: Q8_0 +11.8%; Q4_0 +10.7%
- resident CUDA decode: Q8_0 -0.34%; Q4_0 -0.35%
- all measured deterministic outputs were token-identical

The full methodology and raw-result summary are documented in `docs/perf-deep-dive/PERF_RECEIPTS/same-host/kv-cache-quantization-ab-20260728.md`.

## Validation

- `cargo build --release --bin camelid`
- `cargo test --all-targets --all-features -- --test-threads=1`
  - library: 1,229 passed, 0 failed, 68 ignored
  - 59 test-result sections with no failures
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
