### PR TITLE
fix(cluster): give the topology a way out of the sample fabric

### DIFF
--- a/frontend/src/views/ClusterView.jsx
+++ b/frontend/src/views/ClusterView.jsx
@@ -7,8 +7,9 @@ import { ClusterDrawer } from '../components/cluster/ClusterDrawer'
 import { AddServerWizard } from '../components/cluster/AddServerWizard'
 import { DiscoverDevices } from '../components/cluster/DiscoverDevices'
 import { Button } from '../components/ui/Button'
+import { ConfirmDialog } from '../components/ui/ConfirmDialog'
 import {
-  IconPlus, IconNetwork, IconCheckCircle, IconCheck, IconDownload, IconGrid, IconChart,
+  IconPlus, IconNetwork, IconCheckCircle, IconCheck, IconDownload, IconGrid, IconChart, IconTrash,
 } from '../components/ui/icons'
 
 export default function ClusterView({ showNotice }) {
@@ -17,6 +18,7 @@ export default function ClusterView({ showNotice }) {
   const [wizardOpen, setWizardOpen] = useState(false)
   const [discoverOpen, setDiscoverOpen] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [clearOpen, setClearOpen] = useState(false)
 
   const resetLayout = () => { cluster.applyAutoLayout(); window.setTimeout(() => canvasRef.current?.fit(), 60) }
 
@@ -50,6 +52,9 @@ export default function ClusterView({ showNotice }) {
             <Button variant="ghost" size="sm" icon={<IconDownload size={15} />} onClick={cluster.exportTopology}>Export Diagram</Button>
             <Button variant="ghost" size="sm" icon={<IconGrid size={15} />} onClick={resetLayout}>Reset Layout</Button>
             <Button variant="ghost" size="sm" icon={<IconChart size={15} />} onClick={() => setDrawerOpen(true)}>View Logs</Button>
+            {cluster.nodes.length > 0 && (
+              <Button variant="ghost" size="sm" icon={<IconTrash size={15} />} onClick={() => setClearOpen(true)}>Clear Cluster</Button>
+            )}
           </div>
         </div>
       </header>
@@ -96,6 +101,15 @@ export default function ClusterView({ showNotice }) {
 
       <AddServerWizard open={wizardOpen} onClose={() => setWizardOpen(false)} onAdd={(node) => { cluster.addNode(node); setWizardOpen(false) }} />
       <DiscoverDevices open={discoverOpen} onClose={() => setDiscoverOpen(false)} onDiscover={cluster.discover} onAdd={(partial) => cluster.addNode(partial)} />
+
+      <ConfirmDialog
+        open={clearOpen}
+        title="Clear the cluster topology?"
+        detail={`This removes all ${cluster.nodes.length} node${cluster.nodes.length === 1 ? '' : 's'} and ${cluster.connections.length} link${cluster.connections.length === 1 ? '' : 's'} from this diagram, including the sample fabric. It only clears what is drawn here — no machine is touched and nothing is uninstalled. Export the diagram first if you want a copy.`}
+        confirmLabel="Clear topology"
+        onCancel={() => setClearOpen(false)}
+        onConfirm={() => { cluster.resetTopology(); setClearOpen(false); showNotice?.('Cluster topology cleared.', 'info') }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## The problem

The Cluster view's empty state offers **"Load a sample fabric"**. Clicking it writes six fabricated machines (RFC 5737 `192.0.2.x`) into `localStorage` under `camelid.clusterTopology` — and there is no way back out.

`useClusterTopology` already implements and exports `resetTopology`, but **nothing in the tree ever rendered it**, so it was dead code. The only escapes were:

- removing each node one at a time from the inspector, or
- clearing site data for the origin.

The sample also survives reload, and the auto-detect sweep fires two cross-origin probes per addressed node on every page load — with the sample loaded that is 24 requests per load to hosts that do not exist.

## The fix

Wire the existing `resetTopology` to a **Clear Cluster** ghost button in `.cluster-header__secondary`, rendered only when `cluster.nodes.length > 0`, guarded by the repo's standard `ConfirmDialog` (same convention as `ModelsView`, `DownloadedModelsView`, and `App.jsx`).

The confirm text names the exact node and link counts, says plainly that clearing only affects the drawing (no machine is touched, nothing is uninstalled), and points at Export Diagram for anyone who wants a copy first. A success notice is shown on confirm.

One file, 15 insertions, 1 deletion. No new state shape, no storage-format change, no backend involvement — the Cluster view is a browser-side planner with no Rust counterpart.

## Validation

- `npm run build` (vite) clean.
- Verified live on the dev server at `127.0.0.1:4175`: loaded the sample fabric, confirmed the button appears only once nodes exist, cleared, and reloaded to confirm the topology stays empty and the cancel path leaves the topology untouched.
- `scripts/check-public-scrub.sh` passes.
