### PR TITLE
Add downloaded model management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,8 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tempfile",
  "windows-sys 0.59.0",
 ]
 
@@ -2621,6 +2623,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3156,6 +3159,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3994,6 +4021,64 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -5202,6 +5287,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5233,11 +5327,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5271,6 +5382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5281,6 +5398,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5295,10 +5418,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5313,6 +5448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5323,6 +5464,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5337,6 +5484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5347,6 +5500,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/README.md
+++ b/README.md
@@ -75,10 +75,15 @@ administrator access, macOS asks for your password through `sudo`. To update lat
 `git pull` followed by `./scripts/install-macos-desktop.sh` again.
 
 Downloaded models live in
-`~/Library/Application Support/app.camelid.desktop/models` and are preserved when the app is
-rebuilt or reinstalled. On launch, Desktop loads the model marked **Starts automatically** on the
-Models page; when no choice has been saved yet, the first installed GGUF is selected
-automatically. Use **Make default** beside another installed model to change the next launch.
+`~/Library/Application Support/app.camelid.desktop/models` by default and are preserved when the
+app is rebuilt or reinstalled. The **Downloaded models** tab shows the active folder, disk usage,
+and every local GGUF; from there you can change the next-launch storage folder, choose the startup
+default, or permanently delete an unused model after unloading the active model. Changing storage
+folders takes effect after restart and does not move existing files automatically.
+
+On launch, Desktop loads the model marked **Starts automatically**; when no choice has been saved
+yet, the first installed GGUF is selected automatically. Use **Make default** beside another
+installed model to change the next launch.
 See [Camelid Desktop](camelid-desktop/README.md) for the sidecar design and manual packaging
 details.
 

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -18,11 +18,15 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-# Native-webview shell. No extra features for v1: the window simply navigates to the
-# sidecar's already-embedded UI, so we need neither the HTTP plugin nor remote IPC.
+# Native-webview shell. The dialog plugin is the one narrow native bridge used
+# by the sidecar UI: choosing a model-library directory.
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 # Job object with KILL_ON_JOB_CLOSE: ties the sidecar's lifetime to ours so a desktop

--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -88,7 +88,7 @@ From the repository root on an Apple Silicon Mac:
 This builds the frontend, release engine, app bundle, and DMG; closes an existing Camelid Desktop
 instance cleanly; installs the new app at `/Applications/Camelid Desktop.app`; verifies its
 ad-hoc signature; and launches it. The script uses `sudo` only when `/Applications` is not writable.
-The model directory under the user's Application Support folder is not replaced.
+Neither the default Application Support model directory nor a custom model directory is replaced.
 
 Prerequisites are macOS 12 or newer, the Xcode Command Line Tools, Rust, and Node.js 22 with npm.
 The app is not notarized yet, so this path is intended for local testing and developer
@@ -136,7 +136,9 @@ and performs no notarization. macOS may therefore require the user to approve th
 **System Settings → Privacy & Security** after downloading it.
 
 Downloaded models are stored under the app's per-user Application Support directory rather
-than inside the app bundle.
+than inside the app bundle by default. The **Downloaded models** tab can save a different local
+folder for the next launch. Existing GGUFs are never moved automatically, so changing the folder
+does not risk an implicit multi-gigabyte copy or deletion.
 
 ## Scope notes (intentionally deferred)
 
@@ -145,8 +147,6 @@ v1 deliberately keeps the native shell thin and ships the engine's real UI as-is
 - **No fabricated metrics, by construction.** The splash shows only real lifecycle status;
   all chat metrics (e.g. tokens/sec) come from the embedded UI rendering the engine's real
   generation/telemetry events. Nothing in this crate computes or smooths a metric.
-- **Native tray / native GGUF file-picker are deferred.** Both would require granting Tauri
-  IPC to the loopback-origin page, widening the attack surface this design intentionally
-  avoids — and the embedded UI already loads local/catalog models via the existing
-  `/api/models/load` path, so a native picker adds no capability. They can be added later
-  behind a scoped capability if desired.
+- **Native tray / arbitrary GGUF file-picker are deferred.** The loopback-origin page receives
+  only a scoped native folder chooser for configuring model storage; it does not receive broad
+  filesystem access. Local/catalog model loading still goes through the engine's existing API.

--- a/camelid-desktop/capabilities/sidecar.json
+++ b/camelid-desktop/capabilities/sidecar.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/remote-schema.json",
+  "identifier": "sidecar-ui",
+  "description": "Allows the Camelid loopback sidecar UI to call the desktop shell's narrow model-directory commands. No arbitrary filesystem permission is granted.",
+  "windows": ["main"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
+  },
+  "permissions": ["core:default"]
+}

--- a/camelid-desktop/src/main.rs
+++ b/camelid-desktop/src/main.rs
@@ -11,10 +11,14 @@
 
 mod engine;
 
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State};
+use tauri_plugin_dialog::DialogExt;
 
 use engine::Engine;
+
+const MODELS_DIRECTORY_PREFERENCE_FILE: &str = "models-directory.json";
 
 /// Managed state holding the running sidecar so it can be torn down on exit.
 #[derive(Default)]
