### PR TITLE
serve: an auto-selected startup model that fails to load must not exit

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2373,10 +2373,42 @@ fn router_with_state_and_policy(state: AppState, policy: server::ServerPolicy) -
         .with_state(state)
 }
 
+/// The model `serve` loads at startup, and where that choice came from.
+///
+/// The origin decides what a load failure means. A path the user named on the
+/// command line is a request, so failing it loudly with a non-zero exit is the
+/// honest answer. A path Camelid picked out of the models directory for itself
+/// is a convenience, and one unreadable file there must not cost the user the
+/// whole server — the UI they would use to pick another model is served by the
+/// very process that failure would take down.
+pub struct StartupModel {
+    pub path: PathBuf,
+    /// `true` when the path came from `--model`.
+    pub explicit: bool,
+}
+
+impl StartupModel {
+    /// A model the user named; a load failure is fatal.
+    pub fn explicit(path: PathBuf) -> Self {
+        Self {
+            path,
+            explicit: true,
+        }
+    }
+
+    /// A model Camelid chose from the models directory; a load failure is not.
+    pub fn auto_selected(path: PathBuf) -> Self {
+        Self {
+            path,
+            explicit: false,
+        }
+    }
+}
+
 pub async fn serve(
     addr: SocketAddr,
     configured_threads: Option<usize>,
-    initial_model: Option<PathBuf>,
+    initial_model: Option<StartupModel>,
     open_ui: bool,
     default_enable_thinking: bool,
     models_dir: Option<PathBuf>,
@@ -2471,16 +2503,33 @@ pub async fn serve(
     // kills the sidecar when its health poll goes unanswered for 40s, and a
     // large startup model (auto-selected whenever the models dir is populated)
     // used to keep the port closed for the entire load — a healthy engine
-    // looked dead exactly when it had the most work to do. Failure still exits
-    // `serve` with the same message and non-zero status as before.
-    if let Some(model_path) = initial_model {
-        if let Err(err) = load_model_from_path(&startup_state, model_path, None, true).await {
+    // looked dead exactly when it had the most work to do.
+    //
+    // A model the user NAMED still exits with the same message and non-zero
+    // status. A model Camelid auto-selected does not: the pick is made by
+    // filename order over whatever sits in the models directory, so a single
+    // unreadable file there (an interrupted `pull` leaves a short .gguf under
+    // the final name, and `curl -C -` needs it to stay there to resume) would
+    // otherwise take down the server on every launch, including the UI the
+    // user needs to choose a different model. Reinstalling does not help —
+    // the models directory outlives the app — so the failure is permanent.
+    if let Some(StartupModel { path, explicit }) = initial_model {
+        if let Err(err) = load_model_from_path(&startup_state, path.clone(), None, true).await {
             tracing::error!(error=%err, "failed to load startup model");
-            eprintln!("\n  Could not load that model: {err}");
-            eprintln!("  Camelid serves specific validated Q8_0 rows. To get one:");
-            eprintln!("      camelid pull            # list supported models");
-            eprintln!("      camelid pull <id>       # download one into ./models\n");
-            return Err(std::io::Error::other(err.to_string()));
+            if explicit {
+                eprintln!("\n  Could not load that model: {err}");
+                eprintln!("  Camelid serves specific validated Q8_0 rows. To get one:");
+                eprintln!("      camelid pull            # list supported models");
+                eprintln!("      camelid pull <id>       # download one into ./models\n");
+                return Err(std::io::Error::other(err.to_string()));
+            }
+            eprintln!("\n  Could not load {}: {err}", path.display());
+            eprintln!(
+                "  Camelid picked that file automatically from {}.",
+                startup_state.models_dir.display()
+            );
+            eprintln!("  The server is still running. Open the UI to choose another model,");
+            eprintln!("  or delete that file if it is a broken download and fetch it again.\n");
         }
     }
     // Warm the generation path BEFORE telling the user we're ready. The GPU resident
@@ -2516,6 +2565,112 @@ pub async fn serve(
         crate::web_ui::open_in_browser(&url);
     }
     server.await.map_err(std::io::Error::other)?
+}
+
+#[cfg(test)]
+mod startup_model_tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+
+    /// A GGUF by file extension only — what an interrupted download leaves
+    /// behind, and what any corrupt or unsupported file looks like to the
+    /// loader. Every load path rejects it.
+    fn unloadable_gguf(dir: &std::path::Path) -> PathBuf {
+        let path = dir.join("broken.gguf");
+        std::fs::write(&path, b"not a gguf").expect("write broken gguf");
+        path
+    }
+
+    /// Reserve a loopback port and return its address; the listener is dropped
+    /// so `serve` can bind it.
+    fn reserved_loopback_addr() -> SocketAddr {
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback ephemeral port");
+        listener.local_addr().expect("read reserved port")
+    }
+
+    /// The desktop supervisor's own gate, byte for byte: a loopback GET of
+    /// `/v1/health` that counts only a 200.
+    fn health_ok(addr: SocketAddr) -> bool {
+        let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(500)) else {
+            return false;
+        };
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+        let request =
+            format!("GET /v1/health HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n");
+        if stream.write_all(request.as_bytes()).is_err() {
+            return false;
+        }
+        let mut buf = [0u8; 64];
+        matches!(stream.read(&mut buf), Ok(read) if read > 0
+            && String::from_utf8_lossy(&buf[..read]).starts_with("HTTP/1.1 200"))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn an_auto_selected_startup_model_that_cannot_load_keeps_the_server_up() {
+        let dir = tempfile::tempdir().expect("temp models dir");
+        let broken = unloadable_gguf(dir.path());
+        let addr = reserved_loopback_addr();
+
+        let server = tokio::spawn(serve(
+            addr,
+            None,
+            Some(StartupModel::auto_selected(broken)),
+            false,
+            false,
+            Some(dir.path().to_path_buf()),
+            ServeOptions::default(),
+        ));
+
+        // Camelid picked the file itself, so it owes the user a running server
+        // and the UI to choose again — not an exit that reinstalling can't fix,
+        // because the models directory outlives the app.
+        let mut healthy = false;
+        for _ in 0..100 {
+            if server.is_finished() {
+                break;
+            }
+            if tokio::task::spawn_blocking(move || health_ok(addr))
+                .await
+                .unwrap_or(false)
+            {
+                healthy = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        server.abort();
+
+        assert!(
+            healthy,
+            "an auto-selected startup model that cannot load must not take the server down"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn an_explicitly_named_startup_model_that_cannot_load_still_fails_the_run() {
+        let dir = tempfile::tempdir().expect("temp models dir");
+        let broken = unloadable_gguf(dir.path());
+        let addr = reserved_loopback_addr();
+
+        // `--model` is a request, not a guess, so it keeps failing loudly.
+        let result = serve(
+            addr,
+            None,
+            Some(StartupModel::explicit(broken)),
+            false,
+            false,
+            Some(dir.path().to_path_buf()),
+            ServeOptions::default(),
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "an explicitly named model that cannot load must fail the run"
+        );
+    }
 }
 
 /// One-shot self-request to build/warm the generation engine, awaited so startup

--- a/src/main.rs
+++ b/src/main.rs
@@ -1746,7 +1746,12 @@ async fn main() -> anyhow::Result<()> {
             // Open-and-use launch: if no model was named, load the user's saved
             // default from the configured model library. With no saved choice,
             // the first local GGUF is the zero-configuration default.
-            let model = model.or_else(|| auto_select_model(models_dir.as_deref()));
+            let model = match model {
+                Some(path) => Some(api::StartupModel::explicit(path)),
+                None => {
+                    auto_select_model(models_dir.as_deref()).map(api::StartupModel::auto_selected)
+                }
+            };
             // Open the browser only when run interactively and not opted out.
             let open_ui = !no_open && std::io::IsTerminal::is_terminal(&std::io::stdout());
             // Journal the run. A `session_start` with no matching `session_exit`
@@ -1930,7 +1935,7 @@ async fn main() -> anyhow::Result<()> {
                 api::serve(
                     addr,
                     threads,
-                    Some(model),
+                    Some(api::StartupModel::explicit(model)),
                     false,
                     false,
                     None,


### PR DESCRIPTION
## The bug

`serve` without `--model` picks a startup model for the user: the saved default, or failing that the **first GGUF in the models directory by filename order**. If that pick failed to load, `serve` printed the error and exited non-zero — and that exit is what a user actually experiences as a permanently broken app.

Three things compound:

- the pick is made by filename sort over whatever is in the directory, and is never validated;
- an interrupted `camelid pull` leaves a short `.gguf` under its **final** name (deliberately — `curl -C -` resumes it), so a broken file lands in exactly the place the picker reads from;
- the models directory outlives the app (`~/Library/Application Support/app.camelid.desktop/models` on macOS), so uninstalling, reinstalling, and rebooting all leave the failure in place.

Under Camelid Desktop the engine exit surfaces as `the camelid engine exited before becoming healthy`, with no indication of which file or where it lives. Reproduced on v0.4.6: a models directory holding one truncated GGUF **plus one perfectly good model** exits in 2.0s with `invalid GGUF file: tensor token_embd.weight data extends beyond end of file` — the good model sitting right next to it is never reached.

This came in as a user report (Mac mini M4): worked one day, dead the next, and reinstalling never helped.

## The fix

Distinguish where the startup model came from, because that decides what a load failure means:

- **`--model <path>`** is a request. It still fails loudly, same message, same non-zero exit.
- **Auto-selected** is a convenience. Camelid now reports the failure — naming the file and the models directory it picked from — and **keeps serving**, so the UI that lets the user choose another model is actually reachable.

A new `StartupModel { path, explicit }` carries that origin from `main.rs` into `api::serve`.

## Not changed

- `camelid pull` still downloads to the final filename; the resume contract depends on it. Fixing this at the startup layer covers every way a bad file gets there, not just interrupted pulls.
- The tracked/UI download path already promotes `.part` → destination and has tests for it.
- The 40s desktop health gate is untouched — `90d1e642` already fixed that, and it's verified below.

## Tests

Two new tests in `src/api/mod.rs`, both driving the real `serve`:

- `an_auto_selected_startup_model_that_cannot_load_keeps_the_server_up` — polls `/v1/health` exactly the way the desktop supervisor does, and asserts a 200 after an auto-selected model fails to load.
- `an_explicitly_named_startup_model_that_cannot_load_still_fails_the_run` — pins the fail-fast contract for `--model`.

## Verified on this machine

Measured against the shipped v0.4.6 sidecar and a build of current `main`:

| | v0.4.6 | `main` | this PR |
|---|---|---|---|
| empty models dir | healthy 0.6s | healthy | healthy |
| 1.3 GB model present | healthy **17.5s** | healthy **0.8s** | healthy 0.8s |
| broken GGUF auto-selected | **engine exits 2.0s** | **engine exits** | **serves; reports the file** |
| broken GGUF via `--model` | exits non-zero | exits non-zero | exits non-zero |

## Follow-up worth considering

- Surface "the startup model failed to load: `<file>`" in the UI, not just on stderr — a user whose app now starts cleanly has no in-app signal that their pick was skipped.
- Advance to the next candidate GGUF instead of coming up with no model loaded.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
