### PR TITLE
test: stop the startup-readiness poll failing on slow runners, and say which thing broke

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2641,9 +2641,20 @@ mod startup_model_tests {
         // Camelid picked the file itself, so it owes the user a running server
         // and the UI to choose again — not an exit that reinstalling can't fix,
         // because the models directory outlives the app.
+        //
+        // Two failure modes, asserted separately. The contract this test guards is that the
+        // serve task STAYS ALIVE; reaching /v1/health is how we confirm it is really serving.
+        // Collapsing both into one `healthy` flag made a slow runner indistinguishable from a
+        // genuine regression — the old form polled a fixed 100 × 100 ms and failed CI with
+        // "must not take the server down" even when the server was up and merely slow to bind.
+        // The wait is now deadline-based and generous; it costs nothing in the passing case
+        // because the loop exits the moment health answers.
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
         let mut healthy = false;
-        for _ in 0..100 {
+        let mut exited_early = false;
+        while std::time::Instant::now() < deadline {
             if server.is_finished() {
+                exited_early = true;
                 break;
             }
             if tokio::task::spawn_blocking(move || health_ok(addr))
@@ -2658,8 +2669,15 @@ mod startup_model_tests {
         server.abort();
 
         assert!(
+            !exited_early,
+            "an auto-selected startup model that cannot load must not take the server down, \
+             but the serve task exited on its own"
+        );
+        assert!(
             healthy,
-            "an auto-selected startup model that cannot load must not take the server down"
+            "the serve task stayed alive but never answered /v1/health within 60s — the \
+             startup-model contract held, so suspect a slow or loaded runner rather than a \
+             regression in it"
         );
     }
 


### PR DESCRIPTION
`an_auto_selected_startup_model_that_cannot_load_keeps_the_server_up` polled a fixed `100 × 100ms` for `/v1/health`. `health_ok` fails **instantly** on loopback when nothing is listening yet — connection refused returns immediately — so that is a hard 10-second budget, and a loaded runner blows through it.

It cost a CI cycle during the v0.5.2 release: the identical commit passed the same job in the duplicate run, 1421 passed / 1 failed.

## The worse problem was the diagnosis

Both outcomes collapsed into one `healthy` flag, so CI reported:

```
an auto-selected startup model that cannot load must not take the server down
```

…even when the server was up and merely slow to bind. That is the opposite of what the test guards, and it sends whoever reads it after the wrong defect.

## Fix

Deadline-based at 60s, with the two failure modes asserted separately:

| outcome | meaning |
| --- | --- |
| serve task exited on its own | the regression this test exists to catch |
| alive but health never answered | says so, and points at the runner rather than the startup-model contract |

Costs nothing in the passing case — the loop still exits the moment health answers. Measured locally: **10.38s for both startup tests together**, unchanged.

## Scope

Checked for the same pattern elsewhere in the crate. The only other fixed-iteration poll is `warmup_request`, which is production code that swallows errors by design and cannot fail a test.

Gates: `cargo fmt --all --check` clean, `clippy -p camelid --all-targets --all-features -D warnings` clean, both startup tests pass locally, scrub passes.