### PR TITLE
chore(release): bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump: `0.5.0` -> `0.5.1`. Four files, five lines, `Cargo.lock` edited in place so
`cargo build --release --locked` stays satisfied.

## Why 0.5.1 and not a re-tag of 0.5.0

v0.5.0's `desktop-windows` job failed, so that release published its server artifacts and no
Windows desktop assets, and the completeness guard demoted it to a prerelease. The fix is #587,
which landed after the v0.5.0 tag.

Re-pointing the `v0.5.0` tag at the fixed commit would attach already-published bytes to a
different ref — the exact thing this workflow's tag-identity design forbids ("a dispatch cannot
build one ref and attach those bytes to a different tag"). So v0.5.0 stays as a demoted
prerelease and this is the release that carries the fix.

## What lands here

| PR | change |
| --- | --- |
| #587 | sign log printed unconditionally; signing failure ships an unsigned installer instead of no installer; broken signature stays fatal; fixed the `2>&1` under `ErrorActionPreference=Stop` trap |

Everything already in v0.5.0 (#581, #583, #585) rides along, since v0.5.0's code is in `main`.

## What this release run should show

The sign log is now printed whether the bundle passes or fails, so this is the first run that
can actually answer whether Azure signing works from inside the bundler — and it answers it
either way, because a signing failure no longer stops the installer being produced.

Expected outcomes, all of which end with a usable Windows installer:

- signing works -> installed `camelid-desktop.exe` verifies `Valid`; first release ever to do so
- signing fails -> installer still ships with an unsigned payload, log shows exactly why
- broken signature -> job fails, release demoted, `releases/latest` stays on v0.4.7

`releases/latest` currently resolves to v0.4.7 and installs correctly; the one-command install
works today regardless of this release.