### PR TITLE
nvfp4: fix release-only sNaN miscompile in the encode amax scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,38 @@ jobs:
           RUST_MIN_STACK: 8388608
         run: cargo test --all-targets ${{ matrix.features }}
 
+      # Everything above this line is a DEBUG build, and that is exactly how a
+      # release-only defect in the NVFP4 encoder sat in main unnoticed: while
+      # `amax` is still the literal 0.0, LLVM peels the first compare of the
+      # sub-block amax scan and folds it into a max intrinsic (`fmaxnm` on
+      # aarch64), which QUIETS a signaling NaN into the result instead of
+      # discarding it the way the pin's `<` does. A leading sNaN therefore zeroed
+      # the sub-block scale at -O and only at -O; every debug run was green.
+      #
+      # The suites below exist to reproduce the pin BYTE-FOR-BYTE, so they are
+      # the ones that have to hold in the profile we actually ship. Scoped to
+      # those rather than a second full `--all-targets` run to keep the added
+      # wall-clock bounded — this gates the optimization-sensitive numeric
+      # kernels, NOT the whole suite, so a release-only defect elsewhere is still
+      # ungated. Runs on every OS leg on purpose: the defect was a codegen fold,
+      # and codegen differs per target (the fmaxnm form is aarch64/macOS).
+      - name: Tests (release, bit-exactness suites)
+        # Explicit: the default shell on windows-latest is pwsh, which does not
+        # take `\` line continuations.
+        shell: bash
+        env:
+          RUST_MIN_STACK: 8388608
+        run: |
+          set -euo pipefail
+          cargo test --release --lib ${{ matrix.features }} nvfp4
+          cargo test --release ${{ matrix.features }} \
+            --test nvfp4_format \
+            --test nvfp4_wire_lane_refusals \
+            --test nvfp4_e4b_spotcheck \
+            --test runnable_dequant \
+            --test dg_quant_parity \
+            --test gemma4_kquant_regression
+
       # The Windows linker reserves an 8 MiB stack for camelid.exe because the
       # debug Clap parser needs it. Unit tests exercise a libtest executable,
       # so they cannot prove the shipped debug binary starts. Keep this direct

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -6025,7 +6025,8 @@ fn nvfp4_best_index(x: f32, d: f32) -> u8 {
 /// comparison (all-NaN rows therefore encode to an all-zero wire, and +/-Inf rows
 /// saturate the scale to 0x7E while `best_index` leaves every element at code 0),
 /// scale byte = `fp32_to_ue4m3(amax / 6)`, elements quantized against the DECODED
-/// scale via first-wins nearest-LUT search.
+/// scale via first-wins nearest-LUT search. The amax scan compares BIT PATTERNS,
+/// not floats — see the comment in the loop; a plain `<` is miscompiled at `-O`.
 #[cfg(test)]
 pub(crate) fn encode_nvfp4_block(
     x: &[f32; NVFP4_VALUES_PER_BLOCK],
@@ -6035,8 +6036,22 @@ pub(crate) fn encode_nvfp4_block(
         let xb = &x[s * NVFP4_SUB_BLOCK_VALUES..(s + 1) * NVFP4_SUB_BLOCK_VALUES];
         let mut amax = 0.0_f32;
         for &v in xb {
-            if amax < v.abs() {
-                amax = v.abs();
+            let a = v.abs();
+            // The pin's `if (amax < a) amax = a;` never fires on a NaN, so a NaN
+            // element must leave `amax` untouched. Spelling that as the float `<`
+            // is NOT enough: while `amax` is still the literal 0.0, LLVM peels the
+            // first iteration and folds `select(0.0 < a, a, 0.0)` into a max
+            // intrinsic — `fmaxnm` on aarch64 — and `fmaxnm` returns the QUIETED
+            // operand when one input is a SIGNALING NaN (it returns the other
+            // operand only for a quiet one). A leading sNaN therefore poisoned
+            // `amax`, zeroing the sub-block scale, in optimized builds ONLY;
+            // fixture row `path-snan-first` caught it, debug builds never did.
+            // Here both operands are non-negative and non-NaN, and over that
+            // domain unsigned bit-pattern order IS IEEE magnitude order — so this
+            // is the same predicate, expressed as an integer compare that no
+            // float fold can rewrite.
+            if !a.is_nan() && a.to_bits() > amax.to_bits() {
+                amax = a;
             }
         }
         let ue = fp32_to_ue4m3(amax / 6.0);
@@ -6060,7 +6075,8 @@ pub(crate) fn encode_nvfp4_block(
 mod nvfp4_tests {
     use super::{
         decode_nvfp4_tensor, encode_nvfp4_block, fp32_to_ue4m3, nvfp4_block_decode_into,
-        KVALUES_MXFP4, NVFP4_VALUES_PER_BLOCK, NVFP4_WIRE_BYTES_PER_BLOCK, UE4M3_TO_F32,
+        KVALUES_MXFP4, NVFP4_SUB_BLOCK_VALUES, NVFP4_VALUES_PER_BLOCK, NVFP4_WIRE_BYTES_PER_BLOCK,
+        UE4M3_TO_F32,
     };
 
     fn fixture_json(name: &str) -> serde_json::Value {
@@ -6226,6 +6242,52 @@ mod nvfp4_tests {
                 seen_spotlock_tags.contains(expected),
                 "fixture is missing spot-lock tag {expected}: the semantic lock never ran"
             );
+        }
+    }
+
+    /// OPTIMIZATION-SENSITIVITY LOCK for the amax scan (see [`encode_nvfp4_block`]).
+    /// A NaN element must change NOTHING except its own nibble: not the sub-block
+    /// scale, not its 63 neighbours' codes. Asserted against a NaN-free encode of
+    /// the same row rather than a golden blob, so it keeps testing the property if
+    /// the fixtures are ever regenerated — and swept over EVERY slot and all four
+    /// NaN encodings, because the defect it guards was position- and
+    /// signalling-specific: only slot 0 of a sub-block (where `amax` is still the
+    /// literal 0.0, so LLVM peels the compare into `fmaxnm`) and only a SIGNALING
+    /// NaN (which `fmaxnm` quiets INTO the result instead of discarding). That
+    /// combination is one row of `nvfp4_encode_vectors.json` (`path-snan-first`)
+    /// and it failed in release while every debug build passed.
+    #[test]
+    fn encode_amax_ignores_nan_in_every_slot_and_encoding() {
+        let clean = encode_nvfp4_block(&[2.0_f32; NVFP4_VALUES_PER_BLOCK]);
+        // Anchor the NaN-free baseline so a broken encoder cannot make this test
+        // vacuous by agreeing with itself: amax 2.0 -> ue4m3(1/3) = 0x2B, and 2.0
+        // sits nearest code 7 (12 * 0.171875 = 2.0625).
+        assert_eq!(clean[..4], [0x2B; 4], "baseline scale bytes");
+        assert!(clean[4..].iter().all(|&b| b == 0x77), "baseline codes");
+
+        for slot in 0..NVFP4_VALUES_PER_BLOCK {
+            for nan_bits in [
+                0x7f80_0001_u32, // +sNaN (the regressing input)
+                0xff80_0001,     // -sNaN
+                0x7fc0_0000,     // +qNaN
+                0xffc0_0000,     // -qNaN
+            ] {
+                let mut x = [2.0_f32; NVFP4_VALUES_PER_BLOCK];
+                x[slot] = f32::from_bits(nan_bits);
+
+                // Only the NaN's own nibble goes to code 0; `best_index` never lets
+                // a NaN beat the initial candidate.
+                let mut want = clean;
+                let within = slot % NVFP4_SUB_BLOCK_VALUES;
+                let byte = 4 + (slot / NVFP4_SUB_BLOCK_VALUES) * 8 + within % 8;
+                want[byte] &= if within < 8 { 0xF0 } else { 0x0F };
+
+                assert_eq!(
+                    encode_nvfp4_block(&x),
+                    want,
+                    "NaN {nan_bits:#010x} in slot {slot} must not disturb the block"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## The bug

`tensor::nvfp4_tests::encode_vectors_reproduce_pin_wire_bytes_and_dequant` **passes in debug and fails in release** on `main`, at fixture row `path-snan-first`:

```
left:  [0, 43, 43, 43, 0, 0, 0, 0, 0, 0, 0, 0, 119, ...]
right: [43, 43, 43, 43, 112, 119, 119, 119, 119, ...]
```

Sub-block 0's scale byte came out `0` instead of `0x2B`, taking every element code in that sub-block with it.

## Root cause

`encode_nvfp4_block`'s per-sub-block amax scan spelled the pin's NaN-insensitive comparison as a plain float `<`:

```rust
let mut amax = 0.0_f32;
for &v in xb { if amax < v.abs() { amax = v.abs(); } }
```

While `amax` is still the literal `0.0`, LLVM peels the first iteration and folds `select(0.0 < a, a, 0.0)` into a max intrinsic. Disassembly of a reduced repro (aarch64, the repo's `lto = "fat"` / `codegen-units = 1` release profile):

```
fabs   s0, s0        ; |x[0]|
movi.2d v2, #0       ; 0.0
fmaxnm s0, s0, s2    ; <-- iteration 0 folded into FMAXNM
fcmp   s0, s1        ; iterations 1..15 keep fcmp+fcsel (correct)
fcsel  s0, s1, s0, mi
```

`FMAXNM` returns the *other* operand for a **quiet** NaN, but the **quieted operand itself** for a **signaling** one. So `amax` became NaN, and `fp32_to_ue4m3(NaN / 6.0)` is `0`.

Both conditions are required — measured across the full cross-product:

| | slot 0 | slot 1 | slot 7 | slot 15 |
|---|---|---|---|---|
| sNaN | **NaN** | 2.0 | 2.0 | 2.0 |
| qNaN | 2.0 | 2.0 | 2.0 | 2.0 |

That is exactly why `path-snan-first` failed while `path-qnan-mixed` (quiet NaN at index 3) passed.

**The fixture is right, the encoder was wrong.** Verified against the pin by hand: amax `2.0` → `ue4m3(1/3) = 0x2B = 43`, and `2.0` is nearest code 7 (`12 × 0.171875 = 2.0625`) → `43,43,43,43,0x70,0x77…`.

## Scope — the fail-closed promise was never at risk

`encode_nvfp4_block` is `#[cfg(test)]` and does not ship. D17/T5 fail-closed is enforced by `nvfp4_find_nan_scale` and `nvfp4_metal_sentinel_check`, both pure integer scans for `0x7F`/`0xFF` scale bytes with no floating point — structurally immune to this class.

The two shipped sites with a similar shape were checked rather than assumed, and neither is affected: `quantize_q8_k_blocks` keeps its compare live via the tied `max = v` assignment (incidental, not by design), and `quantize_q8_0_arm` uses `f32::max`, whose NaN behaviour is contractual.

## The fix

```rust
let a = v.abs();
if !a.is_nan() && a.to_bits() > amax.to_bits() { amax = a; }
```

Both operands are non-negative and non-NaN, where unsigned bit-pattern order *is* IEEE magnitude order — the same predicate, as an integer compare no float fold can rewrite. `black_box` was rejected: it is a best-effort hint, not a guarantee. No assertion was relaxed.

New `encode_amax_ignores_nan_in_every_slot_and_encoding` sweeps all 64 slots × 4 NaN encodings, asserting against a NaN-free encode of the same row rather than a golden blob so it survives fixture regeneration. **Verified non-vacuous:** reverting only the loop makes it fail with `NaN 0x7f800001 in slot 0 must not disturb the block`.

## CI

Debug-only testing is what hid this, so the `rust` job gets a release step over the bit-exactness suites, on all three OS legs — the defect is a codegen fold and codegen differs per target. `shell: bash` is pinned because the Windows default is pwsh, which rejects `\` continuations.

Two honest limits: the release profile is `lto = "fat"` + `codegen-units = 1`, so this leg is **not cheap** (scoping it to `macos-latest` is a one-line change if the CI time is unwelcome); and it gates those suites, **not** the whole test set, so a release-only defect elsewhere is still ungated. The step comment says both.

## Verification (local, M4)

- `fmt` clean; `clippy --all-targets -- -D warnings` clean
- 36 NVFP4 tests green in **both** profiles, including 2 Metal GPU tests on a real device
- Release integration suites (the exact new CI command) green
- `cargo test --all-targets` debug: **1349 passed**

One pre-existing failure, `test_distributed_pipeline_parallel_inference` (TCP `ConnectionReset`/`UnexpectedEof`), is unrelated — it reproduces identically on a stashed zero-diff tree against `origin/main` and is being handled separately.
