### PR TITLE
gemma4 distributed tests: ephemeral ports, no silent worker death

### DIFF
--- a/src/gemma4_distributed.rs
+++ b/src/gemma4_distributed.rs
@@ -155,6 +155,22 @@ pub fn run_worker(model: &Path, addr: &str, range: Range<usize>) -> Result<()> {
     // Bind BEFORE the (slow) shard load so a master can connect immediately;
     // its handshake waits in the accept backlog until the weights are ready.
     let listener = TcpListener::bind(addr).map_err(|e| io_err("bind", e))?;
+    run_worker_on_listener(model, listener, range)
+}
+
+/// Serve the worker protocol on an already-bound listener.
+///
+/// Callers that must know the port before the worker starts — tests binding
+/// `127.0.0.1:0` for an ephemeral port — bind themselves and hand the listener
+/// over. That removes both the hard-coded port that can collide with whatever
+/// else is on the box and the window in which the address is unbound, so no
+/// readiness poll is needed: the socket is listening before this is called.
+pub fn run_worker_on_listener(
+    model: &Path,
+    listener: TcpListener,
+    range: Range<usize>,
+) -> Result<()> {
+    let addr = listener.local_addr().map_err(|e| io_err("local_addr", e))?;
     let runtime = Gemma4Runtime::load_layer_range(model, Some(range.clone()))?;
     if runtime.local_layer_range().end != runtime.block_count() {
         return Err(BackendError::InvalidModelMetadata(format!(

--- a/tests/gemma4_api_smoke.rs
+++ b/tests/gemma4_api_smoke.rs
@@ -276,22 +276,26 @@ async fn live_gemma4_distributed_chat_serve_smoke() {
         .and_then(|v| v.parse().ok())
         .unwrap_or(default_split.max(1));
 
-    let addr = "127.0.0.1:39414".to_string();
+    // Bind an OS-assigned free port here rather than hard-coding one: this box
+    // may already be running `camelid serve`, and a lost bind race inside the
+    // worker thread would surface only as an opaque ConnectionReset on the
+    // master's first read. Binding before the spawn also means the socket is
+    // listening by the time we connect, so no readiness poll is needed.
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback ephemeral port");
+    let addr = listener.local_addr().unwrap().to_string();
     let worker_model = model_path.clone();
-    let worker_addr = addr.clone();
     std::thread::spawn(move || {
-        let _ = camelid::gemma4_distributed::run_worker(
+        if let Err(e) = camelid::gemma4_distributed::run_worker_on_listener(
             &worker_model,
-            &worker_addr,
+            listener,
             split..block_count,
-        );
-    });
-    for _ in 0..100 {
-        if std::net::TcpStream::connect(&addr).is_ok() {
-            break;
+        ) {
+            // Surface the worker's own failure; without this the only symptom
+            // is an unexplained EOF on the master's read.
+            eprintln!("gemma4 worker exited with error: {e:#}");
         }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
+    });
 
     let runtime = tokio::task::spawn_blocking({
         let p = model_path.clone();
@@ -334,9 +338,17 @@ async fn live_gemma4_distributed_chat_serve_smoke() {
         )
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    let body: Value =
-        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    // Read the body before asserting the status: on a 5xx the error payload is
+    // the only thing that says *why*, and asserting first throws it away.
+    let status = response.status();
+    let raw = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "distributed chat completion failed: {}",
+        String::from_utf8_lossy(&raw)
+    );
+    let body: Value = serde_json::from_slice(&raw).unwrap();
     let content = body["choices"][0]["message"]["content"]
         .as_str()
         .unwrap_or_default();

--- a/tests/gemma4_distributed_parity.rs
+++ b/tests/gemma4_distributed_parity.rs
@@ -10,10 +10,12 @@
 //!       CAMELID_GEMMA4_SPLIT=8 \
 //!       cargo test --release --test gemma4_distributed_parity -- --nocapture`
 
+use std::net::TcpListener;
+use std::ops::Range;
 use std::path::PathBuf;
 
 use camelid::gemma4_distributed::{
-    run_master, run_worker, Gemma4Handshake, Gemma4WorkerClient, GEMMA4_WIRE_VERSION,
+    run_master, run_worker_on_listener, Gemma4Handshake, Gemma4WorkerClient, GEMMA4_WIRE_VERSION,
 };
 use camelid::gemma4_runtime::Gemma4Runtime;
 
@@ -31,6 +33,29 @@ struct OracleResult {
 
 fn repo_path(rel: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+/// Bind loopback on an OS-assigned free port, serve the worker shard on it, and
+/// return the address the master should dial.
+///
+/// These tests used to hard-code ports 39411-39413. On a box that also runs
+/// `camelid serve` the bind loses the race, the worker thread dies silently
+/// inside `let _ = run_worker(..)`, and the master then connects to whatever
+/// else holds the port — producing an opaque `ConnectionReset`/`UnexpectedEof`
+/// on the *master's* read with no hint that the worker never started. Binding
+/// here rather than inside the thread also means the socket is listening before
+/// the master dials, so no readiness poll is needed.
+fn spawn_worker(model: PathBuf, range: Range<usize>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback ephemeral port");
+    let addr = listener.local_addr().expect("local_addr").to_string();
+    std::thread::spawn(move || {
+        if let Err(e) = run_worker_on_listener(&model, listener, range) {
+            // Surface the worker's own failure. Without this the only symptom
+            // is an unexplained EOF on the master's read.
+            eprintln!("gemma4 worker exited with error: {e:#}");
+        }
+    });
+    addr
 }
 
 #[test]
@@ -101,20 +126,7 @@ fn distributed_greedy_matches_single_node_and_oracle() {
     eprintln!("row {row}: {block_count} layers, split at {split}");
 
     // Worker thread on an ephemeral localhost port (real TCP, real protocol).
-    let port = 39411;
-    let addr = format!("127.0.0.1:{port}");
-    let worker_model = model.clone();
-    let worker_addr = addr.clone();
-    std::thread::spawn(move || {
-        run_worker(&worker_model, &worker_addr, split..block_count).expect("worker run");
-    });
-    // Wait for the listener.
-    for _ in 0..100 {
-        if std::net::TcpStream::connect(&addr).is_ok() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
+    let addr = spawn_worker(model.clone(), split..block_count);
 
     // One prompt is enough for wire parity (the full pack runs in the
     // generation-parity test); use the first oracle prompt.
@@ -157,19 +169,7 @@ fn distributed_wire_version_mismatch_fails_closed() {
         block_count / 2
     };
 
-    let port = 39412;
-    let addr = format!("127.0.0.1:{port}");
-    let worker_model = model.clone();
-    let worker_addr = addr.clone();
-    std::thread::spawn(move || {
-        let _ = run_worker(&worker_model, &worker_addr, split..block_count);
-    });
-    for _ in 0..100 {
-        if std::net::TcpStream::connect(&addr).is_ok() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
+    let addr = spawn_worker(model.clone(), split..block_count);
 
     let handshake = Gemma4Handshake {
         wire_version: GEMMA4_WIRE_VERSION + 1, // deliberately wrong
@@ -226,19 +226,7 @@ fn distributed_serve_runtime_streaming_matches_oracle() {
         .and_then(|v| v.parse().ok())
         .unwrap_or(default_split.max(1));
 
-    let port = 39413;
-    let addr = format!("127.0.0.1:{port}");
-    let worker_model = model.clone();
-    let worker_addr = addr.clone();
-    std::thread::spawn(move || {
-        let _ = run_worker(&worker_model, &worker_addr, split..block_count);
-    });
-    for _ in 0..100 {
-        if std::net::TcpStream::connect(&addr).is_ok() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
+    let addr = spawn_worker(model.clone(), split..block_count);
 
     let runtime =
         camelid::gemma4_distributed::Gemma4DistributedRuntime::connect(&model, &addr, split)


### PR DESCRIPTION
The gemma4 distributed tests hard-coded their listener ports — `39414` in the API smoke, `39411`–`39413` in the parity suite — and spawned the worker as `let _ = run_worker(..)`.

On a box already running `camelid serve`, the bind loses the race. The swallowed `AddrInUse` kills the worker thread silently, and the readiness poll that follows connects happily to *whatever else* holds the port. The test then fails much later, on the master's side, as an opaque `ConnectionReset` / `UnexpectedEof` pointing nowhere near the actual cause. This is the same defect just fixed in the llama distributed tests.

## What changed

**`run_worker` split into a thin bind-then-delegate wrapper over a new `run_worker_on_listener`**, mirroring `run_worker_loop_on_listener` and `run_network_benchmark_worker_on_listener` in `src/distributed.rs`.

**Tests bind `127.0.0.1:0` themselves**, read the assigned port from `local_addr()`, and move the listener into the worker thread. Because the socket is listening *before* the thread is spawned, the connect-polling loops are gone — along with the throwaway probe connection they left in the worker log as `hello read: failed to fill whole buffer`.

**Worker errors are printed instead of discarded.** `let _ =` became `if let Err(e) = … { eprintln!(…) }` at all four call sites.

`run_worker` keeps its bind-before-the-slow-shard-load property: the caller's bind now happens strictly *earlier*, so an eager master still waits in the accept backlog rather than being refused.

The three parity call sites were identical, so they collapse into one `spawn_worker` helper — net −86/+110 across the two test files.

Also: the distributed serve smoke now reads the response body *before* asserting the status, so a 5xx reports the server's error message instead of only `left: 500, right: 200`. That is how the follow-up defect below was diagnosed at all.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- Ungated (what CI runs): `gemma4_api_smoke` 6/6, `gemma4_distributed_parity` 4/4
- `cargo test --lib` 1408 passed, 0 failed
- Gated against a real `gemma-4-E2B-it-Q8_0` GGUF: ephemeral ports confirmed working end-to-end — worker binds an OS-assigned port, handshake round-trips, and both fail-closed tests (`distributed_split_through_shared_kv_block_fails_closed`, `distributed_wire_version_mismatch_fails_closed`) pass over real TCP.

## What this PR does NOT claim

- **It does not make the gated generation tests pass on a slow model volume.** `distributed_greedy_matches_single_node_and_oracle`, `distributed_serve_runtime_streaming_matches_oracle` and `live_gemma4_distributed_chat_serve_smoke` still fail on a USB-backed volume, on a *separate, pre-existing* defect: the worker's cold shard demand-fault lands inside the master's 30s `SO_RCVTIMEO`. That was verified to reproduce on unmodified `main` by stashing this diff, with the hard-coded port confirmed free. It is fixed in the stacked follow-up, not here.
- **It changes no production behavior.** The only `src/` change is the `run_worker` / `run_worker_on_listener` split; `run_worker`'s own semantics are unchanged and `src/main.rs` still calls it.
- **It does not add coverage.** These tests remain env-gated on `CAMELID_GEMMA4_GGUF`, so CI continues to skip the live legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
