### PR TITLE
perf(tokenizer): index the special-token set instead of scanning the vocabulary

### DIFF
--- a/docs/performance/tokenizer-specials-index-2026-07-31.md
+++ b/docs/performance/tokenizer-specials-index-2026-07-31.md
@@ -1,0 +1,270 @@
+# Tokenizer special-token scan — O(chars x vocab) removed
+
+Executed 2026-07-31 on a 16 GB Apple M4 Mac mini (10 cores), base `2c13e52e`.
+
+## 0. Verdict
+
+`Tokenizer::encode` scanned the **entire vocabulary at every character** of the
+input whenever the special-token partition was active. On the gemma-3-1b-it-Q8_0
+row (262,144 entries) that cost **0.53 ms per output token** — about 500x the
+plain path — and it sat on the critical path of every `/v1/chat/completions`
+request, outside the inference engine.
+
+Replacing the scan with a first-byte-bucketed index built once at tokenizer
+construction removes the vocabulary term entirely. The special-aware path is now
+**indistinguishable from the plain path** (delta 0.0 us/token, within noise) on
+every family measured, and token ids are **byte-identical** — 3,547,564 ids over
+13 tokenizer rows.
+
+The measurement that opened this was taken on gemma-3, which is the only family
+in tree whose `parse_special = false` path was already fast. **Every other family
+paid the same scan in BOTH modes**, so this was never a chat-only problem — plain
+`/v1/completions` on llama3, qwen3, mistral, tinyllama and phi-4-mini paid it
+too. See section 3.
+
+## 1. The defect
+
+`longest_control_token_at` (src/tokenizer/mod.rs) answered "is there a special
+token starting at this byte offset?" by filtering `self.tokens`:
+
+```rust
+self.tokens
+    .iter()
+    .filter(|token| matches!(token.kind, TokenKind::UserDefined)
+        || (include_control && matches!(token.kind, TokenKind::Control)))
+    .filter(|token| !token.text.is_empty())
+    .filter(|token| text[byte_start..].starts_with(&token.text))
+    .max_by_key(|token| token.text.len())
+```
+
+`next_control_token_start` then called it **once per character**:
+
+```rust
+text[byte_start..].char_indices()
+    .map(|(offset, _)| byte_start + offset)
+    .find(|idx| self.longest_control_token_at(text, *idx, include_control).is_some())
+```
+
+so finding the next special in a 10,765-character prompt on a 262k-entry vocab
+performed ~2.8 x 10^9 iterations. That is the whole of the reported
+"0.525 ms/token, strictly linear, no fixed component" shape: the cost is per
+character, and only *looks* per-token because tokens/character is roughly
+constant for natural text.
+
+Two entry points reach it:
+
+| caller | `include_control` | families affected |
+|---|---|---|
+| `encode_piece` (SPM) | `true`, only when `parse_special` | gemma3, gemma4, mistral, tinyllama, phi-3 |
+| `encode_bpe_text` (GPT-2/BPE) | `parse_special` — **runs in both modes** | llama3, qwen3, qwen2.5, phi-4-mini |
+| `add_dummy_prefix_after_control_tokens` (SPM, `parse_special = false`) | `true` | any SPM row with `add_space_prefix = true` |
+
+The third row is why gemma-3 looked different: gemma-3 carries
+`add_space_prefix = false`, so its plain path returns before the scan. Mistral
+and TinyLlama carry `add_space_prefix = true` and paid it with
+`parse_special = false`.
+
+A third full-vocabulary scan, `chat_control_marker_rstrips`, ran once per
+special token matched.
+
+## 2. The fix
+
+`SpecialsIndex`, built once from `tokens`:
+
+- **first-byte bitset**, one per `include_control` mode — an O(1) reject that
+  is the whole per-character fast path. A byte whose bit is clear cannot start
+  any eligible pattern.
+- **first-byte buckets**, each ordered longest-first, so the first kind-eligible
+  hit IS the longest match. Buckets are tiny: the largest in tree is gemma-3's
+  `<` bucket at 6,321 patterns, and it is only consulted at an actual `<`.
+- **rstrip marker set**, replacing the `chat_control_marker_rstrips` scan.
+
+`next_control_token_start` now scans raw bytes rather than `char_indices`. That
+is equivalent, not an approximation: a pattern's text is a `&str`, so its first
+byte is never a UTF-8 continuation byte, so the filter cannot fire at a
+non-boundary offset — and `longest_at` re-checks `is_char_boundary` before
+slicing regardless.
+
+The index is a `OnceLock` field. `from_gguf` seeds it eagerly so real rows pay
+the build at load time; struct-literal construction (test fixtures, and the two
+call sites in src/api/mod.rs that replace `tokens` after construction) leaves it
+empty and it is built on first use, so those stay correct. A `debug_assert` on
+the recorded vocabulary length catches a stale index in test builds.
+
+Nothing about the *answer* changed: same kind filter, same `starts_with`, same
+longest-match rule.
+
+## 3. Before / after — in-process `encode`
+
+`examples/tokenizer_probe.rs bench`, best of 3, same content string per row, no
+HTTP. "before" is the same example built against unmodified `2c13e52e`.
+
+#### 2,730-char prompt
+
+| family | tokens | before plain ms | before special ms | after plain ms | after special ms | special speedup |
+|---|---|---|---|---|---|---|
+| gemma3-1b | 589 | 0.40 | 318.01 | 0.387 | 0.355 | **896x** |
+| mistral-7b | 673 | 38.27 | 38.25 | 0.368 | 0.320 | **120x** |
+| tinyllama | 673 | 35.62 | 35.48 | 0.270 | 0.260 | **136x** |
+| llama3-8b | 589 | 172.66 | 175.82 | 0.674 | 0.660 | **266x** |
+| qwen3-0.6b | 589 | 171.05 | 170.34 | 0.676 | 0.673 | **253x** |
+| phi4-mini | 589 | 228.12 | 215.69 | 0.655 | 0.654 | **330x** |
+
+#### 21,450-char prompt
+
+| family | tokens | before plain ms | before special ms | after plain ms | after special ms | special speedup |
+|---|---|---|---|---|---|---|
+| gemma3-1b | 4621 | 3.63 | 2494.89 | 3.700 | 3.793 | **658x** |
+| mistral-7b | 5281 | 381.15 | 394.38 | 3.593 | 3.494 | **113x** |
+| tinyllama | 5281 | 321.16 | 273.91 | 2.292 | 2.219 | **123x** |
+| llama3-8b | 4621 | 1150.62 | 1174.78 | 5.144 | 5.040 | **233x** |
+| qwen3-0.6b | 4621 | 1338.27 | 1304.88 | 5.100 | 5.243 | **249x** |
+| phi4-mini | 4621 | 1810.66 | 1818.52 | 5.110 | 5.117 | **355x** |
+
+Read the "before plain" column: on every family except gemma-3 it is as large as
+"before special". The scan was never gated on `parse_special` for those rows.
+
+Per-token delta between the two modes, gemma-3-1b — the quantity originally
+reported at 0.525 ms/token:
+
+| chars | tokens | before delta us/token | after delta us/token |
+|---|---|---|---|
+| 130 | 29 | 530.6 | -0.1 |
+| 650 | 141 | 534.2 | -0.1 |
+| 2730 | 589 | 539.2 | -0.1 |
+| 5460 | 1177 | 539.4 | -0.1 |
+| 10725 | 2311 | 540.5 | 0.0 |
+| 21450 | 4621 | 539.1 | 0.0 |
+
+The mode delta is gone. What remains is the shared cost of the encoder itself.
+
+gemma-4 is unchanged by this work and remains ~13x slower per character than
+gemma-3 in **both** modes (4.7 ms vs 0.36 ms at 2,730 chars): that is the
+rank-based symbol-merge path in `encode_spm_segment`, a separate lever. It has
+only 23 special tokens, so it never had a scan problem.
+
+## 4. Before / after — `/tokenize` endpoint
+
+Same content string per row in both modes, best of 3, one server alive at a time,
+each killed by saved PID and confirmed dead before the next started. "before" is
+an untouched `2c13e52e` release build,
+sha256 `66552fc25537df22993a4abe5c40c6d03a163613febef8de355ffeae4428ee7f`. The
+~19–23 ms floor is the HTTP + JSON round trip of the endpoint itself, not
+tokenizer time.
+
+| chars | tokens | before plain ms | before special ms | after plain ms | after special ms | before delta us/tok | after delta us/tok |
+|---|---|---|---|---|---|---|---|
+| 38 | 10 | 18.80 | 25.06 | 20.19 | 18.95 | 625.6 | -124.0 |
+| 152 | 37 | 19.45 | 37.81 | 18.89 | 18.89 | 496.2 | -0.0 |
+| 304 | 73 | 18.86 | 55.88 | 19.52 | 19.32 | 507.0 | -2.7 |
+| 722 | 172 | 19.08 | 105.60 | 19.46 | 19.20 | 503.0 | -1.5 |
+| 1444 | 343 | 19.21 | 191.49 | 19.46 | 19.40 | 502.3 | -0.2 |
+| 2888 | 685 | 19.40 | 364.68 | 19.42 | 19.69 | 504.1 | 0.4 |
+| 5776 | 1369 | 20.18 | 708.76 | 19.97 | 20.07 | 503.0 | 0.1 |
+| 11362 | 2692 | 20.90 | 1370.91 | 21.35 | 20.93 | 501.5 | -0.2 |
+| 22724 | 5383 | 22.94 | 2727.67 | 23.30 | 23.41 | 502.5 | 0.0 |
+
+Before, `parse_special = true` cost **118.9x** `parse_special = false` at the top
+of the ladder. After, the ratio is **1.00x**: both modes are pinned to the same
+HTTP floor and the special path no longer has a slope. Reproduces the published
+shape (flat plain path, ~0.5 ms/token special path) before the change and
+removes it after.
+
+Endpoint token ids: 9 sizes x 2 modes, 21,528 ids, identical before and after.
+
+### Chat path, end to end
+
+The quantity the write-up called "1.35 s of pure pre-engine latency". Streaming
+`/v1/chat/completions`, `CAMELID_STREAM_TIMING_DIAGNOSTICS=1`, 11,362-char user
+message (2,700 prompt tokens), greedy, `max_tokens = 1`, 3 runs each, same
+session, one server at a time:
+
+| build | `timings_ms.tokenize` | wall clock |
+|---|---|---|
+| before | 1499 / 1622 / 1676 ms | 53.33 / 53.35 / 53.78 s |
+| after | 2 / 2 / 2 ms | 51.60 / 51.87 / 51.73 s |
+
+**~1.6 s removed from TTFT on every chat request on this row**, and it shows up
+one-for-one in wall clock. It is still hidden behind a ~51 s prefill today; after
+the gemma-3 Metal prefill work lands it would have been the largest single
+remaining term.
+
+## 5. Identity gate
+
+Tokenization identity is load-bearing for every parity receipt in this repo, so
+the gate is exact equality of token ids, not a tolerance.
+
+`examples/tokenizer_probe.rs dump` encodes 876 cases under all four
+`(add_special, parse_special)` combinations and writes the ids to JSON. The same
+876 cases were run against the unmodified `2c13e52e` build and the fixed build,
+on the same GGUF artifacts, and diffed.
+
+Cases: every string value found anywhere in the committed prompt packs
+(`qa/prompt-packs/*.json`, 529 cases — including all three packs the task names,
+`gemma3-chat-template-shapes-v1`, `gemma3-chat-gate-pack-v1`,
+`gemma3-windowed-context-pack-v1`), plus 347 synthetic adversarial strings:
+every marker shape in tree at string start/end/adjacent/wrapped, partial and
+overlapping markers, markers beside multi-byte and astral characters, and long
+repeated chat scaffolds.
+
+| family | vocab | model | specials | encode results | token ids | verdict |
+|---|---|---|---|---|---|---|
+| gemma3-1b | 262144 | llama_spm | 6414 | 3504 | 274520 | IDENTICAL |
+| gemma4-E2B | 262144 | llama_spm | 23 | 3504 | 276178 | IDENTICAL |
+| gemma4-E4B | 262144 | llama_spm | 23 | 3504 | 276178 | IDENTICAL |
+| llama3-8b | 128256 | gpt2_bpe | 256 | 3504 | 236174 | IDENTICAL |
+| llama32-1b | 128256 | gpt2_bpe | 256 | 3504 | 236174 | IDENTICAL |
+| mistral-7b | 32768 | llama_spm | 770 | 3504 | 302928 | IDENTICAL |
+| mixtral-8x7b | 32000 | llama_spm | 2 | 3504 | 303126 | IDENTICAL |
+| phi3-mini | 32064 | llama_spm | 13 | 3504 | 299354 | IDENTICAL |
+| phi4-mini | 200064 | gpt2_bpe | 14 | 3504 | 235106 | IDENTICAL |
+| qwen25-05b | 151936 | gpt2_bpe | 22 | 3504 | 269276 | IDENTICAL |
+| qwen3-06b | 151936 | gpt2_bpe | 26 | 3504 | 269016 | IDENTICAL |
+| qwen3-8b | 151936 | gpt2_bpe | 26 | 3504 | 269016 | IDENTICAL |
+| tinyllama | 32000 | llama_spm | 2 | 3504 | 300518 | IDENTICAL |
+
+**13 families, 45,552 encode results each side, 3,547,564 token ids, zero
+divergence.**
+
+In-tree, permanently: `specials_index_reference_scan` and friends in
+`src/tokenizer/mod.rs` keep the replaced vocabulary scan verbatim as
+`reference_longest_control_token_at` / `reference_next_control_token_start` /
+`reference_chat_control_marker_rstrips`, and assert the index agrees at **every
+byte offset** of an adversarial corpus, in both modes, on a fixture vocabulary
+built to hit every branch (prefix overlaps, the same shape as USER_DEFINED in one
+entry and CONTROL in another, multi-byte patterns, an empty-text entry).
+`specials_index_matches_reference_on_real_vocab_when_available` replays the same
+comparison against real 262k-entry rows when the artifacts are reachable.
+
+Suites run: `cargo test --lib` 1414 passed / 0 failed; `--test tokenizer` 27
+passed; `--test runnable_tokenizer`, `--test dg_tokenizer_parity`,
+`--test gemma4_template_shapes` all pass. `cargo fmt --all --check` clean,
+`cargo clippy --all-targets -- -D warnings` clean.
+
+## 6. Reproduce
+
+```bash
+cargo build --release --example tokenizer_probe
+
+# 1. build the case list from the committed prompt packs + adversarial strings
+python3 scripts/gen-tokenizer-identity-cases.py qa/prompt-packs cases.json
+
+# 2. dump ids per row, once per build under test
+target/release/examples/tokenizer_probe dump <row.gguf> cases.json before/<row>.json
+
+# 3. the gate — exits non-zero on any divergence
+python3 scripts/diff-tokenizer-identity-dumps.py before after
+
+# throughput, both parse_special modes over a content ladder
+target/release/examples/tokenizer_probe bench <row.gguf> 5
+# special-token population and first-byte distribution for a row
+target/release/examples/tokenizer_probe stats <row.gguf>
+```
+
+## 7. Out of scope, found on the way
+
+- **`Tokenizer::from_gguf` takes 72 s on Phi-4-mini-instruct-Q4_K_M** (200,064
+  entries). Unrelated to the special-token scan — it is in construction, not
+  encode, and is unchanged by this work. Every other row builds in under 1.4 s.
+- **gemma-4's `encode_spm_segment` rank-merge path** is ~13x slower per
+  character than gemma-3's, in both modes.

