### PR TITLE
feat(tokenizer): support the tekken pre-tokenizer, add stablelm2, refuse command-r

### DIFF
--- a/qa/prompt-packs/mistral-nemo-tekken-tokenizer-oracle-v1.json
+++ b/qa/prompt-packs/mistral-nemo-tekken-tokenizer-oracle-v1.json
@@ -1,0 +1,499 @@
+{
+  "oracle": {
+    "command": "llama-tokenize -m <gguf> -p <input> --ids --no-bos --no-escape --log-disable",
+    "commit": "acd79d603cb2e1c84c0886137b80f1ad649b6857",
+    "model": "Mistral-Nemo-Instruct-2407-Q4_K_M.gguf",
+    "pre_tokenizer": "tekken"
+  },
+  "cases": [
+    {
+      "id": "contraction-s",
+      "input": "John's book",
+      "input_utf8_hex": "4a6f686e277320626f6f6b",
+      "expected_token_ids": [
+        14979,
+        1681,
+        4978
+      ]
+    },
+    {
+      "id": "contraction-t",
+      "input": "don't stop",
+      "input_utf8_hex": "646f6e27742073746f70",
+      "expected_token_ids": [
+        21797,
+        2405,
+        5304
+      ]
+    },
+    {
+      "id": "contraction-re",
+      "input": "we're here",
+      "input_utf8_hex": "77652772652068657265",
+      "expected_token_ids": [
+        1808,
+        6185,
+        3226
+      ]
+    },
+    {
+      "id": "contraction-ve",
+      "input": "they've gone",
+      "input_utf8_hex": "7468657927766520676f6e65",
+      "expected_token_ids": [
+        43880,
+        6483,
+        13141
+      ]
+    },
+    {
+      "id": "contraction-ll",
+      "input": "it'll work",
+      "input_utf8_hex": "6974276c6c20776f726b",
+      "expected_token_ids": [
+        1276,
+        7534,
+        2196
+      ]
+    },
+    {
+      "id": "contraction-d",
+      "input": "I'd like",
+      "input_utf8_hex": "492764206c696b65",
+      "expected_token_ids": [
+        1073,
+        6813,
+        2479
+      ]
+    },
+    {
+      "id": "contraction-upper",
+      "input": "JOHN'S BOOK",
+      "input_utf8_hex": "4a4f484e275320424f4f4b",
+      "expected_token_ids": [
+        1074,
+        16724,
+        1078,
+        44161,
+        27478,
+        13257
+      ]
+    },
+    {
+      "id": "digits-run",
+      "input": "1234567890",
+      "input_utf8_hex": "31323334353637383930",
+      "expected_token_ids": [
+        1049,
+        1050,
+        1051,
+        1052,
+        1053,
+        1054,
+        1055,
+        1056,
+        1057,
+        1048
+      ]
+    },
+    {
+      "id": "digits-embedded",
+      "input": "abc123def",
+      "input_utf8_hex": "616263313233646566",
+      "expected_token_ids": [
+        35416,
+        1049,
+        1050,
+        1051,
+        3149
+      ]
+    },
+    {
+      "id": "digits-mixed",
+      "input": "v2.1.0 build 4567",
+      "input_utf8_hex": "76322e312e30206275696c642034353637",
+      "expected_token_ids": [
+        1118,
+        1050,
+        1046,
+        1049,
+        1046,
+        1048,
+        4317,
+        1032,
+        1052,
+        1053,
+        1054,
+        1055
+      ]
+    },
+    {
+      "id": "digits-leading-space",
+      "input": " 42",
+      "input_utf8_hex": "203432",
+      "expected_token_ids": [
+        1032,
+        1052,
+        1050
+      ]
+    },
+    {
+      "id": "camel-case",
+      "input": "HelloWorld",
+      "input_utf8_hex": "48656c6c6f576f726c64",
+      "expected_token_ids": [
+        22177,
+        20249
+      ]
+    },
+    {
+      "id": "camel-acronym",
+      "input": "getHTTPResponse",
+      "input_utf8_hex": "67657448545450526573706f6e7365",
+      "expected_token_ids": [
+        1689,
+        30499,
+        6566
+      ]
+    },
+    {
+      "id": "all-caps",
+      "input": "HELLO WORLD",
+      "input_utf8_hex": "48454c4c4f20574f524c44",
+      "expected_token_ids": [
+        7626,
+        1076,
+        7618,
+        88164
+      ]
+    },
+    {
+      "id": "single-upper",
+      "input": "A b C d",
+      "input_utf8_hex": "41206220432064",
+      "expected_token_ids": [
+        1065,
+        1289,
+        1359,
+        1266
+      ]
+    },
+    {
+      "id": "leading-space-word",
+      "input": " hello",
+      "input_utf8_hex": "2068656c6c6f",
+      "expected_token_ids": [
+        52528
+      ]
+    },
+    {
+      "id": "punct-prefix-word",
+      "input": "(hello",
+      "input_utf8_hex": "2868656c6c6f",
+      "expected_token_ids": [
+        1040,
+        29706
+      ]
+    },
+    {
+      "id": "slash-path",
+      "input": "a/b/c",
+      "input_utf8_hex": "612f622f63",
+      "expected_token_ids": [
+        1097,
+        15836,
+        5938
+      ]
+    },
+    {
+      "id": "url",
+      "input": "https://example.com/path?q=1",
+      "input_utf8_hex": "68747470733a2f2f6578616d706c652e636f6d2f706174683f713d31",
+      "expected_token_ids": [
+        3299,
+        2345,
+        16609,
+        2354,
+        109366,
+        92404,
+        1061,
+        1049
+      ]
+    },
+    {
+      "id": "punct-run",
+      "input": "!!!???",
+      "input_utf8_hex": "2121213f3f3f",
+      "expected_token_ids": [
+        7290,
+        8937,
+        45509
+      ]
+    },
+    {
+      "id": "punct-newline",
+      "input": "x!\ny",
+      "input_utf8_hex": "78210a79",
+      "expected_token_ids": [
+        1120,
+        11330,
+        1121
+      ]
+    },
+    {
+      "id": "multi-space",
+      "input": "a   b",
+      "input_utf8_hex": "6120202062",
+      "expected_token_ids": [
+        1097,
+        1256,
+        1289
+      ]
+    },
+    {
+      "id": "trailing-space",
+      "input": "end   ",
+      "input_utf8_hex": "656e64202020",
+      "expected_token_ids": [
+        1474,
+        1293
+      ]
+    },
+    {
+      "id": "newlines",
+      "input": "x\n\ny",
+      "input_utf8_hex": "780a0a79",
+      "expected_token_ids": [
+        1120,
+        1267,
+        1121
+      ]
+    },
+    {
+      "id": "tab",
+      "input": "a\tb",
+      "input_utf8_hex": "610962",
+      "expected_token_ids": [
+        1097,
+        40796
+      ]
+    },
+    {
+      "id": "leading-newline",
+      "input": "\nstart",
+      "input_utf8_hex": "0a7374617274",
+      "expected_token_ids": [
+        1010,
+        10460
+      ]
+    },
+    {
+      "id": "accented-lower",
+      "input": "élan vital",
+      "input_utf8_hex": "c3a96c616e20766974616c",
+      "expected_token_ids": [
+        4759,
+        1271,
+        21970
+      ]
+    },
+    {
+      "id": "accented-upper",
+      "input": "ÉLAN VITAL",
+      "input_utf8_hex": "c3894c414e20564954414c",
+      "expected_token_ids": [
+        7904,
+        65744,
+        1581,
+        4778,
+        4286
+      ]
+    },
+    {
+      "id": "accented-mixed",
+      "input": "Café Zürich",
+      "input_utf8_hex": "436166c3a9205ac3bc72696368",
+      "expected_token_ids": [
+        1067,
+        4032,
+        1337,
+        51438
+      ]
+    },
+    {
+      "id": "cyrillic",
+      "input": "Привет мир",
+      "input_utf8_hex": "d09fd180d0b8d0b2d0b5d18220d0bcd0b8d180",
+      "expected_token_ids": [
+        45497,
+        13745,
+        50430
+      ]
+    },
+    {
+      "id": "greek",
+      "input": "Ελληνικά",
+      "input_utf8_hex": "ce95cebbcebbceb7cebdceb9cebaceac",
+      "expected_token_ids": [
+        36742,
+        53660,
+        13865
+      ]
+    },
+    {
+      "id": "cjk",
+      "input": "日本語のテキスト",
+      "input_utf8_hex": "e697a5e69cace8aa9ee381aee38386e382ade382b9e38388",
+      "expected_token_ids": [
+        10008,
+        15199,
+        2439,
+        7282,
+        14742,
+        13854
+      ]
+    },
+    {
+      "id": "korean",
+      "input": "한국어 텍스트",
+      "input_utf8_hex": "ed959ceab5adec96b420ed858dec8aa4ed8ab8",
+      "expected_token_ids": [
+        2316,
+        6430,
+        2897,
+        1915,
+        18550,
+        26043
+      ]
+    },
+    {
+      "id": "emoji",
+      "input": "hi 👋 there 🎉",
+      "input_utf8_hex": "686920f09f918b20746865726520f09f8e89",
+      "expected_token_ids": [
+        8101,
+        119685,
+        1145,
+        1139,
+        2156,
+        119685,
+        1142,
+        1137
+      ]
+    },
+    {
+      "id": "combining",
+      "input": "égalité",
+      "input_utf8_hex": "65cc8167616c697465cc81",
+      "expected_token_ids": [
+        1101,
+        1204,
+        1129,
+        7048,
+        1752,
+        1204,
+        1129
+      ]
+    },
+    {
+      "id": "prose",
+      "input": "The quick brown fox jumps over the lazy dog.",
+      "input_utf8_hex": "54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f672e",
+      "expected_token_ids": [
+        1784,
+        7586,
+        22980,
+        94137,
+        72993,
+        2136,
+        1278,
+        42757,
+        10575,
+        1046
+      ]
+    },
+    {
+      "id": "code",
+      "input": "fn main() { let x = vec![1, 2, 3]; }",
+      "input_utf8_hex": "666e206d61696e2829207b206c65742078203d20766563215b312c20322c20335d3b207d",
+      "expected_token_ids": [
+        28117,
+        2830,
+        1690,
+        1445,
+        2878,
+        2460,
+        1376,
+        11405,
+        10614,
+        1049,
+        1044,
+        1032,
+        1050,
+        1044,
+        1032,
+        1051,
+        18290,
+        1495
+      ]
+    },
+    {
+      "id": "json",
+      "input": "{\"key\": \"value\", \"n\": 42}",
+      "input_utf8_hex": "7b226b6579223a202276616c7565222c20226e223a2034327d",
+      "expected_token_ids": [
+        19227,
+        3892,
+        2811,
+        1429,
+        3386,
+        1897,
+        1429,
+        1110,
+        2811,
+        1032,
+        1052,
+        1050,
+        1125
+      ]
+    },
+    {
+      "id": "mixed",
+      "input": "Mistral's Nemo-12B: 128K ctx, released 2024/07/18!",
+      "input_utf8_hex": "4d69737472616c2773204e656d6f2d3132423a203132384b206374782c2072656c656173656420323032342f30372f313821",
+      "expected_token_ids": [
+        1077,
+        1416,
+        2784,
+        1681,
+        1464,
+        15030,
+        1045,
+        1049,
+        1050,
+        1066,
+        1058,
+        1032,
+        1049,
+        1050,
+        1056,
+        1075,
+        18920,
+        1044,
+        7358,
+        1032,
+        1050,
+        1048,
+        1050,
+        1052,
+        1047,
+        1048,
+        1055,
+        1047,
+        1049,
+        1056,
+        1033
+      ]
+    }
+  ]
+}

