### PR TITLE
fix(tokenizer): the TinyLlama edge pack's add_special contradicted its own token arrays

### DIFF
--- a/fixtures/tokenizer/tinyllama-chat-template-edge-cases.json
+++ b/fixtures/tokenizer/tinyllama-chat-template-edge-cases.json
@@ -8,6 +8,9 @@
     "source": "committed llama.cpp parity reports",
     "evidence_bundle": "qa/evidence-bundles/tinyllama-broader-template-context-perf-rss-20260505T044519Z-head-864e07b51f36/manifest.json",
     "tool": "llama.cpp llama-tokenize via chat-parity harness",
+    "invocation": "llama-tokenize -m tinyllama-1.1b-chat-v1.0.Q8_0.gguf --ids --log-disable -p <expected_prompt>",
+    "harness": "scripts/chat-parity-llama3.mjs --render-mode tinyllama-marker (tokenizeExpectedPrompt)",
+    "add_special_provenance": "No --no-bos and no --no-parse-special were passed, so llama-tokenize used add_bos = llama_vocab_get_add_bos(vocab) and parse_special = true. This GGUF carries tokenizer.ggml.model=llama (SPM) and no tokenizer.ggml.add_bos_token override, so add_bos resolved to true and every tokens array below leads with 1 (<s>). The per-case add_special field therefore records true; it read false until 2026-07-31, which contradicted the arrays it was filed alongside.",
     "generated_utc": "2026-05-05T04:49:26.998Z"
   },
   "notes": "Tokenizer/chat-template edge-case reference pack for the already-supported TinyLlama Q8_0 row. This hardens the current supported gate only and does not promote any neighboring row, quantization, tokenizer family, or generation support.",
@@ -19,7 +22,7 @@
       "expected_prompt": "<|user|>\nReply with the word camelid and preserve this prompt's trailing spaces.</s>\n<|assistant|>\n",
       "reference_prompt_token_count": 34,
       "prompt_tokens_match": true,
