### PR TITLE
Add runtime scheduling and cache foundations

### DIFF
--- a/config/runtime-capabilities.json
+++ b/config/runtime-capabilities.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": 1,
+  "projects": [
+    {
+      "id": "runtime-capability-registry",
+      "project": 2,
+      "status": "implemented",
+      "default_enabled": true,
+      "configuration": [],
+      "dependencies": [],
+      "evidence": [
+        "runtime_manifest::tests::bundled_runtime_manifest_is_valid_and_covers_selected_projects",
+        "api::tests::capabilities_expose_runtime_project_registry"
+      ],
+      "safety_contract": "Runtime project status is distinct from exact model support and cannot promote model compatibility rows."
+    },
+    {
+      "id": "cpu-kquant-prefill-owner",
+      "project": 4,
+      "status": "parity_gated",
+      "default_enabled": false,
+      "configuration": [
+        "CAMELID_X86_KQUANT_MATMUL_OWNER"
+      ],
+      "dependencies": [
+        "runtime-capability-registry"
+      ],
+      "evidence": [
+        "inference::tests::q4_k_owner_prefill_bitwise_matches_block_dot_core",
+        "inference::tests::q6_k_owner_prefill_bitwise_matches_block_dot_core"
+      ],
+      "safety_contract": "Owner dispatch remains opt-in until repeatable end-to-end prefill receipts show a win; outputs must remain bit-identical to block-dot."
+    },
+    {
+      "id": "indexed-ngram-speculation",
+      "project": 5,
+      "status": "implemented_default_when_ngram_selected",
+      "default_enabled": false,
+      "configuration": [
+        "CAMELID_SPEC_DECODE=ngram",
+        "CAMELID_NGRAM_INDEX_MAX_ENTRIES"
+      ],
+      "dependencies": [
+        "runtime-capability-registry"
+      ],
+      "evidence": [
+        "inference::speculative::tests::indexed_ngram_matches_reference_scanner",
+        "inference::speculative::tests::ngram_index_is_bounded_and_survives_rollback"
+      ],
+      "safety_contract": "Candidate hashes are always token-verified and retained candidates preserve longest-then-most-recent scan semantics; bounded eviction may suppress a draft but can never alter target-model output."
+    },
+    {
+      "id": "unified-kv-sequence-pool",
+      "project": 6,
+      "status": "foundation_default_off",
+      "default_enabled": false,
+      "configuration": [
+        "CAMELID_KV_POOL_BUDGET_BYTES"
+      ],
+      "dependencies": [
+        "runtime-capability-registry"
+      ],
+      "evidence": [
+        "inference::kv_pool::tests::pool_enforces_global_budget_and_evicts_only_idle_sequences",
+        "inference::kv_pool::tests::checkpoint_rollback_is_sequence_local"
+      ],
+      "safety_contract": "Sequence IDs isolate cache state; active leases are never evicted; global allocation is checked before admission."
+    },
+    {
+      "id": "continuous-batch-scheduler",
+      "project": 7,
+      "status": "foundation_default_one_slot",
+      "default_enabled": false,
+      "configuration": [
+        "CAMELID_CONTINUOUS_BATCH_SLOTS"
+      ],
+      "dependencies": [
+        "runtime-capability-registry",
+        "unified-kv-sequence-pool"
+      ],
+      "evidence": [
+        "api::continuous_batch::tests::round_robin_is_fair_and_slot_bounded",
+        "api::engine::tests::slot_snapshot_tracks_real_active_task"
+      ],
+      "safety_contract": "The production engine remains single-owner by default; multi-slot token stepping is not advertised as production-ready until inference integration and throughput/parity receipts land."
+    }
+  ]
+}

--- a/docs/RUNTIME_FOUNDATIONS_2_4_5_6_7.md
+++ b/docs/RUNTIME_FOUNDATIONS_2_4_5_6_7.md
@@ -1,0 +1,33 @@
+# Runtime foundations: projects 2, 4, 5, 6, and 7
+
+This slice deliberately separates implemented foundations from production
+promotion. Exact model support remains governed by the existing evidence
+ledger.
+
+## Delivered
+
+- **2 — capability/config registry:** typed bounds for new runtime controls
+  plus `config/runtime-capabilities.json`, exposed by `/api/capabilities`.
+- **4 — CPU prefill:** centralized the Q4_K/Q6_K owner gate and reused Q6_K
+  Rayon scratch per worker. The owner stays opt-in; bitwise Q4_K/Q6_K parity
+  tests are the promotion floor.
+- **5 — speculative decoding 2.0:** bounded incremental n-gram index with
+  collision verification, rollback rebuild, exact longest/recent selection
+  for retained candidates, stats, and a release microbenchmark.
+- **6 — unified KV manager:** stable sequence IDs, active/idle lifecycle,
+  global allocation budget, idle-only LRU eviction, and sequence-local
+  checkpoints over the existing quantized `LlamaKvCache`.
+- **7 — batching/slots:** real production-engine active-task snapshots power
+  `/slots`; a slot-bounded fair token-step scheduler is implemented and tested
+  as the integration foundation.
+
+## Default behavior
+
+- The production inference engine remains one exclusive owner.
+- Continuous batching and the unified KV pool are not yet wired into default
+  generation.
+- Q4_K/Q6_K owner prefill remains default-off.
+- N-gram indexing is used only when n-gram speculation itself is selected.
+
+These defaults avoid throughput, memory, or output changes in ordinary serving
+while the remaining integration and real-model benchmark gates are completed.

--- a/docs/perf-deep-dive/PERF_RECEIPTS/same-host/runtime-foundations-default-decode-ab-20260728.md
+++ b/docs/perf-deep-dive/PERF_RECEIPTS/same-host/runtime-foundations-default-decode-ab-20260728.md
@@ -1,0 +1,32 @@
+# Runtime foundations default-decode A/B — 2026-07-28
+
+Scope: regression check for the default-neutral project 2/4/5/6/7 slice.
+This is a small same-host smoke, not a support-promotion benchmark.
+
+Compared:
+
+- before: saved pre-slice release binary
+  `target/kv-bench-binaries/camelid-after.exe`
+- after: `target/release/camelid.exe`
+
+Configuration:
+
+- `Llama-3.2-3B-Instruct-Q8_0.gguf`
+- deterministic CPU, 8 threads
+- five-token prompt, 65 generated tokens
+- one warmup plus two measured iterations per process
+- balanced order: before, after, after, before
+- f32 head-major KV baseline
+- speculative decode, CUDA resident decode, and K-quant owner disabled
+
+Results:
+
+| Metric | Before | After | Change |
+|---|---:|---:|---:|
+| decode tok/s, mean of 4 | 7.537 | 7.757 | +2.9% |
+| prefill ms, mean of 4 | 173.22 | 175.75 | +1.5% |
+| peak working set, mean | 4,235,455,488 B | 4,243,330,048 B | +0.19% |
+
+All four before and all four after iterations emitted the same 65 token IDs.
+The small timing and working-set differences are within ordinary same-host run
+noise; this smoke found no default decode throughput or output regression.

--- a/docs/perf-deep-dive/PERF_RECEIPTS/same-host/runtime-foundations-ngram-20260728.md
+++ b/docs/perf-deep-dive/PERF_RECEIPTS/same-host/runtime-foundations-ngram-20260728.md
@@ -1,0 +1,36 @@
+# Indexed n-gram lookup receipt — 2026-07-28
+
+Scope: synthetic lookup-only benchmark for project 5. This is not an
+end-to-end generation tok/s claim.
+
+Command:
+
+```text
+cargo test --release --lib indexed_ngram_microbench_against_reference_scan -- --ignored --nocapture
+```
+
+Workload:
+
+- 16,384-token unique base history
+- 512 incremental lookups
+- match lengths 3 through 4
+- miss-heavy suffixes (the historical implementation scans the history)
+- release profile, Windows x86_64, same process
+
+Result:
+
+```text
+indexed=2.2129ms
+scan=59.8836ms
+speedup=27.06x
+```
+
+Correctness gates run separately:
+
+- `indexed_ngram_matches_reference_scanner`: PASS across 1,200 incremental
+  histories and draft budgets 1, 3, and 7.
+- `ngram_index_is_bounded_and_survives_rollback`: PASS with a 48-record
+  ceiling and history rollback/re-append.
+- Every hash candidate is compared token-for-token before drafting.
+- A bounded eviction can suppress a proposal, but target-model verification
+  remains authoritative and generated output cannot change.

