### PR TITLE
Add macOS desktop sidecar support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# `camelid-desktop` (a Tauri v2 native Windows app) is an ADDITIVE workspace member.
+# `camelid-desktop` (a Tauri v2 native desktop app) is an ADDITIVE workspace member.
 # resolver = "2" keeps this root package's feature resolution identical to the standalone
 # edition-2021 default it had before the workspace existed. default-members = ["."] scopes
 # bare `cargo build`/`cargo test` to the `camelid` server exactly as before — the desktop

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ ready to use.
 > roughly 1–8 GB each. Give yourself some free disk space and a few minutes for the first model
 > to download.
 
-### Option A — Windows desktop app (easiest)
+### Option A — Desktop app (easiest)
+
+#### Windows
 
 1. Download the signed installer from the [latest release][latest-release]:
    - `Camelid.Desktop_<version>_x64-setup.exe` — signed installer; installs per-user, no admin rights.
@@ -53,6 +55,29 @@ ready to use.
   engine as everything below. Windows CUDA evidence is limited to the exact rows and recorded GPU,
   driver, and CUDA versions in [COMPATIBILITY.md](COMPATIBILITY.md); it makes no general
   token-parity or throughput claim.
+
+#### macOS Apple Silicon — command-line install
+
+The macOS desktop app currently uses an ad-hoc signature and is **not notarized**. Until a
+notarized release is available, the simplest honest installation path is to build the current
+source and install it from Terminal. It requires macOS 12 or newer on Apple Silicon, the Xcode
+Command Line Tools, [Rust](https://rustup.rs/), and Node.js 22 with npm.
+
+```bash
+git clone https://github.com/timtoole02/Camelid.git
+cd Camelid
+./scripts/install-macos-desktop.sh
+```
+
+The install script builds the web UI and Metal-enabled engine, creates an ad-hoc-signed app,
+installs it as `/Applications/Camelid Desktop.app`, and launches it. If `/Applications` requires
+administrator access, macOS asks for your password through `sudo`. To update later, run
+`git pull` followed by `./scripts/install-macos-desktop.sh` again.
+
+Downloaded models live in
+`~/Library/Application Support/app.camelid.desktop/models` and are preserved when the app is
+rebuilt or reinstalled. See [Camelid Desktop](camelid-desktop/README.md) for the sidecar design
+and manual packaging details.
 
 ### Option B — Prebuilt engine (Windows, macOS, or Linux)
 
@@ -172,7 +197,7 @@ Every interface talks to the same local engine — pick whichever fits your work
 
 | Interface | How to start it | Best for |
 |---|---|---|
-| **Desktop app** | Install `Camelid.Desktop_<version>_x64-setup.exe` (Windows) | A one-click, no-terminal setup |
+| **Desktop app** | Windows installer, or `./scripts/install-macos-desktop.sh` on Apple Silicon | A native app with the engine bundled as a local sidecar |
 | **Browser chat** | `camelid serve --model <gguf>` opens the web UI automatically | Everyday chatting in a familiar UI |
 | **Terminal UI** | `camelid chat` — full-screen; `--plain` for a line REPL over SSH | Working entirely in the shell |
 | **HTTP API** | OpenAI-style `/v1/*`, served alongside the UI on the same port | Wiring Camelid into your own apps |
@@ -331,7 +356,7 @@ Camelid ships for three platforms today.
 | Platform | Distribution | Acceleration |
 |---|---|---|
 | Windows x86_64 | Desktop installer, portable desktop ZIP, engine ZIP | Experimental CUDA on named exact rows and recorded NVIDIA configurations; CPU fallback |
-| macOS Apple Silicon | Engine archive (`.tar.gz`) | Metal and CPU |
+| macOS Apple Silicon | Source-installed desktop app (ad-hoc signed), engine archive (`.tar.gz`) | Metal and CPU |
 | Linux x86_64 | Engine archive (`.tar.gz`) | NVIDIA CUDA compiled in by default; CPU fallback |
 
 CUDA is compiled into the default build on Windows and x86_64 Linux. On Windows, the GPU path is

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -3,10 +3,10 @@ name = "camelid-desktop"
 version = "0.4.4"
 edition = "2021"
 rust-version = "1.89"
-description = "Camelid Desktop — additive native Windows chat app that embeds the camelid engine as a loopback sidecar"
+description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"
 license = "MIT"
 repository = "https://github.com/timtoole02/Camelid"
-# Never published to crates.io; it is shipped only as a bundled Windows artifact.
+# Never published to crates.io; it is shipped only as a bundled desktop artifact.
 publish = false
 
 [[bin]]
@@ -14,11 +14,11 @@ name = "camelid-desktop"
 path = "src/main.rs"
 
 [build-dependencies]
-# Embeds the splash assets + Windows icon resource and validates tauri.conf.json.
+# Embeds the splash assets and platform icon resources, and validates tauri.conf.json.
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-# WebView2-hosted shell. No extra features for v1: the window simply navigates to the
+# Native-webview shell. No extra features for v1: the window simply navigates to the
 # sidecar's already-embedded UI, so we need neither the HTTP plugin nor remote IPC.
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }

