### PR TITLE
feat(sampler): add typical_p, top_n_sigma and min_keep

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -642,6 +642,14 @@ pub struct ChatCompletionRequest {
     /// (llama.cpp `repeat_last_n`). Omit for the whole history — OpenAI's
     /// semantics and this engine's default; `0` disables the penalties.
     pub penalty_last_n: Option<u32>,
+    /// Locally-typical sampling (llama.cpp `typical_p`). Omit or `1.0` disables.
+    pub typical_p: Option<f32>,
+    /// Keep tokens within `n` standard deviations of the max logit
+    /// (llama.cpp `top_n_sigma`). Omit or `<= 0.0` disables.
+    pub top_n_sigma: Option<f32>,
+    /// Floor on how many candidates the truncating filters may leave
+    /// (llama.cpp `min_keep`). Defaults to 1.
+    pub min_keep: Option<u32>,
     pub logit_bias: Option<HashMap<String, f32>>,
     pub stop: Option<StopSpec>,
     pub n: Option<u32>,
@@ -722,6 +730,14 @@ pub struct CompletionRequest {
     /// clamped to `0` and silently disables penalties instead of meaning
     /// "whole context", so that spelling is deliberately not accepted here.
     pub penalty_last_n: Option<u32>,
+    /// Locally-typical sampling (llama.cpp `typical_p`). Omit or `1.0` disables.
+    pub typical_p: Option<f32>,
+    /// Keep tokens within `n` standard deviations of the max logit
+    /// (llama.cpp `top_n_sigma`). Omit or `<= 0.0` disables.
+    pub top_n_sigma: Option<f32>,
+    /// Floor on how many candidates the truncating filters may leave
+    /// (llama.cpp `min_keep`). Defaults to 1.
+    pub min_keep: Option<u32>,
     pub logit_bias: Option<HashMap<String, f32>>,
     pub stop: Option<StopSpec>,
     pub n: Option<u32>,
@@ -952,6 +968,14 @@ pub struct LlamaServerCompletionRequest {
     /// clamped to `0` and silently disables penalties instead of meaning
     /// "whole context", so that spelling is deliberately not accepted here.
     pub penalty_last_n: Option<u32>,
+    /// Locally-typical sampling (llama.cpp `typical_p`). Omit or `1.0` disables.
+    pub typical_p: Option<f32>,
+    /// Keep tokens within `n` standard deviations of the max logit
+    /// (llama.cpp `top_n_sigma`). Omit or `<= 0.0` disables.
+    pub top_n_sigma: Option<f32>,
+    /// Floor on how many candidates the truncating filters may leave
+    /// (llama.cpp `min_keep`). Defaults to 1.
+    pub min_keep: Option<u32>,
     pub logit_bias: Option<HashMap<String, f32>>,
     pub stop: Option<StopSpec>,
     #[serde(flatten)]
@@ -1179,6 +1203,14 @@ pub struct GenerationSessionRequest {
     /// clamped to `0` and silently disables penalties instead of meaning
     /// "whole context", so that spelling is deliberately not accepted here.
     pub penalty_last_n: Option<u32>,
+    /// Locally-typical sampling (llama.cpp `typical_p`). Omit or `1.0` disables.
+    pub typical_p: Option<f32>,
+    /// Keep tokens within `n` standard deviations of the max logit
+    /// (llama.cpp `top_n_sigma`). Omit or `<= 0.0` disables.
+    pub top_n_sigma: Option<f32>,
+    /// Floor on how many candidates the truncating filters may leave
+    /// (llama.cpp `min_keep`). Defaults to 1.
+    pub min_keep: Option<u32>,
     pub logit_bias: Option<HashMap<String, f32>>,
     pub stop: Option<StopSpec>,
     pub n: Option<u32>,
@@ -2925,6 +2957,9 @@ async fn llama_server_completion(
         min_p: req.min_p,
         repeat_penalty: req.repeat_penalty,
         penalty_last_n: req.penalty_last_n,
+        typical_p: req.typical_p,
+        top_n_sigma: req.top_n_sigma,
+        min_keep: req.min_keep,
         logit_bias: req.logit_bias,
         stop: req.stop,
         n: None,
@@ -9666,6 +9701,9 @@ async fn completions(
         min_p: req.min_p,
         repeat_penalty: req.repeat_penalty,
         penalty_last_n: req.penalty_last_n,
+        typical_p: req.typical_p,
+        top_n_sigma: req.top_n_sigma,
+        min_keep: req.min_keep,
         logit_bias: req.logit_bias,
         stop: req.stop,
         n: req.n,
@@ -10061,6 +10099,9 @@ async fn chat_completions(
         min_p: req.min_p,
         repeat_penalty: req.repeat_penalty,
         penalty_last_n: req.penalty_last_n,
+        typical_p: req.typical_p,
+        top_n_sigma: req.top_n_sigma,
+        min_keep: req.min_keep,
         logit_bias: req.logit_bias,
         stop: req.stop,
         n: req.n,
@@ -10479,6 +10520,9 @@ async fn replay_loaded_receipt_request(
         min_p: None,
         repeat_penalty: None,
         penalty_last_n: None,
+        typical_p: None,
+        top_n_sigma: None,
+        min_keep: None,
         logit_bias: None,
         stop: if request.stop.is_empty() {
             None
@@ -11865,8 +11909,9 @@ fn validate_unsupported_generation_fields(
             "OpenAI stream_options are not supported yet; Camelid streams plain SSE chunks"
         }
         "echo" | "suffix" => "completion echo/suffix compatibility is not supported yet",
-        "mirostat" | "mirostat_tau" | "mirostat_eta" | "typical_p" | "tfs_z" | "ignore_eos"
-        | "n_keep" => "this llama-server sampler/control field is not supported yet",
+        "mirostat" | "mirostat_tau" | "mirostat_eta" | "tfs_z" | "ignore_eos" | "n_keep" => {
+            "this llama-server sampler/control field is not supported yet"
+        }
         "cache_prompt" | "id_slot" | "id_task" | "slot_id" => {
             "llama-server slot/cache controls are not supported by this compatibility route yet"
         }
@@ -11899,7 +11944,6 @@ fn static_param_name(param: &str) -> &'static str {
         "mirostat" => "mirostat",
         "mirostat_tau" => "mirostat_tau",
         "mirostat_eta" => "mirostat_eta",
-        "typical_p" => "typical_p",
         "tfs_z" => "tfs_z",
         "ignore_eos" => "ignore_eos",
         "n_keep" => "n_keep",
@@ -11975,6 +12019,9 @@ fn sampling_config_from_request(
         top_k: req.top_k.map(|value| value as usize),
         top_p: req.top_p,
         min_p: req.min_p,
+        typical_p: req.typical_p,
+        top_n_sigma: req.top_n_sigma,
+        min_keep: req.min_keep.map(|value| value as usize),
         seed: req.seed,
         presence_penalty: req.presence_penalty.unwrap_or(0.0),
         frequency_penalty: req.frequency_penalty.unwrap_or(0.0),
@@ -15820,6 +15867,9 @@ mod tests {
             min_p: None,
             repeat_penalty: None,
             penalty_last_n: None,
+            typical_p: None,
+            top_n_sigma: None,
+            min_keep: None,
             seed: None,
             presence_penalty: None,
             frequency_penalty: None,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2230,6 +2230,29 @@ pub struct SamplingConfig {
     /// against the peak, it is invariant to renormalization — but not to
     /// temperature, which is why temperature must stay last.
     pub min_p: Option<f32>,
+    /// Locally-typical sampling (llama.cpp `typical_p`): keep the tokens whose
+    /// surprisal `-ln p` is closest to the distribution's entropy, smallest
+    /// difference first, until their mass exceeds `typical_p`. `None`/`1.0`
+    /// disables it. Runs between `top_k` and `top_p`.
+    ///
+    /// Unlike every other filter here it is not a prefix of the logit ordering —
+    /// it can drop the argmax and keep a middling token.
+    pub typical_p: Option<f32>,
+    /// Keep only tokens whose logit is within `n` population standard deviations
+    /// of the maximum logit (llama.cpp `top_n_sigma`). `None`/`<= 0.0` disables it.
+    ///
+    /// Runs FIRST, before `top_k`, because the mean and standard deviation are
+    /// taken over the full candidate set. Operates in logit space, so it is
+    /// unaffected by temperature regardless of chain position.
+    pub top_n_sigma: Option<f32>,
+    /// Floor on how many candidates the truncating filters may leave
+    /// (llama.cpp `min_keep`). Defaults to 1 — never empty the set.
+    ///
+    /// llama.cpp's own default is 0, which its samplers treat as "no floor" via
+    /// explicit `min_keep == 0` guards; 1 is the same behaviour spelled without
+    /// the sentinel, since every one of those samplers already refuses to return
+    /// an empty set.
+    pub min_keep: Option<usize>,
     pub seed: Option<u64>,
     pub presence_penalty: f32,
     pub frequency_penalty: f32,
@@ -2267,6 +2290,9 @@ impl Default for SamplingConfig {
             top_k: None,
             top_p: None,
             min_p: None,
+            typical_p: None,
+            top_n_sigma: None,
+            min_keep: None,
             seed: None,
             presence_penalty: 0.0,
             frequency_penalty: 0.0,
@@ -6397,6 +6423,25 @@ impl SamplingConfig {
                 )));
             }
         }
+        if let Some(typical_p) = self.typical_p {
+            if !typical_p.is_finite() || !(0.0..=1.0).contains(&typical_p) {
+                return Err(BackendError::RuntimeShapeMismatch(format!(
+                    "typical_p must be finite and in [0, 1], got {typical_p}"
+                )));
+            }
+        }
+        if let Some(top_n_sigma) = self.top_n_sigma {
+            if !top_n_sigma.is_finite() || top_n_sigma < 0.0 {
+                return Err(BackendError::RuntimeShapeMismatch(format!(
+                    "top_n_sigma must be finite and non-negative, got {top_n_sigma}"
+                )));
+            }
+        }
+        if matches!(self.min_keep, Some(0)) {
+            return Err(BackendError::RuntimeShapeMismatch(
+                "min_keep must be greater than zero when provided".to_string(),
+            ));
+        }
         if !self.repeat_penalty.is_finite() || self.repeat_penalty <= 0.0 {
             return Err(BackendError::RuntimeShapeMismatch(format!(
                 "repeat_penalty must be finite and greater than zero, got {}",
@@ -6568,6 +6613,36 @@ fn sample_with_config(
     }
 
     let mut candidates: Vec<(usize, f32)> = adjusted.data.iter().copied().enumerate().collect();
+    let min_keep = config.min_keep.unwrap_or(1).max(1);
+
+    // top_n_sigma runs FIRST in the reference chain (before top_k) and works in
+    // logit space, not probability space: keep every token whose logit is within
+    // `n` population standard deviations of the max. llama.cpp
+    // `llama_sampler_top_n_sigma_apply` masks to -INFINITY; truncating the set is
+    // equivalent here because a masked token can never be drawn.
+    //
+    // The mean and std are taken over the FULL candidate set, which is why this
+    // must run before top_k narrows it.
+    if let Some(n_sigma) = config.top_n_sigma.filter(|n| *n > 0.0) {
+        if candidates.len() > 1 {
+            let valid: Vec<f32> = candidates
+                .iter()
+                .map(|(_, logit)| *logit)
+                .filter(|logit| logit.is_finite())
+                .collect();
+            if !valid.is_empty() {
+                let max = valid.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                let mean = valid.iter().sum::<f32>() / valid.len() as f32;
+                let variance =
+                    valid.iter().map(|l| (l - mean).powi(2)).sum::<f32>() / valid.len() as f32;
+                let threshold = max - n_sigma * variance.sqrt();
+                // Keep at least the argmax: the max itself always clears the
+                // threshold for any n >= 0, so this cannot empty the set.
+                candidates.retain(|(_, logit)| *logit >= threshold);
+            }
+        }
+    }
+
     if let Some(top_k) = config.top_k {
         // Partition around K before ordering the survivors. The comparator is a
         // total order (token id breaks equal-logit ties), so sorting the selected
@@ -6596,6 +6671,44 @@ fn sample_with_config(
     // cannot reorder logits. At temperature == 1.0 the two orders are bit-exact
     // (division by one is exact), which is why every existing sampler test —
     // all of which pin temperature to 0.0 or 1.0 — is untouched by this change.
+    // typical_p sits between top_k and top_p. It keeps the tokens whose surprisal
+    // is CLOSEST to the distribution's entropy — locally typical sampling — rather
+    // than the most probable ones, so unlike every other filter here its survivors
+    // are not a prefix of the logit ordering.
+    //
+    // llama.cpp `llama_sampler_typical_apply` leaves the array reordered by
+    // shifted score and sets `sorted = false`, letting a later sampler re-sort.
+    // This engine's top_p/min_p stages rely on descending-logit order, so the
+    // survivors are re-sorted here instead. The retained SET is identical.
+    if let Some(typical_p) = config.typical_p.filter(|p| *p < 1.0) {
+        let probabilities = softmax_candidates(&candidates, 1.0)?;
+        let entropy: f32 = probabilities
+            .iter()
+            .map(|p| if *p > 0.0 { -*p * p.ln() } else { 0.0 })
+            .sum();
+        let mut order: Vec<usize> = (0..candidates.len()).collect();
+        order.sort_by(|a, b| {
+            let score = |i: usize| (-probabilities[i].ln() - entropy).abs();
+            score(*a).total_cmp(&score(*b)).then_with(|| a.cmp(b))
+        });
+
+        let mut cumulative = 0.0f32;
+        let mut keep = order.len();
+        for (rank, idx) in order.iter().enumerate() {
+            cumulative += probabilities[*idx];
+            if cumulative > typical_p && rank + 1 >= min_keep {
+                keep = rank + 1;
+                break;
+            }
+        }
+        let mut survivors: Vec<(usize, f32)> =
+            order.iter().take(keep).map(|i| candidates[*i]).collect();
+        survivors.sort_by(|(left_idx, left), (right_idx, right)| {
+            right.total_cmp(left).then_with(|| left_idx.cmp(right_idx))
+        });
+        candidates = survivors;
+    }
+
     if config.top_p.is_some_and(|top_p| top_p < 1.0)
         || config.min_p.is_some_and(|min_p| min_p > 0.0)
     {
@@ -6609,11 +6722,11 @@ fn sample_with_config(
             for probability in &probabilities {
                 cumulative += *probability;
                 keep += 1;
-                if cumulative >= top_p {
+                if cumulative >= top_p && keep >= min_keep {
                     break;
                 }
             }
-            let keep = keep.max(1);
+            let keep = keep.max(min_keep).min(candidates.len());
             candidates.truncate(keep);
             probabilities.truncate(keep);
         }
@@ -6628,7 +6741,8 @@ fn sample_with_config(
                 .iter()
                 .take_while(|probability| **probability >= threshold)
                 .count()
-                .max(1);
+                .max(min_keep)
+                .min(candidates.len());
             candidates.truncate(keep);
         }
     }

--- a/tests/inference_session.rs
+++ b/tests/inference_session.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use camelid::{
     inference::{
         LlamaInferenceSession, LlamaKvCachePlan, LlamaLayerWeights, LlamaLoadedWeights,
@@ -687,6 +689,137 @@ fn rejects_attention_head_configuration_that_cannot_share_kv_heads() {
 
     assert!(err.contains("attention head count 2"));
     assert!(err.contains("kv head count 3"));
+}
+
+#[test]
+fn top_n_sigma_keeps_only_logits_within_n_standard_deviations() {
+    // logits [10, 9, 1, 0]: mean 5.0, population variance
+    // (25 + 16 + 16 + 25)/4 = 20.5, std 4.5277. With n = 1 the threshold is
+    // 10 - 4.5277 = 5.4723, so only tokens 0 and 1 survive.
+    let logits = tensor("logits", vec![1, 4], vec![10.0, 9.0, 1.0, 0.0]);
+    let mut drawn = std::collections::BTreeSet::new();
+    for seed in 0u64..64 {
+        drawn.insert(
+            LlamaSampler::Sampling(SamplingConfig {
+                temperature: 1.0,
+                top_n_sigma: Some(1.0),
+                seed: Some(seed),
+                ..SamplingConfig::default()
+            })
+            .sample(&logits)
+            .unwrap(),
+        );
+    }
+    assert!(
+        drawn.is_subset(&BTreeSet::from([0, 1])),
+        "tokens beyond one sigma must be cut, drew {drawn:?}"
+    );
+    assert!(drawn.contains(&0) && drawn.contains(&1), "drew {drawn:?}");
+}
+
+#[test]
+fn typical_p_can_drop_the_argmax() {
+    // The property that distinguishes locally-typical sampling from every other
+    // filter here: its survivors are not a prefix of the logit ordering, so the
+    // most probable token can be cut.
+    //
+    // These logits are ln(0.6), ln(0.3), ln(0.1), so the softmax is exactly
+    // [0.6, 0.3, 0.1] and the entropy is 0.89795 nats. Surprisals are 0.51083,
+    // 1.20397, 2.30259, so |surprisal - entropy| is 0.38712, 0.30602, 1.40464 --
+    // token 1, NOT the argmax, is the most "typical". With typical_p = 0.25 the
+    // first candidate alone (0.3) already exceeds it, so token 1 is the only
+    // survivor.
+    // Written as logs of the target probabilities rather than decimal literals:
+    // softmax is shift-invariant, so softmax(ln p) == p exactly for a normalized p.
+    let logits = tensor(
+        "logits",
+        vec![1, 3],
+        vec![0.6f32.ln(), 0.3f32.ln(), 0.1f32.ln()],
+    );
+
+    // Baseline: the argmax is token 0.
+    assert_eq!(LlamaSampler::Greedy.sample(&logits).unwrap(), 0);
+
+    for seed in [0u64, 1, 7, 42, 12345] {
+        let token = LlamaSampler::Sampling(SamplingConfig {
+            temperature: 1.0,
+            typical_p: Some(0.25),
+            seed: Some(seed),
+            ..SamplingConfig::default()
+        })
+        .sample(&logits)
+        .unwrap();
+        assert_eq!(
+            token, 1,
+            "typical_p must keep the most typical token and drop the argmax (seed {seed})"
+        );
+    }
+}
+
+#[test]
+fn min_keep_floors_the_truncating_filters() {
+    // min_p = 1.0 keeps only the argmax; min_keep = 2 raises the floor to two
+    // candidates, so token 1 becomes reachable again.
+    let logits = tensor("logits", vec![1, 3], vec![3.0, 2.0, 1.0]);
+    let draw = |min_keep| {
+        let mut drawn = std::collections::BTreeSet::new();
+        for seed in 0u64..64 {
+            drawn.insert(
+                LlamaSampler::Sampling(SamplingConfig {
+                    temperature: 1.0,
+                    min_p: Some(1.0),
+                    min_keep,
+                    seed: Some(seed),
+                    ..SamplingConfig::default()
+                })
+                .sample(&logits)
+                .unwrap(),
+            );
+        }
+        drawn
+    };
+
+    assert_eq!(
+        draw(None),
+        BTreeSet::from([0]),
+        "min_p=1 keeps only the argmax"
+    );
+    let floored = draw(Some(2));
+    assert!(
+        floored.contains(&1),
+        "min_keep=2 must keep a second candidate, drew {floored:?}"
+    );
+    assert!(
+        !floored.contains(&2),
+        "min_keep=2 must not keep a third, drew {floored:?}"
+    );
+}
+
+#[test]
+fn rejects_out_of_range_typical_p_top_n_sigma_and_min_keep() {
+    let logits = tensor("logits", vec![1, 2], vec![0.0, 1.0]);
+    let err = |config: SamplingConfig| {
+        LlamaSampler::Sampling(config)
+            .sample(&logits)
+            .unwrap_err()
+            .to_string()
+    };
+
+    assert!(err(SamplingConfig {
+        typical_p: Some(1.5),
+        ..SamplingConfig::default()
+    })
+    .contains("typical_p"));
+    assert!(err(SamplingConfig {
+        top_n_sigma: Some(-1.0),
+        ..SamplingConfig::default()
+    })
+    .contains("top_n_sigma"));
+    assert!(err(SamplingConfig {
+        min_keep: Some(0),
+        ..SamplingConfig::default()
+    })
+    .contains("min_keep"));
 }
 
 fn tiny_config() -> LlamaModelConfig {


### PR DESCRIPTION
> **Stacked on #534.** These samplers are inserted into the corrected chain order, so #534 has to land first. Base will retarget to `main` automatically when #534 merges.

## What

Three more of llama.cpp's samplers. Each is a **no-op at its default**, so no existing caller's output moves.

### `top_n_sigma`

Keeps every token whose logit is within `n` **population** standard deviations of the max (`llama_sampler_top_n_sigma_apply`). Runs **first**, before `top_k`, because the mean and std are taken over the full candidate set. Works in logit space, so temperature never affects it regardless of chain position.

The reference masks to `-INFINITY`; truncating the set is equivalent, because a masked token can never be drawn.

### `typical_p`

Locally-typical sampling (`llama_sampler_typical_apply`): keep the tokens whose surprisal `-ln p` is **closest to the distribution's entropy**, smallest difference first, until their mass exceeds `typical_p`. Sits between `top_k` and `top_p`.

Unlike every other filter here, its survivors are **not a prefix of the logit ordering** — it can drop the argmax. The test pins exactly that:

> logits `ln(0.6), ln(0.3), ln(0.1)` ⇒ entropy 0.89795 nats; surprisals 0.51083 / 1.20397 / 2.30259 ⇒ `|surprisal − entropy|` of 0.38712 / **0.30602** / 1.40464. Token 1, not the argmax, is the most typical. With `typical_p = 0.25` it is the only survivor.

The reference leaves the array reordered by shifted score and sets `sorted = false` for a later sampler to re-sort. This engine's `top_p`/`min_p` stages rely on descending-logit order, so the survivors are re-sorted here instead — the retained **set** is identical.

### `min_keep`

Floors how many candidates the truncating filters may leave; now honoured by `typical_p`, `top_p` and `min_p`.

llama.cpp's default is `0`, which its samplers treat as "no floor" via explicit `min_keep == 0` guards. This defaults to `1` — the same behaviour spelled without the sentinel, since each of those samplers already refuses to return an empty set.

## Also

`typical_p` was previously rejected with *"this llama-server sampler/control field is not supported yet"*. That arm is removed, since it is now a typed field — leaving it would have made the rejection message a lie.

## Not implemented here, deliberately

**XTC and DRY.** DRY needs z-algorithm pattern matching over the history with configurable sequence breakers. A subtly wrong repetition sampler is worse than an absent one, and there is no running reference on this host to diff an implementation against. Better as its own change with real comparison evidence.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets` clean
- `cargo test --all-targets` — **1607 passed / 0 failed** (1603 on the base branch, +4 new tests)
- `check-ledger-drift` passed
