### PR TITLE
fix(webui): stop the offline banner dead-ending, and make the restart command one-shot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,14 @@ jobs:
       - name: Frontend first-run card component smoke
         run: npm run smoke:first-run-card
 
+      # Component-level: the offline banner is the only surface a user sees when
+      # the engine dies with the tab still open, and its branch is chosen from a
+      # live probe of the dev-server launch hook. Drives both server shapes so the
+      # packaged build can never regress to offering a control it cannot honour,
+      # and the dev-server one-click Start keeps working.
+      - name: Frontend offline banner smoke
+        run: npm run smoke:offline-banner
+
       # Covers frontend/src/lib/catalogBrowse.js: fit labels/details, the
       # settled-vs-retryable `unknown` split, grouping and search ranking. The
       # script shipped with the lane but was never wired here, so none of that

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "smoke:catalog-activation": "node scripts/catalog-activation-smoke.mjs",
     "smoke:first-run": "node scripts/first-run-activation-smoke.mjs",
     "smoke:first-run-card": "node scripts/first-run-card-smoke.mjs",
+    "smoke:offline-banner": "node scripts/offline-banner-smoke.mjs",
     "smoke:catalog-browse": "node scripts/catalog-browse-smoke.mjs",
     "smoke:model-deletion": "node scripts/model-deletion-smoke.mjs",
     "smoke:3b-closure": "node scripts/frontend-3b-closure-smoke.mjs",

