### PR TITLE
chore(release): bump version to 0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump for the v0.4.7 release: `0.4.6` -> `0.4.7` across the four files that
carry it (`Cargo.toml`, `Cargo.lock` x2 entries, `camelid-desktop/Cargo.toml`,
`camelid-desktop/tauri.conf.json`). Same shape as the v0.4.6 bump — 4 files, 5 lines,
no other content.

`Cargo.lock` is edited in place rather than regenerated so the release build's
`cargo build --release --locked` stays satisfied with no incidental dependency churn.

v0.4.6 -> v0.4.7 is a large release: 120 commits and ~30 merged PRs. Highlights include
the gemma3/gemma4 GPU-resident CUDA lanes, the gemma3 Metal resident lane, the Responses
API and streaming tool contract, the one-command Windows and macOS desktop installers,
six newly decodable quant formats, new pre-tokenizer dialects, and the tokenizer
special-token index from #572. The release notes are generated by the tag run
(`generate_release_notes: true`), so the full list is produced automatically.

Tag after this and #573 are both merged.