### PR TITLE
Ship a prebuilt macOS desktop DMG with a one-command installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,10 +282,11 @@ jobs:
       - name: Docs
         run: cargo doc --no-deps ${{ matrix.features }}
 
-  # Windows-only build / lint / test of the additive camelid-desktop crate. The `rust`
+  # Windows build / lint / test of the additive camelid-desktop crate. The `rust`
   # job above scopes clippy/test/doc to default-members (the server), so without this the
-  # desktop crate would only be fmt-checked. Tauri/WebView2 is Windows-only and the crate
-  # is Windows-only, so this lives on its own leg rather than in the cross-OS `rust` matrix.
+  # desktop crate would only be fmt-checked. WebView2 is Windows-only, but the crate itself
+  # also builds on macOS (WKWebView), where the release `desktop-macos` job packages it;
+  # this leg covers the Windows build rather than joining the cross-OS `rust` matrix.
   # It needs no frontend build: the desktop app bundles only its static splash; the embedded
   # web UI lives in camelid.exe, which this job does not build. The base tauri.conf.json
   # declares no sidecar resources (those are in the bundle-only overlay), so the crate builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         description: 'Release tag to publish (e.g. v0.1.1)'
         required: true
       skip_desktop:
-        description: 'Skip the additive camelid-desktop (Windows) build'
+        description: 'Skip the additive camelid-desktop (Windows + macOS) builds'
         required: false
         default: 'false'
 
@@ -523,6 +523,140 @@ jobs:
             camelid-desktop-windows-x64.zip
             camelid-desktop-windows-x64.zip.sha256
             *-setup.exe
