### PR TITLE
chore(release): bump version to 0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump for the v0.4.8 release: `0.4.7` -> `0.4.8` across the four files that carry it
(`Cargo.toml`, two `Cargo.lock` entries, `camelid-desktop/Cargo.toml`,
`camelid-desktop/tauri.conf.json`). Same shape as the v0.4.6 and v0.4.7 bumps — 4 files, 5 lines,
no other content. `Cargo.lock` is edited in place rather than regenerated so the release build's
`cargo build --release --locked` stays satisfied with no incidental dependency churn.

## What v0.4.8 carries

| PR | change |
| --- | --- |
| #576 | TinyLlama edge pack: `add_special` contradicted its own token arrays |
| #577 | pin the Phi-4-mini artifact by its header region, not all 2.5 GB |
| #578 | sign the installer's payload from inside the bundler, plus a release gate that installs the built installer and asserts the unpacked binary verifies |
| #579 | make every supported row reachable on the Models page |
| #580 | report the running engine version on the System page |

## Watch item for this release run

#578's signing path **has never executed**. It only runs on a tag push, so this release is its
first real exercise. If the Azure dlib wiring is wrong, the new `Prove the INSTALLED binary is
signed` step fails the desktop job rather than publishing a broken signature — and that job is in
no other job's `needs`, so the server artifacts still publish. Worst case is a re-run with the
Windows desktop assets missing, not a bad release.

That gate exists because the two previous releases both shipped defects in exactly the copy no
check could see: v0.4.6 delivered `camelid-desktop.exe` unsigned, v0.4.7 delivered it
`HashMismatch`.