### PR TITLE
chat: deterministic deadline error for control-request socket timeouts

### DIFF
--- a/src/chat/client.rs
+++ b/src/chat/client.rs
@@ -277,13 +277,29 @@ impl Client {
         if connect_timeout.is_zero() {
             anyhow::bail!("request exceeded its deadline");
         }
-        let mut stream = TcpStream::connect_timeout(&self.addr, connect_timeout)?;
+        // When a budget below was set by the caller's deadline (rather than a
+        // fixed reachability/stall cap), an OS-level timeout on it IS the
+        // deadline elapsing — report it as such instead of leaking the
+        // platform's socket-timeout message.
+        let mut stream = TcpStream::connect_timeout(&self.addr, connect_timeout).map_err(
+            |error| -> anyhow::Error {
+                if connect_timeout == timeout && is_timeout(&error) {
+                    anyhow::anyhow!("request exceeded its deadline")
+                } else {
+                    error.into()
+                }
+            },
+        )?;
         stream.set_read_timeout(Some(Duration::from_millis(100)))?;
-        stream.set_write_timeout(Some(
-            deadline
-                .saturating_duration_since(Instant::now())
-                .min(Duration::from_secs(30)),
-        ))?;
+        let write_timeout = deadline
+            .saturating_duration_since(Instant::now())
+            .min(Duration::from_secs(30));
+        if write_timeout.is_zero() {
+            // set_write_timeout rejects a zero Duration; a spent budget means
+            // the deadline elapsed during connect/encode.
+            anyhow::bail!("request exceeded its deadline");
+        }
+        stream.set_write_timeout(Some(write_timeout))?;
         let raw_request = encode_request(
             method,
             path,
@@ -294,8 +310,15 @@ impl Client {
         if cancel.load(Ordering::Relaxed) {
             anyhow::bail!("request cancelled");
         }
-        stream.write_all(&raw_request.0)?;
-        stream.write_all(&raw_request.1)?;
+        let map_write_error = |error: std::io::Error| -> anyhow::Error {
+            if write_timeout < Duration::from_secs(30) && is_timeout(&error) {
+                anyhow::anyhow!("request exceeded its deadline")
+            } else {
+                error.into()
+            }
+        };
+        stream.write_all(&raw_request.0).map_err(map_write_error)?;
+        stream.write_all(&raw_request.1).map_err(map_write_error)?;
 
         let mut raw = Vec::new();
         let mut chunk = [0_u8; 4096];


### PR DESCRIPTION
## Problem

`chat::client::tests::generation_preflight_control_honors_cancellation_and_deadline` flaked on the **windows-latest** leg of main run 30499908305 (d9053ec4): `assertion failed: error.to_string().contains("deadline")`. The same code passed on the PR run — timing-sensitive, not a regression.

The test gives `generation_preflight_with_control` a 30 ms deadline against a fake server that accepts then parks. On a slow runner the failure can surface through three paths in `request_with_control` that leak a raw OS error whose message lacks "deadline":

1. `TcpStream::connect_timeout` with the 30 ms budget expiring → platform "connection timed out" text
2. connect + encode consuming the whole budget → `set_write_timeout(Some(Duration::ZERO))` → "cannot set a 0 duration timeout"
3. `write_all` timing out → raw `WouldBlock`/`TimedOut` OS message

The read loop was already deterministic (timeout → retry → explicit deadline check).

## Fix

Fix the mapping, not the test: whenever a socket budget was set by the **caller's deadline** (rather than the fixed 2 s connect / 30 s write caps), an OS-level timeout on it now reports `request exceeded its deadline`. A spent write budget bails with the same error before calling `set_write_timeout`.

Budgets governed by the fixed caps keep the raw OS error — with the production 30 s timeout the connect budget is the 2 s reachability cap, so genuine unreachability still reports truthfully. Non-timeout errors (refused/reset) propagate raw everywhere. The mapping reads no clocks, so the outcome can't flake on timer granularity.

## Validation (macOS M4)

- `cargo test --lib chat::client::tests` — 10/10 pass
- the affected test run 100× via the test binary — 100/100 pass
- `cargo test --all-targets` — full suite green
- `cargo fmt --check` clean, `cargo clippy --all-targets` 0 warnings

Windows cannot be run locally; the fix is reasoned from the error-construction paths above and made deterministic by construction.