--- a/scripts/gen-tekken-tokenizer-oracle.mjs
+++ b/scripts/gen-tekken-tokenizer-oracle.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Generate the tekken tokenizer oracle pack from the pinned llama.cpp
+// `llama-tokenize`, for `tokenizer::tests::tekken_tokenizer_matches_pinned_oracle`.
+//
+//   node scripts/gen-tekken-tokenizer-oracle.mjs \
+//     --gguf <Mistral-Nemo-*.gguf> --bin <llama-tokenize.exe> --commit <sha> \
+//     > qa/prompt-packs/mistral-nemo-tekken-tokenizer-oracle-v1.json
+//
+// The cases deliberately concentrate on the two places tekken differs from
+// gpt-4o (no contraction group; single-digit grouping) plus the branches they
+// share, since a pre-tokenizer bug is silently-different tokens, not a crash.
+
+import { execFileSync } from 'node:child_process';
+import { Buffer } from 'node:buffer';
+
+const args = process.argv.slice(2);
+const arg = (name) => {
+  const i = args.indexOf(`--${name}`);
+  if (i === -1 || i + 1 >= args.length) {
+    throw new Error(`missing --${name}`);
+  }
+  return args[i + 1];
+};
+
+const gguf = arg('gguf');
+const bin = arg('bin');
+const commit = arg('commit');
+
+const CASES = [
+  // --- tekken difference 1: no contraction group in the word alternatives ---
+  ['contraction-s', "John's book"],
+  ['contraction-t', "don't stop"],
+  ['contraction-re', "we're here"],
+  ['contraction-ve', "they've gone"],
+  ['contraction-ll', "it'll work"],
+  ['contraction-d', "I'd like"],
+  ['contraction-upper', "JOHN'S BOOK"],
+
+  // --- tekken difference 2: digits are one segment each ---
+  ['digits-run', '1234567890'],
+  ['digits-embedded', 'abc123def'],
+  ['digits-mixed', 'v2.1.0 build 4567'],
+  ['digits-leading-space', ' 42'],
+
+  // --- shared: case-run word grammar (prefix? UPPER* LOWER+ | UPPER+ LOWER*) ---
+  ['camel-case', 'HelloWorld'],
+  ['camel-acronym', 'getHTTPResponse'],
+  ['all-caps', 'HELLO WORLD'],
+  ['single-upper', 'A b C d'],
+  ['leading-space-word', ' hello'],
+  ['punct-prefix-word', '(hello'],
+
+  // --- shared: punctuation branch, whose tail is [\r\n/]* (note the slash) ---
+  ['slash-path', 'a/b/c'],
+  ['url', 'https://example.com/path?q=1'],
+  ['punct-run', '!!!???'],
+  ['punct-newline', 'x!\ny'],
+
+  // --- shared: whitespace branches ---
+  ['multi-space', 'a   b'],
+  ['trailing-space', 'end   '],
+  ['newlines', 'x\n\ny'],
+  ['tab', 'a\tb'],
+  ['leading-newline', '\nstart'],
+
+  // --- unicode: the ASCII case classes make non-ASCII letters both upper- and
+  // lower-like, which is the subtle part of this dialect ---
+  ['accented-lower', 'élan vital'],
+  ['accented-upper', 'ÉLAN VITAL'],
+  ['accented-mixed', 'Café Zürich'],
+  ['cyrillic', 'Привет мир'],
+  ['greek', 'Ελληνικά'],
+  ['cjk', '日本語のテキスト'],
+  ['korean', '한국어 텍스트'],
+  ['emoji', 'hi 👋 there 🎉'],
+  ['combining', 'égalité'],
+
+  // --- prose and code, the realistic shapes ---
+  ['prose', 'The quick brown fox jumps over the lazy dog.'],
+  ['code', 'fn main() { let x = vec![1, 2, 3]; }'],
+  ['json', '{"key": "value", "n": 42}'],
+  ['mixed', "Mistral's Nemo-12B: 128K ctx, released 2024/07/18!"],
+];
+
+const cases = CASES.map(([id, input]) => {
+  // --no-bos     : the vector is the pre-tokenizer + BPE result alone, with no
+  //                BOS policy folded in.
+  // --no-escape  : REQUIRED. Without it llama-tokenize interprets `\n`/`\t`
+  //                sequences in the argument, so any case containing a literal
+  //                backslash would be re-interpreted and the oracle would not
+  //                describe the bytes we actually feed Camelid.
+  // --log-disable: keep model-load chatter off stderr.
+  const out = execFileSync(
+    bin,
+    ['-m', gguf, '-p', input, '--ids', '--no-bos', '--no-escape', '--log-disable'],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  // llama-tokenize --ids prints a bracketed list, e.g. "[1, 2, 3]".
+  const match = out.match(/\[[^\]]*\]/);
+  if (!match) {
+    throw new Error(`could not parse ids for case ${id}: ${out}`);
+  }
+  const ids = JSON.parse(match[0]);
+  return {
+    id,
+    input,
+    input_utf8_hex: Buffer.from(input, 'utf8').toString('hex'),
+    expected_token_ids: ids,
+  };
+});
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      oracle: {
+        command: `llama-tokenize -m <gguf> -p <input> --ids --no-bos --no-escape --log-disable`,
+        commit,
+        model: 'Mistral-Nemo-Instruct-2407-Q4_K_M.gguf',
+        pre_tokenizer: 'tekken',
+      },
+      cases,
+    },
+    null,
+    2,
+  )}\n`,
+);

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -40,7 +40,29 @@ pub enum BpePreTokenizer {
     /// up to three (`\p{N}{1,3}`).
     #[default]
     Llama3,
-    /// command-r pre-tokenizer, standard byte-fallback tiktoken behavior.
+    /// **Unreachable scaffolding — does NOT model llama.cpp's `command-r`.**
+    ///
+    /// This variant is parameterised as "llama-bpe with 3-digit grouping", but the
+    /// reference `LLAMA_VOCAB_PRE_TYPE_COMMAND_R` is not in the llama3 family at
+    /// all. llama.cpp groups it with SMOLLM/STARCODER/REFACT and uses a TWO-regex
+    /// list (`src/llama-vocab.cpp`):
+    ///
+    /// ```text
+    /// "\p{N}",
+    /// "'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)"
+    /// ```
+    ///
+    /// That differs from llama3 on three axes, not one: digits split individually
+    /// (the leading `\p{N}` isolates each, so the later ` ?\p{N}+` can never regroup
+    /// them) rather than in runs of three; the letter branch is ` ?\p{L}+` (space
+    /// prefix only) rather than `[^\r\n\p{L}\p{N}]?\p{L}+` (any non-alphanumeric
+    /// prefix); and the contractions are case-SENSITIVE rather than `'[sS]`-style.
+    ///
+    /// It is scaffolding rather than a live defect: command-r is refused at the
+    /// architecture axis before any tokenizer runs, and `resolve_gpt2_pre_tokenizer`
+    /// now refuses the `command-r` metadata value outright, so this variant cannot
+    /// be reached from a GGUF. Implementing it properly means adding a genuinely
+    /// different splitter, not another `digit_group_max` value.
     CommandR,
     /// llama.cpp `qwen2` (Qwen2/Qwen3): each digit is its own piece (`\p{N}`).
     /// Byte-for-byte identical to `llama-bpe` in every other branch — verified
