### PR TITLE
api: runnable serve lane label reports the actual architecture

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7572,7 +7572,15 @@ async fn runnable_chat_nonstreaming(
             "completion_tokens": ids.len(),
             "total_tokens": prompt_token_count + ids.len(),
         },
-        "camelid": { "generated_token_ids": ids, "lane": "runnable_qwen35" },
+        // Lane is the neutral "runnable" (the bridge serves qwen35, gemma2, and
+        // gemma3); the actual model architecture is disclosed separately so the
+        // label never misreports one arch as another (matches the parity-artifact
+        // shape in tests/runnable_parity.rs).
+        "camelid": {
+            "generated_token_ids": ids,
+            "lane": "runnable",
+            "architecture": runtime.architecture.as_str(),
+        },
     });
     (StatusCode::OK, Json(body)).into_response()
 }


### PR DESCRIPTION
The runnable bridge's non-streaming chat handler hardcoded `"lane": "runnable_qwen35"` in the `camelid` response block, so a gemma3 (or gemma2) model served through the bridge was mislabeled as qwen35 — verified live 2026-07-29 with `gemma-3-1b-it-Q8_0.gguf`.

**Fix:** report the neutral `"lane": "runnable"` plus an `"architecture"` field carrying the runtime's real arch, matching the parity-artifact shape in `tests/runnable_parity.rs` (`lane: runnable` + `architecture`).

**Consumer audit before renaming:** the exact string `runnable_qwen35` appears nowhere else live — the only other hit is the frozen QA evidence capture `qa/evidence-bundles/gemma3-1b-q8-runnable-serve-chat-parity-20260716-head-6d0d57eb` (historical, left untouched). The frontend passes `message.camelid` through opaquely (`Diagnostics.jsx` reads only `timings_ms`; `ParityReceipt.jsx` keys on the separate parity-receipt `execution_lane`), and no test, script, or ledger entry cites the string. The streaming handler emits no `camelid.lane` at all, so it needed no change.

**Validation:** `cargo test --all-targets` — 60 suites, 1661 passed, 0 failed.