-      "add_special": false,
+      "add_special": true,
       "parse_special": true,
       "tokens": [
         1,
@@ -65,7 +68,7 @@
       "expected_prompt": "<|user|>\nEcho a compact summary of these symbols: []{}<>|~^`\\ and emoji alpaca 🦙.</s>\n<|assistant|>\n",
       "reference_prompt_token_count": 47,
       "prompt_tokens_match": true,
-      "add_special": false,
+      "add_special": true,
       "parse_special": true,
       "tokens": [
         1,
@@ -124,7 +127,7 @@
       "expected_prompt": "<|system|>\nKeep the response concise and deterministic.</s>\n<|user|>\nLine one asks for a tiny checklist.\n\n  Line two is indented and mentions TinyLlama Q8_0.\nLine three asks for exactly three terse bullets about evidence hygiene.</s>\n<|assistant|>\n",
       "reference_prompt_token_count": 82,
       "prompt_tokens_match": true,
-      "add_special": false,
+      "add_special": true,
       "parse_special": true,
       "tokens": [
         1,
@@ -218,7 +221,7 @@
       "expected_prompt": "<|user|>\nComplete the word: cam</s>\n<|assistant|>\nelid</s>\n",
       "reference_prompt_token_count": 27,
       "prompt_tokens_match": true,
-      "add_special": false,
+      "add_special": true,
       "parse_special": true,
       "tokens": [
         1,
@@ -257,7 +260,7 @@
       "expected_prompt": "<|system|>\nPreserve line breaks in reasoning inputs.</s>\n<|user|>\nLine one.\n\n  Indented line two.  </s>\n<|assistant|>\n",
       "reference_prompt_token_count": 46,
       "prompt_tokens_match": true,
-      "add_special": false,
+      "add_special": true,
       "parse_special": true,
       "tokens": [
         1,

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -204,8 +204,17 @@ fn tinyllama_edge_reference_pack_records_required_prompt_shapes_and_tokens() {
     ] {
         let case = &cases[name];
         assert_eq!(case["prompt_tokens_match"], true, "case {name}");
-        assert_eq!(case["add_special"], false, "case {name}");
+        // The reference ran llama-tokenize without --no-bos against an SPM vocab that carries no
+        // tokenizer.ggml.add_bos_token override, so add_bos resolved to true. Every tokens array
+        // therefore leads with BOS, and add_special must say so — pinning it here keeps the two
+        // halves of each case from drifting apart again.
+        assert_eq!(case["add_special"], true, "case {name}");
         assert_eq!(case["parse_special"], true, "case {name}");
+        assert_eq!(
+            case["tokens"].as_array().unwrap()[0],
+            1,
+            "case {name}: add_special is true, so the reference arrays must lead with BOS (1)"
+        );
         assert_eq!(
             case["tokens"].as_array().unwrap().len(),
             case["reference_prompt_token_count"].as_u64().unwrap() as usize,
@@ -235,6 +244,10 @@ fn encodes_tinyllama_edge_reference_pack_like_llama_cpp_when_available() {
     .unwrap();
     let cases = fixture["cases"].as_object().unwrap();
 
+    // Collect every mismatch instead of panicking on the first case: a systematic fixture defect
+    // (a wrong flag applied to all five cases) looks exactly like one broken case when assert_eq!
+    // aborts the loop, which sends the reader hunting for a bug in a single prompt shape.
+    let mut failures = Vec::new();
     for (name, case) in cases {
         let text = case["expected_prompt"].as_str().unwrap();
         let add_special = case["add_special"].as_bool().unwrap();
@@ -246,12 +259,32 @@ fn encodes_tinyllama_edge_reference_pack_like_llama_cpp_when_available() {
             .map(|value| value.as_u64().unwrap() as u32)
             .collect();
 
-        assert_eq!(
-            tokenizer.encode(text, add_special, parse_special).unwrap(),
-            expected,
-            "TinyLlama tokenizer/chat-template edge parity failed for {name}; expected IDs are from fixtures/tokenizer/tinyllama-chat-template-edge-cases.json backed by the committed llama.cpp parity reports"
-        );
+        let actual = tokenizer.encode(text, add_special, parse_special).unwrap();
+        if actual != expected {
+            let diff_at = actual
+                .iter()
+                .zip(expected.iter())
+                .position(|(a, b)| a != b)
+                .unwrap_or_else(|| actual.len().min(expected.len()));
+            failures.push(format!(
+                "  {name} (add_special={add_special}, parse_special={parse_special}): first \
+                 divergence at index {diff_at}\n    actual   ({} ids) {actual:?}\n    expected ({} ids) {expected:?}",
+                actual.len(),
+                expected.len()
+            ));
+        }
     }
+
+    assert!(
+        failures.is_empty(),
+        "TinyLlama tokenizer/chat-template edge parity failed for {}/{} case(s); expected IDs are \
+         from fixtures/tokenizer/tinyllama-chat-template-edge-cases.json backed by the committed \
+         llama.cpp parity reports. Do not edit the fixture to match the encoder — re-derive it \
+         with the invocation recorded under reference.invocation.\n{}",
+        failures.len(),
+        cases.len(),
+        failures.join("\n")
+    );
 }
 
 #[test]
@@ -612,15 +645,29 @@ fn rejects_unknown_token_type_value() {
     assert!(err.contains("unknown tokenizer token type 42"));
 }
 
+/// Skipping is correct for contributors and for CI legs that carry no GGUF artifacts, but a skip
+/// that reports "ok" is indistinguishable from coverage — that is how a parity fixture rots
+/// unnoticed. A job that is CONFIGURED to prove tokenizer parity opts in with
+/// CAMELID_REQUIRE_MODEL_TESTS=1 and then cannot silently degrade to a no-op.
+fn require_model_tests(what: &str, var: &str, path: &Path) {
+    assert!(
+        std::env::var("CAMELID_REQUIRE_MODEL_TESTS").as_deref() != Ok("1"),
+        "CAMELID_REQUIRE_MODEL_TESTS=1 but no {what} artifact is present at {} — this job is \
+         configured to prove tokenizer parity and cannot. Set {var} to the GGUF path.",
+        path.display()
+    );
+    eprintln!(
+        "SKIP {what} tokenizer parity; set {var} or place the artifact at {}",
+        path.display()
+    );
+}
+
 fn load_real_llama3_tokenizer() -> Option<(Tokenizer, Vec<String>)> {
     let path = std::env::var("LLAMA3_GGUF")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| std::path::PathBuf::from("models/Meta-Llama-3-8B-Instruct-Q8_0.gguf"));
     if !path.exists() {
-        eprintln!(
-            "skipping real Llama 3 tokenizer parity; set LLAMA3_GGUF or place the artifact at {}",
-            path.display()
-        );
+        require_model_tests("Llama 3", "LLAMA3_GGUF", &path);
         return None;
     }
 
@@ -637,10 +684,7 @@ fn load_real_tinyllama_tokenizer() -> Option<Tokenizer> {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| std::path::PathBuf::from("models/tinyllama-1.1b-chat-v1.0.Q8_0.gguf"));
     if !path.exists() {
-        eprintln!(
-            "skipping real TinyLlama tokenizer parity; set TINYLLAMA_GGUF or place the artifact at {}",
-            path.display()
-        );
+        require_model_tests("TinyLlama", "TINYLLAMA_GGUF", &path);
         return None;
     }
 
@@ -653,10 +697,7 @@ fn load_real_mistral_tokenizer() -> Option<Tokenizer> {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| std::path::PathBuf::from("models/Mistral-7B-Instruct-v0.3-Q8_0.gguf"));
     if !path.exists() {
-        eprintln!(
-            "skipping real Mistral tokenizer parity; set MISTRAL_GGUF or place the artifact at {}",
-            path.display()
-        );
+        require_model_tests("Mistral", "MISTRAL_GGUF", &path);
         return None;
     }
 
@@ -671,10 +712,7 @@ fn load_real_mixtral_tokenizer() -> Option<Tokenizer> {
             std::path::PathBuf::from("models/mixtral-8x7b-instruct-v0.1-q8_0.gguf")
         });
     if !path.exists() {
-        eprintln!(
-            "skipping real Mixtral tokenizer parity; set MIXTRAL_GGUF or place the artifact at {}",
-            path.display()
-        );
+        require_model_tests("Mixtral", "MIXTRAL_GGUF", &path);
         return None;
     }
 


### PR DESCRIPTION
## Summary

- Every case in `fixtures/tokenizer/tinyllama-chat-template-edge-cases.json` recorded `"add_special": false` while every `tokens` array led with `1` (`<s>`). The two halves of each case disagreed.
- `encodes_tinyllama_edge_reference_pack_like_llama_cpp_when_available` therefore failed on any machine holding the pinned GGUF — by exactly that leading token, in all five cases. It was invisible in CI because runners carry no GGUF artifacts, so the loader returned `None` and the test returned silently.
- The reference applied BOS, so the arrays are right and the flag was wrong. `add_special` is now `true`.
- Hardens the gate so this cannot rot again: the flag is pinned against the arrays, all mismatching cases are reported instead of just the first, and a missing artifact can be made fatal.

## Why this change exists

A parity fixture that disagrees with itself is worse than no fixture: it fails for anyone who actually has the artifact, and passes everywhere else. The tempting fix — flip `add_special` because it makes our encoder pass — is exactly how a parity gate rots into a tautology, so the flag was decided from the reference side instead.

The bundle was produced by `scripts/chat-parity-llama3.mjs --render-mode tinyllama-marker`, whose `tokenizeExpectedPrompt()` runs `llama-tokenize -m MODEL --ids --log-disable -p PROMPT`. Three independent lines of evidence agree that this applied BOS:

1. **Recorded intent.** The comment at that call site says the evidence "renders the checked-in prompt shape itself, then asks the tokenizer to add BOS."
2. **Source derivation.** No `--no-bos` was passed, so `tokenize.cpp` computes `add_bos = llama_vocab_get_add_bos(vocab)`. The artifact is SPM (`tokenizer.ggml.model=llama`) and carries no `tokenizer.ggml.add_bos_token` key, and `llama-vocab.cpp` defaults SPM to `add_bos = true`.
3. **Reproduction.** Re-running that exact invocation against the pinned artifact reproduces all five arrays byte-identically, 5/5. With `--no-bos`, every case differs by exactly the leading `1`, and `no-bos == fixture[1:]` in each.

`parse_special: true` was checked the same way and is correct — `--no-parse-special` changes all five arrays, two of them in length. So only `add_special` was mislabeled.

The artifact was confirmed to be the pinned one, not a substitution: its SHA-256 equals the fixture's own `model_sha256` (`a4c9bb1d…`).

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets` (exit 0)
- [ ] `cd frontend && npm run build` — not run; this PR touches no frontend code
- [x] Other evidence attached below

Tokenizer suite: 27/27 with the artifact present and `CAMELID_REQUIRE_MODEL_TESTS=1`, and 27/27 without artifacts (clean skip). Negative check: temporarily restoring `add_special: false` makes the gate report `5/5 case(s)` with first divergence at index 0 in each — confirming the gate is not vacuous and that the new diagnostics work.

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included
- [x] Remote validation blockers are summarized generically
- [x] `bash scripts/check-public-scrub.sh`
- [x] `node scripts/audit-evidence-bundle-privacy.mjs --strict` — 0 findings

## Support-contract check

- [x] This PR does not overclaim support
- [x] TinyLlama Q8_0 remains the current full-support gate; this corrects reference metadata to match what the reference actually did and changes no support claim, row, quantization, or tokenizer family
- [x] No 1B / 3B / 8B wording is touched

## Evidence / artifacts

The fixture now records the exact invocation and the derivation under `reference.invocation`, `reference.harness` and `reference.add_special_provenance`, so the next reader does not have to re-derive it.

## Docs impact

None. `fixtures/README.md` still describes the pack accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
