### PR TITLE
fix(distributed): give the serve-distributed coordinator the output head

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9682,27 +9682,36 @@ async fn load_weights_lru(
     }
 
     let store = TensorStore::open(&model.path, &model.gguf);
-    let range = if let Some(&(layer_start, layer_end)) = crate::distributed::DISTRIBUTED_RANGE.get()
-    {
-        tracing::info!(
-            "API loader running in distributed coordinator mode; loading layers {}..{}",
-            layer_start,
-            layer_end
-        );
-        Some(layer_start..layer_end)
-    } else {
-        None
-    };
-    let weights = Arc::new(
-        LlamaLoadedWeights::load(&store, binding, range).map_err(|err| {
-            api_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "loaded_cpu_weights_unavailable",
-                err.to_string(),
-                Some("model"),
+    // Only the coordinator reaches the API loader; a worker runs `run_worker_loop` instead.
+    // Its ownership is role-derived, not positional -- see `distributed::PipelineRole`.
+    let loaded = match crate::distributed::DISTRIBUTED_RANGE.get() {
+        Some(&(layer_start, layer_end)) => {
+            let (load_embedding, load_output) =
+                crate::distributed::PipelineRole::Coordinator.tensor_ownership();
+            tracing::info!(
+                "API loader running in distributed coordinator mode; loading layers {}..{}",
+                layer_start,
+                layer_end
+            );
+            LlamaLoadedWeights::load_distributed(
+                &store,
+                binding,
+                layer_start,
+                layer_end,
+                load_embedding,
+                load_output,
             )
-        })?,
-    );
+        }
+        None => LlamaLoadedWeights::load(&store, binding, None),
+    };
+    let weights = Arc::new(loaded.map_err(|err| {
+        api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "loaded_cpu_weights_unavailable",
+            err.to_string(),
+            Some("model"),
+        )
+    })?);
 
     state
         .cached_weights

--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -7,6 +7,62 @@ use crate::error::{BackendError, Result};
 use crate::inference::LlamaInferenceSession;
 use crate::tensor::{CpuTensor, Q4KRepack8Cell, RuntimeDType, TensorShape};
 
