### PR TITLE
gemma4 CUDA: route the tied head through its lane's GPU layout

### DIFF
--- a/qa/gemma4-cuda-head-repack/RESULT.md
+++ b/qa/gemma4-cuda-head-repack/RESULT.md
@@ -1,0 +1,100 @@
+# gemma4 CUDA-resident lane: the tied head uploaded raw wire into repacked-layout GEMVs
+
+`gemma-4-E2B-it-Q4_0.gguf` decoded as `passe dép oficialmenteynam shalthapp lenghtynam`
+on the CUDA-resident lane where the CPU gemma4 runtime said `Paris`, reproducibly, on an
+RTX 3060 Laptop. The lane loaded without error and produced fluent-looking wrong tokens —
+it failed silently rather than refusing.
+
+**The Q4_0 projections were never the defect.** `q4_0_gemv` and its repack are correct.
+
+## Root cause
+
+`Gemma4CudaResident::load` picks a tied-head lane from `token_embd`'s format and uploads
+the weight. The Q8_0 arm repacked to SoA; the **Q4_K and Q6_K arms `clone_htod`'d the raw
+GGUF wire**. Neither of those kernels reads the stock wire:
+
+| Lane | What the GEMV indexes | What it was fed |
+|---|---|---|
+| `q8_gemv` | SoA split (`q8_wire_to_soa`) | ✅ SoA |
+| `q4k_gemv` | quant-byte **swizzle** (`swz_q4k_blocks`) — each aux lane's four stride-8 bytes as one aligned `i32` for `__dp4a` | ❌ raw 144 B wire |
+| `q6k_gemv` | **224 B padded** stride (`pad_q6k_blocks`) | ❌ raw 210 B wire |
+
+Every other resident lane in the tree routes through `cuda_resident::repack_for_lane`,
+which applies exactly these. The gemma4 head bypassed it.
+
+A Q4_0-quantized gemma4 export carries a **Q4_K `token_embd`**. So the E2B Q4_0 row ran
+`q4k_gemv` over unswizzled bytes: correctly-addressed but **wrongly-paired** nibbles. The
+hidden states stayed correct and only the logits were garbage — which is exactly why the
+output looked fluent instead of crashing.
+
+The Q6_K arm was the same defect one step worse: the 210-vs-224 stride mismatch also reads
+past the end of the allocation.
+
+### Why this survived so long
+
+Head lane is a property of `token_embd`, which no admission or coverage check inspects
+(`nvfp4_cuda_lane_check` covers layer *projections*, correctly — the head is simply not in
+its remit):
+
+| Row | `token_embd` → head lane | Before |
+|---|---|---|
+| E4B Q8_0 — *the bring-up row* | Q8_0 → `Q8_0` | ✅ correct |
+| E2B Q8_0 | Q8_0 → `Q8_0` | ✅ correct |
+| **E2B Q4_0** | **Q4_K → `Q4K`** | ❌ **garbage** |
+| 26B Q4_0 | Q6_K → `Q6K` | ❌ broken |
+| E4B NVFP4 | Q6_K → `Q6K` | ❌ broken |
+
+**The only gemma4 row ever validated on this lane is the one whose head happened to be
+Q8_0.** Every row with a K-quant head was broken.
+
+Note what did *not* catch it: `q4k_gemv` has a passing bit-parity unit test, and so does
+`q4_0_gemv`. Both kernels were correct throughout. **Kernel parity is not row parity** — a
+per-kernel test cannot see a layout mismatch at the upload site.
+
+## Fix
+
+All three head lanes route through one function, `gemma4_head_upload`, mirroring
+`repack_for_lane`. Two kernel parameter comments that claimed "raw 210-byte Q6_K wire" and
+"RAW 144-byte Q4_K wire" — contradicting their own `WIRE` constants, and the most likely
+reason the head was wired this way — are corrected.
+
+`gemma4_head_upload_matches_each_lane_gemv_layout` pins each lane's layout with explicit
+index arithmetic rather than by calling the repack helpers back, so it still fails if a
+helper is later changed to agree with a broken caller. Verified both directions: **fails**
+with raw upload restored, **passes** with the fix.
+
+## Receipt: greedy parity, CUDA-resident vs CPU gemma4 runtime
+
+`gemma-4-E2B-it-Q4_0.gguf`, greedy, gemma chat template, one engine resident at a time.
+Capture: `run-q4_0-parity.sh` → `q4_0-parity.json`.
+
+| Prompt | Token-identical |
+|---|---|
+| Name the capital of France in one word. | ✅ |
+| What color is the sky on a clear day? | ✅ |
+| Name the largest ocean on Earth. | ✅ |
+| What is 2 + 2? | ✅ |
+| List three primary colors. | ✅ |
+
+**5/5 legs token-identical (`all_pass: true`)** — full token streams, not just first-token
+argmax. The in-tree `gemma4_cuda_matches_cpu_greedy` also passes on this row.
+
+End-to-end through `serve` on the surface the defect was reported on, with the lane
+actually resident (1557 MiB VRAM in use):
+
+| | Output |
+|---|---|
+| Before | `passe dép oficialmenteynam shalthapp lenghtynam` |
+| **After** | **`Paris`** |
+
+## Scope
+
+Measured on RTX 3060 Laptop (6 GB), Windows 11, `gemma-4-E2B-it-Q4_0.gguf`. The **Q6_K**
+head fix is proven by unit test and by inspection against `pad_q6k_blocks`, **not** by a
+row receipt — no Q6_K-head gemma4 row fits this card (26B Q4_0, E4B NVFP4). No throughput
+claim is made.
+
+Serving a Q4_0 gemma4 row on the CUDA lane also requires the admission predicate on
+`feat/gemma3-cuda-resident`, which pins admission to Q8_0; relaxing that pin onto the
+receipt above is tracked on that branch, not here. This PR is the correctness fix alone,
+and applies regardless of which rows are admitted.

