### PR TITLE
Stop three Metal gate tests from mutating the process environment

### DIFF
--- a/qa/speed/verify-gates.sh
+++ b/qa/speed/verify-gates.sh
@@ -5,18 +5,34 @@
 #   metal_verify_gemv_batched_bit_identical   (Phase 3 C0 — the batched GEMV)
 #   metal_spec_verify_bit_identical           (Phase 3 — linear verify_batch)
 #   metal_tree_verify_bit_identical           (Phase 4 — tree verify_batch_tree)
-# guard on process-wide OnceLock env gates (f32y / wire / nsg8 / attn2 / split-K). Under a shared
-# `cargo test --all-targets` run, a sibling test can read (and latch) those gates OFF *before* the
-# gate test runs, so the gate takes its SKIP branch — and a skipped #[test] counts as PASS. So a
-# green `--all-targets` does NOT, by itself, exercise the byte-exact assertions.
+# guard on process-wide OnceLock env gates (f32y / wire / nsg8 / attn2 / split-K), which the
+# CALLER must arm — a test may not arm them for itself (see the export block below). A plain
+# `cargo test --all-targets` arms nothing, so all three take their SKIP branch, and a skipped
+# #[test] counts as PASS. So a green `--all-targets` does NOT, by itself, exercise the byte-exact
+# assertions; only this script does.
 #
-# This script runs each gate in ITS OWN cargo process (fresh OnceLocks), where the gate sets the
-# env and latches the gates ON before any sibling can — so the to_bits assertions actually run.
-# THIS is the byte-exactness proof of record; CI should run this, not rely on --all-targets.
+# This script runs each gate in ITS OWN cargo process (fresh OnceLocks) with the gates armed in
+# the environment that process inherits — so the to_bits assertions actually run, and no sibling
+# test is dragged onto the wire path. THIS is the byte-exactness proof of record; CI should run
+# this, not rely on --all-targets.
 #
 # Usage:  qa/speed/verify-gates.sh
 set -uo pipefail
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/Volumes/Untitled/camelid-target}"
+
+# ARM THE GATES HERE, not inside the tests. They are process-wide OnceLocks, so an in-test
+# `set_var` mutates the environment for every other Metal test in the binary — whichever have
+# not read the gates yet then latch onto the wire path, where the standalone block helpers'
+# 36-byte uploads are read as 34-byte wire blocks and come back NaN. The three gates below
+# therefore SKIP unless the caller armed them, which is what this script is for.
+export CAMELID_METAL_F32Y=1
+export CAMELID_METAL_WIRE=1
+export CAMELID_METAL_WIRE_NSG8=1
+export CAMELID_METAL_ATTN2=1
+# Split-K attention is default-ON (CAMELID_METAL_ATTN_SPLITK=0 opts out). Set it explicitly so an
+# opt-out in the caller's environment cannot silently drop the straddle windows onto the v2 path —
+# which would SKIP the linear/tree gates and fail this script rather than quietly prove less.
+export CAMELID_METAL_ATTN_SPLITK=1
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
@@ -33,10 +49,10 @@ for g in "${GATES[@]}"; do
   if ! cargo test --release --lib "$g" -- --nocapture >"$log" 2>&1; then
     echo "  FAIL: $g returned non-zero"; tail -20 "$log"; rc=1; rm -f "$log"; continue
   fi
-  # A SKIP in an isolated process means the gates couldn't latch on even with no sibling — a real
+  # A SKIP here means the gates did not take effect even though this script armed them — a real
   # problem (Metal unavailable, or a gate dependency changed), NOT the benign --all-targets skip.
   if grep -q "SKIP $g" "$log"; then
-    echo "  FAIL: $g SKIPPED in isolation (Metal device unavailable or gates won't latch) — investigate"
+    echo "  FAIL: $g SKIPPED with the gates armed (Metal device unavailable or a gate changed) — investigate"
     grep "SKIP $g" "$log" | sed 's/^/    /'; rc=1; rm -f "$log"; continue
   fi
   if ! grep -q "BIT-IDENTICAL" "$log"; then

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -16898,20 +16898,27 @@ mod tests {
             return;
         }
         // The reference path is `encode_q8_matmul_f32y`, which only selects the NSG=8