--- a/examples/tokenizer_probe.rs
+++ b/examples/tokenizer_probe.rs
@@ -1,0 +1,183 @@
+//! Tokenizer identity + throughput probe.
+//!
+//! `dump`  — encode every case in a case file under all four
+//!           (add_special, parse_special) combinations and write the token ids
+//!           to JSON. Diffing two dumps taken across a code change is the
+//!           byte-identical-ids gate: tokenization identity is load-bearing for
+//!           every parity receipt in this repo, so the diff must be empty.
+//!
+//! `bench` — time `encode` on a synthetic content ladder in both
+//!           `parse_special` modes, in-process (no HTTP round trip).
+//!
+//! Usage:
+//!   cargo run --release --example tokenizer_probe -- dump  <gguf> <cases.json> <out.json>
+//!   cargo run --release --example tokenizer_probe -- bench <gguf> [reps]
+
+use std::time::Instant;
+
+use camelid::{gguf::read_metadata, tokenizer::Tokenizer};
+
+const MODES: [(bool, bool); 4] = [(false, false), (false, true), (true, false), (true, true)];
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: tokenizer_probe <dump|bench> <gguf> [...]");
+        std::process::exit(2);
+    }
+    let mode = args[1].as_str();
+    let gguf_path = &args[2];
+
+    let load_start = Instant::now();
+    let gguf = read_metadata(gguf_path).expect("read gguf metadata");
+    let tokenizer = Tokenizer::from_gguf(&gguf).expect("build tokenizer");
+    let load_ms = load_start.elapsed().as_secs_f64() * 1e3;
+    eprintln!(
+        "loaded {} vocab={} model={} load_ms={:.1}",
+        gguf_path,
+        tokenizer.tokens.len(),
+        tokenizer.model.as_summary_model(),
+        load_ms
+    );
+
+    match mode {
+        "dump" => dump(&tokenizer, gguf_path, &args[3], &args[4]),
+        "stats" => stats(&tokenizer),
+        "bench" => {
+            let reps: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(5);
+            bench(&tokenizer, gguf_path, reps);
+        }
+        other => {
+            eprintln!("unknown mode {other}");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// How many vocabulary entries the special-token matcher has to consider, and
+/// how they distribute over first bytes — the shape that decides whether a
+/// first-byte bucket is enough or a deeper structure is needed.
+fn stats(tokenizer: &Tokenizer) {
+    use std::collections::BTreeMap;
+    let mut by_first: BTreeMap<u8, usize> = BTreeMap::new();
+    let mut user_defined = 0usize;
+    let mut control = 0usize;
+    let mut pattern_bytes = 0usize;
+    for token in &tokenizer.tokens {
+        let is_control = match token.kind {
+            camelid::tokenizer::TokenKind::UserDefined => false,
+            camelid::tokenizer::TokenKind::Control => true,
+            _ => continue,
+        };
+        let Some(&first) = token.text.as_bytes().first() else {
+            continue;
+        };
+        if is_control {
+            control += 1;
+        } else {
+            user_defined += 1;
+        }
+        pattern_bytes += token.text.len();
+        *by_first.entry(first).or_default() += 1;
+    }
+    let total = user_defined + control;
+    println!("specials total={total} user_defined={user_defined} control={control} pattern_bytes={pattern_bytes}");
+    let mut buckets: Vec<_> = by_first.into_iter().collect();
+    buckets.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+    println!("distinct first bytes: {}", buckets.len());
+    for (byte, n) in buckets.iter().take(8) {
+        println!("  0x{byte:02x} {:?} -> {n}", *byte as char);
+    }
+}
+
+fn dump(tokenizer: &Tokenizer, gguf_path: &str, cases_path: &str, out_path: &str) {
+    let raw = std::fs::read_to_string(cases_path).expect("read cases");
+    let parsed: serde_json::Value = serde_json::from_str(&raw).expect("parse cases");
+    let cases = parsed["cases"].as_array().expect("cases array");
+
+    let mut out = Vec::with_capacity(cases.len() * MODES.len());
+    let mut total_ids: u64 = 0;
+    for case in cases {
+        let name = case["name"].as_str().unwrap_or("");
+        let text = case["text"].as_str().unwrap_or("");
+        for (add_special, parse_special) in MODES {
+            let ids = tokenizer
+                .encode(text, add_special, parse_special)
+                .unwrap_or_else(|err| {
+                    panic!("encode failed for {name} ({add_special},{parse_special}): {err}")
+                });
+            total_ids += ids.len() as u64;
+            out.push(serde_json::json!({
+                "name": name,
+                "add_special": add_special,
+                "parse_special": parse_special,
+                "ids": ids,
+            }));
+        }
+    }
+
+    let doc = serde_json::json!({
+        "gguf": gguf_path,
+        "vocab": tokenizer.tokens.len(),
+        "tokenizer_model": tokenizer.model.as_summary_model(),
+        "add_space_prefix": tokenizer.config.add_space_prefix,
+        "cases": out.len(),
+        "total_ids": total_ids,
+        "results": out,
+    });
+    std::fs::write(out_path, serde_json::to_vec(&doc).expect("serialize")).expect("write dump");
+    eprintln!("wrote {out_path}: {} results, {total_ids} ids", out.len());
+}
+
+/// Content ladder mirroring the /tokenize sweep in the Phase 0 write-up.
+fn ladder() -> Vec<String> {
+    let unit = "The quick brown fox jumps over the lazy dog near the river bank. ";
+    [1usize, 2, 4, 10, 21, 42, 84, 165, 330]
+        .iter()
+        .map(|reps| unit.repeat(*reps))
+        .collect()
+}
+
+fn bench(tokenizer: &Tokenizer, gguf_path: &str, reps: usize) {
+    println!("# in-process encode, {gguf_path}, best of {reps}");
+    println!("chars\ttokens\tplain_ms\tspecial_ms\tdelta_us_per_token");
+    let mut rows = Vec::new();
+    for text in ladder() {
+        let mut best = [f64::MAX; 2];
+        let mut ntok = 0usize;
+        for (slot, parse_special) in [false, true].into_iter().enumerate() {
+            for _ in 0..reps {
+                let start = Instant::now();
+                let ids = tokenizer
+                    .encode(&text, false, parse_special)
+                    .expect("encode");
+                let ms = start.elapsed().as_secs_f64() * 1e3;
+                if ms < best[slot] {
+                    best[slot] = ms;
+                }
+                ntok = ids.len();
+            }
+        }
+        let delta_us_per_token = if ntok > 0 {
+            (best[1] - best[0]) * 1e3 / ntok as f64
+        } else {
+            0.0
+        };
+        println!(
+            "{}\t{}\t{:.3}\t{:.3}\t{:.1}",
+            text.len(),
+            ntok,
+            best[0],
+            best[1],
+            delta_us_per_token
+        );
+        rows.push(serde_json::json!({
+            "chars": text.len(),
+            "tokens": ntok,
+            "plain_ms": best[0],
+            "special_ms": best[1],
+            "delta_us_per_token": delta_us_per_token,
+        }));
+    }
+    eprintln!("{}", serde_json::to_string(&rows).expect("serialize rows"));
+}

--- a/scripts/diff-tokenizer-identity-dumps.py
+++ b/scripts/diff-tokenizer-identity-dumps.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Byte-identical token-id gate: baseline dump vs after dump, per family.
+
+Exit 0 only if every (case, add_special, parse_special) triple yields exactly
+the same id sequence in both dumps, for every family present in both dirs.
+"""
+import json
+import os
+import sys
+
+BASE = sys.argv[1]
+AFTER = sys.argv[2]
+
+families = sorted(f for f in os.listdir(BASE) if f.endswith(".json"))
+missing = []
+failures = 0
+grand_ids = 0
+grand_cases = 0
+
+print(f"{'family':<14} {'vocab':>8} {'model':<10} {'cases':>6} {'ids':>9}  verdict")
+print("-" * 70)
+
+for fname in families:
+    bp = os.path.join(BASE, fname)
+    ap = os.path.join(AFTER, fname)
+    if not os.path.exists(ap):
+        missing.append(fname)
+        continue
+    b = json.load(open(bp))
+    a = json.load(open(ap))
+
+    problems = []
+    for key in ("vocab", "tokenizer_model", "add_space_prefix", "cases", "total_ids"):
+        if b.get(key) != a.get(key):
+            problems.append(f"{key}: {b.get(key)!r} -> {a.get(key)!r}")
+
+    br, ar = b["results"], a["results"]
+    if len(br) != len(ar):
+        problems.append(f"result count {len(br)} -> {len(ar)}")
+    else:
+        for i, (rb, ra) in enumerate(zip(br, ar)):
+            if (rb["name"], rb["add_special"], rb["parse_special"]) != (
+                ra["name"], ra["add_special"], ra["parse_special"]
+            ):
+                problems.append(f"case order diverged at {i}")
+                break
+            if rb["ids"] != ra["ids"]:
+                problems.append(
+                    f"IDS DIVERGED case={rb['name']!r} "
+                    f"add_special={rb['add_special']} parse_special={rb['parse_special']}\n"
+                    f"    before ({len(rb['ids'])}): {rb['ids'][:24]}...\n"
+                    f"    after  ({len(ra['ids'])}): {ra['ids'][:24]}..."
+                )
+                if len(problems) > 3:
+                    break
+
+    verdict = "IDENTICAL" if not problems else "DIVERGED"
+    if problems:
+        failures += 1
+    grand_ids += b.get("total_ids", 0)
+    grand_cases += b.get("cases", 0)
+    print(
+        f"{fname[:-5]:<14} {b.get('vocab', 0):>8} {b.get('tokenizer_model', '?'):<10} "
+        f"{b.get('cases', 0):>6} {b.get('total_ids', 0):>9}  {verdict}"
+    )
+    for p in problems:
+        print(f"    {p}")
+
+print("-" * 70)
+print(f"{len(families) - len(missing)} families compared, "
+      f"{grand_cases} encode results each, {grand_ids} token ids total")
+if missing:
+    print(f"MISSING from after/: {', '.join(missing)}")
+if failures or missing:
+    print("GATE: FAIL")
+    sys.exit(1)
+print("GATE: PASS — token ids byte-identical in both parse_special modes")

--- a/scripts/gen-tokenizer-identity-cases.py
+++ b/scripts/gen-tokenizer-identity-cases.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Build the tokenizer parity case list.
+
+Over-inclusive by design: every string value found anywhere in the committed
+prompt packs becomes a case, plus a block of synthetic adversarial strings that
+stress the special-token matcher (boundaries, overlaps, partial markers,
+multi-byte neighbours). Both parse_special modes are exercised per case by the
+Rust probe, so the gate covers the special path AND the plain path.
+"""
+import json
+import os
+import sys
+
+PACK_DIR = sys.argv[1] if len(sys.argv) > 1 else "qa/prompt-packs"
+OUT = sys.argv[2] if len(sys.argv) > 2 else "cases.json"
+
+# The three packs the task names, first, so they lead the case list.
+NAMED = [
+    "gemma3-chat-template-shapes-v1.json",
+    "gemma3-chat-gate-pack-v1.json",
+    "gemma3-windowed-context-pack-v1.json",
+]
+
+cases = []
+seen = set()
+
+
+def add(name, text):
+    if not isinstance(text, str) or text == "":
+        return
+    key = text
+    if key in seen:
+        return
+    seen.add(key)
+    cases.append({"name": name, "text": text})
+
+
+def walk(node, path, name_prefix):
+    if isinstance(node, str):
+        add(f"{name_prefix}:{path}", node)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            walk(v, f"{path}[{i}]", name_prefix)
+    elif isinstance(node, dict):
+        for k, v in node.items():
+            walk(v, f"{path}.{k}" if path else k, name_prefix)
+
+
+pack_files = NAMED + sorted(
+    f for f in os.listdir(PACK_DIR) if f.endswith(".json") and f not in NAMED
+)
+for fname in pack_files:
+    p = os.path.join(PACK_DIR, fname)
+    if not os.path.exists(p):
+        print(f"WARN missing pack {p}", file=sys.stderr)
+        continue
+    with open(p) as fh:
+        try:
+            data = json.load(fh)
+        except Exception as exc:  # noqa: BLE001
+            print(f"WARN unparsable {p}: {exc}", file=sys.stderr)
+            continue
+    walk(data, "", fname[:-5])
+
+pack_case_count = len(cases)
+
+# ---- synthetic adversarial cases -------------------------------------------
+# Marker vocabulary spanning every family in tree. A marker that does not exist
+# in a given model's vocab is still a useful case: it must tokenize as plain
+# text identically before and after.
+MARKERS = [
+    "<start_of_turn>", "<end_of_turn>", "<bos>", "<eos>", "<pad>", "<unk>",
+    "<|im_start|>", "<|im_end|>", "<think>", "</think>", "<tool_call>",
+    "</tool_call>", "<|begin_of_text|>", "<|end_of_text|>",
+    "<|start_header_id|>", "<|end_header_id|>", "<|eot_id|>",
+    "[INST]", "[/INST]", "<s>", "</s>", "<|user|>", "<|assistant|>", "<|end|>",
+    "<|system|>", "<turn|>", "<|turn>", "<unused0>", "<mask>", "<2mass>",
+]
+
+for m in MARKERS:
+    add(f"syn:bare:{m}", m)
+    add(f"syn:lead:{m}", m + "hello world")
+    add(f"syn:trail:{m}", "hello world" + m)
+    add(f"syn:wrap:{m}", m + "hello world" + m)
+    add(f"syn:nl:{m}", m + "\nhello\n" + m + "\n")
+    add(f"syn:space:{m}", " " + m + " x " + m + " ")
+    add(f"syn:adjacent:{m}", m + m + m)
+    add(f"syn:partial-open:{m}", m[:-1] + "hello")
+    add(f"syn:partial-close:{m}", "hello" + m[1:])
+    add(f"syn:utf8:{m}", "éé" + m + "中文\U0001F600" + m + "ß")
+    add(f"syn:tab:{m}", m + "\t\t  x")
+
+# Overlap / longest-match stress: prefixes of one marker inside another.
+add("syn:overlap:think", "<th<think>ink</think></th>")
+add("syn:overlap:im", "<|im_<|im_start|>start|><|im_end|>")
+add("syn:overlap:turn", "<start_of_<start_of_turn>turn>")
+add("syn:lt-run", "<<<<<<<<<<>>>>>>>>>>")
+add("syn:angle-soup", "a<b<c<|d|>e<f>g</h>i<start_of_turn>j")
+add("syn:only-lt", "<")
+add("syn:only-gt", ">")
+add("syn:pipe", "|>|<|")
+add("syn:ws-only", "   \n\t  ")
+add("syn:ctrl-chars", "a\x01b\x1fc\x7fd")
+add("syn:emoji", "\U0001F600\U0001F1EC\U0001F1E7 hello")
+add("syn:combining", "áé nfc/nfd")
+add("syn:long-plain", "The quick brown fox jumps over the lazy dog. " * 40)
+add(
+    "syn:long-mixed",
+    ("<start_of_turn>user\nThe quick brown fox jumps over the lazy dog.<end_of_turn>\n"
+     "<start_of_turn>model\nA reply sentence here.<end_of_turn>\n") * 20,
+)
+add(
+    "syn:long-chatml",
+    ("<|im_start|>user\nExplain gradient descent briefly.<|im_end|>\n"
+     "<|im_start|>assistant\nIt walks downhill.<|im_end|>\n") * 20,
+)
+add(
+    "syn:long-llama3",
+    ("<|start_header_id|>user<|end_header_id|>\n\nWhat is 2+2?<|eot_id|>"
+     "<|start_header_id|>assistant<|end_header_id|>\n\n4<|eot_id|>") * 20,
+)
+add("syn:long-inst", ("<s>[INST] Say hi. [/INST] Hi.</s>") * 30)
+
+with open(OUT, "w") as fh:
+    json.dump({"cases": cases}, fh)
+
+print(f"{len(cases)} cases ({pack_case_count} from packs, "
+      f"{len(cases) - pack_case_count} synthetic) -> {OUT}")

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6402,6 +6402,7 @@ mod gemma4_template_tests {
                 remove_extra_whitespaces: false,
             },
             chat_template: Some(template.to_string()),
+            specials_index: OnceLock::new(),
         }
     }
 