--- a/qa/gemma4-cuda-head-repack/q4_0-parity.json
+++ b/qa/gemma4-cuda-head-repack/q4_0-parity.json
@@ -1,0 +1,12 @@
+{
+  "model": "gemma-4-E2B-it-Q4_0.gguf",
+  "max_tokens": 32,
+  "legs": [
+    {"prompt": "Name the capital of France in one word.", "cuda_ids": "[50429, 236820, 643, 236779, 1340, 236779, 887, 236813]", "cpu_ids": "[50429, 236820, 643, 236779, 1340, 236779, 887, 236813]", "token_identical": true},
+    {"prompt": "What color is the sky on a clear day?", "cuda_ids": "[818, 7217, 580, 496, 3582, 1719, 563, 11082, 5213, 9503, 84750]", "cpu_ids": "[818, 7217, 580, 496, 3582, 1719, 563, 11082, 5213, 9503, 84750]", "token_identical": true},
+    {"prompt": "Name the largest ocean on Earth.", "cuda_ids": "[818, 7488, 12461, 580, 10824, 563, 506, 14225, 18414, 21603, 643, 236779, 1340, 236779, 887, 236813]", "cpu_ids": "[818, 7488, 12461, 580, 10824, 563, 506, 14225, 18414, 21603, 643, 236779, 1340, 236779, 887, 236813]", "token_identical": true},
+    {"prompt": "What is 2 + 2?", "cuda_ids": "[236778, 900, 236743, 236778, 563, 236743, 236812, 236761]", "cpu_ids": "[236778, 900, 236743, 236778, 563, 236743, 236812, 236761]", "token_identical": true},
+    {"prompt": "List three primary colors.", "cuda_ids": "[236820, 643, 236779, 1340, 236779, 887, 236813]", "cpu_ids": "[236820, 643, 236779, 1340, 236779, 887, 236813]", "token_identical": true}
+  ],
+  "all_pass": true
+}