-        // wire kernel when the f32y/wire/nsg8 gates are on. Those are process-wide
-        // OnceLocks; set the env BEFORE the first gate read so they latch on. If a
-        // sibling test in this process already latched them off (e.g. a full --lib
-        // run that read them earlier), SKIP rather than compare against a different
-        // kernel. A targeted run (`--lib metal_verify_gemv_batched_bit_identical`) has
-        // no such sibling, so the gates latch on here.
-        std::env::set_var("CAMELID_METAL_F32Y", "1");
-        std::env::set_var("CAMELID_METAL_WIRE", "1");
-        std::env::set_var("CAMELID_METAL_WIRE_NSG8", "1");
+        // wire kernel when the f32y/wire/nsg8 gates are on. Those gates must be armed
+        // BY THE CALLER, never with an in-test `set_var`: they are process-wide
+        // OnceLocks read by every other Metal test in this binary, so setting them here
+        // latches whichever siblings have not read them yet onto the wire path — where
+        // the standalone block helpers' 36-byte uploads are read as 34-byte wire blocks
+        // and come back NaN. Measured: with the gates armed across a shared
+        // `cargo test --lib metal::tests`, metal_attention_block_resident_matches_standalone,
+        // metal_ffn_block_resident_matches_standalone, metal_decode_layer_resident_matches_blocks,
+        // metal_decode_forward_resident_matches_per_layer and
+        // metal_resident_decode_state_matches_full_upload fail on NaN comparisons. Setting
+        // them here bought nothing either: in a shared run a sibling latches the gates
+        // first, so this test skipped anyway. Unarmed it is a no-op; the enforced proof
+        // lane is qa/speed/verify-gates.sh, which exports the gates and runs each gate in
+        // its own process.
         if !(f32y_gemv_enabled() && wire_weights_enabled() && wire_nsg8_enabled()) {
             eprintln!(
-                "SKIP metal_verify_gemv_batched_bit_identical: f32y/wire/nsg8 gates \
-                 inactive (OnceLock latched off earlier in this process); run targeted: \
-                 cargo test --release --lib metal_verify_gemv_batched_bit_identical"
+                "SKIP metal_verify_gemv_batched_bit_identical: the f32y/wire/nsg8 GEMV \
+                 gates are not armed. Run targeted: CAMELID_METAL_F32Y=1 \
+                 CAMELID_METAL_WIRE=1 CAMELID_METAL_WIRE_NSG8=1 cargo test --release \
+                 --lib metal_verify_gemv_batched_bit_identical -- --nocapture \
+                 (or qa/speed/verify-gates.sh, which arms all three gates)"
             );
             return;
         }
