### PR TITLE
fix(release): sign the installer's payload from inside the bundler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,22 +310,34 @@ jobs:
   # release camelid.exe as a loopback sidecar, signs its artifacts with the same Azure
   # Trusted Signing identity as build-windows, and attaches them to the release itself.
   #
-  # Signing layout (azure/artifact-signing-action is folder-based, so every pass signs a
-  # staged folder rather than a named file):
-  #   - sidecar camelid.exe  -> signed BEFORE bundling (so it is signed inside the installer
-  #                             and the portable zip)
-  #   - camelid-desktop.exe  -> signed BEFORE bundling, for the same reason
-  #   - NSIS installer       -> signed AFTER bundling (it does not exist before)
+  # Signing layout. There are TWO distinct copies of camelid-desktop.exe, and they are signed
+  # by different mechanisms because only one of them is reachable from a folder-based pass:
+  #   - sidecar camelid.exe   -> signed BEFORE bundling, by the action (a folder pass over
+  #                              camelid-desktop/sidecar). The bundler copies it verbatim as a
+  #                              resource, so the signature survives into both artifacts.
+  #   - the exe INSIDE the     -> signed by the bundler itself, through
+  #     installer                 bundle.windows.signCommand (camelid-desktop/windows/
+  #                              sign-artifact-signing.ps1). Nothing else can sign this copy.
+  #   - portable exe + the     -> signed AFTER bundling, by the action (a folder pass over the
+  #     NSIS installer            assembled portable layout).
   #
-  # Through v0.4.6 the desktop exe was signed only AFTER bundling, which was recorded as an
-  # accepted v1 limitation: the copy sealed inside the installer went out unsigned, so the
-  # documented one-command install ran an unsigned app while the portable zip's identical
-  # binary was signed. The premise behind accepting it -- that Tauri patches the exe during
-  # bundling, so it could only be signed afterwards -- does not hold. Authenticode is a pure
-  # append: on the published v0.4.6 artifacts the signed copy's PE certificate table begins
-  # at offset 10513920, exactly the unsigned copy's length. The bundler embeds the same
-  # payload either way, so the exe is now signed before the bundler reads it, with a
-  # fail-closed assertion between the two steps.
+  # WHY signCommand IS REQUIRED. Tauri stamps the bundle type into the binary it stages for
+  # the installer, rewriting `__TAURI_BUNDLE_TYPE_VAR_UNK` to `..._NSS` so the installed app
+  # knows how it was installed. It rewrites a STAGED COPY, not target/release. Any signature
+  # applied before `tauri build` is therefore invalidated by that rewrite, and no signature
+  # applied afterwards can reach a binary already sealed inside the installer. signCommand is
+  # the only hook that runs in between.
+  #
+  # Both shipped defects lived in exactly that copy:
+  #   v0.4.6 - signed only after bundling  -> installed exe NotSigned
+  #   v0.4.7 - signed only before bundling -> installed exe HashMismatch (a BROKEN signature,
+  #            a worse posture than unsigned). Diagnosed on the published artifacts: the
+  #            installed and portable copies differ in exactly two places, the 3-byte marker
+  #            at 0x8043c8 and the PE CheckSum, which Authenticode excludes.
+  #
+  # `Prove the INSTALLED binary is signed` below is the check that closes this class of bug
+  # for good: it silently installs the built installer on the runner and asserts the unpacked
+  # binary verifies. It would have caught both defects before publishing.
   # See DECISIONS.md D11 for the desktop app's design record.
   desktop-windows:
     if: ${{ github.event.inputs.skip_desktop != 'true' }}
