### PR TITLE
perf(tokenizer): pin the Phi-4-mini artifact by its header region, not all 2.5 GB

### DIFF
--- a/examples/tokenizer_probe.rs
+++ b/examples/tokenizer_probe.rs
@@ -30,14 +30,21 @@ fn main() {
 
     let load_start = Instant::now();
     let gguf = read_metadata(gguf_path).expect("read gguf metadata");
+    let meta_ms = load_start.elapsed().as_secs_f64() * 1e3;
+    let data_start_offset = gguf.data_start_offset;
+    let build_start = Instant::now();
     let tokenizer = Tokenizer::from_gguf(&gguf).expect("build tokenizer");
+    let build_ms = build_start.elapsed().as_secs_f64() * 1e3;
     let load_ms = load_start.elapsed().as_secs_f64() * 1e3;
     eprintln!(
-        "loaded {} vocab={} model={} load_ms={:.1}",
+        "loaded {} vocab={} model={} load_ms={:.1} meta_ms={:.1} build_ms={:.1} header_bytes={}",
         gguf_path,
         tokenizer.tokens.len(),
         tokenizer.model.as_summary_model(),
-        load_ms
+        load_ms,
+        meta_ms,
+        build_ms,
+        data_start_offset
     );
 
     match mode {

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -520,27 +520,57 @@ fn resolve_gpt2_pre_tokenizer(
     }
 }
 
-const PHI4_MINI_Q4KM_SHA256: &str =
-    "88c00229914083cd112853aab84ed51b87bdf6b9ce42f532d8c85c7c63b1730a";
+/// SHA-256 of the pinned artifact's GGUF *header region* — bytes
+/// `[0, data_start_offset)`: magic, version, counts, the whole KV metadata
+/// block, and every tensor descriptor. Tensor payload bytes are deliberately
+/// excluded.
+///
+/// This pin used to cover the entire 2.5 GB file, which cost ~72 s of pure
+/// read on every `Tokenizer::from_gguf` — before any encode, so it landed on
+/// model load / first request. The narrowing is sound rather than merely
+/// cheaper: the gate exists to admit the `gpt-4o` dialect only for the one
+/// artifact its tokenization was validated against, and *everything* that can
+/// change tokenization lives in the header region (`tokenizer.ggml.pre`, the
+/// token list, merges, token_type, scores, the special ids). Tensor payload
+/// bytes cannot move a token id. The descriptors are still covered, so the
+/// quantization and tensor layout stay pinned too.
+///
+/// Regenerate after any intentional artifact change with:
+///   head -c "$(offset)" model.gguf | shasum -a 256
+/// where `$(offset)` is the `data_start_offset` the reader reports.
+const PHI4_MINI_Q4KM_HEADER_SHA256: &str =
+    "971d9aac49438815528a5036221d85b2b0cbaf8c13e05f412c4574e16d186312";
 
 fn is_exact_phi4_mini_q4km(file: &GgufFile) -> bool {
     let named_phi4 = file.architecture() == Some("phi3")
         && file.model_name() == Some("Phi 4 Mini Instruct")
         && file.path.file_name().and_then(|name| name.to_str())
             == Some("Phi-4-mini-instruct-Q4_K_M.gguf");
-    named_phi4 && sha256_file(&file.path).is_some_and(|sha256| sha256 == PHI4_MINI_Q4KM_SHA256)
+    named_phi4
+        && sha256_file_prefix(&file.path, file.data_start_offset)
+            .is_some_and(|sha256| sha256 == PHI4_MINI_Q4KM_HEADER_SHA256)
 }
 
-fn sha256_file(path: &std::path::Path) -> Option<String> {
+/// SHA-256 of exactly the first `len` bytes of `path`, or `None` if the file
+/// cannot be opened, is shorter than `len`, or `len` is zero. A short file
+/// yields `None` rather than the hash of whatever was there: a truncated
+/// artifact must not be able to satisfy a pin over a region it does not have.
+fn sha256_file_prefix(path: &std::path::Path, len: u64) -> Option<String> {
+    if len == 0 {
+        return None;
+    }
     let mut file = File::open(path).ok()?;
     let mut digest = sha2::Sha256::new();
     let mut buffer = [0u8; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer).ok()?;
+    let mut remaining = len;
+    while remaining > 0 {
+        let want = remaining.min(buffer.len() as u64) as usize;
+        let read = file.read(&mut buffer[..want]).ok()?;
         if read == 0 {
-            break;
+            return None;
         }
         digest.update(&buffer[..read]);
+        remaining -= read as u64;
     }
     Some(format!("{:x}", digest.finalize()))
 }
@@ -2892,6 +2922,58 @@ mod tests {
         let mut renamed = exact.clone();
         renamed.path = PathBuf::from("renamed.gguf");
         assert!(!is_exact_phi4_mini_q4km(&renamed));
+    }
+
+    // The artifact pin hashes only `[0, data_start_offset)`, so the bounded
+    // read has to be exact: hash every byte of the region and refuse anything
+    // that cannot supply the whole of it. Getting this wrong either breaks the
+    // gpt-4o gate for the real artifact or lets a truncated file satisfy a pin
+    // over bytes it does not have.
+    #[test]
+    fn sha256_file_prefix_hashes_exactly_the_requested_region() {
+        use sha2::Digest;
+
+        // Larger than the 64 KiB read buffer, so the final partial chunk (and
+        // the `min(remaining, buffer)` clamp) is actually exercised.
+        let bytes: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("artifact.bin");
+        std::fs::write(&path, &bytes).expect("write fixture");
+
+        let expect = |len: usize| {
+            let mut digest = sha2::Sha256::new();
+            digest.update(&bytes[..len]);
+            format!("{:x}", digest.finalize())
+        };
+
+        // A prefix hash must equal the hash of that prefix alone — never of
+        // the whole file, and never of a buffer-rounded amount.
+        for len in [1usize, 65_536, 65_537, 131_072, 199_999] {
+            assert_eq!(
+                super::sha256_file_prefix(&path, len as u64),
+                Some(expect(len)),
+                "prefix hash diverged at len={len}"
+            );
+        }
+        // Whole file, requested exactly.
+        assert_eq!(
+            super::sha256_file_prefix(&path, bytes.len() as u64),
+            Some(expect(bytes.len()))
+        );
+
+        // Truncated artifact: the region is not there, so there is no hash to
+        // report — NOT the hash of the short content.
+        assert_eq!(
+            super::sha256_file_prefix(&path, bytes.len() as u64 + 1),
+            None
+        );
+        // A zero-length region pins nothing and must never match.
+        assert_eq!(super::sha256_file_prefix(&path, 0), None);
+        // Unreadable path.
+        assert_eq!(
+            super::sha256_file_prefix(&dir.path().join("absent.bin"), 32),
+            None
+        );
     }
 
     // Parity gate for the missing-`pre` Llama-3 rescue: the exact Meta-Llama-3-8B GGUF


### PR DESCRIPTION
## Summary

- `is_exact_phi4_mini_q4km` hashed the entire 2.5 GB GGUF on every `Tokenizer::from_gguf`. That runs before any encode, so the cost landed on model load / first request.
- The pin now covers the header region `[0, data_start_offset)` — magic, version, counts, the whole KV metadata block, and every tensor descriptor. Tensor payload bytes are excluded.
- `sha256_file_prefix` fails closed on a short or zero-length region rather than hashing whatever was there.
- `tokenizer_probe` now splits metadata read from tokenizer build and reports the pinned region size, so this cost stays attributable.

## Why this change exists

Warm load of the pinned artifact went from ~5.4 s to ~0.4 s; first touch went from ~65 s to under half a second. That cost was paid on every tokenizer construction, for a gate that only decides one boolean.

The narrowing is sound rather than merely cheaper. The gate exists to admit the `gpt-4o` pre-tokenizer dialect only for the one artifact whose tokenization was validated against the pinned llama.cpp oracle. Everything that can change tokenization lives in the header region — `tokenizer.ggml.pre`, the token list, merges, `token_type`, scores, the special ids. Tensor payload bytes cannot move a token id. Tensor descriptors are inside the region too, so quantization and layout stay pinned.

Blast radius is tokenization-only: the sole production call site is `resolve_gpt2_pre_tokenizer` in `src/tokenizer/mod.rs`.

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets` (exit 0)
- [ ] `cd frontend && npm run build` — not run; this PR touches no frontend code
- [x] Other evidence attached below

`cargo test --lib tokenizer`: 27 passed. That run exercised the real-vocab specials-index pin against three rows (Qwen3-0.6B, Mistral-7B-v0.3, gemma-4-E2B) rather than skipping it.

## Evidence / artifacts

**The gate still admits the real artifact.** `phi4_mini_gpt4o_tokenizer_matches_pinned_oracle` is `#[ignore]`d by default because the artifact is multi-gigabyte; run against the pinned Phi-4-mini Q4_K_M GGUF it passes — the artifact is admitted by the narrowed pin *and* still tokenizes byte-identically to the llama.cpp `acd79d603` oracle vectors.

**The pinned hash is independently reproducible.** A GGUF parser written separately from the code under test resolves `data_start_offset = 8250976` and hashes that prefix to the committed value, so the pin is not merely self-consistent with the reader that produced it.

**Before / after**, same host and cache state, `tokenizer_probe bench <gguf> 1`, `header_bytes=8250976`:

| | first touch | warm | warm |
|---|---|---|---|
| before (whole-file pin) | 64909.9 ms | 5372.4 ms | 5521.3 ms |
| after (header-region pin) | 402.3 ms | 408.0 ms | 400.8 ms |

After the change, `meta_ms` is ~332 and `build_ms` ~71, so the remaining time is metadata read and vocab construction rather than hashing.

**Fail-closed behavior is covered.** `sha256_file_prefix_hashes_exactly_the_requested_region` walks lengths either side of the 64 KiB buffer boundary, asserts the prefix hash equals the hash of that prefix alone (never the whole file, never a buffer-rounded amount), and asserts `None` for a truncated region, a zero-length region, and an unreadable path. A truncated artifact must not be able to satisfy a pin over bytes it does not have.

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included
- [x] Remote validation blockers are summarized generically
- [x] `bash scripts/check-public-scrub.sh`
- [x] `node scripts/audit-evidence-bundle-privacy.mjs --strict` — 0 findings

## Support-contract check

- [x] This PR does not overclaim support
- [x] TinyLlama Q8_0 remains the current full-support gate; Phi-4-mini is unchanged in status — this only narrows how its artifact identity is checked, and the oracle receipt is unchanged
- [x] No 1B / 3B / 8B wording is touched

## Docs impact

None. The regeneration recipe for the pin is documented in a doc comment beside the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