@@ -91,6 +95,130 @@ fn startup_snapshot(state: State<'_, StartupState>) -> StartupSnapshot {
     state.snapshot()
 }
 
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct ModelsDirectoryPreference {
+    path: PathBuf,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ModelsDirectoryChoice {
+    path: Option<String>,
+    restart_required: bool,
+}
+
+fn models_directory_preference_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join(MODELS_DIRECTORY_PREFERENCE_FILE)
+}
+
+fn validate_models_directory(path: PathBuf) -> Result<PathBuf, String> {
+    if !path.is_absolute() {
+        return Err("the models directory must be an absolute path".to_string());
+    }
+    let metadata = std::fs::metadata(&path)
+        .map_err(|err| format!("could not access {}: {err}", path.display()))?;
+    if !metadata.is_dir() {
+        return Err(format!("{} is not a directory", path.display()));
+    }
+    path.canonicalize()
+        .map_err(|err| format!("could not resolve {}: {err}", path.display()))
+}
+
+fn read_models_directory_preference(app_data_dir: &Path) -> Result<Option<PathBuf>, String> {
+    let preference_path = models_directory_preference_path(app_data_dir);
+    let bytes = match std::fs::read(&preference_path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(format!(
+                "could not read {}: {err}",
+                preference_path.display()
+            ))
+        }
+    };
+    let preference: ModelsDirectoryPreference = serde_json::from_slice(&bytes)
+        .map_err(|err| format!("{} is invalid: {err}", preference_path.display()))?;
+    validate_models_directory(preference.path).map(Some)
+}
+
+fn write_models_directory_preference(
+    app_data_dir: &Path,
+    selected: PathBuf,
+) -> Result<PathBuf, String> {
+    let selected = validate_models_directory(selected)?;
+    std::fs::create_dir_all(app_data_dir)
+        .map_err(|err| format!("could not create {}: {err}", app_data_dir.display()))?;
+    let preference_path = models_directory_preference_path(app_data_dir);
+    let bytes = serde_json::to_vec_pretty(&ModelsDirectoryPreference {
+        path: selected.clone(),
+    })
+    .map_err(|err| format!("could not encode the models-directory preference: {err}"))?;
+    std::fs::write(&preference_path, bytes)
+        .map_err(|err| format!("could not save {}: {err}", preference_path.display()))?;
+    Ok(selected)
+}
+
+fn clear_models_directory_preference(app_data_dir: &Path) -> Result<(), String> {
+    let preference_path = models_directory_preference_path(app_data_dir);
+    match std::fs::remove_file(&preference_path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(format!(
+            "could not remove {}: {err}",
+            preference_path.display()
+        )),
+    }
+}
+
+fn default_models_directory(app_data_dir: &Path) -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(app_data_dir.join("models"))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app_data_dir;
+        None
+    }
+}
+
+#[tauri::command]
+fn choose_models_directory(app: tauri::AppHandle) -> Result<Option<ModelsDirectoryChoice>, String> {
+    let Some(selected) = app
+        .dialog()
+        .file()
+        .set_title("Choose Camelid model storage")
+        .blocking_pick_folder()
+    else {
+        return Ok(None);
+    };
+    let selected = selected
+        .into_path()
+        .map_err(|err| format!("the selected folder is not a local filesystem path: {err}"))?;
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|err| format!("could not resolve Camelid application data: {err}"))?;
+    let selected = write_models_directory_preference(&app_data_dir, selected)?;
+    Ok(Some(ModelsDirectoryChoice {
+        path: Some(selected.to_string_lossy().into_owned()),
+        restart_required: true,
+    }))
+}
+
+#[tauri::command]
+fn reset_models_directory(app: tauri::AppHandle) -> Result<ModelsDirectoryChoice, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|err| format!("could not resolve Camelid application data: {err}"))?;
+    clear_models_directory_preference(&app_data_dir)?;
+    Ok(ModelsDirectoryChoice {
+        path: default_models_directory(&app_data_dir)
+            .map(|path| path.to_string_lossy().into_owned()),
+        restart_required: true,
+    })
+}
+
 /// Report real startup progress to the splash. Never emits a "ready" state that isn't backed
 /// by a passing health check.
 fn emit_status(app: &tauri::AppHandle, message: &str) {
@@ -112,9 +240,14 @@ fn emit_error(app: &tauri::AppHandle, title: &str, guidance: &str, detail: &str)
 
 fn main() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .manage(EngineState::default())
         .manage(StartupState::default())
-        .invoke_handler(tauri::generate_handler![startup_snapshot])
+        .invoke_handler(tauri::generate_handler![
+            startup_snapshot,
+            choose_models_directory,
+            reset_models_directory
+        ])
         .setup(|app| {
             let handle = app.handle().clone();
             // Start the sidecar off the UI thread so the splash paints immediately.
@@ -145,25 +278,29 @@ fn start_engine(app: tauri::AppHandle) {
         }
     };
 
-    // A signed macOS app bundle is immutable application code. Keep downloaded GGUFs in
-    // the per-user Application Support directory instead of beside the bundled sidecar
-    // under `Camelid Desktop.app/Contents/Resources`. Windows deliberately retains its
-    // existing per-user installer layout with `models/` beside `camelid.exe`.
-    #[cfg(target_os = "macos")]
+    // A user choice overrides the platform default. The directory is selected
+    // before launch and never changed underneath a running engine.
     let models_dir = match app.path().app_data_dir() {
-        Ok(path) => Some(path.join("models")),
+        Ok(app_data_dir) => match read_models_directory_preference(&app_data_dir) {
+            Ok(Some(path)) => Some(path),
+            Ok(None) => default_models_directory(&app_data_dir),
+            Err(err) => {
+                eprintln!(
+                    "[desktop] custom model storage is unavailable ({err}); using platform default"
+                );
+                default_models_directory(&app_data_dir)
+            }
+        },
         Err(e) => {
             emit_error(
                 &app,
-                "Model storage is unavailable",
-                "Check access to your user Library folder, then retry.",
-                &format!("could not resolve the Application Support directory: {e}"),
+                "Model storage settings are unavailable",
+                "Check access to your user application-data folder, then retry.",
+                &format!("could not resolve the application data directory: {e}"),
             );
             return;
         }
     };
-    #[cfg(not(target_os = "macos"))]
-    let models_dir: Option<std::path::PathBuf> = None;
 
     emit_status(&app, "Starting engine\u{2026}");
     match engine::spawn(&engine_path, models_dir.as_deref()) {
@@ -220,7 +357,12 @@ fn shutdown_engine(app_handle: &tauri::AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{StartupSnapshot, StartupState};
+    use std::path::PathBuf;
+
+    use super::{
+        clear_models_directory_preference, read_models_directory_preference,
+        write_models_directory_preference, StartupSnapshot, StartupState,
+    };
 
     #[test]
     fn startup_error_is_replayable_after_the_listener_would_register() {
@@ -236,5 +378,36 @@ mod tests {
         assert_eq!(error.title, "Camelid engine is missing");
         assert_eq!(error.guidance, "Restore camelid.exe and retry.");
         assert_eq!(error.detail, "failed to launch camelid.exe");
+    }
+
+    #[test]
+    fn models_directory_preference_round_trips_and_resets() {
+        let root = tempfile::tempdir().unwrap();
+        let app_data = root.path().join("app-data");
+        let selected = root.path().join("model-library");
+        std::fs::create_dir(&selected).unwrap();
+
+        let saved =
+            write_models_directory_preference(&app_data, selected.clone()).expect("save choice");
+        assert_eq!(saved, selected.canonicalize().unwrap());
+        assert_eq!(
+            read_models_directory_preference(&app_data).unwrap(),
+            Some(selected.canonicalize().unwrap())
+        );
+
+        clear_models_directory_preference(&app_data).unwrap();
+        assert_eq!(read_models_directory_preference(&app_data).unwrap(), None);
+    }
+
+    #[test]
+    fn models_directory_preference_rejects_files_and_relative_paths() {
+        let root = tempfile::tempdir().unwrap();
+        let file = root.path().join("not-a-folder");
+        std::fs::write(&file, b"fixture").unwrap();
+        assert!(write_models_directory_preference(root.path(), file).is_err());
+        assert!(
+            write_models_directory_preference(root.path(), PathBuf::from("relative/models"))
+                .is_err()
+        );
     }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ const AnalyticsView = lazy(() => import('./views/AnalyticsView'))
 const HistoryView = lazy(() => import('./views/HistoryView'))
 const MemoryView = lazy(() => import('./views/MemoryView'))
 const ModelsView = lazy(() => import('./views/ModelsView'))
+const DownloadedModelsView = lazy(() => import('./views/DownloadedModelsView'))
 const ApiView = lazy(() => import('./views/ApiView'))
 const SystemView = lazy(() => import('./views/SystemView'))
 const SettingsView = lazy(() => import('./views/SettingsView'))
@@ -30,7 +31,7 @@ const InferenceObservatoryView = lazy(() => import('./views/InferenceObservatory
 const WorkspaceView = lazy(() => import('./views/WorkspaceView'))
 
 const DEMO_UI = import.meta.env?.VITE_CAMELID_DEMO_UI === 'true'
-const HASH_TABS = new Set(['chat', 'workspace', 'library', 'api', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster', 'observatory', 'compatibility', 'telemetry'])
+const HASH_TABS = new Set(['chat', 'workspace', 'library', 'downloads', 'api', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster', 'observatory', 'compatibility', 'telemetry'])
 
 function App() {
   const { notice, noticeTone, showNotice, clearNotice } = useNotice()
@@ -344,6 +345,15 @@ function App() {
                 apiBase={apiBase}
               />
             </div>
+          )}
+
+          {tab === 'downloads' && (
+            <DownloadedModelsView
+              runtime={runtime}
+              apiBase={apiBase}
+              unloadCurrentModel={unloadCurrentModel}
+              onOpenModels={() => navigateTab('library')}
+            />
           )}
 
           {tab === 'api' && <ApiView runtime={runtime} selectedModel={selectedModel} capabilities={dashboard?.capabilities} />}

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -11,6 +11,7 @@ const TITLES = {
   chat: 'Chat',
   workspace: 'Workspace',
   library: 'Models',
+  downloads: 'Downloaded models',
   api: 'API',
   compatibility: 'Compatibility ledger',
   analytics: 'Analytics',

--- a/frontend/src/components/layout/SidebarRail.jsx
+++ b/frontend/src/components/layout/SidebarRail.jsx
@@ -6,12 +6,13 @@ import { Tooltip } from '../ui/Tooltip'
 import { ConversationListItem } from './ConversationListItem'
 import {
   IconAnalytics, IconApi, IconBolt, IconChart, IconChat, IconHistory, IconMemory, IconModels,
-  IconNetwork, IconNewChat, IconObservatory, IconReceipt, IconSearch, IconSettings, IconSidebar, IconSystem,
+  IconDownload, IconNetwork, IconNewChat, IconObservatory, IconReceipt, IconSearch, IconSettings, IconSidebar, IconSystem,
 } from '../ui/icons'
 
 const NAV = [
   { tab: 'workspace', label: 'Workspace', Icon: IconBolt },
   { tab: 'library', label: 'Models', Icon: IconModels },
+  { tab: 'downloads', label: 'Downloaded models', Icon: IconDownload },
   { tab: 'history', label: 'Chat history', Icon: IconHistory },
   { tab: 'analytics', label: 'Analytics', Icon: IconAnalytics },
   { tab: 'telemetry', label: 'Telemetry', Icon: IconChart },

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -19,7 +19,7 @@ const LOCAL_MODELS_STORAGE_KEY = 'camelid.localModels'
 const CONVERSATIONS_STORAGE_KEY = 'camelid.conversations'
 const MEMORIES_STORAGE_KEY = 'camelid.memories'
 const API_BASE_STORAGE_KEY = 'camelid.apiBase'
-const VALID_TABS = new Set(['chat', 'workspace', 'library', 'api', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster', 'compatibility', 'telemetry'])
+const VALID_TABS = new Set(['chat', 'workspace', 'library', 'downloads', 'api', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster', 'compatibility', 'telemetry'])
 // Where the UI looks for the camelid API by default:
 //   1. an explicit VITE_CAMELID_API_BASE override always wins;
 //   2. otherwise use the page origin. Production is served by Camelid directly;

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -433,6 +433,82 @@
 /* ---- cxv: active button state (toggles) ---- */
 .cxv .cx-btn.is-active { background: var(--color-accent-soft); border-color: var(--color-selected-row-border); color: var(--color-accent-text); }
 
+/* ---- Downloaded models library ---- */
+.downloaded-storage { gap: var(--space-3); }
+.downloaded-storage__path,
+.downloaded-storage__next code {
+  display: block;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+}
+.downloaded-storage__path {
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-code-bg);
+  color: var(--color-text);
+}
+.downloaded-storage__next {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-text);
+}
+.downloaded-storage__next span { font-size: var(--text-xs); font-weight: 700; }
+.downloaded-storage__note,
+.downloaded-storage__desktop-only {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+}
+.downloaded-storage__actions { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
+.downloaded-storage__desktop-only { margin-left: var(--space-1); }
+.downloaded-active {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 38%, var(--color-border-soft));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-warning) 8%, var(--color-surface));
+  font-size: var(--text-sm);
+}
+.downloaded-active > div { min-width: 0; overflow-wrap: anywhere; }
+.downloaded-model { min-width: 0; }
+.downloaded-model--active {
+  border-color: color-mix(in srgb, var(--color-ready) 44%, var(--color-border-soft));
+  box-shadow: inset 3px 0 0 var(--color-ready), var(--shadow-1);
+}
+.downloaded-model__tags { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: var(--space-1); }
+.downloaded-model .cxv-card__foot { align-items: flex-end; flex-wrap: wrap; }
+.downloaded-model .cxv-card__actions { margin-left: auto; }
+.downloaded-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-8) var(--space-5);
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+.downloaded-empty strong { color: var(--color-text); font-size: var(--text-lg); }
+.downloaded-empty .cx-btn { margin-top: var(--space-2); }
+@media (max-width: 640px) {
+  .downloaded-active { align-items: stretch; flex-direction: column; }
+  .downloaded-storage__next { grid-template-columns: 1fr; gap: var(--space-1); }
+  .downloaded-model .cxv-card__foot { align-items: stretch; flex-direction: column; }
+  .downloaded-model .cxv-card__actions { justify-content: flex-end; margin-left: 0; }
+}
+
 /* ---- cxv: forms ---- */
 .cxv-form { gap: var(--space-3); }
 .cxv-card__sub-plain { font-size: var(--text-sm); color: var(--color-text-muted); }

--- a/frontend/src/views/DownloadedModelsView.jsx
+++ b/frontend/src/views/DownloadedModelsView.jsx
@@ -1,0 +1,347 @@
+import { useMemo, useState } from 'react'
+import { Button } from '../components/ui/Button'
+import { ConfirmDialog } from '../components/ui/ConfirmDialog'
+import {
+  IconDownload,
+  IconModels,
+  IconRefresh,
+  IconSearch,
+  IconTrash,
+} from '../components/ui/icons'
+import { useModelsPageData } from '../hooks/useModelsPageData'
+import { modelDeleteBlockedReason } from '../lib/modelDeletion'
+import {
+  describeModel,
+  metaLine,
+  prettySize,
+} from '../components/models/LaneRows'
+
+function desktopInvoke() {
+  if (typeof window === 'undefined') return null
+  return window.__TAURI__?.core?.invoke || null
+}
+
+export default function DownloadedModelsView({
+  runtime,
+  apiBase = '',
+  unloadCurrentModel,
+  onOpenModels,
+}) {
+  const runtimeApiBase = (runtime?.api_base || '').replace(/\/$/, '')
+  const spine = useModelsPageData({ apiBase: runtimeApiBase || apiBase })
+  const [query, setQuery] = useState('')
+  const [pendingDelete, setPendingDelete] = useState(null)
+  const [deletingFilename, setDeletingFilename] = useState('')
+  const [defaultingFilename, setDefaultingFilename] = useState('')
+  const [unloading, setUnloading] = useState(false)
+  const [notice, setNotice] = useState('')
+  const [error, setError] = useState('')
+  const [storageBusy, setStorageBusy] = useState(false)
+  const [nextStoragePath, setNextStoragePath] = useState('')
+
+  const models = spine.local?.models || []
+  const totalBytes = models.reduce((sum, model) => sum + Number(model.size_bytes || 0), 0)
+  const normalizedQuery = query.trim().toLowerCase()
+  const filteredModels = useMemo(
+    () => models.filter((model) => {
+      if (!normalizedQuery) return true
+      return [
+        model.filename,
+        model.architecture,
+        model.quantization,
+        model.tokenizer_kind,
+      ].some((value) => String(value || '').toLowerCase().includes(normalizedQuery))
+    }),
+    [models, normalizedQuery],
+  )
+  const deleteBlockedReason = modelDeleteBlockedReason({
+    activeFilename: spine.activeFilename,
+    downloads: spine.downloads,
+    loading: unloading,
+  })
+  const invoke = desktopInvoke()
+
+  const clearMessages = () => {
+    setNotice('')
+    setError('')
+  }
+
+  const makeDefault = async (filename) => {
+    clearMessages()
+    setDefaultingFilename(filename)
+    try {
+      await spine.setDefaultModel(filename)
+      setNotice(`${filename} will load automatically when Camelid starts.`)
+    } catch (err) {
+      setError(String(err?.message || err))
+    } finally {
+      setDefaultingFilename('')
+    }
+  }
+
+  const unload = async () => {
+    clearMessages()
+    setUnloading(true)
+    try {
+      await unloadCurrentModel()
+      await spine.refreshCurrent()
+      setNotice('The active model was unloaded. Downloaded files can now be deleted.')
+    } catch (err) {
+      setError(String(err?.message || err))
+    } finally {
+      setUnloading(false)
+    }
+  }
+
+  const confirmDelete = async () => {
+    if (!pendingDelete || deletingFilename) return
+    const entry = pendingDelete
+    clearMessages()
+    setDeletingFilename(entry.filename)
+    try {
+      const result = await spine.deleteLocalModel(entry)
+      setPendingDelete(null)
+      setNotice(`Deleted ${entry.filename} and freed ${prettySize(result.bytes_freed)}.`)
+    } catch (err) {
+      setPendingDelete(null)
+      setError(String(err?.message || err))
+    } finally {
+      setDeletingFilename('')
+    }
+  }
+
+  const chooseStorage = async () => {
+    if (!invoke) return
+    clearMessages()
+    setStorageBusy(true)
+    try {
+      const choice = await invoke('choose_models_directory')
+      if (choice?.path) {
+        setNextStoragePath(choice.path)
+        setNotice('The new model folder will be used after Camelid Desktop restarts.')
+      }
+    } catch (err) {
+      setError(String(err?.message || err))
+    } finally {
+      setStorageBusy(false)
+    }
+  }
+
+  const resetStorage = async () => {
+    if (!invoke) return
+    clearMessages()
+    setStorageBusy(true)
+    try {
+      const choice = await invoke('reset_models_directory')
+      setNextStoragePath(choice?.path || 'Camelid Desktop default')
+      setNotice('The default model folder will be restored after Camelid Desktop restarts.')
+    } catch (err) {
+      setError(String(err?.message || err))
+    } finally {
+      setStorageBusy(false)
+    }
+  }
+
+  return (
+    <section className="downloaded-models-view cxv">
+      <header className="cxv-head">
+        <div className="cxv-head__copy">
+          <p className="cxv-kicker"><IconDownload size={14} /> Local library</p>
+          <h1>Downloaded models</h1>
+          <p className="cxv-sub">
+            See every GGUF in Camelid&apos;s active model folder, choose the startup default,
+            and permanently remove files you no longer need.
+          </p>
+        </div>
+        <div className="cxv-stats">
+          <div className="cxv-stat">
+            <span>Models</span>
+            <strong>{models.length}</strong>
+            <small>on disk</small>
+          </div>
+          <div className="cxv-stat">
+            <span>Storage</span>
+            <strong>{prettySize(totalBytes) || '0 MB'}</strong>
+            <small>GGUF files</small>
+          </div>
+        </div>
+      </header>
+
+      <article className="cxv-card cxv-card--flat downloaded-storage">
+        <div className="cxv-card__head">
+          <div className="cxv-card__titles">
+            <strong>Model storage folder</strong>
+            <span className="cxv-card__sub-plain">
+              Downloads and local scans use this folder.
+            </span>
+          </div>
+          <span className="cxv-tag cxv-tag--accent">Active</span>
+        </div>
+        <code className="downloaded-storage__path">
+          {spine.local?.models_dir || (spine.localLoading ? 'Loading…' : 'Unavailable')}
+        </code>
+        {nextStoragePath ? (
+          <div className="downloaded-storage__next" role="status">
+            <span>After restart</span>
+            <code>{nextStoragePath}</code>
+          </div>
+        ) : null}
+        <p className="downloaded-storage__note">
+          Changing folders takes effect after restart. Existing model files stay in the current
+          folder; Camelid does not move or copy them automatically.
+        </p>
+        <div className="downloaded-storage__actions">
+          <Button variant="outline" size="sm" onClick={chooseStorage} disabled={!invoke || storageBusy}>
+            {storageBusy ? 'Choosing…' : 'Choose folder…'}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={resetStorage} disabled={!invoke || storageBusy}>
+            Use default folder
+          </Button>
+          {!invoke ? (
+            <span className="downloaded-storage__desktop-only">
+              Folder selection is available in Camelid Desktop.
+            </span>
+          ) : null}
+        </div>
+      </article>
+
+      {spine.activeFilename ? (
+        <div className="downloaded-active" id="model-delete-guard">
+          <div>
+            <strong>{spine.activeFilename}</strong>
+            <span> is loaded. Unload it before deleting any model file.</span>
+          </div>
+          <Button variant="outline" size="sm" onClick={unload} loading={unloading}>
+            Unload current model
+          </Button>
+        </div>
+      ) : null}
+
+      {error ? <p className="lane-error" role="alert">{error}</p> : null}
+      {notice ? <p className="lane-delete-success" role="status">{notice}</p> : null}
+      {spine.localError && !spine.local ? (
+        <p className="lane-error">Could not list downloaded models: {spine.localError}</p>
+      ) : null}
+
+      <div className="cxv-toolbar downloaded-toolbar">
+        <label className="cxv-search">
+          <IconSearch size={17} />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search downloaded models"
+            aria-label="Search downloaded models"
+          />
+        </label>
+        <Button
+          variant="outline"
+          size="sm"
+          icon={<IconRefresh size={16} />}
+          onClick={() => spine.refreshAll()}
+          disabled={spine.localLoading}
+        >
+          {spine.localLoading ? 'Refreshing…' : 'Refresh'}
+        </Button>
+        <Button
+          variant="tonal"
+          size="sm"
+          icon={<IconModels size={16} />}
+          onClick={onOpenModels}
+        >
+          Get more models
+        </Button>
+      </div>
+
+      {!spine.local && spine.localLoading ? (
+        <p className="lane-empty">Scanning the model folder…</p>
+      ) : filteredModels.length ? (
+        <div className="cxv-grid downloaded-grid">
+          {filteredModels.map((entry) => {
+            const isActive = entry.filename === spine.activeFilename
+            const isDefault = entry.filename === spine.defaultFilename
+            const deleteAvailable = Boolean(entry.delete_token)
+            const canStartAutomatically = entry.lane_class !== 'unsupported'
+            return (
+              <article
+                className={`cxv-card downloaded-model${isActive ? ' downloaded-model--active' : ''}`}
+                key={entry.filename}
+              >
+                <div className="cxv-card__head">
+                  <div className="cxv-card__titles">
+                    <strong title={entry.filename}>{entry.filename}</strong>
+                    <span className="cxv-card__sub">{metaLine(entry) || prettySize(entry.size_bytes)}</span>
+                  </div>
+                  <div className="downloaded-model__tags">
+                    {isActive ? <span className="cxv-tag cxv-tag--ready">Loaded</span> : null}
+                    {isDefault ? <span className="cxv-tag cxv-tag--accent">Default</span> : null}
+                  </div>
+                </div>
+                <p className="cxv-card__preview">{describeModel(entry)}</p>
+                <div className="cxv-card__foot">
+                  <div className="cxv-card__meta">
+                    <strong>{prettySize(entry.size_bytes) || 'Unknown size'}</strong>
+                    <span className="cxv-dot">·</span>
+                    <span>{entry.chat_capable ? 'Chat model' : 'Text model'}</span>
+                  </div>
+                  <div className="cxv-card__actions">
+                    {!isDefault && canStartAutomatically ? (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => makeDefault(entry.filename)}
+                        loading={defaultingFilename === entry.filename}
+                        disabled={Boolean(deletingFilename)}
+                      >
+                        Make default
+                      </Button>
+                    ) : null}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="cxv-danger"
+                      icon={<IconTrash size={17} />}
+                      onClick={() => {
+                        clearMessages()
+                        setPendingDelete(entry)
+                      }}
+                      disabled={!deleteAvailable || Boolean(deleteBlockedReason) || Boolean(deletingFilename)}
+                      aria-label={`Delete ${entry.filename} from disk`}
+                      aria-describedby={deleteBlockedReason ? 'model-delete-guard' : undefined}
+                      title={
+                        deleteBlockedReason
+                        || (deleteAvailable ? 'Delete from disk' : 'Deletion is unavailable from this client')
+                      }
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      ) : models.length ? (
+        <p className="lane-empty">No downloaded models match “{query}”.</p>
+      ) : (
+        <div className="downloaded-empty">
+          <IconDownload size={28} />
+          <strong>No downloaded models</strong>
+          <span>Open Models to choose and download a local GGUF.</span>
+          <Button variant="tonal" size="sm" onClick={onOpenModels}>Browse models</Button>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={Boolean(pendingDelete)}
+        title={pendingDelete ? `Delete ${pendingDelete.filename}?` : 'Delete model?'}
+        detail={pendingDelete
+          ? `This permanently removes ${prettySize(pendingDelete.size_bytes) || 'this file'} from disk. This cannot be undone.`
+          : ''}
+        confirmLabel="Delete model"
+        busy={Boolean(deletingFilename)}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={confirmDelete}
+      />
+    </section>
+  )
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20,7 +20,7 @@ use minijinja::{
     UndefinedBehavior,
 };
 use serde::{Deserialize, Serialize};
-#[cfg(windows)]
+#[cfg(any(windows, unix))]
 use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
@@ -127,7 +127,7 @@ pub struct AppState {
     model_transition: Arc<tokio::sync::Mutex<()>>,
     /// Per-process nonce makes scan-issued deletion tokens opaque and prevents
     /// clients from constructing authorization from visible file metadata.
-    #[cfg(windows)]
+    #[cfg(any(windows, unix))]
     model_delete_nonce: Arc<str>,
     /// Destructive local-file management is available only when the listener
     /// itself is bound to loopback.
@@ -178,7 +178,7 @@ impl Default for AppState {
             cached_prompt_prefix: Arc::new(Mutex::new(PromptPrefixCachePool::from_env())),
             model_file_lifecycle: Arc::new(RwLock::new(())),
             model_transition: Arc::new(tokio::sync::Mutex::new(())),
-            #[cfg(windows)]
+            #[cfg(any(windows, unix))]
             model_delete_nonce: Arc::from(uuid::Uuid::new_v4().to_string()),
             allow_local_model_delete: false,
             generation_sessions: Arc::new(RwLock::new(HashMap::new())),
@@ -19769,7 +19769,7 @@ pub struct LocalModelsResponse {
     pub models: Vec<LocalModelEntry>,
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, unix))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct LocalModelFileIdentity {
     size_bytes: u64,
@@ -19781,7 +19781,7 @@ fn validate_local_model_filename(filename: &str) -> bool {
     model_default::valid_local_model_filename(filename)
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, unix))]
 fn local_model_delete_token(
     nonce: &str,
     filename: &str,
@@ -19913,14 +19913,66 @@ fn local_model_file_identity(
     windows_handle_identity(handle.0, filename, nonce)
 }
 
-#[cfg(windows)]
+#[cfg(unix)]
+fn unix_metadata_identity(
+    metadata: &std::fs::Metadata,
+    filename: &str,
+    nonce: &str,
+) -> Option<LocalModelFileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    if !metadata.file_type().is_file() {
+        return None;
+    }
+    let size_bytes = metadata.size();
+    let modified_nanos = if metadata.mtime() >= 0 {
+        (metadata.mtime() as u128)
+            .saturating_mul(1_000_000_000)
+            .saturating_add(metadata.mtime_nsec().max(0) as u128)
+    } else {
+        0
+    };
+    let platform_id = format!(
+        "unix:{}:{}:{}:{}:{}:{}:{}",
+        metadata.dev(),
+        metadata.ino(),
+        metadata.nlink(),
+        metadata.mtime(),
+        metadata.mtime_nsec(),
+        metadata.ctime(),
+        metadata.ctime_nsec()
+    );
+    let delete_token = (metadata.nlink() == 1).then(|| {
+        local_model_delete_token(nonce, filename, size_bytes, modified_nanos, &platform_id)
+    });
+    Some(LocalModelFileIdentity {
+        size_bytes,
+        modified_nanos,
+        delete_token,
+    })
+}
+
+#[cfg(unix)]
+fn local_model_file_identity(
+    models_dir: &std::path::Path,
+    filename: &str,
+    nonce: &str,
+) -> std::io::Result<Option<LocalModelFileIdentity>> {
+    if !validate_local_model_filename(filename) {
+        return Ok(None);
+    }
+    let metadata = std::fs::symlink_metadata(models_dir.join(filename))?;
+    Ok(unix_metadata_identity(&metadata, filename, nonce))
+}
+
+#[cfg(any(windows, unix))]
 #[derive(Debug, serde::Deserialize)]
 struct DeleteLocalModelRequest {
     filename: String,
     delete_token: String,
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, unix))]
 #[derive(Debug, serde::Serialize)]
 struct DeleteLocalModelResponse {
     deleted: bool,
@@ -20154,10 +20206,11 @@ mod default_model_api_tests {
     }
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, unix))]
 #[derive(Debug)]
 enum DeleteLocalModelError {
     Io(std::io::Error),
+    #[cfg(windows)]
     Busy(std::io::Error),
     Changed,
     Unsafe,
@@ -20169,6 +20222,48 @@ fn classify_delete_io(err: std::io::Error) -> DeleteLocalModelError {
         Some(32 | 33) => DeleteLocalModelError::Busy(err),
         _ => DeleteLocalModelError::Io(err),
     }
+}
+
+#[cfg(unix)]
+fn delete_identity_bound_local_model(
+    path: &std::path::Path,
+    filename: &str,
+    nonce: &str,
+    expected_token: &str,
+) -> Result<u64, DeleteLocalModelError> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let handle = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .map_err(DeleteLocalModelError::Io)?;
+    let handle_identity = unix_metadata_identity(
+        &handle.metadata().map_err(DeleteLocalModelError::Io)?,
+        filename,
+        nonce,
+    )
+    .ok_or(DeleteLocalModelError::Unsafe)?;
+    if handle_identity.delete_token.as_deref() != Some(expected_token) {
+        return Err(DeleteLocalModelError::Changed);
+    }
+
+    // Re-read the directory entry immediately before unlinking it. The open
+    // handle proves the token still names the same inode, while O_NOFOLLOW and
+    // the path identity check reject symlink or replacement attacks.
+    let path_identity = unix_metadata_identity(
+        &std::fs::symlink_metadata(path).map_err(DeleteLocalModelError::Io)?,
+        filename,
+        nonce,
+    )
+    .ok_or(DeleteLocalModelError::Unsafe)?;
+    if path_identity != handle_identity
+        || path_identity.delete_token.as_deref() != Some(expected_token)
+    {
+        return Err(DeleteLocalModelError::Changed);
+    }
+    std::fs::remove_file(path).map_err(DeleteLocalModelError::Io)?;
+    Ok(handle_identity.size_bytes)
 }
 
 #[cfg(windows)]
@@ -20204,7 +20299,7 @@ fn delete_identity_bound_local_model(
     Ok(identity.size_bytes)
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, unix)))]
 async fn delete_local_model(
     State(_state): State<AppState>,
     _headers: HeaderMap,
@@ -20218,7 +20313,7 @@ async fn delete_local_model(
     )
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, unix))]
 async fn delete_local_model(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -20345,6 +20440,7 @@ async fn delete_local_model(
                 Some("filename"),
             )
         }
+        #[cfg(windows)]
         Ok(Err(DeleteLocalModelError::Busy(err))) => {
             return api_error(
                 StatusCode::CONFLICT,
@@ -20433,7 +20529,7 @@ async fn local_models(
     _headers: HeaderMap,
 ) -> Json<LocalModelsResponse> {
     let _reader = state.model_file_lifecycle.read().await;
-    #[cfg(windows)]
+    #[cfg(any(windows, unix))]
     let expose_delete_tokens =
         state.allow_local_model_delete && local_management_request_allowed(&_headers);
     let dir = state.models_dir.clone();
@@ -20464,7 +20560,7 @@ async fn local_models(
                     continue;
                 }
             };
-            #[cfg(windows)]
+            #[cfg(any(windows, unix))]
             let identity = match local_model_file_identity(
                 &dir,
                 &filename,
@@ -20476,21 +20572,21 @@ async fn local_models(
                     None
                 }
             };
-            #[cfg(windows)]
+            #[cfg(any(windows, unix))]
             let delete_token = identity
                 .as_ref()
                 .and_then(|identity| expose_delete_tokens.then(|| identity.delete_token.clone()))
                 .flatten();
-            #[cfg(not(windows))]
+            #[cfg(not(any(windows, unix)))]
             let delete_token = None;
-            #[cfg(windows)]
+            #[cfg(any(windows, unix))]
             let deletable_identity = identity
                 .as_ref()
                 .filter(|identity| identity.delete_token.is_some());
-            #[cfg(windows)]
+            #[cfg(any(windows, unix))]
             let size_bytes =
                 deletable_identity.map_or_else(|| metadata.len(), |identity| identity.size_bytes);
-            #[cfg(not(windows))]
+            #[cfg(not(any(windows, unix)))]
             let size_bytes = metadata.len();
             let metadata_mtime_secs = metadata
                 .modified()
@@ -20498,11 +20594,11 @@ async fn local_models(
                 .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
                 .map(|duration| duration.as_secs())
                 .unwrap_or_default();
-            #[cfg(windows)]
+            #[cfg(any(windows, unix))]
             let mtime_secs = deletable_identity.map_or(metadata_mtime_secs, |identity| {
                 (identity.modified_nanos / 1_000_000_000) as u64
             });
-            #[cfg(not(windows))]
+            #[cfg(not(any(windows, unix)))]
             let mtime_secs = metadata_mtime_secs;
 
             // Reuse cached metadata facts when the file is unchanged; only the cheap
@@ -21356,7 +21452,7 @@ async fn acknowledge_catalog_download(
     StatusCode::NO_CONTENT.into_response()
 }
 
-#[cfg(all(test, windows))]
+#[cfg(all(test, any(windows, unix)))]
 mod local_model_delete_tests {
     use super::{active_downloads_map, router_with_state, ActiveDownload, AppState};
     use axum::{
@@ -21769,7 +21865,7 @@ mod local_model_delete_tests {
     }
 }
 
-#[cfg(all(test, not(windows)))]
+#[cfg(all(test, not(any(windows, unix))))]
 mod non_windows_model_delete_tests {
     use super::{router_with_state, AppState};
     use axum::{


### PR DESCRIPTION
## What changed

- add a dedicated **Downloaded models** tab with local inventory, search, disk usage, active/default status, unload guidance, and permanent-delete confirmation
- extend identity-bound local GGUF deletion to macOS and other Unix hosts while preserving loopback, same-origin, lifecycle lease, active-model, download, hard-link, and stale-token safeguards
- add a scoped native desktop folder chooser and persisted next-launch model-directory preference
- keep storage changes non-destructive: existing GGUFs are not moved automatically, and an unavailable custom directory falls back to the platform default
- document the new model-management and storage workflow in the root and desktop READMEs

## Why

Desktop users could download and load models but did not have a focused place to inspect disk usage, remove unused files, or choose where multi-gigabyte model files are stored. The existing deletion endpoint was also Windows-only.

## User impact

macOS users now have one tab for managing downloaded models. Deletion is available after unloading the active model, always requires confirmation, and remains constrained to the exact unchanged scanned GGUF. A custom storage folder is used after restarting Camelid Desktop without silently moving existing files.

## Validation

- `CARGO_TARGET_DIR="$PWD/target-inspect" cargo test local_model_delete_tests --lib` — 10 passed
- `CARGO_TARGET_DIR="$PWD/target-inspect/desktop" cargo test --manifest-path camelid-desktop/Cargo.toml` — 10 passed
- `npm run build` — passed
- `npm run smoke:model-deletion` — passed
- packaged and installed `/Applications/Camelid Desktop.app`; ad-hoc signature verified
- live sidecar cold-started the configured default model with `loaded_now=true` and `generation_ready=true`
- live Downloaded models flow exposed deletion after unload, rendered the permanent-delete confirmation, and preserved the installed 1.3 GB model after cancel