@@ -415,61 +427,71 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-      # Build the desktop binary but STOP before bundling, so camelid-desktop.exe can be
-      # signed while it is still the bundler's input. Through v0.4.6 this was one
-      # `tauri build`, which meant the NSIS installer was assembled around the unsigned
-      # binary and every user who installed via the installer ran an unsigned app --
-      # even though the portable zip's copy of the same binary was signed.
-      # Same config overlay as the bundle step below, so the compiled binary is identical
-      # to what the single-pass `tauri build` produced -- the only thing this split
-      # changes is WHEN the exe is signed, not what is built.
-      - name: Build desktop binary (no bundle yet)
-        working-directory: camelid-desktop
-        run: npx tauri build --no-bundle --config tauri.bundle.conf.json
-
-      # Sign in a dedicated folder: `files-folder` + an `exe` filter pointed at
-      # target/release would sweep in every other executable cargo left there.
-      - name: Stage camelid-desktop.exe for pre-bundle signing
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          New-Item -ItemType Directory -Force -Path sign-stage | Out-Null
-          Copy-Item target/release/camelid-desktop.exe sign-stage -Force
-
-      - name: Sign camelid-desktop.exe BEFORE bundling (Azure Artifact Signing)
-        uses: azure/artifact-signing-action@v2
+      # The dlib that lets signtool reach Artifact Signing is a .NET 8 component.
+      - name: Install .NET 8 runtime (Artifact Signing dlib dependency)
+        uses: actions/setup-dotnet@v5
         with:
-          endpoint: ${{ vars.SIGNING_ENDPOINT }}
-          signing-account-name: ${{ vars.SIGNING_ACCOUNT }}
-          certificate-profile-name: ${{ vars.SIGNING_PROFILE }}
-          files-folder: ${{ github.workspace }}\sign-stage
-          files-folder-filter: exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+          dotnet-version: '8.0.x'
 
-      # Return the signed bytes to the path the bundler reads, and fail closed if they are
-      # not signed -- this assertion is the gate the shipped defect would trip. Signing
-      # before bundling is safe because Authenticode is a pure append: on the v0.4.6
-      # artifacts the signed copy's PE certificate table starts at exactly the unsigned
-      # copy's length, so the bundler embeds the same payload either way.
-      - name: Return the signed exe to the bundler's input path
+      # Assemble the toolchain that camelid-desktop/windows/sign-artifact-signing.ps1 drives,
+      # and hand it over through the environment. That script is Tauri's
+      # `bundle.windows.signCommand`, so the bundler signs each binary AFTER it finishes
+      # rewriting it -- which is the fix. See the header comment on this job.
+      #
+      # signtool must come from the SDK Build Tools package: the dlib documents a minimum of
+      # 10.0.2261.755 and explicitly does not work with the 20348 SDK, so the runner's
+      # preinstalled signtool is not safe to assume.
+      - name: Prepare Artifact Signing tooling for the bundler
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          Copy-Item sign-stage/camelid-desktop.exe target/release/camelid-desktop.exe -Force
-          $status = (Get-AuthenticodeSignature 'target/release/camelid-desktop.exe').Status
-          if ($status -ne 'Valid') {
-            throw "camelid-desktop.exe is '$status' going into the bundler; the installer would ship an unsigned app"
-          }
-          Write-Host "pre-bundle signature: $status"
+          $ProgressPreference = 'SilentlyContinue'
+          $tools = Join-Path $env:GITHUB_WORKSPACE 'signing-tools'
+          New-Item -ItemType Directory -Force -Path $tools | Out-Null
 
