### PR TITLE
cli: fail closed for runnable-only archs on the direct session path

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7160,8 +7160,11 @@ fn runnable_serve_flag(value: Option<&str>) -> bool {
 /// Deliberate side effect of listing an arch here: when the lane is opted out
 /// (`CAMELID_RUNNABLE_SERVE=0`) its chat requests get a typed 503 instead of
 /// falling through to the mis-bound optimized engine — fail-closed by design.
+/// Delegates to [`crate::model::is_runnable_only_arch`] — the single source of
+/// truth shared with the CLI direct-session guard — so the serve router and the
+/// direct lanes can never disagree about which archs must fail closed.
 fn is_runnable_serve_arch(arch: &str) -> bool {
-    matches!(arch, "qwen35" | "gemma2" | "gemma3")
+    crate::model::is_runnable_only_arch(arch)
 }
 
 /// A runnable-lane model wrapped for the serve path: greedy generation + the GGUF
@@ -20058,6 +20061,7 @@ mod tests {
 
     fn tiny_spec_config() -> LlamaModelConfig {
         LlamaModelConfig {
+            architecture: "llama".to_string(),
             context_length: 48,
             ..tiny_config()
         }
@@ -20242,6 +20246,7 @@ mod tests {
 
     fn tiny_config() -> LlamaModelConfig {
         LlamaModelConfig {
+            architecture: "llama".to_string(),
             context_length: 4,
             embedding_length: 4,
             block_count: 1,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2703,6 +2703,24 @@ impl LlamaInferenceSession {
                  layer from a single cos/sin table and cannot express the skip; CPU reference"
             );
         }
+        // TEMPORARY arch-keyed disqualifier — remove in Phase 3 of the gemma3 Metal
+        // campaign (branch feat/gemma3-metal-resident), which lands a resident encode
+        // that applies these tensors. gemma3/gemma2 must never reach the resident
+        // dense kernels today: the dense binder drops their QK-norm and
+        // post-attention/post-FFN ("sandwich") norm tensors (gemma3-1b: 104 of them)
+        // and the dense forward has no GeGLU or dual-RoPE, so the resident lane —
+        // like the CPU dense forward — would decode fluent-looking garbage under a
+        // supported label. Checked before the backend-enabled gate because this is a
+        // property of the model, not of the available backends (same rationale as
+        // the NoPE check above; keeps the regression test causal on CPU-only hosts).
+        if matches!(self.config.architecture.as_str(), "gemma2" | "gemma3") {
+            bail!(format!(
+                "architecture {:?} is runnable-lane-only: the dense binder drops its QK/sandwich \
+                 norm tensors and has no GeGLU, so the resident kernels would run a mis-bound \
+                 forward; serve/chat route it to the runnable bridge instead",
+                self.config.architecture
+            ));
+        }
         // GPU-runnable tier: an uncurated model is admitted to the resident path only after
         // it passes the one-time parity self-check. A recorded FAIL forbids the resident
         // path here — the single choke point — so no `set_resident_paths_disabled` site can

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -1410,6 +1410,7 @@ fn prefill_layer_major_scoped_q8_cache_reuses_file_reads_across_chunks() {
     temp_file.flush().unwrap();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 2,
         embedding_length: 32,
         block_count: 1,
@@ -1521,6 +1522,7 @@ fn tiny_kv_budget_session(context_length: u32) -> (LlamaInferenceSession, tempfi
     temp_file.flush().unwrap();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length,
         embedding_length: 32,
         block_count: 1,
@@ -1624,6 +1626,37 @@ fn nope_config_disqualifies_the_resident_gpu_path() {
             .expect("eligibility check should not error"),
         "a NoPE config must be refused for the want-logits path too"
     );
+}
+
+/// gemma3/gemma2 must never reach the resident GPU engines: the dense binder
+/// silently drops their QK-norm and post-attention/post-FFN ("sandwich") norm
+/// tensors and the dense forward has no GeGLU, so the resident lane would decode
+/// fluent-looking garbage under a supported label. TEMPORARY until the gemma3
+/// Metal campaign (feat/gemma3-metal-resident) lands its resident encode in
+/// Phase 3 — this test then flips alongside the disqualifier's removal.
+///
+/// Like the NoPE test above, the arch check sits before the backend-enabled
+/// gate in `resident_decode_eligible`, so the assertion is causal on a
+/// CPU-only host too.
+#[test]
+fn runnable_only_arch_disqualifies_the_resident_gpu_path() {
+    let (mut session, _temp) = tiny_kv_budget_session(64);
+
+    for arch in ["gemma3", "gemma2"] {
+        session.config.architecture = arch.to_string();
+        assert!(
+            !session
+                .resident_decode_eligible(false)
+                .expect("eligibility check should not error"),
+            "a {arch} config must be refused by the resident GPU gate"
+        );
+        assert!(
+            !session
+                .resident_decode_eligible(true)
+                .expect("eligibility check should not error"),
+            "a {arch} config must be refused for the want-logits path too"
+        );
+    }
 }
 
 /// End-to-end proof that the KV predict-and-abort budget guard fires through the
@@ -8618,6 +8651,7 @@ fn applies_rope_to_each_attention_head() {
     std::env::remove_var("CAMELID_ROPE_POSITION_MODE");
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 4,
         embedding_length: 4,
         block_count: 1,
@@ -8662,6 +8696,7 @@ fn apply_rope_uses_configured_frequency_base() {
     clear_dense_diagnostic_env();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 8192,
         embedding_length: 4,
         block_count: 1,
@@ -8716,6 +8751,7 @@ fn apply_rope_uses_llama3_frequency_scaling_metadata() {
     clear_dense_diagnostic_env();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 32,
         embedding_length: 4,
         block_count: 1,
@@ -8774,6 +8810,7 @@ fn apply_rope_uses_gguf_rope_frequency_factors() {
     clear_dense_diagnostic_env();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 32,
         embedding_length: 4,
         block_count: 1,
@@ -8839,6 +8876,7 @@ fn rope_diagnostics_reconstruct_reported_rotation() {
     std::env::remove_var("CAMELID_ROPE_POSITION_MODE");
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 4,
         embedding_length: 4,
         block_count: 1,
@@ -8909,6 +8947,7 @@ fn zero_delta_selector_accepts_all_none_and_layer_lists() {
 #[test]
 fn split_half_rope_pairing_is_available_for_diagnostics() {
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 4,
         embedding_length: 4,
         block_count: 1,
@@ -8993,6 +9032,7 @@ fn split_half_rope_pairing_is_available_for_diagnostics() {
 #[test]
 fn inverse_rope_direction_is_available_for_diagnostics() {
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 4,
         embedding_length: 2,
         block_count: 1,
@@ -9076,6 +9116,7 @@ fn one_based_rope_position_mode_is_available_for_diagnostics() {
     std::env::set_var("CAMELID_ROPE_POSITION_MODE", "one_based");
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 4,
         embedding_length: 2,
         block_count: 1,
@@ -10695,6 +10736,7 @@ fn single_token_forward_diagnostics_follow_llama_stage_order() {
     std::env::set_var("CAMELID_FORWARD_RSS_TIMINGS", "1");
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 4,
         embedding_length: 2,
         block_count: 1,
@@ -10986,6 +11028,7 @@ fn chunked_prefill_matches_sequential_prefill_outputs_and_cache() {
     clear_dense_diagnostic_env();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 12,
         embedding_length: 2,
         block_count: 1,
@@ -11217,6 +11260,7 @@ fn prefill_layer_rejects_misaligned_kv_cache_cursor() {
     clear_dense_diagnostic_env();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 8,
         embedding_length: 2,
         block_count: 1,
@@ -11332,6 +11376,7 @@ fn batch_attention_rejects_reads_beyond_allocated_kv_cache() {
     clear_dense_diagnostic_env();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 2,
         embedding_length: 2,
         block_count: 1,
@@ -11486,6 +11531,7 @@ fn zero_prefill_chunk_env_falls_back_without_panicking() {
     clear_dense_diagnostic_env();
 
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 8,
         embedding_length: 2,
         block_count: 1,
@@ -12372,6 +12418,7 @@ fn resident_prefill_rope_tables_match_per_position_builder() {
     // Llama3-scaled config so the batched builder exercises the smooth-factor path the
     // 3B row actually uses; the claim is bit-identical tables, not approximate ones.
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 64,
         embedding_length: 8,
         block_count: 1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1939,6 +1939,7 @@ async fn main() -> anyhow::Result<()> {
                 .await?
             } else if role == "worker" {
                 let gguf = camelid::gguf::read_metadata(&model)?;
+                ensure_arch_has_direct_dense_session(&gguf)?;
                 let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
                 let binding = camelid::model::LlamaTensorBinding::bind(&gguf, &config)?;
                 let store = camelid::tensor::TensorStore::open(&model, &gguf);
@@ -2626,6 +2627,9 @@ async fn main() -> anyhow::Result<()> {
             trace_big,
             max_per_token,
         } => {
+            // The alloc gate runs a real dense decode; refuse runnable-lane-only
+            // archs before the library loads weights (metadata read is cheap).
+            ensure_arch_has_direct_dense_session(&read_metadata(&model)?)?;
             let report = camelid::alloc_gate::run_decode_alloc_gate(
                 &model,
                 warmup,
@@ -3381,6 +3385,7 @@ fn run_ghost(
 
     println!("[ghost] loading GGUF metadata from {:?}...", model);
     let gguf = read_metadata(&model)?;
+    ensure_arch_has_direct_dense_session(&gguf)?;
     let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
     let binding = camelid::model::LlamaTensorBinding::bind(&gguf, &config)?;
     let store = TensorStore::open(&model, &gguf);
@@ -3815,6 +3820,7 @@ fn gait_profile_trial(
     }
 
     let gguf = read_metadata(model)?;
+    ensure_arch_has_direct_dense_session(&gguf)?;
     // Apply this candidate's plan before loading weights, exactly as bench-generate does.
     let plan = camelid::execution_plan::plan_for_model(model, &gguf, threads);
     camelid::execution_plan::PlannerEnv::capture().apply(&plan.env_updates);
@@ -4478,6 +4484,7 @@ fn known_arch_config(arch: &str) -> anyhow::Result<LlamaModelConfig> {
         other => anyhow::bail!("unknown --arch {other:?}; known: llama-8b"),
     };
     Ok(LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length,
         embedding_length,
         block_count,
@@ -4538,6 +4545,7 @@ fn run_bench_owner_sweep(
     // Load once. The owner is selected at runtime (env read per linear call), so a single load
     // serves every config; the PackedRows4 repack the owner consumes is built at load regardless.
     let gguf = read_metadata(&model)?;
+    ensure_arch_has_direct_dense_session(&gguf)?;
     let plan_outcome = camelid::execution_plan::plan_for_model(&model, &gguf, threads);
     camelid::execution_plan::PlannerEnv::capture().apply(&plan_outcome.env_updates);
     let config = LlamaModelConfig::from_gguf(&gguf)?;
@@ -4693,6 +4701,7 @@ fn run_bench_generate(
     // Load the model once; this cost is measured separately from generation.
     let load_start = Instant::now();
     let gguf = read_metadata(&model)?;
+    ensure_arch_has_direct_dense_session(&gguf)?;
     // Apply the model's execution plan (as serve/chat do) BEFORE loading weights so the
     // CPU Q8 runtime repack + packed-rows4 fast path is selected at load time. Without
     // this, bench-generate measures the unplanned safe (scalar) path.
@@ -5362,6 +5371,7 @@ fn load_model_drafter(
     threads: Option<usize>,
 ) -> anyhow::Result<SpeculativeDrafter> {
     let gguf = read_metadata(path)?;
+    ensure_arch_has_direct_dense_session(&gguf)?;
     let plan_outcome = camelid::execution_plan::plan_for_model(path, &gguf, threads);
     camelid::execution_plan::PlannerEnv::capture().apply(&plan_outcome.env_updates);
     let config = LlamaModelConfig::from_gguf(&gguf)?;
@@ -5416,6 +5426,7 @@ fn run_bench_speculative(
 
     // Load the target exactly as bench-generate does (execution plan applied before weights).
     let gguf = read_metadata(&model)?;
+    ensure_arch_has_direct_dense_session(&gguf)?;
     let plan_outcome = camelid::execution_plan::plan_for_model(&model, &gguf, threads);
     camelid::execution_plan::PlannerEnv::capture().apply(&plan_outcome.env_updates);
     let config = LlamaModelConfig::from_gguf(&gguf)?;
@@ -5712,6 +5723,30 @@ fn infer_quantization(path: &std::path::Path) -> String {
     "unknown".to_string()
 }
 
+/// Fail closed BEFORE weights load on every CLI lane that would construct a
+/// direct dense `LlamaInferenceSession` for a runnable-lane-only architecture
+/// (qwen35 / gemma2 / gemma3). The dense binder silently drops gemma3's
+/// QK-norm and post-attention/post-FFN norm tensors and the dense forward has
+/// no GeGLU, so BOTH the CPU dense forward and the GPU resident lane decode
+/// fluent-looking garbage for these archs; qwen35's hybrid layers do not fit
+/// the dense tensor map at all. `camelid serve` (and `camelid chat`, which
+/// drives serve over HTTP) route these archs to the correct runnable bridge —
+/// point the user there instead of running a mis-bound forward. Mirrors
+/// serve's `is_runnable_serve_arch` via the shared
+/// `camelid::model::is_runnable_only_arch` predicate.
+fn ensure_arch_has_direct_dense_session(gguf: &camelid::gguf::GgufFile) -> anyhow::Result<()> {
+    let arch = gguf.architecture().unwrap_or_default();
+    if camelid::model::is_runnable_only_arch(arch) {
+        anyhow::bail!(
+            "architecture '{arch}' is served only through the runnable lane; this command's \
+             direct dense-session path would run a mis-bound forward and emit wrong output, \
+             so it fails closed. Use `camelid serve` (or `camelid chat`), which routes this \
+             architecture to its correct runtime."
+        );
+    }
+    Ok(())
+}
+
 /// The measured-fastest Metal configuration is on by default for the CLI: Q8_0 weights
 /// upload in wire format, NSG=8 GEMV dispatch, f32-activation GEMV chain, tiled decode
 /// attention, and the one-command-buffer GPU prefill. Each remains overridable: set the
@@ -5981,6 +6016,7 @@ async fn run_distribute_worker(
 
     println!("Loading GGUF metadata from {:?}...", path);
     let gguf = read_metadata(&path)?;
+    ensure_arch_has_direct_dense_session(&gguf)?;
     let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
     let binding = camelid::model::LlamaTensorBinding::bind(&gguf, &config)?;
     let store = TensorStore::open(&path, &gguf);
@@ -6112,6 +6148,7 @@ async fn run_distribute_master(
 
     println!("Loading GGUF metadata from {:?}...", path);
     let gguf = read_metadata(&path)?;
+    ensure_arch_has_direct_dense_session(&gguf)?;
     let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
     let binding = camelid::model::LlamaTensorBinding::bind(&gguf, &config)?;
     let store = TensorStore::open(&path, &gguf);

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,6 +9,15 @@ use crate::{
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct LlamaModelConfig {
+    /// The GGUF `general.architecture` this config was built from (e.g. "llama",
+    /// "qwen3", "gemma3"). Carried so downstream engine gates can key on the
+    /// architecture itself instead of inferring it from config shape — the
+    /// resident-decode eligibility check uses it to fail closed for architectures
+    /// whose only correct forward lives in the runnable lane (see
+    /// [`is_runnable_only_arch`] and `resident_decode_eligible`). Synthetic
+    /// configs (benches, tests, the SafeTensors summary) set the family they
+    /// emulate ("llama").
+    pub architecture: String,
     pub context_length: u32,
     pub embedding_length: u32,
     pub block_count: u32,
@@ -116,6 +125,19 @@ pub fn is_implemented_architecture(architecture: &str) -> bool {
     )
 }
 
+/// Architectures whose ONLY correct forward pass lives in the runnable lane
+/// (`crate::runnable`): the optimized dense binder cannot represent them —
+/// for gemma3/gemma2 it silently drops the QK-norm and post-attention/post-FFN
+/// ("sandwich") norm tensors and the dense forward has no GeGLU or dual-RoPE,
+/// and qwen35's hybrid gated-delta-net layers do not fit the dense tensor map
+/// at all. `camelid serve` routes these archs to the runnable serve bridge
+/// (`api::is_runnable_serve_arch` delegates here); every OTHER lane that would
+/// construct a direct dense session for them must fail closed instead of
+/// decoding fluent-looking garbage.
+pub fn is_runnable_only_arch(architecture: &str) -> bool {
+    matches!(architecture, "qwen35" | "gemma2" | "gemma3")
+}
+
 impl LlamaModelConfig {
     /// True when decoder layer `layer_idx` (0-based) applies RoPE to Q and K.
     ///
@@ -218,6 +240,7 @@ impl LlamaModelConfig {
             _ => required_u32(gguf, &architecture_key(architecture, "feed_forward_length"))?,
         };
         Ok(Self {
+            architecture: architecture.to_string(),
             context_length: required_u32(gguf, &architecture_key(architecture, "context_length"))?,
             embedding_length: required_u32(
                 gguf,
@@ -2144,6 +2167,30 @@ mod tests {
             assert!(
                 super::arch_no_rope_layer_step(arch).is_none(),
                 "{arch} must not be treated as a NoPE architecture"
+            );
+        }
+    }
+
+    #[test]
+    fn runnable_only_arch_set_is_exactly_the_serve_bridge_set() {
+        // Must stay in lockstep with the serve router's runnable bridge
+        // (`api::is_runnable_serve_arch` delegates here): these archs have no
+        // correct dense forward — the dense binder drops gemma3/gemma2's
+        // QK/sandwich norms and has no GeGLU, and qwen35's hybrid layers do not
+        // fit the dense tensor map — so every direct dense-session lane fails
+        // closed for them instead of decoding fluent-looking garbage.
+        for arch in ["qwen35", "gemma2", "gemma3"] {
+            assert!(
+                super::is_runnable_only_arch(arch),
+                "{arch} must be classified runnable-lane-only"
+            );
+        }
+        for arch in [
+            "llama", "mistral", "qwen2", "qwen3", "smollm3", "gemma4", "phi3", "lfm2", "",
+        ] {
+            assert!(
+                !super::is_runnable_only_arch(arch),
+                "{arch:?} must not be classified runnable-lane-only"
             );
         }
     }

--- a/src/model_source.rs
+++ b/src/model_source.rs
@@ -88,6 +88,9 @@ impl HfLlamaConfigSummary {
         let explicit_head_dim = self.head_dim.filter(|&h| h > 0);
         let head_dim = explicit_head_dim.unwrap_or(default_head_dim);
         crate::model::LlamaModelConfig {
+            // The summary is validated llama-only upstream (`inspect_model_source`
+            // rejects every non-`llama` `model_type`), so the family is static.
+            architecture: "llama".to_string(),
             context_length: self.max_position_embeddings,
             embedding_length: self.hidden_size,
             block_count: self.num_hidden_layers,

--- a/tests/inference_session.rs
+++ b/tests/inference_session.rs
@@ -695,6 +695,7 @@ fn smollm3_nope_layers_are_every_fourth_zero_based() {
     // For the 36-layer SmolLM3-3B (smollm3.cpp:7-10 maps case 36 => LLM_TYPE_3B)
     // that skips 9 of 36 layers, INCLUDING the final one.
     let config = LlamaModelConfig {
+        architecture: "llama".to_string(),
         block_count: 36,
         no_rope_layer_step: Some(4),
         ..tiny_config()
@@ -715,6 +716,7 @@ fn layer_uses_rope_matches_the_reference_formula() {
     // tuned to reproduce step 4.
     for step in [1u32, 2, 3, 4, 5, 8] {
         let config = LlamaModelConfig {
+            architecture: "llama".to_string(),
             no_rope_layer_step: Some(step),
             ..tiny_config()
         };
@@ -732,6 +734,7 @@ fn layer_uses_rope_matches_the_reference_formula() {
     // models/afmoe.cpp:137).
     for step in [None, Some(0)] {
         let config = LlamaModelConfig {
+            architecture: "llama".to_string(),
             no_rope_layer_step: step,
             ..tiny_config()
         };
@@ -751,6 +754,7 @@ fn nope_layer_is_identity_at_position_zero() {
     let mut roped = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
     let mut nope = LlamaInferenceSession::new(
         LlamaModelConfig {
+            architecture: "llama".to_string(),
             // (0 + 1) % 1 == 0, so the single layer 0 is NoPE.
             no_rope_layer_step: Some(1),
             ..tiny_config()
@@ -773,6 +777,7 @@ fn nope_layer_changes_output_at_nonzero_position() {
     let mut roped = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
     let mut nope = LlamaInferenceSession::new(
         LlamaModelConfig {
+            architecture: "llama".to_string(),
             no_rope_layer_step: Some(1),
             ..tiny_config()
         },
@@ -800,6 +805,7 @@ fn nope_step_two_ropes_layer_zero() {
     let mut baseline = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
     let mut stepped = LlamaInferenceSession::new(
         LlamaModelConfig {
+            architecture: "llama".to_string(),
             no_rope_layer_step: Some(2),
             ..tiny_config()
         },
@@ -825,6 +831,7 @@ fn nope_gate_is_live_on_the_prompt_path() {
     let mut roped = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
     let mut nope = LlamaInferenceSession::new(
         LlamaModelConfig {
+            architecture: "llama".to_string(),
             no_rope_layer_step: Some(1),
             ..tiny_config()
         },
@@ -846,6 +853,7 @@ fn nope_gate_is_live_on_the_prompt_path() {
     // A step that ropes layer 0 must be indistinguishable from the baseline.
     let mut stepped = LlamaInferenceSession::new(
         LlamaModelConfig {
+            architecture: "llama".to_string(),
             no_rope_layer_step: Some(2),
             ..tiny_config()
         },
@@ -990,6 +998,7 @@ fn rejects_out_of_range_typical_p_top_n_sigma_and_min_keep() {
 
 fn tiny_config() -> LlamaModelConfig {
     LlamaModelConfig {
+        architecture: "llama".to_string(),
         context_length: 4,
         embedding_length: 4,
         block_count: 1,


### PR DESCRIPTION
## Bug

`camelid serve` fail-closes qwen35/gemma2/gemma3 chat to the correct-but-slow runnable bridge (`is_runnable_serve_arch`), but the CLI direct-session lanes had **no such guard**. The optimized dense binder silently drops gemma3's QK-norm and post-attention/post-FFN ("sandwich") norm tensors — gemma3 is neither `expects_qk_norm` nor `forbids_qk_norm`, so 104 tensors of the 1B row vanish without an error — and the dense forward has no GeGLU or dual-RoPE.

Reproduced on the default CLI fast stack with the promoted `gemma-3-1b-it-Q8_0.gguf`:

- Metal resident lane: runs all 26 layers at full speed (~38 tok/s) emitting garbage token ids (e.g. 251392 / 70408 / 143805) that detokenize to fluent-looking nonsense.
- `CAMELID_METAL_RESIDENT_DECODE=0`: the CPU dense forward emits garbage too (diverging from the GPU stream at generated index 3 — both lanes are wrong, differently).

A **Supported** row silently produced wrong output on the default CLI path. qwen35 was already loud here (its hybrid layers fail the dense tensor bind), but with an unactionable missing-tensor error.

## Fix

Two layers deep, mirroring serve's predicate:

- **Resident-lane disqualifier** — `resident_decode_eligible` now refuses `gemma2`/`gemma3` by architecture, with a `CAMELID_RESIDENT_TRACE` line naming the reason. Placed with the model-property checks before the backend-enabled gate (same rationale as the NoPE check, keeps the regression test causal on CPU-only hosts). **TEMPORARY**: Phase 3 of the gemma3 Metal campaign (`feat/gemma3-metal-resident`) removes it when the resident encode that applies these tensors lands.
- **CLI direct-session guard** — every CLI lane that constructs a direct dense `LlamaInferenceSession` (`bench-generate`, `bench-speculative` target+draft, `bench-owner-sweep`, `bench-alloc-gate`, `ghost-run`, gait trials, `distribute-worker`/`distribute-master`, `serve-distributed` worker) refuses qwen35/gemma2/gemma3 **before weights load** with an actionable error pointing at `camelid serve` / `camelid chat`, which route these archs to the correct runnable runtime.

Plumbing: `LlamaModelConfig` now carries the GGUF `general.architecture`, and the serve predicate delegates to the new shared `model::is_runnable_only_arch`, so the router and the CLI guard cannot drift apart.

**Serve is unaffected**: chat still routes these archs to the runnable bridge, `/v1/completions` still 422s, and the ledger drift check passes unchanged. `camelid chat` was already correct (it drives serve over HTTP, DECISIONS D6).

## Verification

- new unit tests: `runnable_only_arch_disqualifies_the_resident_gpu_path` (pins the eligibility gate for gemma3+gemma2, both want_logits variants) and `runnable_only_arch_set_is_exactly_the_serve_bridge_set` (pins the predicate in lockstep with the serve bridge set)
- `cargo fmt` / `clippy --all-targets -D warnings` clean; `cargo test --all-targets` fully green (1312 lib + all integration binaries, 0 failed); `scripts/check-ledger-drift.mjs` + public scrub pass
- end-to-end on macOS (release): `bench-generate` on `gemma-3-1b-it-Q8_0.gguf` now exits 1 with the actionable error on both the default fast stack and `CAMELID_METAL_RESIDENT_DECODE=0` (previously: fluent-looking garbage on both); TinyLlama 1.1B Q8_0 still decodes coherently at 77 tok/s and Qwen3-1.7B Q8_0 at 39.6 tok/s on the unchanged fast stack