@@ -282,8 +304,24 @@ fn resolve_gpt2_pre_tokenizer(
 ) -> Result<BpePreTokenizer> {
     match pre {
         Some("llama-bpe") => Ok(BpePreTokenizer::Llama3),
-        Some("command-r") => Ok(BpePreTokenizer::CommandR),
+        // `command-r` is refused rather than mapped: [`BpePreTokenizer::CommandR`]
+        // models it as llama3-with-3-digit-grouping, but the reference dialect is
+        // a different two-regex form entirely (see that variant's docs). Accepting
+        // it here would silently mis-tokenize. The architecture is refused upstream
+        // anyway, so this closes a latent footgun rather than removing a capability.
+        Some("command-r") => Err(BackendError::UnsupportedTokenizer(
+            "command-r's pre-tokenizer is not implemented: the reference dialect is \
+             not in the llama-bpe family (digits split individually, ` ?\\p{L}+` \
+             letter branch, case-sensitive contractions) and Camelid's CommandR \
+             variant does not model it"
+                .to_string(),
+        )),
         Some("qwen2") => Ok(BpePreTokenizer::Qwen2),
+        // `stablelm2` is an EXACT alias of `qwen2`: llama.cpp puts
+        // LLAMA_VOCAB_PRE_TYPE_STABLELM2 and _QWEN2 in the same switch arm with one
+        // shared regex body, so no new splitter is required. Verified
+        // character-for-character against `src/llama-vocab.cpp`.
+        Some("stablelm2") => Ok(BpePreTokenizer::Qwen2),
         Some("qwen35") => Ok(BpePreTokenizer::Qwen35),
         Some("gpt-4o") if allow_gpt4o => Ok(BpePreTokenizer::Gpt4o),
         Some("gpt-4o") => Err(BackendError::UnsupportedTokenizer(
@@ -292,7 +330,7 @@ fn resolve_gpt2_pre_tokenizer(
         )),
         None if is_llama3_bpe_signature(token_texts) => Ok(BpePreTokenizer::Llama3),
         other => Err(BackendError::UnsupportedTokenizer(format!(
-            "unsupported GPT-2/BPE pre-tokenizer {other:?}; currently supported: llama-bpe, command-r, qwen2, qwen35"
+            "unsupported GPT-2/BPE pre-tokenizer {other:?}; currently supported: llama-bpe, qwen2, qwen35, stablelm2"
         ))),
     }
 }
@@ -2183,6 +2221,40 @@ mod tests {
             Ok(BpePreTokenizer::Gpt4o)
         ));
         assert!(resolve_gpt2_pre_tokenizer(Some("gpt-4o"), &no_sig, false).is_err());