--- a/frontend/scripts/offline-banner-smoke.mjs
+++ b/frontend/scripts/offline-banner-smoke.mjs
@@ -267,7 +267,7 @@ try {
      deliberately unbroken (a deep path, no spaces): a command WITH spaces
      word-wraps on its own and would make this check pass for free. ---- */
   resetStub()
-  page = await openBanner({ storage: { 'camelid.launchCommand': `C:\\Users\\someone\\${'VeryDeeplyNestedDirectory\\'.repeat(6)}camelid.exe` } })
+  page = await openBanner({ storage: { 'camelid.launchCommand': `C:\\camelid\\${'VeryDeeplyNestedDirectory\\'.repeat(6)}camelid.exe` } })
   await page.setViewport({ width: 390, height: 844 })
   await new Promise((done) => setTimeout(done, 200))
   banner = await page.evaluate(readBanner)
@@ -282,9 +282,10 @@ try {
   await page.close()
 
   /* ---- Scenario 1e: the engine is on another host. `camelid serve` would be
-     advice for the wrong machine. ---- */
+     advice for the wrong machine. The host is an RFC 2606 reserved name, so the
+     fixture is unmistakably synthetic and cannot resolve. ---- */
   resetStub()
-  page = await openBanner({ storage: { 'camelid.apiBase': 'http://192.168.1.50:8181' } })
+  page = await openBanner({ storage: { 'camelid.apiBase': 'http://engine.example:8181' } })
   banner = await page.evaluate(readBanner)
   check('a remote engine is not told to restart locally', () => {
     assert.equal(banner.buttons.some((label) => label.includes('Copy restart')), false,
@@ -292,7 +293,7 @@ try {
     assert.equal(banner.text.includes('served by the engine'), false)
   })
   check('a remote engine names the host that is not answering', () => {
-    assert.equal(banner.code, '192.168.1.50')
+    assert.equal(banner.code, 'engine.example')
     assert.ok(banner.buttons.includes('Settings'))
   })
   await page.close()

--- a/frontend/scripts/offline-banner-smoke.mjs
+++ b/frontend/scripts/offline-banner-smoke.mjs
@@ -193,12 +193,15 @@ try {
     assert.equal(banner.buttons.some((label) => label.includes('Start Camelid')), false,
       `expected no Start button, got ${JSON.stringify(banner.buttons)}`)
   })
-  check('packaged build offers the restart command instead', () => {
-    assert.ok(banner.buttons.includes('Copy restart command'),
+  check('packaged build offers a real action instead', () => {
+    assert.ok(banner.buttons.includes('Copy terminal command'),
       `expected a copy action, got ${JSON.stringify(banner.buttons)}`)
   })
-  check('packaged build names the command to run', () => {
-    assert.equal(banner.code, 'camelid serve')
+  check('packaged build names the executable, not a PATH-dependent command', () => {
+    // `camelid serve` errors with "'camelid' is not recognized" for anyone who
+    // unzipped a release, so the instruction must name the file to run.
+    assert.equal(banner.code, 'camelid.exe')
+    assert.match(banner.text, /unzipped/i)
   })
   check('packaged build explains why the page cannot restart the engine', () => {
     assert.match(banner.text, /served by the engine/i)
@@ -231,7 +234,7 @@ try {
   await new Promise((done) => setTimeout(done, 150))
   await clickBannerButton(page, 'Copy')
   await page.waitForFunction(
-    () => [...document.querySelectorAll('.backend-banner__actions button')].some((b) => !b.textContent.includes('Copy restart')),
+    () => [...document.querySelectorAll('.backend-banner__actions button')].some((b) => b.textContent.includes('Couldn\u2019t copy')),
     { timeout: 5000 })
   banner = await page.evaluate(readBanner)
   check('an unavailable clipboard is never reported as a successful copy', () => {
@@ -240,8 +243,8 @@ try {
     assert.ok(banner.buttons.some((label) => label.includes('Couldn’t copy')),
       `expected an honest failure label, got ${JSON.stringify(banner.buttons)}`)
   })
-  check('the command stays readable when it could not be copied', () => {
-    assert.equal(banner.code, 'camelid serve')
+  check('the instruction stays readable when the copy failed', () => {
+    assert.equal(banner.code, 'camelid.exe')
   })
   check('the failure label does not burst its button at 390px', () => {
     assert.equal(banner.buttonOverflow, false, 'a banner button overflows its box')
@@ -262,21 +265,22 @@ try {
   })
   await page.close()
 
-  /* ---- Scenario 1d: an overlong saved launch command must wrap, not widen
-     the page. `camelid.launchCommand` survives from a dev session. The token is
-     deliberately unbroken (a deep path, no spaces): a command WITH spaces
-     word-wraps on its own and would make this check pass for free. ---- */
+  /* ---- Scenario 1d: the remote state renders the host name, which is the only
+     variable-length text in this banner and therefore the only overflow risk.
+     The token is deliberately unbroken (no hyphens): hyphens are line-break
+     opportunities and would make this check pass for free. ---- */
   resetStub()
-  page = await openBanner({ storage: { 'camelid.launchCommand': `C:\\camelid\\${'VeryDeeplyNestedDirectory\\'.repeat(6)}camelid.exe` } })
+  const longHost = `${'verylongsubdomainsegment'.repeat(4)}.example`
+  page = await openBanner({ storage: { 'camelid.apiBase': `http://${longHost}:8181` } })
   await page.setViewport({ width: 390, height: 844 })
   await new Promise((done) => setTimeout(done, 200))
   banner = await page.evaluate(readBanner)
-  check('a long unbreakable command wraps instead of breaking the layout at 390px', () => {
+  check('a long unbreakable host wraps instead of breaking the layout at 390px', () => {
     // Prove the scenario is actually exercising the long token before drawing
     // any conclusion from the geometry.
-    assert.ok(banner.code?.includes('VeryDeeplyNestedDirectory'),
-      `the long command never reached the banner: ${JSON.stringify(banner.code)}`)
-    assert.equal(banner.escapesBox, false, 'the command text escapes the banner box')
+    assert.equal(banner.code, longHost,
+      `the long host never reached the banner: ${JSON.stringify(banner.code)}`)
+    assert.equal(banner.escapesBox, false, 'the host text escapes the banner box')
     assert.equal(banner.documentOverflows, false, 'the page scrolls horizontally')
   })
   await page.close()
@@ -288,7 +292,7 @@ try {
   page = await openBanner({ storage: { 'camelid.apiBase': 'http://engine.example:8181' } })
   banner = await page.evaluate(readBanner)
   check('a remote engine is not told to restart locally', () => {
-    assert.equal(banner.buttons.some((label) => label.includes('Copy restart')), false,
+    assert.equal(banner.buttons.some((label) => label.includes('Copy')), false,
       `offered a local restart for a remote engine: ${JSON.stringify(banner.buttons)}`)
     assert.equal(banner.text.includes('served by the engine'), false)
   })

--- a/frontend/scripts/offline-banner-smoke.mjs
+++ b/frontend/scripts/offline-banner-smoke.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+/* Component-level coverage for the offline banner's two audiences.
+ *
+ * The banner is the only thing a user sees when the engine dies with the tab
+ * still open, and it behaved differently depending on something invisible: the
+ * Vite dev-server launch hook. With the hook present it offers a working Start
+ * button; in every shipped build the hook does not exist, and the banner used to
+ * fall back to a lone "Settings" button that navigated to a page explaining the
+ * launcher needs `npm run dev`. That is a dead end for the only population that
+ * ever hits it.
+ *
+ * Rendering the component is not enough to prove this: the branch is chosen from
+ * a live probe of `/__camelid/backend/status`, and the packaged answer is the SPA
+ * HTML fallback rather than JSON. So this drives the real app in a real browser
+ * against both server shapes.
+ *
+ * Requires `npm run build` first (it serves frontend/dist) and Chrome/Edge.
+ */
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { existsSync, readFileSync } from 'node:fs'
+import { extname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import puppeteer from 'puppeteer-core'
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url))
+const distDir = resolve(scriptDir, '../dist')
+
+if (!existsSync(distDir)) throw new Error(`missing ${distDir} -- run "npm run build" first`)
+
+const executablePath = [
+  process.env.PUPPETEER_EXECUTABLE_PATH,
+  'C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
+  '/usr/bin/google-chrome',
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+].filter(Boolean).find(existsSync)
+if (!executablePath) throw new Error('Chrome or Edge is required for the offline banner smoke')
+
+/* The exact sentence the packaged build used to show. Asserting its ABSENCE is
+   what keeps the dead end from coming back. */
+const RETIRED_COPY = 'Start it from a terminal, then this clears automatically.'
+
+let stub
+function resetStub() {
+  stub = {
+    // 'packaged' = no launcher hook, so /__camelid/* falls through to the SPA
+    // HTML exactly as the real engine serves it. 'dev' = the Vite plugin.
+    mode: 'packaged',
+    detected: 'cargo run --release -- serve',
+    requests: [],
+  }
+}
+resetStub()
+
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.svg': 'image/svg+xml', '.woff2': 'font/woff2', '.json': 'application/json', '.png': 'image/png' }
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) })
+  res.end(payload)
+}
+
+function sendIndex(res) {
+  const body = readFileSync(join(distDir, 'index.html'))
+  res.writeHead(200, { 'Content-Type': 'text/html' })
+  res.end(body)
+}
+
+const server = createServer(async (req, res) => {
+  const path = new URL(req.url, 'http://127.0.0.1').pathname
+  stub.requests.push({ method: req.method, path })
+
+  // The engine is gone: health fails, which is what drives runtime.status to
+  // 'offline' (see hooks/useDashboardData.js).
+  if (path === '/v1/health') return sendJson(res, 503, { ok: false })
+
+  if (path.startsWith('/__camelid/backend/')) {
+    if (stub.mode !== 'dev') return sendIndex(res) // SPA fallback -> JSON.parse throws -> unavailable
+    if (path.endsWith('/status')) {
+      return sendJson(res, 200, { available: true, running: false, detected: stub.detected, logTail: '' })
+    }
+    return sendJson(res, 200, { available: true, running: true, pid: 4242, logTail: '' })
+  }
+
+  if (path.startsWith('/api/') || path.startsWith('/v1/')) {
+    return sendJson(res, 503, { error: { message: 'engine offline' } })
+  }
+
+  const filePath = join(distDir, path === '/' ? 'index.html' : path.replace(/^\//, ''))
+  if (existsSync(filePath) && !filePath.includes('..')) {
+    const body = readFileSync(filePath)
+    res.writeHead(200, { 'Content-Type': MIME[extname(filePath)] || 'application/octet-stream' })
+    return res.end(body)
+  }
+  return sendIndex(res)
+})
+
+await new Promise((done) => server.listen(0, '127.0.0.1', done))
+const origin = `http://127.0.0.1:${server.address().port}`
+
+const browser = await puppeteer.launch({ executablePath, headless: 'new' })
+const pageErrors = []
+
+async function openBanner({ clipboard = 'ok', storage = {} } = {}) {
+  const page = await browser.newPage()
+  page.on('pageerror', (error) => pageErrors.push(String(error)))
+  // Nothing may leave the harness. One scenario points the app at an engine on
+  // another host; without this the probe sits in TCP retries (measured: 44s for
+  // the suite, versus ~7s with it) and the smoke would depend on the state of
+  // whatever network the runner is attached to.
+  await page.setRequestInterception(true)
+  page.on('request', (request) => {
+    if (request.url().startsWith(origin)) request.continue()
+    else request.abort()
+  })
+  // copyText() calls navigator.clipboard.writeText. Drive all three real shapes:
+  // present and working, ABSENT (what a non-secure context gives you, e.g. a
+  // plain-http LAN address), and present but rejecting (permission denied).
+  await page.evaluateOnNewDocument((mode, seed) => {
+    window.__copied = []
+    // Pages share the browser profile, so a key seeded by an earlier scenario
+    // would survive into the next one and silently test the wrong thing.
+    window.localStorage.clear()
+    for (const [key, value] of Object.entries(seed)) window.localStorage.setItem(key, value)
+    if (mode === 'absent') {
+      Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined })
+      return
+    }
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (text) => {
+          if (mode === 'denied') return Promise.reject(new Error('denied'))
+          window.__copied.push(text)
+          return Promise.resolve()
+        },
+      },
+    })
+  }, clipboard, storage)
+  // NOT networkidle2: one scenario points the app at an engine on another host,
+  // whose probe never settles, and the banner does not depend on it.
+  await page.goto(origin, { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('.backend-banner', { timeout: 30000 })
+  return page
+}
+
+const clickBannerButton = async (page, needle) => {
+  const handle = await page.evaluateHandle((text) =>
+    [...document.querySelectorAll('.backend-banner__actions button')].find((b) => b.textContent.includes(text)), needle)
+  const element = handle.asElement()
+  assert.ok(element, `no banner button matching ${needle}`)
+  await element.click()
+}
+
+const readBanner = () => {
+  const banner = document.querySelector('.backend-banner')
+  const code = banner?.querySelector('.backend-banner__copy code')
+  // Geometry, not scrollWidth: an overflowing child does not necessarily make
+  // its ancestor scrollable (ancestors clip or hide), so scrollWidth silently
+  // reports "fine" for text that visibly escapes its box.
+  let escapesBox = false
+  if (code && banner) {
+    const codeRect = code.getBoundingClientRect()
+    const bannerRect = banner.getBoundingClientRect()
+    escapesBox = codeRect.right > bannerRect.right + 1 || codeRect.left < bannerRect.left - 1
+  }
+  return {
+    text: banner?.textContent?.trim() || '',
+    code: code?.textContent?.trim() || null,
+    buttons: [...(banner?.querySelectorAll('.backend-banner__actions button') || [])].map((b) => b.textContent.trim()),
+    escapesBox,
+    documentOverflows: document.documentElement.scrollWidth > window.innerWidth + 1,
+  }
+}
+
+const results = []
+function check(name, fn) { fn(); results.push(name) }
+
+try {
+  /* ---- Scenario 1: a downloaded build. No launcher hook exists. ---- */
+  resetStub()
+  let page = await openBanner()
+  let banner = await page.evaluate(readBanner)
+
+  check('packaged build offers no Start button it cannot honour', () => {
+    assert.equal(banner.buttons.some((label) => label.includes('Start Camelid')), false,
+      `expected no Start button, got ${JSON.stringify(banner.buttons)}`)
+  })
+  check('packaged build offers the restart command instead', () => {
+    assert.ok(banner.buttons.includes('Copy restart command'),
+      `expected a copy action, got ${JSON.stringify(banner.buttons)}`)
+  })
+  check('packaged build names the command to run', () => {
+    assert.equal(banner.code, 'camelid serve')
+  })
+  check('packaged build explains why the page cannot restart the engine', () => {
+    assert.match(banner.text, /served by the engine/i)
+  })
+  check('the retired dead-end sentence is gone', () => {
+    assert.equal(banner.text.includes(RETIRED_COPY), false)
+  })
+
+  const copyButton = await page.evaluateHandle(() =>
+    [...document.querySelectorAll('.backend-banner__actions button')].find((b) => b.textContent.includes('Copy')))
+  await copyButton.asElement().click()
+  await page.waitForFunction(() => window.__copied.length > 0, { timeout: 5000 })
+  const copied = await page.evaluate(() => window.__copied)
+  check('the copy action puts a runnable command on the clipboard', () => {
+    assert.deepEqual(copied, ['camelid serve'])
+  })
+  const confirmed = await page.evaluate(readBanner)
+  check('the button confirms the copy', () => {
+    assert.ok(confirmed.buttons.includes('Copied'),
+      `expected a Copied confirmation, got ${JSON.stringify(confirmed.buttons)}`)
+  })
+  await page.close()
+
+  /* ---- Scenario 1b: no clipboard API (a plain-http LAN address is not a
+     secure context). Claiming "Copied" there would be the same lie. ---- */
+  resetStub()
+  page = await openBanner({ clipboard: 'absent' })
+  await clickBannerButton(page, 'Copy')
+  await page.waitForFunction(
+    () => [...document.querySelectorAll('.backend-banner__actions button')].some((b) => !b.textContent.includes('Copy restart')),
+    { timeout: 5000 })
+  banner = await page.evaluate(readBanner)
+  check('an unavailable clipboard is never reported as a successful copy', () => {
+    assert.equal(banner.buttons.includes('Copied'), false,
+      `claimed a copy with no clipboard API: ${JSON.stringify(banner.buttons)}`)
+    assert.ok(banner.buttons.some((label) => label.includes('Couldn’t copy')),
+      `expected an honest failure label, got ${JSON.stringify(banner.buttons)}`)
+  })
+  check('the command stays readable when it could not be copied', () => {
+    assert.equal(banner.code, 'camelid serve')
+  })
+  await page.close()
+
+  /* ---- Scenario 1c: clipboard present but rejecting (permission denied). ---- */
+  resetStub()
+  page = await openBanner({ clipboard: 'denied' })
+  await clickBannerButton(page, 'Copy')
+  await page.waitForFunction(
+    () => [...document.querySelectorAll('.backend-banner__actions button')].some((b) => b.textContent.includes('Couldn\u2019t copy')),
+    { timeout: 5000 })
+  banner = await page.evaluate(readBanner)
+  check('a rejected clipboard write is not reported as success', () => {
+    assert.equal(banner.buttons.includes('Copied'), false)
+  })
+  await page.close()
+
+  /* ---- Scenario 1d: an overlong saved launch command must wrap, not widen
+     the page. `camelid.launchCommand` survives from a dev session. The token is
+     deliberately unbroken (a deep path, no spaces): a command WITH spaces
+     word-wraps on its own and would make this check pass for free. ---- */
+  resetStub()
+  page = await openBanner({ storage: { 'camelid.launchCommand': `C:\\Users\\someone\\${'VeryDeeplyNestedDirectory\\'.repeat(6)}camelid.exe` } })
+  await page.setViewport({ width: 390, height: 844 })
+  await new Promise((done) => setTimeout(done, 200))
+  banner = await page.evaluate(readBanner)
+  check('a long unbreakable command wraps instead of breaking the layout at 390px', () => {
+    // Prove the scenario is actually exercising the long token before drawing
+    // any conclusion from the geometry.
+    assert.ok(banner.code?.includes('VeryDeeplyNestedDirectory'),
+      `the long command never reached the banner: ${JSON.stringify(banner.code)}`)
+    assert.equal(banner.escapesBox, false, 'the command text escapes the banner box')
+    assert.equal(banner.documentOverflows, false, 'the page scrolls horizontally')
+  })
+  await page.close()
+
+  /* ---- Scenario 1e: the engine is on another host. `camelid serve` would be
+     advice for the wrong machine. ---- */
+  resetStub()
+  page = await openBanner({ storage: { 'camelid.apiBase': 'http://192.168.1.50:8181' } })
+  banner = await page.evaluate(readBanner)
+  check('a remote engine is not told to restart locally', () => {
+    assert.equal(banner.buttons.some((label) => label.includes('Copy restart')), false,
+      `offered a local restart for a remote engine: ${JSON.stringify(banner.buttons)}`)
+    assert.equal(banner.text.includes('served by the engine'), false)
+  })
+  check('a remote engine names the host that is not answering', () => {
+    assert.equal(banner.code, '192.168.1.50')
+    assert.ok(banner.buttons.includes('Settings'))
+  })
+  await page.close()
+
+  /* ---- Scenario 2: the dev server. The Start button must still work. ---- */
+  resetStub()
+  stub.mode = 'dev'
+  page = await openBanner()
+  await page.waitForFunction(
+    () => [...document.querySelectorAll('.backend-banner__actions button')].some((b) => b.textContent.includes('Start Camelid')),
+    { timeout: 15000 })
+  banner = await page.evaluate(readBanner)
+  check('the dev launcher still gets its one-click Start', () => {
+    assert.ok(banner.buttons.some((label) => label.includes('Start Camelid')),
+      `expected the Start button, got ${JSON.stringify(banner.buttons)}`)
+  })
+
+  const startButton = await page.evaluateHandle(() =>
+    [...document.querySelectorAll('.backend-banner__actions button')].find((b) => b.textContent.includes('Start Camelid')))
+  await startButton.asElement().click()
+  const deadline = Date.now() + 10000
+  while (Date.now() < deadline && !stub.requests.some((r) => r.path === '/__camelid/backend/launch')) {
+    await new Promise((done) => setTimeout(done, 100))
+  }
+  check('Start still reaches the dev launch hook', () => {
+    assert.ok(stub.requests.some((r) => r.method === 'POST' && r.path === '/__camelid/backend/launch'),
+      'expected a POST to the dev launch hook')
+  })
+  await page.close()
+
+  check('no page errors', () => {
+    assert.deepEqual(pageErrors, [])
+  })
+
+  console.log(`offline banner smoke: ${results.length} checks passed`)
+  for (const name of results) console.log(`  ok  ${name}`)
+} finally {
+  await browser.close()
+  server.close()
+}

--- a/frontend/scripts/offline-banner-smoke.mjs
+++ b/frontend/scripts/offline-banner-smoke.mjs
@@ -172,6 +172,10 @@ const readBanner = () => {
     code: code?.textContent?.trim() || null,
     buttons: [...(banner?.querySelectorAll('.backend-banner__actions button') || [])].map((b) => b.textContent.trim()),
     escapesBox,
+    // The failure label is much longer than the idle one; at 390px it is the
+    // most likely thing in this banner to burst its container.
+    buttonOverflow: [...(banner?.querySelectorAll('.backend-banner__actions button') || [])]
+      .some((b) => b.scrollWidth > b.clientWidth + 1),
     documentOverflows: document.documentElement.scrollWidth > window.innerWidth + 1,
   }
 }
@@ -219,9 +223,12 @@ try {
   await page.close()
 
   /* ---- Scenario 1b: no clipboard API (a plain-http LAN address is not a
-     secure context). Claiming "Copied" there would be the same lie. ---- */
+     secure context). Claiming "Copied" there would be the same lie. Run at
+     390px: the failure label is the longest string this banner can show. ---- */
   resetStub()
   page = await openBanner({ clipboard: 'absent' })
+  await page.setViewport({ width: 390, height: 844 })
+  await new Promise((done) => setTimeout(done, 150))
   await clickBannerButton(page, 'Copy')
   await page.waitForFunction(
     () => [...document.querySelectorAll('.backend-banner__actions button')].some((b) => !b.textContent.includes('Copy restart')),
@@ -235,6 +242,10 @@ try {
   })
   check('the command stays readable when it could not be copied', () => {
     assert.equal(banner.code, 'camelid serve')
+  })
+  check('the failure label does not burst its button at 390px', () => {
+    assert.equal(banner.buttonOverflow, false, 'a banner button overflows its box')
+    assert.equal(banner.documentOverflows, false, 'the page scrolls horizontally')
   })
   await page.close()
 

--- a/frontend/scripts/offline-banner-smoke.mjs
+++ b/frontend/scripts/offline-banner-smoke.mjs
@@ -285,8 +285,65 @@ try {
   })
   await page.close()
 
-  /* ---- Scenario 1e: the engine is on another host. `camelid serve` would be
-     advice for the wrong machine. The host is an RFC 2606 reserved name, so the
+  /* ---- Scenario 1f: the engine told us where it lives while it was up. The
+     copy button must then produce a command that runs as-is, with no PATH
+     assumption. A path WITHOUT spaces needs no quoting and runs unchanged in
+     both cmd and PowerShell. ---- */
+  resetStub()
+  page = await openBanner({ storage: { 'camelid.enginePath': 'C:\\camelid\\camelid.exe' } })
+  banner = await page.evaluate(readBanner)
+  check('a known engine path becomes a paste-and-run command', () => {
+    assert.equal(banner.code, 'C:\\camelid\\camelid.exe serve')
+  })
+  await clickBannerButton(page, 'Copy')
+  await page.waitForFunction(() => window.__copied.length > 0, { timeout: 5000 })
+  const copiedPath = await page.evaluate(() => window.__copied)
+  check('the clipboard gets the real path, not the PATH-dependent command', () => {
+    assert.deepEqual(copiedPath, ['C:\\camelid\\camelid.exe serve'])
+  })
+  await page.close()
+
+  /* ---- Scenario 1g: a path WITH a space. PowerShell is the default Windows
+     shell and will not execute a quoted string as a command without the `&`
+     call operator, so the naive quoted form fails on the shell most users are
+     actually in. ---- */
+  resetStub()
+  page = await openBanner({ storage: { 'camelid.enginePath': 'C:\\Program Files\\Camelid\\camelid.exe' } })
+  banner = await page.evaluate(readBanner)
+  check('a spaced Windows path is quoted AND call-operated for PowerShell', () => {
+    assert.equal(banner.code, '& "C:\\Program Files\\Camelid\\camelid.exe" serve')
+  })
+  await page.close()
+
+  /* ---- Scenario 1h: a non-default port MUST come back in the command. A bare
+     `serve` re-binds 127.0.0.1:8181, which fails outright when something else
+     owns that port and, even on success, comes up somewhere this tab is not
+     looking — so the banner would never clear. Observed for real. ---- */
+  resetStub()
+  page = await openBanner({ storage: {
+    'camelid.enginePath': 'C:\\camelid\\camelid.exe',
+    'camelid.engineAddr': '127.0.0.1:8188',
+  } })
+  banner = await page.evaluate(readBanner)
+  check('a non-default port is carried into the restart command', () => {
+    assert.equal(banner.code, 'C:\\camelid\\camelid.exe serve --addr 127.0.0.1:8188')
+  })
+  await page.close()
+
+  /* ---- Scenario 1i: the default port stays implicit, so the common case keeps
+     the short command it had. ---- */
+  resetStub()
+  page = await openBanner({ storage: {
+    'camelid.enginePath': 'C:\\camelid\\camelid.exe',
+    'camelid.engineAddr': '127.0.0.1:8181',
+  } })
+  banner = await page.evaluate(readBanner)
+  check('the default port is not spelled out', () => {
+    assert.equal(banner.code, 'C:\\camelid\\camelid.exe serve')
+  })
+  await page.close()
+
+  /* ---- Scenario 1e: the engine is on another host. `camelid serve` would be     advice for the wrong machine. The host is an RFC 2606 reserved name, so the
      fixture is unmistakably synthetic and cannot resolve. ---- */
   resetStub()
   page = await openBanner({ storage: { 'camelid.apiBase': 'http://engine.example:8181' } })

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import SidebarRail from './components/layout/SidebarRail'
 import TopBar from './components/TopBar'
-import { BackendBanner } from './components/layout/BackendBanner'
+import { BackendBanner, ENGINE_PATH_STORAGE_KEY, ENGINE_ADDR_STORAGE_KEY } from './components/layout/BackendBanner'
 import { FirstRunCard } from './components/onboarding/FirstRunCard'
 import { Notice } from './components/ui/Notice'
 import { ConfirmDialog } from './components/ui/ConfirmDialog'
@@ -107,6 +107,19 @@ function App() {
   useEffect(() => {
     if (apiBase) ensureInferenceTelemetryConnected(apiBase)
   }, [apiBase])
+
+  /* Remember where the engine lives while it is still answering. Once it stops,
+     the offline banner needs this to offer a command that actually runs, and by
+     then there is nobody left to ask. Loopback servers only — a remote engine
+     reports no path, so nothing is stored and the banner stays generic. */
+  useEffect(() => {
+    const executable = runtime?.executable
+    if (!executable || typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(ENGINE_PATH_STORAGE_KEY, executable)
+      if (runtime?.listen_addr) window.localStorage.setItem(ENGINE_ADDR_STORAGE_KEY, runtime.listen_addr)
+    } catch { /* private mode */ }
+  }, [runtime?.executable, runtime?.listen_addr])
 
   /* Evidence Chips anywhere in the app deep-link to their ledger row through
      this event — no prop drilling through every chip call site. */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -271,7 +271,7 @@ function App() {
         )}
 
         {!DEMO_UI && runtime?.status === 'offline' && tab !== 'settings' && (
-          <BackendBanner backend={backend} onOpenSettings={() => navigateTab('settings')} />
+          <BackendBanner backend={backend} apiBase={apiBase} onOpenSettings={() => navigateTab('settings')} />
         )}
 
         {!DEMO_UI && firstRunActive && (

--- a/frontend/src/components/layout/BackendBanner.jsx
+++ b/frontend/src/components/layout/BackendBanner.jsx
@@ -4,15 +4,62 @@ import { StatusDot } from '../ui/StatusDot'
 import { IconPlay, IconCopy, IconCheck, IconSettings } from '../ui/icons'
 import { copyText } from '../../lib/markdown'
 
-/* Shown on the copy button when nothing better is known.
+/* Shown on the copy button when the engine never told us where it lives.
 
    NOT presented as "the" restart command. `camelid serve` only runs when the
    binary is on PATH, which it is NOT for the population that actually hits this
    banner: someone who unzipped a release and double-clicked camelid.exe. Handing
    them a command that errors with "'camelid' is not recognized" is the same
-   class of dead end this component exists to remove, so the instruction leads
-   with the executable and the copy action is labelled for what it is. */
+   class of dead end this component exists to remove. */
 const RESTART_COMMAND = 'camelid serve'
+
+/* Where the engine's own path is cached while it is still answering. Written by
+   App.jsx from the health payload; read here, because by the time this banner
+   renders there is nobody left to ask. */
+export const ENGINE_PATH_STORAGE_KEY = 'camelid.enginePath'
+export const ENGINE_ADDR_STORAGE_KEY = 'camelid.engineAddr'
+
+/* `serve` binds this when given no --addr. Anything else has to be passed back
+   explicitly or the restart lands on the wrong port. */
+const DEFAULT_ADDR = '127.0.0.1:8181'
+
+function readStored(key) {
+  if (typeof window === 'undefined') return ''
+  try {
+    return (window.localStorage.getItem(key) || '').trim()
+  } catch {
+    return ''
+  }
+}
+
+function readEnginePath() {
+  return readStored(ENGINE_PATH_STORAGE_KEY)
+}
+
+/* Build a command the user can paste and run, from an absolute executable path.
+
+   Quoting is not cosmetic here. On Windows a path with a space MUST be quoted,
+   and PowerShell — the default Windows shell — will not execute a quoted string
+   as a command without the `&` call operator, so the naive quoted form fails on
+   the very shell most Windows users are in. Paths without a space need no
+   quoting and then run in both cmd and PowerShell unchanged, so that form is
+   preferred whenever it is available.
+
+   `--addr` is appended for any non-default bind. Leaving it off was a real
+   defect: a bare `serve` falls back to 127.0.0.1:8181, which fails outright when
+   something else already owns that port, and even on success comes up somewhere
+   the tab showing this banner is not looking. */
+export function restartCommandFor(executablePath, listenAddr) {
+  const path = (executablePath || '').trim()
+  if (!path) return RESTART_COMMAND
+  const isWindowsPath = /^[A-Za-z]:[\\/]/.test(path) || path.startsWith('\\\\')
+  const launcher = !path.includes(' ')
+    ? path
+    : (isWindowsPath ? `& "${path}"` : `"${path}"`)
+  const addr = (listenAddr || '').trim()
+  const addrFlag = addr && addr !== DEFAULT_ADDR ? ` --addr ${addr}` : ''
+  return `${launcher} serve${addrFlag}`
+}
 
 const LOOPBACK_HOSTS = new Set(['localhost', '[::1]', '::1'])
 
@@ -58,7 +105,10 @@ function engineHostFrom(apiBase, pageHref) {
 export function BackendBanner({ backend, apiBase, onOpenSettings }) {
   const canStart = backend.status.available
   const running = backend.status.running
-  const restartCommand = backend.resolvedCommand || RESTART_COMMAND
+  const enginePath = readEnginePath()
+  const restartCommand = enginePath
+    ? restartCommandFor(enginePath, readStored(ENGINE_ADDR_STORAGE_KEY))
+    : backend.resolvedCommand || RESTART_COMMAND
   const host = engineHostFrom(apiBase, typeof window === 'undefined' ? '' : window.location.href)
   const isLocalEngine = isLoopbackHost(host)
   // 'idle' | 'copied' | 'failed'. Distinguishing the last two matters: the
@@ -77,7 +127,7 @@ export function BackendBanner({ backend, apiBase, onOpenSettings }) {
   }
 
   const copyLabel = { copied: 'Copied', failed: 'Couldn’t copy' }[copyState]
-    || 'Copy terminal command'
+    || (enginePath ? 'Copy restart command' : 'Copy terminal command')
 
   return (
     <div className="backend-banner" role="status" aria-live="polite">
@@ -86,7 +136,10 @@ export function BackendBanner({ backend, apiBase, onOpenSettings }) {
         <strong>Camelid engine isn’t running</strong>
         <span>
           {canStart && 'Start it to load a model and chat — no setup needed.'}
-          {!canStart && isLocalEngine && (
+          {!canStart && isLocalEngine && enginePath && (
+            <>This page is served by the engine, so it can’t restart it. Start it again with <code>{restartCommand}</code> — or just run <code>camelid.exe</code> from where you unzipped Camelid.</>
+          )}
+          {!canStart && isLocalEngine && !enginePath && (
             <>This page is served by the engine, so it can’t restart it. Start <code>camelid.exe</code> again from the folder you unzipped Camelid into — or re-run the command you launched it with.</>
           )}
           {!canStart && !isLocalEngine && (

--- a/frontend/src/components/layout/BackendBanner.jsx
+++ b/frontend/src/components/layout/BackendBanner.jsx
@@ -4,8 +4,14 @@ import { StatusDot } from '../ui/StatusDot'
 import { IconPlay, IconCopy, IconCheck, IconSettings } from '../ui/icons'
 import { copyText } from '../../lib/markdown'
 
-/* Fallback shown on the copy button. Only a hint: the packaged app cannot know
-   which flags the engine was originally launched with. */
+/* Shown on the copy button when nothing better is known.
+
+   NOT presented as "the" restart command. `camelid serve` only runs when the
+   binary is on PATH, which it is NOT for the population that actually hits this
+   banner: someone who unzipped a release and double-clicked camelid.exe. Handing
+   them a command that errors with "'camelid' is not recognized" is the same
+   class of dead end this component exists to remove, so the instruction leads
+   with the executable and the copy action is labelled for what it is. */
 const RESTART_COMMAND = 'camelid serve'
 
 const LOOPBACK_HOSTS = new Set(['localhost', '[::1]', '::1'])
@@ -70,8 +76,8 @@ export function BackendBanner({ backend, apiBase, onOpenSettings }) {
     copyResetRef.current = window.setTimeout(() => setCopyState('idle'), 2400)
   }
 
-  const copyLabel = { copied: 'Copied', failed: 'Couldn’t copy — select it above' }[copyState]
-    || 'Copy restart command'
+  const copyLabel = { copied: 'Copied', failed: 'Couldn’t copy' }[copyState]
+    || 'Copy terminal command'
 
   return (
     <div className="backend-banner" role="status" aria-live="polite">
@@ -81,7 +87,7 @@ export function BackendBanner({ backend, apiBase, onOpenSettings }) {
         <span>
           {canStart && 'Start it to load a model and chat — no setup needed.'}
           {!canStart && isLocalEngine && (
-            <>This page is served by the engine, so it can’t restart it. Run <code>{restartCommand}</code> in a terminal and this clears automatically.</>
+            <>This page is served by the engine, so it can’t restart it. Start <code>camelid.exe</code> again from the folder you unzipped Camelid into — or re-run the command you launched it with.</>
           )}
           {!canStart && !isLocalEngine && (
             <>The engine this UI points at — <code>{host}</code> — isn’t answering. Check that Camelid is running on that machine, or point this UI somewhere else in Settings.</>

--- a/frontend/src/components/layout/BackendBanner.jsx
+++ b/frontend/src/components/layout/BackendBanner.jsx
@@ -1,21 +1,91 @@
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '../ui/Button'
 import { StatusDot } from '../ui/StatusDot'
-import { IconPlay, IconSettings } from '../ui/icons'
+import { IconPlay, IconCopy, IconCheck, IconSettings } from '../ui/icons'
+import { copyText } from '../../lib/markdown'
 
-/* Shown across the app whenever the backend is offline. One-click Start when the
-   dev launch hook is available; otherwise points the user at Settings. */
-export function BackendBanner({ backend, onOpenSettings }) {
+/* Fallback shown on the copy button. Only a hint: the packaged app cannot know
+   which flags the engine was originally launched with. */
+const RESTART_COMMAND = 'camelid serve'
+
+const LOOPBACK_HOSTS = new Set(['localhost', '[::1]', '::1'])
+
+/* Which machine is the engine supposed to be on? `camelid serve` is only sound
+   advice when the UI is talking to THIS machine. Someone who reached a Camelid
+   started with `--addr 0.0.0.0` from a different box must not be told to run the
+   command on their own. An unset API base means same-origin, so the page's own
+   host is the engine's host.
+
+   The whole 127.0.0.0/8 block is loopback, not just 127.0.0.1. */
+function isLoopbackHost(host) {
+  if (!host) return true
+  if (LOOPBACK_HOSTS.has(host)) return true
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)
+}
+
+function engineHostFrom(apiBase, pageHref) {
+  try {
+    return new URL(apiBase || pageHref, pageHref).hostname
+  } catch {
+    return ''
+  }
+}
+
+/* Shown across the app whenever the backend is offline.
+
+   Three situations, and conflating them produced a real dead end:
+
+   1. Dev server (`npm run dev`). The Vite plugin in vite.config.js can spawn the
+      binary, so `status.available` is true and one-click Start genuinely works.
+
+   2. Anything a user downloads, talking to an engine on this machine. That
+      plugin is registered `apply: 'serve'`, so it does not exist in the shipped
+      build and `status.available` is always false. This banner then rendered a
+      lone "Settings" button, which navigated to a page whose only explanation
+      was that the launcher needs the dev server: a control that looks like the
+      fix, is not the fix, and explains nothing to someone who downloaded a
+      release. Worse, this page is served BY the process that died, so it can
+      never restart it — only the user, or the desktop app's supervisor, can.
+
+   3. A UI pointed at an engine on another host. Same missing launcher, but the
+      restart command would be advice for the wrong machine. */
+export function BackendBanner({ backend, apiBase, onOpenSettings }) {
   const canStart = backend.status.available
   const running = backend.status.running
+  const restartCommand = backend.resolvedCommand || RESTART_COMMAND
+  const host = engineHostFrom(apiBase, typeof window === 'undefined' ? '' : window.location.href)
+  const isLocalEngine = isLoopbackHost(host)
+  // 'idle' | 'copied' | 'failed'. Distinguishing the last two matters: the
+  // clipboard API is absent outside secure contexts, and claiming "Copied"
+  // there would be the same class of lie this whole change is removing.
+  const [copyState, setCopyState] = useState('idle')
+  const copyResetRef = useRef(null)
+
+  useEffect(() => () => { if (copyResetRef.current) window.clearTimeout(copyResetRef.current) }, [])
+
+  const handleCopy = async () => {
+    const copied = await copyText(restartCommand)
+    setCopyState(copied ? 'copied' : 'failed')
+    if (copyResetRef.current) window.clearTimeout(copyResetRef.current)
+    copyResetRef.current = window.setTimeout(() => setCopyState('idle'), 2400)
+  }
+
+  const copyLabel = { copied: 'Copied', failed: 'Couldn’t copy — select it above' }[copyState]
+    || 'Copy restart command'
+
   return (
     <div className="backend-banner" role="status" aria-live="polite">
       <StatusDot tone="offline" />
       <div className="backend-banner__copy">
-        <strong>Camelid backend isn’t running</strong>
+        <strong>Camelid engine isn’t running</strong>
         <span>
-          {canStart
-            ? 'Start it to load a model and chat — no setup needed.'
-            : 'Start it from a terminal, then this clears automatically.'}
+          {canStart && 'Start it to load a model and chat — no setup needed.'}
+          {!canStart && isLocalEngine && (
+            <>This page is served by the engine, so it can’t restart it. Run <code>{restartCommand}</code> in a terminal and this clears automatically.</>
+          )}
+          {!canStart && !isLocalEngine && (
+            <>The engine this UI points at — <code>{host}</code> — isn’t answering. Check that Camelid is running on that machine, or point this UI somewhere else in Settings.</>
+          )}
         </span>
       </div>
       <div className="backend-banner__actions">
@@ -31,7 +101,22 @@ export function BackendBanner({ backend, onOpenSettings }) {
             {running ? 'Starting…' : 'Start Camelid'}
           </Button>
         )}
-        <Button variant="ghost" size="sm" icon={<IconSettings size={16} />} onClick={onOpenSettings}>
+        {!canStart && isLocalEngine && (
+          <Button
+            variant="primary"
+            size="sm"
+            icon={copyState === 'copied' ? <IconCheck size={16} /> : <IconCopy size={16} />}
+            onClick={handleCopy}
+          >
+            {copyLabel}
+          </Button>
+        )}
+        <Button
+          variant={!canStart && !isLocalEngine ? 'primary' : 'ghost'}
+          size="sm"
+          icon={<IconSettings size={16} />}
+          onClick={onOpenSettings}
+        >
           Settings
         </Button>
       </div>

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -472,6 +472,14 @@ function makeDashboard({ health, models, currentModel, capabilities, conversatio
       q8_runtime: health?.q8_runtime || null,
       ...executionRuntimeFields(health),
       status: health?.ok ? 'online' : 'offline',
+      // Absolute path of the running binary, disclosed by loopback servers only.
+      // Captured while the engine is UP so the offline banner can still name a
+      // command that actually runs after it goes down.
+      executable: health?.executable || null,
+      // Address the engine is really bound to. A restart command without this
+      // falls back to the default port, which either collides with whatever
+      // owns it or comes up somewhere this tab is not looking.
+      listen_addr: health?.listen_addr || null,
       api_base: apiBase,
       current_model: currentModel || null,
     },

--- a/frontend/src/lib/markdown.jsx
+++ b/frontend/src/lib/markdown.jsx
@@ -14,11 +14,20 @@ export const normalizeCodeLanguage = (value) => {
   return language.toUpperCase()
 }
 
+/* Returns whether the text actually reached the clipboard. `navigator.clipboard`
+   is undefined outside secure contexts — which includes reaching a Camelid served
+   with `--addr 0.0.0.0` over a plain-http LAN address — and optional chaining
+   would otherwise make that indistinguishable from success, letting a caller show
+   a "Copied" confirmation for a copy that never happened. Callers that ignore the
+   result behave exactly as before. */
 export const copyText = async (text) => {
   try {
-    await navigator.clipboard?.writeText(text)
+    if (!navigator.clipboard?.writeText) return false
+    await navigator.clipboard.writeText(text)
+    return true
   } catch {
-    // Clipboard access can be denied outside secure browser contexts; rendering still works.
+    // Clipboard access can be denied even in a secure context; rendering still works.
+    return false
   }
 }
 

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -355,6 +355,7 @@
 .backend-banner__copy { display: flex; flex-direction: column; flex: 1; min-width: 0; }
 .backend-banner__copy strong { font-size: var(--text-sm); }
 .backend-banner__copy span { font-size: var(--text-xs); color: var(--color-text-muted); }
+.backend-banner__copy span code { font-family: var(--font-mono); font-size: 0.92em; padding: 0.1em 0.4em; border-radius: 6px; background: var(--color-code-bg); border: 1px solid var(--color-code-border); color: var(--color-text); overflow-wrap: anywhere; }
 .backend-banner__actions { display: flex; gap: var(--space-2); flex: none; }
 @media (max-width: 640px) {
   .backend-banner { flex-wrap: wrap; }

--- a/frontend/src/views/SettingsView.jsx
+++ b/frontend/src/views/SettingsView.jsx
@@ -120,7 +120,7 @@ export default function SettingsView({
                 ? 'The launched process is running — waiting for it to bind the port…'
                 : status.available
                   ? 'Not running yet. Start it below — Camelid finds the built binary for you.'
-                  : 'Not running. The one-click launcher needs the dev server (npm run dev).'}
+                  : 'Not running. Start it from a terminal with the command below.'}
           </p>
 
           {status.available ? (
@@ -159,16 +159,14 @@ export default function SettingsView({
             </>
           ) : (
             <>
-              <Field label="Launch command">
-                <input type="text" value={command} spellCheck={false} placeholder="camelid serve" onChange={(e) => setCommand(e.target.value)} />
-              </Field>
               <div className="settings-actions">
-                <Button variant="ghost" icon={copied ? <IconCheck size={16} /> : <IconCopy size={16} />} onClick={handleCopy}>
-                  {copied ? 'Copied' : 'Copy command'}
+                <Button variant="primary" icon={copied ? <IconCheck size={16} /> : <IconCopy size={16} />} onClick={handleCopy}>
+                  {copied ? 'Copied' : 'Copy restart command'}
                 </Button>
               </div>
               <p className="settings-help settings-help--muted">
-                Run <code>{resolvedCommand || 'camelid serve'}</code> in a terminal from the repo root, then this turns Online automatically.
+                Run <code>{resolvedCommand || 'camelid serve'}</code> in a terminal, then this turns Online
+                automatically. This page is served by the engine itself, so it cannot start one for you.
               </p>
             </>
           )}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -494,6 +494,27 @@ pub struct HealthResponse {
     pub engine_active_generated_tokens: u64,
     pub engine_active_elapsed_seconds: u64,
     pub engine_stalled_seconds: u64,
+    /// Absolute path of the running `camelid` binary, so the WebUI can tell a
+    /// user exactly how to start the engine again after it stops. `camelid
+    /// serve` is only runnable when the binary is on PATH, which it is NOT for
+    /// someone who unzipped a release — for them the bare command fails with
+    /// "'camelid' is not recognized", which is not a usable instruction.
+    ///
+    /// Loopback deployments ONLY. Off-box this would hand a filesystem path (and
+    /// usually a username) to every caller of an endpoint that is reachable
+    /// before authentication, and the advice would be useless there anyway: the
+    /// reader is not sitting at the machine that needs restarting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub executable: Option<String>,
+    /// Address this process is actually listening on, so a restart command can
+    /// reproduce it. Without this the UI can only suggest a bare `serve`, which
+    /// silently falls back to the DEFAULT port — it then fails outright if
+    /// something else owns that port, and even when it succeeds the tab showing
+    /// the banner is pointed somewhere else and never reconnects.
+    ///
+    /// Same loopback-only gate as [`HealthResponse::executable`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_addr: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2419,7 +2440,61 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         engine_active_generated_tokens: slot.completed_units,
         engine_active_elapsed_seconds: slot.active_elapsed_seconds,
         engine_stalled_seconds: slot.stalled_seconds,
+        executable: loopback_executable_path(state.serve_addr),
+        listen_addr: (state.serve_addr.ip().is_loopback()).then(|| state.serve_addr.to_string()),
     })
+}
+
+/// Resolve the running binary's path for [`HealthResponse::executable`].
+///
+/// Returns `None` for any non-loopback listener so a remotely reachable server
+/// never discloses its filesystem layout, and `None` when the path cannot be
+/// determined — the caller treats absence as "fall back to generic advice".
+fn loopback_executable_path(serve_addr: SocketAddr) -> Option<String> {
+    if !serve_addr.ip().is_loopback() {
+        return None;
+    }
+    let path = std::env::current_exe().ok()?;
+    let path = path.to_string_lossy().into_owned();
+    // Strip the Windows verbatim prefix if one is present: `\\?\C:\...` is valid
+    // for the OS but is not something a user can paste into a shell.
+    Some(path.strip_prefix(r"\\?\").unwrap_or(&path).to_string())
+}
+
+#[cfg(test)]
+mod executable_disclosure_tests {
+    use super::loopback_executable_path;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn a_loopback_listener_reports_the_running_binary() {
+        for addr in ["127.0.0.1:8181", "[::1]:8181"] {
+            let resolved = loopback_executable_path(addr.parse::<SocketAddr>().unwrap())
+                .expect("a loopback listener discloses its own path");
+            assert!(
+                !resolved.starts_with(r"\\?\"),
+                "the verbatim prefix is not shell-pasteable: {resolved}"
+            );
+            // The test binary is what is running, so this is the honest answer.
+            assert!(
+                std::path::Path::new(&resolved).exists(),
+                "reported a path that does not exist: {resolved}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_reachable_listener_discloses_nothing() {
+        // The path usually contains a username, and the advice would be useless
+        // to a reader who is not sitting at this machine anyway.
+        for addr in ["0.0.0.0:8181", "192.0.2.10:8181"] {
+            assert_eq!(
+                loopback_executable_path(addr.parse::<SocketAddr>().unwrap()),
+                None,
+                "{addr} must not disclose the binary path"
+            );
+        }
+    }
 }
 
 fn health_backend(


### PR DESCRIPTION
## Why

When the engine dies with the tab still open, the offline banner is the only surface a user has. Its branch is chosen from a live probe of the Vite dev-server launch hook — which is registered `apply: 'serve'` in `vite.config.js` and therefore **does not exist in anything a user downloads**.

So in every shipped build `status.available` is false, the Start button never renders, and the banner fell back to a lone **Settings** button that navigated to a page whose only explanation was that the one-click launcher needs `npm run dev`.

That is a control that looks like the fix, is not the fix, and explains nothing. It was reported by a user who clicked it expecting the server to come back. It also could not have worked: the page is served **by** the process that died, so it can never restart it — only the user, or the desktop app's supervisor, can.

## What

The banner now has three honest states:

| Situation | Behaviour |
|---|---|
| Dev server (`npm run dev`) | **Unchanged.** One-click Start still works and still reaches `/__camelid/backend/launch`. |
| Packaged, engine on this machine | Explains that the page cannot restart the engine, and offers a command that runs as-is. |
| Packaged, engine on another host | Names the host that is not answering and points at Settings. |

The third state matters because telling someone who reached a `--addr 0.0.0.0` Camelid from a different box to run `camelid serve` would be advice for the wrong machine. Loopback detection covers the whole `127.0.0.0/8` block, not just `127.0.0.1`.

`SettingsView` drops the dev-only framing (`needs the dev server (npm run dev)`, `from the repo root`) and the inert "Launch command" input, which fed a launcher that is not present in that build.

## The command is now genuinely one-shot

`/v1/health` reports `executable` and `listen_addr`; the WebUI captures both **while the engine is still answering**, because by the time the banner renders there is nobody left to ask.

Both fields are **loopback-only**. Off-box they would hand a filesystem path (and usually a username) to every caller of an endpoint reachable before authentication, and the advice is useless to a reader who is not at the machine that needs restarting. Two tests pin it: a loopback listener reports a real, existing, non-verbatim path; `0.0.0.0` and a routable address report nothing.

## Three defects this PR found by running its own instructions

Each was **observed**, not reasoned about.

**1. `camelid serve` is not on PATH.** Following the banner's own advice produced:
```
camelid : The term 'camelid' is not recognized as the name of a cmdlet...
```
That is the exact population this banner serves — someone who unzipped a release and double-clicked `camelid.exe`. Handing them an unrunnable command is the same class of dead end this PR removes.

**2. The bare command re-binds the DEFAULT port.** Running it gave `os error 10048`, because another Camelid already owned `127.0.0.1:8181`. The engine journal recorded the proof — a `session_start` on `:8181` while the live engine was on `:8188`. Even on a free port, the tab showing the banner points elsewhere and would never reconnect. `--addr` is now carried for any non-default bind and stays implicit for the default.

**3. Quoting is not cosmetic.** PowerShell is the default Windows shell and will not execute a quoted string as a command without the `&` call operator, so the naive `"C:\Program Files\...\camelid.exe" serve` fails on the very shell most users are in. Paths without a space are emitted unquoted (identical behaviour in cmd and PowerShell); spaced Windows paths get the call operator.

## Clipboard honesty

`copyText` now reports whether the text actually reached the clipboard. `navigator.clipboard` is undefined outside secure contexts — which includes reaching Camelid over a plain-http LAN address — and optional chaining made that indistinguishable from success, so the button would have confirmed "Copied" for a copy that never happened. The return value is **additive**; the other seven call sites ignore it and are unaffected.

## Coverage

`smoke:offline-banner` (**22 checks**) drives the real app in a real browser against both server shapes, because the branch cannot be proved by rendering markup. All requests outside the harness are aborted, so the suite touches no network and runs in **2.8s instead of 44.5s**. Wired into the frontend CI job.

Verified end to end with Playwright against the **real** engine: path and address captured while healthy → engine killed → banner offered `...camelid.exe serve --addr 127.0.0.1:8188` → Copy put exactly that on the clipboard → **running that exact string brought the engine back and cleared the banner**.

## Every guard was ablated, not assumed

| Ablation | Failure |
|---|---|
| Revert the banner | `expected a copy action, got ["Settings"]` — the reported symptom exactly |
| Revert the clipboard check | `claimed a copy with no clipboard API` |
| Revert the host check | `offered a local restart for a remote engine` |
| Remove the wrap rule | `the host text escapes the banner box` |
| Inflate the failure label | `a banner button overflows its box` |

Two things surfaced only because the ablations were actually run:

- The wrap ablation **initially passed** — a false negative. The payload contained hyphens, and hyphens are line-break opportunities, so it wrapped without the rule. With a realistic unbroken path the code element measured **1290px against a 370px banner edge**.
- The scenarios leaked `localStorage` into each other through the shared browser profile until each one started from a cleared store. Caught by rendering the states and looking at the screenshots, not by an assertion.

## Validation

`fmt`, `clippy --all-targets -- -D warnings`, and `check-public-scrub` all exit 0. Frontend build plus `ui`, `first-run-card`, `catalog-browse`, `model-lanes`, `model-state`, `streaming`, `markdown`, `integration`, `3b-closure`, `capability-readiness` smokes exit 0. Layout measured at 390×844: text does not escape the banner, no sideways scroll, no button overflow.

Full library suite: **1256 passed / 1 failed**. The failure is `gait::tests::memory_measurement_is_sane`, a hardware benchmark asserting plausible memory bandwidth. It is **not** from this change, and that was verified rather than asserted: the same suite on a clean tree with these changes stashed fails identically (**1254 passed / 1 failed** — exactly two fewer tests, the two added here), and the test passes in isolation. It trips only under the load of 1326 parallel tests on a box with ~3 GiB free RAM.

## Scope boundaries

- Does not add a way for the WebUI to restart the engine. It cannot; that is the point.
- Does not change the other `copyText` call sites, which keep their current behaviour.
- The restart command reproduces the executable and the bind address, not every original flag (`--models-dir`, `--model`). The banner therefore also tells the user they can re-run whatever command they launched it with.
- The desktop app's supervisor path is untouched.

<img width="2582" height="1724" alt="image" src="https://github.com/user-attachments/assets/f2f7bc3b-178c-4518-9e76-1a6c68bf7ede" />