@@ -21456,20 +21463,17 @@ mod tests {
         if !detect_metal_device().available {
             return;
         }
-        // Production GEMV stack + tiled/split-K attention. Latch the OnceLock gates ON
-        // before the first read; if a sibling test already latched f32y/wire/nsg8 OFF (a
-        // full --lib run read them earlier), SKIP rather than compare against a different
-        // kernel. A targeted run has no such sibling, so the gates latch on here (and ATTN2
-        // engages the split-K path the straddle windows are designed to exercise).
-        std::env::set_var("CAMELID_METAL_F32Y", "1");
-        std::env::set_var("CAMELID_METAL_WIRE", "1");
-        std::env::set_var("CAMELID_METAL_WIRE_NSG8", "1");
-        std::env::set_var("CAMELID_METAL_ATTN2", "1");
-        // Require the split-K attention path (ATTN2 + split-K) too, so the straddle-126 / deep-510
-        // windows genuinely exercise the split-K verify kernels instead of silently falling to the
-        // v2 path when a sibling latched attn2/split-K OFF first. SKIP loudly otherwise — the
-        // targeted run (qa/speed/verify-gates.sh, --test-threads=1) is the enforced proof lane; a
-        // green --all-targets does NOT by itself exercise these byte-exact gates.
+        // Production GEMV stack + tiled/split-K attention. These gates must be armed BY THE
+        // CALLER, never with an in-test `set_var`: they are process-wide OnceLocks read by
+        // every other Metal test in this binary, so setting them here latches whichever
+        // siblings have not read them yet onto the wire path and NaNs them (the five measured
+        // casualties are listed on metal_verify_gemv_batched_bit_identical).
+        // Requiring ATTN2 + split-K as well keeps the straddle-126 / deep-510 windows on the
+        // split-K verify kernels instead of silently falling to the v2 path. Unarmed this test
+        // is a no-op — which is what a shared run already got, since a sibling latches the
+        // gates first — and a green --all-targets does NOT exercise these byte-exact
+        // assertions. The enforced proof lane is qa/speed/verify-gates.sh (--test-threads=1),
+        // which exports the gates and runs each one in its own process.
         if !(f32y_gemv_enabled()
             && wire_weights_enabled()
             && wire_nsg8_enabled()
@@ -21477,10 +21481,11 @@ mod tests {
             && splitk_attention_enabled())
         {
             eprintln!(
-                "SKIP metal_spec_verify_bit_identical: f32y/wire/nsg8/attn2/split-K gates inactive \
-                 (OnceLock latched off earlier in this process); run targeted: \
-                 qa/speed/verify-gates.sh (or cargo test --release --lib \
-                 metal_spec_verify_bit_identical)"
+                "SKIP metal_spec_verify_bit_identical: the f32y/wire/nsg8/attn2/split-K gates are \
+                 not armed. Run targeted: qa/speed/verify-gates.sh (or CAMELID_METAL_F32Y=1 \
+                 CAMELID_METAL_WIRE=1 CAMELID_METAL_WIRE_NSG8=1 CAMELID_METAL_ATTN2=1 cargo test \
+                 --release --lib metal_spec_verify_bit_identical -- --nocapture, leaving \
+                 CAMELID_METAL_ATTN_SPLITK unset — split-K is default-on)"
             );
             return;
         }
@@ -21733,15 +21738,12 @@ mod tests {
         if !detect_metal_device().available {
             return;
         }
-        // Latch the production GEMV + tiled/split-K attention gates ON before the first read
-        // (identical to the linear gate); SKIP if a sibling latched them off earlier.
-        std::env::set_var("CAMELID_METAL_F32Y", "1");
-        std::env::set_var("CAMELID_METAL_WIRE", "1");
-        std::env::set_var("CAMELID_METAL_WIRE_NSG8", "1");
-        std::env::set_var("CAMELID_METAL_ATTN2", "1");
-        // Require the split-K attention path too (see metal_spec_verify_bit_identical) so the
-        // linear-anchor straddle-126 / deep-510 windows really exercise split-K; SKIP loudly
-        // otherwise. Targeted proof lane: qa/speed/verify-gates.sh (--test-threads=1).
+        // Same contract as metal_spec_verify_bit_identical: the production GEMV + tiled/split-K
+        // attention gates are armed BY THE CALLER, never with an in-test `set_var` (those gates
+        // are process-wide OnceLocks; setting them here latches siblings onto the wire path and
+        // NaNs them). Requiring split-K too keeps the linear-anchor straddle-126 / deep-510
+        // windows on the split-K kernels. Unarmed this test is a no-op; the enforced proof lane
+        // is qa/speed/verify-gates.sh (--test-threads=1).
         if !(f32y_gemv_enabled()
             && wire_weights_enabled()
             && wire_nsg8_enabled()
@@ -21749,10 +21751,11 @@ mod tests {
             && splitk_attention_enabled())
         {
             eprintln!(
-                "SKIP metal_tree_verify_bit_identical: f32y/wire/nsg8/attn2/split-K gates inactive \
-                 (OnceLock latched off earlier in this process); run targeted: \
-                 qa/speed/verify-gates.sh (or cargo test --release --lib \
-                 metal_tree_verify_bit_identical)"
+                "SKIP metal_tree_verify_bit_identical: the f32y/wire/nsg8/attn2/split-K gates are \
+                 not armed. Run targeted: qa/speed/verify-gates.sh (or CAMELID_METAL_F32Y=1 \
+                 CAMELID_METAL_WIRE=1 CAMELID_METAL_WIRE_NSG8=1 CAMELID_METAL_ATTN2=1 cargo test \
+                 --release --lib metal_tree_verify_bit_identical -- --nocapture, leaving \
+                 CAMELID_METAL_ATTN_SPLITK unset — split-K is default-on)"
             );
             return;
         }


### PR DESCRIPTION
Three Metal gate tests mutate the process environment before their own skip check:

```rust
std::env::set_var("CAMELID_METAL_F32Y", "1");   // + WIRE, WIRE_NSG8, ATTN2
```

`metal_verify_gemv_batched_bit_identical`, `metal_spec_verify_bit_identical` and
`metal_tree_verify_bit_identical` all do it, so a plain `cargo test` that never intends to touch
the wire path arms those gates anyway. They are process-wide `OnceLock`s read by every other Metal
test in the binary; whichever siblings have not read them yet then latch onto the wire path, where
the standalone block helpers' 36-byte uploads are read as 34-byte wire blocks and come back NaN.

## Measured

Arming the gates across a shared run — exactly the state an in-test `set_var` creates when it
lands before a sibling's first gate read:

```
CAMELID_METAL_F32Y=1 CAMELID_METAL_WIRE=1 CAMELID_METAL_WIRE_NSG8=1 cargo test --lib metal::tests

test result: FAILED. 55 passed; 5 failed; 1 ignored
failures:
    metal::tests::metal_attention_block_resident_matches_standalone
    metal::tests::metal_ffn_block_resident_matches_standalone
    metal::tests::metal_decode_layer_resident_matches_blocks
    metal::tests::metal_decode_forward_resident_matches_per_layer
    metal::tests::metal_resident_decode_state_matches_full_upload
  "NaN != NaN", "NaN != 1.9598103", "token 0: -12.95156 != NaN"
```

Which siblings get hit is a race — it depends on who reads a gate first — which is why the suite is
usually green. The same pattern was diagnosed and fixed on a gemma3 gate test in `faa2f75d`
(`feat/gemma3-metal-resident`), where it took down these same five; this PR is the rest of it.

**The `set_var` bought the three tests nothing.** At the merge commit, in both threading modes, all
three already take their SKIP branch in a shared run, because a sibling latches the gates first:

```
cargo test --lib metal::tests -- --nocapture                  -> 3x SKIP, 60 passed
cargo test --lib metal::tests -- --nocapture --test-threads=1 -> 3x SKIP, 60 passed
```

So the environment mutation never enabled an assertion. It only armed process-wide gates for
whatever had not read them yet.

## Fix

Same shape as `faa2f75d`: never set the gates from inside the test, keep the gate check, and SKIP
with the full armed invocation in the message. This restores the contract
[`WIN2METAL_PHASE3_PLAN.md` §7 risk 1](docs/perf-deep-dive/WIN2METAL_PHASE3_PLAN.md) already
specified — *"test must read gates and SKIP if inactive; harness sets env before process start"*.

`qa/speed/verify-gates.sh` **is** that harness and relied on the tests arming themselves, so it now
exports the gates. It also pins `CAMELID_METAL_ATTN_SPLITK=1` (default-on, opt-out) so a caller's
opt-out cannot silently drop the straddle windows onto the v2 path; its existing SKIP-means-FAIL
check catches a lane that stops engaging.

## Verification

| check | result |
| --- | --- |
| `cargo test --lib metal::tests` x5 | green every time, 60 passed |
| `qa/speed/verify-gates.sh` | **PASS — all three ENGAGED** |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |

The proof lane still exercises every byte-exact assertion:

```
metal_verify_gemv_batched_bit_identical: k=1/2/7/8 BIT-IDENTICAL (130 rows x 7 blocks)
metal_spec_verify_bit_identical: base=126 k=6 BIT-IDENTICAL (split_k_engaged=true)
metal_spec_verify_bit_identical: base=510 k=6 BIT-IDENTICAL (split_k_engaged=true)
metal_tree_verify_bit_identical: LINEAR base=126 k=6 BIT-IDENTICAL
metal_tree_verify_bit_identical: LINEAR base=510 k=6 BIT-IDENTICAL
metal_tree_verify_bit_identical: BRANCH base=126 path=[0, 2, 5] compaction==linear-decode + class-A PASS
PASS: all 3 byte-exact verify gates ran ENGAGED (split-K straddle 126 & 510) and are BIT-IDENTICAL.
```

## Scope note

Test-only plus the QA script — no production code paths change. The three tests are now no-ops in
any unarmed run, which is what they already were in practice; `qa/speed/verify-gates.sh` remains the
enforced proof of record, as its header has always said.
