### PR TITLE
Load a default model at desktop startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ administrator access, macOS asks for your password through `sudo`. To update lat
 
 Downloaded models live in
 `~/Library/Application Support/app.camelid.desktop/models` and are preserved when the app is
-rebuilt or reinstalled. See [Camelid Desktop](camelid-desktop/README.md) for the sidecar design
-and manual packaging details.
+rebuilt or reinstalled. On launch, Desktop loads the model marked **Starts automatically** on the
+Models page; when no choice has been saved yet, the first installed GGUF is selected
+automatically. Use **Make default** beside another installed model to change the next launch.
+See [Camelid Desktop](camelid-desktop/README.md) for the sidecar design and manual packaging
+details.
 
 ### Option B — Prebuilt engine (Windows, macOS, or Linux)
 

--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -62,9 +62,11 @@ error and captured stderr under **Technical details**; it never navigates to a f
 | **Engine startup failed** | The sidecar exited before it became healthy for another reason. | Review the visible technical details and retry. |
 
 Model readiness is separate from sidecar startup. Once `/v1/health` passes, Desktop navigates to
-the engine's existing UI; if no eligible model is loaded, that UI remains the authority and shows
-its normal model-required state. Desktop does not claim a ready model or manufacture a model error
-on the splash.
+the engine's existing UI. If local GGUFs exist, the sidecar loads the saved default from the
+configured models directory; without a saved preference, it loads the first local GGUF. The Models
+page labels that row **Starts automatically** and offers **Make default** on other loadable rows.
+If no eligible model exists, the UI remains the authority and shows its normal model-required
+state. Desktop does not claim a ready model or manufacture a model error on the splash.
 
 ## Requirements
 

--- a/frontend/src/components/models/LaneRows.jsx
+++ b/frontend/src/components/models/LaneRows.jsx
@@ -79,7 +79,39 @@ function DeleteModelButton({ entry, busy, blockedReason, onDelete }) {
   )
 }
 