--- a/qa/gemma4-cuda-head-repack/run-q4_0-parity.sh
+++ b/qa/gemma4-cuda-head-repack/run-q4_0-parity.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Greedy-parity capture for the gemma4 E2B Q4_0 row: CUDA-resident lane vs the CPU
+# gemma4 runtime, one engine resident at a time (this box has 6 GB VRAM / 16 GB RAM).
+# Prompts carry the gemma chat template, because that is the shape serve feeds and
+# the shape the original mis-decode was reported on.
+set -u
+BIN=./target/release/camelid.exe
+MODEL="${1:?usage: run-q4_0-parity.sh <gguf>}"
+OUT="${2:-qa/gemma3-cuda/phase5/q4_0-parity.json}"
+MAXTOK=32
+
+PROMPTS=(
+  "Name the capital of France in one word."
+  "What color is the sky on a clear day?"
+  "Name the largest ocean on Earth."
+  "What is 2 + 2?"
+  "List three primary colors."
+)
+
+echo "{" >"$OUT"
+echo "  \"model\": \"$(basename "$MODEL")\"," >>"$OUT"
+echo "  \"max_tokens\": $MAXTOK," >>"$OUT"
+echo "  \"legs\": [" >>"$OUT"
+
+all_pass=true
+first=true
+for p in "${PROMPTS[@]}"; do
+  tmpl=$'<start_of_turn>user\n'"$p"$'<end_of_turn>\n<start_of_turn>model\n'
+  cuda=$("$BIN" gemma4-cuda-generate "$MODEL" --prompt "$tmpl" --max-tokens $MAXTOK 2>&1 |
+    grep -oP '(?<=token_ids: ).*' | tail -1)
+  cpu=$("$BIN" gemma4-generate "$MODEL" --prompt "$tmpl" --max-tokens $MAXTOK 2>&1 |
+    grep -oP '(?<=token_ids: ).*' | tail -1)
+  if [ "$cuda" = "$cpu" ]; then match=true; else match=false; all_pass=false; fi
+  echo "    prompt: $p"
+  echo "      cuda: $cuda"
+  echo "      cpu : $cpu"
+  echo "      match: $match"
+  $first || echo "," >>"$OUT"
+  first=false
+  printf '    {"prompt": %s, "cuda_ids": "%s", "cpu_ids": "%s", "token_identical": %s}' \
+    "$(printf '%s' "$p" | sed 's/"/\\"/g; s/^/"/; s/$/"/')" "$cuda" "$cpu" "$match" >>"$OUT"
+done
+
+echo "" >>"$OUT"
+echo "  ]," >>"$OUT"
+echo "  \"all_pass\": $all_pass" >>"$OUT"
+echo "}" >>"$OUT"
+echo "all_pass: $all_pass  -> $OUT"

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -601,7 +601,7 @@ extern "C" __global__ void nvfp4_gemv(
 extern "C" __global__ void q4k_gemv(
     const float* __restrict__ input_scales,         // n_sb f32 (Q8_K d per superblock)
     const signed char* __restrict__ input_quants,   // n_sb*256 i8 (Q8_K quants)
-    const unsigned char* __restrict__ weight_bytes, // RAW 144-byte Q4_K wire, row-major
+    const unsigned char* __restrict__ weight_bytes, // SWIZZLED 144-byte Q4_K blocks, row-major
     int rows, int n_sb, float* __restrict__ output, int residual
 ) {
     extern __shared__ unsigned char smem4[];
@@ -925,7 +925,7 @@ extern "C" __global__ void q5k_gemv(
 extern "C" __global__ void q6k_gemv(
     const float* __restrict__ input_scales,         // n_sb f32 (Q8_K d per superblock)
     const signed char* __restrict__ input_quants,   // n_sb*256 i8 (Q8_K quants)
-    const unsigned char* __restrict__ weight_bytes, // raw 210-byte Q6_K wire, row-major
+    const unsigned char* __restrict__ weight_bytes, // 224-byte PADDED Q6_K blocks, row-major
     int rows, int n_sb, float* __restrict__ output, int residual
 ) {
     extern __shared__ unsigned char smem6[];

--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -3125,19 +3125,54 @@ fn q8_wire_to_soa(wire: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Quant lane of the GPU tied head: Q8_0 (`q8_gemv` over SoA-repacked weight, Q8_0
-/// input) or Q6_K (`q6k_gemv` over raw wire, Q8_K input).
+/// Quant lane of the GPU tied head: Q8_0 (`q8_gemv`, Q8_0 input), Q4_K (`q4k_gemv`,
+/// Q8_K input) or Q6_K (`q6k_gemv`, Q8_K input). Each lane's GEMV reads a specific
+/// GPU-side byte layout — see [`gemma4_head_upload`], which is the ONLY way the head
+/// weight may reach VRAM.
 #[cfg(feature = "cuda")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum HeadLane {
     Q8_0,
     Q4K,
     Q6K,
 }
 
-/// Resident GPU tied head. `weight` is the vocab-major projection (SoA for Q8_0, raw
-/// Q6_K wire otherwise); input is quantized by the fused rms_norm+quantize into
-/// `inq`/`ins`; `logits` is dtoh'd once per token. `blocks` is blocks-per-row passed
-/// to the GEMV (`hidden/32` for Q8_0, `hidden/256` for Q6_K).
+/// Convert the tied head's GGUF wire bytes into the GPU layout ITS GEMV reads.
+///
+/// None of these kernels reads the stock wire: `q8_gemv` wants the SoA split (quants
+/// then f16 scales), `q4k_gemv` wants the quant-byte swizzle that makes each aux
+/// lane's four stride-8 bytes one aligned i32, and `q6k_gemv` indexes super-blocks at
+/// a 224-byte PADDED stride, not the 210-byte wire stride. This mirrors
+/// `cuda_resident::repack_for_lane`, which is what every OTHER resident lane in the
+/// tree already routes through.
+///
+/// Root cause of the gemma4 Q4_0 mis-decode: the Q4_K and Q6_K arms used to
+/// `clone_htod` the raw wire while only the Q8_0 arm repacked. Since a Q4_0-quantized
+/// gemma4 export carries a **Q4_K** `token_embd` (the E2B Q4_0 row does), that row ran
+/// `q4k_gemv` over unswizzled bytes: every logit was formed from correctly-addressed
+/// but wrongly-PAIRED nibbles, so the lane emitted fluent-looking nonsense instead of
+/// refusing. Measured before the fix, "Name the capital of France in one word." →
+/// "passe dép oficialmenteynam shalthapp lenghtynam" on CUDA vs "Paris" on the CPU
+/// runtime. The Q6_K arm had the same defect one step worse — a 210-vs-224 stride
+/// mismatch that also reads past the end of the allocation.
+///
+/// Head lane is chosen from `token_embd`'s format, which no admission check inspects,
+/// so the only gemma4 row ever validated on this lane (E4B Q8_0) was the one whose
+/// head happened to be Q8_0. Routing all three lanes through one function is what
+/// keeps that class of bug from coming back.
+#[cfg(feature = "cuda")]
+fn gemma4_head_upload(lane: HeadLane, wire: &[u8]) -> Vec<u8> {
+    match lane {
+        HeadLane::Q8_0 => q8_wire_to_soa(wire),
+        HeadLane::Q4K => crate::cuda_resident::swz_q4k_blocks(wire),
+        HeadLane::Q6K => crate::cuda_resident::pad_q6k_blocks(wire),
+    }
+}
+
+/// Resident GPU tied head. `weight` is the vocab-major projection in its lane's GPU
+/// layout (always via [`gemma4_head_upload`]); input is quantized by the fused
+/// rms_norm+quantize into `inq`/`ins`; `logits` is dtoh'd once per token. `blocks` is
+/// blocks-per-row passed to the GEMV (`hidden/32` for Q8_0, `hidden/256` for K-quants).
 #[cfg(feature = "cuda")]
 struct Gemma4HeadDev {
     lane: HeadLane,
@@ -3397,7 +3432,7 @@ impl Gemma4CudaResident {
                 Some(Gemma4HeadDev {
                     lane: HeadLane::Q8_0,
                     weight: s
-                        .clone_htod(&q8_wire_to_soa(cpu.token_embd.bytes()))
+                        .clone_htod(&gemma4_head_upload(HeadLane::Q8_0, cpu.token_embd.bytes()))
                         .map_err(cu)?,
                     output_norm: s.clone_htod(&cpu.output_norm).map_err(cu)?,
                     logits: s.alloc_zeros::<f32>(vocab).map_err(cu)?,
@@ -3411,7 +3446,9 @@ impl Gemma4CudaResident {
                 let blocks = hidden / 256;
                 Some(Gemma4HeadDev {
                     lane: HeadLane::Q6K,
-                    weight: s.clone_htod(cpu.token_embd.bytes()).map_err(cu)?,
+                    weight: s
+                        .clone_htod(&gemma4_head_upload(HeadLane::Q6K, cpu.token_embd.bytes()))
+                        .map_err(cu)?,
                     output_norm: s.clone_htod(&cpu.output_norm).map_err(cu)?,
                     logits: s.alloc_zeros::<f32>(vocab).map_err(cu)?,
                     inq: s.alloc_zeros::<i8>(blocks * 256).map_err(cu)?,
@@ -3420,12 +3457,15 @@ impl Gemma4CudaResident {
                     softcap,
                 })
             }
-            // Q4_K tied head (mixed Q4_0 file): q4k_gemv over raw 144-byte wire, Q8_K input.
+            // Q4_K tied head (the format a Q4_0-quantized gemma4 export carries):
+            // q4k_gemv over the SWIZZLED 144-byte super-blocks, Q8_K input.
             WireFormat::Q4K if hidden.is_multiple_of(256) => {
                 let blocks = hidden / 256;
                 Some(Gemma4HeadDev {
                     lane: HeadLane::Q4K,
-                    weight: s.clone_htod(cpu.token_embd.bytes()).map_err(cu)?,
+                    weight: s
+                        .clone_htod(&gemma4_head_upload(HeadLane::Q4K, cpu.token_embd.bytes()))
+                        .map_err(cu)?,
                     output_norm: s.clone_htod(&cpu.output_norm).map_err(cu)?,
                     logits: s.alloc_zeros::<f32>(vocab).map_err(cu)?,
                     inq: s.alloc_zeros::<i8>(blocks * 256).map_err(cu)?,
@@ -5104,6 +5144,100 @@ impl Gemma4CudaResident {
 #[cfg(all(test, feature = "cuda"))]
 mod cuda_parity_tests {
     use super::*;
+
+    /// Deterministic filler for the head-upload layout tests (no rand dep).
+    fn lcg_bytes(n: usize, mut seed: u32) -> Vec<u8> {
+        (0..n)
+            .map(|_| {
+                seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                (seed >> 24) as u8
+            })
+            .collect()
+    }
+
+    // Root-cause regression for the gemma4 Q4_0 mis-decode. The tied-head GEMVs do
+    // NOT read the stock GGUF wire: `q4k_gemv` indexes a SWIZZLED quant region and
+    // `q6k_gemv` indexes super-blocks at a 224-byte PADDED stride. The Q4_K and Q6_K
+    // head arms used to `clone_htod` the raw wire, so a Q4_0-quantized gemma4 export
+    // (whose token_embd is Q4_K) computed every logit from wrongly-paired nibbles —
+    // fluent-looking nonsense, no error. `gemma4_head_upload` is now the single upload
+    // path; this pins each lane's layout so raw passthrough cannot come back.
+    //
+    // Asserted with explicit index arithmetic rather than by calling the repack
+    // helpers back, so the test still fails if a helper is changed to agree with a
+    // broken caller.
+    #[test]
+    fn gemma4_head_upload_matches_each_lane_gemv_layout() {
+        // --- Q4_K: pure byte permutation of the quant region, header untouched. ---
+        const Q4K_WIRE: usize = 144;
+        let blocks = 5usize;
+        let wire = lcg_bytes(blocks * Q4K_WIRE, 0x4b_4b_01);
+        let up = gemma4_head_upload(HeadLane::Q4K, &wire);
+        assert_eq!(up.len(), wire.len(), "the swizzle must not change size");
+        assert!(
+            up != wire,
+            "raw passthrough is the defect: q4k_gemv reads swizzled quant bytes"
+        );
+        for b in 0..blocks {
+            let (s, d) = (&wire[b * Q4K_WIRE..], &up[b * Q4K_WIRE..]);
+            assert_eq!(
+                &d[..16],
+                &s[..16],
+                "d/dmin/packed-scale header is untouched"
+            );
+            // The four stride-8 bytes an aux lane consumes must land contiguous.
+            for g in 0..4 {
+                for l in 0..8 {
+                    for k in 0..4 {
+                        assert_eq!(
+                            d[16 + g * 32 + l * 4 + k],
+                            s[16 + g * 32 + l + k * 8],
+                            "q4k swizzle mismatch at block {b} group {g} lane {l} k {k}"
+                        );
+                    }
+                }
+            }
+        }
+
+        // --- Q6_K: 210-byte wire blocks padded to the 224-byte stride the kernel
+        // indexes. Uploading raw here under-sizes the buffer AND mis-addresses every
+        // block past the first, so this length check is the load-bearing assertion.
+        const Q6K_WIRE: usize = 210;
+        const Q6K_PADDED: usize = 224;
+        let wire = lcg_bytes(blocks * Q6K_WIRE, 0x6b_6b_02);
+        let up = gemma4_head_upload(HeadLane::Q6K, &wire);
+        assert_eq!(
+            up.len(),
+            blocks * Q6K_PADDED,
+            "q6k_gemv strides super-blocks by 224 B, not the 210 B wire"
+        );
+        for b in 0..blocks {
+            assert_eq!(
+                &up[b * Q6K_PADDED..b * Q6K_PADDED + Q6K_WIRE],
+                &wire[b * Q6K_WIRE..(b + 1) * Q6K_WIRE],
+                "q6k payload block {b} must survive the pad verbatim"
+            );
+        }
+
+        // --- Q8_0: the SoA split q8_gemv reads (all quants, then all f16 scales). ---
+        const Q8_WIRE: usize = 34;
+        let wire = lcg_bytes(blocks * Q8_WIRE, 0x08_08_03);
+        let up = gemma4_head_upload(HeadLane::Q8_0, &wire);
+        assert_eq!(up.len(), wire.len());
+        for b in 0..blocks {
+            let src = &wire[b * Q8_WIRE..(b + 1) * Q8_WIRE];
+            assert_eq!(
+                &up[b * 32..b * 32 + 32],
+                &src[2..34],
+                "q8 quants are SoA-first"
+            );
+            assert_eq!(
+                &up[blocks * 32 + b * 2..blocks * 32 + b * 2 + 2],
+                &src[0..2],
+                "q8 f16 scales trail the quant plane"
+            );
+        }
+    }
 
     // Greedy parity: the CUDA gemma4 forward must match the CPU Gemma4Runtime oracle
     // token-for-token on the E4B Q8_0 file (the oracle that the CPU runtime loads).


### PR DESCRIPTION
## The defect

`gemma-4-E2B-it-Q4_0.gguf` decoded as `passe dép oficialmenteynam shalthapp lenghtynam` on the CUDA-resident lane where the CPU gemma4 runtime said `Paris`. Reproducible on an RTX 3060 Laptop. The lane loaded without error and produced fluent-looking wrong tokens — it failed silently rather than refusing.

**The Q4_0 projections were never the defect.** `q4_0_gemv` and its repack are correct.

## Root cause

`Gemma4CudaResident::load` picks a tied-head lane from `token_embd`'s format, then uploads the weight. The Q8_0 arm repacked to SoA; the **Q4_K and Q6_K arms uploaded the raw GGUF wire**. Neither of those kernels reads stock wire:

| Lane | What the GEMV indexes | What it was fed |
|---|---|---|
| `q8_gemv` | SoA split (`q8_wire_to_soa`) | ✅ SoA |
| `q4k_gemv` | quant-byte **swizzle** (`swz_q4k_blocks`) — each aux lane's four stride-8 bytes as one aligned `i32` for `__dp4a` | ❌ raw 144 B wire |
| `q6k_gemv` | **224 B padded** stride (`pad_q6k_blocks`) | ❌ raw 210 B wire |

Every other resident lane routes through `cuda_resident::repack_for_lane`. The gemma4 head bypassed it.

A Q4_0-quantized gemma4 export carries a **Q4_K `token_embd`**, so that row ran `q4k_gemv` over unswizzled bytes: every logit formed from correctly-addressed but **wrongly-paired** nibbles. Hidden states stayed correct and only the logits were garbage — which is why it read as fluent nonsense. The Q6_K arm was worse: the stride mismatch also reads past the end of the allocation.

## Why it survived

Head lane is a property of `token_embd`, which no coverage check inspects — `nvfp4_cuda_lane_check` covers layer *projections*, correctly; the head is not in its remit.

| Row | `token_embd` → head lane | Before |
|---|---|---|
| E4B Q8_0 — *the bring-up row* | Q8_0 → `Q8_0` | ✅ correct |
| E2B Q8_0 | Q8_0 → `Q8_0` | ✅ correct |
| **E2B Q4_0** | **Q4_K → `Q4K`** | ❌ **garbage** |
| 26B Q4_0 | Q6_K → `Q6K` | ❌ broken |
| E4B NVFP4 | Q6_K → `Q6K` | ❌ broken |

**The only gemma4 row ever validated on this lane is the one whose head happened to be Q8_0.**

⚠️ `q4k_gemv` **and** `q4_0_gemv` both had passing bit-parity unit tests the entire time this shipped garbage. Kernel parity is not row parity — a per-kernel test cannot see a layout mismatch at the upload site.

## Fix

- All three head lanes route through one `gemma4_head_upload`, mirroring `repack_for_lane`.
- Corrected two kernel parameter comments claiming "raw 210-byte Q6_K wire" / "RAW 144-byte Q4_K wire" that contradicted their own `WIRE` constants — the most likely reason the head was wired this way.
- `gemma4_head_upload_matches_each_lane_gemv_layout` pins each layout with explicit index arithmetic rather than calling the repack helpers back, so it still fails if a helper is later changed to agree with a broken caller. **Verified it fails with the raw upload restored and passes with the fix.**

## Receipts — `qa/gemma4-cuda-head-repack/`

5/5 greedy prompts **token-identical** against the CPU gemma4 runtime on the E2B Q4_0 row (full token streams, not just first-token argmax), plus `gemma4_cuda_matches_cpu_greedy`. End-to-end through `serve` with the lane actually resident (1557 MiB VRAM):

| | Output |
|---|---|
| Before | `passe dép oficialmenteynam shalthapp lenghtynam` |
| **After** | **`Paris`** |

## Scope and honest limits

- The **Q6_K** arm is proven by unit test and inspection against `pad_q6k_blocks`, **not** by a row receipt — no Q6_K-head gemma4 row fits a 6 GB card (26B Q4_0, E4B NVFP4).
- Measured on RTX 3060 Laptop (6 GB) / Windows 11 only. No throughput claim.
- Serving a Q4_0 gemma4 row on the CUDA lane also needs the admission predicate on `feat/gemma3-cuda-resident`, which pins admission to Q8_0. Relaxing that pin onto this receipt is tracked on that branch. **This PR is the correctness fix alone and applies regardless of which rows are admitted.**

## Gates

`cargo fmt --all --check` clean · `cargo clippy --all-targets --all-features -D warnings` clean · `scripts/check-public-scrub.sh` clean · lib tests pass.

Two lib tests (`slot_occupancy_tracks_cooperative_and_exclusive_work`, `cooperative_stream_job_seeds_from_the_prompt_prefix_cache`) fail on **any GPU dev box, including clean `origin/main`** — `total_slots()` hard-returns 1 when the resident CUDA lane is active. Both pass with `CAMELID_CUDA_RESIDENT_DECODE=0`. Pre-existing and unrelated to this change; not fixed here to keep the diff focused.
