### PR TITLE
serve: keep /health and /api/capabilities answerable during model loads

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -96,12 +96,13 @@ cleanup() {
 trap cleanup EXIT
 
 # --- 3. wait for generation_ready -------------------------------------------
-# `serve` loads the model *before* it binds the port, so /health stays
-# unreachable until load finishes — then reports generation_ready almost at
-# once. A long silent wait therefore means a slow/stuck load (often memory
-# pressure), not a half-ready server. Budget is generous and configurable.
+# `serve` opens the port before the startup model finishes loading (so health
+# checks stay answerable during the load); /health reports generation_ready
+# only once the model is actually served. A long wait therefore means a
+# slow/stuck load (often memory pressure), not a half-ready server. Budget is
+# generous and configurable.
 TIMEOUT="${CAMELID_SMOKE_TIMEOUT:-300}"
-say "waiting for the model to load (up to ${TIMEOUT}s; the port opens only once load finishes)"
+say "waiting for the model to load (up to ${TIMEOUT}s; the port opens before load finishes)"
 ready=""
 for _ in $(seq 1 "$TIMEOUT"); do
   if ! kill -0 "$SERVER_PID" 2>/dev/null; then
@@ -117,7 +118,7 @@ for _ in $(seq 1 "$TIMEOUT"); do
 done
 if [[ -z "$ready" ]]; then
   echo "--- server log ---" >&2; cat "$SERVER_LOG" >&2
-  fail "model did not finish loading within ${TIMEOUT}s — the port never opened. Likely a slow/stuck load (e.g. low free memory). Raise CAMELID_SMOKE_TIMEOUT or free up RAM and retry."
+  fail "model did not become generation_ready within ${TIMEOUT}s. Likely a slow/stuck load (e.g. low free memory). Raise CAMELID_SMOKE_TIMEOUT or free up RAM and retry."
 fi
 say "server reports generation_ready"
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2227,16 +2227,6 @@ pub async fn serve(
         .with_models_dir(models_dir)
         .with_serve_addr(addr)
         .with_server_policy(&policy);
-    if let Some(model_path) = initial_model {
-        if let Err(err) = load_model_from_path(&state, model_path, None, true).await {
-            tracing::error!(error=%err, "failed to load startup model");
-            eprintln!("\n  Could not load that model: {err}");
-            eprintln!("  Camelid serves specific validated Q8_0 rows. To get one:");
-            eprintln!("      camelid pull            # list supported models");
-            eprintln!("      camelid pull <id>       # download one into ./models\n");
-            return Err(std::io::Error::other(err.to_string()));
-        }
-    }
     let workspace_cli_credential = if addr.ip().is_loopback() {
         match crate::workspace_auth::WorkspaceCliCredential::issue(addr) {
             Ok(credential) => Some(credential),
@@ -2286,16 +2276,10 @@ pub async fn serve(
             .collect(),
     );
 
-    // Warm the generation path BEFORE telling the user we're ready. The GPU resident
-    // engine (NVRTC kernel compile + multi-GB weight upload + first prefill) is built
-    // lazily on the first generation â€” a one-time cost of several seconds. If it lands
-    // on the user's first prompt the model looks "dog slow" (it's really the cold
-    // build, on the GPU the whole time). So: start serving in the background, fire one
-    // tiny self-request through the exact same code path to build the engine, BLOCK on
-    // it, and only then print "ready". After this the first real request is warm
-    // (~0.5s) instead of ~10s. The warm-up is best-effort â€” any failure just falls back
-    // to the old lazy build and is not fatal.
-    let warm_model_id = state.active_model_id.read().await.clone();
+    // The router owns `state`; the startup load below shares the same Arcs, so
+    // a model it loads is visible to every request the listener is already
+    // answering.
+    let startup_state = state.clone();
     let app = router_with_state_and_policy(state, policy.clone());
     let tls_enabled = policy.tls.is_some();
     let server = if let Some(tls) = &policy.tls {
@@ -2318,6 +2302,33 @@ pub async fn serve(
         let listener = tokio::net::TcpListener::from_std(std_listener)?;
         tokio::spawn(async move { axum::serve(listener, app).await })
     };
+    // Load the startup model AFTER the listener is accepting, so /health and
+    // /api/capabilities answer throughout the load. The desktop supervisor
+    // kills the sidecar when its health poll goes unanswered for 40s, and a
+    // large startup model (auto-selected whenever the models dir is populated)
+    // used to keep the port closed for the entire load — a healthy engine
+    // looked dead exactly when it had the most work to do. Failure still exits
+    // `serve` with the same message and non-zero status as before.
+    if let Some(model_path) = initial_model {
+        if let Err(err) = load_model_from_path(&startup_state, model_path, None, true).await {
+            tracing::error!(error=%err, "failed to load startup model");
+            eprintln!("\n  Could not load that model: {err}");
+            eprintln!("  Camelid serves specific validated Q8_0 rows. To get one:");
+            eprintln!("      camelid pull            # list supported models");
+            eprintln!("      camelid pull <id>       # download one into ./models\n");
+            return Err(std::io::Error::other(err.to_string()));
+        }
+    }
+    // Warm the generation path BEFORE telling the user we're ready. The GPU resident
+    // engine (NVRTC kernel compile + multi-GB weight upload + first prefill) is built
+    // lazily on the first generation â€” a one-time cost of several seconds. If it lands
+    // on the user's first prompt the model looks "dog slow" (it's really the cold
+    // build, on the GPU the whole time). So: start serving in the background, fire one
+    // tiny self-request through the exact same code path to build the engine, BLOCK on
+    // it, and only then print "ready". After this the first real request is warm
+    // (~0.5s) instead of ~10s. The warm-up is best-effort â€” any failure just falls back
+    // to the old lazy build and is not fatal.
+    let warm_model_id = startup_state.active_model_id.read().await.clone();
     if let Some(model_id) = warm_model_id {
         // Word the banner for the device that will actually serve â€” saying "GPU"
         // on a CPU-only run (e.g. CUDA_VISIBLE_DEVICES=-1) was misleading.
@@ -2445,7 +2456,30 @@ async fn telemetry_stream() -> Response {
         .into_response()
 }
 
+/// Upper bound on how long the liveness endpoints (`/health`, `/v1/health`,
+/// `/api/capabilities`) may wait on the shared model registries.
+///
+/// These endpoints gate external supervision — the desktop app kills the
+/// sidecar when a health poll goes unanswered for its 40s startup window — so
+/// a model load/unload mutating the registries must never make them
+/// unresponsive. The registry locks are fair: once a load's write is queued,
+/// new readers park behind it, so an unbounded `read().await` here inherits
+/// the full latency of whatever the writer is stuck on. On timeout the
+/// endpoints answer from lock-free state instead of parking.
+const LIVENESS_LOCK_BUDGET: Duration = Duration::from_millis(500);
+
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
+    match tokio::time::timeout(LIVENESS_LOCK_BUDGET, health_registry_snapshot(&state)).await {
+        Ok(response) => Json(response),
+        // A model transition is holding the registries: answer from lock-free
+        // state rather than queueing behind the writer. `ok` stays true — the
+        // process is alive and serving; the registry-derived fields report
+        // not-ready, which the next poll refreshes once the transition ends.
+        Err(_busy) => Json(busy_health_response(&state)),
+    }
+}
+
+async fn health_registry_snapshot(state: &AppState) -> HealthResponse {
     let active_id_lock = state.active_model_id.read().await;
     let loaded_models = state.loaded_models.read().await;
     let model = active_id_lock.as_ref().and_then(|id| loaded_models.get(id));
@@ -2484,7 +2518,7 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         .and_then(|id| execution_plans.get(id))
         .cloned();
     let slot = state.engine.slot_snapshot();
-    Json(HealthResponse {
+    HealthResponse {
         ok: true,
         engine: "camelid",
         loaded_now,
@@ -2503,7 +2537,35 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         engine_stalled_seconds: slot.stalled_seconds,
         executable: loopback_executable_path(state.serve_addr),
         listen_addr: (state.serve_addr.ip().is_loopback()).then(|| state.serve_addr.to_string()),
-    })
+    }
+}
+
+/// `/health` while a model transition holds the registries: every field that
+/// would need a registry lock reports the in-flux state as not-ready; the
+/// engine gauges, Q8 policy, and listener identity are lock-free and stay
+/// live. The process is alive and serving, so `ok` remains true.
+fn busy_health_response(state: &AppState) -> HealthResponse {
+    let slot = state.engine.slot_snapshot();
+    HealthResponse {
+        ok: true,
+        engine: "camelid",
+        loaded_now: false,
+        generation_ready: false,
+        active_model_id: None,
+        q8_runtime: q8_runtime_health(),
+        execution_plan: None,
+        backend: health_backend(false, false, false, false),
+        model_family: None,
+        gemma4_available: false,
+        engine_queue_depth: state.engine.depth(),
+        engine_queued_tasks: slot.queued_tasks,
+        engine_active_task_id: slot.active_task_id,
+        engine_active_generated_tokens: slot.completed_units,
+        engine_active_elapsed_seconds: slot.active_elapsed_seconds,
+        engine_stalled_seconds: slot.stalled_seconds,
+        executable: loopback_executable_path(state.serve_addr),
+        listen_addr: (state.serve_addr.ip().is_loopback()).then(|| state.serve_addr.to_string()),
+    }
 }
 
 /// Resolve the running binary's path for [`HealthResponse::executable`].
@@ -3689,12 +3751,21 @@ async fn set_gpu_runtime(Json(req): Json<GpuRuntimeRequest>) -> Json<GpuRuntimeS
 }
 
 async fn capabilities(State(state): State<AppState>) -> Json<CapabilitiesResponse> {
-    let active_id_lock = state.active_model_id.read().await;
-    let execution_plans = state.execution_plans.read().await;
-    let execution_plan = active_id_lock
-        .as_ref()
-        .and_then(|id| execution_plans.get(id))
-        .cloned();
+    // Bounded like /health: capabilities is polled by supervisors while loads
+    // are in flight. Everything except the active execution plan is static, so
+    // a busy registry degrades to the static response with no plan instead of
+    // queueing behind the transition's writer.
+    let execution_plan = tokio::time::timeout(LIVENESS_LOCK_BUDGET, async {
+        let active_id_lock = state.active_model_id.read().await;
+        let execution_plans = state.execution_plans.read().await;
+        active_id_lock
+            .as_ref()
+            .and_then(|id| execution_plans.get(id))
+            .cloned()
+    })
+    .await
+    .ok()
+    .flatten();
     Json(capabilities_response_with_plan(execution_plan))
 }
 
@@ -8380,65 +8451,41 @@ async fn load_model_from_path_with_activation(
             }
         }
     }
-    let mut gguf = read_metadata(&path)?;
-    let outcome = plan_for_model(&path, &gguf, state.configured_threads);
+    // The load pipeline's heavy phases run on blocking threads, never inline on
+    // this async worker. Inline they pin a tokio worker for seconds on a large
+    // model (metadata read, tokenizer build, and a full-file receipt hash), and
+    // under CPU/memory contention that starves trivially cheap requests — the
+    // desktop's /v1/health poll goes unanswered and it kills a healthy engine
+    // at its 40s startup gate.
+    //
+    // Phase 1: GGUF metadata read + execution planning (file I/O + hardware
+    // probing). env_updates are applied between the phases, preserving the
+    // ordering the old inline pipeline had.
+    let metadata_path = path.clone();
+    let configured_threads = state.configured_threads;
+    let (gguf, outcome) = tokio::task::spawn_blocking(move || {
+        let gguf = read_metadata(&metadata_path)?;
+        let outcome = plan_for_model(&metadata_path, &gguf, configured_threads);
+        Ok::<_, BackendError>((gguf, outcome))
+    })
+    .await
+    .map_err(|join_error| {
+        BackendError::InvalidModelMetadata(format!("model metadata task panicked: {join_error}"))
+    })??;
     state.planner_env.apply(&outcome.env_updates);
     log_selected_execution_plan(&outcome.plan);
     let id = id
         .or_else(|| gguf.model_name().map(ToOwned::to_owned))
         .or_else(|| path.file_stem().map(|s| s.to_string_lossy().to_string()))
         .unwrap_or_else(|| "loaded-model".to_string());
-    let llama_config_result = LlamaModelConfig::from_gguf(&gguf);
-    // Some dense decoders (e.g. phi3) ship fused attn_qkv / gate-up tensors. Synthesize
-    // the split tensors the binder + forward path expect (no-op for already-split rows),
-    // so the fused layout becomes attemptable without touching the parity-gated path.
-    if let Ok(config) = &llama_config_result {
-        if let Err(err) = crate::model::expand_fused_dense_tensors(&mut gguf, config) {
-            eprintln!("[camelid] fused-tensor expansion skipped: {err}");
-        }
-    }
-    // Capture the exact typed blocker so a loaded-but-non-runnable model surfaces
-    // WHY it fails closed (architecture not implemented, missing/invalid metadata,
-    // DiffusionGemma redirect, â€¦) instead of silently sitting non-generative.
-    let unsupported_runtime = match &llama_config_result {
-        Err(
-            err @ (BackendError::UnsupportedModelArchitecture(_)
-            | BackendError::InvalidModelMetadata(_)
-            | BackendError::UnsupportedGguf(_)),
-        ) => Some(UnsupportedRuntimeSummary {
-            code: backend_error_code(err),
-            message: err.to_string(),
-        }),
-        _ => None,
-    };
-    let llama_config = llama_config_result.ok();
-    let llama_tensors = llama_config
-        .as_ref()
-        .and_then(|config| LlamaTensorBinding::bind(&gguf, config).ok());
-    let tokenizer_result = Tokenizer::from_gguf(&gguf);
-    let tokenizer = tokenizer_state_from_result(tokenizer_result.as_ref());
-    let tokenizer_runtime = tokenizer_result.ok().map(Arc::new);
-    // Hash the exact GGUF bytes once at load time so receipts can name the
-    // lane without re-hashing per request.
-    let gguf_sha256 = receipt::sha256_file_hex(&path).map_err(|err| match err {
-        receipt::ReceiptError::Io { path, source } => BackendError::Io { path, source },
-        other => BackendError::InvalidModelMetadata(other.to_string()),
-    })?;
-    let tokenizer_kind = tokenizer_runtime
-        .as_ref()
-        .map(|tokenizer| tokenizer.model.as_summary_model());
-    let lane = LaneIdentity::capture(&id, &path, &gguf, tokenizer_kind, gguf_sha256);
-    let loaded = LoadedModel {
-        id: id.clone(),
-        path,
-        gguf,
-        llama_config,
-        llama_tensors,
-        unsupported_runtime,
-        tokenizer,
-        tokenizer_runtime,
-        lane,
-    };
+    // Phase 2: config/tensor binding, tokenizer construction, and the
+    // multi-gigabyte lane hash.
+    let build_id = id.clone();
+    let loaded = tokio::task::spawn_blocking(move || build_loaded_model(path, build_id, gguf))
+        .await
+        .map_err(|join_error| {
+            BackendError::InvalidModelMetadata(format!("model load task panicked: {join_error}"))
+        })??;
 
     state
         .loaded_models
@@ -8484,6 +8531,68 @@ async fn load_model_from_path_with_activation(
     }
 
     Ok(loaded)
+}
+
+/// Blocking phase 2 of a model load: fused-tensor expansion, config + tensor
+/// binding, tokenizer construction, and the full-file lane hash. Pure CPU and
+/// file work — always entered via `spawn_blocking` from
+/// `load_model_from_path_with_activation`, never inline on an async worker.
+fn build_loaded_model(
+    path: PathBuf,
+    id: String,
+    mut gguf: GgufFile,
+) -> Result<LoadedModel, BackendError> {
+    let llama_config_result = LlamaModelConfig::from_gguf(&gguf);
+    // Some dense decoders (e.g. phi3) ship fused attn_qkv / gate-up tensors. Synthesize
+    // the split tensors the binder + forward path expect (no-op for already-split rows),
+    // so the fused layout becomes attemptable without touching the parity-gated path.
+    if let Ok(config) = &llama_config_result {
+        if let Err(err) = crate::model::expand_fused_dense_tensors(&mut gguf, config) {
+            eprintln!("[camelid] fused-tensor expansion skipped: {err}");
+        }
+    }
+    // Capture the exact typed blocker so a loaded-but-non-runnable model surfaces
+    // WHY it fails closed (architecture not implemented, missing/invalid metadata,
+    // DiffusionGemma redirect, â€¦) instead of silently sitting non-generative.
+    let unsupported_runtime = match &llama_config_result {
+        Err(
+            err @ (BackendError::UnsupportedModelArchitecture(_)
+            | BackendError::InvalidModelMetadata(_)
+            | BackendError::UnsupportedGguf(_)),
+        ) => Some(UnsupportedRuntimeSummary {
+            code: backend_error_code(err),
+            message: err.to_string(),
+        }),
+        _ => None,
+    };
+    let llama_config = llama_config_result.ok();
+    let llama_tensors = llama_config
+        .as_ref()
+        .and_then(|config| LlamaTensorBinding::bind(&gguf, config).ok());
+    let tokenizer_result = Tokenizer::from_gguf(&gguf);
+    let tokenizer = tokenizer_state_from_result(tokenizer_result.as_ref());
+    let tokenizer_runtime = tokenizer_result.ok().map(Arc::new);
+    // Hash the exact GGUF bytes once at load time so receipts can name the
+    // lane without re-hashing per request.
+    let gguf_sha256 = receipt::sha256_file_hex(&path).map_err(|err| match err {
+        receipt::ReceiptError::Io { path, source } => BackendError::Io { path, source },
+        other => BackendError::InvalidModelMetadata(other.to_string()),
+    })?;
+    let tokenizer_kind = tokenizer_runtime
+        .as_ref()
+        .map(|tokenizer| tokenizer.model.as_summary_model());
+    let lane = LaneIdentity::capture(&id, &path, &gguf, tokenizer_kind, gguf_sha256);
+    Ok(LoadedModel {
+        id,
+        path,
+        gguf,
+        llama_config,
+        llama_tensors,
+        unsupported_runtime,
+        tokenizer,
+        tokenizer_runtime,
+        lane,
+    })
 }
 
 /// Load (or reload) the gemma4 serve runtime for a model id. With
@@ -15682,6 +15791,54 @@ mod tests {
             "gemma4-runtime",
             "the eagerly loaded Gemma4 runtime has highest precedence"
         );
+    }
+
+    /// The liveness endpoints must answer while a model transition holds the
+    /// registry locks. The desktop supervisor kills the sidecar when its
+    /// health poll goes unanswered for 40s, and the registry RwLocks are
+    /// fair — a queued load writer parks every later reader — so an unbounded
+    /// `read().await` in these handlers inherits the whole transition's
+    /// latency. Regression for the desktop killing a healthy engine mid-load.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn health_and_capabilities_answer_while_registry_writers_hold_the_locks() {
+        use tower::ServiceExt;
+
+        let state = AppState::default();
+        let app = router_with_state(state.clone());
+
+        // Wedge every registry lock the liveness endpoints read, the way a
+        // stuck load/unload would.
+        let _loaded = state.loaded_models.write().await;
+        let _active = state.active_model_id.write().await;
+        let _plans = state.execution_plans.write().await;
+
+        for uri in ["/health", "/v1/health", "/api/capabilities"] {
+            let response = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                app.clone().oneshot(
+                    axum::http::Request::builder()
+                        .uri(uri)
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                ),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("{uri} must answer while the registries are held"))
+            .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{uri}");
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["engine"], "camelid", "{uri}");
+            if uri != "/api/capabilities" {
+                assert_eq!(body["ok"], true, "{uri} must stay ok while busy");
+                assert_eq!(
+                    body["backend"], "none",
+                    "{uri} busy snapshot reports the in-flux registries as not ready"
+                );
+            }
+        }
     }
 
     // ---------------------------------------------------------------------