-export function SupportedRow({ entry, active, busy, deleteBusy, blockedReason, onUse, onDelete }) {
+function DefaultModelControl({ entry, isDefault, busy, onMakeDefault }) {
+  if (isDefault) {
+    return (
+      <span className="lane-row-default" title="Camelid loads this model when the app starts">
+        ★ Starts automatically
+      </span>
+    )
+  }
+  return (
+    <button
+      type="button"
+      className="lane-row-default-action"
+      onClick={() => onMakeDefault(entry.filename)}
+      disabled={busy}
+      title="Load this model automatically the next time Camelid starts"
+    >
+      {busy ? 'Saving…' : 'Make default'}
+    </button>
+  )
+}
+
+export function SupportedRow({
+  entry,
+  active,
+  busy,
+  deleteBusy,
+  defaultBusy,
+  isDefault,
+  blockedReason,
+  onUse,
+  onDelete,
+  onMakeDefault,
+}) {
   return (
     <article
       className={`lane-row lane-row--supported${active ? ' lane-row--active' : ''}`}
@@ -93,21 +125,39 @@ export function SupportedRow({ entry, active, busy, deleteBusy, blockedReason, o
         <EvidenceChip state="supported" asText>Supported</EvidenceChip>
       </div>
       <p className="lane-row-note">{describeModel(entry)}</p>
-      {active ? (
-        <p className="lane-row-loaded">● Loaded — this is the active chat model.</p>
-      ) : (
-        <div className="lane-row-actions">
+      {active ? <p className="lane-row-loaded">● Loaded — this is the active chat model.</p> : null}
+      <div className="lane-row-actions">
+        {!active ? (
           <button type="button" className="lane-row-action" onClick={onUse} disabled={busy || deleteBusy}>
             {busy ? 'Loading…' : 'Use for chat'}
           </button>
-          <DeleteModelButton entry={entry} busy={busy || deleteBusy} blockedReason={blockedReason} onDelete={onDelete} />
-        </div>
-      )}
+        ) : null}
+        <DefaultModelControl
+          entry={entry}
+          isDefault={isDefault}
+          busy={defaultBusy || busy || deleteBusy}
+          onMakeDefault={onMakeDefault}
+        />
+        {!active ? (
+          <DeleteModelButton entry={entry} busy={busy || deleteBusy || defaultBusy} blockedReason={blockedReason} onDelete={onDelete} />
+        ) : null}
+      </div>
     </article>
   )
 }
 
-export function CompatibleRow({ entry, receipt, busy, deleteBusy, blockedReason, onUse, onDelete }) {
+export function CompatibleRow({
+  entry,
+  receipt,
+  busy,
+  deleteBusy,
+  defaultBusy,
+  isDefault,
+  blockedReason,
+  onUse,
+  onDelete,
+  onMakeDefault,
+}) {
   return (
     <article className="lane-row lane-row--runnable" aria-label={`Compatible model ${entry.filename}`}>
       <div className="lane-row-head">
@@ -133,7 +183,13 @@ export function CompatibleRow({ entry, receipt, busy, deleteBusy, blockedReason,
         <button type="button" className="lane-row-action" onClick={onUse} disabled={busy || deleteBusy}>
           {busy ? 'Loading…' : 'Use for chat (experimental)'}
         </button>
-        <DeleteModelButton entry={entry} busy={busy || deleteBusy} blockedReason={blockedReason} onDelete={onDelete} />
+        <DefaultModelControl
+          entry={entry}
+          isDefault={isDefault}
+          busy={defaultBusy || busy || deleteBusy}
+          onMakeDefault={onMakeDefault}
+        />
+        <DeleteModelButton entry={entry} busy={busy || deleteBusy || defaultBusy} blockedReason={blockedReason} onDelete={onDelete} />
       </div>
     </article>
   )
@@ -160,7 +216,17 @@ export function EligibleRow({ entry, busy, deleteBusy, blockedReason, onRun, onD
   )
 }
 
-export function NotAnchoredRow({ entry, busy, deleteBusy, blockedReason, onUse, onDelete }) {
+export function NotAnchoredRow({
+  entry,
+  busy,
+  deleteBusy,
+  defaultBusy,
+  isDefault,
+  blockedReason,
+  onUse,
+  onDelete,
+  onMakeDefault,
+}) {
   return (
     <article className="lane-row lane-row--blocked" aria-label={`Experimental model ${entry.filename}`}>
       <div className="lane-row-head">
@@ -180,7 +246,13 @@ export function NotAnchoredRow({ entry, busy, deleteBusy, blockedReason, onUse, 
         <button type="button" className="lane-row-action" onClick={onUse} disabled={busy || deleteBusy}>
           {busy ? 'Loading…' : 'Use for chat (experimental)'}
         </button>
-        <DeleteModelButton entry={entry} busy={busy || deleteBusy} blockedReason={blockedReason} onDelete={onDelete} />
+        <DefaultModelControl
+          entry={entry}
+          isDefault={isDefault}
+          busy={defaultBusy || busy || deleteBusy}
+          onMakeDefault={onMakeDefault}
+        />
+        <DeleteModelButton entry={entry} busy={busy || deleteBusy || defaultBusy} blockedReason={blockedReason} onDelete={onDelete} />
       </div>
     </article>
   )

--- a/frontend/src/hooks/useModelsPageData.js
+++ b/frontend/src/hooks/useModelsPageData.js
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { localModelDeleteRequest } from '../lib/modelDeletion'
 
-/* Single data spine for the Models page. Owns fetch + refresh for the three
+/* Single data spine for the Models page. Owns fetch + refresh for the four
    backend truths the page renders from — /api/models/local (disk scan with lane
    facts), /api/models/current (loaded model), /api/models/catalog/downloads
-   (live download progress) — so every zone reads the same snapshot instead of
-   fetching privately. Capabilities stay a prop (already lifted in
+   (live download progress), and /api/models/default (next-launch selection) —
+   so every zone reads the same snapshot instead of fetching privately.
+   Capabilities stay a prop (already lifted in
    useDashboardData); this hook never touches localStorage: "downloaded" is only
    ever the live disk scan.
 
@@ -26,6 +27,7 @@ export function useModelsPageData({ apiBase = '' } = {}) {
   const [localLoading, setLocalLoading] = useState(false)
   const [localError, setLocalError] = useState('')
   const [current, setCurrent] = useState(null) // { path } from /api/models/current
+  const [startupDefault, setStartupDefault] = useState(null) // { filename, configured }
   const [downloads, setDownloads] = useState([])
   const [polling, setPolling] = useState(true) // one initial pass on mount
 
@@ -107,6 +109,41 @@ export function useModelsPageData({ apiBase = '' } = {}) {
     }
   }, [base])
 
+  const refreshDefault = useCallback(async () => {
+    try {
+      const res = await fetch(`${base}/api/models/default`)
+      if (!res.ok) return null
+      const next = await res.json()
+      if (baseRef.current !== base) return null
+      setStartupDefault(next)
+      return next
+    } catch {
+      return null
+    }
+  }, [base])
+
+  const setDefaultModel = useCallback(
+    async (filename) => {
+      const res = await fetch(`${base}/api/models/default`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename }),
+      })
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        throw new Error(body?.error?.message || `default model update failed (HTTP ${res.status})`)
+      }
+      if (baseRef.current === base) setStartupDefault(body)
+      return body
+    },
+    [base],
+  )
+
+  const refreshLocalAndDefault = useCallback(async () => {
+    const [nextLocal] = await Promise.all([refreshLocal(), refreshDefault()])
+    return nextLocal
+  }, [refreshDefault, refreshLocal])
+
   /* Wake the downloads poller — call right after starting an install. */
   const kickDownloadsPoll = useCallback(() => {
     idleTicksRef.current = 0
@@ -141,13 +178,17 @@ export function useModelsPageData({ apiBase = '' } = {}) {
         await Promise.all([
           refreshLocal({ force: true }),
           refreshCurrent(),
+          refreshDefault(),
           refreshDownloads(),
         ])
         const error = new Error(body?.error?.message || `delete failed (HTTP ${res.status})`)
         error.code = body?.error?.code || 'model_delete_failed'
         throw error
       }
-      const verified = await refreshLocal({ force: true })
+      const [verified] = await Promise.all([
+        refreshLocal({ force: true }),
+        refreshDefault(),
+      ])
       if (!verified) {
         setLocal((current) => current
           ? { ...current, models: current.models.filter((model) => model.filename !== entry.filename) }
@@ -155,16 +196,17 @@ export function useModelsPageData({ apiBase = '' } = {}) {
       }
       return body
     },
-    [base, refreshCurrent, refreshDownloads, refreshLocal],
+    [base, refreshCurrent, refreshDefault, refreshDownloads, refreshLocal],
   )
 
   const refreshAll = useCallback(async () => {
-    await Promise.all([refreshLocal(), refreshCurrent(), refreshDownloads()])
-  }, [refreshLocal, refreshCurrent, refreshDownloads])
+    await Promise.all([refreshLocal(), refreshCurrent(), refreshDefault(), refreshDownloads()])
+  }, [refreshLocal, refreshCurrent, refreshDefault, refreshDownloads])
 
   useEffect(() => {
     setLocal(null)
     setCurrent(null)
+    setStartupDefault(null)
     setDownloads([])
     setLocalLoading(false)
     refreshLocalPromiseRef.current = null
@@ -175,7 +217,8 @@ export function useModelsPageData({ apiBase = '' } = {}) {
     setPolling(true)
     refreshLocal()
     refreshCurrent()
-  }, [base, refreshLocal, refreshCurrent])
+    refreshDefault()
+  }, [base, refreshLocal, refreshCurrent, refreshDefault])
 
   useEffect(() => {
     if (!polling) return undefined
@@ -189,7 +232,7 @@ export function useModelsPageData({ apiBase = '' } = {}) {
       const settled = [...prevDownloadIdsRef.current].some((id) => !ids.has(id))
       prevDownloadIdsRef.current = ids
       if (settled) {
-        refreshLocal()
+        refreshLocalAndDefault()
       }
       if (ids.size === 0) {
         idleTicksRef.current += 1
@@ -204,7 +247,7 @@ export function useModelsPageData({ apiBase = '' } = {}) {
       cancelled = true
       clearInterval(timer)
     }
-  }, [polling, refreshDownloads, refreshLocal])
+  }, [polling, refreshDownloads, refreshLocalAndDefault])
 
   const activeFilename = String(current?.path || '').split(/[\\/]/).pop() || ''
   const localFilenames = new Set((local?.models || []).map((m) => m.filename))
@@ -216,14 +259,19 @@ export function useModelsPageData({ apiBase = '' } = {}) {
     localError,
     current,
     activeFilename,
+    defaultFilename: startupDefault?.filename || '',
+    defaultConfigured: Boolean(startupDefault?.configured),
     localFilenames,
     downloads,
     refreshLocal,
+    refreshLocalAndDefault,
     refreshCurrent,
+    refreshDefault,
     refreshDownloads,
     refreshAll,
     kickDownloadsPoll,
     cancelDownload,
     deleteLocalModel,
+    setDefaultModel,
   }
 }

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -1233,6 +1233,10 @@
 .lane-row-action:disabled { opacity: 0.6; }
 .lane-row-actions { display: flex; align-items: center; gap: var(--space-2); margin-top: var(--space-2); }
 .lane-row-actions .lane-row-action { margin-top: 0; }
+.lane-row-default { font-size: var(--text-xs); font-weight: 700; color: var(--color-ready); }
+.lane-row-default-action { padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm); border: 1px solid var(--color-border-soft); background: transparent; color: var(--color-text-muted); font-size: var(--text-xs); font-weight: 700; }
+.lane-row-default-action:hover:not(:disabled) { color: var(--color-text); border-color: var(--color-text-muted); }
+.lane-row-default-action:disabled { opacity: 0.6; }
 .lane-row-delete { display: inline-grid; place-items: center; width: 32px; height: 32px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--color-border-soft); background: transparent; color: var(--color-text-muted); }
 .lane-row-delete:hover:not(:disabled) { color: var(--color-error); border-color: color-mix(in srgb, var(--color-error) 45%, transparent); background: color-mix(in srgb, var(--color-error) 10%, transparent); }
 .lane-row-delete:disabled { opacity: 0.45; cursor: not-allowed; }

--- a/frontend/src/views/ModelsView.jsx
+++ b/frontend/src/views/ModelsView.jsx
@@ -60,6 +60,7 @@ export default function ModelsView({
   const [importing, setImporting] = useState(false)
   const [pendingDeleteEntry, setPendingDeleteEntry] = useState(null)
   const [deletingFilename, setDeletingFilename] = useState('')
+  const [defaultingFilename, setDefaultingFilename] = useState('')
   const [deleteNotice, setDeleteNotice] = useState('')
   const [catalogOperations, setCatalogOperations] = useState(new Set())
   const loadInFlightRef = useRef('')
@@ -259,6 +260,20 @@ export default function ModelsView({
     setPendingDeleteEntry(entry)
   }
 
+  const makeDefaultModel = async (filename) => {
+    setDefaultingFilename(filename)
+    setLaneError('')
+    setDeleteNotice('')
+    try {
+      await spine.setDefaultModel(filename)
+      setDeleteNotice(`${filename} will load automatically the next time Camelid starts.`)
+    } catch (error) {
+      setLaneError(String(error?.message || error))
+    } finally {
+      setDefaultingFilename('')
+    }
+  }
+
   useEffect(() => {
     if (pendingDeleteEntry && deleteBlockedReason && !deletingFilename) {
       setPendingDeleteEntry(null)
@@ -409,9 +424,12 @@ export default function ModelsView({
               active={m.filename === spine.activeFilename}
               busy={usingFilename === m.filename}
               deleteBusy={deletingFilename === m.filename}
+              defaultBusy={defaultingFilename === m.filename}
+              isDefault={spine.defaultFilename === m.filename}
               blockedReason={deleteBlockedReason}
               onUse={() => loadModelForChat(m.filename)}
               onDelete={requestDeleteModel}
+              onMakeDefault={makeDefaultModel}
             />
           ))
         ) : (
@@ -439,9 +457,12 @@ export default function ModelsView({
                 receipt={receipts[m.filename]}
                 busy={usingFilename === m.filename}
                 deleteBusy={deletingFilename === m.filename}
+                defaultBusy={defaultingFilename === m.filename}
+                isDefault={spine.defaultFilename === m.filename}
                 blockedReason={deleteBlockedReason}
                 onUse={() => loadModelForChat(m.filename)}
                 onDelete={requestDeleteModel}
+                onMakeDefault={makeDefaultModel}
               />
             ))}
             {laneBuckets.eligible.map((m) => (
@@ -461,9 +482,12 @@ export default function ModelsView({
                 entry={m}
                 busy={usingFilename === m.filename}
                 deleteBusy={deletingFilename === m.filename}
+                defaultBusy={defaultingFilename === m.filename}
+                isDefault={spine.defaultFilename === m.filename}
                 blockedReason={deleteBlockedReason}
                 onUse={() => loadModelForChat(m.filename)}
                 onDelete={requestDeleteModel}
+                onMakeDefault={makeDefaultModel}
               />
             ))}
           </>
@@ -493,7 +517,7 @@ export default function ModelsView({
         }
         onInstallStarted={spine.kickDownloadsPoll}
         onDownloadAcknowledged={spine.refreshDownloads}
-        onAcquired={spine.refreshLocal}
+        onAcquired={spine.refreshLocalAndDefault}
         canceledCatalogIds={canceledCatalogIds}
         onDownloadRetry={clearCanceledDownload}
         onStartModel={loadModelForChat}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -54,6 +54,7 @@ use crate::{
         DenseLlamaDims, LlamaAttentionTensors, LlamaFfnTensors, LlamaModelConfig,
         LlamaTensorBinding,
     },
+    model_default,
     model_source::{inspect_model_source, ModelSourceInspection, ModelSourceKind},
     receipt::{
         self, LaneIdentity, ParityBlock, ParityReceipt, ReceiptResult, ReferenceIdentity,
@@ -2036,6 +2037,10 @@ pub fn router_with_state(state: AppState) -> Router {
         )
         .route("/api/models/local", get(local_models))
         .route("/api/models/local/delete", post(delete_local_model))
+        .route(
+            "/api/models/default",
+            get(default_model).post(set_default_model),
+        )
         .route("/api/models/runnable-receipt", get(runnable_receipt))
         .route("/api/models/runnable-smoke", post(run_runnable_smoke))
         .route("/api/models/catalog", get(get_catalog))
@@ -19773,17 +19778,7 @@ struct LocalModelFileIdentity {
 }
 
 fn validate_local_model_filename(filename: &str) -> bool {
-    let path = std::path::Path::new(filename);
-    filename == filename.trim()
-        && !filename.is_empty()
-        && !filename.contains(['/', '\\', ':'])
-        && matches!(
-            (path.components().next(), path.components().nth(1)),
-            (Some(std::path::Component::Normal(_)), None)
-        )
-        && path
-            .extension()
-            .is_some_and(|extension| extension.eq_ignore_ascii_case("gguf"))
+    model_default::valid_local_model_filename(filename)
 }
 
 #[cfg(windows)]
@@ -19933,7 +19928,6 @@ struct DeleteLocalModelResponse {
     bytes_freed: u64,
 }
 
-#[cfg(windows)]
 fn local_management_request_allowed(headers: &HeaderMap) -> bool {
     let authority = headers
         .get("host")
@@ -19968,6 +19962,196 @@ fn local_management_request_allowed(headers: &HeaderMap) -> bool {
             .get("sec-fetch-site")
             .and_then(|value| value.to_str().ok())
             == Some("same-origin")
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct SetDefaultModelRequest {
+    filename: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct DefaultModelResponse {
+    filename: Option<String>,
+    configured: bool,
+}
+
+impl DefaultModelResponse {
+    fn from_models_dir(models_dir: &std::path::Path) -> Self {
+        match model_default::effective_default_model(models_dir) {
+            Some(choice) => Self {
+                filename: Some(choice.filename),
+                configured: choice.configured,
+            },
+            None => Self {
+                filename: None,
+                configured: false,
+            },
+        }
+    }
+}
+
+/// The startup choice is always readable. With no explicit preference the first
+/// local GGUF is returned, matching the zero-configuration startup behavior.
+async fn default_model(State(state): State<AppState>) -> Json<DefaultModelResponse> {
+    Json(DefaultModelResponse::from_models_dir(&state.models_dir))
+}
+
+/// Persist a startup choice beside the local model library. This mutation is
+/// limited to Camelid's same-origin loopback UI even though the server's general
+/// API CORS policy is permissive.
+async fn set_default_model(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<SetDefaultModelRequest>,
+) -> Response {
+    if !state.serve_addr.ip().is_loopback() || !local_management_request_allowed(&headers) {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "local_management_forbidden",
+            "the default model can be changed only from Camelid's loopback web UI".to_string(),
+            None,
+        );
+    }
+    match model_default::set_default_model(&state.models_dir, &req.filename) {
+        Ok(choice) => (
+            StatusCode::OK,
+            Json(DefaultModelResponse {
+                filename: Some(choice.filename),
+                configured: true,
+            }),
+        )
+            .into_response(),
+        Err(err) if err.kind() == std::io::ErrorKind::InvalidInput => api_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_default_model",
+            err.to_string(),
+            Some("filename"),
+        ),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => api_error(
+            StatusCode::NOT_FOUND,
+            "default_model_not_found",
+            err.to_string(),
+            Some("filename"),
+        ),
+        Err(err) => api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "default_model_write_failed",
+            format!("could not save the default model: {err}"),
+            Some("filename"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod default_model_api_tests {
+    use super::{router_with_state, AppState};
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+    };
+    use serde_json::{json, Value};
+    use tower::ServiceExt;
+
+    async fn response_json(app: axum::Router, request: Request<Body>) -> (StatusCode, Value) {
+        let response = app.oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn default_model_endpoint_reports_fallback_and_persists_a_choice() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("alpha.gguf"), []).unwrap();
+        std::fs::write(dir.path().join("chosen.gguf"), []).unwrap();
+        let app =
+            router_with_state(AppState::default().with_models_dir(Some(dir.path().to_path_buf())));
+
+        let (status, body) = response_json(
+            app.clone(),
+            Request::builder()
+                .uri("/api/models/default")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body,
+            json!({ "filename": "alpha.gguf", "configured": false })
+        );
+
+        let (status, body) = response_json(
+            app.clone(),
+            Request::builder()
+                .method("POST")
+                .uri("/api/models/default")
+                .header("host", "127.0.0.1:8181")
+                .header("sec-fetch-site", "same-origin")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "filename": "chosen.gguf" }).to_string()))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body,
+            json!({ "filename": "chosen.gguf", "configured": true })
+        );
+
+        let (_, body) = response_json(
+            app,
+            Request::builder()
+                .uri("/api/models/default")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(
+            body,
+            json!({ "filename": "chosen.gguf", "configured": true })
+        );
+    }
+
+    #[tokio::test]
+    async fn default_model_mutation_rejects_cross_origin_and_unsafe_names() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("safe.gguf"), []).unwrap();
+        let app =
+            router_with_state(AppState::default().with_models_dir(Some(dir.path().to_path_buf())));
+
+        let (status, _) = response_json(
+            app.clone(),
+            Request::builder()
+                .method("POST")
+                .uri("/api/models/default")
+                .header("host", "127.0.0.1:8181")
+                .header("origin", "https://attacker.example")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "filename": "safe.gguf" }).to_string()))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+
+        let (status, body) = response_json(
+            app,
+            Request::builder()
+                .method("POST")
+                .uri("/api/models/default")
+                .header("host", "127.0.0.1:8181")
+                .header("sec-fetch-site", "same-origin")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "filename": "../outside.gguf" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "invalid_default_model");
+    }
 }
 
 #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod hf_browse;
 pub mod inference;
 pub mod metal;
 pub mod model;
+pub mod model_default;
 pub mod model_source;
 pub mod offload;
 pub mod platform_fs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,12 +90,16 @@ fn default_launch_command() -> Command {
     }
 }
 
-/// Find a GGUF to load when `serve` is started without an explicit `--model`,
-/// so the open-and-use launch lands directly in a usable chat. Looks next to the
-/// executable (the shipped layout: `camelid.exe` beside a `models/` folder) and
-/// in the working directory; returns the first `*.gguf` found.
-fn auto_select_model() -> Option<PathBuf> {
+/// Find the effective default GGUF when `serve` starts without an explicit
+/// `--model`. The configured models directory wins (this is where the desktop
+/// sidecar stores downloads), followed by the historical shipped/CWD layouts.
+/// Within each directory an explicit saved preference wins; otherwise the first
+/// local GGUF is the zero-configuration default.
+fn auto_select_model(configured_models_dir: Option<&std::path::Path>) -> Option<PathBuf> {
     let mut dirs: Vec<PathBuf> = Vec::new();
+    if let Some(dir) = configured_models_dir {
+        dirs.push(dir.to_path_buf());
+    }
     if let Ok(exe) = std::env::current_exe() {
         if let Some(parent) = exe.parent() {
             dirs.push(parent.join("models"));
@@ -105,22 +109,29 @@ fn auto_select_model() -> Option<PathBuf> {
     dirs.push(PathBuf::from("models"));
     dirs.push(PathBuf::from("."));
     for dir in dirs {
-        if let Ok(entries) = std::fs::read_dir(&dir) {
-            let mut ggufs: Vec<PathBuf> = entries
-                .flatten()
-                .map(|entry| entry.path())
-                .filter(|path| {
-                    path.extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case("gguf"))
-                })
-                .collect();
-            ggufs.sort();
-            if let Some(first) = ggufs.into_iter().next() {
-                return Some(first);
-            }
+        if let Some(choice) = camelid::model_default::effective_default_model(&dir) {
+            return Some(choice.path);
         }
     }
     None
+}
+
+#[cfg(test)]
+mod auto_select_model_tests {
+    use super::auto_select_model;
+
+    #[test]
+    fn configured_desktop_models_directory_wins_at_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("first.gguf"), []).unwrap();
+        std::fs::write(dir.path().join("preferred.gguf"), []).unwrap();
+        camelid::model_default::set_default_model(dir.path(), "preferred.gguf").unwrap();
+
+        assert_eq!(
+            auto_select_model(Some(dir.path())),
+            Some(dir.path().join("preferred.gguf"))
+        );
+    }
 }
 
 /// Windows + CUDA: make the NVIDIA runtime DLLs (NVRTC etc.) loadable without the
@@ -1607,9 +1618,10 @@ async fn main() -> anyhow::Result<()> {
             unsafe {
                 pthread_set_qos_class_self_np(0x09, 0); // QOS_CLASS_BACKGROUND (forces network I/O onto E-cores)
             }
-            // Open-and-use launch: if no model was named, load the first GGUF we
-            // can find (beside the exe or in ./models) so the UI lands in a chat.
-            let model = model.or_else(auto_select_model);
+            // Open-and-use launch: if no model was named, load the user's saved
+            // default from the configured model library. With no saved choice,
+            // the first local GGUF is the zero-configuration default.
+            let model = model.or_else(|| auto_select_model(models_dir.as_deref()));
             // Open the browser only when run interactively and not opted out.
             let open_ui = !no_open && std::io::IsTerminal::is_terminal(&std::io::stdout());
             api::serve(addr, threads, model, open_ui, enable_thinking, models_dir).await?

--- a/src/model_default.rs
+++ b/src/model_default.rs
@@ -1,0 +1,158 @@
+use std::{
+    fs, io,
+    path::{Component, Path, PathBuf},
+};
+
+/// A small, human-readable preference file kept beside the downloaded models.
+/// Keeping it in `models_dir` makes the choice follow the desktop installation's
+/// model library without introducing another platform-specific config path.
+pub const DEFAULT_MODEL_PREFERENCE_FILE: &str = ".camelid-default-model";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DefaultModelChoice {
+    pub filename: String,
+    pub path: PathBuf,
+    /// `true` when the user explicitly chose this model. When false, Camelid is
+    /// using the first local GGUF as a zero-configuration default.
+    pub configured: bool,
+}
+
+pub fn valid_local_model_filename(filename: &str) -> bool {
+    let path = Path::new(filename);
+    filename == filename.trim()
+        && !filename.is_empty()
+        && !filename.contains(['/', '\\', ':'])
+        && matches!(
+            (path.components().next(), path.components().nth(1)),
+            (Some(Component::Normal(_)), None)
+        )
+        && path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("gguf"))
+}
+
+fn existing_model(
+    models_dir: &Path,
+    filename: &str,
+    configured: bool,
+) -> Option<DefaultModelChoice> {
+    if !valid_local_model_filename(filename) {
+        return None;
+    }
+    let path = models_dir.join(filename);
+    path.is_file().then(|| DefaultModelChoice {
+        filename: filename.to_string(),
+        path,
+        configured,
+    })
+}
+
+pub fn configured_default_model(models_dir: &Path) -> Option<DefaultModelChoice> {
+    let filename = fs::read_to_string(models_dir.join(DEFAULT_MODEL_PREFERENCE_FILE)).ok()?;
+    existing_model(models_dir, filename.trim(), true)
+}
+
+pub fn first_local_model(models_dir: &Path) -> Option<DefaultModelChoice> {
+    let mut paths = fs::read_dir(models_dir)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("gguf"))
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+    let path = paths.into_iter().next()?;
+    let filename = path.file_name()?.to_str()?.to_string();
+    Some(DefaultModelChoice {
+        filename,
+        path,
+        configured: false,
+    })
+}
+
+pub fn effective_default_model(models_dir: &Path) -> Option<DefaultModelChoice> {
+    configured_default_model(models_dir).or_else(|| first_local_model(models_dir))
+}
+
+pub fn set_default_model(models_dir: &Path, filename: &str) -> io::Result<DefaultModelChoice> {
+    if !valid_local_model_filename(filename) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "default model must be one local GGUF filename",
+        ));
+    }
+    let Some(choice) = existing_model(models_dir, filename, true) else {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "default model does not exist in the configured models directory",
+        ));
+    };
+    fs::write(
+        models_dir.join(DEFAULT_MODEL_PREFERENCE_FILE),
+        format!("{filename}\n"),
+    )?;
+    Ok(choice)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_local_gguf_is_the_zero_configuration_default() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("zulu.gguf"), []).unwrap();
+        fs::write(dir.path().join("alpha.GGUF"), []).unwrap();
+        fs::write(dir.path().join("ignore.txt"), []).unwrap();
+
+        let choice = effective_default_model(dir.path()).unwrap();
+        assert_eq!(choice.filename, "alpha.GGUF");
+        assert!(!choice.configured);
+    }
+
+    #[test]
+    fn configured_default_wins_and_survives_a_rescan() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("alpha.gguf"), []).unwrap();
+        fs::write(dir.path().join("chosen.gguf"), []).unwrap();
+
+        let saved = set_default_model(dir.path(), "chosen.gguf").unwrap();
+        assert_eq!(saved.filename, "chosen.gguf");
+        assert!(saved.configured);
+
+        let choice = effective_default_model(dir.path()).unwrap();
+        assert_eq!(choice, saved);
+    }
+
+    #[test]
+    fn stale_or_unsafe_preference_falls_back_to_first_local_model() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("available.gguf"), []).unwrap();
+        fs::write(
+            dir.path().join(DEFAULT_MODEL_PREFERENCE_FILE),
+            "../outside.gguf\n",
+        )
+        .unwrap();
+
+        let choice = effective_default_model(dir.path()).unwrap();
+        assert_eq!(choice.filename, "available.gguf");
+        assert!(!choice.configured);
+
+        assert_eq!(
+            set_default_model(dir.path(), "../outside.gguf")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert_eq!(
+            set_default_model(dir.path(), "missing.gguf")
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+}


### PR DESCRIPTION
## What changed

- Search the configured desktop models directory before legacy locations when `serve` starts without `--model`.
- Automatically use the first installed GGUF when no preference exists.
- Persist an explicit startup choice through a same-origin loopback `/api/models/default` endpoint.
- Add **Make default** and **Starts automatically** controls to the Models page.
- Refresh the effective default after model downloads and deletion attempts.
- Document the macOS desktop startup behavior.

## Why

The macOS sidecar passes its Application Support model directory with `--models-dir`, but startup auto-selection ignored that directory. As a result, a downloaded model appeared in the UI but was not loaded after restarting the app.

## Impact

Camelid Desktop now opens generation-ready when at least one usable local GGUF is installed. Users with multiple models can choose which one starts automatically.

## Validation

- Rust unit tests for fallback selection, persistence, stale/unsafe preferences, API authorization, and startup directory precedence
- Frontend production build
- Frontend integration, model-state, model-lanes, and UI regression smokes
- macOS release build, ad-hoc signature verification, reinstall, and true cold-start check
- Installed app reported `loaded_now: true` and `generation_ready: true`
- Visible Models-page check confirmed the active model and **Starts automatically** marker