### PR TITLE
chore(release): bump version to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump: `0.5.1` -> `0.5.2`. Four files, five lines.

## What lands here

| PR | change |
| --- | --- |
| #589 | signature read-back retries and is non-fatal when unreadable; `trap` names any unhandled error |

Everything from v0.5.0 and v0.5.1 rides along — #581, #583, #585, #587 are all in `main`.

## Why this one should complete

v0.5.1's sign log confirmed **Azure signing works**:

```
Signing completed with status 'Succeeded' in 2.7648885s
Successfully signed: ...\target\release\camelid-desktop.exe
Number of errors: 0
```

The bundle failed 0.28s later, in the `Get-AuthenticodeSignature` read-back that follows — a race
against the file signtool had just closed. #589 retries that read and treats an unreadable result
as a warning rather than a failure, because unreadable is not broken and failing there discards a
correctly signed binary.

Expected: the first release whose installed `camelid-desktop.exe` verifies as `Valid`.
v0.4.6 shipped it `NotSigned`, v0.4.7 `HashMismatch`, v0.4.8 / v0.5.0 / v0.5.1 shipped no Windows
installer at all.

If anything still goes wrong, the guards hold as they have throughout: the bundle no longer fails
on a signing problem, `verify-release-assets` demotes an incomplete release, `releases/latest`
stays on v0.4.7, and the one-command install keeps working.