+/// Which whole-model tensors a node loads in the `serve-distributed` pipeline.
+///
+/// Ownership here is a property of the **role**, not of the layer range. A worker's
+/// [`LlamaInferenceSession::forward_worker_layers`] returns a bare hidden state — it
+/// applies neither `output_norm` nor the output projection — so the coordinator always
+/// finalizes the forward pass and needs both ends of the model whatever shard it holds.
+///
+/// [`crate::inference::LlamaLoadedWeights::load`] instead derives ownership *positionally*,
+/// for a generic pipeline whose LAST stage emits logits. Using that rule here gives a
+/// `0..k` coordinator no output projection, and every request fails with
+/// `runtime shape mismatch: ... requires rank-2 weight token_embd.weight, got [0]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipelineRole {
+    /// Runs the HTTP API, owns its layer shard plus the embedding and output head.
+    Coordinator,
+    /// Owns its layer shard only.
+    Worker,
+}
+
+impl PipelineRole {
+    /// `(load_embedding, load_output)` for
+    /// [`crate::inference::LlamaLoadedWeights::load_distributed`].
+    pub const fn tensor_ownership(self) -> (bool, bool) {
+        match self {
+            Self::Coordinator => (true, true),
+            Self::Worker => (false, false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod pipeline_role_tests {
+    use super::PipelineRole;
+
+    /// The rule this transport needs is deliberately *not* the positional one. If anyone
+    /// "simplifies" `tensor_ownership` back to deriving from the layer range, a `0..k`
+    /// coordinator silently loses the output head again and every request 503s.
+    #[test]
+    fn the_coordinator_owns_both_ends_whatever_shard_it_holds() {
+        assert_eq!(PipelineRole::Coordinator.tensor_ownership(), (true, true));
+        assert_eq!(PipelineRole::Worker.tensor_ownership(), (false, false));
+
+        // The positional rule `LlamaLoadedWeights::load` applies, restated here: the first
+        // shard owns the embedding, the last shard owns the output head.
+        let total_layers = 16;
+        let head_shard = 0..8;
+        let positional = (head_shard.start == 0, head_shard.end >= total_layers);
+        assert_eq!(positional, (true, false));
+        assert_ne!(
+            PipelineRole::Coordinator.tensor_ownership(),
+            positional,
+            "a head-shard coordinator must not inherit the positional rule"
+        );
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct DistributedHeader {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4547,7 +4547,8 @@ impl LlamaInferenceSession {
             if let Some(range) = &self.weights.layer_range {
                 if !range.contains(&layer_idx) {
                     if let Some(client) = crate::distributed::DISTRIBUTED_CLIENT.get() {
-                        let _worker_response = client.forward_to_worker(
+                        // Prefill only warms KV; this returns timings, so the reply is unused.
+                        client.forward_to_worker(
                             &hidden,
                             true,
                             token_ids.len(),
@@ -4794,13 +4795,13 @@ impl LlamaInferenceSession {
             if let Some(range) = &self.weights.layer_range {
                 if !range.contains(&layer_idx) {
                     if let Some(client) = crate::distributed::DISTRIBUTED_CLIENT.get() {
-                        let worker_response = client.forward_to_worker(
+                        // Prefill only warms KV; this returns timings, so the reply is unused.
+                        client.forward_to_worker(
                             &hidden,
                             true,
                             token_ids.len(),
                             self.kv_cache.position,
                         )?;
-                        hidden = worker_response;
                         break;
                     } else {
                         continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1957,13 +1957,15 @@ async fn main() -> anyhow::Result<()> {
                     layer_start,
                     layer_end
                 );
+                let (load_embedding, load_output) =
+                    camelid::distributed::PipelineRole::Worker.tensor_ownership();
                 let weights = camelid::inference::LlamaLoadedWeights::load_distributed(
                     &store,
                     &binding,
                     layer_start,
                     layer_end,
-                    false,
-                    false,
+                    load_embedding,
+                    load_output,
                 )?;
 
                 tracing::info!("Worker weights loaded successfully. Initializing session.");

--- a/tests/distributed_tests.rs
+++ b/tests/distributed_tests.rs
@@ -4,12 +4,12 @@ use tempfile::tempdir;
 use camelid::{
     distributed::{
         run_network_benchmark_worker_on_listener, run_worker_loop_on_listener, DistributedClient,
-        DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE,
+        PipelineRole, DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE,
     },
     gguf::read_metadata,
     inference::{LlamaInferenceSession, LlamaLoadedWeights},
     model::{LlamaModelConfig, LlamaTensorBinding},
-    tensor::TensorStore,
+    tensor::{CpuTensor, TensorStore},
 };
 
 /// Bind loopback on an OS-assigned free port.
@@ -176,6 +176,69 @@ fn pipeline_load_puts_output_weights_on_last_node() {
         "last node loads output_norm"
     );
     last.validate_dense_shapes(&config).unwrap();
+}
+
+/// Regression for defect D1. `serve-distributed` computes logits on the **coordinator** —
+/// `run_worker_loop`'s `forward_worker_layers` returns a bare hidden state, applying
+/// neither `output_norm` nor the output projection — so a coordinator holding a head shard
+/// must still own the output head. That is what `PipelineRole::Coordinator` encodes, and
+/// what `test_distributed_pipeline_parallel_inference` above has always assumed.
+///
+/// The shipped API loader instead derived ownership positionally through
+/// `LlamaLoadedWeights::load`, which reserves the output head for the LAST shard (see
+/// `pipeline_load_puts_output_weights_on_last_node`, correct for that other topology).
+/// The second half here is the negative control: it reproduces in-process the exact
+/// failure that mismatch produced over HTTP.
+#[test]
+fn distributed_coordinator_head_shard_owns_the_output_head() {
+    let dir = tempdir().unwrap();
+    let model_path = dir.path().join("tiny_model.gguf");
+    write_tiny_llama_gguf(&model_path);
+    let gguf = read_metadata(&model_path).unwrap();
+    let binding =
+        LlamaTensorBinding::bind(&gguf, &LlamaModelConfig::from_gguf(&gguf).unwrap()).unwrap();
+    let store = TensorStore::open(&model_path, &gguf);
+
+    // Shaped like a hidden state the worker hands back: [seq, hidden].
+    let from_worker = CpuTensor::from_f32("wire_activation", vec![1, 8], vec![0.0; 8]).unwrap();
+
+    let (load_embedding, load_output) = PipelineRole::Coordinator.tensor_ownership();
+    let coordinator =
+        LlamaLoadedWeights::load_distributed(&store, &binding, 0, 1, load_embedding, load_output)
+            .unwrap();
+    let coordinator =
+        LlamaInferenceSession::new(LlamaModelConfig::from_gguf(&gguf).unwrap(), coordinator)
+            .unwrap();
+    let logits = coordinator
+        .forward_final_norm_and_logits(&from_worker)
+        .expect("a coordinator owning the output head can finalize the forward pass");
+    assert_eq!(logits.shape.dims, vec![1, 16], "[seq, vocab]");
+
+    let positional = LlamaLoadedWeights::load(&store, &binding, Some(0..1)).unwrap();
+    assert_eq!(
+        positional.output_norm.shape.dims,
+        vec![0],
+        "positional ownership leaves a head shard without output_norm"
+    );
+    assert_eq!(
+        positional.output.as_ref().map(|o| o.shape.dims.clone()),
+        Some(vec![0]),
+        "positional ownership leaves a head shard without the output projection"
+    );
+    let positional =
+        LlamaInferenceSession::new(LlamaModelConfig::from_gguf(&gguf).unwrap(), positional)
+            .unwrap();
+    let err = positional
+        .forward_final_norm_and_logits(&from_worker)
+        .expect_err("positional ownership cannot finalize; this was the shipped defect");
+    // Which check trips first depends on the finalize path and on whether the model ties
+    // its output to the embedding; the served 1B model reported the projection
+    // (`token_embd.weight, got [0]`), this untied fixture reports the norm. Both are the
+    // same missing output head, so assert the empty shape rather than one message.
+    assert!(
+        err.to_string().contains("[0]"),
+        "expected a missing-output-head shape error, got: {err}"
+    );
 }
 
 fn write_tiny_llama_gguf(path: &Path) {


### PR DESCRIPTION
## Summary

`camelid serve-distributed --role coordinator` now serves generated tokens, and its output is
identical to a single-node run of the same model.

Before this change the lane could not produce a token. The model loaded, `/v1/health` reported
`generation_ready: true`, and then every generation request failed:

```
HTTP 503
runtime shape mismatch: token-major output projection requires
rank-2 weight token_embd.weight, got [0]
```

Because the failure was at generation time rather than load time, nothing at startup reported a
problem.

## Root cause

Whole-model tensor ownership for the coordinator was derived **positionally** from its layer range.

`api::load_weights_lru` called `LlamaLoadedWeights::load(&store, binding, Some(range))`, and that
helper implements the rule for a generic pipeline whose **last** stage emits logits:

```rust
let load_embedding = layer_range.as_ref().is_none_or(|r| r.start == 0);
let load_output    = layer_range.as_ref().is_none_or(|r| r.end >= total_layers);
```

`serve-distributed` is not that kind of pipeline. Its worker
(`distributed::run_worker_loop` → `LlamaInferenceSession::forward_worker_layers`) returns a **bare
hidden state**; it applies neither `output_norm` nor the output projection. The **coordinator**
always finalizes the forward pass, so it needs the output head no matter which shard it holds.

A coordinator holding `0..k` of `L` therefore evaluated `load_output = false` and owned neither
`output_norm` nor the output projection. `load_output` gates both:

```rust
let output_norm = if load_output { store.load_cpu_f32(&binding.output_norm.name)? } else { /* [0] */ };
let output      = if load_output { /* real */ } else { /* [0] */ };
```

For a tied-embedding model the projection *is* `token_embd.weight`, which is why the error names
that tensor. The coordinator did load the token embedding (`start == 0`), so the embedding was
never the missing piece — the output head was.

`tests/distributed_tests.rs::test_distributed_pipeline_parallel_inference` has always constructed
its coordinator with `(load_embedding: true, load_output: true)`, so the in-process transport test
exercised the correct ownership throughout. The served path was the only caller applying the
positional rule.

## What changed

Ownership is a property of the **role**, not of the layer range, so it is now named in the module
that owns the protocol:

```rust
// src/distributed.rs
pub enum PipelineRole { Coordinator, Worker }

impl PipelineRole {
    pub const fn tensor_ownership(self) -> (bool, bool) {
        match self {
            Self::Coordinator => (true, true),
            Self::Worker      => (false, false),
        }
    }
}
```

Both call sites derive ownership from it instead of hardcoding booleans:

- `src/api/mod.rs` — the coordinator's load. Only the coordinator reaches the API loader; a worker
  runs `run_worker_loop` and never calls `api::serve`. The non-distributed path is unchanged and
  still calls `LlamaLoadedWeights::load(..., None)`.
- `src/main.rs` — the worker's load, previously a bare `(false, false)`.

The two distributed prefill hand-off sites in `src/inference.rs` also now express the same thing.
One bound the worker's reply to `hidden` and the other to `_worker_response`, which read as a
disagreement about correctness. It is not one: both functions return only timings and neither reads
the hidden state after the hand-off, so the reply is dead in both. They are now identical.

`LlamaLoadedWeights::load` and its positional rule are untouched — that rule is correct for the
topology it serves, which `pipeline_load_puts_output_weights_on_last_node` continues to pin.

## Validation

Three layers, each proving something different.

**1. The rule** — `distributed::pipeline_role_tests`. Asserts the role→ownership mapping and that it
is deliberately *different* from the positional rule for a head shard, so a future "simplification"
back to positional derivation fails the build.

**2. The mechanism** — `distributed_coordinator_head_shard_owns_the_output_head`. Builds coordinator
weights from the in-tree tiny GGUF fixture and shows they can finalize a forward pass, then builds
the same shard under the positional rule and shows it cannot. Carries its own negative control; needs
no model file and no network.

**3. The served product** — real HTTP requests through `serve-distributed`. This is the only layer
that fails without the change.

`Llama-3.2-1B-Instruct-Q8_0` (sha256 `3f87a880…c7ffd1`, 16 layers), split `0..8` / `8..16`, CPU lane
forced and recorded on every node, greedy (`temperature: 0`, `seed: 0`), 65 generated tokens:

| Arm | Backend | Wall | Output sha256 |
|---|---|---:|---|
| single-node | `cpu_q8_runtime_repack` | 3.03 s | `1d18b243…9202` |
| coordinator + worker, one host | `cpu_q8_runtime_repack` | 4.97 s | `1d18b243…9202` |
| coordinator + worker on a second machine (Apple M5 Pro) | `cpu_q8_runtime_repack` | 7.29 s | `1d18b243…9202` |

Generated text and token IDs are identical across all three. Both machines were confirmed to be
running the same source by git tree hash before the run.

Additional coverage against the single-node reference, all byte-identical on both the single-node
and distributed arms:

| Case | Why it matters |
|---|---|
| Three sequential requests | The worker keeps its session across requests; request 2+ is where position/KV errors would appear |
| 8,684-character prompt (~2k tokens) | Crosses the 512-token chunk boundary and exercises the chunked prefill hand-off, which a short prompt never reaches |
| Streaming | Different response path; reassembled SSE deltas match the non-streaming body exactly |

**Gates:** `cargo test --lib` 1425 passed / 0 failed; `cargo test --tests` all green; `cargo clippy
--all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.

## Scope and limits

- **Distributed layer sharding is slower than a single node**, by 1.64× and 2.41× in the runs above.
  That is inherent to pipeline sharding — the nodes take turns, so aggregate memory bandwidth is
  never used simultaneously. This change makes the lane correct, not fast. It is a capacity
  feature: it exists for models that do not fit on one machine.
- **No parity receipt is minted for the served path.** `camelid.distributed-parity-receipt/v1` is
  built for in-process runs (`DistributedRunRecord` + `ParityVerdict`) and nothing over HTTP produces
  one. The evidence above is generated-text sha256 and token-ID equality, not a sealed receipt. The
  lane should not be described as receipt-gated.
- **No support-row promotion is claimed.** One model, one prompt set, one quantisation, CPU lane.
- The cross-machine arm matched byte-for-byte across x86_64 AVX2 and ARM64 NEON, but one prompt on
  one model is not a basis for a general byte-parity claim across architectures.
- Prefill still ships the worker's hidden state back over the wire and nothing reads it — roughly
  half the prefill traffic. Removing it is a protocol change and is deliberately out of scope here.
- The worker's forward pass does not use the wide prefill thread pool that every single-node prefill
  path uses. That is a separate, unmeasured performance question and is not addressed here.
- No transport authentication or encryption is added by this change; the worker port remains
  unauthenticated and should not be exposed beyond a trusted link.
