### PR TITLE
fix(release): make signing observable, and never trade an installer for a signature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,11 +472,24 @@ jobs:
             CorrelationId          = "${{ github.run_id }}-${{ github.run_attempt }}"
           } | ConvertTo-Json | Set-Content -Path $metadata -Encoding utf8
 
+          # Tauri discards the sign command's output when it exits non-zero, so the hook also
+          # writes to this log and the step below prints it unconditionally. Three releases
+          # failed here with nothing but `failed to run <cmd>` to go on.
+          $signLog = Join-Path $env:RUNNER_TEMP 'camelid-sign.log'
+          New-Item -ItemType File -Force -Path $signLog | Out-Null
+
           "CAMELID_SIGNTOOL=$($signtool.FullName)"     | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
           "CAMELID_SIGN_DLIB=$($dlib.FullName)"        | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
           "CAMELID_SIGN_METADATA=$metadata"            | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+          "CAMELID_SIGN_LOG=$signLog"                  | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
           Write-Host "signtool: $($signtool.FullName)"
           Write-Host "dlib    : $($dlib.FullName)"
+          Write-Host "sign log: $signLog"
+
+          # Print the metadata the dlib will read. Endpoint/account/profile come from repo vars;
+          # if any were empty the signing would fail with an opaque error, so surface them.
+          Write-Host "metadata.json:"
+          (Get-Content $metadata -Raw) -split "`n" | ForEach-Object { Write-Host "  $_" }
 
           # Generate the signCommand overlay with ABSOLUTE paths.
           #
@@ -523,6 +536,21 @@ jobs:
         # error. tauri.signing.conf.json is generated above and carries the absolute-path
         # signCommand. Later --config wins on conflict, so signing is applied last.
         run: npx tauri build --config tauri.bundle.conf.json --config tauri.signing.conf.json
+
+      # ALWAYS print the sign log, pass or fail. Tauri discards the hook's output on a non-zero
+      # exit and reports only `failed to bundle project: failed to run <cmd>`, which is what made
+      # three consecutive release failures undiagnosable from CI alone.
+      - name: Sign-command log
+        if: always()
+        shell: pwsh
+        run: |
+          if ($env:CAMELID_SIGN_LOG -and (Test-Path $env:CAMELID_SIGN_LOG)) {
+            Write-Host "----- $env:CAMELID_SIGN_LOG -----"
+            Get-Content $env:CAMELID_SIGN_LOG
+            Write-Host "----- end -----"
+          } else {
+            Write-Host "no sign log at '$($env:CAMELID_SIGN_LOG)' - the hook never ran"
+          }
 
       # Assemble the portable layout, and stage the installer INTO it so a single post-build
       # signing pass covers both the portable camelid-desktop.exe and the NSIS installer.
@@ -628,20 +656,32 @@ jobs:
 
           $sig = Get-AuthenticodeSignature $exe
           Write-Host "installed camelid-desktop.exe -> $($sig.Status)"
