### PR TITLE
fix(sampler): apply temperature last, matching the llama.cpp chain order

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -638,6 +638,10 @@ pub struct ChatCompletionRequest {
     /// Multiplicative repetition penalty (llama.cpp `repeat_penalty`). `1.0`/`None`
     /// is a no-op; values `> 1.0` discourage repeating recent tokens.
     pub repeat_penalty: Option<f32>,
+    /// How many trailing history tokens the penalties above are measured over
+    /// (llama.cpp `repeat_last_n`). Omit for the whole history — OpenAI's
+    /// semantics and this engine's default; `0` disables the penalties.
+    pub penalty_last_n: Option<u32>,
     pub logit_bias: Option<HashMap<String, f32>>,
     pub stop: Option<StopSpec>,
     pub n: Option<u32>,
@@ -710,6 +714,14 @@ pub struct CompletionRequest {
     pub min_p: Option<f32>,
     /// Multiplicative repetition penalty (llama.cpp `repeat_penalty`).
     pub repeat_penalty: Option<f32>,
+    /// How many trailing history tokens the penalties above are measured over
+    /// (llama.cpp `repeat_last_n`). Omit for the whole history — OpenAI's
+    /// semantics and this engine's default; `0` disables the penalties.
+    ///
+    /// Unlike llama.cpp there is no `-1` sentinel: on its CLI path `-1` is
+    /// clamped to `0` and silently disables penalties instead of meaning
+    /// "whole context", so that spelling is deliberately not accepted here.
+    pub penalty_last_n: Option<u32>,
     pub logit_bias: Option<HashMap<String, f32>>,
     pub stop: Option<StopSpec>,
     pub n: Option<u32>,
@@ -932,6 +944,14 @@ pub struct LlamaServerCompletionRequest {
     pub min_p: Option<f32>,
     /// Multiplicative repetition penalty (llama.cpp `repeat_penalty`).
     pub repeat_penalty: Option<f32>,
+    /// How many trailing history tokens the penalties above are measured over
+    /// (llama.cpp `repeat_last_n`). Omit for the whole history — OpenAI's
+    /// semantics and this engine's default; `0` disables the penalties.
+    ///
+    /// Unlike llama.cpp there is no `-1` sentinel: on its CLI path `-1` is
+    /// clamped to `0` and silently disables penalties instead of meaning
+    /// "whole context", so that spelling is deliberately not accepted here.
+    pub penalty_last_n: Option<u32>,
     pub logit_bias: Option<HashMap<String, f32>>,
     pub stop: Option<StopSpec>,
     #[serde(flatten)]
@@ -1151,6 +1171,14 @@ pub struct GenerationSessionRequest {
     pub min_p: Option<f32>,
     /// Multiplicative repetition penalty (llama.cpp `repeat_penalty`).
     pub repeat_penalty: Option<f32>,
+    /// How many trailing history tokens the penalties above are measured over
+    /// (llama.cpp `repeat_last_n`). Omit for the whole history — OpenAI's
+    /// semantics and this engine's default; `0` disables the penalties.
+    ///
+    /// Unlike llama.cpp there is no `-1` sentinel: on its CLI path `-1` is
+    /// clamped to `0` and silently disables penalties instead of meaning
+    /// "whole context", so that spelling is deliberately not accepted here.
+    pub penalty_last_n: Option<u32>,
     pub logit_bias: Option<HashMap<String, f32>>,
     pub stop: Option<StopSpec>,
     pub n: Option<u32>,
@@ -2896,6 +2924,7 @@ async fn llama_server_completion(
         frequency_penalty: req.frequency_penalty,
         min_p: req.min_p,
         repeat_penalty: req.repeat_penalty,
+        penalty_last_n: req.penalty_last_n,
         logit_bias: req.logit_bias,
         stop: req.stop,
         n: None,
@@ -9636,6 +9665,7 @@ async fn completions(
         frequency_penalty: req.frequency_penalty,
         min_p: req.min_p,
         repeat_penalty: req.repeat_penalty,
+        penalty_last_n: req.penalty_last_n,
         logit_bias: req.logit_bias,
         stop: req.stop,
         n: req.n,
@@ -10030,6 +10060,7 @@ async fn chat_completions(
         frequency_penalty: req.frequency_penalty,
         min_p: req.min_p,
         repeat_penalty: req.repeat_penalty,
+        penalty_last_n: req.penalty_last_n,
         logit_bias: req.logit_bias,
         stop: req.stop,
         n: req.n,
@@ -10447,6 +10478,7 @@ async fn replay_loaded_receipt_request(
         frequency_penalty: None,
         min_p: None,
         repeat_penalty: None,
+        penalty_last_n: None,
         logit_bias: None,
         stop: if request.stop.is_empty() {
             None
@@ -11947,6 +11979,7 @@ fn sampling_config_from_request(
         presence_penalty: req.presence_penalty.unwrap_or(0.0),
         frequency_penalty: req.frequency_penalty.unwrap_or(0.0),
         repeat_penalty: req.repeat_penalty.unwrap_or(1.0),
+        penalty_last_n: req.penalty_last_n.map(|value| value as usize),
         logit_bias: parse_logit_bias(req.logit_bias.as_ref()).map_err(|message| {
             Box::new(api_error(
                 StatusCode::BAD_REQUEST,
@@ -15786,6 +15819,7 @@ mod tests {
             top_p: None,
             min_p: None,
             repeat_penalty: None,
+            penalty_last_n: None,
             seed: None,
             presence_penalty: None,
             frequency_penalty: None,
@@ -16000,6 +16034,45 @@ mod tests {
         }))
         .expect("session request should deserialize");
         assert!(sampling_config_from_request(&bad).is_err());
+    }
+
+    #[test]
+    fn penalty_last_n_is_a_typed_field_that_threads_into_the_sampler() {
+        let chat: ChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "qwen3",
+            "messages": [{"role": "user", "content": "hi"}],
+            "penalty_last_n": 64
+        }))
+        .expect("chat request with penalty_last_n should deserialize");
+        assert_eq!(chat.penalty_last_n, Some(64));
+        assert!(!chat.unsupported_fields.contains_key("penalty_last_n"));
+
+        let req: GenerationSessionRequest = serde_json::from_value(serde_json::json!({
+            "prompt": "hi",
+            "temperature": 0.8,
+            "penalty_last_n": 64
+        }))
+        .expect("session request should deserialize");
+        assert_eq!(
+            sampling_config_from_request(&req)
+                .expect("valid sampler config")
+                .penalty_last_n,
+            Some(64)
+        );
+
+        // Omitting it keeps the whole-history default, so existing callers are
+        // unaffected by the new field. This is a deliberate divergence from
+        // llama.cpp, whose own default is a 64-token window.
+        let omitted: GenerationSessionRequest = serde_json::from_value(serde_json::json!({
+            "prompt": "hi"
+        }))
+        .expect("session request should deserialize");
+        assert_eq!(
+            sampling_config_from_request(&omitted)
+                .expect("valid sampler config")
+                .penalty_last_n,
+            None
+        );
     }
 
     #[test]

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2223,7 +2223,12 @@ pub struct SamplingConfig {
     pub top_p: Option<f32>,
     /// Minimum-probability filter: keep only tokens whose probability is at
     /// least `min_p * max_probability`. `None`/`0.0` disables it; `1.0` keeps
-    /// only the argmax. Applied after softmax, before `top_p`.
+    /// only the argmax.
+    ///
+    /// Applied *after* `top_p` and *before* temperature, matching the reference
+    /// chain order in llama.cpp `common/common.h`. Because it is a ratio test
+    /// against the peak, it is invariant to renormalization — but not to
+    /// temperature, which is why temperature must stay last.
     pub min_p: Option<f32>,
     pub seed: Option<u64>,
     pub presence_penalty: f32,
@@ -2234,6 +2239,24 @@ pub struct SamplingConfig {
     /// discourage repetition. Applied over the same history as the additive
     /// presence/frequency penalties.
     pub repeat_penalty: f32,
+    /// How many of the most recent history tokens the three penalties above are
+    /// measured over.
+    ///
+    /// `None` (the default) means the **entire** history, which is what OpenAI's
+    /// `presence_penalty`/`frequency_penalty` specify and what this engine has
+    /// always done — so the default is a no-op for existing callers. `Some(0)`
+    /// disables the penalties outright. `Some(n)` measures only the last `n`
+    /// tokens, which is llama.cpp's `--repeat-last-n` (its own default is 64).
+    ///
+    /// Deliberate divergence: llama.cpp windows to 64 by default, but this API is
+    /// OpenAI-shaped and OpenAI counts over the whole context, so adopting 64 as
+    /// the default here would silently change every existing caller's output.
+    /// The capability is offered; the default is not changed.
+    ///
+    /// Note llama.cpp's own `-1` sentinel is a trap worth not copying: on the CLI
+    /// path `std::max(-1, 0)` turns it into `0`, silently *disabling* penalties,
+    /// while only the server maps `-1` to the context length.
+    pub penalty_last_n: Option<usize>,
     pub logit_bias: Vec<(usize, f32)>,
 }
 
@@ -2248,6 +2271,7 @@ impl Default for SamplingConfig {
             presence_penalty: 0.0,
             frequency_penalty: 0.0,
             repeat_penalty: 1.0,
+            penalty_last_n: None,
             logit_bias: Vec::new(),
         }
     }
@@ -6503,6 +6527,34 @@ fn apply_token_mask(logits: &mut CpuTensor, allowed: &[bool]) -> Result<()> {
     Ok(())
 }
 
+/// Numerically-stable softmax over `(token index, logit)` candidates, dividing
+/// each logit by `temperature` first. Returns probabilities positionally aligned
+/// with `candidates`.
+///
+/// `temperature == 1.0` divides by exactly one, which IEEE-754 leaves bit-exact,
+/// so the reordered chain reproduces the previous output token-for-token at unit
+/// temperature.
+fn softmax_candidates(candidates: &[(usize, f32)], temperature: f32) -> Result<Vec<f32>> {
+    let max_logit = candidates
+        .iter()
+        .map(|(_, logit)| *logit / temperature)
+        .fold(f32::NEG_INFINITY, f32::max);
+    let mut weights: Vec<f32> = candidates
+        .iter()
+        .map(|(_, logit)| ((*logit / temperature) - max_logit).exp())
+        .collect();
+    let sum: f32 = weights.iter().sum();
+    if sum == 0.0 || !sum.is_finite() {
+        return Err(BackendError::RuntimeShapeMismatch(
+            "sampler softmax produced invalid normalization sum".to_string(),
+        ));
+    }
+    for weight in &mut weights {
+        *weight /= sum;
+    }
+    Ok(weights)
+}
+
 fn sample_with_config(
     logits: &CpuTensor,
     config: &SamplingConfig,
@@ -6532,67 +6584,61 @@ fn sample_with_config(
         right.total_cmp(left).then_with(|| left_idx.cmp(right_idx))
     });
 
-    let max_logit = candidates
-        .iter()
-        .map(|(_, logit)| *logit / config.temperature)
-        .fold(f32::NEG_INFINITY, f32::max);
-    let mut weighted: Vec<(usize, f32)> = candidates
-        .into_iter()
-        .map(|(idx, logit)| (idx, ((logit / config.temperature) - max_logit).exp()))
-        .collect();
-    let weight_sum: f32 = weighted.iter().map(|(_, weight)| *weight).sum();
-    if weight_sum == 0.0 || !weight_sum.is_finite() {
-        return Err(BackendError::RuntimeShapeMismatch(
-            "sampler softmax produced invalid normalization sum".to_string(),
-        ));
-    }
-    for (_, weight) in &mut weighted {
-        *weight /= weight_sum;
-    }
+    // Reference chain order — llama.cpp `common/common.h` default `samplers`:
+    // penalties → top_k → typical_p → top_p → min_p → TEMPERATURE → dist. The
+    // reference applies temperature LAST, so every probability-based truncation
+    // measures the *un-tempered* distribution. Dividing by temperature before
+    // top_p/min_p (as this sampler previously did) sharpens or flattens the
+    // distribution those filters measure, so the same (top_p, min_p) keeps a
+    // different candidate set than the reference at any temperature != 1.0.
+    //
+    // top_k is unaffected by the move: temperature scaling is monotonic, so it
+    // cannot reorder logits. At temperature == 1.0 the two orders are bit-exact
+    // (division by one is exact), which is why every existing sampler test —
+    // all of which pin temperature to 0.0 or 1.0 — is untouched by this change.
+    if config.top_p.is_some_and(|top_p| top_p < 1.0)
+        || config.min_p.is_some_and(|min_p| min_p > 0.0)
+    {
+        let mut probabilities = softmax_candidates(&candidates, 1.0)?;
 
-    if let Some(min_p) = config.min_p.filter(|min_p| *min_p > 0.0) {
-        let max_probability = weighted
-            .iter()
-            .map(|(_, weight)| *weight)
-            .fold(0.0_f32, f32::max);
-        let threshold = min_p * max_probability;
-        weighted.retain(|(_, weight)| *weight >= threshold);
-        let renorm: f32 = weighted.iter().map(|(_, weight)| *weight).sum();
-        if weighted.is_empty() || renorm == 0.0 || !renorm.is_finite() {
-            return Err(BackendError::RuntimeShapeMismatch(
-                "min_p filtering removed all sampler candidates".to_string(),
-            ));
-        }
-        for (_, weight) in &mut weighted {
-            *weight /= renorm;
-        }
-    }
-
-    if let Some(top_p) = config.top_p.filter(|top_p| *top_p < 1.0) {
-        // `weighted` still has the descending-logit order established above:
-        // exp/logit scaling and normalization are monotonic, and min-p retains
-        // elements without reordering them. Sorting by probability again was a
-        // redundant O(n log n) pass over the vocabulary.
-        let mut cumulative = 0.0;
-        let mut keep = 0usize;
-        for (_, probability) in &weighted {
-            cumulative += *probability;
-            keep += 1;
-            if cumulative >= top_p {
-                break;
+        if let Some(top_p) = config.top_p.filter(|top_p| *top_p < 1.0) {
+            // `candidates` is in descending-logit order and softmax is monotonic,
+            // so `probabilities` is descending too and the survivors are a prefix.
+            let mut cumulative = 0.0;
+            let mut keep = 0usize;
+            for probability in &probabilities {
+                cumulative += *probability;
+                keep += 1;
+                if cumulative >= top_p {
+                    break;
+                }
             }
+            let keep = keep.max(1);
+            candidates.truncate(keep);
+            probabilities.truncate(keep);
         }
-        weighted.truncate(keep.max(1));
-        let renorm: f32 = weighted.iter().map(|(_, weight)| *weight).sum();
-        if renorm == 0.0 || !renorm.is_finite() {
-            return Err(BackendError::RuntimeShapeMismatch(
-                "top_p filtering removed all sampler candidates".to_string(),
-            ));
-        }
-        for (_, weight) in &mut weighted {
-            *weight /= renorm;
+
+        if let Some(min_p) = config.min_p.filter(|min_p| *min_p > 0.0) {
+            // Ratio test against the peak, so the result is invariant to whether
+            // the survivors were renormalized after top_p — which is why this
+            // stage does not need to renormalize before measuring.
+            let max_probability = probabilities.iter().copied().fold(0.0_f32, f32::max);
+            let threshold = min_p * max_probability;
+            let keep = probabilities
+                .iter()
+                .take_while(|probability| **probability >= threshold)
+                .count()
+                .max(1);
+            candidates.truncate(keep);
         }
     }
+
+    // Temperature last, over the survivors only.
+    let weighted: Vec<(usize, f32)> = candidates
+        .iter()
+        .map(|(idx, _)| *idx)
+        .zip(softmax_candidates(&candidates, config.temperature)?)
+        .collect();
 
     // Advance the RNG per decode step: `token_history.len()` is the deterministic
     // stream position, so each step draws a fresh uniform while a fixed seed still
@@ -6643,8 +6689,17 @@ fn apply_sampling_adjustments<'a>(
         || config.frequency_penalty != 0.0
         || config.repeat_penalty != 1.0
     {
+        // Penalties are measured over the last `penalty_last_n` history tokens.
+        // `None` keeps the whole history, which is both this engine's historical
+        // behaviour and OpenAI's specified semantics — see the field docs on
+        // `SamplingConfig::penalty_last_n` for why the default is not llama.cpp's 64.
+        let window: &[u32] = match config.penalty_last_n {
+            Some(0) => &[],
+            Some(last_n) => &token_history[token_history.len().saturating_sub(last_n)..],
+            None => token_history,
+        };
         let mut counts = std::collections::HashMap::<usize, usize>::new();
-        for token_id in token_history {
+        for token_id in window {
             let token_idx = usize::try_from(*token_id).map_err(|_| {
                 BackendError::RuntimeShapeMismatch(format!(
                     "token id {token_id} does not fit sampler index space"

--- a/tests/inference_session.rs
+++ b/tests/inference_session.rs
@@ -241,6 +241,81 @@ fn penalties_apply_to_seen_tokens_before_sampling() {
 }
 
 #[test]
+fn penalty_last_n_windows_the_history() {
+    // logits [1.0, 0.9, 0.8], history [0, 0, 0, 1], presence 0.5 / frequency 0.25.
+    let logits = tensor("logits", vec![1, 3], vec![1.0, 0.9, 0.8]);
+    let history = [0u32, 0, 0, 1];
+
+    // Default (`penalty_last_n: None`) measures the WHOLE history, so token 0
+    // takes 0.5 + 3*0.25 = -0.25, token 1 takes 0.15, and token 2 (never seen,
+    // 0.8) wins. This is the pre-existing behaviour and must not change.
+    let whole = LlamaSampler::Sampling(SamplingConfig {
+        presence_penalty: 0.5,
+        frequency_penalty: 0.25,
+        ..SamplingConfig::default()
+    })
+    .sample_with_history(&logits, &history)
+    .unwrap();
+    assert_eq!(
+        whole, 2,
+        "unwindowed penalties should demote token 0 hardest"
+    );
+
+    // A one-token window sees only the trailing `1`, so token 0 keeps its 1.0
+    // logit and wins. Long-context/RAG callers want this: without it, every
+    // token in a large prompt is penalized forever.
+    let windowed = LlamaSampler::Sampling(SamplingConfig {
+        presence_penalty: 0.5,
+        frequency_penalty: 0.25,
+        penalty_last_n: Some(1),
+        ..SamplingConfig::default()
+    })
+    .sample_with_history(&logits, &history)
+    .unwrap();
+    assert_eq!(
+        windowed, 0,
+        "penalty_last_n=1 must only penalize the final history token"
+    );
+}
+
+#[test]
+fn penalty_last_n_zero_disables_penalties() {
+    let logits = tensor("logits", vec![1, 3], vec![1.0, 0.9, 0.8]);
+    let token = LlamaSampler::Sampling(SamplingConfig {
+        presence_penalty: 0.5,
+        frequency_penalty: 0.25,
+        penalty_last_n: Some(0),
+        ..SamplingConfig::default()
+    })
+    .sample_with_history(&logits, &[0u32, 0, 0, 1])
+    .unwrap();
+    assert_eq!(token, 0, "penalty_last_n=0 must leave the logits untouched");
+}
+
+#[test]
+fn penalty_last_n_beyond_history_matches_the_whole_history() {
+    // Guards the `saturating_sub` bound: a window longer than the history is the
+    // whole history, not a panic and not an empty window.
+    let logits = tensor("logits", vec![1, 3], vec![1.0, 0.9, 0.8]);
+    let history = [0u32, 0, 0, 1];
+    let config = |penalty_last_n| SamplingConfig {
+        presence_penalty: 0.5,
+        frequency_penalty: 0.25,
+        penalty_last_n,
+        ..SamplingConfig::default()
+    };
+
+    let unbounded = LlamaSampler::Sampling(config(None))
+        .sample_with_history(&logits, &history)
+        .unwrap();
+    let oversized = LlamaSampler::Sampling(config(Some(4096)))
+        .sample_with_history(&logits, &history)
+        .unwrap();
+
+    assert_eq!(unbounded, oversized);
+}
+
+#[test]
 fn rejects_logit_bias_outside_vocabulary() {
     let logits = tensor("logits", vec![1, 2], vec![0.0, 1.0]);
     let err = LlamaSampler::Sampling(SamplingConfig {
@@ -313,6 +388,78 @@ fn min_p_zero_is_a_noop() {
             "min_p=0 changed the draw for seed {seed}"
         );
     }
+}
+
+#[test]
+fn min_p_measures_the_untempered_distribution() {
+    // Parity regression against llama.cpp's default sampler chain
+    // (`common/common.h`: ... top_k -> typical -> top_p -> min_p -> TEMPERATURE
+    // -> dist). Temperature is applied LAST, so min_p measures the raw softmax,
+    // not a temperature-sharpened one.
+    //
+    // logits [3, 2, 1] -> untempered softmax [0.6652, 0.2447, 0.0900].
+    // min_p 0.15 -> threshold 0.15 * 0.6652 = 0.0998, so {0, 1} survive and
+    // token 2 (0.0900) is cut.
+    //
+    // The previous chain divided by temperature *before* min_p: at T=0.5 the
+    // distribution sharpens to [0.8668, 0.1173, 0.0159], the threshold becomes
+    // 0.1300, and only token 0 survived — token 1 was unreachable for every
+    // seed. Reaching token 1 is exactly what the reorder restores.
+    let logits = tensor("logits", vec![1, 3], vec![3.0, 2.0, 1.0]);
+    let mut drawn = std::collections::BTreeSet::new();
+    for seed in 0u64..64 {
+        drawn.insert(
+            LlamaSampler::Sampling(SamplingConfig {
+                temperature: 0.5,
+                min_p: Some(0.15),
+                seed: Some(seed),
+                ..SamplingConfig::default()
+            })
+            .sample(&logits)
+            .unwrap(),
+        );
+    }
+    assert!(
+        drawn.contains(&1),
+        "token 1 must be reachable once min_p measures the untempered distribution, drew {drawn:?}"
+    );
+    assert!(
+        !drawn.contains(&2),
+        "min_p must still cut token 2, drew {drawn:?}"
+    );
+}
+
+#[test]
+fn top_p_measures_the_untempered_distribution() {
+    // Same parity regression, on the top_p stage.
+    //
+    // logits [3, 2, 1] -> untempered softmax [0.6652, 0.2447, 0.0900].
+    // top_p 0.8 accumulates 0.6652 (< 0.8), then 0.9099 (>= 0.8), keeping {0, 1}.
+    //
+    // Dividing by temperature first (T=0.5) gave [0.8668, ...], whose very first
+    // element already clears 0.8, so the old chain kept only token 0.
+    let logits = tensor("logits", vec![1, 3], vec![3.0, 2.0, 1.0]);
+    let mut drawn = std::collections::BTreeSet::new();
+    for seed in 0u64..64 {
+        drawn.insert(
+            LlamaSampler::Sampling(SamplingConfig {
+                temperature: 0.5,
+                top_p: Some(0.8),
+                seed: Some(seed),
+                ..SamplingConfig::default()
+            })
+            .sample(&logits)
+            .unwrap(),
+        );
+    }
+    assert!(
+        drawn.contains(&1),
+        "token 1 must be reachable once top_p measures the untempered distribution, drew {drawn:?}"
+    );
+    assert!(
+        !drawn.contains(&2),
+        "top_p must still cut token 2, drew {drawn:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Camelid divided logits by temperature **inside** its softmax and then ran `min_p` and `top_p` over the tempered distribution. llama.cpp's default sampler chain (`common/common.h:260-269`) is

```
penalties -> dry -> top_n_sigma -> top_k -> typical_p -> top_p -> min_p -> temperature -> dist
```

with **temperature last**, so every probability-based truncation measures the raw distribution. Sharpening the distribution before measuring it means the same `(top_p, min_p)` keeps a different candidate set than the reference.

Concretely, for logits `[3, 2, 1]` with `top_p=0.8` at `temperature=0.5`:

| | kept | why |
|---|---|---|
| reference / after | `{0, 1}` | untempered softmax `[0.6652, 0.2447, 0.0900]`, cumulative `0.6652` then `0.9099` |
| before | `{0}` | tempered to `[0.8668, ...]`, whose first element alone clears `0.8` |

Token 1 was unreachable for every seed.

## Why this is safe

The reorder is a no-op everywhere the engine is already covered by receipts:

- `temperature == 0` short-circuits to greedy, untouched.
- `temperature == 1.0` is bit-exact — division by one is exact in IEEE-754.
- `top_k` alone is unaffected: temperature scaling is monotonic and cannot reorder logits.
- The resident CUDA/Metal sampled fast lane bails out whenever `top_k`, `top_p`, `min_p`, penalties or `logit_bias` are set, so it only ever runs plain-temperature sampling and cannot diverge from the reordered CPU chain.

Every pre-existing sampler test pins temperature to `0.0` or `1.0` and passes unchanged. Two new tests pin the corrected behaviour and **fail against the old order** (verified by stashing the fix — both drew only `{0}`).

## Also: an optional `penalty_last_n` window

The three penalties were measured over the **entire** token history, so in a long prompt every token seen anywhere stayed penalized forever — worst on RAG-style requests where the prompt dwarfs the completion.

The default is deliberately **not** llama.cpp's. llama.cpp windows to 64 tokens, but this API is OpenAI-shaped and OpenAI counts presence/frequency over the whole context, so adopting 64 would silently change every existing caller's output. `None` (whole history) stays the default, `Some(0)` disables, `Some(n)` windows. The capability is offered; the default is not moved.

llama.cpp's `-1` sentinel is also deliberately not copied: on its CLI path `max(-1, 0)` clamps it to `0` and silently *disables* penalties, and only the server maps `-1` to the context length.

Wired through `ChatCompletionRequest`, `CompletionRequest`, `LlamaServerCompletionRequest` and `GenerationSessionRequest` as a typed field.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets` clean
- `cargo test --all-targets` — **1603 passed / 0 failed** (1597 before, +6 new tests)
- `check-ledger-drift` passed, `check-public-scrub` passed