--- a/src/api/continuous_batch.rs
+++ b/src/api/continuous_batch.rs
@@ -1,0 +1,146 @@
+//! Cooperative round-robin scheduler foundation for continuous batching.
+//!
+//! The current production engine still runs one exclusive closure at a time.
+//! This scheduler captures the lifecycle and fairness rules needed when decode
+//! jobs are converted to one-token `step` tasks.  Keeping it independent makes
+//! those rules testable before the hot inference path is switched over.
+
+use std::collections::VecDeque;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct BatchTaskId(u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StepOutcome {
+    Continue,
+    Complete,
+}
+
+#[derive(Debug)]
+struct BatchTask<T> {
+    id: BatchTaskId,
+    state: T,
+}
+
+#[derive(Debug)]
+pub(crate) struct ContinuousBatch<T> {
+    max_slots: usize,
+    next_id: u64,
+    waiting: VecDeque<BatchTask<T>>,
+    active: VecDeque<BatchTask<T>>,
+}
+
+impl<T> ContinuousBatch<T> {
+    pub(crate) fn from_env() -> Self {
+        Self::new(crate::runtime_config::continuous_batch_slots())
+    }
+
+    pub(crate) fn new(max_slots: usize) -> Self {
+        Self {
+            max_slots: max_slots.max(1),
+            next_id: 1,
+            waiting: VecDeque::new(),
+            active: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn admit(&mut self, state: T) -> BatchTaskId {
+        let id = BatchTaskId(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        self.waiting.push_back(BatchTask { id, state });
+        id
+    }
+
+    pub(crate) fn cancel(&mut self, id: BatchTaskId) -> Option<T> {
+        remove_task(&mut self.waiting, id).or_else(|| remove_task(&mut self.active, id))
+    }
+
+    pub(crate) fn active_len(&self) -> usize {
+        self.active.len()
+    }
+
+    pub(crate) fn waiting_len(&self) -> usize {
+        self.waiting.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.active.is_empty() && self.waiting.is_empty()
+    }
+
+    /// Run at most one token-step for every active slot. Tasks that need more
+    /// work rotate to the tail; completed tasks release their slot before the
+    /// next round. Returns completed IDs in completion order.
+    pub(crate) fn run_round(
+        &mut self,
+        mut step: impl FnMut(BatchTaskId, &mut T) -> StepOutcome,
+    ) -> Vec<BatchTaskId> {
+        self.fill_slots();
+        let round_len = self.active.len();
+        let mut completed = Vec::new();
+        for _ in 0..round_len {
+            let mut task = self.active.pop_front().expect("round length is exact");
+            match step(task.id, &mut task.state) {
+                StepOutcome::Continue => self.active.push_back(task),
+                StepOutcome::Complete => completed.push(task.id),
+            }
+        }
+        self.fill_slots();
+        completed
+    }
+
+    fn fill_slots(&mut self) {
+        while self.active.len() < self.max_slots {
+            let Some(task) = self.waiting.pop_front() else {
+                break;
+            };
+            self.active.push_back(task);
+        }
+    }
+}
+
+fn remove_task<T>(queue: &mut VecDeque<BatchTask<T>>, id: BatchTaskId) -> Option<T> {
+    let index = queue.iter().position(|task| task.id == id)?;
+    queue.remove(index).map(|task| task.state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_robin_is_fair_and_slot_bounded() {
+        let mut scheduler = ContinuousBatch::new(2);
+        let ids = [
+            scheduler.admit(0usize),
+            scheduler.admit(0usize),
+            scheduler.admit(0usize),
+        ];
+        let mut order = Vec::new();
+        for _ in 0..3 {
+            scheduler.run_round(|id, steps| {
+                order.push(id);
+                *steps += 1;
+                if *steps == 2 {
+                    StepOutcome::Complete
+                } else {
+                    StepOutcome::Continue
+                }
+            });
+            assert!(scheduler.active_len() <= 2);
+        }
+        assert_eq!(order, vec![ids[0], ids[1], ids[0], ids[1], ids[2]]);
+        assert_eq!(scheduler.active_len(), 1);
+        assert_eq!(scheduler.waiting_len(), 0);
+    }
+
+    #[test]
+    fn cancellation_releases_waiting_and_active_tasks() {
+        let mut scheduler = ContinuousBatch::new(1);
+        let first = scheduler.admit("first");
+        let second = scheduler.admit("second");
+        scheduler.run_round(|_, _| StepOutcome::Continue);
+        assert_eq!(scheduler.cancel(second), Some("second"));
+        assert_eq!(scheduler.cancel(first), Some("first"));
+        assert!(scheduler.is_empty());
+    }
+}

--- a/src/api/engine.rs
+++ b/src/api/engine.rs
@@ -17,15 +17,14 @@
 //! and queued jobs from dropped handlers return immediately when they run.
 
 use std::sync::{
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicU64, AtomicUsize, Ordering},
     Arc,
 };
 
 /// Bounded queue depth (queued jobs, not counting the one running).
 /// Overridable for hardening runs; the default keeps a small, honest queue —
 /// beyond it the server answers 503 rather than parking unbounded waiters.
-pub(crate) const QUEUE_DEPTH_ENV: &str = "CAMELID_QUEUE_DEPTH";
-const DEFAULT_QUEUE_DEPTH: usize = 8;
+pub(crate) const QUEUE_DEPTH_ENV: &str = crate::runtime_config::ENGINE_QUEUE_DEPTH_ENV;
 
 type ExclusiveJob = Box<dyn FnOnce() + Send + 'static>;
 
@@ -57,14 +56,36 @@ pub(crate) struct EngineHandle {
     /// Jobs accepted but not yet finished (queued + running). Surfaced in
     /// `/v1/health` and `/v1/slots` so backpressure is observable.
     depth: Arc<AtomicUsize>,
+    /// Real task currently executing on the single-owner engine. Zero means
+    /// idle; public snapshots convert the sentinel to `None`.
+    active_task_id: Arc<AtomicU64>,
+    next_task_id: Arc<AtomicU64>,
 }
 
 fn queue_depth_from_env() -> usize {
-    std::env::var(QUEUE_DEPTH_ENV)
-        .ok()
-        .and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|depth| *depth >= 1)
-        .unwrap_or(DEFAULT_QUEUE_DEPTH)
+    crate::runtime_config::engine_queue_depth()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EngineSlotSnapshot {
+    pub(crate) active_task_id: Option<u64>,
+    pub(crate) queued_tasks: usize,
+}
+
+impl EngineSlotSnapshot {
+    pub(crate) fn is_processing(self) -> bool {
+        self.active_task_id.is_some()
+    }
+}
+
+struct ActiveTaskGuard {
+    active_task_id: Arc<AtomicU64>,
+}
+
+impl Drop for ActiveTaskGuard {
+    fn drop(&mut self) {
+        self.active_task_id.store(0, Ordering::SeqCst);
+    }
 }
 
 impl EngineHandle {
@@ -73,6 +94,7 @@ impl EngineHandle {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<EngineTask>(queue_depth_from_env());
         let depth = Arc::new(AtomicUsize::new(0));
         let worker_depth = Arc::clone(&depth);
+        let active_task_id = Arc::new(AtomicU64::new(0));
         std::thread::Builder::new()
             .name("camelid-engine".to_string())
             .spawn(move || {
@@ -92,7 +114,12 @@ impl EngineHandle {
                 }
             })
             .expect("spawn camelid-engine worker thread");
-        Self { tx, depth }
+        Self {
+            tx,
+            depth,
+            active_task_id,
+            next_task_id: Arc::new(AtomicU64::new(1)),
+        }
     }
 
     /// Jobs accepted and not yet finished.
@@ -100,10 +127,30 @@ impl EngineHandle {
         self.depth.load(Ordering::SeqCst)
     }
 
+    /// Privacy-safe, read-only state for the production engine's real slot.
+    /// Queue depth remains separate because queued jobs do not own a slot.
+    pub(crate) fn slot_snapshot(&self) -> EngineSlotSnapshot {
+        let active = self.active_task_id.load(Ordering::SeqCst);
+        let depth = self.depth();
+        EngineSlotSnapshot {
+            active_task_id: (active != 0).then_some(active),
+            queued_tasks: depth.saturating_sub(usize::from(active != 0)),
+        }
+    }
+
     /// Post a job without waiting for queue room: full queue is an explicit,
     /// typed condition (503 + Retry-After at the HTTP layer), never an
     /// invisible pile of waiters.
     pub(crate) fn post(&self, task: EngineTask) -> Result<(), EnginePostError> {
+        let task_id = self.next_task_id.fetch_add(1, Ordering::SeqCst);
+        let active_task_id = Arc::clone(&self.active_task_id);
+        let task = match task {
+            EngineTask::Exclusive(job) => EngineTask::Exclusive(Box::new(move || {
+                active_task_id.store(task_id, Ordering::SeqCst);
+                let _guard = ActiveTaskGuard { active_task_id };
+                job();
+            })),
+        };
         self.depth.fetch_add(1, Ordering::SeqCst);
         match self.tx.try_send(task) {
             Ok(()) => Ok(()),
@@ -228,5 +275,40 @@ mod tests {
             assert!(std::time::Instant::now() < deadline, "depth never drained");
             tokio::time::sleep(std::time::Duration::from_millis(5)).await;
         }
+    }
+
+    #[tokio::test]
+    async fn slot_snapshot_tracks_real_active_task() {
+        let engine = EngineHandle::spawn();
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        engine
+            .post(EngineTask::Exclusive(Box::new(move || {
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            })))
+            .unwrap();
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("engine starts task");
+
+        let busy = engine.slot_snapshot();
+        assert!(busy.is_processing());
+        assert!(busy.active_task_id.is_some());
+        assert_eq!(busy.queued_tasks, 0);
+
+        release_tx.send(()).unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while engine.depth() != 0 {
+            assert!(std::time::Instant::now() < deadline);
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+        assert_eq!(
+            engine.slot_snapshot(),
+            EngineSlotSnapshot {
+                active_task_id: None,
+                queued_tasks: 0,
+            }
+        );
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -25,6 +25,8 @@ use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
+#[allow(dead_code)]
+mod continuous_batch;
 mod engine;
 mod workspace;
 
@@ -484,6 +486,9 @@ pub struct CapabilitiesResponse {
     pub supported_model_families: Vec<SupportItem>,
     pub planned_model_families: Vec<SupportItem>,
     pub model_compatibility: Vec<ModelCompatibilityTarget>,
+    /// Machine-readable implementation/evidence state for runtime projects.
+    /// This registry is intentionally separate from model support rows.
+    pub runtime_projects: Vec<crate::runtime_manifest::RuntimeProjectCapability>,
     pub api_features: Vec<SupportItem>,
     pub notes: Vec<&'static str>,
 }
@@ -1083,6 +1088,7 @@ pub struct LlamaServerSlotCamelid {
     /// Engine-queue backpressure gauge: generation jobs accepted and not yet
     /// finished (queued + running). See `HealthResponse::engine_queue_depth`.
     pub engine_queue_depth: usize,
+    pub queued_tasks: usize,
     pub unsupported: Vec<&'static str>,
 }
 
@@ -2641,8 +2647,10 @@ async fn llama_server_slots(
     let loaded_models = state.loaded_models.read().await;
     let model = active_id_lock.as_ref().and_then(|id| loaded_models.get(id));
     let generation_ready = model.is_some_and(loaded_model_generation_ready);
+    let slot = state.engine.slot_snapshot();
 
-    if query.fail_on_no_slot.as_deref() == Some("1") && !generation_ready {
+    if query.fail_on_no_slot.as_deref() == Some("1") && (!generation_ready || slot.is_processing())
+    {
         return api_error(
             StatusCode::SERVICE_UNAVAILABLE,
             "no_available_slot",
@@ -2655,20 +2663,26 @@ async fn llama_server_slots(
         .and_then(|model| model.llama_config.as_ref())
         .map(|config| config.context_length)
         .unwrap_or(0);
-    let status = if generation_ready {
-        "idle_generation_ready"
-    } else {
+    let status = if !generation_ready {
         "unavailable"
+    } else if slot.is_processing() {
+        "processing"
+    } else {
+        "idle_generation_ready"
     };
+    let id_task = slot
+        .active_task_id
+        .map(|id| id.min(i32::MAX as u64) as i32)
+        .unwrap_or(-1);
 
     (
         StatusCode::OK,
         Json(vec![LlamaServerSlotResponse {
             id: 0,
-            id_task: -1,
+            id_task,
             n_ctx,
             speculative: false,
-            is_processing: false,
+            is_processing: slot.is_processing(),
             params: LlamaServerDefaultGenerationParams {
                 n_predict: -1,
                 seed: u32::MAX,
@@ -2697,6 +2711,7 @@ async fn llama_server_slots(
                 generation_ready,
                 status,
                 engine_queue_depth: state.engine.depth(),
+                queued_tasks: slot.queued_tasks,
                 unsupported: vec![
                     "post_slots",
                     "slot_cache_save_restore_erase",
@@ -4690,6 +4705,9 @@ fn capabilities_response_with_plan(execution_plan: Option<ExecutionPlan>) -> Cap
                 next_step: "capture acquisition path, model SHA and license/access notes, then add tokenizer/chat-template fixtures and bounded metadata/load checks before any runtime-support wording",
             },
         ],
+        runtime_projects: crate::runtime_manifest::runtime_capability_manifest()
+            .projects
+            .clone(),
         api_features: vec![
             SupportItem {
                 id: "camelid_verify",
@@ -15608,6 +15626,34 @@ mod tests {
         let response = capabilities_response_with_plan(Some(plan.clone()));
 
         assert_eq!(response.execution_plan, Some(plan));
+    }
+
+    #[test]
+    fn capabilities_expose_runtime_project_registry() {
+        let response = capabilities_response();
+        let projects: HashMap<_, _> = response
+            .runtime_projects
+            .iter()
+            .map(|item| (item.project, item))
+            .collect();
+        assert_eq!(projects.len(), 5);
+        for project in [2u32, 4, 5, 6, 7] {
+            let item = projects
+                .get(&project)
+                .unwrap_or_else(|| panic!("project {project} missing"));
+            assert!(!item.id.is_empty());
+            assert!(!item.status.is_empty());
+            assert!(!item.evidence.is_empty());
+            assert!(!item.safety_contract.is_empty());
+        }
+        assert!(
+            !projects[&4].default_enabled,
+            "CPU prefill promotion remains evidence-gated"
+        );
+        assert!(
+            !projects[&7].default_enabled,
+            "continuous batching remains default-neutral until integrated"
+        );
     }
 
     #[test]

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -31,6 +31,7 @@ pub mod draft_merge;
 pub(crate) mod gemma4;
 mod kv_cache;
 mod kv_f16;
+pub mod kv_pool;
 mod metal_resident;
 mod metal_seam;
 mod q8_block_reader;
@@ -61,6 +62,10 @@ pub use diagnostic_config::{
 };
 pub use kv_cache::{
     KvDtype, KvLayout, LlamaKvCache, LlamaKvCachePlan, LlamaKvCachePositionTrace, LlamaKvCacheTrace,
+};
+pub use kv_pool::{
+    KvPoolError, KvPoolSnapshot, KvSequenceCheckpoint, KvSequenceId, KvSequenceState,
+    UnifiedKvCachePool,
 };
 pub use q8_block_reader::Q8BlockReader;
 use q8_runtime::{
@@ -18864,16 +18869,15 @@ fn matmul_rhs_transposed_q4_k_block_dot(
 fn x86_kquant_matmul_owner_enabled() -> bool {
     #[cfg(test)]
     {
-        q8_0_env_flag_enabled_default_off("CAMELID_X86_KQUANT_MATMUL_OWNER")
+        crate::runtime_config::kquant_prefill_owner_enabled()
     }
     #[cfg(not(test))]
     {
         if q8_runtime::bench_uncached_runtime_plan() {
-            return q8_0_env_flag_enabled_default_off("CAMELID_X86_KQUANT_MATMUL_OWNER");
+            return crate::runtime_config::kquant_prefill_owner_enabled();
         }
         static ENABLED: OnceLock<bool> = OnceLock::new();
-        *ENABLED
-            .get_or_init(|| q8_0_env_flag_enabled_default_off("CAMELID_X86_KQUANT_MATMUL_OWNER"))
+        *ENABLED.get_or_init(crate::runtime_config::kquant_prefill_owner_enabled)
     }
 }
 
@@ -19714,78 +19718,86 @@ fn q6_k_owner_prefill_tiled(
     let chunks = out_dim.div_ceil(WEIGHT_CHUNK);
     for row_start in (0..n_rows).step_by(ROW_BLOCK) {
         let row_end = (row_start + ROW_BLOCK).min(n_rows);
-        (0..chunks).into_par_iter().for_each(|chunk_idx| {
-            let o_start = chunk_idx * WEIGHT_CHUNK;
-            let o_end = (o_start + WEIGHT_CHUNK).min(out_dim);
-            // Per-task hoist scratch: rebuilt weights + scales + super-scale
-            // per superblock, reused across the chunk's weight rows.
-            let mut a_all = vec![0i8; superblocks * Q6_K_VALUES_PER_BLOCK];
-            let mut wsc = vec![0u8; superblocks * 16];
-            let mut wd = vec![0f32; superblocks];
-            for o in o_start..o_end {
-                let w_row = &wire[o * row_bytes..(o + 1) * row_bytes];
-                for i in 0..superblocks {
-                    let block =
-                        &w_row[i * Q6_K_WIRE_BYTES_PER_BLOCK..(i + 1) * Q6_K_WIRE_BYTES_PER_BLOCK];
-                    wd[i] = f16_bits_to_f32(u16::from_le_bytes([block[208], block[209]]));
-                    wsc[i * 16..(i + 1) * 16].copy_from_slice(&block[192..208]);
-                    let a_slice = &mut a_all[i * Q6_K_VALUES_PER_BLOCK..];
-                    // SAFETY-free reborrow into the fixed-size rebuild target.
-                    let a_arr: &mut [i8; Q6_K_VALUES_PER_BLOCK] = (&mut a_slice
-                        [..Q6_K_VALUES_PER_BLOCK])
-                        .try_into()
-                        .expect("owner rebuild slice is exactly one superblock");
-                    q6_k_owner_rebuild_superblock(block, a_arr);
-                }
-                let block_rows = row_end - row_start;
-                let mut sumf_block = [0f32; ROW_BLOCK];
-                for (r, blocks) in preps[row_start..row_end].iter().enumerate() {
-                    // Load-bearing f32 shape: 8 lane accumulators per CELL,
-                    // reduced once after all superblocks — verbatim
-                    // `q6_k_wire_row_dot`.
-                    let mut sums = [0f32; 8];
-                    for (i, y) in blocks.iter().enumerate().take(superblocks) {
-                        let d = wd[i] * y.d;
-                        let a: &[i8; Q6_K_VALUES_PER_BLOCK] = a_all
-                            [i * Q6_K_VALUES_PER_BLOCK..(i + 1) * Q6_K_VALUES_PER_BLOCK]
+        (0..chunks).into_par_iter().for_each_init(
+            // Reuse scratch for every chunk executed by one Rayon worker.
+            // The old per-chunk allocation repeated for each 64-row prompt
+            // block on wide projections.
+            || {
+                (
+                    vec![0i8; superblocks * Q6_K_VALUES_PER_BLOCK],
+                    vec![0u8; superblocks * 16],
+                    vec![0f32; superblocks],
+                )
+            },
+            |scratch, chunk_idx| {
+                let (a_all, wsc, wd) = scratch;
+                let o_start = chunk_idx * WEIGHT_CHUNK;
+                let o_end = (o_start + WEIGHT_CHUNK).min(out_dim);
+                for o in o_start..o_end {
+                    let w_row = &wire[o * row_bytes..(o + 1) * row_bytes];
+                    for i in 0..superblocks {
+                        let block = &w_row
+                            [i * Q6_K_WIRE_BYTES_PER_BLOCK..(i + 1) * Q6_K_WIRE_BYTES_PER_BLOCK];
+                        wd[i] = f16_bits_to_f32(u16::from_le_bytes([block[208], block[209]]));
+                        wsc[i * 16..(i + 1) * 16].copy_from_slice(&block[192..208]);
+                        let a_slice = &mut a_all[i * Q6_K_VALUES_PER_BLOCK..];
+                        // SAFETY-free reborrow into the fixed-size rebuild target.
+                        let a_arr: &mut [i8; Q6_K_VALUES_PER_BLOCK] = (&mut a_slice
+                            [..Q6_K_VALUES_PER_BLOCK])
                             .try_into()
-                            .expect("owner superblock slice is exactly 256 weights");
-                        let scales: &[u8; 16] = wsc[i * 16..(i + 1) * 16]
-                            .try_into()
-                            .expect("owner scale slice is exactly 16 bytes");
-                        // `use_avx2` is read on every target (the cfg split is
-                        // inside the arm), so non-x86 builds see no unused
-                        // binding.
-                        let aux32 = if use_avx2 {
-                            #[cfg(target_arch = "x86_64")]
-                            // SAFETY: avx2 confirmed present at dispatch; the
-                            // fixed-size array refs guarantee the 256/16-byte
-                            // reads are in bounds.
-                            unsafe {
-                                q6_k_owner_aux32_avx2(a, scales, &y.qs)
+                            .expect("owner rebuild slice is exactly one superblock");
+                        q6_k_owner_rebuild_superblock(block, a_arr);
+                    }
+                    let block_rows = row_end - row_start;
+                    let mut sumf_block = [0f32; ROW_BLOCK];
+                    for (r, blocks) in preps[row_start..row_end].iter().enumerate() {
+                        // Load-bearing f32 shape: 8 lane accumulators per CELL,
+                        // reduced once after all superblocks — verbatim
+                        // `q6_k_wire_row_dot`.
+                        let mut sums = [0f32; 8];
+                        for (i, y) in blocks.iter().enumerate().take(superblocks) {
+                            let d = wd[i] * y.d;
+                            let a: &[i8; Q6_K_VALUES_PER_BLOCK] = a_all
+                                [i * Q6_K_VALUES_PER_BLOCK..(i + 1) * Q6_K_VALUES_PER_BLOCK]
+                                .try_into()
+                                .expect("owner superblock slice is exactly 256 weights");
+                            let scales: &[u8; 16] = wsc[i * 16..(i + 1) * 16]
+                                .try_into()
+                                .expect("owner scale slice is exactly 16 bytes");
+                            // `use_avx2` is read on every target (the cfg split is
+                            // inside the arm), so non-x86 builds see no unused
+                            // binding.
+                            let aux32 = if use_avx2 {
+                                #[cfg(target_arch = "x86_64")]
+                                // SAFETY: avx2 confirmed present at dispatch; the
+                                // fixed-size array refs guarantee the 256/16-byte
+                                // reads are in bounds.
+                                unsafe {
+                                    q6_k_owner_aux32_avx2(a, scales, &y.qs)
+                                }
+                                #[cfg(not(target_arch = "x86_64"))]
+                                q6_k_owner_aux32_scalar(a, scales, &y.qs)
+                            } else {
+                                q6_k_owner_aux32_scalar(a, scales, &y.qs)
+                            };
+                            for l in 0..8 {
+                                sums[l] += d * aux32[l] as f32;
                             }
-                            #[cfg(not(target_arch = "x86_64"))]
-                            q6_k_owner_aux32_scalar(a, scales, &y.qs)
-                        } else {
-                            q6_k_owner_aux32_scalar(a, scales, &y.qs)
-                        };
-                        for l in 0..8 {
-                            sums[l] += d * aux32[l] as f32;
+                        }
+                        sumf_block[r] = sums.iter().sum();
+                    }
+                    let ptr = out_ptr;
+                    for (r, sumf) in sumf_block[..block_rows].iter().enumerate() {
+                        // SAFETY: (row, o) cells are disjoint across tasks — this
+                        // task exclusively owns channels [o_start, o_end) and the
+                        // row loop is serial within the task.
+                        unsafe {
+                            *ptr.0.add((row_start + r) * out_dim + o) = *sumf;
                         }
                     }
-                    sumf_block[r] = sums.iter().sum();
                 }
-                let ptr = out_ptr;
-                for (r, sumf) in sumf_block[..block_rows].iter().enumerate() {
-                    // SAFETY: (row, o) cells are disjoint across tasks — this
-                    // task exclusively owns channels [o_start, o_end) and the
-                    // row loop is serial within the task.
-                    unsafe {
-                        *ptr.0.add((row_start + r) * out_dim + o) = *sumf;
-                    }
-                }
-            }
-        });
+            },
+        );
     }
     CpuTensor::from_f32(name, vec![n_rows, out_dim], out)
 }

--- a/src/inference/kv_cache.rs
+++ b/src/inference/kv_cache.rs
@@ -524,6 +524,24 @@ impl LlamaKvCache {
         }
     }
 
+    /// Allocation size after reserving `required_sequence_length`, without
+    /// mutating or allocating. The unified multi-sequence pool uses this to
+    /// enforce its global budget before any individual cache grows.
+    pub(crate) fn projected_allocated_bytes(&self, required_sequence_length: usize) -> Result<u64> {
+        if required_sequence_length > self.plan.max_sequence_length {
+            return Err(BackendError::RuntimeShapeMismatch(format!(
+                "KV cache position {required_sequence_length} exceeds context length {}",
+                self.plan.max_sequence_length
+            )));
+        }
+        let target = if required_sequence_length <= self.allocated_sequence_length {
+            self.allocated_sequence_length
+        } else {
+            self.grow_sequence_length(required_sequence_length)
+        };
+        Ok((target as u64).saturating_mul(self.kv_bytes_per_token()))
+    }
+
     /// Whether the f32 `keys`/`values` buffers are ADDRESSABLE over `[0, position)` for every
     /// layer through `last_layer` — i.e. whether a reader may index them with
     /// [`offset`](Self::offset) over that range without going out of bounds.

--- a/src/inference/kv_pool.rs
+++ b/src/inference/kv_pool.rs
@@ -1,0 +1,344 @@
+//! Budgeted multi-sequence ownership for Llama K/V caches.
+//!
+//! `LlamaKvCache` remains the storage implementation. This layer adds stable
+//! sequence identity, lifecycle state, a global byte ceiling, idle-only LRU
+//! eviction, and sequence-local checkpoints. It is intentionally not wired
+//! into the default serve loop yet; doing that safely requires the cooperative
+//! token-step scheduler to own session lifetimes end-to-end.
+
+use std::collections::HashMap;
+
+use super::LlamaKvCache;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KvSequenceId(u64);
+
+impl KvSequenceId {
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KvSequenceState {
+    Idle,
+    Active,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KvSequenceCheckpoint {
+    pub sequence_id: KvSequenceId,
+    pub position: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KvPoolSnapshot {
+    pub sequence_count: usize,
+    pub active_sequences: usize,
+    pub allocated_bytes: u64,
+    pub budget_bytes: u64,
+    pub evictions: u64,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum KvPoolError {
+    #[error("unknown KV sequence {0}")]
+    UnknownSequence(u64),
+    #[error("KV sequence {0} is already active")]
+    AlreadyActive(u64),
+    #[error("KV sequence {0} is not active")]
+    NotActive(u64),
+    #[error(
+        "unified KV pool needs {needed_bytes} bytes but its global budget is {budget_bytes} bytes"
+    )]
+    BudgetExceeded {
+        needed_bytes: u64,
+        budget_bytes: u64,
+    },
+    #[error("KV sequence {0} is active and cannot be removed")]
+    ActiveSequence(u64),
+    #[error("KV cache operation failed: {0}")]
+    Cache(String),
+}
+
+struct PoolEntry {
+    cache: LlamaKvCache,
+    state: KvSequenceState,
+    last_used: u64,
+}
+
+pub struct UnifiedKvCachePool {
+    entries: HashMap<KvSequenceId, PoolEntry>,
+    budget_bytes: u64,
+    next_id: u64,
+    clock: u64,
+    evictions: u64,
+}
+
+impl UnifiedKvCachePool {
+    pub fn from_env() -> Self {
+        Self::new(crate::runtime_config::kv_pool_budget_bytes())
+    }
+
+    pub fn new(budget_bytes: u64) -> Self {
+        Self {
+            entries: HashMap::new(),
+            budget_bytes: budget_bytes.max(1),
+            next_id: 1,
+            clock: 0,
+            evictions: 0,
+        }
+    }
+
+    pub fn insert(&mut self, cache: LlamaKvCache) -> Result<KvSequenceId, KvPoolError> {
+        let needed = cache.allocated_bytes();
+        self.make_room(needed, None)?;
+        let id = KvSequenceId(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        let last_used = self.tick();
+        self.entries.insert(
+            id,
+            PoolEntry {
+                cache,
+                state: KvSequenceState::Idle,
+                last_used,
+            },
+        );
+        Ok(id)
+    }
+
+    pub fn activate(&mut self, id: KvSequenceId) -> Result<(), KvPoolError> {
+        let last_used = self.tick();
+        let entry = self.entry_mut(id)?;
+        if entry.state == KvSequenceState::Active {
+            return Err(KvPoolError::AlreadyActive(id.0));
+        }
+        entry.state = KvSequenceState::Active;
+        entry.last_used = last_used;
+        Ok(())
+    }
+
+    pub fn deactivate(&mut self, id: KvSequenceId) -> Result<(), KvPoolError> {
+        let last_used = self.tick();
+        let entry = self.entry_mut(id)?;
+        if entry.state != KvSequenceState::Active {
+            return Err(KvPoolError::NotActive(id.0));
+        }
+        entry.state = KvSequenceState::Idle;
+        entry.last_used = last_used;
+        Ok(())
+    }
+
+    /// Reserve one sequence's cache under the pool-wide budget. Idle LRU
+    /// sequences may be evicted, but the target and every active sequence are
+    /// protected.
+    pub fn reserve(
+        &mut self,
+        id: KvSequenceId,
+        required_sequence_length: usize,
+    ) -> Result<(), KvPoolError> {
+        let current = self
+            .entries
+            .get(&id)
+            .ok_or(KvPoolError::UnknownSequence(id.0))?
+            .cache
+            .allocated_bytes();
+        let projected = self
+            .entries
+            .get(&id)
+            .expect("checked above")
+            .cache
+            .projected_allocated_bytes(required_sequence_length)
+            .map_err(|error| KvPoolError::Cache(error.to_string()))?;
+        let additional = projected.saturating_sub(current);
+        self.make_room(additional, Some(id))?;
+        let last_used = self.tick();
+        let entry = self.entry_mut(id)?;
+        entry
+            .cache
+            .ensure_position_capacity(required_sequence_length)
+            .map_err(|error| KvPoolError::Cache(error.to_string()))?;
+        entry.last_used = last_used;
+        Ok(())
+    }
+
+    pub fn checkpoint(&mut self, id: KvSequenceId) -> Result<KvSequenceCheckpoint, KvPoolError> {
+        let last_used = self.tick();
+        let entry = self.entry_mut(id)?;
+        entry.last_used = last_used;
+        Ok(KvSequenceCheckpoint {
+            sequence_id: id,
+            position: entry.cache.position,
+        })
+    }
+
+    pub fn rollback(&mut self, checkpoint: KvSequenceCheckpoint) -> Result<(), KvPoolError> {
+        let last_used = self.tick();
+        let entry = self.entry_mut(checkpoint.sequence_id)?;
+        entry
+            .cache
+            .rollback_to_position(checkpoint.position)
+            .map_err(|error| KvPoolError::Cache(error.to_string()))?;
+        entry.last_used = last_used;
+        Ok(())
+    }
+
+    pub fn cache(&self, id: KvSequenceId) -> Result<&LlamaKvCache, KvPoolError> {
+        self.entries
+            .get(&id)
+            .map(|entry| &entry.cache)
+            .ok_or(KvPoolError::UnknownSequence(id.0))
+    }
+
+    pub fn cache_mut(&mut self, id: KvSequenceId) -> Result<&mut LlamaKvCache, KvPoolError> {
+        let last_used = self.tick();
+        let entry = self.entry_mut(id)?;
+        entry.last_used = last_used;
+        Ok(&mut entry.cache)
+    }
+
+    pub fn remove(&mut self, id: KvSequenceId) -> Result<LlamaKvCache, KvPoolError> {
+        let entry = self
+            .entries
+            .get(&id)
+            .ok_or(KvPoolError::UnknownSequence(id.0))?;
+        if entry.state == KvSequenceState::Active {
+            return Err(KvPoolError::ActiveSequence(id.0));
+        }
+        Ok(self.entries.remove(&id).expect("checked above").cache)
+    }
+
+    pub fn snapshot(&self) -> KvPoolSnapshot {
+        KvPoolSnapshot {
+            sequence_count: self.entries.len(),
+            active_sequences: self
+                .entries
+                .values()
+                .filter(|entry| entry.state == KvSequenceState::Active)
+                .count(),
+            allocated_bytes: self.allocated_bytes(),
+            budget_bytes: self.budget_bytes,
+            evictions: self.evictions,
+        }
+    }
+
+    fn entry_mut(&mut self, id: KvSequenceId) -> Result<&mut PoolEntry, KvPoolError> {
+        self.entries
+            .get_mut(&id)
+            .ok_or(KvPoolError::UnknownSequence(id.0))
+    }
+
+    fn allocated_bytes(&self) -> u64 {
+        self.entries
+            .values()
+            .map(|entry| entry.cache.allocated_bytes())
+            .fold(0u64, u64::saturating_add)
+    }
+
+    fn tick(&mut self) -> u64 {
+        self.clock = self.clock.wrapping_add(1);
+        self.clock
+    }
+
+    fn make_room(
+        &mut self,
+        additional_bytes: u64,
+        protected: Option<KvSequenceId>,
+    ) -> Result<(), KvPoolError> {
+        loop {
+            let needed = self.allocated_bytes().saturating_add(additional_bytes);
+            if needed <= self.budget_bytes {
+                return Ok(());
+            }
+            let victim = self
+                .entries
+                .iter()
+                .filter(|(id, entry)| {
+                    Some(**id) != protected && entry.state == KvSequenceState::Idle
+                })
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(id, _)| *id);
+            let Some(victim) = victim else {
+                return Err(KvPoolError::BudgetExceeded {
+                    needed_bytes: needed,
+                    budget_bytes: self.budget_bytes,
+                });
+            };
+            self.entries.remove(&victim);
+            self.evictions = self.evictions.saturating_add(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::{KvDtype, KvLayout, LlamaKvCachePlan};
+
+    fn cache() -> LlamaKvCache {
+        let shape = vec![1, 32, 1, 4];
+        LlamaKvCache::new_with_layout_and_dtype(
+            LlamaKvCachePlan {
+                max_sequence_length: 32,
+                layer_count: 1,
+                kv_head_count: 1,
+                head_dim: 4,
+                k_head_dim: 4,
+                v_head_dim: 4,
+                key_shape: shape.clone(),
+                value_shape: shape,
+            },
+            KvLayout::PositionMajor,
+            KvDtype::F32,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn pool_enforces_global_budget_and_evicts_only_idle_sequences() {
+        // 1 layer * 1 head * 4 values * K+V * 4 bytes = 32 bytes/token.
+        let mut pool = UnifiedKvCachePool::new(64);
+        let first = pool.insert(cache()).unwrap();
+        let second = pool.insert(cache()).unwrap();
+        pool.reserve(first, 1).unwrap();
+        pool.reserve(second, 1).unwrap();
+        pool.activate(first).unwrap();
+
+        let third = pool.insert(cache()).unwrap();
+        pool.reserve(third, 1).unwrap();
+        assert!(pool.cache(first).is_ok(), "active cache must survive");
+        assert!(
+            pool.cache(second).is_err(),
+            "oldest idle cache should be evicted"
+        );
+        assert!(pool.cache(third).is_ok());
+        assert_eq!(pool.snapshot().allocated_bytes, 64);
+
+        let fourth = pool.insert(cache()).unwrap();
+        pool.activate(third).unwrap();
+        assert!(matches!(
+            pool.reserve(fourth, 1),
+            Err(KvPoolError::BudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn checkpoint_rollback_is_sequence_local() {
+        let mut pool = UnifiedKvCachePool::new(4096);
+        let first = pool.insert(cache()).unwrap();
+        let second = pool.insert(cache()).unwrap();
+        pool.reserve(first, 16).unwrap();
+        pool.reserve(second, 16).unwrap();
+        pool.cache_mut(first).unwrap().position = 8;
+        pool.cache_mut(first).unwrap().materialized_through = 8;
+        pool.cache_mut(second).unwrap().position = 7;
+        let checkpoint = pool.checkpoint(first).unwrap();
+        pool.cache_mut(first).unwrap().position = 12;
+        pool.cache_mut(first).unwrap().materialized_through = 12;
+
+        pool.rollback(checkpoint).unwrap();
+        assert_eq!(pool.cache(first).unwrap().position, 8);
+        assert_eq!(pool.cache(first).unwrap().materialized_through, 8);
+        assert_eq!(pool.cache(second).unwrap().position, 7);
+    }
+}

--- a/src/inference/speculative.rs
+++ b/src/inference/speculative.rs
@@ -23,6 +23,10 @@
 
 use crate::inference::{LlamaInferenceSession, LlamaSampler};
 use crate::Result;
+use std::{
+    cell::RefCell,
+    collections::{HashMap, VecDeque},
+};
 
 /// Default drafted tokens per round for the n-gram drafter. The n-gram lookup
 /// itself is nearly free, but each extra draft widens the batched verify GEMM, so
@@ -80,10 +84,50 @@ impl SpeculativeDrafter {
 /// Prompt-lookup drafting: find the longest n-gram suffix of `history`
 /// (between `min_ngram` and `max_ngram`) that occurred earlier, preferring
 /// the most recent occurrence, and propose the tokens that followed it.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NGramDrafter {
     pub max_ngram: usize,
     pub min_ngram: usize,
+    index: RefCell<BoundedNGramIndex>,
+}
+
+impl Clone for NGramDrafter {
+    fn clone(&self) -> Self {
+        // A clone is a new drafting stream. Copying a long prompt index is
+        // expensive and can also couple two unrelated histories; preserve the
+        // policy/capacity and let the clone index its own first history.
+        Self::new_with_index_capacity(
+            self.min_ngram,
+            self.max_ngram,
+            self.index.borrow().max_entries,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NGramIndexStats {
+    pub indexed_tokens: usize,
+    pub records: usize,
+    pub rebuilds: u64,
+    pub appended_tokens: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct NGramKey {
+    len: usize,
+    hash: u64,
+}
+
+#[derive(Debug, Clone)]
+struct BoundedNGramIndex {
+    history: Vec<u32>,
+    occurrences: HashMap<NGramKey, VecDeque<usize>>,
+    insertion_order: VecDeque<(NGramKey, usize)>,
+    max_entries: usize,
+    min_ngram: usize,
+    max_ngram: usize,
+    rebuilds: u64,
+    appended_tokens: u64,
 }
 
 impl Default for NGramDrafter {
@@ -97,9 +141,20 @@ impl Default for NGramDrafter {
 
 impl NGramDrafter {
     pub fn new(min_ngram: usize, max_ngram: usize) -> Self {
+        Self::new_with_index_capacity(
+            min_ngram,
+            max_ngram,
+            crate::runtime_config::ngram_index_max_entries(),
+        )
+    }
+
+    pub fn new_with_index_capacity(min_ngram: usize, max_ngram: usize, max_entries: usize) -> Self {
+        let min_ngram = min_ngram.max(1);
+        let max_ngram = max_ngram.max(min_ngram);
         Self {
-            min_ngram: min_ngram.max(1),
-            max_ngram: max_ngram.max(min_ngram.max(1)),
+            min_ngram,
+            max_ngram,
+            index: RefCell::new(BoundedNGramIndex::new(min_ngram, max_ngram, max_entries)),
         }
     }
 
@@ -107,25 +162,132 @@ impl NGramDrafter {
         if max_tokens == 0 || self.min_ngram == 0 || history.len() <= self.min_ngram {
             return Vec::new();
         }
-        let len = history.len();
+        let mut index = self.index.borrow_mut();
+        index.sync(history);
+        index.draft(max_tokens)
+    }
+
+    pub fn index_stats(&self) -> NGramIndexStats {
+        self.index.borrow().stats()
+    }
+}
+
+impl BoundedNGramIndex {
+    fn new(min_ngram: usize, max_ngram: usize, max_entries: usize) -> Self {
+        Self {
+            history: Vec::new(),
+            occurrences: HashMap::new(),
+            insertion_order: VecDeque::new(),
+            max_entries: max_entries.max(1),
+            min_ngram,
+            max_ngram,
+            rebuilds: 0,
+            appended_tokens: 0,
+        }
+    }
+
+    fn sync(&mut self, history: &[u32]) {
+        let append_only = self.history.len() <= history.len() && history.starts_with(&self.history);
+        if !append_only {
+            self.history.clear();
+            self.occurrences.clear();
+            self.insertion_order.clear();
+            self.rebuilds = self.rebuilds.saturating_add(1);
+        }
+        let old_len = self.history.len();
+        for &token in &history[old_len..] {
+            self.history.push(token);
+            self.index_new_tail();
+        }
+        self.appended_tokens = self
+            .appended_tokens
+            .saturating_add((history.len() - old_len) as u64);
+    }
+
+    fn index_new_tail(&mut self) {
+        let end = self.history.len();
+        for len in self.min_ngram..=self.max_ngram.min(end) {
+            let start = end - len;
+            let key = NGramKey {
+                len,
+                hash: hash_ngram(&self.history[start..end]),
+            };
+            self.occurrences.entry(key).or_default().push_back(start);
+            self.insertion_order.push_back((key, start));
+        }
+        while self.insertion_order.len() > self.max_entries {
+            let (key, start) = self
+                .insertion_order
+                .pop_front()
+                .expect("length checked above");
+            let remove_key = if let Some(starts) = self.occurrences.get_mut(&key) {
+                if starts.front() == Some(&start) {
+                    starts.pop_front();
+                } else if let Some(index) = starts.iter().position(|candidate| *candidate == start)
+                {
+                    starts.remove(index);
+                }
+                starts.is_empty()
+            } else {
+                false
+            };
+            if remove_key {
+                self.occurrences.remove(&key);
+            }
+        }
+    }
+
+    fn draft(&self, max_tokens: usize) -> Vec<u32> {
+        let len = self.history.len();
         let max_n = self.max_ngram.min(len.saturating_sub(1));
         for n in (self.min_ngram..=max_n).rev() {
-            let pattern = &history[len - n..];
-            // Most recent earlier occurrence; the window at len-n is the
-            // suffix itself and is excluded.
-            for start in (0..len - n).rev() {
-                if &history[start..start + n] == pattern {
-                    let continuation_start = start + n;
-                    let continuation_end = (continuation_start + max_tokens).min(len);
-                    if continuation_start < continuation_end {
-                        return history[continuation_start..continuation_end].to_vec();
-                    }
-                    break;
+            let suffix_start = len - n;
+            let pattern = &self.history[suffix_start..];
+            let key = NGramKey {
+                len: n,
+                hash: hash_ngram(pattern),
+            };
+            let Some(starts) = self.occurrences.get(&key) else {
+                continue;
+            };
+            for &start in starts.iter().rev() {
+                // Exclude the suffix itself and token-verify every hash hit.
+                // A collision can cost lookup work, never change a draft.
+                if start >= suffix_start
+                    || &self.history[start..start + n] != pattern
+                    || start + n >= len
+                {
+                    continue;
                 }
+                let continuation_start = start + n;
+                let continuation_end = (continuation_start + max_tokens).min(len);
+                return self.history[continuation_start..continuation_end].to_vec();
             }
         }
         Vec::new()
     }
+
+    fn stats(&self) -> NGramIndexStats {
+        NGramIndexStats {
+            indexed_tokens: self.history.len(),
+            records: self.insertion_order.len(),
+            rebuilds: self.rebuilds,
+            appended_tokens: self.appended_tokens,
+        }
+    }
+}
+
+fn hash_ngram(tokens: &[u32]) -> u64 {
+    // Stable FNV-1a over token bytes. Hashes are lookup accelerators only:
+    // every candidate is compared token-for-token before it can draft.
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for token in tokens {
+        for byte in token.to_le_bytes() {
+            hash ^= byte as u64;
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    hash
 }
 
 /// Draft-model drafting: a smaller model with the SAME token mapping runs
@@ -448,10 +610,7 @@ mod tests {
 
     #[test]
     fn ngram_caps_at_requested_tokens() {
-        let drafter = NGramDrafter {
-            max_ngram: 3,
-            min_ngram: 2,
-        };
+        let drafter = NGramDrafter::new(2, 3);
         let history = vec![1, 2, 9, 8, 7, 6, 1, 2];
         assert_eq!(drafter.draft(&history, 2), vec![9, 8]);
         assert_eq!(drafter.draft(&history, 10), vec![9, 8, 7, 6, 1, 2]);
@@ -471,6 +630,131 @@ mod tests {
         let inverted = NGramDrafter::new(5, 2);
         assert_eq!(inverted.min_ngram, 5);
         assert_eq!(inverted.max_ngram, 5);
+    }
+
+    fn reference_ngram_draft(
+        history: &[u32],
+        min_ngram: usize,
+        max_ngram: usize,
+        max_tokens: usize,
+    ) -> Vec<u32> {
+        if max_tokens == 0 || history.len() <= min_ngram {
+            return Vec::new();
+        }
+        let len = history.len();
+        let max_n = max_ngram.min(len.saturating_sub(1));
+        for n in (min_ngram..=max_n).rev() {
+            let pattern = &history[len - n..];
+            for start in (0..len - n).rev() {
+                if &history[start..start + n] == pattern {
+                    let continuation_start = start + n;
+                    let continuation_end = (continuation_start + max_tokens).min(len);
+                    if continuation_start < continuation_end {
+                        return history[continuation_start..continuation_end].to_vec();
+                    }
+                    break;
+                }
+            }
+        }
+        Vec::new()
+    }
+
+    #[test]
+    fn indexed_ngram_matches_reference_scanner() {
+        let drafter = NGramDrafter::new_with_index_capacity(2, 6, 1_000_000);
+        let mut history = Vec::new();
+        let mut state = 0x9e37_79b9u32;
+        for step in 0..1200usize {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            // Small alphabet creates matches; occasional copied runs exercise
+            // longest-match and most-recent tie-breaking.
+            let token = if step > 32 && step % 17 < 5 {
+                history[step - 17]
+            } else {
+                state % 23
+            };
+            history.push(token);
+            for max_tokens in [1usize, 3, 7] {
+                assert_eq!(
+                    drafter.draft(&history, max_tokens),
+                    reference_ngram_draft(&history, 2, 6, max_tokens),
+                    "indexed/reference mismatch at history length {}",
+                    history.len()
+                );
+            }
+        }
+        let stats = drafter.index_stats();
+        assert_eq!(stats.indexed_tokens, history.len());
+        assert_eq!(
+            stats.rebuilds, 0,
+            "append-only history must stay incremental"
+        );
+    }
+
+    #[test]
+    fn ngram_index_is_bounded_and_survives_rollback() {
+        let drafter = NGramDrafter::new_with_index_capacity(2, 5, 48);
+        let mut history: Vec<u32> = (0..400).map(|i| (i % 19) as u32).collect();
+        let _ = drafter.draft(&history, 5);
+        assert!(drafter.index_stats().records <= 48);
+
+        history.truncate(220);
+        let indexed = drafter.draft(&history, 5);
+        let reference = reference_ngram_draft(&history, 2, 5, 5);
+        // The bounded index may intentionally miss an evicted old pattern,
+        // but any proposal it does return must retain exact scan semantics.
+        assert!(indexed.is_empty() || indexed == reference);
+        let stats = drafter.index_stats();
+        assert_eq!(stats.indexed_tokens, history.len());
+        assert!(stats.records <= 48);
+        assert_eq!(stats.rebuilds, 1);
+
+        history.extend([7, 8, 9, 7, 8, 9]);
+        let _ = drafter.draft(&history, 3);
+        assert_eq!(
+            drafter.index_stats().rebuilds,
+            1,
+            "append after rollback rebuild must be incremental"
+        );
+    }
+
+    #[test]
+    #[ignore = "microbenchmark; run explicitly with --release --nocapture"]
+    fn indexed_ngram_microbench_against_reference_scan() {
+        use std::{hint::black_box, time::Instant};
+
+        const BASE_TOKENS: usize = 16_384;
+        const ROUNDS: usize = 512;
+        let appended: Vec<u32> = (BASE_TOKENS..BASE_TOKENS + ROUNDS)
+            .map(|token| token as u32)
+            .collect();
+
+        let drafter = NGramDrafter::new_with_index_capacity(3, 4, 100_000);
+        let mut indexed_history: Vec<u32> = (0..BASE_TOKENS as u32).collect();
+        assert!(drafter.draft(&indexed_history, 5).is_empty());
+        let indexed_start = Instant::now();
+        for token in &appended {
+            indexed_history.push(*token);
+            black_box(drafter.draft(black_box(&indexed_history), 5));
+        }
+        let indexed_elapsed = indexed_start.elapsed();
+
+        let mut reference_history: Vec<u32> = (0..BASE_TOKENS as u32).collect();
+        let reference_start = Instant::now();
+        for token in &appended {
+            reference_history.push(*token);
+            black_box(reference_ngram_draft(
+                black_box(&reference_history),
+                3,
+                4,
+                5,
+            ));
+        }
+        let reference_elapsed = reference_start.elapsed();
+        println!(
+            "ngram lookup: indexed={indexed_elapsed:?}, scan={reference_elapsed:?}, speedup={:.2}x",
+            reference_elapsed.as_secs_f64() / indexed_elapsed.as_secs_f64()
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ pub mod offload;
 pub mod platform_fs;
 pub mod receipt;
 pub mod runnable;
+pub mod runtime_config;
+pub mod runtime_manifest;
 pub mod telemetry;
 pub mod tensor;
 pub mod tokenizer;

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -1,0 +1,189 @@
+//! Typed configuration for the runtime-foundation work.
+//!
+//! Camelid historically accumulated one-off environment reads near each hot
+//! path.  New runtime features resolve through this module so defaults,
+//! bounds, and aliases are explicit and independently testable.  Invalid
+//! values fail closed to the documented default.
+
+use std::env;
+
+pub const ENGINE_QUEUE_DEPTH_ENV: &str = "CAMELID_QUEUE_DEPTH";
+pub const NGRAM_INDEX_MAX_ENTRIES_ENV: &str = "CAMELID_NGRAM_INDEX_MAX_ENTRIES";
+pub const KV_POOL_BUDGET_BYTES_ENV: &str = "CAMELID_KV_POOL_BUDGET_BYTES";
+pub const CONTINUOUS_BATCH_SLOTS_ENV: &str = "CAMELID_CONTINUOUS_BATCH_SLOTS";
+pub const KQUANT_PREFILL_OWNER_ENV: &str = "CAMELID_X86_KQUANT_MATMUL_OWNER";
+
+pub const DEFAULT_ENGINE_QUEUE_DEPTH: usize = 8;
+pub const DEFAULT_NGRAM_INDEX_MAX_ENTRIES: usize = 131_072;
+pub const DEFAULT_KV_POOL_BUDGET_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+pub const DEFAULT_CONTINUOUS_BATCH_SLOTS: usize = 1;
+
+const MAX_ENGINE_QUEUE_DEPTH: usize = 65_536;
+const MAX_NGRAM_INDEX_ENTRIES: usize = 4_194_304;
+const MAX_CONTINUOUS_BATCH_SLOTS: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    pub engine_queue_depth: usize,
+    pub ngram_index_max_entries: usize,
+    pub kv_pool_budget_bytes: u64,
+    pub continuous_batch_slots: usize,
+    pub kquant_prefill_owner: bool,
+}
+
+impl RuntimeConfig {
+    pub fn from_env() -> Self {
+        Self {
+            engine_queue_depth: bounded_usize(
+                ENGINE_QUEUE_DEPTH_ENV,
+                DEFAULT_ENGINE_QUEUE_DEPTH,
+                1,
+                MAX_ENGINE_QUEUE_DEPTH,
+            ),
+            ngram_index_max_entries: bounded_usize(
+                NGRAM_INDEX_MAX_ENTRIES_ENV,
+                DEFAULT_NGRAM_INDEX_MAX_ENTRIES,
+                1,
+                MAX_NGRAM_INDEX_ENTRIES,
+            ),
+            kv_pool_budget_bytes: bounded_u64(
+                KV_POOL_BUDGET_BYTES_ENV,
+                DEFAULT_KV_POOL_BUDGET_BYTES,
+                1,
+                u64::MAX,
+            ),
+            continuous_batch_slots: bounded_usize(
+                CONTINUOUS_BATCH_SLOTS_ENV,
+                DEFAULT_CONTINUOUS_BATCH_SLOTS,
+                1,
+                MAX_CONTINUOUS_BATCH_SLOTS,
+            ),
+            kquant_prefill_owner: env_flag_default_off(KQUANT_PREFILL_OWNER_ENV),
+        }
+    }
+}
+
+pub fn engine_queue_depth() -> usize {
+    RuntimeConfig::from_env().engine_queue_depth
+}
+
+pub fn ngram_index_max_entries() -> usize {
+    RuntimeConfig::from_env().ngram_index_max_entries
+}
+
+pub fn kv_pool_budget_bytes() -> u64 {
+    RuntimeConfig::from_env().kv_pool_budget_bytes
+}
+
+pub fn continuous_batch_slots() -> usize {
+    RuntimeConfig::from_env().continuous_batch_slots
+}
+
+pub fn kquant_prefill_owner_enabled() -> bool {
+    RuntimeConfig::from_env().kquant_prefill_owner
+}
+
+fn bounded_usize(name: &str, default: usize, min: usize, max: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|value| (min..=max).contains(value))
+        .unwrap_or(default)
+}
+
+fn bounded_u64(name: &str, default: u64, min: u64, max: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| (min..=max).contains(value))
+        .unwrap_or(default)
+}
+
+pub fn env_flag_default_off(name: &str) -> bool {
+    env::var(name)
+        .map(|value| {
+            let value = value.trim();
+            value.eq_ignore_ascii_case("1")
+                || value.eq_ignore_ascii_case("true")
+                || value.eq_ignore_ascii_case("on")
+                || value.eq_ignore_ascii_case("enabled")
+                || value.eq_ignore_ascii_case("yes")
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_and_out_of_range_values_fail_closed() {
+        let _guard = crate::test_support::env_lock();
+        for key in [
+            ENGINE_QUEUE_DEPTH_ENV,
+            NGRAM_INDEX_MAX_ENTRIES_ENV,
+            KV_POOL_BUDGET_BYTES_ENV,
+            CONTINUOUS_BATCH_SLOTS_ENV,
+            KQUANT_PREFILL_OWNER_ENV,
+        ] {
+            env::remove_var(key);
+        }
+        env::set_var(ENGINE_QUEUE_DEPTH_ENV, "0");
+        env::set_var(NGRAM_INDEX_MAX_ENTRIES_ENV, "not-a-number");
+        env::set_var(KV_POOL_BUDGET_BYTES_ENV, "0");
+        env::set_var(CONTINUOUS_BATCH_SLOTS_ENV, "999");
+        env::set_var(KQUANT_PREFILL_OWNER_ENV, "maybe");
+
+        assert_eq!(
+            RuntimeConfig::from_env(),
+            RuntimeConfig {
+                engine_queue_depth: DEFAULT_ENGINE_QUEUE_DEPTH,
+                ngram_index_max_entries: DEFAULT_NGRAM_INDEX_MAX_ENTRIES,
+                kv_pool_budget_bytes: DEFAULT_KV_POOL_BUDGET_BYTES,
+                continuous_batch_slots: DEFAULT_CONTINUOUS_BATCH_SLOTS,
+                kquant_prefill_owner: false,
+            }
+        );
+
+        for key in [
+            ENGINE_QUEUE_DEPTH_ENV,
+            NGRAM_INDEX_MAX_ENTRIES_ENV,
+            KV_POOL_BUDGET_BYTES_ENV,
+            CONTINUOUS_BATCH_SLOTS_ENV,
+            KQUANT_PREFILL_OWNER_ENV,
+        ] {
+            env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn valid_values_resolve_to_typed_fields() {
+        let _guard = crate::test_support::env_lock();
+        env::set_var(ENGINE_QUEUE_DEPTH_ENV, "17");
+        env::set_var(NGRAM_INDEX_MAX_ENTRIES_ENV, "2048");
+        env::set_var(KV_POOL_BUDGET_BYTES_ENV, "4096");
+        env::set_var(CONTINUOUS_BATCH_SLOTS_ENV, "4");
+        env::set_var(KQUANT_PREFILL_OWNER_ENV, "yes");
+
+        assert_eq!(
+            RuntimeConfig::from_env(),
+            RuntimeConfig {
+                engine_queue_depth: 17,
+                ngram_index_max_entries: 2048,
+                kv_pool_budget_bytes: 4096,
+                continuous_batch_slots: 4,
+                kquant_prefill_owner: true,
+            }
+        );
+
+        for key in [
+            ENGINE_QUEUE_DEPTH_ENV,
+            NGRAM_INDEX_MAX_ENTRIES_ENV,
+            KV_POOL_BUDGET_BYTES_ENV,
+            CONTINUOUS_BATCH_SLOTS_ENV,
+            KQUANT_PREFILL_OWNER_ENV,
+        ] {
+            env::remove_var(key);
+        }
+    }
+}

--- a/src/runtime_manifest.rs
+++ b/src/runtime_manifest.rs
@@ -1,0 +1,109 @@
+//! Machine-readable status and evidence registry for runtime projects.
+//!
+//! This is deliberately separate from model support.  A runtime optimization
+//! can be implemented or benchmark-gated without accidentally promoting a
+//! model/quantization support row.
+
+use std::{collections::HashSet, sync::OnceLock};
+
+use serde::{Deserialize, Serialize};
+
+const RUNTIME_CAPABILITIES_JSON: &str = include_str!("../config/runtime-capabilities.json");
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCapabilityManifest {
+    pub schema_version: u32,
+    pub projects: Vec<RuntimeProjectCapability>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeProjectCapability {
+    pub id: String,
+    pub project: u32,
+    pub status: String,
+    pub default_enabled: bool,
+    pub configuration: Vec<String>,
+    pub dependencies: Vec<String>,
+    pub evidence: Vec<String>,
+    pub safety_contract: String,
+}
+
+static MANIFEST: OnceLock<RuntimeCapabilityManifest> = OnceLock::new();
+
+pub fn runtime_capability_manifest() -> &'static RuntimeCapabilityManifest {
+    MANIFEST.get_or_init(|| {
+        let manifest: RuntimeCapabilityManifest = serde_json::from_str(RUNTIME_CAPABILITIES_JSON)
+            .expect("config/runtime-capabilities.json must parse");
+        validate_manifest(&manifest).expect("config/runtime-capabilities.json must be valid");
+        manifest
+    })
+}
+
+fn validate_manifest(manifest: &RuntimeCapabilityManifest) -> Result<(), String> {
+    if manifest.schema_version != 1 {
+        return Err(format!(
+            "unsupported runtime capability schema {}",
+            manifest.schema_version
+        ));
+    }
+    if manifest.projects.is_empty() {
+        return Err("runtime capability project list is empty".to_string());
+    }
+    let mut ids = HashSet::new();
+    let mut projects = HashSet::new();
+    for item in &manifest.projects {
+        if item.id.trim().is_empty() || item.status.trim().is_empty() {
+            return Err("runtime capability id/status cannot be empty".to_string());
+        }
+        if !ids.insert(item.id.as_str()) {
+            return Err(format!("duplicate runtime capability id {}", item.id));
+        }
+        if !projects.insert(item.project) {
+            return Err(format!(
+                "duplicate runtime capability project {}",
+                item.project
+            ));
+        }
+        if item.safety_contract.trim().is_empty() {
+            return Err(format!("{} has no safety contract", item.id));
+        }
+        if item.evidence.is_empty() {
+            return Err(format!("{} has no evidence target", item.id));
+        }
+    }
+    for item in &manifest.projects {
+        for dependency in &item.dependencies {
+            if !ids.contains(dependency.as_str()) {
+                return Err(format!(
+                    "{} refers to unknown dependency {dependency}",
+                    item.id
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_runtime_manifest_is_valid_and_covers_selected_projects() {
+        let manifest = runtime_capability_manifest();
+        assert_eq!(manifest.schema_version, 1);
+        let projects: HashSet<_> = manifest.projects.iter().map(|item| item.project).collect();
+        assert_eq!(projects, HashSet::from([2, 4, 5, 6, 7]));
+    }
+
+    #[test]
+    fn validator_rejects_unknown_dependencies() {
+        let mut manifest = runtime_capability_manifest().clone();
+        manifest.projects[0]
+            .dependencies
+            .push("does-not-exist".to_string());
+        assert!(validate_manifest(&manifest)
+            .unwrap_err()
+            .contains("unknown dependency"));
+    }
+}


### PR DESCRIPTION
## What changed

- add a typed runtime configuration layer and machine-readable capability/evidence registry
- replace repeated n-gram history scans with a bounded incremental index with collision verification and rollback handling
- add a budgeted multi-sequence KV pool with stable sequence IDs, active/idle lifecycle, idle-only LRU eviction, and checkpoints
- add a fair slot-bounded continuous-batch scheduler foundation
- make `/slots` report the production engine's real active task and queue state
- reuse per-worker scratch in the Q6_K prefill owner while keeping Q4_K/Q6_K owner dispatch default-off
- add implementation and same-host performance receipts

## Why

These are the safe foundations for unified KV ownership and cooperative token-step batching. The implementation keeps existing production defaults neutral while making scheduling, cache ownership, feature status, and evidence explicit and testable.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --no-fail-fast`
- `cargo test --doc --all-features`
- `cargo build --release`
- Q4_K and Q6_K owner bitwise parity tests
- 1,200-history indexed n-gram equivalence test plus bounded rollback test
- same-host deterministic before/after decode A/B: identical 65-token outputs; mean 7.537 -> 7.757 tok/s
- release n-gram lookup microbenchmark: 59.88 ms scan -> 2.21 ms indexed (27.06x)