-      - name: Bundle the NSIS installer around the signed exe
+          Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile "$tools/nuget.exe"
+          & "$tools/nuget.exe" install Microsoft.Windows.SDK.BuildTools -x -OutputDirectory $tools
+          if ($LASTEXITCODE -ne 0) { throw "nuget install Microsoft.Windows.SDK.BuildTools failed ($LASTEXITCODE)" }
+          & "$tools/nuget.exe" install Microsoft.ArtifactSigning.Client -x -OutputDirectory $tools
+          if ($LASTEXITCODE -ne 0) { throw "nuget install Microsoft.ArtifactSigning.Client failed ($LASTEXITCODE)" }
+
+          $signtool = Get-ChildItem -Path $tools -Recurse -Filter signtool.exe |
+            Where-Object { $_.FullName -match '\\x64\\' } | Select-Object -First 1
+          if (-not $signtool) { throw 'signtool.exe (x64) not found in the SDK Build Tools package' }
+          $dlib = Get-ChildItem -Path $tools -Recurse -Filter Azure.CodeSigning.Dlib.dll |
+            Where-Object { $_.FullName -match '\\x64\\' } | Select-Object -First 1
+          if (-not $dlib) { throw 'Azure.CodeSigning.Dlib.dll (x64) not found in the Artifact Signing client package' }
+
+          # Endpoint/account/profile are the same repo vars the signing action uses, so the
+          # hook and the action always sign against one identity.
+          $metadata = Join-Path $tools 'metadata.json'
+          @{
+            Endpoint               = '${{ vars.SIGNING_ENDPOINT }}'
+            CodeSigningAccountName = '${{ vars.SIGNING_ACCOUNT }}'
+            CertificateProfileName = '${{ vars.SIGNING_PROFILE }}'
+            CorrelationId          = "${{ github.run_id }}-${{ github.run_attempt }}"
+          } | ConvertTo-Json | Set-Content -Path $metadata -Encoding utf8
+
+          "CAMELID_SIGNTOOL=$($signtool.FullName)"     | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+          "CAMELID_SIGN_DLIB=$($dlib.FullName)"        | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+          "CAMELID_SIGN_METADATA=$metadata"            | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+          Write-Host "signtool: $($signtool.FullName)"
+          Write-Host "dlib    : $($dlib.FullName)"
+
+          # The hook path in tauri.conf.json is relative to the Tauri project directory. If it
+          # ever stops resolving, signCommand silently never runs, so assert it here.
+          if (-not (Test-Path 'camelid-desktop/windows/sign-artifact-signing.ps1')) {
+            throw 'signCommand script missing at camelid-desktop/windows/sign-artifact-signing.ps1'
+          }
+
+      # One pass again, as before v0.4.7. The binary is signed from inside the bundler via
+      # signCommand, at the only moment its bytes are final.
+      - name: Build desktop bundle (NSIS installer)
         working-directory: camelid-desktop
         # The bundle-only config overlay adds the staged sidecar/* as resources. It is
         # kept out of the base tauri.conf.json so a plain `cargo build -p camelid-desktop`
         # (no sidecar staged) never hits the empty-glob error.
-        run: npx tauri bundle --config tauri.bundle.conf.json
+        run: npx tauri build --config tauri.bundle.conf.json
 
       # Assemble the portable layout, and stage the installer INTO it so a single post-build
       # signing pass covers both the portable camelid-desktop.exe and the NSIS installer.
@@ -549,6 +571,49 @@ jobs:
           if (-not $setup) { throw 'no NSIS installer was produced' }
           if ($setup.Length -le 0) { throw "installer $($setup.Name) is zero bytes" }
           Write-Host "installer: $($setup.Name) ($([math]::Round($setup.Length / 1MB, 1)) MB)"
+
+      # Open the installer the way a USER does, and check what it actually delivers.
+      #
+      # Every other signing check in this job inspects a file we hand to the signer. None of
+      # them can see the binary sealed INSIDE the installer, which is a different copy -- and
+      # that is precisely where both shipped defects lived: v0.4.6 delivered it unsigned, and
+      # v0.4.7 delivered it HashMismatch because the bundler rewrote the bundle-type marker
+      # after signing. A silent install into a scratch directory is the only check that sees
+      # what the user gets. The runner is ephemeral, so installing on it costs nothing.
+      - name: Prove the INSTALLED binary is signed
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $setup = (Get-ChildItem -Filter '*-setup.exe' | Select-Object -First 1).FullName
+          $target = Join-Path $env:RUNNER_TEMP 'installed-check'
+          Remove-Item -Recurse -Force $target -ErrorAction SilentlyContinue
+
+          # /S = NSIS silent, /D = install directory (must be last, unquoted, no trailing slash).
+          $p = Start-Process -FilePath $setup -ArgumentList '/S', "/D=$target" -Wait -PassThru
+          if ($p.ExitCode -ne 0) { throw "installer exited $($p.ExitCode)" }
+
+          $exe = Join-Path $target 'camelid-desktop.exe'
+          if (-not (Test-Path $exe)) { throw "installer did not place camelid-desktop.exe in $target" }
+
+          $sig = Get-AuthenticodeSignature $exe
+          Write-Host "installed camelid-desktop.exe -> $($sig.Status)"
+          if ($sig.Status -ne 'Valid') {
+            throw ("the installer delivers camelid-desktop.exe as '$($sig.Status)'. " +
+              "A user installing this release would run a binary Windows does not trust. " +
+              "Check that bundle.windows.signCommand ran (look for 'sign-artifact-signing:' above).")
+          }
+
+          # The sidecar is signed before bundling and must survive the same path.
+          $side = Join-Path $target 'sidecar\camelid.exe'
+          if (Test-Path $side) {
+            $ss = (Get-AuthenticodeSignature $side).Status
+            Write-Host "installed sidecar camelid.exe -> $ss"
+            if ($ss -ne 'Valid') { throw "the installer delivers sidecar\camelid.exe as '$ss'" }
+          } else {
+            throw "installer did not place sidecar\camelid.exe in $target"
+          }
+
+          Remove-Item -Recurse -Force $target -ErrorAction SilentlyContinue
 
       - name: Upload desktop artifacts (CI)
         uses: actions/upload-artifact@v4

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -619,6 +619,44 @@ Failure is non-fatal by construction: `Delete` on a missing or locked file sets 
 without aborting, so the worst case is the orphan surviving to the next upgrade — never a broken
 install.
 