+          fail_on_unmatched_files: true
+
+  # ---------------------------------------------------------------------------------
+  # ADDITIVE: native macOS desktop app (camelid-desktop on Apple Silicon). Same
+  # independence contract as desktop-windows: it is in NO job's `needs`, so it cannot
+  # change or gate the server artifacts, their checksums, or the server publish step,
+  # and it is skippable via the same `skip_desktop` dispatch input. It reuses
+  # scripts/build-macos-desktop.sh — the exact path a developer runs locally — which
+  # builds the web UI, the release Metal-enabled `camelid` sidecar, the ad-hoc-signed
+  # .app, and a drag-to-Applications DMG. There is no Developer ID identity yet, so
+  # the bundle is ad-hoc signed and NOT notarized; scripts/get-desktop-macos.sh is
+  # the documented quarantine-free install path. See camelid-desktop/README.md.
+  desktop-macos:
+    if: ${{ github.event.inputs.skip_desktop != 'true' }}
+    runs-on: macos-14 # Apple Silicon; build-macos-desktop.sh refuses non-arm64 hosts
+    permissions:
+      contents: write # attach the DMG to the release (no signing secrets involved)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.87.0
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      # One build path for CI and developers: the script builds the frontend, the
+      # release sidecar, the Tauri .app, and the DMG (ad-hoc signature). Invoked
+      # through `bash` like every other repo script in CI, so it does not depend
+      # on the executable bit surviving in the index.
+      - name: Build the app bundle and DMG
+        run: bash scripts/build-macos-desktop.sh
+
+      # The DMG is renamed to a STABLE, versionless asset name so
+      # `releases/latest/download/camelid-desktop-macos-arm64.dmg` — the URL
+      # scripts/get-desktop-macos.sh and the README rely on — is the same for
+      # every release. (GitHub also rewrites the space in the Tauri file name
+      # on upload, so the built name could not be published verbatim anyway.)
+      - name: Stage the DMG under its release name
+        run: |
+          set -euo pipefail
+          version="$(node -e 'const fs = require("fs"); process.stdout.write(JSON.parse(fs.readFileSync("camelid-desktop/tauri.conf.json", "utf8")).version)')"
+          src="target/release/bundle/dmg/Camelid Desktop_${version}_aarch64.dmg"
+          if [ ! -f "$src" ]; then
+            echo "expected DMG not found: $src" >&2
+            exit 1
+          fi
+          cp "$src" camelid-desktop-macos-arm64.dmg
+          shasum -a 256 camelid-desktop-macos-arm64.dmg > camelid-desktop-macos-arm64.dmg.sha256
+
+      # Open the box that ships, like the server jobs: mount the DMG a user would
+      # mount, copy the app out the way the installer copies it, verify the ad-hoc
+      # signature survived the round-trip, and boot the BUNDLED sidecar model-less.
+      # The sidecar is the engine that must serve — launching the Tauri GUI
+      # headless on a runner proves nothing (same reasoning as desktop-windows).
+      # The smoke reuses the macos-arm64 spec: the bundled sidecar directory holds
+      # the same single `camelid` binary the server tarball ships.
+      - name: Verify the packaged desktop artifact
+        run: |
+          set -euo pipefail
+          # The published .sha256 must name and match the exact bytes being
+          # uploaded — proven with the SAME parser the other jobs' gates use
+          # (a one-record sidecar the user's own `shasum -c` also consumes),
+          # plus that literal user command itself.
+          shasum -a 256 -c camelid-desktop-macos-arm64.dmg.sha256
+          node --input-type=module -e '
+            import { readFile } from "node:fs/promises"
+            import { parseChecksumFile, sha256File } from "./scripts/check-release-artifact.mjs"
+            const record = parseChecksumFile(await readFile("camelid-desktop-macos-arm64.dmg.sha256", "utf8"))
+            if (record.name !== "camelid-desktop-macos-arm64.dmg") throw new Error(`sidecar names ${record.name}`)
+            const hash = await sha256File("camelid-desktop-macos-arm64.dmg")
+            if (hash !== record.hash) throw new Error(`sidecar hash ${record.hash} != actual ${hash}`)
+            console.log("checksum sidecar round-trip OK")
+          '
+          rm -rf verify-desktop dmg-mount && mkdir -p verify-desktop dmg-mount
+          hdiutil attach camelid-desktop-macos-arm64.dmg -nobrowse -readonly -mountpoint dmg-mount -quiet
+          test -d "dmg-mount/Camelid Desktop.app"
+          test -L "dmg-mount/Applications"
+          ditto --noextattr --noqtn "dmg-mount/Camelid Desktop.app" "verify-desktop/Camelid Desktop.app"
+          # Freshly attached volumes can be transiently busy on runners
+          # (Spotlight/XProtect scan new mounts), so detach with retries and a
+          # -force fallback. Everything below runs on the copied-out bundle,
+          # not the mount.
+          detached=0
+          for attempt in 1 2 3 4 5; do
+            if hdiutil detach dmg-mount -quiet 2>/dev/null; then detached=1; break; fi
+            sleep 2
+          done
+          if [ "$detached" -eq 0 ]; then hdiutil detach dmg-mount -force; fi
+          codesign --verify --deep --strict "verify-desktop/Camelid Desktop.app"
+          # The bundled sidecar payload is a closed set: exactly the engine binary.
+          [ "$(ls -A "verify-desktop/Camelid Desktop.app/Contents/Resources/sidecar")" = "camelid" ]
+          node scripts/smoke-release-artifact.mjs \
+            --dir "verify-desktop/Camelid Desktop.app/Contents/Resources/sidecar" \
+            --label macos-arm64 \
+            --expect-version "${{ env.RELEASE_TAG }}" \
+            --out camelid-desktop-macos-arm64-smoke-receipt.json
+
+      - name: Upload desktop artifacts (CI)
+        uses: actions/upload-artifact@v4
+        with:
+          name: camelid-desktop-macos-arm64
+          path: |
+            camelid-desktop-macos-arm64.dmg
+            camelid-desktop-macos-arm64.dmg.sha256
+
+      - name: Upload verification receipts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verification-receipts-desktop-macos-arm64
+          path: camelid-desktop-macos-arm64-*-receipt.json
+          if-no-files-found: ignore
+
+      # Publish to the SAME GitHub release, independently of the server `release`
+      # job (identical pattern to desktop-windows: softprops is idempotent, and a
+      # desktop failure never blocks the server release — the DMG is just absent).
+      - name: Publish the desktop DMG to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: |
+            camelid-desktop-macos-arm64.dmg
+            camelid-desktop-macos-arm64.dmg.sha256
           fail_on_unmatched_files: true
 
   release:

--- a/README.md
+++ b/README.md
@@ -56,23 +56,35 @@ ready to use.
   driver, and CUDA versions in [COMPATIBILITY.md](COMPATIBILITY.md); it makes no general
   token-parity or throughput claim.
 
-#### macOS Apple Silicon — command-line install
+#### macOS Apple Silicon
 
-The macOS desktop app currently uses an ad-hoc signature and is **not notarized**. Until a
-notarized release is available, the simplest honest installation path is to build the current
-source and install it from Terminal. It requires macOS 12 or newer on Apple Silicon, the Xcode
-Command Line Tools, [Rust](https://rustup.rs/), and Node.js 22 with npm.
+Paste one command into Terminal — it downloads the latest release DMG, verifies its checksum,
+installs `Camelid Desktop.app` into `/Applications`, and launches it. No toolchain required;
+it needs macOS 12 or newer on Apple Silicon.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/timtoole02/Camelid/main/scripts/get-desktop-macos.sh | bash
+```
+
+To update later, run the same command again; models and settings are preserved. If
+`/Applications` requires administrator access, macOS asks for your password through `sudo`.
+
+Prefer to install by hand? Download `camelid-desktop-macos-arm64.dmg` from the
+[latest release][latest-release] and drag **Camelid Desktop** into **Applications**. The app is
+ad-hoc signed and **not notarized**, so macOS quarantines a browser download and blocks the first
+launch: approve it under **System Settings → Privacy & Security → Open Anyway** (on macOS 12:
+**System Preferences → Security & Privacy → General**), or clear the
+quarantine once with `xattr -cr "/Applications/Camelid Desktop.app"`. The install command above
+avoids this entirely, because command-line downloads are not quarantined.
+
+To build and install from source instead — requires the Xcode Command Line Tools,
+[Rust](https://rustup.rs/), and Node.js 22 with npm:
 
 ```bash
 git clone https://github.com/timtoole02/Camelid.git
 cd Camelid
 ./scripts/install-macos-desktop.sh
 ```
-
-The install script builds the web UI and Metal-enabled engine, creates an ad-hoc-signed app,
-installs it as `/Applications/Camelid Desktop.app`, and launches it. If `/Applications` requires
-administrator access, macOS asks for your password through `sudo`. To update later, run
-`git pull` followed by `./scripts/install-macos-desktop.sh` again.
 
 Downloaded models live in
 `~/Library/Application Support/app.camelid.desktop/models` by default and are preserved when the
@@ -216,7 +228,7 @@ Every interface talks to the same local engine — pick whichever fits your work
 
 | Interface | How to start it | Best for |
 |---|---|---|
-| **Desktop app** | Windows installer, or `./scripts/install-macos-desktop.sh` on Apple Silicon | A native app with the engine bundled as a local sidecar |
+| **Desktop app** | Windows installer, or the one-command macOS installer in [Quick start](#quick-start) | A native app with the engine bundled as a local sidecar |
 | **Browser chat** | `camelid serve --model <gguf>` opens the web UI automatically | Everyday chatting in a familiar UI |
 | **Terminal UI** | `camelid chat` — full-screen; `--plain` for a line REPL over SSH | Working entirely in the shell |
 | **HTTP API** | OpenAI-style `/v1/*`, served alongside the UI on the same port | Wiring Camelid into your own apps |
@@ -375,7 +387,7 @@ Camelid ships for three platforms today.
 | Platform | Distribution | Acceleration |
 |---|---|---|
 | Windows x86_64 | Desktop installer, portable desktop ZIP, engine ZIP | Experimental CUDA on named exact rows and recorded NVIDIA configurations; CPU fallback |
-| macOS Apple Silicon | Source-installed desktop app (ad-hoc signed), engine archive (`.tar.gz`) | Metal and CPU |
+| macOS Apple Silicon | Desktop DMG (prebuilt, ad-hoc signed) or source-installed desktop app, engine archive (`.tar.gz`) | Metal and CPU |
 | Linux x86_64 | Engine archive (`.tar.gz`) | NVIDIA CUDA compiled in by default; CPU fallback |
 
 CUDA is compiled into the default build on Windows and x86_64 Linux. On Windows, the GPU path is

--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -73,13 +73,29 @@ state. Desktop does not claim a ready model or manufacture a model error on the 
 - **Windows:** Windows 10/11 with the **WebView2 runtime** (preinstalled on current Windows 10/11; the
   Tauri bundle ships the bootstrapper otherwise).
 - **macOS:** Apple Silicon running macOS 12 or newer. The current macOS desktop bundle is
-  ad-hoc signed for local/developer distribution and is not notarized.
+  ad-hoc signed and not notarized; it ships prebuilt as the release DMG (see
+  [macOS install](#macos-install)).
 - A bundled platform engine. The portable ZIP, Windows installer, and macOS app bundle
   include it automatically.
 
-## macOS command-line install
+## macOS install
 
-From the repository root on an Apple Silicon Mac:
+**Prebuilt (recommended).** On an Apple Silicon Mac, one command downloads the release DMG
+(`camelid-desktop-macos-arm64.dmg`, built by the additive `desktop-macos` release job), verifies
+its published SHA-256, installs `/Applications/Camelid Desktop.app`, and launches it — no
+toolchain required:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/timtoole02/Camelid/main/scripts/get-desktop-macos.sh | bash
+```
+
+The app is ad-hoc signed and not notarized, so a browser-downloaded DMG is quarantined and
+Gatekeeper blocks the first launch (approve under **System Settings → Privacy & Security** — on
+macOS 12, **System Preferences → Security & Privacy → General** — or
+`xattr -cr` the installed app). The script path avoids that: command-line downloads carry no
+quarantine attribute. Pass a tag to pin a version (`... | bash -s -- v0.4.5`).
+
+**From source.** From the repository root on an Apple Silicon Mac:
 
 ```sh
 ./scripts/install-macos-desktop.sh
@@ -88,11 +104,10 @@ From the repository root on an Apple Silicon Mac:
 This builds the frontend, release engine, app bundle, and DMG; closes an existing Camelid Desktop
 instance cleanly; installs the new app at `/Applications/Camelid Desktop.app`; verifies its
 ad-hoc signature; and launches it. The script uses `sudo` only when `/Applications` is not writable.
-Neither the default Application Support model directory nor a custom model directory is replaced.
-
 Prerequisites are macOS 12 or newer, the Xcode Command Line Tools, Rust, and Node.js 22 with npm.
-The app is not notarized yet, so this path is intended for local testing and developer
-distribution.
+
+Neither path replaces the default Application Support model directory or a custom model
+directory: installed models survive updates and reinstalls.
 
 ## Building (developers)
 
@@ -119,8 +134,8 @@ The server build is unaffected by this crate: `cargo build --release --locked --
 does not pull `camelid-desktop` into its graph (workspace `resolver = "2"`,
 `default-members = ["."]`).
 
-For a bundled installer + portable zip, see the additive `desktop-windows` job in
-`../.github/workflows/release.yml`.
+For the shipped bundles — Windows installer + portable zip, and the macOS DMG — see the
+additive `desktop-windows` and `desktop-macos` jobs in `../.github/workflows/release.yml`.
 
 ### Building the macOS app and DMG
 
@@ -133,7 +148,8 @@ On an Apple Silicon Mac:
 The script builds the real frontend, the release Metal-enabled `camelid` sidecar, and the
 Tauri `.app` and `.dmg`. It uses an ad-hoc signature (`-`), not a Developer ID signature,
 and performs no notarization. macOS may therefore require the user to approve the app in
-**System Settings → Privacy & Security** after downloading it.
+**System Settings → Privacy & Security** (on macOS 12, **System Preferences → Security &
+Privacy → General**) after downloading it.
 
 Downloaded models are stored under the app's per-user Application Support directory rather
 than inside the app bundle by default. The **Downloaded models** tab can save a different local

--- a/scripts/get-desktop-macos.sh
+++ b/scripts/get-desktop-macos.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# get-desktop-macos.sh — install the prebuilt Camelid Desktop app on an Apple
+# Silicon Mac with one command, no toolchain required:
+#
+#   curl -fsSL https://raw.githubusercontent.com/timtoole02/Camelid/main/scripts/get-desktop-macos.sh | bash
+#
+# Downloads the release DMG, verifies its published SHA-256, installs the app
+# bundle into /Applications, and launches it. Pass a tag to pin a version
+# (`... | bash -s -- v0.4.5`), or set CAMELID_DESKTOP_TAG. Model files under
+# the app's Application Support directory are never touched.
+#
+# Why a script instead of "download the DMG and double-click": the macOS app is
+# ad-hoc signed and not notarized, so a browser-downloaded copy is quarantined
+# and Gatekeeper blocks the first launch. Command-line downloads carry no
+# quarantine attribute, so this path installs an app that opens immediately.
+# To build from source instead, see scripts/install-macos-desktop.sh.
+set -euo pipefail
+
+repo="${CAMELID_REPO:-timtoole02/Camelid}"
+tag="${1:-${CAMELID_DESKTOP_TAG:-latest}}"
+asset="camelid-desktop-macos-arm64.dmg"
+app_name="Camelid Desktop.app"
+applications_dir="/Applications"
+installed_app="$applications_dir/$app_name"
+desktop_process="$installed_app/Contents/MacOS/camelid-desktop"
+sidecar_process="$installed_app/Contents/Resources/sidecar/camelid serve"
+
+if [ "$(uname -s)" != "Darwin" ] || [ "$(uname -m)" != "arm64" ]; then
+  echo "error: Camelid Desktop currently requires an Apple Silicon Mac" >&2
+  exit 1
+fi
+
+if [ "$tag" = "latest" ]; then
+  base_url="https://github.com/$repo/releases/latest/download"
+else
+  base_url="https://github.com/$repo/releases/download/$tag"
+fi
+
+work_dir="$(mktemp -d /tmp/camelid-desktop-get.XXXXXX)"
+mount_point="$work_dir/mount"
+
+# Freshly mounted images can stay transiently busy (Spotlight/XProtect scan new
+# volumes), so detach with retries — and never let an unmount hiccup fail an
+# install that already succeeded.
+is_mounted() {
+  [ -d "$mount_point" ] \
+    && [ "$(stat -f %d "$mount_point" 2>/dev/null)" != "$(stat -f %d "$work_dir" 2>/dev/null)" ]
+}
+detach_image() {
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    is_mounted || return 0
+    if hdiutil detach "$mount_point" -quiet 2>/dev/null; then return 0; fi
+    sleep 1
+  done
+  hdiutil detach "$mount_point" -force -quiet 2>/dev/null || true
+  ! is_mounted
+}
+cleanup() {
+  detach_image || true
+  # Never delete through a mount point that refused to detach.
+  if [[ "$work_dir" == /tmp/camelid-desktop-get.* ]] && ! is_mounted; then
+    rm -rf -- "$work_dir"
+  fi
+}
+trap cleanup EXIT
+
+echo "Downloading $asset ($tag) ..."
+if ! curl -fL --retry 3 --progress-bar -o "$work_dir/$asset" "$base_url/$asset"; then
+  echo "error: could not download $base_url/$asset" >&2
+  echo "The requested release may not include the macOS desktop app (the DMG first shipped" >&2
+  echo "after v0.4.4), or the network request failed. To build from source instead:" >&2
+  echo "  git clone https://github.com/$repo.git && cd ${repo##*/} && ./scripts/install-macos-desktop.sh" >&2
+  exit 1
+fi
+
+# The sidecar checksum names the asset file, so verification must run beside it.
+curl -fsSL -o "$work_dir/$asset.sha256" "$base_url/$asset.sha256"
+(cd "$work_dir" && shasum -a 256 -c "$asset.sha256")
+
+# Give a running app a chance to terminate its loopback sidecar cleanly before
+# the bundle is replaced (same shutdown handshake as install-macos-desktop.sh).
+osascript -e 'tell application "Camelid Desktop" to quit' 2>/dev/null || true
+for _ in {1..20}; do
+  if ! pgrep -f "$desktop_process" >/dev/null \
+    && ! pgrep -f "$sidecar_process" >/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+
+if pgrep -f "$desktop_process" >/dev/null || pgrep -f "$sidecar_process" >/dev/null; then
+  echo "error: Camelid Desktop did not exit cleanly; close it and run this script again" >&2
+  exit 1
+fi
+
+mkdir -p "$mount_point"
+hdiutil attach "$work_dir/$asset" -nobrowse -readonly -mountpoint "$mount_point" -quiet
+
+if [ ! -d "$mount_point/$app_name" ]; then
+  echo "error: the DMG does not contain $app_name" >&2
+  exit 1
+fi
+
+# Replace (not merge-over) any existing bundle so no stale files from an older
+# version survive inside the app. Model files live in Application Support, not
+# in the bundle, so they are unaffected.
+if [ -w "$applications_dir" ] && { [ ! -e "$installed_app" ] || [ -w "$installed_app" ]; }; then
+  rm -rf -- "$installed_app"
+  ditto --noextattr --noqtn "$mount_point/$app_name" "$installed_app"
+  xattr -cr "$installed_app"
+else
+  echo "Installing into $applications_dir requires administrator access."
+  sudo rm -rf -- "$installed_app"
+  sudo ditto --noextattr --noqtn "$mount_point/$app_name" "$installed_app"
+  sudo xattr -cr "$installed_app"
+fi
+
+detach_image \
+  || echo "note: the installer image at $mount_point is still busy; it will detach on its own" >&2
+codesign --verify --deep --strict "$installed_app"
+open "$installed_app"
+
+echo "Installed and launched $installed_app"


