### PR TITLE
fix(smollm3): implement the NoPE layer schedule, and stop mis-roping every layer

### DIFF
--- a/BACKEND_ASKS.md
+++ b/BACKEND_ASKS.md
@@ -73,3 +73,38 @@ runnable lane (`RUNNABLE_LANE_SPEC.md`). Each entry: what's needed, why, blockin
   `COVERED_ARCHITECTURES`) keys off `{llama, qwen2, qwen3, gemma2, gemma3, phi3}`,
   intentionally independent of `model.rs`'s optimized-lane allowlist. Revisit only if
   a model the supported lane handles (e.g. mistral) must also run runnable.
+
+## RA-5 — `smollm3` is a NoPE architecture — **IMPLEMENTED (CPU), EVIDENCE OWED**
+- **What:** `smollm3` sat in the optimized-lane allowlist (`src/model.rs`
+  `is_implemented_architecture` / `from_gguf`) while the engine applied RoPE to every
+  layer. llama.cpp hardcodes `n_no_rope_layer_step = 4` (`src/models/smollm3.cpp:5` —
+  there is **no GGUF key** for it, so it cannot be read from the file) and its graph at
+  `:69` skips `ggml_rope_ext` on **both Q and K** whenever `(il + 1) % 4 == 0`. Because
+  SmolLM3 is llama-shaped it bound cleanly and then mis-roped: **silently wrong output
+  under a claimed-implemented architecture**, not a clean refusal. For a 36-layer
+  SmolLM3-3B the affected layers are 3, 7, 11, 15, 19, 23, 27, 31, 35 — 9 of 36,
+  including the final layer.
+- **Fixed:** `LlamaModelConfig::no_rope_layer_step` + `layer_uses_rope`, applied at both
+  CPU RoPE call sites (single-token decode and batched prefill). The resident GPU
+  engines **fail closed** to CPU for NoPE models (`resident_decode_eligible`): they
+  build one cos/sin table per forward and rope every layer unconditionally, so they
+  cannot express the skip and would diverge from the CPU path.
+- **Audit:** the other nine admitted architectures were each checked against their
+  llama.cpp graph builder and rope unconditionally (`models/llama.cpp:146,152`,
+  `qwen2.cpp:86,92`, `qwen3.cpp:91,100`, `phi3.cpp:107,113`, `mistral3.cpp:137,143`).
+  `gemma3`/`gemma4`/`qwen35` carry per-layer rope **bases**, not skips, and those are
+  modelled elsewhere. `smollm3` was the only silent-wrong-output case.
+- **OWED:** no SmolLM3 GGUF exists on the dev host, so there is **no greedy-parity
+  receipt** against the pinned llama.cpp. The tests prove the layer-skip logic and its
+  wiring into both CPU forward paths, and nothing more. Specifically unproven:
+  end-to-end token identity on real weights, tokenizer/chat-template fidelity, the
+  interaction of NoPE layers with SmolLM3's long-context rope scaling, and every GPU
+  lane (deliberately refused). **No ledger row claims `smollm3`, and none should be
+  added until a receipt exists.**
+- **Follow-ups found during the same audit (NOT fixed here):** (a) `gemma3` is accepted
+  by the dense `from_gguf` path but its per-layer dual rope base is only modelled in the
+  runnable lane (`src/runnable/model.rs`), so a gemma3 file reaching the dense path
+  would use one base for all layers; (b) `lfm2` is claimed implemented but its recurrent
+  layers carry `shortconv.in_proj/out_proj` and no `attn_q/k/v`, so the dense binding
+  fails to bind — a load-time error rather than silent wrongness, but still a claim
+  with no path that can run it.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19931,6 +19931,7 @@ mod tests {
             vocab_size: Some(3),
             file_type: Some(0),
             rope_neox_pairing: false,
+            no_rope_layer_step: None,
             attention_key_length: None,
             logit_scale: None,
             moe: None,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2640,6 +2640,19 @@ impl LlamaInferenceSession {
         if self.resident_paths_disabled {
             bail!("resident paths disabled for this session (CPU-authoritative KV required)");
         }
+        // NoPE architectures (smollm3) must stay on the CPU reference path. The
+        // resident engines build ONE cos/sin table for the whole forward and rope
+        // every layer unconditionally (cuda_resident launch_rope / launch_rope_batched,
+        // and the Metal equivalents), so they cannot express a per-layer skip — a
+        // NoPE model on a resident lane would silently produce different, wrong
+        // tokens from the fixed CPU path. Checked before the backend-enabled gate
+        // because this is a property of the model, not of the available backends.
+        if self.config.no_rope_layer_step.is_some() {
+            bail!(
+                "NoPE architecture (per-layer RoPE skip): the resident GPU engines rope every \
+                 layer from a single cos/sin table and cannot express the skip; CPU reference"
+            );
+        }
         // GPU-runnable tier: an uncurated model is admitted to the resident path only after
         // it passes the one-time parity self-check. A recorded FAIL forbids the resident
         // path here — the single choke point — so no `set_resident_paths_disabled` site can
@@ -7021,20 +7034,34 @@ fn forward_layer_timed(
     };
     let q_before_rope = q;
     let k_before_rope = k;
-    let q = apply_rope(
-        &q_before_rope,
-        kv_cache.position,
-        config.attention_head_count as usize,
-        config,
-        rope_freqs,
-        config
-            .mla
-            .as_ref()
-            .map_or(0, |mla| mla.nope_head_dim as usize),
-        &cached_layer_label!(layer_idx, "attention_q_rope"),
-    )?;
-    let k = if config.mla.is_some() {
-        // k is already RoPE'd and in the exact cached layout (1 head of [c_kv, k_pe])
+    // NoPE layers (smollm3): llama.cpp `models/smollm3.cpp:69` skips ggml_rope_ext
+    // on BOTH Q and K when `(il + 1) % n_no_rope_layer_step == 0`. The un-roped K
+    // is what goes into the cache, exactly as in the reference graph.
+    //
+    // The `.clone()` on the skip branch is required, not incidental: the scratch
+    // pool below recycles `q_before_rope`/`k_before_rope` alongside `q`/`k`, so
+    // the two must be distinct buffers. This is the same shape the MLA branch
+    // already uses.
+    let layer_ropes = config.layer_uses_rope(layer_idx);
+    let q = if layer_ropes {
+        apply_rope(
+            &q_before_rope,
+            kv_cache.position,
+            config.attention_head_count as usize,
+            config,
+            rope_freqs,
+            config
+                .mla
+                .as_ref()
+                .map_or(0, |mla| mla.nope_head_dim as usize),
+            &cached_layer_label!(layer_idx, "attention_q_rope"),
+        )?
+    } else {
+        q_before_rope.clone()
+    };
+    let k = if config.mla.is_some() || !layer_ropes {
+        // MLA: k is already RoPE'd and in the exact cached layout (1 head of
+        // [c_kv, k_pe]). NoPE layer: k is carried through un-roped.
         k_before_rope.clone()
     } else {
         apply_rope(
@@ -7050,12 +7077,19 @@ fn forward_layer_timed(
     let attention_q_rope_stats = collect_diagnostics
         .then(|| LlamaTensorStats::from_tensor(&q))
         .transpose()?;
+    // On a NoPE layer the expected rotation is the IDENTITY, so the reconstruction
+    // is taken at position 0 (angle 0 => cos 1, sin 0). A zero delta then positively
+    // asserts "this layer correctly applied no rotation", instead of reporting a
+    // spurious divergence against a rotation that was deliberately skipped.
+    // The diagnostic is still produced either way: the consumer field is not
+    // optional (see the `.expect` on attention_q_rope_reconstruction).
+    let rope_diagnostic_position = if layer_ropes { kv_cache.position } else { 0 };
     let attention_q_rope_diagnostic = collect_diagnostics
         .then(|| {
             rope_diagnostics(
                 &q_before_rope,
                 &q,
-                kv_cache.position,
+                rope_diagnostic_position,
                 config.attention_head_count as usize,
                 config,
                 rope_freqs,
@@ -7071,7 +7105,7 @@ fn forward_layer_timed(
             rope_diagnostics(
                 &k_before_rope,
                 &k,
-                kv_cache.position,
+                rope_diagnostic_position,
                 config.attention_head_count_kv as usize,
                 config,
                 rope_freqs,
@@ -7630,24 +7664,36 @@ fn forward_prefill_layer_chunk_timed(
         )?,
         None => k,
     };
-    let q = apply_rope_batch(
-        &q,
-        params.base_position,
-        config.attention_head_count as usize,
-        config,
-        params.rope_freqs,
-        0,
-        cached_layer_label!(layer_idx, "prefill_attention_q_rope"),
-    )?;
-    let k = apply_rope_batch(
-        &k,
-        params.base_position,
-        config.attention_head_count_kv as usize,
-        config,
-        params.rope_freqs,
-        0,
-        cached_layer_label!(layer_idx, "prefill_attention_k_rope"),
-    )?;
+    // NoPE layers (smollm3): same predicate as the single-token decode path in
+    // `forward_layer_timed`, applied to the batched prefill. Both paths must agree
+    // or the KV written during prefill would not match what decode expects.
+    let layer_ropes = config.layer_uses_rope(layer_idx);
+    let q = if layer_ropes {
+        apply_rope_batch(
+            &q,
+            params.base_position,
+            config.attention_head_count as usize,
+            config,
+            params.rope_freqs,
+            0,
+            cached_layer_label!(layer_idx, "prefill_attention_q_rope"),
+        )?
+    } else {
+        q
+    };
+    let k = if layer_ropes {
+        apply_rope_batch(
+            &k,
+            params.base_position,
+            config.attention_head_count_kv as usize,
+            config,
+            params.rope_freqs,
+            0,
+            cached_layer_label!(layer_idx, "prefill_attention_k_rope"),
+        )?
+    } else {
+        k
+    };
     timings.attention_rope = started.elapsed().as_micros();
     if let Some(memory) = &mut memory {
         memory.record_after_attention_rope(capture_memory_sample(kv_cache));

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -1424,6 +1424,7 @@ fn prefill_layer_major_scoped_q8_cache_reuses_file_reads_across_chunks() {
         vocab_size: Some(2),
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -1534,6 +1535,7 @@ fn tiny_kv_budget_session(context_length: u32) -> (LlamaInferenceSession, tempfi
         vocab_size: Some(2),
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -1589,6 +1591,35 @@ fn tiny_kv_budget_session(context_length: u32) -> (LlamaInferenceSession, tempfi
     };
     let session = LlamaInferenceSession::new(config, weights).unwrap();
     (session, temp_file)
+}
+
+/// A NoPE model must never reach the resident GPU engines. They build ONE cos/sin
+/// table for the whole forward and rope every layer unconditionally
+/// (`cuda_resident` launch_rope / launch_rope_batched and the Metal equivalents),
+/// so they cannot express the per-layer skip — a smollm3 file on a CUDA build
+/// would silently produce different, wrong tokens from the fixed CPU path.
+///
+/// The gate is checked before the backend-enabled test, so this holds on a
+/// CPU-only host too. Note that on a host where the resident path is not eligible
+/// for some *other* reason this assertion is satisfied but not causal; the
+/// ordering of the check in `resident_decode_eligible` is what makes it load-bearing.
+#[test]
+fn nope_config_disqualifies_the_resident_gpu_path() {
+    let (mut session, _temp) = tiny_kv_budget_session(64);
+
+    session.config.no_rope_layer_step = Some(4);
+    assert!(
+        !session
+            .resident_decode_eligible(false)
+            .expect("eligibility check should not error"),
+        "a NoPE config must be refused by the resident GPU gate"
+    );
+    assert!(
+        !session
+            .resident_decode_eligible(true)
+            .expect("eligibility check should not error"),
+        "a NoPE config must be refused for the want-logits path too"
+    );
 }
 
 /// End-to-end proof that the KV predict-and-abort budget guard fires through the
@@ -8601,6 +8632,7 @@ fn applies_rope_to_each_attention_head() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -8644,6 +8676,7 @@ fn apply_rope_uses_configured_frequency_base() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -8697,6 +8730,7 @@ fn apply_rope_uses_llama3_frequency_scaling_metadata() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -8754,6 +8788,7 @@ fn apply_rope_uses_gguf_rope_frequency_factors() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -8818,6 +8853,7 @@ fn rope_diagnostics_reconstruct_reported_rotation() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -8887,6 +8923,7 @@ fn split_half_rope_pairing_is_available_for_diagnostics() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -8970,6 +9007,7 @@ fn inverse_rope_direction_is_available_for_diagnostics() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -9052,6 +9090,7 @@ fn one_based_rope_position_mode_is_available_for_diagnostics() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -10670,6 +10709,7 @@ fn single_token_forward_diagnostics_follow_llama_stage_order() {
         vocab_size: Some(3),
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -10960,6 +11000,7 @@ fn chunked_prefill_matches_sequential_prefill_outputs_and_cache() {
         vocab_size: Some(4),
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -11190,6 +11231,7 @@ fn prefill_layer_rejects_misaligned_kv_cache_cursor() {
         vocab_size: Some(4),
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -11304,6 +11346,7 @@ fn batch_attention_rejects_reads_beyond_allocated_kv_cache() {
         vocab_size: Some(4),
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -11457,6 +11500,7 @@ fn zero_prefill_chunk_env_falls_back_without_panicking() {
         vocab_size: Some(4),
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,
@@ -12342,6 +12386,7 @@ fn resident_prefill_rope_tables_match_per_position_builder() {
         vocab_size: None,
         file_type: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4475,6 +4475,7 @@ fn known_arch_config(arch: &str) -> anyhow::Result<LlamaModelConfig> {
         file_type: Some(7), // Q8_0
         attention_key_length: None,
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         moe: None,
         gemma4: None,
         qwen35: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -41,6 +41,25 @@ pub struct LlamaModelConfig {
     /// against llama.cpp); `false` for llama/mistral/etc. The env override
     /// `CAMELID_ROPE_PAIRING` still takes precedence for diagnostics.
     pub rope_neox_pairing: bool,
+    /// NoPE (no-positional-encoding) layer step. When `Some(step)` with `step > 0`,
+    /// decoder layer `il` (0-based) SKIPS RoPE on BOTH Q and K whenever
+    /// `(il + 1) % step == 0`; every other layer ropes normally. `None` means every
+    /// layer is roped, which is the case for every admitted architecture except
+    /// `smollm3` (each verified against its llama.cpp graph builder).
+    ///
+    /// Hardcoded per architecture because llama.cpp hardcodes it too:
+    /// `hparams.n_no_rope_layer_step` has NO GGUF key backing it — llama.cpp
+    /// `src/models/smollm3.cpp:5` assigns the literal `4` in `load_arch_hparams`,
+    /// `src/llama-hparams.h:203` is only the struct default, and
+    /// `tests/test-llama-archs.cpp:93` records it as "hard-coded to 4". There is no
+    /// `LLM_KV_*` enum and no writer, so it cannot be inferred from the file.
+    ///
+    /// (HuggingFace's `SmolLM3Config` does carry a `no_rope_layers` array, but
+    /// llama.cpp ignores it. The parity target here is llama.cpp, so hardcoding 4
+    /// is the only parity-faithful choice — disclosed rather than hidden.)
+    ///
+    /// See [`LlamaModelConfig::layer_uses_rope`].
+    pub no_rope_layer_step: Option<u32>,
     /// Logit scale — applied before softmax, commonly in Command R models.
     pub logit_scale: Option<f32>,
     pub moe: Option<MixtralMoeMetadata>,
@@ -64,6 +83,23 @@ pub struct LlamaModelConfig {
 /// two against drift). It is a pure architecture-string check for classification
 /// (e.g. labeling a loaded model's lane); it makes NO support/parity claim — an
 /// implemented architecture is only *attemptable*, never automatically supported.
+///
+/// NOTE on `smollm3`: it is a **NoPE** architecture — every 4th layer (0-based
+/// `il` with `(il + 1) % 4 == 0`) skips RoPE on Q and K, per llama.cpp
+/// `src/models/smollm3.cpp:5,69`. Before that schedule was implemented this
+/// function claimed `smollm3` while the engine roped every layer, which is
+/// silently wrong output rather than a clean refusal. The skip now matches the
+/// reference graph on the **CPU path only**; the resident GPU engines fail closed
+/// to CPU for NoPE models (see `resident_decode_eligible`).
+///
+/// EVIDENCE OWED: no SmolLM3 GGUF has been run against the pinned llama.cpp
+/// reference, so there is no greedy-parity receipt. Unproven specifically:
+/// end-to-end token identity on real weights, tokenizer/chat-template fidelity,
+/// the interaction of NoPE layers with SmolLM3's long-context rope scaling, and
+/// every GPU lane (deliberately refused). The correct claim today is "smollm3 is
+/// attemptable and its NoPE schedule matches the reference graph" — NOT that
+/// smollm3 is supported. No ledger row claims it, and none should be added until
+/// a receipt exists.
 pub fn is_implemented_architecture(architecture: &str) -> bool {
     matches!(
         architecture,
@@ -81,6 +117,28 @@ pub fn is_implemented_architecture(architecture: &str) -> bool {
 }
 
 impl LlamaModelConfig {
+    /// True when decoder layer `layer_idx` (0-based) applies RoPE to Q and K.
+    ///
+    /// Verbatim llama.cpp `src/models/smollm3.cpp:69`:
+    /// `use_rope = (il + 1) % n_no_rope_layer_step != 0`.
+    ///
+    /// The `(il + 1)` is load-bearing and NOT interchangeable with `il % step`:
+    /// llama.cpp uses the `il % step` convention elsewhere
+    /// (`src/models/smallthinker.cpp:109`), and the two disagree on which layers
+    /// are skipped. For a 36-layer SmolLM3-3B this formula skips layers
+    /// 3, 7, 11, 15, 19, 23, 27, 31, 35 — including the final layer.
+    ///
+    /// A step of 0 is treated as "rope every layer", mirroring the `step > 0 &&`
+    /// guard in llama.cpp `src/models/afmoe.cpp:137` and keeping the modulo total.
+    pub fn layer_uses_rope(&self, layer_idx: usize) -> bool {
+        match self.no_rope_layer_step {
+            // `!x.is_multiple_of(step)` is exactly `x % step != 0`; spelled this
+            // way because clippy rejects the manual modulo under `-D warnings`.
+            Some(step) if step > 0 => !(layer_idx + 1).is_multiple_of(step as usize),
+            _ => true,
+        }
+    }
+
     pub fn from_gguf(gguf: &GgufFile) -> Result<Self> {
         let architecture = match gguf.architecture() {
             Some(
@@ -234,6 +292,7 @@ impl LlamaModelConfig {
             // with partial RoPE over the first `rope.dimension_count` (64) of the
             // 256-wide head — handled in the runnable qwen35 path.
             rope_neox_pairing: arch_uses_neox_rope_pairing(architecture),
+            no_rope_layer_step: arch_no_rope_layer_step(architecture),
             logit_scale: gguf.metadata_f32(&architecture_key(architecture, "logit_scale")),
             moe,
             gemma4,
@@ -752,6 +811,27 @@ impl Qwen35Metadata {
 /// conversions). Pure so the gate is unit-testable.
 fn arch_uses_neox_rope_pairing(architecture: &str) -> bool {
     matches!(architecture, "qwen2" | "qwen3" | "qwen35" | "phi3")
+}
+
+/// NoPE layer step per architecture.
+///
+/// `smollm3` is the only NoPE architecture in the admitted set: llama.cpp
+/// `src/models/smollm3.cpp:5` sets `n_no_rope_layer_step = 4` and its graph at
+/// `:69` gates both `ggml_rope_ext` calls on `(il + 1) % step != 0`.
+///
+/// Every other admitted architecture ropes unconditionally — verified against
+/// llama.cpp `models/llama.cpp:146,152`, `qwen2.cpp:86,92`, `qwen3.cpp:91,100`,
+/// `phi3.cpp:107,113` and `mistral3.cpp:137,143`. `gemma3`/`gemma4`/`qwen35`
+/// carry per-layer rope *bases* or schedules rather than skips, and those are
+/// modelled elsewhere (`Gemma4Metadata`, `Qwen35Metadata`,
+/// `runnable::model::layer_rope_base`), not here.
+///
+/// Pure so the gate is unit-testable without a model file.
+fn arch_no_rope_layer_step(architecture: &str) -> Option<u32> {
+    match architecture {
+        "smollm3" => Some(4),
+        _ => None,
+    }
 }
 
 fn architecture_key(architecture: &str, suffix: &str) -> String {
@@ -2043,6 +2123,29 @@ mod tests {
         assert!(!super::arch_uses_neox_rope_pairing("mistral"));
         assert!(!super::arch_uses_neox_rope_pairing("gemma3"));
         assert!(!super::arch_uses_neox_rope_pairing("gemma4"));
+    }
+
+    #[test]
+    fn no_rope_layer_step_covers_exactly_smollm3() {
+        // smollm3 is the ONLY NoPE architecture in the admitted set. llama.cpp
+        // `src/models/smollm3.cpp:5` hardcodes n_no_rope_layer_step = 4 (there is
+        // no GGUF key for it) and `:69` skips rotary on both Q and K when
+        // (il + 1) % 4 == 0.
+        assert_eq!(super::arch_no_rope_layer_step("smollm3"), Some(4));
+
+        // Every other admitted architecture ropes unconditionally, verified
+        // against its llama.cpp graph builder: models/llama.cpp:146,152 ·
+        // qwen2.cpp:86,92 · qwen3.cpp:91,100 · phi3.cpp:107,113 ·
+        // mistral3.cpp:137,143. gemma3/gemma4/qwen35 carry per-layer rope BASES
+        // or schedules — not skips — and those live in their own metadata.
+        for arch in [
+            "llama", "mistral", "qwen2", "qwen3", "qwen35", "gemma3", "gemma4", "phi3", "lfm2",
+        ] {
+            assert!(
+                super::arch_no_rope_layer_step(arch).is_none(),
+                "{arch} must not be treated as a NoPE architecture"
+            );
+        }
     }
 
     #[test]

--- a/src/model_source.rs
+++ b/src/model_source.rs
@@ -123,6 +123,7 @@ impl HfLlamaConfigSummary {
             // it MUST be revisited together with tensor orientation before
             // generation is enabled for a SafeTensors source.
             rope_neox_pairing: false,
+            no_rope_layer_step: None,
             logit_scale: None,
             moe: None,
             gemma4: None,

--- a/tests/inference_session.rs
+++ b/tests/inference_session.rs
@@ -542,6 +542,175 @@ fn rejects_attention_head_configuration_that_cannot_share_kv_heads() {
     assert!(err.contains("kv head count 3"));
 }
 
+#[test]
+fn smollm3_nope_layers_are_every_fourth_zero_based() {
+    // llama.cpp models/smollm3.cpp:69 — use_rope = (il + 1) % 4 != 0, il 0-based.
+    // For the 36-layer SmolLM3-3B (smollm3.cpp:7-10 maps case 36 => LLM_TYPE_3B)
+    // that skips 9 of 36 layers, INCLUDING the final one.
+    let config = LlamaModelConfig {
+        block_count: 36,
+        no_rope_layer_step: Some(4),
+        ..tiny_config()
+    };
+
+    let skipped: Vec<usize> = (0..36).filter(|i| !config.layer_uses_rope(*i)).collect();
+    assert_eq!(skipped, vec![3, 7, 11, 15, 19, 23, 27, 31, 35]);
+    assert_eq!((0..36).filter(|i| config.layer_uses_rope(*i)).count(), 27);
+
+    // Layer 35 is the case an off-by-one silently gets wrong.
+    assert!(!config.layer_uses_rope(35));
+    assert!(config.layer_uses_rope(0));
+}
+
+#[test]
+fn layer_uses_rope_matches_the_reference_formula() {
+    // Proves the predicate is the reference formula across steps, not something
+    // tuned to reproduce step 4.
+    for step in [1u32, 2, 3, 4, 5, 8] {
+        let config = LlamaModelConfig {
+            no_rope_layer_step: Some(step),
+            ..tiny_config()
+        };
+        for il in 0..24usize {
+            assert_eq!(
+                config.layer_uses_rope(il),
+                (il + 1) % (step as usize) != 0,
+                "step {step} layer {il}"
+            );
+        }
+    }
+
+    // None and Some(0) both mean "rope every layer"; Some(0) defensively, so the
+    // modulo stays total (mirrors the `step > 0 &&` guard in llama.cpp
+    // models/afmoe.cpp:137).
+    for step in [None, Some(0)] {
+        let config = LlamaModelConfig {
+            no_rope_layer_step: step,
+            ..tiny_config()
+        };
+        assert!(
+            (0..24).all(|il| config.layer_uses_rope(il)),
+            "step {step:?} must rope every layer"
+        );
+    }
+}
+
+#[test]
+fn nope_layer_is_identity_at_position_zero() {
+    // At position 0 the rotation angle is 0 (cos=1, sin=0), so RoPE is the
+    // identity and skipping it must give bit-identical logits. This proves the
+    // skip branch does not corrupt the tensor, its shape, or the decode scratch
+    // pool recycle that reuses q_before_rope/k_before_rope.
+    let mut roped = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
+    let mut nope = LlamaInferenceSession::new(
+        LlamaModelConfig {
+            // (0 + 1) % 1 == 0, so the single layer 0 is NoPE.
+            no_rope_layer_step: Some(1),
+            ..tiny_config()
+        },
+        tiny_weights(),
+    )
+    .unwrap();
+
+    let roped_out = roped.forward_single_token(1).unwrap();
+    let nope_out = nope.forward_single_token(1).unwrap();
+
+    assert_eq!(roped_out.logits.data, nope_out.logits.data);
+}
+
+#[test]
+fn nope_layer_changes_output_at_nonzero_position() {
+    // Companion to the identity test: without this, that test would still pass if
+    // the gate were dead code. At position 1 the rotation is not the identity, so
+    // skipping it must change the logits.
+    let mut roped = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
+    let mut nope = LlamaInferenceSession::new(
+        LlamaModelConfig {
+            no_rope_layer_step: Some(1),
+            ..tiny_config()
+        },
+        tiny_weights(),
+    )
+    .unwrap();
+
+    roped.forward_single_token(1).unwrap();
+    nope.forward_single_token(1).unwrap();
+    let roped_out = roped.forward_single_token(2).unwrap();
+    let nope_out = nope.forward_single_token(2).unwrap();
+
+    assert_ne!(
+        roped_out.logits.data, nope_out.logits.data,
+        "the NoPE gate must be live on the decode path"
+    );
+}
+
+#[test]
+fn nope_step_two_ropes_layer_zero() {
+    // Pins the 0-based `(il + 1)` convention numerically. With step 2, layer 0 has
+    // (0 + 1) % 2 == 1 != 0, so it IS roped and must match the baseline exactly.
+    // An `il % step` implementation — the convention llama.cpp uses in
+    // models/smallthinker.cpp:109 — would skip layer 0 here and fail.
+    let mut baseline = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
+    let mut stepped = LlamaInferenceSession::new(
+        LlamaModelConfig {
+            no_rope_layer_step: Some(2),
+            ..tiny_config()
+        },
+        tiny_weights(),
+    )
+    .unwrap();
+
+    for token in [1u32, 2] {
+        let baseline_out = baseline.forward_single_token(token).unwrap();
+        let stepped_out = stepped.forward_single_token(token).unwrap();
+        assert_eq!(
+            baseline_out.logits.data, stepped_out.logits.data,
+            "step 2 must rope layer 0"
+        );
+    }
+}
+
+#[test]
+fn nope_gate_is_live_on_the_prompt_path() {
+    // The prompt path has its own rope call site (forward_prefill_layer_chunk_timed);
+    // this proves the skip is wired there too and not only in single-token decode.
+    let prompt = [1u32, 2, 1];
+    let mut roped = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
+    let mut nope = LlamaInferenceSession::new(
+        LlamaModelConfig {
+            no_rope_layer_step: Some(1),
+            ..tiny_config()
+        },
+        tiny_weights(),
+    )
+    .unwrap();
+
+    let roped_step = roped
+        .generate_next_token(&prompt, LlamaSampler::Greedy)
+        .unwrap();
+    let nope_step = nope
+        .generate_next_token(&prompt, LlamaSampler::Greedy)
+        .unwrap();
+    assert_ne!(
+        roped_step.logits.data, nope_step.logits.data,
+        "the NoPE gate must be live on the prompt path"
+    );
+
+    // A step that ropes layer 0 must be indistinguishable from the baseline.
+    let mut stepped = LlamaInferenceSession::new(
+        LlamaModelConfig {
+            no_rope_layer_step: Some(2),
+            ..tiny_config()
+        },
+        tiny_weights(),
+    )
+    .unwrap();
+    let stepped_step = stepped
+        .generate_next_token(&prompt, LlamaSampler::Greedy)
+        .unwrap();
+    assert_eq!(roped_step.logits.data, stepped_step.logits.data);
+}
+
 fn tiny_config() -> LlamaModelConfig {
     LlamaModelConfig {
         context_length: 4,
@@ -562,6 +731,7 @@ fn tiny_config() -> LlamaModelConfig {
         vocab_size: Some(3),
         file_type: Some(0),
         rope_neox_pairing: false,
+        no_rope_layer_step: None,
         attention_key_length: None,
         logit_scale: None,
         moe: None,


### PR DESCRIPTION
## The bug

`smollm3` sat in the optimized-lane allowlist (`src/model.rs` `is_implemented_architecture` and the `from_gguf` accept arm) while the engine applied RoPE to **every** layer.

SmolLM3 is a **NoPE** architecture. llama.cpp `src/models/smollm3.cpp:5` sets `n_no_rope_layer_step = 4` and its graph at `:69` gates **both** `ggml_rope_ext` calls on

```c
const bool use_rope = (il + 1) % hparams.n_no_rope_layer_step != 0;
```

Because SmolLM3 is llama-shaped it bound cleanly and then mis-roped — **silently wrong output under a claimed-implemented architecture**, rather than a clean refusal. For a 36-layer SmolLM3-3B the affected layers are `3, 7, 11, 15, 19, 23, 27, 31, 35` — 9 of 36, **including the final layer**.

## Why the step is hardcoded

It has to be. `n_no_rope_layer_step` has **no GGUF key**: there is no `LLM_KV_*` enum and no writer. `llama-hparams.h:203` is only the struct default, and `tests/test-llama-archs.cpp:93` records it as "hard-coded to 4". It cannot be read from the file.

HuggingFace's `SmolLM3Config` *does* carry a `no_rope_layers` array, but llama.cpp ignores it — and llama.cpp is the parity target here. Disclosed in the field docs rather than hidden.

## The change

- `LlamaModelConfig::no_rope_layer_step` + `layer_uses_rope()`, applied at **both** CPU RoPE call sites: `forward_layer_timed` (single-token decode) and `forward_prefill_layer_chunk_timed` (batched prefill). Both must agree or the KV written during prefill would not match what decode expects.
- The resident GPU engines **fail closed** for NoPE models (`resident_decode_eligible`). They build one cos/sin table per forward and rope every layer unconditionally, so they cannot express the skip; a smollm3 file on a CUDA build would otherwise diverge from the fixed CPU path. Checked *before* the backend-enabled gate, so it holds on a CPU-only host too.
- The rope reconstruction diagnostic is reconstructed at **position 0** on a NoPE layer, where the rotation is the identity — so a zero delta positively asserts "this layer correctly applied no rotation". Skipping the diagnostic instead is not an option: the consumer field is not `Option` and `.expect()`s it. (Caught by `nope_gate_is_live_on_the_prompt_path`, which panicked before this was fixed.)

## Architecture audit

All ten admitted architectures were checked against their llama.cpp graph builders. The other nine rope unconditionally — `models/llama.cpp:146,152` · `qwen2.cpp:86,92` · `qwen3.cpp:91,100` · `phi3.cpp:107,113` · `mistral3.cpp:137,143`. `gemma3`/`gemma4`/`qwen35` carry per-layer rope **bases**, not skips, and those are modelled elsewhere. **`smollm3` was the only silent-wrong-output case.**

## Evidence owed

No SmolLM3 GGUF exists on the dev host, so there is **no greedy-parity receipt** against pinned llama.cpp. These tests prove the layer-skip logic and its wiring into both CPU forward paths, and nothing more.

Specifically unproven: end-to-end token identity on real weights, tokenizer/chat-template fidelity, the interaction of NoPE layers with SmolLM3's long-context rope scaling, and every GPU lane (deliberately refused).

The correct claim after this PR is *"smollm3 is attemptable and its NoPE schedule matches the reference graph"* — **not** that smollm3 is supported. No ledger row claims it and none is added here.

## Follow-ups found in the same audit, deliberately not fixed here

Recorded as `BACKEND_ASKS.md` RA-5:

1. **`gemma3`** is accepted by the dense `from_gguf` path, but its per-layer dual rope base is only modelled in the runnable lane (`src/runnable/model.rs`) — a gemma3 file reaching the dense path would use one base for all layers.
2. **`lfm2`** is claimed implemented, but its recurrent layers carry `shortconv.in_proj/out_proj` and no `attn_q/k/v`, so the dense binding fails to bind. A load-time error rather than silent wrongness, but still a claim with no path that can run it.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets` clean
- `cargo test --all-targets` — **1611 passed / 0 failed** (+8 new tests)
- `check-ledger-drift` passed, `check-public-scrub` passed