-          if ($sig.Status -ne 'Valid') {
-            throw ("the installer delivers camelid-desktop.exe as '$($sig.Status)'. " +
-              "A user installing this release would run a binary Windows does not trust. " +
-              "Check that bundle.windows.signCommand ran (look for 'sign-artifact-signing:' above).")
+          # `Valid` is the goal; `NotSigned` is tolerated; anything else FAILS.
+          #
+          # A BROKEN signature is the one outcome worse than no signature: Windows reports a
+          # tampered chain, it earns no SmartScreen reputation, and it cannot be explained as
+          # "unsigned". That is what v0.4.7 shipped (HashMismatch on every installed copy).
+          # `NotSigned` is a known, previously accepted posture (v0.4.6) and, crucially, still
+          # produces an installer that works -- failing the release over it is how users ended up
+          # with NO Windows installer at all on v0.4.8 and v0.5.0, which is strictly worse.
+          if ($sig.Status -eq 'Valid') {
+            Write-Host 'OK: the installer delivers a correctly signed camelid-desktop.exe'
+          } elseif ($sig.Status -eq 'NotSigned') {
+            Write-Warning ("the installer delivers camelid-desktop.exe UNSIGNED. The release still " +
+              "ships and installs, but signing did not run -- see the Sign-command log step above.")
+          } else {
+            throw ("the installer delivers camelid-desktop.exe as '$($sig.Status)' -- a BROKEN " +
+              "signature, which is worse than none. Refusing to publish it.")
           }
 
-          # The sidecar is signed before bundling and must survive the same path.
+          # The sidecar is signed before bundling by the signing action, which is a proven path,
+          # so the same three-way rule applies but a regression here is far more suspicious.
           $side = Join-Path $target 'sidecar\camelid.exe'
-          if (Test-Path $side) {
-            $ss = (Get-AuthenticodeSignature $side).Status
-            Write-Host "installed sidecar camelid.exe -> $ss"
-            if ($ss -ne 'Valid') { throw "the installer delivers sidecar\camelid.exe as '$ss'" }
-          } else {
-            throw "installer did not place sidecar\camelid.exe in $target"
+          if (-not (Test-Path $side)) { throw "installer did not place sidecar\camelid.exe in $target" }
+          $ss = (Get-AuthenticodeSignature $side).Status
+          Write-Host "installed sidecar camelid.exe -> $ss"
+          if ($ss -notin @('Valid', 'NotSigned')) {
+            throw "the installer delivers sidecar\camelid.exe as '$ss' -- a broken signature"
           }
 
           Remove-Item -Recurse -Force $target -ErrorAction SilentlyContinue

--- a/camelid-desktop/tests/installer_hooks.rs
+++ b/camelid-desktop/tests/installer_hooks.rs
@@ -96,21 +96,67 @@ fn sign_command_paths_must_be_absolute() {
     );
 }
 
-/// The signing script must fail rather than return success when it cannot sign. A hook that
-/// swallows an error hands the bundler an unsigned binary and reports nothing, which is
-/// exactly the silent failure the release gate exists to catch.
+/// The signing script's failure policy, which is deliberately asymmetric.
+///
+/// A signtool failure must NOT fail the bundle: the release still has to produce an installer.
+/// Failing there is what left users with no Windows installer at all on v0.4.8 and v0.5.0 —
+/// strictly worse than the unsigned-payload installer v0.4.6 shipped, which installed and ran.
+///
+/// A signature that does not verify IS fatal: v0.4.7 shipped `HashMismatch` on every installed
+/// copy, and Windows reports that as a tampered chain. Broken is worse than absent.
 #[test]
-fn sign_script_fails_closed_on_a_signing_error() {
+fn sign_script_ships_unsigned_on_failure_but_never_ships_a_broken_signature() {
     let src =
         std::fs::read_to_string(desktop_dir().join(SIGN_SCRIPT)).expect("read signing script");
 
     assert!(
-        src.contains("$LASTEXITCODE -ne 0"),
-        "the signing script must check signtool's exit code"
+        src.contains("$signExit -ne 0"),
+        "the signing script must capture and check signtool's exit code"
+    );
+    assert!(
+        src.contains("shipping this file UNSIGNED rather than failing the bundle"),
+        "a signtool failure must be non-fatal, or a signing outage means users get no installer"
+    );
+    assert!(
+        src.contains("refusing to seal a broken signature"),
+        "a result that does not verify must be fatal: a broken signature is worse than none"
     );
     assert!(
         src.contains("-ne 'Valid'"),
-        "the signing script must verify the resulting signature, not just signtool's exit code"
+        "the script must verify the resulting signature, not just signtool's exit code"
+    );
+}
+
+/// The hook must log to a file, because Tauri DISCARDS its output on a non-zero exit and
+/// reports only `failed to bundle project: failed to run <cmd>`. Three consecutive releases
+/// failed here with nothing else to go on, and each diagnosis was guesswork.
+///
+/// It must also drop `$ErrorActionPreference` for the native signtool call: Windows PowerShell
+/// wraps a redirected native command's stderr in NativeCommandError records, and under `Stop`
+/// that is terminating — the script would die on signtool's first diagnostic line and never
+/// reach its own exit-code handling, turning any hiccup into an unexplained bundle failure.
+#[test]
+fn sign_script_is_observable_when_tauri_swallows_its_output() {
+    let src =
+        std::fs::read_to_string(desktop_dir().join(SIGN_SCRIPT)).expect("read signing script");
+    let wf = release_workflow();
+
+    assert!(
+        src.contains("CAMELID_SIGN_LOG"),
+        "the signing script must write to a log file; Tauri discards its stdout on failure"
+    );
+    assert!(
+        src.contains("$ErrorActionPreference = 'Continue'"),
+        "the native signtool call must run with ErrorActionPreference dropped, or a stderr line \
+         terminates the script before its exit-code handling runs"
+    );
+    assert!(
+        wf.contains("CAMELID_SIGN_LOG=$signLog"),
+        "the release workflow must set CAMELID_SIGN_LOG"
+    );
+    assert!(
+        wf.contains("name: Sign-command log"),
+        "the release workflow must print the sign log so a failure is diagnosable from CI alone"
     );
 }
 

--- a/camelid-desktop/windows/sign-artifact-signing.ps1
+++ b/camelid-desktop/windows/sign-artifact-signing.ps1
@@ -41,12 +41,28 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# EVERYTHING goes to a log file as well as stdout.
+#
+# Tauri SWALLOWS this script's output when it exits non-zero -- it prints
+# `failed to bundle project: failed to run <cmd>` and nothing else. Three consecutive releases
+# died here and every diagnosis was guesswork, because the one thing that would have explained
+# the failure was the output being discarded. CAMELID_SIGN_LOG is an absolute path the workflow
+# sets and prints after the bundle step, whether that step passed or failed.
+$logPath = $env:CAMELID_SIGN_LOG
+function Note([string]$message) {
+    $line = "sign-artifact-signing: $message"
+    Write-Host $line
+    if ($logPath) {
+        try { Add-Content -LiteralPath $logPath -Value "[$(Get-Date -Format o)] $line" } catch { }
+    }
+}
+
 $signtool = $env:CAMELID_SIGNTOOL
 $dlib = $env:CAMELID_SIGN_DLIB
 $metadata = $env:CAMELID_SIGN_METADATA
 
 if (-not $signtool -and -not $dlib -and -not $metadata) {
-    Write-Host "sign-artifact-signing: signing not configured (CAMELID_SIGNTOOL unset) - skipping $Path"
+    Note "signing not configured (CAMELID_SIGNTOOL unset) - skipping $Path"
     exit 0
 }
 
@@ -57,33 +73,66 @@ foreach ($pair in @(
         @{ Name = 'CAMELID_SIGN_DLIB'; Value = $dlib },
         @{ Name = 'CAMELID_SIGN_METADATA'; Value = $metadata })) {
     if (-not $pair.Value) {
-        throw "signing is partially configured: $($pair.Name) is empty while others are set"
+        Note "FATAL: signing is partially configured: $($pair.Name) is empty while others are set"
+        exit 1
     }
-    if ($pair.Name -ne 'CAMELID_SIGNTOOL' -and -not (Test-Path $pair.Value)) {
-        throw "$($pair.Name) points at '$($pair.Value)', which does not exist"
+    if (-not (Test-Path -LiteralPath $pair.Value)) {
+        Note "FATAL: $($pair.Name) points at '$($pair.Value)', which does not exist"
+        exit 1
     }
 }
 
-if (-not (Test-Path $Path)) {
-    throw "nothing to sign at '$Path'"
+if (-not (Test-Path -LiteralPath $Path)) {
+    Note "FATAL: nothing to sign at '$Path'"
+    exit 1
 }
 
-Write-Host "sign-artifact-signing: signing $Path"
+Note "signing $Path"
 
 # Timestamping is not optional here: Artifact Signing certificates are valid for three days,
 # so an untimestamped signature stops verifying almost immediately after release.
-& $signtool sign /v /debug /fd SHA256 `
-    /tr http://timestamp.acs.microsoft.com /td SHA256 `
-    /dlib $dlib /dmdf $metadata `
-    $Path
-if ($LASTEXITCODE -ne 0) {
-    throw "signtool failed with exit code $LASTEXITCODE for $Path"
+#
+# `$ErrorActionPreference` is dropped to Continue for exactly this call. Windows PowerShell wraps
+# every stderr line of a native command in a NativeCommandError ErrorRecord when the stream is
+# redirected, and under 'Stop' that is TERMINATING -- the script would die on signtool's first
+# diagnostic line and never reach the exit-code check below, turning any signing hiccup into an
+# unexplained bundle failure. Verified locally: with 'Stop' this path exited 1 instead of 0.
+$previousPreference = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    $output = & $signtool sign /v /debug /fd SHA256 `
+        /tr http://timestamp.acs.microsoft.com /td SHA256 `
+        /dlib $dlib /dmdf $metadata `
+        $Path 2>&1
+    $signExit = $LASTEXITCODE
+} finally {
+    $ErrorActionPreference = $previousPreference
+}
+foreach ($line in @($output)) { Note "  signtool| $line" }
+
+# A SIGNTOOL FAILURE IS NOT FATAL TO THE BUILD.
+#
+# The bundler must still produce an installer. Failing here is what left users with no Windows
+# installer at all on v0.4.8 and v0.5.0 -- strictly worse than the unsigned-payload installer
+# v0.4.6 shipped, which at least installed and ran. An unsigned binary is a known, previously
+# accepted posture; no binary is not. The release's `Prove the INSTALLED binary is signed` step
+# reports what actually shipped, and `verify-release-assets` guarantees an incomplete release
+# never becomes `latest`.
+if ($signExit -ne 0) {
+    Note "WARNING: signtool exited $signExit for $Path - shipping this file UNSIGNED rather than failing the bundle"
+    exit 0
 }
 
-# Fail closed on the result, not just the exit code: a signature that does not verify on the
-# machine that just produced it will not verify on a user's machine either.
-$status = (Get-AuthenticodeSignature -FilePath $Path).Status
+# THIS one is fatal, and it is the only fatal case.
+#
+# signtool claiming success while the result does not verify means we are about to seal a
+# BROKEN signature into the installer -- exactly what v0.4.7 shipped, where every installed copy
+# reported HashMismatch. A broken signature is worse than no signature: Windows reports a
+# tampered chain, it earns no SmartScreen reputation, and it cannot be explained away as
+# "unsigned". Better to fail the release than ship that.
+$status = (Get-AuthenticodeSignature -LiteralPath $Path).Status
 if ($status -ne 'Valid') {
-    throw "signtool reported success but $Path verifies as '$status'"
+    Note "FATAL: signtool reported success but $Path verifies as '$status' - refusing to seal a broken signature"
+    exit 1
 }
-Write-Host "sign-artifact-signing: $Path -> Valid"
+Note "$Path -> Valid"


### PR DESCRIPTION
Three consecutive releases died in the same bundler step and every diagnosis was guesswork, because **Tauri discards the sign command's output on a non-zero exit** — it prints `failed to bundle project: failed to run <cmd>` and nothing else. On v0.5.0 the hook ran for five seconds and emitted nothing visible.

## Observability

The hook now writes every line — including signtool's own stderr — to `CAMELID_SIGN_LOG`, and the workflow prints that log **unconditionally** after the bundle step (`if: always()`). The prep step also echoes the generated `metadata.json`, since an empty endpoint/account/profile would otherwise fail opaquely.

## Policy, deliberately asymmetric

| outcome | before | now |
| --- | --- | --- |
| signtool fails | bundle fails → **no installer at all** | installer ships, payload unsigned, loud warning |
| signature does not verify | shipped (v0.4.7 `HashMismatch`) | **fatal**, refuses to publish |

Failing the bundle on a signing error is what left users with no Windows installer on v0.4.8 and v0.5.0. That is strictly worse than the unsigned-payload installer v0.4.6 shipped, which installed and ran — unsigned is a posture this project has already shipped; no installer is not. A *broken* signature stays fatal: Windows reports a tampered chain and it earns no SmartScreen reputation.

`Prove the INSTALLED binary is signed` now applies the same three-way rule (`Valid` ok, `NotSigned` warn, anything else fail) instead of demanding `Valid`.

## A bug found while testing this

Capturing signtool's output with `2>&1` under `$ErrorActionPreference = 'Stop'` made the script die on signtool's **first stderr line**. Windows PowerShell wraps a redirected native command's stderr in `NativeCommandError` records, and under `Stop` that is terminating — so it exited 1 where it had to exit 0, never reaching its own exit-code handling. The native call now runs with the preference dropped and restored in a `finally`.

Caught only by running the script directly. Asserting on its text would have missed it — the same mistake that shipped v0.4.8.

## Verified

A real bundle with a deliberately failing signtool, which is the exact v0.5.0 scenario:

```
sign-artifact-signing:   signtool| ERROR: Invalid argument or option - '/v'.
sign-artifact-signing: WARNING: signtool exited 2 for ...Camelid Desktop_0.5.0_x64-setup.exe
                       - shipping this file UNSIGNED rather than failing the bundle
    Finished 1 bundle at: ...\Camelid Desktop_0.5.0_x64-setup.exe
TAURI EXIT: 0
```

All 8 invocations warn, the bundle exits 0, **the installer is produced**, and the log carries the exact signtool error.

Gates: `cargo fmt --all --check` clean, clippy `-D warnings` clean, 9 tests passing (two new ones pin the failure policy and the observability contract), `check-public-scrub.sh` passes, workflow YAML parses.

## Release state while this lands

`releases/latest` currently resolves to **v0.4.7**, a complete release with a working installer. v0.4.8 and v0.5.0 are demoted to prereleases — their assets stay downloadable, they just cannot be `latest`. The one-command install works today regardless, because the script walks back to the newest release that publishes an installer.