### PR TITLE
feat(system): report the running engine version on the System page

### DIFF
--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -466,6 +466,11 @@ function makeDashboard({ health, models, currentModel, capabilities, conversatio
     models,
     runtime: {
       engine: normalizeEngineName(health?.engine),
+      // Which build is answering. `runtime` is an explicit projection of health, not a
+      // pass-through, so a field absent here is invisible to every view no matter what
+      // /v1/health serializes.
+      version: health?.version || null,
+      build: health?.build || null,
       loaded_now: Boolean(health?.loaded_now ?? health?.active_model_id),
       active_model_id: health?.active_model_id || null,
       generation_ready: Boolean(health?.generation_ready),

--- a/frontend/src/views/SystemView.jsx
+++ b/frontend/src/views/SystemView.jsx
@@ -25,6 +25,19 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
   const runtimePill = runtimeReadinessLabel(runtime)
   const selectedModelName = selectedModel?.name || 'No next-chat model selected'
   const apiBase = runtime?.api_base || 'Local API unavailable'
+  // Version comes from /v1/health, so it names the engine actually answering rather than
+  // whatever this bundle was built alongside. Unknown until health responds.
+  const engineVersion = runtime?.version || null
+  const engineBuild = runtime?.build || null
+  const engineVersionLabel = engineVersion ? `v${engineVersion}` : 'Unknown until /v1/health responds'
+  // A build identity that is not just the version restated means this engine is not a
+  // released binary — worth showing rather than hiding behind a matching version number.
+  const engineBuildDetail = engineBuild && engineBuild !== engineVersion && engineBuild !== `v${engineVersion}`
+    ? engineBuild
+    : null
+  const engineLabel = runtime?.engine
+    ? (engineVersion ? `${runtime.engine} v${engineVersion}` : runtime.engine)
+    : 'engine unknown'
   const modelId = getRuntimeRequestModelId(selectedModel, runtime, '<loaded-model-id>') || '<loaded-model-id>'
   const supportContract = capabilities?.support_contract
   const supportContractCurrentGate = frontendSupportContractCopy(capabilities)
@@ -104,7 +117,7 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
       )}
 
       <div className="cxv-stat-grid">
-        <div className="cxv-stat"><span>Runtime</span><strong>{runtimeState}</strong><small>{runtime?.engine || 'engine unknown'}</small></div>
+        <div className="cxv-stat"><span>Runtime</span><strong>{runtimeState}</strong><small title={engineBuildDetail || undefined}>{engineLabel}</small></div>
         <div className="cxv-stat"><span>Generation</span><strong>{runtime?.generation_ready ? 'Yes' : 'No'}</strong><small>{runtimePill}</small></div>
         <div className="cxv-stat"><span>Loaded model</span><strong>{runtime?.loaded_now ? 'Active' : 'None'}</strong><small title={runtime?.loaded_now ? runtime?.active_model_id : 'Nothing loaded'}>{runtime?.loaded_now ? runtime?.active_model_id : 'Nothing loaded'}</small></div>
         <div className="cxv-stat"><span>Selected gate</span><strong>{gateStat}</strong><small>{gateStatSub}</small></div>
@@ -117,6 +130,10 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
           <div className="sys-defs">
             <div><span>Runtime state</span><strong>{runtime?.generation_ready ? 'Generation-ready' : runtime?.loaded_now ? 'Loaded, not generation-ready' : runtime?.status === 'offline' ? 'Backend offline' : 'Online, no model loaded'}</strong></div>
             <div><span>Local engine</span><strong>{runtime?.engine || 'Unknown'}</strong></div>
+            <div><span>Engine version</span><strong title={engineBuildDetail || undefined}>{engineVersionLabel}</strong></div>
+            {engineBuildDetail && (
+              <div><span>Build</span><strong>{engineBuildDetail}</strong></div>
+            )}
             <div><span>Loaded model</span><strong>{runtime?.loaded_now ? runtime?.active_model_id : 'Nothing loaded'}</strong></div>
             <div><span>Generation ready</span><strong>{runtime?.generation_ready ? 'Yes' : 'No'}</strong></div>
             <div><span>Selected device at load</span><strong>{execution.device}</strong></div>

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -503,6 +503,15 @@ pub struct LoadModelRequest {
 pub struct HealthResponse {
     pub ok: bool,
     pub engine: &'static str,
+    /// Release version of the running engine (the crate version, e.g. `0.4.7`), so an
+    /// operator can tell which build is answering without reading the binary's metadata.
+    /// Unlike [`HealthResponse::executable`] this is safe off-box: it names a public
+    /// release, not the host's filesystem.
+    pub version: &'static str,
+    /// Exact build identity — `git describe` when the tree had it at compile time,
+    /// otherwise the crate version. On a released binary these two agree; on a developer
+    /// build this is the field that says how far the process has drifted from a tag.
+    pub build: String,
     pub loaded_now: bool,
     pub generation_ready: bool,
     pub active_model_id: Option<String>,
@@ -2846,6 +2855,8 @@ async fn health_registry_snapshot(state: &AppState) -> HealthResponse {
     HealthResponse {
         ok: true,
         engine: "camelid",
+        version: env!("CARGO_PKG_VERSION"),
+        build: crate::receipt::camelid_version(),
         loaded_now,
         generation_ready,
         active_model_id: active_id_lock.clone(),
@@ -2875,6 +2886,8 @@ fn busy_health_response(state: &AppState) -> HealthResponse {
     HealthResponse {
         ok: true,
         engine: "camelid",
+        version: env!("CARGO_PKG_VERSION"),
+        build: crate::receipt::camelid_version(),
         loaded_now: false,
         generation_ready: false,
         active_model_id: None,
@@ -17194,6 +17207,60 @@ mod tests {
                     "{uri} busy snapshot reports the in-flux registries as not ready"
                 );
             }
+        }
+    }
+
+    /// `/health` names the build that is answering. The WebUI's System view reads these
+    /// two fields directly, so an operator looking at a running engine can tell which
+    /// version it is without inspecting the binary — and they must survive a busy
+    /// snapshot, which is exactly when someone is most likely to be asking.
+    #[tokio::test]
+    async fn health_reports_the_running_engine_version_even_while_busy() {
+        use tower::ServiceExt;
+
+        let state = AppState::default();
+        let app = router_with_state(state.clone());
+
+        // Same wedge as above: the busy path builds a different HealthResponse, and a
+        // field added to only one of the two constructors would vanish here.
+        let _loaded = state.loaded_models.write().await;
+        let _active = state.active_model_id.write().await;
+        let _plans = state.execution_plans.write().await;
+
+        for uri in ["/health", "/v1/health"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    axum::http::Request::builder()
+                        .uri(uri)
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{uri}");
+            let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+            assert_eq!(
+                body["version"],
+                env!("CARGO_PKG_VERSION"),
+                "{uri} must report the crate version the process was built from"
+            );
+            // Deliberately only a non-empty check. `build` is `git describe`, which names
+            // the most recent TAG — so between a version bump and its tag it legitimately
+            // reads `v0.4.7-3-gabc` while the crate already says `0.4.8`. Asserting the two
+            // agree would fail every release-bump PR, which is the one moment they must be
+            // allowed to differ.
+            let build = body["build"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{uri} must report a build identity"));
+            assert!(
+                !build.is_empty(),
+                "{uri} build identity must never be empty"
+            );
         }
     }
 


### PR DESCRIPTION
The System page is the operational view, but it could not answer the first question you ask a running process: **which version is this?** Nothing in the UI named the build, so the only way to tell was to inspect the binary.

## What changed

`/v1/health` now carries two fields:

| field | value | why both |
| --- | --- | --- |
| `version` | crate version, e.g. `0.4.7` | matches the release tag |
| `build` | `git describe` when the tree had it at compile time, else the crate version | on a released binary the two agree; on a developer build this says how far the process has drifted from a tag |

The System page shows **Engine version** in the Runtime panel and `camelid v0.4.7` on the Runtime stat tile, with a separate **Build** row only when the build identity says something the version does not.

Both `HealthResponse` constructors are covered. The busy snapshot is a separate literal, and a field added to only one would vanish exactly when someone is most likely to be asking — so the test asserts both paths.

## The bug this nearly shipped with

`runtime` in `useDashboardData.js` is an explicit **projection** of the health payload, not a pass-through. Serializing a field server-side is not enough — it has to be mapped there too, or every view sees `undefined`.

The API test passed either way. The page rendered `Unknown until /v1/health responds` against a health endpoint that was, in fact, responding with the version. It was only caught by rendering the page, and the fix is included here.

## Verified

Rendered the real production bundle against a stubbed health endpoint:

| stub `build` | Engine version | Build row | Runtime tile |
| --- | --- | --- | --- |
| `v0.4.7-3-gfeedface` | `v0.4.7` | shown | `camelid v0.4.7` |
| `v0.4.7` (adds nothing) | `v0.4.7` | correctly hidden | `camelid v0.4.7` |

Gates run locally: `clippy -p camelid --all-targets --all-features -D warnings` (exit 0), `cargo test -p camelid --lib health_reports_the_running_engine_version_even_while_busy` (passed), `npm run smoke:ui`, `npm run smoke:integration`.

## One deliberate looseness in the test

`build` is only checked non-empty, never compared against `version`. It is `git describe`, which names the most recent **tag** — so between a version bump and its tag it legitimately reads `v0.4.7-3-gabc` while the crate already says `0.4.8`. Asserting the two agree would fail every release-bump PR, which is the one moment they must be allowed to differ.