+
+        // `stablelm2` is an EXACT alias of `qwen2` — llama.cpp puts
+        // LLAMA_VOCAB_PRE_TYPE_STABLELM2 and _QWEN2 in one switch arm sharing a
+        // single regex body, so it needs no new splitter.
+        assert!(matches!(
+            resolve_gpt2_pre_tokenizer(Some("stablelm2"), &no_sig, false),
+            Ok(BpePreTokenizer::Qwen2)
+        ));
+
+        // `command-r` is REFUSED, not mapped. BpePreTokenizer::CommandR models it
+        // as llama3-with-3-digit-grouping, but the reference dialect is a different
+        // two-regex form (digits split individually, ` ?\p{L}+` letter branch,
+        // case-sensitive contractions). Accepting it would silently mis-tokenize.
+        assert!(resolve_gpt2_pre_tokenizer(Some("command-r"), &no_sig, false).is_err());
+        assert!(resolve_gpt2_pre_tokenizer(Some("command-r"), &sig, false).is_err());
+
+        // Dialects that are NOT aliases of anything implemented stay refused: each
+        // needs a genuinely different splitter, not another digit-grouping value.
+        //   tekken       -> case-run lookahead groups
+        //   smollm       -> two-regex GPT-2 form (same arm as command-r)
+        //   deepseek-llm -> six-regex list with explicit Unicode range classes
+        //   llama4       -> maps to GPT4O upstream, which is sha256-gated here
+        for unsupported in [
+            "tekken",
+            "smollm",
+            "deepseek-llm",
+            "deepseek-coder",
+            "llama4",
+        ] {
+            assert!(
+                resolve_gpt2_pre_tokenizer(Some(unsupported), &no_sig, false).is_err(),
+                "{unsupported} must stay refused until its splitter exists"
+            );
+        }
 
         // Missing pre + Llama-3 signature => recovered as Llama3 (the fix).
         assert!(matches!(

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -80,6 +80,24 @@ pub enum BpePreTokenizer {
     /// llama.cpp `gpt-4o`: its collapsed-regex dialect uses ASCII-only case
     /// classes over Unicode General Category `L` code points.
     Gpt4o,
+    /// llama.cpp `tekken` (Mistral Nemo / Ministral / Mistral Small 3.x).
+    ///
+    /// Shares gpt-4o's case-run word grammar verbatim — same two alternatives,
+    /// same `[^\r\n\p{L}\p{N}]?` prefix, same ` ?[^\s\p{L}\p{N}]+[\r\n/]*`
+    /// punctuation branch (note the `/` in the tail, which llama-bpe lacks), same
+    /// whitespace branches. Diffed character-for-character against
+    /// `LLAMA_VOCAB_PRE_TYPE_TEKKEN` and `_GPT4O` in `src/llama-vocab.cpp`; they
+    /// differ in exactly two places:
+    ///
+    /// 1. gpt-4o appends an optional contraction group to both word alternatives;
+    ///    tekken has none. So `"John's"` is ONE segment under gpt-4o and TWO
+    ///    under tekken.
+    /// 2. gpt-4o groups digits `\p{N}{1,3}`; tekken is `\p{N}` — one per segment.
+    ///
+    /// Unlike [`Self::Gpt4o`], which is admitted only for one sha256-pinned
+    /// artifact, tekken is validated against a real Mistral Nemo GGUF via
+    /// token-id agreement with the pinned `llama-tokenize` oracle.
+    Tekken,
 }
 
 impl BpePreTokenizer {
@@ -87,7 +105,7 @@ impl BpePreTokenizer {
     fn digit_group_max(self) -> usize {
         match self {
             Self::Llama3 | Self::CommandR | Self::Gpt4o => 3,
-            Self::Qwen2 | Self::Qwen35 => 1,
+            Self::Qwen2 | Self::Qwen35 | Self::Tekken => 1,
         }
     }
 
@@ -95,6 +113,23 @@ impl BpePreTokenizer {
     /// excluded from the punctuation class) — the qwen35 regex dialect.
     fn fold_marks(self) -> bool {
         matches!(self, Self::Qwen35)
+    }
+
+    /// Whether a word segment may absorb a trailing English contraction.
+    ///
+    /// gpt-4o appends an optional `(?:'[sS]|'[tT]|…)?` to BOTH word alternatives;
+    /// tekken's regex is otherwise character-identical but has no contraction
+    /// group at all, so `"John's"` is one segment under gpt-4o and two under
+    /// tekken. This is one of only two differences between the dialects.
+    fn word_takes_contraction(self) -> bool {
+        !matches!(self, Self::Tekken)
+    }
+
+    /// Whether this dialect uses the case-run word grammar
+    /// (`prefix? UPPER* LOWER+ | prefix? UPPER+ LOWER*`) rather than the
+    /// llama-bpe `prefix? \p{L}+` grammar.
+    fn uses_case_run_words(self) -> bool {
+        matches!(self, Self::Gpt4o | Self::Tekken)
     }
 }
 
@@ -322,6 +357,11 @@ fn resolve_gpt2_pre_tokenizer(
         // shared regex body, so no new splitter is required. Verified
         // character-for-character against `src/llama-vocab.cpp`.
         Some("stablelm2") => Ok(BpePreTokenizer::Qwen2),
+        // `tekken` (Mistral Nemo / Ministral / Mistral Small 3.x). Ungated, unlike
+        // `gpt-4o`: this dialect is validated by token-id agreement against the
+        // pinned llama-tokenize oracle on a real Mistral Nemo GGUF, not by an
+        // artifact hash.
+        Some("tekken") => Ok(BpePreTokenizer::Tekken),
         Some("qwen35") => Ok(BpePreTokenizer::Qwen35),
         Some("gpt-4o") if allow_gpt4o => Ok(BpePreTokenizer::Gpt4o),
         Some("gpt-4o") => Err(BackendError::UnsupportedTokenizer(
@@ -330,7 +370,7 @@ fn resolve_gpt2_pre_tokenizer(
         )),
         None if is_llama3_bpe_signature(token_texts) => Ok(BpePreTokenizer::Llama3),
         other => Err(BackendError::UnsupportedTokenizer(format!(
-            "unsupported GPT-2/BPE pre-tokenizer {other:?}; currently supported: llama-bpe, qwen2, qwen35, stablelm2"
+            "unsupported GPT-2/BPE pre-tokenizer {other:?}; currently supported: llama-bpe, qwen2, qwen35, stablelm2, tekken"
         ))),
     }
 }
@@ -909,9 +949,10 @@ impl Tokenizer {
                 .unwrap_or(text.len());
 
             let segments = match self.bpe_pre_tokenizer {
-                BpePreTokenizer::Gpt4o => bpe_pretokenize_gpt4o(
+                pre_tokenizer if pre_tokenizer.uses_case_run_words() => bpe_pretokenize_gpt4o(
                     &text[byte_start..byte_end],
-                    self.bpe_pre_tokenizer.digit_group_max(),
+                    pre_tokenizer.digit_group_max(),
+                    pre_tokenizer.word_takes_contraction(),
                 ),
                 pre_tokenizer => bpe_pretokenize_with(
                     &text[byte_start..byte_end],
@@ -1533,12 +1574,23 @@ fn bpe_pretokenize(text: &str) -> Vec<&str> {
 /// collapsed Unicode categories, not the more readable tokenizer.json regex in
 /// the adjacent source comment. In particular, marks are not letters and only
 /// ASCII `a-z`/`A-Z` affect the two ordered word alternatives.
-fn bpe_pretokenize_gpt4o(text: &str, digit_group_max: usize) -> Vec<&str> {
+/// Case-run word splitter shared by the `gpt-4o` and `tekken` dialects.
+///
+/// Their regexes are character-identical apart from two parameters:
+/// `digit_group_max` (3 for gpt-4o, 1 for tekken) and `word_takes_contraction`
+/// (gpt-4o appends an optional `(?:'[sS]|…)?` to both word alternatives; tekken
+/// has no contraction group).
+fn bpe_pretokenize_gpt4o(
+    text: &str,
+    digit_group_max: usize,
+    word_takes_contraction: bool,
+) -> Vec<&str> {
     let mut segments = Vec::new();
     let mut byte_start = 0;
 
     while byte_start < text.len() {
-        let byte_end = next_gpt4o_segment_end(text, byte_start, digit_group_max);
+        let byte_end =
+            next_gpt4o_segment_end(text, byte_start, digit_group_max, word_takes_contraction);
         segments.push(&text[byte_start..byte_end]);
         byte_start = byte_end;
     }
@@ -1546,8 +1598,13 @@ fn bpe_pretokenize_gpt4o(text: &str, digit_group_max: usize) -> Vec<&str> {
     segments
 }
 
-fn next_gpt4o_segment_end(text: &str, byte_start: usize, digit_group_max: usize) -> usize {
-    if let Some(end) = consume_gpt4o_word(text, byte_start) {
+fn next_gpt4o_segment_end(
+    text: &str,
+    byte_start: usize,
+    digit_group_max: usize,
+    word_takes_contraction: bool,
+) -> usize {
+    if let Some(end) = consume_gpt4o_word(text, byte_start, word_takes_contraction) {
         return end;
     }
 
@@ -1568,7 +1625,11 @@ fn next_gpt4o_segment_end(text: &str, byte_start: usize, digit_group_max: usize)
     byte_start + ch.len_utf8()
 }
 
-fn consume_gpt4o_word(text: &str, byte_start: usize) -> Option<usize> {
+fn consume_gpt4o_word(
+    text: &str,
+    byte_start: usize,
+    word_takes_contraction: bool,
+) -> Option<usize> {
     let first = next_char(text, byte_start)?;
     let word_start = if is_gpt4o_letter(first) {
         byte_start
@@ -1582,6 +1643,11 @@ fn consume_gpt4o_word(text: &str, byte_start: usize) -> Option<usize> {
 
     let word_end = consume_gpt4o_first_word_alternative(text, word_start)
         .or_else(|| consume_gpt4o_second_word_alternative(text, word_start))?;
+    if !word_takes_contraction {
+        // tekken's word alternatives carry no `(?:'[sS]|…)?` group, so a trailing
+        // contraction is left for the punctuation branch to pick up separately.
+        return Some(word_end);
+    }
     Some(consume_contraction(text, word_end).unwrap_or(word_end))
 }
 
@@ -2191,6 +2257,45 @@ mod tests {
     }
 
     #[test]
+    fn tekken_differs_from_gpt4o_in_exactly_two_places() {
+        use super::bpe_pretokenize_gpt4o;
+
+        // The two dialects share one splitter; these are the only two knobs.
+        //   gpt-4o: digit_group_max = 3, word_takes_contraction = true
+        //   tekken: digit_group_max = 1, word_takes_contraction = false
+        let gpt4o = |t: &'static str| bpe_pretokenize_gpt4o(t, 3, true);
+        let tekken = |t: &'static str| bpe_pretokenize_gpt4o(t, 1, false);
+
+        // Difference 1 — contractions. gpt-4o's word alternatives end in an
+        // optional `(?:'[sS]|…)?`; tekken's do not.
+        assert_eq!(gpt4o("John's"), vec!["John's"]);
+        assert_eq!(tekken("John's"), vec!["John", "'s"]);
+
+        // Difference 2 — digit grouping.
+        assert_eq!(gpt4o("1234"), vec!["123", "4"]);
+        assert_eq!(tekken("1234"), vec!["1", "2", "3", "4"]);
+
+        // Everything else is shared and must stay identical between the two.
+        for shared in [
+            "HelloWorld", // case-run split: prefix? UPPER* LOWER+
+            "HELLO",      // second alternative: prefix? UPPER+ LOWER*
+            " hello",     // the [^\r\n\p{L}\p{N}]? prefix absorbs the space
+            "a/b",        // punctuation branch tail is [\r\n/]*, which includes '/'
+            "x\n\ny",     // \s*[\r\n]+
+            "end   ",     // \s+(?!\S) then \s+
+        ] {
+            assert_eq!(
+                gpt4o(shared),
+                tekken(shared),
+                "{shared:?} must split identically under both dialects"
+            );
+        }
+
+        // Spot-check the shared case-run grammar itself.
+        assert_eq!(tekken("HelloWorld"), vec!["Hello", "World"]);
+    }
+
+    #[test]
     fn resolve_gpt2_pre_tokenizer_gates_the_missing_pre_recovery() {
         use super::{is_exact_phi4_mini_q4km, resolve_gpt2_pre_tokenizer, BpePreTokenizer};
         use crate::gguf::{GgufFile, GgufMetadataValue};
@@ -2230,6 +2335,12 @@ mod tests {
             Ok(BpePreTokenizer::Qwen2)
         ));
 
+        // `tekken` (Mistral Nemo / Ministral / Mistral Small 3.x) resolves ungated.
+        assert!(matches!(
+            resolve_gpt2_pre_tokenizer(Some("tekken"), &no_sig, false),
+            Ok(BpePreTokenizer::Tekken)
+        ));
+
         // `command-r` is REFUSED, not mapped. BpePreTokenizer::CommandR models it
         // as llama3-with-3-digit-grouping, but the reference dialect is a different
         // two-regex form (digits split individually, ` ?\p{L}+` letter branch,
@@ -2239,17 +2350,10 @@ mod tests {
 
         // Dialects that are NOT aliases of anything implemented stay refused: each
         // needs a genuinely different splitter, not another digit-grouping value.
-        //   tekken       -> case-run lookahead groups
         //   smollm       -> two-regex GPT-2 form (same arm as command-r)
         //   deepseek-llm -> six-regex list with explicit Unicode range classes
         //   llama4       -> maps to GPT4O upstream, which is sha256-gated here
-        for unsupported in [
-            "tekken",
-            "smollm",
-            "deepseek-llm",
-            "deepseek-coder",
-            "llama4",
-        ] {
+        for unsupported in ["smollm", "deepseek-llm", "deepseek-coder", "llama4"] {
             assert!(
                 resolve_gpt2_pre_tokenizer(Some(unsupported), &no_sig, false).is_err(),
                 "{unsupported} must stay refused until its splitter exists"
@@ -2491,13 +2595,122 @@ mod tests {
 
         for case in pack.cases {
             assert_eq!(
-                bpe_pretokenize_gpt4o(&case.input, BpePreTokenizer::Gpt4o.digit_group_max()),
+                bpe_pretokenize_gpt4o(
+                    &case.input,
+                    BpePreTokenizer::Gpt4o.digit_group_max(),
+                    BpePreTokenizer::Gpt4o.word_takes_contraction(),
+                ),
                 case.expected_segments,
                 "case {} input {:?}",
                 case.id,
                 case.input
             );
         }
+    }
+
+    /// Token-id agreement receipt for the `tekken` dialect against the pinned
+    /// llama.cpp oracle, on a real Mistral Nemo GGUF.
+    ///
+    /// This is what justifies admitting `tekken` ungated (unlike `gpt-4o`, which is
+    /// pinned to one artifact hash). A pre-tokenizer bug is not a crash — it is
+    /// silently different tokens — so the dialect is not claimed on the strength of
+    /// reading the reference regex alone.
+    ///
+    /// Opt-in because the artifact is ~7 GB. Regenerate the pack with
+    /// `scripts/gen-tekken-tokenizer-oracle.mjs`.
+    #[test]
+    #[ignore = "set CAMELID_MISTRAL_NEMO_GGUF to a Mistral-Nemo-Instruct-2407 GGUF"]
+    fn tekken_tokenizer_matches_pinned_oracle() {
+        use super::{BpePreTokenizer, Tokenizer};
+
+        let path = std::env::var("CAMELID_MISTRAL_NEMO_GGUF")
+            .expect("set CAMELID_MISTRAL_NEMO_GGUF to a Mistral-Nemo-Instruct-2407 GGUF");
+        let gguf = crate::gguf::read_metadata(&path).expect("read Mistral Nemo GGUF metadata");
+        assert_eq!(gguf.architecture(), Some("llama"));
+        assert_eq!(gguf.metadata_string("tokenizer.ggml.model"), Some("gpt2"));
+        assert_eq!(gguf.metadata_string("tokenizer.ggml.pre"), Some("tekken"));
+
+        let tokenizer = Tokenizer::from_gguf(&gguf).expect("load Mistral Nemo tokenizer");
+        assert_eq!(tokenizer.bpe_pre_tokenizer, BpePreTokenizer::Tekken);
+
+        // The actual loadability win: every other admission axis already passed for
+        // this artifact (architecture `llama`, tokenizer `gpt2`, tensors Q4_K/Q6_K/F32),
+        // so `tekken` was the SOLE reason a 12B Mistral Nemo was refused.
+        let admitted = crate::runnable::admit::admit(&gguf)
+            .expect("Mistral Nemo must admit once tekken is supported");
+        assert_eq!(admitted.architecture, "llama");
+
+        #[derive(serde::Deserialize)]
+        struct Case {
+            id: String,
+            input: String,
+            input_utf8_hex: String,
+            expected_token_ids: Vec<u32>,
+        }
+        #[derive(serde::Deserialize)]
+        struct Oracle {
+            command: String,
+            commit: String,
+            pre_tokenizer: String,
+        }
+        #[derive(serde::Deserialize)]
+        struct Pack {
+            oracle: Oracle,
+            cases: Vec<Case>,
+        }
+
+        let raw = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/qa/prompt-packs/mistral-nemo-tekken-tokenizer-oracle-v1.json"
+        ))
+        .expect("read tekken tokenizer oracle pack");
+        let pack: Pack = serde_json::from_str(&raw).expect("parse tekken tokenizer oracle pack");
+        assert_eq!(
+            pack.oracle.commit,
+            "acd79d603cb2e1c84c0886137b80f1ad649b6857"
+        );
+        assert!(pack.oracle.command.contains("llama-tokenize"));
+        // --no-escape is load-bearing: without it the oracle would re-interpret
+        // `\n`/`\t` in the argument and would not describe the bytes fed here.
+        assert!(pack.oracle.command.contains("--no-escape"));
+        assert_eq!(pack.oracle.pre_tokenizer, "tekken");
+        assert!(pack.cases.len() >= 30, "oracle pack lost coverage");
+
+        let mut mismatches = Vec::new();
+        for case in &pack.cases {
+            // The hex pins the exact bytes, so a case cannot silently drift via
+            // editor normalization of newlines or Unicode.
+            let hex: String = case
+                .input
+                .as_bytes()
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            assert_eq!(
+                hex, case.input_utf8_hex,
+                "case {} input bytes drifted",
+                case.id
+            );
+
+            let got = tokenizer
+                // (add_special = false, parse_special = true) mirrors the oracle's
+                // `--no-bos` with its default special-token parsing.
+                .encode(&case.input, false, true)
+                .unwrap_or_else(|e| panic!("case {} failed to encode: {e}", case.id));
+            if got != case.expected_token_ids {
+                mismatches.push(format!(
+                    "  {}: input {:?}\n    oracle: {:?}\n    camelid: {:?}",
+                    case.id, case.input, case.expected_token_ids, got
+                ));
+            }
+        }
+        assert!(
+            mismatches.is_empty(),
+            "{} of {} tekken cases diverged from the oracle:\n{}",
+            mismatches.len(),
+            pack.cases.len(),
+            mismatches.join("\n")
+        );
     }
 
     // Pinned llama.cpp `acd79d603` (build 9632) oracle vectors for the exact


### PR DESCRIPTION
P1 loadability, pre-tokenizer axis. Three changes, and **two corrections to the gap analysis that scoped this.**

## The headline: Mistral Nemo now loads

For `Mistral-Nemo-Instruct-2407-Q4_K_M`, **every other admission axis already passed** — architecture `llama`, tokenizer `gpt2`, tensors Q4_K/Q6_K/F32 all covered. `tokenizer.ggml.pre = "tekken"` was the **sole** reason a 12B model was refused. The oracle test asserts the file now *admits*, not merely that it tokenizes.

This unblocks the Tekken family: Mistral Nemo, Ministral, Mistral Small 3.x.

## tekken was cheaper than I predicted — after diffing properly

I told the user this would need "real splitter work". Diffing the reference showed `LLAMA_VOCAB_PRE_TYPE_TEKKEN` and `_GPT4O` are **character-identical** except:

1. gpt-4o appends an optional `(?:'[sS]|…)?` contraction group to **both** word alternatives; tekken has none.
2. gpt-4o groups digits `\p{N}{1,3}`; tekken is `\p{N}`.

Camelid already had the hard part — the case-run word grammar `prefix? UPPER* LOWER+ | prefix? UPPER+ LOWER*` with correct backtracking — built for gpt-4o. So tekken is that splitter with two parameters, not a new one. Unlike gpt-4o (pinned to one artifact hash), tekken resolves **ungated**.

## What the receipt proves — and what it does not

39 cases from the pinned `llama-tokenize` agree exactly. That is genuine end-to-end validation.

**It does not isolate the tekken splitter, and I'm not claiming it does.** I sabotaged the implementation three ways — forcing contraction absorption, forcing 3-digit grouping, and swapping in the llama-bpe `\p{L}+` word grammar entirely — and **all 39 cases still matched**, as did five targeted camelCase probes (`iPhone`, `JavaScript`, `GitHub`, `McDonald`, `eBay`).

The reason is structural: pre-tokenization only *prevents* merges across segment boundaries. Where the BPE merge table already declines to join those pieces — which for this vocab it does, since tekken vocabs carry no multi-digit tokens and no cross-case merges — segmentation is invisible in the final IDs. **For this vocab, Camelid would tokenize Mistral Nemo correctly even without the dedicated dialect.**

It is still implemented to the reference rather than approximated, because that's the parity contract and because other tekken vocabs (Ministral, Mistral Small 3.x) aren't covered by this artifact's merge table. Coverage is split deliberately: the **unit test** pins segmentation at the splitter level where the difference *is* observable; the **oracle test** pins end-to-end IDs. Neither alone is sufficient.

## Also: `stablelm2` added, `command-r` refused

The report claimed pre-tokenizers were *"a whitelist widening, not engine work"* because the 57 upstream names collapse into ~33 bodies, "many of them aliases". Checking each:

| name | reality |
|---|---|
| `stablelm2` | **genuine alias of `qwen2`** — same switch arm, identical regex body |
| `tekken` | two-parameter variant of the existing gpt-4o splitter (this PR) |
| `llama4` | maps to `GPT4O`, which Camelid sha256-gates to one artifact — not aliasable |
| `smollm` | two-regex GPT-2 form, not the llama3 family |
| `deepseek-llm` | six-regex list with explicit Unicode range classes |

`command-r` was previously **accepted** and mapped to `BpePreTokenizer::CommandR`, which models it as llama-bpe-with-3-digit-grouping. The reference groups `COMMAND_R` with `SMOLLM`/`STARCODER` and differs on three axes: digits split individually, a ` ?\p{L}+` letter branch, and case-sensitive contractions. It is **scaffolding, not a shipped defect** — Camelid's own records state command-r is refused at the architecture axis and the tokenizer path is *"unreachable"* — so refusing it closes a latent footgun rather than removing a capability. The variant is retained and documented as *not* a starting point.

`smollm` and `deepseek-llm` stay refused, with a test pinning that so the list can't rot.

## Tooling

`scripts/gen-tekken-tokenizer-oracle.mjs` regenerates the pack. `--no-escape` is load-bearing: without it `llama-tokenize` re-interprets `\n`/`\t` in the argument and the pack wouldn't describe the bytes Camelid is fed. The test asserts the recorded command contains it.

## Gates

- `cargo fmt --all -- --check` clean · `cargo clippy --all-targets` clean
- `cargo test --all-targets` — **1623 passed / 0 failed**
- Opt-in oracle test green against the real 7 GB artifact (`CAMELID_MISTRAL_NEMO_GGUF`)
- `check-ledger-drift` passed, `check-public-scrub` passed
