### PR TITLE
fix(desktop): drop superseded sidecar files on NSIS in-place upgrades

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -582,6 +582,43 @@ the existing SSE `decode_tps` real generation event, rendered unavailable when a
 release job is additive and independently skippable; existing server artifacts are untouched.
 See `camelid-desktop/README.md`.
 
+### D11 (cont.) — NSIS in-place upgrades must remove sidecar files the version no longer ships (2026-07-31)
+
+An overwrite-only installer has a blind spot: it rewrites the files it ships and leaves
+everything else alone, so a file installed by an **older** version that the current one dropped
+survives every future upgrade. Found in the field on a v0.4.6 box — `sidecar\nvrtc64_120_0.alt.dll`,
+85.7 MB, from an install predating the `.alt` filter in `scripts/package-windows-cuda.ps1`. The
+published v0.4.6 artifact correctly contains no `.alt` entry and
+`scripts/check-release-artifact.mjs` has a forbidden rule for it, so **the packaging and artifact
+gates were both already correct** — the defect was only ever in the upgrade path, which is why
+neither gate could see it and why re-running the one-command installer never cleared it.
+
+**Fix: `NSIS_HOOK_PREINSTALL`** (`camelid-desktop/windows/installer-hooks.nsh`, wired via
+`bundle.windows.nsis.installerHooks`), deleting `nvrtc64_*.dll` and `nvrtc-builtins64_*.dll` from
+`$INSTDIR\sidecar` before the file copy re-lays the current set.
+
+Deleting the whole NVRTC family rather than blacklisting `.alt` is the deliberate choice: these
+filenames encode the CUDA version (`nvrtc-builtins64_129.dll` is 12.9; `nvrtc64_120_0.dll` the
+12.x ABI), so a `CUDA_VERSION` bump renames them and strands the previous ones identically. A
+rename is exactly what an overwrite cannot fix, so the blacklist would have to be extended by
+hand every bump; re-laying the family is self-healing. Cost is that the good DLLs are deleted and
+immediately re-extracted — verified below.
+
+**Rejected: clearing `sidecar\` wholesale before extracting.** It looks safe because `sidecar\`
+is shipped content, but it is not: `sidecar_models_dir` (`camelid-desktop/src/engine.rs`) makes
+the desktop's model store `models\` *beside the engine binary* — i.e. `sidecar\models\`. The box
+that reported the orphan had **4.42 GB of user GGUF weights there**. A wholesale clear is
+therefore a data-loss bug, not a cleanup.
+
+**Verified against a real in-place upgrade,** not by reading the template: installer built from
+this config, planted `sidecar\nvrtc64_120_0.alt.dll`, upgraded over the existing install. The
+`.alt` orphan is gone, the shipped NVRTC pair is present and re-extracted at full size, the
+`models\` subtree survives byte-for-byte, and the app relaunches and health-gates.
+
+Failure is non-fatal by construction: `Delete` on a missing or locked file sets the error flag
+without aborting, so the worst case is the orphan surviving to the next upgrade — never a broken
+install.
+
 ## D12 — CPU KV cache: f16-rounded values were stored in f32 buffers; f16 storage + head-major layout lanes (2026-07-01)
 
 Measured finding (Item-3 recon): the CPU KV write path has rounded every stored

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Windows 10 or 11.
 irm https://raw.githubusercontent.com/timtoole02/Camelid/main/scripts/get-desktop-windows.ps1 | iex
 ```
 
-To update later, run the same command again; models and settings are preserved. To pin a
-version, set `CAMELID_DESKTOP_TAG` first (for example `$env:CAMELID_DESKTOP_TAG = 'v0.4.5'`).
+To update later, run the same command again; models and settings are preserved. The upgrade also
+drops superseded CUDA runtime files that an older version installed and the current one no longer
+ships, so an in-place update cannot accumulate dead weight. To pin a version, set
+`CAMELID_DESKTOP_TAG` first (for example `$env:CAMELID_DESKTOP_TAG = 'v0.4.5'`).
 
 Prefer to install by hand? Download either artifact from the [latest release][latest-release]:
 

--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -46,6 +46,21 @@ camelid-desktop ──spawns──▶ camelid serve --addr 127.0.0.1:<ephemeral>
 On window close the sidecar is terminated cleanly. On Windows, a **job object** with
 `KILL_ON_JOB_CLOSE` also prevents a desktop crash from orphaning a `camelid` process.
 