@@ -20477,6 +20478,7 @@ mod tests {
                 remove_extra_whitespaces: false,
             },
             chat_template: Some("<|user|><|assistant|><|system|>".to_string()),
+            specials_index: OnceLock::new(),
         };
 
         assert_eq!(
@@ -20695,6 +20697,7 @@ mod tests {
             chat_template: Some(
                 "<|start_header_id|>{{ role }}<|end_header_id|>{{ content }}<|eot_id|>".to_string(),
             ),
+            specials_index: OnceLock::new(),
         };
 
         assert!(tokenizer.chat_prompt_parse_special());
@@ -21856,6 +21859,7 @@ mod tests {
             chat_template: Some(
                 "{{ bos_token }}[INST] {{ messages[0]['content'] }} [/INST]".to_string(),
             ),
+            specials_index: OnceLock::new(),
         }
     }
 
@@ -21985,6 +21989,7 @@ mod tests {
                 remove_extra_whitespaces: false,
             },
             chat_template: Some(template.to_string()),
+            specials_index: OnceLock::new(),
         }
     }
 
@@ -22169,6 +22174,7 @@ mod tests {
                 remove_extra_whitespaces: false,
             },
             chat_template: None,
+            specials_index: OnceLock::new(),
         }
     }
 

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -1,7 +1,8 @@
 use std::{
-    collections::{BTreeSet, BinaryHeap, HashMap},
+    collections::{BTreeSet, BinaryHeap, HashMap, HashSet},
     fs::File,
     io::Read,
+    sync::OnceLock,
 };
 
 use sha2::Digest;