+## D11 cont. — the binary inside the Windows installer is signed by the bundler, not by a folder pass (2026-08-01)
+
+`camelid-desktop.exe` exists as **two distinct copies**, and a folder-based signing pass can
+only ever reach one of them. Tauri stamps the bundle type into the copy it stages for the
+installer, rewriting `__TAURI_BUNDLE_TYPE_VAR_UNK` to `..._NSS` so the installed app knows how
+it was installed — and it rewrites a *staged copy*, leaving `target/release` untouched.
+
+That gives a window with exactly one entrance. A signature applied **before** `tauri build` is
+invalidated by the rewrite; a signature applied **after** cannot reach a binary already sealed
+inside the installer. Two releases shipped from the two sides of it:
+
+| release | when the desktop exe was signed | what users installed |
+| --- | --- | --- |
+| v0.4.6 | after bundling only | `NotSigned` |
+| v0.4.7 | before bundling only | `HashMismatch` — a *broken* signature |
+
+v0.4.7 was the worse outcome: an invalid signature earns no SmartScreen reputation and reads
+as tampering, where an unsigned binary merely reads as unsigned. It was diagnosed by byte-diffing
+the two published copies, which differ in exactly two places — the 3-byte marker at `0x8043c8`
+and the PE CheckSum, which Authenticode excludes from its hash.
+
+**Fix: `bundle.windows.signCommand`** (`camelid-desktop/windows/sign-artifact-signing.ps1`),
+the only hook Tauri invokes between the rewrite and packaging. It drives `signtool` through
+`Azure.CodeSigning.Dlib`.
+
+**Rejected: `artifact-signing-cli`,** which Tauri's own documentation suggests for Azure. It
+requires `AZURE_CLIENT_SECRET`, and this repo authenticates to Artifact Signing with OIDC
+federated credentials and stores no secret. Adopting it would have traded a short-lived
+federated token for a long-lived secret purely for convenience. The dlib authenticates through
+`DefaultAzureCredential`, which resolves the `azure/login` session the workflow already
+establishes, so OIDC is preserved.
+
+**The gate matters more than the fix.** Every prior signing check inspected a file handed to
+the signer; none could see the installer's payload, which is why two consecutive releases
+shipped defects there. `Prove the INSTALLED binary is signed` silently installs the built
+installer on the runner and asserts the unpacked binary verifies. Runners are ephemeral, so
+this costs nothing, and it would have caught both defects before publishing.
+
 ## D12 — CPU KV cache: f16-rounded values were stored in f32 buffers; f16 storage + head-major layout lanes (2026-07-01)
 
 Measured finding (Item-3 recon): the CPU KV write path has rounded every stored

