### PR TITLE
chore(release): bump version to 0.4.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump for v0.4.9: `0.4.8` -> `0.4.9` across the four files that carry it. Same shape as
every prior bump — 4 files, 5 lines, no other content. `Cargo.lock` is edited in place so the
release build's `cargo build --release --locked` stays satisfied.

## Why this release exists

**v0.4.8 shipped with no Windows desktop installer.** `desktop-windows` failed, the server
artifacts published anyway, the release became `latest`, and the documented one-command install
broke for every user. #583 fixed the cause and added two guards; this release is the first one
where the signing path completes end to end.

| PR | change |
| --- | --- |
| #583 | absolute `signCommand` paths (the v0.4.8 cause), `verify-release-assets` demotion guard, and installer-script fallback |

## What this release run is the first real test of

The Azure signing call itself, and both new guards. The *wiring* is already proven by a real
local bundle — all seven `signCommand` invocations spawn and the installer builds — but the
signing service call only happens on a tag push.

Failure can no longer reach users, which is the point:

- `Prove the INSTALLED binary is signed` installs the built installer on the runner and asserts
  the unpacked binary verifies. A bad signature fails the job instead of publishing.
- `verify-release-assets` demotes any release with a missing asset to a prerelease, so
  `releases/latest` keeps pointing at a release that actually installs.
- `scripts/get-desktop-windows.ps1` walks back to the newest release that publishes an installer
  regardless, so the one-command install works even if a future publish gap slips past CI.