@@ -291,6 +292,144 @@ pub struct TokenizerConfig {
     pub remove_extra_whitespaces: bool,
 }
 
+/// One special-token pattern the raw-text scanner can match: a `UserDefined`
+/// ("added") or `Control` token with non-empty text.
+#[derive(Debug, Clone)]
+struct SpecialPattern {
+    text: Box<str>,
+    /// `Control` tokens participate only under `include_control`
+    /// (= llama.cpp's `parse_special`); `UserDefined` always does.
+    is_control: bool,
+}
+
+/// First-byte-bucketed index over the special-token set, so matching a special
+/// at a position costs O(1) plus a scan of one tiny bucket instead of a scan of
+/// the whole vocabulary.
+///
+/// The naive form of [`Tokenizer::longest_control_token_at`] filtered
+/// `self.tokens` — 262,144 entries on a gemma-3 SPM row — on every call, and
+/// [`Tokenizer::next_control_token_start`] calls it once per character. That is
+/// O(chars x vocab): measured at 0.525 ms per output token on gemma-3-1b-it-Q8_0,
+/// about 500x the `parse_special = false` path, and on the critical path of
+/// every `/v1/chat/completions` request (the chat renderer sets
+/// `parse_special = true` for the `<start_of_turn>` markers).
+///
+/// This index changes only the SEARCH, never the answer: the same kind filter,
+/// the same `starts_with` test and the same longest-match rule decide every
+/// position, so the token ids are byte-identical to the scan it replaces. That
+/// identity is load-bearing — every parity receipt in this repo is keyed on
+/// exact token sequences.
+#[derive(Debug, Clone)]
+pub struct SpecialsIndex {
+    /// Vocabulary size this index was built from. `tokens` is a `pub` field, so
+    /// a caller can replace it after the index was forced; the accessor
+    /// `debug_assert`s on this to catch that in test builds.
+    vocab_len: usize,
+    /// Patterns bucketed by first byte, each bucket ordered longest-first so the
+    /// first kind-eligible hit IS the longest match (mirroring the `max_by_key`
+    /// the scan used). Boxed to keep the 256-entry array cheap when empty.
+    buckets: Box<[Vec<SpecialPattern>; 256]>,
+    /// Bitset of bytes that can begin an eligible pattern, indexed by
+    /// `include_control` — `[0]` is `UserDefined` only, `[1]` adds `Control`.
+    /// A byte with its bit clear cannot start a special, which is the whole of
+    /// the per-character fast path.
+    first_byte: [[u64; 4]; 2],
+    /// Texts of tokens that are `<|...|>` chat-control markers, for the rstrip
+    /// decision in `encode_piece`. Replaces another full-vocabulary scan, run
+    /// once per special token matched.
+    chat_control_marker_texts: HashSet<Box<str>>,
+}
+
+impl SpecialsIndex {
+    fn build(tokens: &[Token]) -> Self {
+        let mut buckets: Box<[Vec<SpecialPattern>; 256]> =
+            Box::new(std::array::from_fn(|_| Vec::new()));
+        let mut first_byte = [[0u64; 4]; 2];
+        let mut chat_control_marker_texts = HashSet::new();
+
+        for token in tokens {
+            if is_chat_control_marker(token) {
+                chat_control_marker_texts.insert(Box::from(token.text.as_str()));
+            }
+
+            let is_control = match token.kind {
+                TokenKind::UserDefined => false,
+                TokenKind::Control => true,
+                _ => continue,
+            };
+            let Some(&first) = token.text.as_bytes().first() else {
+                // Empty text never matches; the scan filtered these out too.
+                continue;
+            };
+            buckets[first as usize].push(SpecialPattern {
+                text: Box::from(token.text.as_str()),
+                is_control,
+            });
+            set_byte_bit(&mut first_byte[1], first);
+            if !is_control {
+                set_byte_bit(&mut first_byte[0], first);
+            }
+        }
+
+        for bucket in buckets.iter_mut() {
+            // Longest-first. Ties are only reachable between patterns with
+            // IDENTICAL text (two matches at one position of equal length are
+            // the same bytes), and callers use the matched text — never the
+            // vocab slot it came from — so tie order cannot change an id.
+            bucket.sort_by_key(|pattern| std::cmp::Reverse(pattern.text.len()));
+            bucket.shrink_to_fit();
+        }
+
+        Self {
+            vocab_len: tokens.len(),
+            buckets,
+            first_byte,
+            chat_control_marker_texts,
+        }
+    }
+
+    /// True when `byte` can begin some eligible pattern. Pure filter: a false
+    /// positive costs one bucket scan, a false negative is impossible because
+    /// every pattern sets its own first byte at build time.
+    #[inline]
+    fn may_start(&self, include_control: bool, byte: u8) -> bool {
+        let set = &self.first_byte[usize::from(include_control)];
+        set[usize::from(byte >> 6)] & (1u64 << (byte & 63)) != 0
+    }
+
+    /// Longest eligible pattern starting exactly at `byte_start`, or `None`.
+    fn longest_at<'a>(
+        &'a self,
+        text: &str,
+        byte_start: usize,
+        include_control: bool,
+    ) -> Option<(&'a str, usize)> {
+        if !text.is_char_boundary(byte_start) {
+            return None;
+        }
+        let rest = &text[byte_start..];
+        let &first = rest.as_bytes().first()?;
+        if !self.may_start(include_control, first) {
+            return None;
+        }
+        self.buckets[first as usize]
+            .iter()
+            .find(|pattern| {
+                (include_control || !pattern.is_control) && rest.starts_with(&*pattern.text)
+            })
+            .map(|pattern| (&*pattern.text, pattern.text.len()))
+    }
+
+    fn is_chat_control_marker_text(&self, token_text: &str) -> bool {
+        self.chat_control_marker_texts.contains(token_text)
+    }
+}
+
+#[inline]
+fn set_byte_bit(set: &mut [u64; 4], byte: u8) {
+    set[usize::from(byte >> 6)] |= 1u64 << (byte & 63);
+}
+
 #[derive(Debug, Clone)]
 pub struct Tokenizer {
     pub model: TokenizerModel,
@@ -305,6 +444,12 @@ pub struct Tokenizer {
     pub special: SpecialTokens,
     pub config: TokenizerConfig,
     pub chat_template: Option<String>,
+    /// Special-token search index, derived entirely from `tokens`. Left empty by
+    /// struct-literal construction and built on first use, so a tokenizer
+    /// assembled by hand (tests) or mutated after construction is still correct;
+    /// [`Tokenizer::from_gguf`] seeds it eagerly so real rows pay the build at
+    /// load time rather than on the first request.
+    pub specials_index: OnceLock<SpecialsIndex>,
 }
 
 /// The Llama-3 tiktoken tokenizer's special-token signature. Llama 3 / 3.1 / 3.2 all
@@ -563,6 +708,11 @@ impl Tokenizer {
         validate_token_id("pad", pad, tokens.len())?;
         validate_token_id("mask", mask, tokens.len())?;
 
+        // Seed the special-token index at load time so the first request does not
+        // pay for building it. Real rows carry up to 262k vocabulary entries.
+        let specials_index = OnceLock::new();
+        let _ = specials_index.set(SpecialsIndex::build(&tokens));
+
         Ok(Self {
             model,
             bpe_pre_tokenizer,
@@ -613,6 +763,7 @@ impl Tokenizer {
             chat_template: file
                 .metadata_string("tokenizer.chat_template")
                 .map(str::to_owned),
+            specials_index,
         })
     }
 
@@ -1109,9 +1260,8 @@ impl Tokenizer {
     /// `<|…|>` shape, and BPE families (Qwen3, Llama 3) never reach this SPM path,
     /// so their committed tokenizations are untouched.
     fn chat_control_marker_rstrips(&self, token_text: &str) -> bool {
-        self.tokens
-            .iter()
-            .any(|token| token.text == token_text && is_chat_control_marker(token))
+        self.specials_index()
+            .is_chat_control_marker_text(token_text)
     }
 
     fn should_insert_dummy_after_control(
@@ -1144,36 +1294,41 @@ impl Tokenizer {
         !rest.starts_with(SPM_SPACE)
     }
 
+    /// The special-token search index, built on first use from `tokens`.
+    fn specials_index(&self) -> &SpecialsIndex {
+        let index = self
+            .specials_index
+            .get_or_init(|| SpecialsIndex::build(&self.tokens));
+        debug_assert_eq!(
+            index.vocab_len,
+            self.tokens.len(),
+            "specials index is stale: `tokens` was replaced after the index was built"
+        );
+        index
+    }
+
     /// Longest special token whose text starts at `byte_start`. USER_DEFINED
     /// ("added") tokens always participate; CONTROL tokens only when
     /// `include_control` (llama.cpp's `parse_special` partition rule).
+    ///
+    /// USER_DEFINED ("added") tokens always match, mirroring llama.cpp's
+    /// special-token partition. Qwen3/qwen35 mark <think>/</think>
+    /// (and many <|...|> markers) as USER_DEFINED (type 4) rather than CONTROL
+    /// (type 3); without matching USER_DEFINED, a rendered ChatML template's
+    /// literal "</think>" tokenizes as text instead of the single special
+    /// token, and chat generation diverges from the reference. CONTROL tokens
+    /// participate only under `include_control` (= `parse_special`).
+    ///
+    /// Served by [`SpecialsIndex`]; `specials_index_reference_scan` in this
+    /// module's tests pins it against the vocabulary scan this replaced.
     fn longest_control_token_at<'a>(
         &'a self,
         text: &str,
         byte_start: usize,
         include_control: bool,
     ) -> Option<(&'a str, usize)> {
-        if !text.is_char_boundary(byte_start) {
-            return None;
-        }
-
-        // USER_DEFINED ("added") tokens always match, mirroring llama.cpp's
-        // special-token partition. Qwen3/qwen35 mark <think>/</think>
-        // (and many <|...|> markers) as USER_DEFINED (type 4) rather than CONTROL
-        // (type 3); without matching USER_DEFINED, a rendered ChatML template's
-        // literal "</think>" tokenizes as text instead of the single special
-        // token, and chat generation diverges from the reference. CONTROL tokens
-        // participate only under `include_control` (= `parse_special`).
-        self.tokens
-            .iter()
-            .filter(|token| {
-                matches!(token.kind, TokenKind::UserDefined)
-                    || (include_control && matches!(token.kind, TokenKind::Control))
-            })
-            .filter(|token| !token.text.is_empty())
-            .filter(|token| text[byte_start..].starts_with(&token.text))
-            .max_by_key(|token| token.text.len())
-            .map(|token| (token.text.as_str(), token.text.len()))
+        self.specials_index()
+            .longest_at(text, byte_start, include_control)
     }
 
     fn encode_piece(&self, piece: &str, parse_special: bool) -> Result<Vec<TokenId>> {
@@ -1251,19 +1406,26 @@ impl Tokenizer {
         Ok(out)
     }
 
+    /// First byte offset at or after `byte_start` where a special token begins.
+    ///
+    /// Scans raw bytes rather than `char_indices`, which is equivalent: a
+    /// pattern's text is a `&str`, so its first byte is never a UTF-8
+    /// continuation byte, so the first-byte filter can never fire at a
+    /// non-boundary offset — and `longest_at` re-checks `is_char_boundary`
+    /// before slicing regardless. The filter is what makes this O(bytes)
+    /// instead of O(bytes x vocab).
     fn next_control_token_start(
         &self,
         text: &str,
         byte_start: usize,
         include_control: bool,
     ) -> Option<usize> {
-        text[byte_start..]
-            .char_indices()
-            .map(|(offset, _)| byte_start + offset)
-            .find(|idx| {
-                self.longest_control_token_at(text, *idx, include_control)
-                    .is_some()
-            })
+        let index = self.specials_index();
+        let bytes = text.as_bytes();
+        (byte_start..bytes.len()).find(|&idx| {
+            index.may_start(include_control, bytes[idx])
+                && index.longest_at(text, idx, include_control).is_some()
+        })
     }
 
     fn encode_spm_segment(&self, segment: &str, out: &mut Vec<TokenId>) -> Result<()> {
@@ -2111,6 +2273,339 @@ mod tests {
         SpecialTokens, Token, TokenKind, Tokenizer, TokenizerConfig, TokenizerModel, SPM_SPACE,
     };
     use std::collections::{BTreeSet, HashMap};
+    use std::sync::OnceLock;
+
+    /// The vocabulary scan `SpecialsIndex` replaced, kept verbatim as the
+    /// reference the index is pinned against. Any divergence between this and
+    /// `Tokenizer::longest_control_token_at` is a tokenization change, and
+    /// tokenization identity is load-bearing for every parity receipt here.
+    fn reference_longest_control_token_at<'a>(
+        tokenizer: &'a Tokenizer,
+        text: &str,
+        byte_start: usize,
+        include_control: bool,
+    ) -> Option<(&'a str, usize)> {
+        if !text.is_char_boundary(byte_start) {
+            return None;
+        }
+        tokenizer
+            .tokens
+            .iter()
+            .filter(|token| {
+                matches!(token.kind, TokenKind::UserDefined)
+                    || (include_control && matches!(token.kind, TokenKind::Control))
+            })
+            .filter(|token| !token.text.is_empty())
+            .filter(|token| text[byte_start..].starts_with(&token.text))
+            .max_by_key(|token| token.text.len())
+            .map(|token| (token.text.as_str(), token.text.len()))
+    }
+
+    /// The `char_indices` scan `next_control_token_start` replaced.
+    fn reference_next_control_token_start(
+        tokenizer: &Tokenizer,
+        text: &str,
+        byte_start: usize,
+        include_control: bool,
+    ) -> Option<usize> {
+        text[byte_start..]
+            .char_indices()
+            .map(|(offset, _)| byte_start + offset)
+            .find(|idx| {
+                reference_longest_control_token_at(tokenizer, text, *idx, include_control).is_some()
+            })
+    }
+
+    /// The full-vocabulary scan `chat_control_marker_rstrips` replaced.
+    fn reference_chat_control_marker_rstrips(tokenizer: &Tokenizer, token_text: &str) -> bool {
+        tokenizer
+            .tokens
+            .iter()
+            .any(|token| token.text == token_text && is_chat_control_marker(token))
+    }
+
+    /// Assert the index and the reference scan agree at EVERY byte offset of
+    /// `text`, in both `include_control` modes.
+    ///
+    /// Costs O(len x vocab) because the reference side is the vocabulary scan;
+    /// keep `text` short when the vocabulary is a real 262k-entry row.
+    fn assert_index_matches_reference(tokenizer: &Tokenizer, text: &str) {
+        for include_control in [false, true] {
+            for byte_start in 0..=text.len() {
+                let fast = tokenizer.longest_control_token_at(text, byte_start, include_control);
+                let slow = reference_longest_control_token_at(
+                    tokenizer,
+                    text,
+                    byte_start,
+                    include_control,
+                );
+                assert_eq!(
+                    fast, slow,
+                    "longest_control_token_at diverged at byte {byte_start} \
+                     (include_control={include_control}) of {text:?}"
+                );
+
+                if text.is_char_boundary(byte_start) {
+                    assert_eq!(
+                        tokenizer.next_control_token_start(text, byte_start, include_control),
+                        reference_next_control_token_start(
+                            tokenizer,
+                            text,
+                            byte_start,
+                            include_control
+                        ),
+                        "next_control_token_start diverged from byte {byte_start} \
+                         (include_control={include_control}) of {text:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Assert the rstrip set agrees with the vocabulary scan it replaced, over
+    /// `sample`. Separate from the positional check because the reference is
+    /// O(vocab) per query — running it over a whole real vocabulary would be
+    /// O(vocab^2).
+    fn assert_marker_rstrips_match<'a>(
+        tokenizer: &Tokenizer,
+        sample: impl IntoIterator<Item = &'a str>,
+    ) {
+        for text in sample {
+            assert_eq!(
+                tokenizer.chat_control_marker_rstrips(text),
+                reference_chat_control_marker_rstrips(tokenizer, text),
+                "chat_control_marker_rstrips diverged for {text:?}"
+            );
+        }
+    }
+
+    /// A vocabulary built to hit every branch the matcher has: overlapping
+    /// patterns where one is a strict prefix of another, the same shape carried
+    /// as USER_DEFINED in one case and CONTROL in another (so `include_control`
+    /// changes the answer), multi-byte patterns, patterns sharing a first byte
+    /// with an ordinary token, and an empty-text token the scan skipped.
+    fn overlap_vocab() -> Vec<Token> {
+        let entries: [(&str, TokenKind); 20] = [
+            ("<s>", TokenKind::Control),
+            ("</s>", TokenKind::Control),
+            ("<start_of_turn>", TokenKind::Control),
+            ("<start_of>", TokenKind::UserDefined),
+            ("<start", TokenKind::Control),
+            ("<end_of_turn>", TokenKind::Control),
+            ("<think>", TokenKind::UserDefined),
+            ("</think>", TokenKind::UserDefined),
+            ("<|im_start|>", TokenKind::Control),
+            ("<|im_end|>", TokenKind::UserDefined),
+            ("<|user|>", TokenKind::UserDefined),
+            ("[INST]", TokenKind::UserDefined),
+            ("[/INST]", TokenKind::Control),
+            ("→", TokenKind::UserDefined),
+            ("→→", TokenKind::Control),
+            ("中文", TokenKind::UserDefined),
+            ("", TokenKind::Control),
+            ("<normal>", TokenKind::Normal),
+            ("<byte>", TokenKind::Byte),
+            ("<unused>", TokenKind::Unused),
+        ];
+        entries
+            .iter()
+            .enumerate()
+            .map(|(id, (text, kind))| Token {
+                id: id as u32,
+                text: (*text).to_string(),
+                score: 0.0,
+                kind: *kind,
+            })
+            .collect()
+    }
+
+    fn overlap_tokenizer() -> Tokenizer {
+        tokenizer_with(
+            TokenizerModel::LlamaSpm,
+            overlap_vocab(),
+            SpecialTokens::default(),
+        )
+    }
+
+    #[test]
+    fn specials_index_reference_scan() {
+        let tokenizer = overlap_tokenizer();
+        let corpus = [
+            "",
+            "<",
+            "<s>",
+            "<start_of_turn>",
+            "<start_of>x",
+            "<start>",
+            "<startle",
+            "<start_of_turnip>",
+            "<s></s><s>",
+            "<|im_start|>user\nhi<|im_end|>",
+            "<think>reason</think>done",
+            "[INST] hello [/INST] hi",
+            "→→→ arrows → here",
+            "中文<start_of_turn>中文",
+            "plain text with no specials at all",
+            "<normal><byte><unused>",
+            "a<b<c<|d|>e<start_of_turn>f",
+            "éé<think>中文\u{1F600}</think>ß",
+            "<<<<>>>><s><s",
+            "trailing<",
+            "\u{1F600}<s>\u{1F600}",
+        ];
+        for text in corpus {
+            assert_index_matches_reference(&tokenizer, text);
+        }
+        assert_marker_rstrips_match(
+            &tokenizer,
+            tokenizer
+                .tokens
+                .iter()
+                .map(|token| token.text.as_str())
+                .chain(["", "<absent|>", "<|absent|>"]),
+        );
+    }
+
+    #[test]
+    fn specials_index_longest_match_respects_include_control() {
+        let tokenizer = overlap_tokenizer();
+        // "<start_of_turn>" (CONTROL, 15 bytes) beats "<start_of>" (USER_DEFINED)
+        // and "<start" (CONTROL) only when control tokens participate; without
+        // them the longest ELIGIBLE match is the USER_DEFINED "<start_of>".
+        assert_eq!(
+            tokenizer.longest_control_token_at("<start_of_turn>x", 0, true),
+            Some(("<start_of_turn>", 15))
+        );
+        assert_eq!(
+            tokenizer.longest_control_token_at("<start_of_turn>x", 0, false),
+            None,
+            "\"<start_of_turn>\" does not start with the USER_DEFINED \"<start_of>\""
+        );
+        assert_eq!(
+            tokenizer.longest_control_token_at("<start_of>x", 0, false),
+            Some(("<start_of>", 10))
+        );
+        // An empty-text vocabulary entry never matches.
+        assert_eq!(tokenizer.longest_control_token_at("zzz", 0, true), None);
+        // Non-special kinds never match, whatever the mode.
+        assert_eq!(
+            tokenizer.longest_control_token_at("<normal>", 0, true),
+            None
+        );
+    }
+
+    #[test]
+    fn specials_index_ignores_non_char_boundaries() {
+        let tokenizer = overlap_tokenizer();
+        // 'é' is two bytes and is NOT in the vocabulary, so bytes 1 and 3 are
+        // continuation bytes with no special starting anywhere before byte 4.
+        let text = "éé<s>";
+        assert_eq!(text.len(), 7);
+        assert_eq!(tokenizer.longest_control_token_at(text, 1, true), None);
+        assert_eq!(tokenizer.longest_control_token_at(text, 3, true), None);
+        assert_eq!(
+            tokenizer.longest_control_token_at(text, 4, true),
+            Some(("<s>", 3))
+        );
+        assert_eq!(tokenizer.next_control_token_start(text, 0, true), Some(4));
+
+        // A multi-byte pattern IS matched at its own boundary: "中文" is a
+        // USER_DEFINED entry in this fixture, so it wins at byte 0.
+        let cjk = "中文<s>";
+        assert_eq!(
+            tokenizer.longest_control_token_at(cjk, 0, false),
+            Some(("中文", 6))
+        );
+        assert_eq!(tokenizer.longest_control_token_at(cjk, 1, true), None);
+        assert_eq!(tokenizer.next_control_token_start(cjk, 1, true), Some(6));
+    }
+
+    #[test]
+    fn specials_index_is_built_lazily_from_current_tokens() {
+        // Struct-literal construction leaves the cell empty; replacing `tokens`
+        // before first use must still be seen. `orphan_test_prepared` and
+        // `tiny_vocab_tokenizer` in src/api/mod.rs do exactly this.
+        let mut tokenizer = tokenizer_with(
+            TokenizerModel::LlamaSpm,
+            Vec::new(),
+            SpecialTokens::default(),
+        );
+        assert!(tokenizer.specials_index.get().is_none());
+        tokenizer.tokens = overlap_vocab();
+        assert_eq!(
+            tokenizer.longest_control_token_at("<s>", 0, true),
+            Some(("<s>", 3))
+        );
+        assert!(tokenizer.specials_index.get().is_some());
+    }
+
+    #[test]
+    fn specials_index_survives_clone() {
+        let tokenizer = overlap_tokenizer();
+        assert_eq!(
+            tokenizer.longest_control_token_at("<think>", 0, false),
+            Some(("<think>", 7))
+        );
+        let cloned = tokenizer.clone();
+        assert_eq!(
+            cloned.longest_control_token_at("<think>", 0, false),
+            Some(("<think>", 7))
+        );
+        assert_index_matches_reference(&cloned, "<think>x</think><s>");
+    }
+
+    /// Real-vocabulary pin. Runs when a row GGUF is reachable (`GEMMA3_GGUF`,
+    /// or any of the other family env vars the tests/ suite already uses) and
+    /// replays the index against the reference scan over the committed prompt
+    /// packs' own marker strings. Skipped, loudly, when no artifact is present.
+    #[test]
+    fn specials_index_matches_reference_on_real_vocab_when_available() {
+        let candidates = [
+            ("GEMMA3_GGUF", "models/gemma-3-1b-it-Q8_0.gguf"),
+            ("LLAMA3_GGUF", "models/Meta-Llama-3-8B-Instruct-Q8_0.gguf"),
+            ("QWEN3_GGUF", "models/Qwen3-0.6B-Q8_0.gguf"),
+            ("MISTRAL_GGUF", "models/Mistral-7B-Instruct-v0.3.Q8_0.gguf"),
+            ("GEMMA4_GGUF", "models/gemma-4-E2B-it-Q8_0.gguf"),
+        ];
+        let mut ran = 0usize;
+        for (var, default) in candidates {
+            let path = std::env::var(var)
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| std::path::PathBuf::from(default));
+            if !path.exists() {
+                continue;
+            }
+            let gguf = crate::gguf::read_metadata(&path).expect("read gguf metadata");
+            let tokenizer = Tokenizer::from_gguf(&gguf).expect("build tokenizer");
+            // Deliberately short: the reference side is the O(vocab) scan, so
+            // each byte offset costs a pass over up to 262k entries.
+            for text in [
+                "<start_of_turn>user\nhi<end_of_turn>\n",
+                "<|im_start|>a<|im_end|><s>[INST]x[/INST]</s><think>y</think>",
+                "plain, no markers: éé 中文 \u{1F600}",
+            ] {
+                assert_index_matches_reference(&tokenizer, text);
+            }
+            // Bounded rstrip sample: `<|...|>`-shaped tokens from the row (the
+            // shape the rstrip rule keys on), capped, plus near-misses.
+            let markers: Vec<&str> = tokenizer
+                .tokens
+                .iter()
+                .filter(|token| token.text.starts_with("<|"))
+                .map(|token| token.text.as_str())
+                .take(64)
+                .chain(["", "<|absent|>", "<start_of_turn>", "not a marker"])
+                .collect();
+            assert_marker_rstrips_match(&tokenizer, markers);
+            ran += 1;
+        }
+        if ran == 0 {
+            eprintln!(
+                "skipping real-vocab specials-index pin; set one of \
+                 GEMMA3_GGUF/LLAMA3_GGUF/QWEN3_GGUF/MISTRAL_GGUF/GEMMA4_GGUF"
+            );
+        }
+    }
 
     fn tok(text: &str, kind: TokenKind) -> Token {
         Token {
@@ -2146,6 +2641,7 @@ mod tests {
                 remove_extra_whitespaces: false,
             },
             chat_template: None,
+            specials_index: OnceLock::new(),
         }
     }
 


### PR DESCRIPTION
## The defect

`Tokenizer::longest_control_token_at` answered "does a special token start at this byte offset?" by filtering the **entire vocabulary** — 262,144 entries on a gemma-3 row — and `next_control_token_start` called it **once per character**. Encoding with the special-token partition active was O(chars × vocab): ~2.8×10⁹ iterations for a 10.7k-character prompt.

That is 0.53 ms per output token on `gemma-3-1b-it-Q8_0`, about 500× the plain path, sitting on the critical path of every `/v1/chat/completions` request and entirely outside the inference engine (`prepare_generation` tokenizes a text prompt with `parse_special: false` but a chat prompt with `true`, which the renderer needs for the `<start_of_turn>` markers).

## The fix

`SpecialsIndex`, built once from `tokens` and seeded in `from_gguf`:

- **per-mode first-byte bitset** — the O(1) reject that carries the per-character loop. A byte whose bit is clear cannot start any eligible pattern.
- **first-byte buckets**, ordered longest-first, so the first kind-eligible hit *is* the longest match. Buckets are small and only consulted on a first-byte hit; the largest in tree is gemma-3's `<` at 6,321 patterns.
- **rstrip marker set**, replacing a third full-vocabulary scan in `chat_control_marker_rstrips`.

`next_control_token_start` now walks raw bytes instead of `char_indices`. That is equivalent, not an approximation: a pattern's text is a `&str`, so its first byte is never a UTF-8 continuation byte, so the filter cannot fire at a non-boundary offset — and the lookup re-checks `is_char_boundary` before slicing regardless.

**The search changes; the answer does not.** Same kind filter, same `starts_with`, same longest-match rule.

## Measured

`/tokenize`, gemma-3-1b-it-Q8_0, best of 3, one server alive at a time:

| chars | tokens | before `parse_special=true` | after | before ratio vs `false` | after ratio |
|---|---|---|---|---|---|
| 2888 | 685 | 364.68 ms | 19.69 ms | 18.8× | 1.01× |
| 11362 | 2692 | 1370.91 ms | 20.93 ms | 65.6× | 0.98× |
| 22724 | 5383 | 2727.67 ms | 23.41 ms | 118.9× | 1.00× |

Both modes are now pinned to the same ~19–23 ms HTTP round-trip floor.

Real chat path — streaming `/v1/chat/completions`, 2,700 prompt tokens, `CAMELID_STREAM_TIMING_DIAGNOSTICS=1`, 3 runs each:

| build | `timings_ms.tokenize` | wall clock |
|---|---|---|
| before | 1499 / 1622 / 1676 ms | 53.33 / 53.35 / 53.78 s |
| after | 2 / 2 / 2 ms | 51.60 / 51.87 / 51.73 s |

~1.6 s off TTFT on every chat request on this row, showing up one-for-one in wall clock.

In-process `encode`, 21,450-char prompt: gemma3 **658×**, phi4-mini **355×**, qwen3 **249×**, llama3 **233×**, tinyllama **123×**, mistral **113×**.

## This was never chat-only

gemma-3 is the *only* family in tree whose `parse_special = false` path was already fast — it carries `add_space_prefix = false`, so it returns before `add_dummy_prefix_after_control_tokens`. Every other family paid the identical scan in **both** modes: llama3/qwen3/qwen2.5/phi-4-mini through `encode_bpe_text`, mistral/tinyllama/phi-3 through `add_space_prefix = true`. Plain `/v1/completions` on those rows was paying 1.1–1.8 s per 21k-char prompt.

## Identity gate

Tokenization identity is load-bearing for every parity receipt in this repo, so the gate is **exact equality, not a tolerance**.

876 cases — every string value in the committed prompt packs (`qa/prompt-packs/*.json`, 529) plus 347 adversarial synthetics (every marker shape in tree at start/end/adjacent/wrapped, partial and overlapping markers, markers beside multi-byte and astral characters, long repeated chat scaffolds) — encoded under all four `(add_special, parse_special)` combinations against **13 tokenizer rows** spanning `llama_spm` and `gpt2_bpe`, before and after, on the same GGUF artifacts.

**45,552 encode results per side, 3,547,564 token ids, zero divergence.**

In-tree and permanent: the replaced vocabulary scan is kept verbatim as `reference_longest_control_token_at` / `reference_next_control_token_start` / `reference_chat_control_marker_rstrips`, and the index is asserted equal to it at **every byte offset** of an adversarial corpus in both modes, on a fixture vocabulary built to hit prefix overlaps, the same shape carried as USER_DEFINED in one entry and CONTROL in another, multi-byte patterns and an empty-text entry. A real-vocabulary variant replays the same comparison against 262k-entry rows when artifacts are reachable.

Gate tooling lands with it: `examples/tokenizer_probe.rs` (`dump` / `bench` / `stats`), `scripts/gen-tokenizer-identity-cases.py`, `scripts/diff-tokenizer-identity-dumps.py`.

## Local validation

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (1414 passed / 0 failed), `--test tokenizer` (27), `--test runnable_tokenizer`, `--test dg_tokenizer_parity`, `--test gemma4_template_shapes`, `scripts/check-public-scrub.sh`, all 27 `scripts/test-*.mjs`, `check-ledger-drift.mjs` — all green.

## Out of scope, found on the way

Both noted in §7 of the receipt, neither touched here:

- `Tokenizer::from_gguf` takes **72 s** on Phi-4-mini-instruct-Q4_K_M (200,064 entries). Construction, not encode; every other row is under 1.4 s.
- gemma-4's `encode_spm_segment` rank-merge path is ~13× slower per character than gemma-3's, in both modes. It has only 23 specials, so it never had a scan problem.

Receipt: `docs/performance/tokenizer-specials-index-2026-07-31.md`