--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -61,6 +61,33 @@ user data**: the desktop's model store is the `models\` folder beside the engine
 (`sidecar_models_dir` in `src/engine.rs`), i.e. `sidecar\models\`, holding multi-GB downloaded
 GGUF weights. Only files the packaging scripts stage may be removed there.
 
+## Windows code signing
+
+Release artifacts are signed with Azure Artifact Signing. The subtlety is that
+`camelid-desktop.exe` exists as **two distinct copies**, and only one of them is reachable
+from an ordinary post-build signing pass:
+
+| copy | signed by | when |
+| --- | --- | --- |
+| `sidecar\camelid.exe` | signing action, folder pass | before bundling; copied verbatim as a resource |
+| the exe **inside** the installer | `bundle.windows.signCommand` | during bundling |
+| portable exe + NSIS installer | signing action, folder pass | after bundling |
+
+The middle row needs its own mechanism because Tauri stamps the bundle type into the binary it
+stages for the installer, rewriting `__TAURI_BUNDLE_TYPE_VAR_UNK` to `..._NSS` so the installed
+app knows how it was installed. It rewrites a *staged copy*, not `target/release`. A signature
+applied before `tauri build` is therefore invalidated by that rewrite, and one applied
+afterwards cannot reach a binary already sealed inside the installer.
+`windows/sign-artifact-signing.ps1` runs in the only window where the bytes are final.
+
+Both shipped releases got this wrong before it was understood: v0.4.6 delivered that copy
+`NotSigned`, and v0.4.7 delivered it `HashMismatch` — a broken signature, which is worse than
+none. The release workflow now installs the built installer on the runner and asserts the
+unpacked binary verifies, so neither failure can ship again unnoticed.
+
+The script no-ops when its tooling environment is absent, so `tauri build` on a developer
+machine still works and simply produces unsigned output.
+
 ## Startup failures
 
 The splash is fail-closed: it stays visible until the sidecar returns `200` from

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -31,6 +31,17 @@
     "shortDescription": "Native chat app for the Camelid local inference engine.",
     "longDescription": "Camelid Desktop embeds the same Camelid engine shipped as the server binary and runs it as a loopback sidecar. It inherits the identical model-support contract; it makes no broader claims.",
     "windows": {
+      "signCommand": {
+        "cmd": "powershell",
+        "args": [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "windows/sign-artifact-signing.ps1",
+          "%1"
+        ]
+      },
       "nsis": {
         "installerHooks": "windows/installer-hooks.nsh"
       }

--- a/camelid-desktop/tests/installer_hooks.rs
+++ b/camelid-desktop/tests/installer_hooks.rs
@@ -1,20 +1,98 @@
-//! The Windows NSIS installer-hook contract (see `../DECISIONS.md`, D11 cont.).
+//! The Windows bundler-hook contract (see `../DECISIONS.md`, D11 cont.) — two hooks that the
+//! compiler cannot see and that fail silently, so they are asserted here instead.
 //!
-//! An overwrite-only installer rewrites the files it ships and leaves everything else alone, so
-//! a file installed by an OLDER version that the current one dropped survives every upgrade —
-//! that is how an 85.7 MB `nvrtc64_120_0.alt.dll` stranded on v0.4.6 boxes. `windows/installer-hooks.nsh`
-//! closes that path by re-laying the NVRTC set on every install.
+//! **`installerHooks`** — an overwrite-only installer rewrites the files it ships and leaves
+//! everything else alone, so a file installed by an OLDER version that the current one dropped
+//! survives every upgrade; that is how an 85.7 MB `nvrtc64_120_0.alt.dll` stranded on v0.4.6
+//! boxes. `windows/installer-hooks.nsh` closes that path by re-laying the NVRTC set on every
+//! install. The wholesale-clear guard below is the load-bearing one: `sidecar\models\` is the
+//! desktop's model store, so widening the hook is a data-loss bug, not a cleanup.
 //!
-//! These tests exist because nothing else can see this. The hook is NSIS source, invisible to
-//! the compiler; `scripts/check-release-artifact.mjs` inspects the built artifact, not the
-//! upgrade path; and the failure is silent — a stranded file changes no behavior, it just
-//! accumulates. The wholesale-clear guard below is the load-bearing one: `sidecar\models\` is
-//! the desktop's model store, so widening the hook is a data-loss bug, not a cleanup.
+//! **`signCommand`** — Tauri rewrites the bundle-type marker on the copy of the binary it
+//! stages for the installer, so that copy can only be signed from inside the bundler. Losing
+//! this config does not fail the build; it ships an installer whose payload Windows refuses to
+//! trust. v0.4.6 shipped it `NotSigned`, v0.4.7 `HashMismatch`.
+//!
+//! Neither failure is visible to anything else in the tree: both hooks are non-Rust source,
+//! and `scripts/check-release-artifact.mjs` inspects the built artifact rather than the
+//! installer's payload or the upgrade path. The release workflow's `Prove the INSTALLED binary
+//! is signed` step is the runtime counterpart to these compile-time assertions.
 
 use std::path::PathBuf;
 
 fn desktop_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn tauri_conf() -> serde_json::Value {
+    let raw = std::fs::read_to_string(desktop_dir().join("tauri.conf.json"))
+        .expect("read tauri.conf.json");
+    serde_json::from_str(&raw).expect("tauri.conf.json is valid JSON")
+}
+
+/// `bundle.windows.signCommand` is the ONLY hook that can sign the copy of
+/// `camelid-desktop.exe` sealed inside the NSIS installer. Tauri rewrites the bundle-type
+/// marker (`__TAURI_BUNDLE_TYPE_VAR_UNK` -> `..._NSS`) on a staged copy, so a signature
+/// applied before `tauri build` is invalidated by that rewrite, and one applied afterwards
+/// cannot reach a binary already inside the installer. v0.4.6 shipped that copy `NotSigned`;
+/// v0.4.7 shipped it `HashMismatch`. Both are what dropping this config looks like.
+#[test]
+fn sign_command_is_wired_to_a_script_that_exists() {
+    let conf = tauri_conf();
+    let sign = &conf["bundle"]["windows"]["signCommand"];
+    assert!(
+        !sign.is_null(),
+        "bundle.windows.signCommand must stay configured: it is the only point at which the \
+         binary inside the NSIS installer can be signed"
+    );
+
+    let args: Vec<&str> = sign["args"]
+        .as_array()
+        .expect("signCommand must use the object notation so paths may contain whitespace")
+        .iter()
+        .map(|a| a.as_str().expect("signCommand args are strings"))
+        .collect();
+    assert!(
+        args.iter().any(|a| *a == "%1"),
+        "signCommand args must contain the %1 placeholder, or Tauri passes no file to sign: {args:?}"
+    );
+
+    let script = args
+        .iter()
+        .find(|a| a.ends_with(".ps1"))
+        .expect("signCommand must invoke a .ps1 script");
+    let path = desktop_dir().join(script);
+    assert!(
+        path.is_file(),
+        "signCommand points at {}, which does not exist — the release bundler would fail",
+        path.display()
+    );
+}
+
+/// The signing script must fail rather than return success when it cannot sign. A hook that
+/// swallows an error hands the bundler an unsigned binary and reports nothing, which is
+/// exactly the silent failure the release gate exists to catch.
+#[test]
+fn sign_script_fails_closed_on_a_signing_error() {
+    let conf = tauri_conf();
+    let args = conf["bundle"]["windows"]["signCommand"]["args"]
+        .as_array()
+        .expect("signCommand args");
+    let script = args
+        .iter()
+        .filter_map(|a| a.as_str())
+        .find(|a| a.ends_with(".ps1"))
+        .expect("signCommand script");
+    let src = std::fs::read_to_string(desktop_dir().join(script)).expect("read signing script");
+
+    assert!(
+        src.contains("$LASTEXITCODE -ne 0"),
+        "the signing script must check signtool's exit code"
+    );
+    assert!(
+        src.contains("-ne 'Valid'"),
+        "the signing script must verify the resulting signature, not just signtool's exit code"
+    );
 }
 
 /// The hook path as the NSIS bundler resolves it: `bundle.windows.nsis.installerHooks`,

