### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.4.8"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.4.8"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump for v0.5.0: `0.4.8` -> `0.5.0` across the four files that carry it. Same shape as
every prior bump — 4 files, 5 lines, no other content. `Cargo.lock` is edited in place so the
release build's `cargo build --release --locked` stays satisfied.

## What v0.5.0 carries

| PR | change |
| --- | --- |
| #581 | GGUF lane hash cache |
| #583 | absolute `signCommand` paths, `verify-release-assets` demotion guard, installer-script fallback |
| #585 | gemma3 long-prompt TTFT: batched windowed prefill and attention (campaign Phases 1-4) |

## Why this release matters beyond its contents

**v0.4.8 published with no Windows desktop installer.** Its `desktop-windows` job failed, the
server artifacts published anyway, the release became `latest`, and the documented one-command
install broke. v0.5.0 is the first release since v0.4.7 that should carry a complete Windows
desktop artifact set — and the first ever where the installer's payload binary is correctly
signed (v0.4.6 shipped it `NotSigned`, v0.4.7 `HashMismatch`, v0.4.8 not at all).

This run is the first real exercise of the Azure signing call and of both new guards. The
signing *wiring* is already proven by a real local bundle — all seven `signCommand` invocations
spawn and the installer builds — but the service call only happens on a tag push.

Failure can no longer reach users:

- `Prove the INSTALLED binary is signed` installs the built installer on the runner and asserts
  the unpacked binary verifies, so a bad signature fails the job instead of publishing.
- `verify-release-assets` demotes any release with a missing asset to a prerelease, keeping
  `releases/latest` on a release that actually installs.
- `scripts/get-desktop-windows.ps1` walks back to the newest release that publishes an installer
  regardless, which is what un-broke the one-command install ahead of this release.