--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -1,9 +1,9 @@
-# Camelid Desktop (add-on, Windows)
+# Camelid Desktop (add-on, Windows and macOS)
 
-**Camelid Desktop is an additive native Windows app.** It gives users a desktop chat
+**Camelid Desktop is an additive native app.** It gives users a desktop chat
 experience with no web browser, by embedding the **same `camelid` engine** that ships as the
-server binary and hosting the existing web UI in a native [WebView2](https://developer.microsoft.com/microsoft-edge/webview2/)
-window via [Tauri v2](https://v2.tauri.app/).
+server binary and hosting the existing web UI in a native WebView2 window on Windows or
+WebKit window on macOS via [Tauri v2](https://v2.tauri.app/).
 
 It is an add-on only. It does **not** modify, gate, or relax any existing support claim,
 parity contract, or the `camelid` server binary. **The web path remains the canonical path.**
@@ -34,17 +34,17 @@ performance, or compatibility.
 ## Architecture (sidecar; see `../DECISIONS.md` D11)
 
 ```
-camelid-desktop.exe ──spawns──▶ camelid.exe serve --addr 127.0.0.1:<ephemeral> --no-open
+camelid-desktop ──spawns──▶ camelid serve --addr 127.0.0.1:<ephemeral> --no-open
         │                                  │  (loopback only)
         │  poll /v1/health (backoff)       │
         ▼                                  ▼
-   WebView2 window  ──navigates to──▶  http://127.0.0.1:<ephemeral>/
+   Native webview   ──navigates to──▶  http://127.0.0.1:<ephemeral>/
    (splash first)                      (UI + API are same-origin; the engine serves the
                                         embedded React UI from its `*` fallback route)
 ```
 
-On window close the sidecar is terminated cleanly; a Windows **job object** with
-`KILL_ON_JOB_CLOSE` is the backstop so a desktop crash cannot orphan a `camelid` process.
+On window close the sidecar is terminated cleanly. On Windows, a **job object** with
+`KILL_ON_JOB_CLOSE` also prevents a desktop crash from orphaning a `camelid` process.
 
 ## Startup failures
 
@@ -56,7 +56,7 @@ error and captured stderr under **Technical details**; it never navigates to a f
 
 | Splash error | Meaning | Next step |
 | --- | --- | --- |
-| **Camelid engine is missing** | `camelid.exe` was not found beside the desktop executable, in the bundled sidecar resources, or on `PATH`. | Reinstall Camelid Desktop or restore `camelid.exe` beside `camelid-desktop.exe`, then retry. |
+| **Camelid engine is missing** | The platform engine was not found beside the desktop executable, in the bundled sidecar resources, or on `PATH`. | Reinstall Camelid Desktop or restore its bundled Camelid engine, then retry. |
 | **Sidecar port unavailable** | The engine reported that it could not bind Camelid's selected ephemeral loopback port. This is not a fixed `8181` port conflict. | Close the conflicting local process and retry. |
 | **Engine startup timed out** | The sidecar did not pass the 40-second `/v1/health` gate. | Retry, then use the visible technical details to diagnose a persistent failure. |
 | **Engine startup failed** | The sidecar exited before it became healthy for another reason. | Review the visible technical details and retry. |
@@ -68,9 +68,29 @@ on the splash.
 
 ## Requirements
 
-- Windows 10/11 with the **WebView2 runtime** (preinstalled on current Windows 10/11; the
+- **Windows:** Windows 10/11 with the **WebView2 runtime** (preinstalled on current Windows 10/11; the
   Tauri bundle ships the bootstrapper otherwise).
-- A `camelid.exe` next to `camelid-desktop.exe` (the portable zip and installer bundle it).
+- **macOS:** Apple Silicon running macOS 12 or newer. The current macOS desktop bundle is
+  ad-hoc signed for local/developer distribution and is not notarized.
+- A bundled platform engine. The portable ZIP, Windows installer, and macOS app bundle
+  include it automatically.
+
+## macOS command-line install
+
+From the repository root on an Apple Silicon Mac:
+
+```sh
+./scripts/install-macos-desktop.sh
+```
+
+This builds the frontend, release engine, app bundle, and DMG; closes an existing Camelid Desktop
+instance cleanly; installs the new app at `/Applications/Camelid Desktop.app`; verifies its
+ad-hoc signature; and launches it. The script uses `sudo` only when `/Applications` is not writable.
+The model directory under the user's Application Support folder is not replaced.
+
+Prerequisites are macOS 12 or newer, the Xcode Command Line Tools, Rust, and Node.js 22 with npm.
+The app is not notarized yet, so this path is intended for local testing and developer
+distribution.
 
 ## Building (developers)
 
@@ -99,6 +119,22 @@ does not pull `camelid-desktop` into its graph (workspace `resolver = "2"`,
 
 For a bundled installer + portable zip, see the additive `desktop-windows` job in
 `../.github/workflows/release.yml`.
+
+### Building the macOS app and DMG
+
+On an Apple Silicon Mac:
+
+```sh
+./scripts/build-macos-desktop.sh
+```
+
+The script builds the real frontend, the release Metal-enabled `camelid` sidecar, and the
+Tauri `.app` and `.dmg`. It uses an ad-hoc signature (`-`), not a Developer ID signature,
+and performs no notarization. macOS may therefore require the user to approve the app in
+**System Settings → Privacy & Security** after downloading it.
+
+Downloaded models are stored under the app's per-user Application Support directory rather
+than inside the app bundle.
 
 ## Scope notes (intentionally deferred)
 

--- a/camelid-desktop/src/engine.rs
+++ b/camelid-desktop/src/engine.rs
@@ -82,7 +82,7 @@ impl EngineError {
     pub fn splash_guidance(&self) -> &'static str {
         match self.kind {
             EngineErrorKind::MissingBinary => {
-                "Reinstall Camelid Desktop or place camelid.exe beside camelid-desktop.exe, then retry."
+                "Reinstall Camelid Desktop or restore its bundled Camelid engine, then retry."
             }
             EngineErrorKind::PortUnavailable => {
                 "Another local process claimed Camelid's selected loopback port. Close it and retry."
@@ -139,7 +139,7 @@ impl Drop for Engine {
 /// Locate the `camelid` engine binary. Resolution order:
 /// 1. Beside the desktop executable (the bundled/portable case — and the dev case, since both
 ///    workspace binaries land in `target/<profile>/`).
-/// 2. An explicit `resource_dir/sidecar/camelid.exe` (Tauri-bundled resource layout).
+/// 2. An explicit `resource_dir/sidecar/<platform engine>` (Tauri-bundled resource layout).
 /// 3. Bare name on `PATH` (developer convenience).
 pub fn resolve_engine_path(resource_dir: Option<PathBuf>) -> Result<PathBuf, EngineError> {
     let file = engine_binary_file();
@@ -218,14 +218,19 @@ pub fn pick_ephemeral_port() -> Result<u16, EngineError> {
 }
 
 /// Spawn `camelid serve --addr 127.0.0.1:<port> --no-open --models-dir <abs>`, bound to
-/// loopback only, and health-gate it. Returns a running [`Engine`] or an [`EngineError`]
-/// carrying engine stderr.
-pub fn spawn(engine_path: &Path) -> Result<Engine, EngineError> {
+/// loopback only, and health-gate it. An explicit models directory lets packaged platforms
+/// keep mutable model data outside the signed application bundle; Windows retains its
+/// existing engine-adjacent directory when no override is supplied.
+pub fn spawn(engine_path: &Path, models_dir: Option<&Path>) -> Result<Engine, EngineError> {
     let port = pick_ephemeral_port()?;
-    spawn_on_port(engine_path, port)
+    spawn_on_port(engine_path, models_dir, port)
 }
 
-fn spawn_on_port(engine_path: &Path, port: u16) -> Result<Engine, EngineError> {
+fn spawn_on_port(
+    engine_path: &Path,
+    models_dir: Option<&Path>,
+    port: u16,
+) -> Result<Engine, EngineError> {
     let addr = format!("127.0.0.1:{port}");
 
     let mut command = Command::new(engine_path);
@@ -240,7 +245,10 @@ fn spawn_on_port(engine_path: &Path, port: u16) -> Result<Engine, EngineError> {
     // the shell), so pin the directory explicitly as an ABSOLUTE path — otherwise the
     // engine's local-models scan, catalog downloads, and relative /api/models/load paths
     // resolve against whatever directory Windows happened to launch the app from.
-    if let Some(models_dir) = sidecar_models_dir(engine_path) {
+    let models_dir = models_dir
+        .map(Path::to_path_buf)
+        .or_else(|| sidecar_models_dir(engine_path));
+    if let Some(models_dir) = models_dir {
         command.arg("--models-dir").arg(models_dir);
     }
     command
@@ -499,7 +507,7 @@ mod tests {
             (
                 EngineErrorKind::MissingBinary,
                 "Camelid engine is missing",
-                "place camelid.exe beside camelid-desktop.exe",
+                "restore its bundled Camelid engine",
             ),
             (
                 EngineErrorKind::PortUnavailable,
@@ -533,7 +541,7 @@ mod tests {
         ));
         let _ = std::fs::remove_file(&missing);
 
-        let error = match spawn(&missing) {
+        let error = match spawn(&missing, None) {
             Ok(_) => panic!("a missing sidecar unexpectedly launched"),
             Err(error) => error,
         };

--- a/camelid-desktop/src/main.rs
+++ b/camelid-desktop/src/main.rs
@@ -1,13 +1,13 @@
-// Camelid Desktop — additive native Windows shell around the camelid engine.
+// Camelid Desktop — additive native shell around the camelid engine.
 //
-// Lifecycle: open the WebView2 window on a bundled splash, spawn `camelid serve` on a
+// Lifecycle: open the native webview on a bundled splash, spawn `camelid serve` on a
 // loopback ephemeral port as a sidecar, health-gate `/v1/health`, then navigate the window
 // to the engine's already-embedded UI (UI + API same-origin). The sidecar is killed on exit;
-// a kill-on-close job object backstops crashes. See DECISIONS.md D11 and engine.rs.
+// a Windows kill-on-close job object backstops crashes. See DECISIONS.md D11 and engine.rs.
 //
 // `windows_subsystem = "windows"` suppresses the console window in release builds; debug
 // builds keep the console so engine stderr is visible while developing.
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
 
 mod engine;
 
@@ -145,8 +145,28 @@ fn start_engine(app: tauri::AppHandle) {
         }
     };
 
+    // A signed macOS app bundle is immutable application code. Keep downloaded GGUFs in
+    // the per-user Application Support directory instead of beside the bundled sidecar
+    // under `Camelid Desktop.app/Contents/Resources`. Windows deliberately retains its
+    // existing per-user installer layout with `models/` beside `camelid.exe`.
+    #[cfg(target_os = "macos")]
+    let models_dir = match app.path().app_data_dir() {
+        Ok(path) => Some(path.join("models")),
+        Err(e) => {
+            emit_error(
+                &app,
+                "Model storage is unavailable",
+                "Check access to your user Library folder, then retry.",
+                &format!("could not resolve the Application Support directory: {e}"),
+            );
+            return;
+        }
+    };
+    #[cfg(not(target_os = "macos"))]
+    let models_dir: Option<std::path::PathBuf> = None;
+
     emit_status(&app, "Starting engine\u{2026}");
-    match engine::spawn(&engine_path) {
+    match engine::spawn(&engine_path, models_dir.as_deref()) {
         Ok(eng) => {
             let url = eng.base_url();
             if let Some(state) = app.try_state::<EngineState>() {

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -28,8 +28,8 @@
     "targets": ["nsis"],
     "publisher": "Camelid",
     "category": "DeveloperTool",
-    "shortDescription": "Native Windows chat app for the camelid local inference engine.",
-    "longDescription": "Camelid Desktop is an additive native Windows app that embeds the same camelid engine shipped as the server binary, run as a loopback sidecar. It inherits the identical model-support contract; it makes no broader claims.",
+    "shortDescription": "Native chat app for the Camelid local inference engine.",
+    "longDescription": "Camelid Desktop embeds the same Camelid engine shipped as the server binary and runs it as a loopback sidecar. It inherits the identical model-support contract; it makes no broader claims.",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/camelid-desktop/tauri.macos.bundle.conf.json
+++ b/camelid-desktop/tauri.macos.bundle.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": ["sidecar/*"]
+  }
+}

--- a/camelid-desktop/tauri.macos.conf.json
+++ b/camelid-desktop/tauri.macos.conf.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": ["app"],
+    "shortDescription": "Native macOS chat app for the Camelid local inference engine.",
+    "longDescription": "Camelid Desktop embeds the same Metal-enabled Camelid engine shipped for Apple Silicon and runs it as a loopback-only sidecar.",
+    "macOS": {
+      "minimumSystemVersion": "12.0",
+      "signingIdentity": "-"
+    }
+  }
+}

--- a/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
+++ b/docs/architecture/MODEL_FIT_ADVISOR_PLAN.md
@@ -44,7 +44,7 @@ Every item below was read in-tree on branch `feat/model-fit-advisor` at
 
 | Concern | Location | What it gives us | Reused for |
 | --- | --- | --- | --- |
-| Host hardware probe | `src/capability.rs` → `HardwareProfile::detect()` | `cuda_available`, `cuda_vram_total_bytes`, `cuda_vram_free_bytes`, `cuda_compute_capability`, `cuda_tensor_cores`, `cpu_logical_cores`, `host_ram_total_bytes`, `host_ram_free_bytes`, `simd`. RAM probed on Windows (`GlobalMemoryStatusEx`) + Linux (`/proc/meminfo`); **returns `(0, 0)` = "unknown" elsewhere (incl. macOS)** | The complete input to the fit function |
+| Host hardware probe | `src/capability.rs` → `HardwareProfile::detect()` | `cuda_available`, `cuda_vram_total_bytes`, `cuda_vram_free_bytes`, `cuda_compute_capability`, `cuda_tensor_cores`, `cpu_logical_cores`, `host_ram_total_bytes`, `host_ram_free_bytes`, `simd`. RAM probed on Windows (`GlobalMemoryStatusEx`), Linux (`/proc/meminfo`), and macOS (`hw.memsize` + Mach VM statistics); returns `(0, 0)` = "unknown" on platforms without a probe | The complete input to the fit function |
 | VRAM headroom policy | `src/cuda_vram.rs` → `evaluate(free_bytes, alloc_bytes, min_headroom_mib) -> Result<VramPlan, VramShortfall>` | Pure, GPU-free, unit-tested arithmetic; default headroom `512 MiB` (env `CAMELID_MIN_VRAM_HEADROOM_MIB`) | Direct call for the VRAM branch of the verdict |
 | RAM/KV budget | `src/inference/kv_cache.rs::ensure_position_capacity` + `kv_bytes_per_token()` | KV projection; budget = `CAMELID_MAX_KV_CACHE_BYTES` else `max(80% avail, 25% total)` RAM | Reference for the KV term + the hard safety net that stays in place |
 | Curated catalog | `src/api/mod.rs` → `curated_catalog() -> Vec<CatalogItem>` (~16 rows) | `CatalogItem { catalog_id, name, repo_id, filename, size_bytes, downloads, likes, quant, architecture, license }` | The rows to annotate; `size_bytes` **is** the on-disk weight footprint |
@@ -70,7 +70,7 @@ Every item below was read in-tree on branch `feat/model-fit-advisor` at
 - **Advisory, not authoritative.** The estimate is a heuristic. The existing
   `VramShortfall` (mid-load) and `KvCacheBudgetExceeded` (mid-gen) guards remain
   the hard safety net and are the source of truth.
-- **Degrade to silence on unknowns.** When `host_ram_total_bytes == 0` (macOS) or
+- **Degrade to silence on unknowns.** When `host_ram_total_bytes == 0` or
   VRAM is unknown, the verdict is `Unknown` and the UI shows nothing scary — it
   **never blocks** a download on an unknown.
 - **Pure and testable.** All math lives in a GPU-free, unit-tested function, in
@@ -86,7 +86,7 @@ enum FitVerdict {
     FitsWithOffload,   // weights exceed VRAM but fit VRAM+host-RAM offload split (CUDA lane)
     CpuOnlyOk,         // no usable GPU, but fits host RAM
     WontFit,           // exceeds every available budget
-    Unknown,           // hardware unknown (e.g. macOS RAM probe returns 0) — advisory-blind
+    Unknown,           // hardware unknown or unavailable — advisory-blind
 }
 ```
 
@@ -353,11 +353,10 @@ tree):
 - **Honest RAM-budget docs (`fit.rs`).** The advisor's `max(80% available, 25% of
   total)` mirrors the *values* of the KV-cache budget constants but is an
   independent reimplementation over `HardwareProfile`. Documented the two real,
-  intentional divergences from the KV runtime guard: (1) different RAM source —
-  advisor probes Windows+Linux (unknown on macOS), the KV guard probes
-  Windows+macOS (unprobed on Linux), so the two enforce on *opposite* non-Windows
-  platforms; (2) on unprobed RAM the KV guard fails open (unbounded) while the
-  advisor abstains (`Unknown`).
+  intentional divergences from the KV runtime guard: (1) the advisor additionally
+  probes Linux, where the KV guard is unprobed; (2) on unprobed RAM the KV guard
+  fails open (unbounded) while the advisor abstains (`Unknown`). On macOS both
+  consumers reuse the same `hw.memsize` + Mach VM-statistics probe.
 - **Cached badge vs live guard (documented).** The catalog badge uses the cached
   startup hardware snapshot; the load guard re-probes live. After a model loads
   and consumes VRAM a badge may still read "fits" while the guard returns 422. The

--- a/scripts/build-macos-desktop.sh
+++ b/scripts/build-macos-desktop.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+desktop_dir="$repo_root/camelid-desktop"
+build_target="${CAMELID_DESKTOP_TARGET_DIR:-$repo_root/target}"
+app_version="$(
+  node -e 'const fs = require("fs"); const config = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(config.version)' \
+    "$desktop_dir/tauri.conf.json"
+)"
+app_path="$build_target/release/bundle/macos/Camelid Desktop.app"
+dmg_dir="$build_target/release/bundle/dmg"
+dmg_path="$dmg_dir/Camelid Desktop_${app_version}_aarch64.dmg"
+
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+  echo "error: the Camelid Desktop macOS bundle must currently be built on Apple Silicon" >&2
+  exit 1
+fi
+
+export CARGO_TARGET_DIR="$build_target"
+
+clean_bundle_metadata() {
+  local bundle_path="$1"
+  xattr -cr "$bundle_path"
+  xattr -d com.apple.FinderInfo "$bundle_path" 2>/dev/null || true
+  xattr -d com.apple.ResourceFork "$bundle_path" 2>/dev/null || true
+  xattr -d 'com.apple.fileprovider.fpfs#P' "$bundle_path" 2>/dev/null || true
+}
+
+(
+  cd "$repo_root/frontend"
+  npm ci
+  npm run build
+)
+
+cargo build \
+  --manifest-path "$repo_root/Cargo.toml" \
+  --release \
+  --locked \
+  --bin camelid
+
+mkdir -p "$desktop_dir/sidecar"
+cp "$build_target/release/camelid" "$desktop_dir/sidecar/camelid"
+chmod 755 "$desktop_dir/sidecar/camelid"
+
+(
+  cd "$desktop_dir"
+  npx --yes @tauri-apps/cli@^2 build --config tauri.macos.bundle.conf.json
+)
+
+# Tauri's styled DMG workflow uses Finder to arrange the image, which can attach FinderInfo
+# metadata to the already-signed app on newer macOS hosts. Build a simple drag-to-Applications
+# image in /tmp instead. Keeping the final staging copy outside Documents/iCloud also prevents
+# file-provider metadata from being reattached between cleaning and signature verification.
+# This can be replaced by Tauri's native DMG target when Developer ID notarization is added.
+stage_dir="$(mktemp -d /tmp/camelid-dmg-stage.XXXXXX)"
+cleanup() {
+  if [[ "$stage_dir" == /tmp/camelid-dmg-stage.* ]]; then
+    rm -rf -- "$stage_dir"
+  fi
+}
+trap cleanup EXIT
+
+ditto --noextattr --noqtn "$app_path" "$stage_dir/Camelid Desktop.app"
+ln -s /Applications "$stage_dir/Applications"
+clean_bundle_metadata "$stage_dir/Camelid Desktop.app"
+codesign --force --deep --sign - --options runtime "$stage_dir/Camelid Desktop.app"
+codesign --verify --deep --strict "$stage_dir/Camelid Desktop.app"
+
+mkdir -p "$dmg_dir"
+hdiutil create \
+  -volname "Camelid Desktop" \
+  -srcfolder "$stage_dir" \
+  -ov \
+  -format UDZO \
+  "$dmg_path"
+
+echo
+echo "macOS app (intermediate): $app_path"
+echo "macOS DMG: $dmg_path"

--- a/scripts/install-macos-desktop.sh
+++ b/scripts/install-macos-desktop.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+build_target="${CAMELID_DESKTOP_TARGET_DIR:-$repo_root/target}"
+built_app="$build_target/release/bundle/macos/Camelid Desktop.app"
+applications_dir="/Applications"
+installed_app="$applications_dir/Camelid Desktop.app"
+desktop_process="$installed_app/Contents/MacOS/camelid-desktop"
+sidecar_process="$installed_app/Contents/Resources/sidecar/camelid serve"
+
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+  echo "error: Camelid Desktop currently requires an Apple Silicon Mac" >&2
+  exit 1
+fi
+
+"$script_dir/build-macos-desktop.sh"
+
+if [ ! -d "$built_app" ]; then
+  echo "error: the macOS build did not produce $built_app" >&2
+  exit 1
+fi
+
+# Give the running app a chance to terminate its loopback sidecar cleanly before
+# replacing the bundle. Model files live in Application Support and are untouched.
+osascript -e 'tell application "Camelid Desktop" to quit' 2>/dev/null || true
+for _ in {1..20}; do
+  if ! pgrep -f "$desktop_process" >/dev/null \
+    && ! pgrep -f "$sidecar_process" >/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+
+if pgrep -f "$desktop_process" >/dev/null || pgrep -f "$sidecar_process" >/dev/null; then
+  echo "error: Camelid Desktop did not exit cleanly; close it and run this script again" >&2
+  exit 1
+fi
+
+if [ -w "$applications_dir" ]; then
+  ditto --noextattr --noqtn "$built_app" "$installed_app"
+  xattr -cr "$installed_app"
+else
+  sudo ditto --noextattr --noqtn "$built_app" "$installed_app"
+  sudo xattr -cr "$installed_app"
+fi
+
+codesign --verify --deep --strict "$installed_app"
+open "$installed_app"
+
+echo "Installed and launched $installed_app"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21704,7 +21704,7 @@ mod catalog_fit_tests {
 
     #[test]
     fn unknown_host_never_reports_wont_fit_for_any_curated_row() {
-        // macOS-style: RAM unprobed (0) and no CUDA → advisory-blind, never WontFit.
+        // An unprobed host with no CUDA is advisory-blind and never claims WontFit.
         let hw = host(false, 0, 0, 0);
         for item in curated_catalog() {
             let view = CatalogItemView::from_curated(&item, &hw);

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -196,7 +196,30 @@ fn host_ram_bytes() -> (u64, u64) {
     (field("MemTotal:"), field("MemAvailable:"))
 }
 
-#[cfg(not(any(windows, target_os = "linux")))]
+#[cfg(target_os = "macos")]
+fn host_ram_bytes() -> (u64, u64) {
+    // Reuse the Mach-backed probe that also protects KV-cache admission so the
+    // catalog fit advisor and runtime safety gate agree on host-memory capacity.
+    crate::gait::host_ram_status().unwrap_or((0, 0))
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
 fn host_ram_bytes() -> (u64, u64) {
     (0, 0)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::host_ram_bytes;
+
+    #[test]
+    fn host_ram_probe_reports_live_physical_ram() {
+        let (total, available) = host_ram_bytes();
+        assert!(total > 0, "total physical RAM must be positive");
+        assert!(available > 0, "available physical RAM must be positive");
+        assert!(
+            available <= total,
+            "available {available} must not exceed total {total}"
+        );
+    }
 }

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -149,10 +149,10 @@ impl FitInputs {
 /// total)` formula as the KV-cache budget in `kv_cache.rs`, but is an independent
 /// reimplementation, not the same guard. Two intentional differences:
 ///
-/// - Source: the advisor reads [`HardwareProfile`] RAM (probed on Windows and Linux;
-///   `(0, 0)` / unknown on macOS), whereas the KV guard reads `gait::host_ram_status`
-///   (probed on Windows and macOS; unprobed on Linux). So on Linux the advisor
-///   enforces a budget while the KV guard is unbounded; on macOS it is the reverse.
+/// - Source: the advisor reads [`HardwareProfile`] RAM (probed on Windows, Linux,
+///   and macOS), whereas the KV guard reads `gait::host_ram_status` (probed on
+///   Windows and macOS; unprobed on Linux). On Linux the advisor enforces a budget
+///   while the KV guard is unbounded.
 /// - Unprobed RAM: the KV guard fails *open* (unbounded); the advisor abstains here
 ///   with `None` (surfaced as [`FitVerdict::Unknown`]) rather than assert a capacity
 ///   it cannot measure.
@@ -566,7 +566,7 @@ mod tests {
 
     #[test]
     fn unknown_when_ram_unprobed_and_no_gpu() {
-        // macOS-style: RAM probe returns 0 and no CUDA. No honest claim possible.
+        // An unprobed host with no CUDA has no capacity signal. No honest claim possible.
         let hw = profile(false, 0, 0, 0);
         let m = inputs(3_421_898_816, 256 * MIB);
         assert_eq!(assess_with_headroom(&hw, &m, H), FitVerdict::Unknown);


### PR DESCRIPTION
## Summary

- add an Apple Silicon Tauri app/DMG build with the existing Camelid engine bundled as a loopback sidecar
- store macOS model downloads in the per-user Application Support directory
- add `scripts/install-macos-desktop.sh` and a copy-pasteable macOS command-line install section to the main README
- reuse the existing Mach memory probe in the model-fit advisor so macOS catalog rows receive real fit verdicts
- document that the current macOS bundle is ad-hoc signed and not notarized

## Why

Camelid Desktop was Windows-only even though the engine and UI already run on Apple Silicon. The thin sidecar design translates cleanly to macOS, but the app bundle needs platform-specific resource packaging and mutable models must live outside the signed bundle.

The model catalog also reported `unknown` for every macOS fit decision because `HardwareProfile` returned `(0, 0)` for host RAM. Reusing the existing `hw.memsize` + Mach VM-statistics probe makes the catalog and runtime safety gate agree.

## User impact

Apple Silicon users can build and install Camelid Desktop from a checkout with:

```bash
./scripts/install-macos-desktop.sh
```

The script builds, ad-hoc signs, installs to `/Applications`, verifies the signature, launches the app, and preserves downloaded models across reinstalls.

## Validation

- `cargo fmt --all -- --check`
- `bash -n scripts/build-macos-desktop.sh scripts/install-macos-desktop.sh`
- README screenshot and public-scrub guards
- macOS host RAM probe test
- 26 fit-advisor tests
- 23 catalog-fit API tests
- 8 `camelid-desktop` lifecycle tests
- end-to-end `./scripts/install-macos-desktop.sh`
- installed app `codesign --verify --deep --strict`
- live catalog API returned concrete `cpu_only_ok`, `insufficient_free_memory`, and `wont_fit` verdicts with no `unknown` rows

## Distribution note

This PR intentionally does not claim notarization. The bundle uses an ad-hoc signature for local/developer distribution until Developer ID signing and notarization are configured.