### PR TITLE
distributed tests: ephemeral ports, no silent worker death

### DIFF
--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -205,9 +205,22 @@ impl DistributedClient {
 pub static DISTRIBUTED_CLIENT: OnceLock<DistributedClient> = OnceLock::new();
 pub static DISTRIBUTED_RANGE: OnceLock<(usize, usize)> = OnceLock::new();
 
-pub fn run_worker_loop(addr: &str, mut session: LlamaInferenceSession) -> anyhow::Result<()> {
+pub fn run_worker_loop(addr: &str, session: LlamaInferenceSession) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr)?;
-    tracing::info!(addr = %addr, "Distributed Worker TCP server listening");
+    run_worker_loop_on_listener(listener, session)
+}
+
+/// Serve the worker protocol on an already-bound listener.
+///
+/// Callers that must know the port before the loop starts — tests binding
+/// `127.0.0.1:0` for an ephemeral port — bind themselves and hand the listener
+/// over, so there is no window in which the address is unbound and no
+/// hard-coded port to collide with.
+pub fn run_worker_loop_on_listener(
+    listener: TcpListener,
+    mut session: LlamaInferenceSession,
+) -> anyhow::Result<()> {
+    tracing::info!(addr = ?listener.local_addr(), "Distributed Worker TCP server listening");
 
     for stream in listener.incoming() {
         let mut stream = match stream {
@@ -274,7 +287,13 @@ pub fn run_worker_loop(addr: &str, mut session: LlamaInferenceSession) -> anyhow
 
 pub fn run_network_benchmark_worker(addr: &str) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr)?;
-    tracing::info!(addr = %addr, "Network benchmark worker TCP server listening");
+    run_network_benchmark_worker_on_listener(listener)
+}
+
+/// Benchmark counterpart to [`run_worker_loop_on_listener`]: serve on a
+/// listener the caller already bound.
+pub fn run_network_benchmark_worker_on_listener(listener: TcpListener) -> anyhow::Result<()> {
+    tracing::info!(addr = ?listener.local_addr(), "Network benchmark worker TCP server listening");
 
     for stream in listener.incoming() {
         let mut stream = match stream {

--- a/tests/distributed_tests.rs
+++ b/tests/distributed_tests.rs
@@ -1,13 +1,29 @@
-use std::{fs, path::Path};
+use std::{fs, net::TcpListener, path::Path};
 use tempfile::tempdir;
 
 use camelid::{
-    distributed::{run_worker_loop, DistributedClient, DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE},
+    distributed::{
+        run_network_benchmark_worker_on_listener, run_worker_loop_on_listener, DistributedClient,
+        DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE,
+    },
     gguf::read_metadata,
     inference::{LlamaInferenceSession, LlamaLoadedWeights},
     model::{LlamaModelConfig, LlamaTensorBinding},
     tensor::TensorStore,
 };
+
+/// Bind loopback on an OS-assigned free port.
+///
+/// These tests used to hard-code 127.0.0.1:8099 and 127.0.0.1:8098. On a
+/// developer box that also runs `camelid serve` the bind lost the race, the
+/// worker thread died silently, and the coordinator connected to whatever else
+/// held the port — producing an opaque `ConnectionReset`/`UnexpectedEof` on the
+/// *client* read with no hint that the worker never started. Binding here (not
+/// inside the worker thread) also means the socket is listening before the
+/// coordinator connects, so no readiness sleep is needed.
+fn bind_ephemeral() -> TcpListener {
+    TcpListener::bind("127.0.0.1:0").expect("bind loopback ephemeral port")
+}
 
 #[test]
 fn test_distributed_pipeline_parallel_inference() {
@@ -36,16 +52,20 @@ fn test_distributed_pipeline_parallel_inference() {
     let worker_config = LlamaModelConfig::from_gguf(&gguf).unwrap();
     let worker_session = LlamaInferenceSession::new(worker_config, worker_weights).unwrap();
 
-    // Spawn Worker in background thread
+    // Spawn Worker in background thread. The listener is already bound, so the
+    // coordinator below can connect immediately.
+    let listener = bind_ephemeral();
+    let worker_addr = listener.local_addr().unwrap().to_string();
     let _worker_handle = std::thread::spawn(move || {
-        let _ = run_worker_loop("127.0.0.1:8099", worker_session);
+        if let Err(e) = run_worker_loop_on_listener(listener, worker_session) {
+            // Surface the worker's own failure. Without this the only symptom is
+            // an unexplained EOF on the coordinator's read.
+            eprintln!("distributed worker loop exited with error: {e:#}");
+        }
     });
 
-    // Wait for worker server to bind
-    std::thread::sleep(std::time::Duration::from_millis(500));
-
     // 2. Coordinator Setup (Loads layer 0..1)
-    let client = DistributedClient::connect("127.0.0.1:8099").unwrap();
+    let client = DistributedClient::connect(&worker_addr).unwrap();
     let _ = DISTRIBUTED_CLIENT.set(client);
     let _ = DISTRIBUTED_RANGE.set((0, 1));
 
@@ -64,7 +84,9 @@ fn test_distributed_pipeline_parallel_inference() {
     let mut coord_session = LlamaInferenceSession::new(coord_config, coord_weights).unwrap();
 
     // Run forward pass on coordinator (which will delegate layer 1 to worker!)
-    let output = coord_session.forward_single_token(0).unwrap();
+    let output = coord_session
+        .forward_single_token(0)
+        .expect("coordinator forward pass (layer 1 is delegated to the worker over TCP)");
 
     // Assert logits are computed and the dimensions are correct
     assert_eq!(output.logits.shape.dims, vec![1, 16]); // [1, vocab_size]
@@ -78,17 +100,18 @@ fn test_distributed_pipeline_parallel_inference() {
 
 #[test]
 fn test_network_benchmark() {
-    // Spawn benchmark worker in background thread
+    // Spawn benchmark worker in background thread on an already-bound listener.
+    let listener = bind_ephemeral();
+    let worker_addr = listener.local_addr().unwrap().to_string();
     let _worker_handle = std::thread::spawn(move || {
-        let _ = camelid::distributed::run_network_benchmark_worker("127.0.0.1:8098");
+        if let Err(e) = run_network_benchmark_worker_on_listener(listener) {
+            eprintln!("network benchmark worker exited with error: {e:#}");
+        }
     });
-
-    // Wait for worker server to bind
-    std::thread::sleep(std::time::Duration::from_millis(200));
 
     // Run coordinator benchmark locally
     let result = camelid::distributed::run_network_benchmark_coordinator(
-        "127.0.0.1:8098",
+        &worker_addr,
         10,   // ping_count
         1024, // payload_size
         10,   // bandwidth_mb


### PR DESCRIPTION
The same defect #562 fixed for the gemma4 distributed tests, in the llama ones. This is the original instance — #562 was modelled on it.

`tests/distributed_tests.rs` hard-coded `127.0.0.1:8099` and `127.0.0.1:8098`, and spawned the worker as `let _ = run_worker_loop(..)`.

On a box already running `camelid serve`, the bind loses the race. The swallowed `AddrInUse` kills the worker thread silently, and the fixed readiness sleep that follows lets the coordinator connect to whatever else holds the port. The test then fails much later as an opaque `ConnectionReset` / `UnexpectedEof` on the *client* read, pointing nowhere near the actual cause.

## What changed

**`run_worker_loop` and `run_network_benchmark_worker` split** into thin bind-then-delegate wrappers over `run_worker_loop_on_listener` and `run_network_benchmark_worker_on_listener`. Production entry points and their semantics are unchanged.

**Tests bind `127.0.0.1:0`**, read the assigned port from `local_addr()`, and move the listener into the worker thread. The socket is listening before the thread is spawned, so both readiness sleeps — 500 ms and 200 ms — are gone, along with the flakiness they papered over.

**Worker errors are printed rather than discarded**, so a worker that dies says so instead of surfacing only as a client-side EOF. The coordinator's forward pass also carries an `expect()` naming what it delegates.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- `cargo test --test distributed_tests` **3/3**
- `cargo test --lib` **1411 passed, 0 failed**
- Rebased onto current `main` (through #565); clean, no conflicts

## What this PR does NOT claim

- **No production behavior change.** The only `src/` change is the wrapper/`_on_listener` split; `run_worker_loop` and `run_network_benchmark_worker` keep their signatures and behavior, and existing callers are untouched.
- **No new coverage.** The same three tests run; they are now deterministic about which port they use rather than gaining new assertions.
- **It does not fix distributed inference itself** — only the tests' port handling and failure legibility. Anything wrong on the wire is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
