### PR TITLE
fix(release): survive the signature read-back race, and make any failure name itself

### DIFF
--- a/camelid-desktop/tests/installer_hooks.rs
+++ b/camelid-desktop/tests/installer_hooks.rs
@@ -158,6 +158,40 @@ fn sign_script_is_observable_when_tauri_swallows_its_output() {
         wf.contains("name: Sign-command log"),
         "the release workflow must print the sign log so a failure is diagnosable from CI alone"
     );
+    assert!(
+        src.contains("trap {"),
+        "the script needs a trap: v0.5.1 signed successfully and then exited non-zero with the \
+         log ending mid-script, because an unhandled terminating error names itself only on \
+         stderr — which Tauri discards"
+    );
+}
+
+/// Reading the signature back must never be able to kill the bundle.
+///
+/// signtool has just closed the file and the signing service wrote to it moments earlier, so
+/// the read can lose a race against antivirus or a lingering handle. On v0.5.1 signtool reported
+/// `Number of errors: 0` and the script still exited non-zero 0.28s later, in exactly this read.
+///
+/// Unreadable is not the same as broken: failing there discards a correctly signed binary over a
+/// transient lock and lands back on the no-installer outcome. A CONFIRMED non-`Valid` result
+/// stays fatal.
+#[test]
+fn signature_readback_retries_and_an_unreadable_result_is_not_fatal() {
+    let src =
+        std::fs::read_to_string(desktop_dir().join(SIGN_SCRIPT)).expect("read signing script");
+
+    assert!(
+        src.contains("for ($attempt = 1; $attempt -le 5; $attempt++)"),
+        "the signature read-back must retry; it races the signing service's own write"
+    );
+    assert!(
+        src.contains("could not read back the signature"),
+        "an unreadable signature must warn and continue, not fail the bundle"
+    );
+    assert!(
+        src.contains("refusing to seal a broken signature"),
+        "a CONFIRMED non-Valid signature must still be fatal"
+    );
 }
 
 /// An incomplete release must never become `latest`. The desktop jobs are independent by

--- a/camelid-desktop/windows/sign-artifact-signing.ps1
+++ b/camelid-desktop/windows/sign-artifact-signing.ps1
@@ -57,6 +57,18 @@ function Note([string]$message) {
     }
 }
 
+# NOTHING may die silently in here again.
+#
+# v0.5.1 signed successfully and then vanished: signtool reported `Number of errors: 0`, and
+# 0.28s later Tauri reported `failed to run <cmd>` with the log ending mid-script. An unhandled
+# terminating error under `ErrorActionPreference = 'Stop'` produces exactly that -- the process
+# exits non-zero, and Tauri discards the stderr that would have named it. This trap makes any
+# such error self-reporting instead of another round of inference.
+trap {
+    Note "FATAL: unhandled error at line $($_.InvocationInfo.ScriptLineNumber): $($_.Exception.GetType().Name): $($_.Exception.Message)"
+    exit 1
+}
+
 $signtool = $env:CAMELID_SIGNTOOL
 $dlib = $env:CAMELID_SIGN_DLIB
 $metadata = $env:CAMELID_SIGN_METADATA
@@ -123,14 +135,41 @@ if ($signExit -ne 0) {
     exit 0
 }
 
-# THIS one is fatal, and it is the only fatal case.
+# Read back what was actually written, with retries.
 #