### PR DESCRIPTION
## What

Mac users currently have to clone the repo and build from source (Rust + Node + Xcode CLT) to get Camelid Desktop, while Windows users get a signed installer. This PR ships the macOS desktop app prebuilt and makes installing it one command.

- **`desktop-macos` release job** (additive, same independence contract as `desktop-windows`: in no job's `needs`, skippable via `skip_desktop`). Reuses `scripts/build-macos-desktop.sh` — the exact path a developer runs locally — then publishes the DMG under the stable asset name `camelid-desktop-macos-arm64.dmg` so `releases/latest/download/…` never changes between releases.
- **Verification opens the box that ships**: the published `.sha256` is round-tripped through the shared `parseChecksumFile`/`sha256File` parser plus a literal `shasum -c`, the DMG is mounted and the app copied out the way the installer copies it, `codesign --verify --deep --strict`, a closed-set assertion on the bundled sidecar payload, and a model-less boot of the bundled engine via the existing `smoke-release-artifact.mjs` (label `macos-arm64`, `--expect-version`).
- **`scripts/get-desktop-macos.sh`** — one-command installer: downloads the DMG, verifies the published SHA-256, cleanly quits a running instance, replaces `/Applications/Camelid Desktop.app`, and launches. Command-line downloads carry no quarantine attribute, so the ad-hoc-signed app opens without a Gatekeeper block. Supports tag pinning (`bash -s -- vX.Y.Z`), a graceful message when the requested release has no DMG, detach retries with a `-force` fallback, and never reports a completed install as a failure.
- **READMEs**: the one-liner is the primary macOS path; manual DMG and build-from-source paths retained; interfaces/platform tables and the desktop Requirements bullet updated to match; "Open Anyway" wording covers macOS 12's System Preferences naming.
- **ci.yml**: corrects the stale "crate is Windows-only" comment on the `desktop` job.

## Verified locally

- Full rehearsal of the CI job on this machine: fresh-worktree `build-macos-desktop.sh` → stable-name staging → `shasum -c` + shared-parser round-trip → mount → structural checks → ditto out → detach → codesign → sidecar boots, serves `/v1/health`, `/api/capabilities`, and the real embedded web UI.
- Installer 404 fallback and tag-pinned URL construction exercised live against the current release (no DMG yet — actionable message + exit 1, nothing touched).
- Mount/detach helpers functionally tested against the built DMG.
- All public-scrub / README contract gates pass locally.

The DMG first ships with the next tagged release; until then the installer prints the build-from-source fallback.