--- a/camelid-desktop/tests/installer_hooks.rs
+++ b/camelid-desktop/tests/installer_hooks.rs
@@ -53,7 +53,7 @@ fn sign_command_is_wired_to_a_script_that_exists() {
         .map(|a| a.as_str().expect("signCommand args are strings"))
         .collect();
     assert!(
-        args.iter().any(|a| *a == "%1"),
+        args.contains(&"%1"),
         "signCommand args must contain the %1 placeholder, or Tauri passes no file to sign: {args:?}"
     );
 

--- a/camelid-desktop/windows/sign-artifact-signing.ps1
+++ b/camelid-desktop/windows/sign-artifact-signing.ps1
@@ -1,0 +1,81 @@
+# Sign one file with Azure Artifact Signing (formerly Trusted Signing).
+#
+# This is Tauri's `bundle.windows.signCommand` hook: the bundler calls it with the path to
+# each binary it is about to package, AFTER it has finished rewriting that binary and BEFORE
+# it seals it into the installer. That timing is the whole point.
+#
+# WHY THIS EXISTS. Tauri stamps the bundle type into the binary it stages for the installer,
+# rewriting the marker `__TAURI_BUNDLE_TYPE_VAR_UNK` to `..._NSS` so the installed app knows
+# it came from NSIS. It patches a STAGED COPY, not target/release. v0.4.7 signed the binary
+# before `tauri bundle` ran, so that rewrite landed on already-signed bytes and every
+# installed copy reported HashMismatch -- a broken signature, which is a worse posture than
+# the unsigned binary v0.4.6 shipped. Signing from inside this hook is the only point at
+# which the bytes are final. Measured on the v0.4.7 artifacts: the installed and portable
+# copies differ in exactly two places, that 3-byte marker and the PE CheckSum (which
+# Authenticode excludes).
+#
+# AUTHENTICATION. signtool reaches the service through Azure.CodeSigning.Dlib, which uses
+# DefaultAzureCredential. The release workflow runs `azure/login` with OIDC beforehand, so
+# the az CLI session is what this authenticates with -- no client secret is stored anywhere.
+# `artifact-signing-cli`, the CLI Tauri's own docs suggest, requires AZURE_CLIENT_SECRET and
+# was rejected for exactly that reason.
+#
+# NOT CONFIGURED = NOT SIGNED, LOUDLY SKIPPED. A developer running `tauri build` on their own
+# machine has none of these tools, so the hook no-ops rather than failing their build. That
+# is safe only because the release workflow independently proves the shipped installer
+# carries a valid signature: it installs the built setup.exe and checks the unpacked binary.
+# Without that gate this skip would be a silent way to ship unsigned bytes.
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+$signtool = $env:CAMELID_SIGNTOOL
+$dlib = $env:CAMELID_SIGN_DLIB
+$metadata = $env:CAMELID_SIGN_METADATA
+
+if (-not $signtool -and -not $dlib -and -not $metadata) {
+    Write-Host "sign-artifact-signing: signing not configured (CAMELID_SIGNTOOL unset) - skipping $Path"
+    exit 0
+}
+
+# A PARTIAL configuration is a broken release job, not a developer build: fail rather than
+# silently skipping and letting the bundler seal an unsigned binary.
+foreach ($pair in @(
+        @{ Name = 'CAMELID_SIGNTOOL'; Value = $signtool },
+        @{ Name = 'CAMELID_SIGN_DLIB'; Value = $dlib },
+        @{ Name = 'CAMELID_SIGN_METADATA'; Value = $metadata })) {
+    if (-not $pair.Value) {
+        throw "signing is partially configured: $($pair.Name) is empty while others are set"
+    }
+    if ($pair.Name -ne 'CAMELID_SIGNTOOL' -and -not (Test-Path $pair.Value)) {
+        throw "$($pair.Name) points at '$($pair.Value)', which does not exist"
+    }
+}
+
+if (-not (Test-Path $Path)) {
+    throw "nothing to sign at '$Path'"
+}
+
+Write-Host "sign-artifact-signing: signing $Path"
+
+# Timestamping is not optional here: Artifact Signing certificates are valid for three days,
+# so an untimestamped signature stops verifying almost immediately after release.
+& $signtool sign /v /debug /fd SHA256 `
+    /tr http://timestamp.acs.microsoft.com /td SHA256 `
+    /dlib $dlib /dmdf $metadata `
+    $Path
+if ($LASTEXITCODE -ne 0) {
+    throw "signtool failed with exit code $LASTEXITCODE for $Path"
+}
+
+# Fail closed on the result, not just the exit code: a signature that does not verify on the
+# machine that just produced it will not verify on a user's machine either.
+$status = (Get-AuthenticodeSignature -FilePath $Path).Status
+if ($status -ne 'Valid') {
+    throw "signtool reported success but $Path verifies as '$status'"
+}
+Write-Host "sign-artifact-signing: $Path -> Valid"


### PR DESCRIPTION
## What v0.4.7 actually shipped

```
portable zip    camelid-desktop.exe   Valid          CN=Tim Toole
NSIS-installed  camelid-desktop.exe   HashMismatch   CN=Tim Toole   <-- broken
sidecar\camelid.exe (both)            Valid          CN=Tim Toole
```

`HashMismatch` means the signature is present but the bytes no longer match it. That is **worse than v0.4.6's `NotSigned`**: an invalid signature earns no SmartScreen reputation and reads as tampering, where an unsigned binary merely reads as unsigned.

## Root cause

Tauri stamps the bundle type into the binary it stages for the installer, rewriting `__TAURI_BUNDLE_TYPE_VAR_UNK` to `..._NSS` so the installed app knows how it was installed. It rewrites a **staged copy**, not `target/release` — which is why the portable exe still reads `UNK` and stayed valid.

That leaves one window with a single entrance:

| where you sign | outcome |
| --- | --- |
| before `tauri build` | the rewrite invalidates it → `HashMismatch` (v0.4.7) |
| after bundling | cannot reach a binary already sealed inside the installer → `NotSigned` (v0.4.6) |
| **from inside the bundler** | **the only point where the bytes are final** |

Diagnosed by byte-diffing the two published v0.4.7 copies. They differ in exactly two places: the 3-byte marker at `0x8043c8`, and the PE CheckSum, which Authenticode excludes.

The reasoning in #573 was wrong, and specifically: it compared file **lengths** and concluded the payload was unchanged. The rewrite is size-preserving, so that measurement could not have detected it. Byte-level comparison is what found it.

## The fix

`bundle.windows.signCommand` → `camelid-desktop/windows/sign-artifact-signing.ps1`, driving `signtool` through `Azure.CodeSigning.Dlib`. This is the hook Tauri invokes between the rewrite and packaging.

**Rejected: `artifact-signing-cli`**, which Tauri's own docs recommend for Azure. It requires `AZURE_CLIENT_SECRET`; this repo authenticates with OIDC federated credentials and stores no secret. Adopting it would trade a short-lived federated token for a long-lived secret purely for convenience. The dlib uses `DefaultAzureCredential`, which resolves the `azure/login` session the workflow already establishes — OIDC preserved, no new secret.

The script no-ops when its tooling env is absent, so a developer's local `tauri build` still works.

## The gate matters more than the fix

Every signing check that existed inspected a file we hand to the signer. **None could see the installer's payload** — which is exactly why two consecutive releases shipped defects there.

`Prove the INSTALLED binary is signed` silently installs the built installer into a scratch dir on the runner and asserts the unpacked `camelid-desktop.exe` (and `sidecar\camelid.exe`) verify as `Valid`. Runners are ephemeral, so this costs nothing. **It would have caught both v0.4.6 and v0.4.7 before publishing.**

Two Rust tests also assert `signCommand` stays wired to a script that exists, and that the script fails closed rather than swallowing a signing error.

## What is and isn't proven here

Locally verified: workflow YAML parses, step order is correct, the signing script parses under the PowerShell AST parser and uses only 5.1-safe cmdlets, both hook paths resolve from the Tauri project dir, `signCommand` and `installerHooks` coexist in the config, the new test assertions hold against the real files, and `scripts/check-public-scrub.sh` passes.

Not provable before merge: the signing path itself only runs on a tag push, so the Azure dlib wiring is first exercised by the v0.4.8 release run. That is what the install gate is for — if the wiring is wrong, the job fails instead of publishing a bad signature. The desktop job remains in no other job's `needs`, so a failure cannot block the server release.