--- a/tools/conformance/run.mjs
+++ b/tools/conformance/run.mjs
@@ -89,6 +89,22 @@ async function waitHealthy(url, attempts = 240) {
   throw new Error(`server at ${url} never became healthy`)
 }
 
+// Camelid opens its port before the startup model finishes loading (health
+// checks stay answerable during the load), so reachability alone does not mean
+// the model is served. Gate on the health payload's generation_ready instead.
+// llama-server keeps using waitHealthy: its /health 503s until the model is
+// ready, so res.ok already implies loaded there.
+async function waitGenerationReady(url, attempts = 240) {
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      const res = await fetch(url)
+      if (res.ok && (await res.json()).generation_ready === true) return
+    } catch {}
+    await sleep(1000)
+  }
+  throw new Error(`server at ${url} never reported generation_ready`)
+}
+
 async function postJson(url, body) {
   const res = await fetch(url, {
     method: 'POST',
@@ -139,7 +155,7 @@ async function probeCamelid(port) {
   console.error(`[camelid] starting on :${port} ...`)
   const { child } = spawnProcess(camelidBin, ['serve', '--addr', `127.0.0.1:${port}`, '--model', modelPath], 'camelid')
   try {
-    await waitHealthy(`${base}/health`)
+    await waitGenerationReady(`${base}/health`)
     let version = 'camelid'
     try {
       const caps = await (await fetch(`${base}/api/capabilities`)).json()


### PR DESCRIPTION
## Problem

The desktop app kills its sidecar when the `/v1/health` poll goes unanswered within the 40s startup window. Observed live on macOS: a long `POST /api/models/load` (runnable-lane load under memory/CPU contention, >22s) starved the health endpoint and the desktop killed a perfectly healthy engine mid-load.

Three compounding server-side causes:

1. **Inline blocking work on the async executor.** The load pipeline ran its heavy phases inline on tokio worker threads: GGUF metadata read, execution planning's hardware probe, tokenizer construction, and a full-file SHA-256 of the multi-GB model. Under contention this starves trivially cheap requests.
2. **Unbounded lock waits in the liveness endpoints.** `/health` and `/api/capabilities` awaited the shared registry RwLocks with no bound. Those locks are fair (FIFO): once a load's write is queued, every later health reader parks behind the entire transition.
3. **Startup load before the listener.** `serve` loaded the startup model (auto-selected whenever the models dir is populated) before `axum::serve` started accepting — the port stayed closed for the whole load, so a large startup model alone could blow the 40s gate.

## Fix

- Load pipeline phases run via `spawn_blocking`; planner env updates are applied between the phases so observable ordering is unchanged.
- `/health`, `/v1/health`, `/api/capabilities` bound their registry waits at 500ms (`LIVENESS_LOCK_BUDGET`) and degrade to a lock-free snapshot: `ok` stays true (the process is alive and serving), registry-derived fields report not-ready until the next poll refreshes them.
- The listener starts before the startup load. A failed startup load still exits `serve` with the identical message and non-zero status.
- `tools/conformance/run.mjs`: the camelid probe now waits for `generation_ready` instead of mere reachability (the port now opens before the load finishes). All other in-repo tooling already loads via POST or polls `generation_ready` (`scripts/smoke.sh` comments updated).

## Verification

- Live, debug build, 16GB M4 under real memory pressure: a 264s `POST /api/models/load` (Qwen3-4B) left **1,876 consecutive polls** of `/api/capabilities` + `/v1/health` all under **250ms** (typical ≤22ms), zero failures.
- Startup path: with an 8GB startup model, `/v1/health` answered 200 **one second** after process start, load still running; `/api/capabilities` held ~8ms mid-load.
- New regression test `health_and_capabilities_answer_while_registry_writers_hold_the_locks` pins the bounded-latency behavior (hangs into its failure timeout on the old code).
- `cargo test --all-targets` green; `cargo fmt --check`, `clippy -D warnings`, and `scripts/check-public-scrub.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)