-# signtool claiming success while the result does not verify means we are about to seal a
-# BROKEN signature into the installer -- exactly what v0.4.7 shipped, where every installed copy
-# reported HashMismatch. A broken signature is worse than no signature: Windows reports a
-# tampered chain, it earns no SmartScreen reputation, and it cannot be explained away as
-# "unsigned". Better to fail the release than ship that.
-$status = (Get-AuthenticodeSignature -LiteralPath $Path).Status
+# signtool has just closed this file and the signing service wrote to it moments earlier, so the
+# read can lose a race against antivirus or a lingering handle. That read must never be able to
+# kill the bundle: on v0.5.1 signtool reported `Number of errors: 0` and the script still exited
+# non-zero 0.28s later, with the log ending right here -- the signature: an unhandled terminating
+# error in this exact read.
+$status = $null
+for ($attempt = 1; $attempt -le 5; $attempt++) {
+    try {
+        $status = (Get-AuthenticodeSignature -LiteralPath $Path).Status
+        break
+    } catch {
+        Note "  verify attempt $attempt could not read the signature: $($_.Exception.Message)"
+        Start-Sleep -Milliseconds 300
+    }
+}
+
+# UNREADABLE is not the same as BROKEN, and must not be treated as such.
+#
+# Failing here would throw away a correctly signed binary over a transient file lock, and put us
+# straight back to the no-installer outcome of v0.4.8 and v0.5.0. The release's `Prove the
+# INSTALLED binary is signed` step opens the finished installer and checks the payload for real;
+# that is the authoritative verdict, and it runs on a settled file.
+if ($null -eq $status) {
+    Note "WARNING: could not read back the signature of $Path after signing - continuing; the release install-verify gate is authoritative"
+    exit 0
+}
+
+# A CONFIRMED bad signature is the one fatal case.
+#
+# signtool claiming success while the result verifies as something other than Valid means we are
+# about to seal a BROKEN signature into the installer -- exactly what v0.4.7 shipped, where every
+# installed copy reported HashMismatch. Windows reports that as a tampered chain, it earns no
+# SmartScreen reputation, and it cannot be explained away as "unsigned".
 if ($status -ne 'Valid') {
     Note "FATAL: signtool reported success but $Path verifies as '$status' - refusing to seal a broken signature"
     exit 1


### PR DESCRIPTION
## Azure signing works

v0.5.1's sign log — the first one that actually got printed — shows the service succeeding:

```
Signing completed with status 'Succeeded' in 2.7648885s
Successfully signed: ...\target\release\camelid-desktop.exe
Number of files successfully Signed: 1
Number of errors: 0
```

Endpoint, account and certificate profile all resolved. The whole Azure path is fine.

## And the bundle failed anyway

```
15:03:36.56  Tauri: Signing camelid-desktop.exe with a custom signing command
15:03:42.19  signtool: Successfully signed. Number of errors: 0
15:03:42.47  Tauri: failed to run powershell            <-- 0.28s later
```

The log ends past signtool's output and before either branch that follows it. The only statement in between is the `Get-AuthenticodeSignature` read-back — and an unhandled terminating error there produces exactly this shape: non-zero exit, with the stderr that would have named it discarded by Tauri.

## Two changes

**1. The read-back retries, and unreadable is not fatal.** signtool has just closed the file and the signing service wrote to it moments earlier, so the read races antivirus and lingering handles. Five attempts, then warn and continue.

Unreadable is not the same as broken. Failing there throws away a *correctly signed* binary over a transient lock and lands straight back on the no-installer outcome. `Prove the INSTALLED binary is signed` opens the finished installer and checks the payload on a settled file — that is the authoritative verdict. A **confirmed** non-`Valid` result stays fatal.

**2. A `trap` that names the failure.** Any unhandled error now logs its line number and exception type. Three releases were diagnosed by inference because the failing statement never identified itself.

## Verified locally

A tampered binary — signtool "succeeds", result does not verify — still exits 1 with the reason logged:

```
FATAL: signtool reported success but ...\tampered.exe verifies as 'NotSigned'
       - refusing to seal a broken signature
  exit=1
```

Gates: fmt clean, clippy `-D warnings` clean, 10 tests passing (two new ones pin the retry contract and the trap), scrub passes.

## Release state

`releases/latest` is v0.4.7 and installs correctly; the one-command install works today. v0.4.8, v0.5.0 and v0.5.1 are demoted prereleases.