+## Windows in-place upgrades
+
+The NSIS installer overwrites the files it ships but, like any overwrite-only installer, cannot
+by itself remove a file an **older** version installed that the current one no longer ships.
+`windows/installer-hooks.nsh` supplies an `NSIS_HOOK_PREINSTALL` that deletes the NVRTC
+redistributables (`nvrtc64_*.dll`, `nvrtc-builtins64_*.dll`) from `sidecar\` before the file
+copy, so every upgrade re-lays exactly the set that version ships. That covers both the
+`nvrtc64_120_0.alt.dll` orphan left by pre-filter releases and any future CUDA version bump,
+which renames these DLLs and would otherwise strand the previous ones.
+
+The hook is deliberately narrow, and widening it to clear `sidecar\` wholesale would **destroy
+user data**: the desktop's model store is the `models\` folder beside the engine binary
+(`sidecar_models_dir` in `src/engine.rs`), i.e. `sidecar\models\`, holding multi-GB downloaded
+GGUF weights. Only files the packaging scripts stage may be removed there.
+
 ## Startup failures
 
 The splash is fail-closed: it stays visible until the sidecar returns `200` from

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -30,6 +30,11 @@
     "category": "DeveloperTool",
     "shortDescription": "Native chat app for the Camelid local inference engine.",
     "longDescription": "Camelid Desktop embeds the same Camelid engine shipped as the server binary and runs it as a loopback sidecar. It inherits the identical model-support contract; it makes no broader claims.",
+    "windows": {
+      "nsis": {
+        "installerHooks": "windows/installer-hooks.nsh"
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/camelid-desktop/tests/installer_hooks.rs
+++ b/camelid-desktop/tests/installer_hooks.rs
@@ -1,0 +1,114 @@
+//! The Windows NSIS installer-hook contract (see `../DECISIONS.md`, D11 cont.).
+//!
+//! An overwrite-only installer rewrites the files it ships and leaves everything else alone, so
+//! a file installed by an OLDER version that the current one dropped survives every upgrade —
+//! that is how an 85.7 MB `nvrtc64_120_0.alt.dll` stranded on v0.4.6 boxes. `windows/installer-hooks.nsh`
+//! closes that path by re-laying the NVRTC set on every install.
+//!
+//! These tests exist because nothing else can see this. The hook is NSIS source, invisible to
+//! the compiler; `scripts/check-release-artifact.mjs` inspects the built artifact, not the
+//! upgrade path; and the failure is silent — a stranded file changes no behavior, it just
+//! accumulates. The wholesale-clear guard below is the load-bearing one: `sidecar\models\` is
+//! the desktop's model store, so widening the hook is a data-loss bug, not a cleanup.
+
+use std::path::PathBuf;
+
+fn desktop_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The hook path as the NSIS bundler resolves it: `bundle.windows.nsis.installerHooks`,
+/// relative to the Tauri project directory.
+fn hooks_path() -> PathBuf {
+    let raw = std::fs::read_to_string(desktop_dir().join("tauri.conf.json"))
+        .expect("read tauri.conf.json");
+    let conf: serde_json::Value =
+        serde_json::from_str(&raw).expect("tauri.conf.json is valid JSON");
+    let rel = conf["bundle"]["windows"]["nsis"]["installerHooks"]
+        .as_str()
+        .expect(
+            "bundle.windows.nsis.installerHooks must stay configured: without it an in-place \
+             upgrade silently strands every sidecar file the current version no longer ships",
+        );
+    desktop_dir().join(rel)
+}
+
+fn hooks_source() -> String {
+    let path = hooks_path();
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read installer hooks at {}: {e}", path.display()))
+}
+
+/// NSIS code on a line, with any trailing `;` or `#` comment removed.
+fn code_of(line: &str) -> &str {
+    let end = line.find([';', '#']).unwrap_or(line.len());
+    line[..end].trim()
+}
+
+#[test]
+fn installer_hooks_file_is_wired_and_present() {
+    let path = hooks_path();
+    assert!(
+        path.is_file(),
+        "installerHooks points at {}, which does not exist — `tauri build` fails at release time",
+        path.display()
+    );
+}
+
+#[test]
+fn preinstall_hook_relays_the_whole_nvrtc_set() {
+    let src = hooks_source();
+    assert!(
+        src.contains("!macro NSIS_HOOK_PREINSTALL"),
+        "the cleanup must run in NSIS_HOOK_PREINSTALL, before the file copy re-lays the set"
+    );
+    // Both families, because both encode the CUDA version in the filename: a CUDA_VERSION bump
+    // renames them, and a rename is exactly what an overwrite-only installer cannot fix.
+    for pattern in [
+        r#"Delete "$INSTDIR\sidecar\nvrtc64_*.dll""#,
+        r#"Delete "$INSTDIR\sidecar\nvrtc-builtins64_*.dll""#,
+    ] {
+        assert!(
+            src.contains(pattern),
+            "installer hook must contain `{pattern}` so superseded NVRTC files cannot strand"
+        );
+    }
+}
+
+#[test]
+fn hook_never_clears_the_sidecar_directory_wholesale() {
+    // `sidecar_models_dir` (src/engine.rs) puts the desktop's model store at
+    // $INSTDIR\sidecar\models\ — multi-GB user-downloaded GGUF weights. Clearing sidecar\ to
+    // catch orphans would delete them. Every removal here must name an explicit NVRTC file.
+    for line in hooks_source().lines() {
+        let code = code_of(line);
+        if code.is_empty() {
+            continue;
+        }
+        let lower = code.to_ascii_lowercase();
+        assert!(
+            !lower.starts_with("rmdir"),
+            "RMDir in an installer hook can take sidecar\\models\\ (user model weights) with it: {code}"
+        );
+        if lower.starts_with("delete") {
+            assert!(
+                code.contains(r"\sidecar\nvrtc"),
+                "every Delete must name an explicit sidecar NVRTC file, never a broader glob: {code}"
+            );
+        }
+    }
+}
+
+#[test]
+fn engine_still_resolves_models_beside_the_sidecar_binary() {
+    // The guard above is only meaningful while this stays true. If the model store ever moves
+    // out of $INSTDIR, this test fails and the wholesale-clear reasoning must be revisited
+    // rather than silently inherited.
+    let engine = std::fs::read_to_string(desktop_dir().join("src").join("engine.rs"))
+        .expect("read src/engine.rs");
+    assert!(
+        engine.contains(r#"parent.join("models")"#),
+        "sidecar_models_dir no longer resolves models/ beside the engine binary — re-check \
+         whether $INSTDIR\\sidecar\\ still holds user data before widening the installer hook"
+    );
+}

--- a/camelid-desktop/windows/installer-hooks.nsh
+++ b/camelid-desktop/windows/installer-hooks.nsh
@@ -1,0 +1,40 @@
+; Camelid Desktop - NSIS installer hooks.
+;
+; PROBLEM. An in-place NSIS upgrade overwrites the files the new version ships, but it
+; never removes a file an OLDER version installed that the current one no longer ships.
+; Such a file strands in $INSTDIR forever: re-running the documented one-command
+; installer cannot clear it, because the installer only ever writes.
+;
+; The case that motivated this: releases built before the `.alt.dll` filter landed in
+; scripts/package-windows-cuda.ps1 staged `nvrtc64_120_0.alt.dll` into sidecar\ - an
+; 85.7 MB alternate JIT backend cudarc never loads. Current releases correctly omit it
+; (the filter, plus the `.alt` forbidden rule in scripts/check-release-artifact.mjs), so
+; nothing in the install path was ever going to overwrite or remove it. Every user who
+; installed before that filter is still carrying the dead 85.7 MB.
+;
+; FIX. Delete the NVRTC redistributables from sidecar\ before the file copy, so the
+; install re-lays exactly the set THIS version ships. Deleting the whole family - rather
+; than blacklisting `.alt` - is what makes this self-healing: NVRTC filenames encode the
+; CUDA version (nvrtc-builtins64_129.dll is CUDA 12.9; nvrtc64_120_0.dll is the 12.x ABI),
+; so a CUDA_VERSION bump renames them and would strand the previous ones exactly the same
+; way. A rename is precisely the case an overwrite-only installer cannot fix.
+;
+; SCOPE - deliberately narrow; do NOT widen this to clear sidecar\ wholesale. sidecar\ is
+; not purely shipped content: the desktop's model store is the `models\` folder BESIDE the
+; engine binary (`sidecar_models_dir` in ../src/engine.rs), i.e. sidecar\models\, which
+; holds multi-GB user-downloaded GGUF weights. Only the nvrtc* DLLs that
+; scripts/package-windows-cuda.ps1 stages are shipped content safe to remove here.
+; tests/installer_hooks.rs enforces that scope in CI.
+;
+; FAILURE MODE is benign by construction. `Delete` on a missing file is a no-op, and on a
+; locked file (the sidecar is running and has the DLL mapped) it sets the error flag but
+; does not abort - the install then proceeds exactly as it does today and the orphan
+; simply survives to the next upgrade. Nothing here can fail the install.
+
+!macro NSIS_HOOK_PREINSTALL
+  DetailPrint "Removing superseded NVRTC runtime files from sidecar..."
+  ; Both patterns are re-extracted from the bundle by the file copy that follows.
+  ; Wildcards match files only, so sidecar\models\ is never a candidate.
+  Delete "$INSTDIR\sidecar\nvrtc64_*.dll"
+  Delete "$INSTDIR\sidecar\nvrtc-builtins64_*.dll"
+!macroend


### PR DESCRIPTION
## The defect

An overwrite-only installer rewrites the files it ships and leaves everything else alone, so a file installed by an **older** version that the current one dropped survives every upgrade. Found in the field on a v0.4.6 box: `sidecar\nvrtc64_120_0.alt.dll`, **85.7 MB**, left by an install predating the `.alt` filter in `scripts/package-windows-cuda.ps1`.

Packaging and the artifact gate were both **already correct** — the published v0.4.6 zip ships no `.alt` entry and `check-release-artifact.mjs` forbids it. That is exactly why neither could catch this: the defect lived only in the upgrade path, which is also why re-running the documented one-command installer never cleared it.

## The fix

`camelid-desktop/windows/installer-hooks.nsh` adds an `NSIS_HOOK_PREINSTALL` (wired via `bundle.windows.nsis.installerHooks`) that deletes the NVRTC redistributables from `$INSTDIR\sidecar` before the file copy re-lays the current set.

Re-laying the whole family rather than blacklisting `.alt` is what makes it self-healing: NVRTC filenames encode the CUDA version (`nvrtc-builtins64_129.dll` is 12.9), so a `CUDA_VERSION` bump renames them and strands the previous ones identically — and a rename is precisely what an overwrite cannot fix.

## Clearing `sidecar\` wholesale was rejected — it is a data-loss bug

`sidecar\` looks like pure shipped content, but `sidecar_models_dir` (`camelid-desktop/src/engine.rs`) puts the desktop's model store at **`$INSTDIR\sidecar\models\`**. The box that reported the orphan had **4.42 GB of user GGUF weights** there. `tests/installer_hooks.rs` pins that scope so a future "just clear sidecar" refactor fails CI — mutation-checked by swapping in `RMDir /r "$INSTDIR\sidecar"`, which the guard rejects.

## Verification — a real in-place upgrade, not a template read

Installer built from this branch, run with the same silent per-user flags `get-desktop-windows.ps1` uses. Run twice: once against the real 85.7 MB orphan, once against a freshly planted dummy.

| Check | Result |
|---|---|
| `sidecar\nvrtc64_120_0.alt.dll` | **removed** |
| planted `sidecar\nvrtc-builtins64_001.dll` (simulated CUDA bump) | **removed** |
| `nvrtc64_120_0.dll` re-extracted | 85.7 MB, SHA-256 identical to pre-test |
| `nvrtc-builtins64_129.dll` re-extracted | 6.9 MB, SHA-256 identical to pre-test |
| `models\` + `sidecar\models\` | **28.07 GB across 10 files untouched** (size + mtime) |
| 5 unrelated user `.bak` files in `sidecar\` | untouched — proves the hook is narrow |
| App relaunch | `/v1/health ok=true`, `cuda_resident_active=true` |

That last row is the load-bearing one: the CUDA resident path compiles kernels through NVRTC at runtime, so it only goes green if NVRTC genuinely reloaded — not merely if a file of the right size is sitting on disk.

Only the two orphans were removed; nothing else in the tree changed.

## Gates

`cargo fmt --check`, `cargo clippy -p camelid-desktop --all-targets -D warnings`, `cargo test -p camelid-desktop --all-targets` (12 + 4 pass), `check-public-scrub.sh`, `check-public-evidence-claims`, `check-ledger-schema`, `check-ledger-drift` — all green locally.

## Scope note

This fixes upgrades **going forward**: users still on a pre-filter install reclaim the 85.7 MB the first time they update to a build containing this hook. Nothing here can fail an install — `Delete` on a missing or locked file sets the error flag without aborting, so the worst case is the orphan surviving to the next upgrade.
