### PR TITLE
feat(distributed): bind node identity and authenticate the worker link

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9682,27 +9682,36 @@ async fn load_weights_lru(
     }
 
     let store = TensorStore::open(&model.path, &model.gguf);
-    let range = if let Some(&(layer_start, layer_end)) = crate::distributed::DISTRIBUTED_RANGE.get()
-    {
-        tracing::info!(
-            "API loader running in distributed coordinator mode; loading layers {}..{}",
-            layer_start,
-            layer_end
-        );
-        Some(layer_start..layer_end)
-    } else {
-        None
-    };
-    let weights = Arc::new(
-        LlamaLoadedWeights::load(&store, binding, range).map_err(|err| {
-            api_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "loaded_cpu_weights_unavailable",
-                err.to_string(),
-                Some("model"),
+    // Only the coordinator reaches the API loader; a worker runs `run_worker_loop` instead.
+    // Its ownership is role-derived, not positional -- see `distributed::PipelineRole`.
+    let loaded = match crate::distributed::DISTRIBUTED_RANGE.get() {
+        Some(&(layer_start, layer_end)) => {
+            let (load_embedding, load_output) =
+                crate::distributed::PipelineRole::Coordinator.tensor_ownership();
+            tracing::info!(
+                "API loader running in distributed coordinator mode; loading layers {}..{}",
+                layer_start,
+                layer_end
+            );
+            LlamaLoadedWeights::load_distributed(
+                &store,
+                binding,
+                layer_start,
+                layer_end,
+                load_embedding,
+                load_output,
             )
-        })?,
-    );
+        }
+        None => LlamaLoadedWeights::load(&store, binding, None),
+    };
+    let weights = Arc::new(loaded.map_err(|err| {
+        api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "loaded_cpu_weights_unavailable",
+            err.to_string(),
+            Some("model"),
+        )
+    })?);
 
     state
         .cached_weights

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -192,6 +192,9 @@ pub struct AppState {
     /// paths never touch it, and a relative path that exists against the
     /// process CWD keeps its historical meaning — this only adds a fallback.
     models_dir: PathBuf,
+    /// Model digest agreed with the worker before a distributed coordinator starts.
+    /// The worker cannot switch models, so every later local load must preserve it.
+    distributed_model_sha256: Option<String>,
     /// Immutable request/token/download ceilings resolved at startup.
     server_limits: server::ServerLimits,
     /// Lock-free process metrics shared by middleware and decode jobs.
@@ -229,6 +232,7 @@ impl Default for AppState {
             configured_threads: None,
             default_enable_thinking: false,
             models_dir: resolve_models_dir(None),
+            distributed_model_sha256: None,
             server_limits: server::ServerPolicy::loopback_default().limits,
             metrics: metrics::ServerMetrics::default(),
         }
@@ -2400,6 +2404,7 @@ pub struct StartupModel {
     pub path: PathBuf,
     /// `true` when the path came from `--model`.
     pub explicit: bool,
+    distributed_model_sha256: Option<String>,
 }
 
 impl StartupModel {
@@ -2408,6 +2413,15 @@ impl StartupModel {
         Self {
             path,
             explicit: true,
+            distributed_model_sha256: None,
+        }
+    }
+
+    pub fn distributed(path: PathBuf, model_sha256: String) -> Self {
+        Self {
+            path,
+            explicit: true,
+            distributed_model_sha256: Some(model_sha256),
         }
     }
 
@@ -2416,6 +2430,7 @@ impl StartupModel {
         Self {
             path,
             explicit: false,
+            distributed_model_sha256: None,
         }
     }
 }
@@ -2438,6 +2453,9 @@ pub async fn serve(
         .with_models_dir(models_dir)
         .with_serve_addr(addr)
         .with_server_policy(&policy);
+    state.distributed_model_sha256 = initial_model
+        .as_ref()
+        .and_then(|model| model.distributed_model_sha256.clone());
     let workspace_cli_credential = if addr.ip().is_loopback() {
         match crate::workspace_auth::WorkspaceCliCredential::issue(addr) {
             Ok(credential) => Some(credential),
@@ -2528,7 +2546,7 @@ pub async fn serve(
     // otherwise take down the server on every launch, including the UI the
     // user needs to choose a different model. Reinstalling does not help —
     // the models directory outlives the app — so the failure is permanent.
-    if let Some(StartupModel { path, explicit }) = initial_model {
+    if let Some(StartupModel { path, explicit, .. }) = initial_model {
         if let Err(err) = load_model_from_path(&startup_state, path.clone(), None, true).await {
             tracing::error!(error=%err, "failed to load startup model");
             if explicit {
@@ -6061,6 +6079,25 @@ fn fit_preload_guard(
     ))
 }
 
+fn enforce_distributed_model_sha256(state: &AppState, path: &std::path::Path) -> crate::Result<()> {
+    let Some(expected) = &state.distributed_model_sha256 else {
+        return Ok(());
+    };
+    let actual = crate::receipt::sha256_file_hex_cached(path).map_err(|err| {
+        BackendError::InvalidModelMetadata(format!(
+            "could not verify the distributed model {}: {err}",
+            path.display()
+        ))
+    })?;
+    if actual != *expected {
+        return Err(BackendError::InvalidModelMetadata(
+            "serve-distributed is pinned to the model agreed with its worker; restart both nodes to use a different GGUF"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 async fn load_model(State(state): State<AppState>, Json(req): Json<LoadModelRequest>) -> Response {
     // Resolve relative request paths against the configured models dir BEFORE
     // the fit guard, so the guard sizes the file that will actually be loaded.
@@ -6075,6 +6112,14 @@ async fn load_model(State(state): State<AppState>, Json(req): Json<LoadModelRequ
             )
         }
     };
+    if let Err(err) = enforce_distributed_model_sha256(&state, &path) {
+        return api_error(
+            StatusCode::CONFLICT,
+            "distributed_model_pinned",
+            err.to_string(),
+            Some("path"),
+        );
+    }
     // What is resident BESIDES the model being requested. A second copy of the
     // same file is not reclaimable room (the load would be idempotent), so it is
     // excluded — otherwise a repeat load would offer to release itself.
@@ -6169,6 +6214,47 @@ async fn load_model_from_path(
     set_active: bool,
 ) -> Result<LoadedModel, BackendError> {
     load_model_from_path_with_activation(state, path, id, set_active).await
+}
+
+#[cfg(test)]
+mod distributed_model_pin_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn distributed_coordinator_rejects_model_switches_before_replace() {
+        let temp = tempfile::tempdir().unwrap();
+        let startup = temp.path().join("startup.gguf");
+        let same_bytes = temp.path().join("same.gguf");
+        let other = temp.path().join("other.gguf");
+        std::fs::write(&startup, b"startup model").unwrap();
+        std::fs::write(&same_bytes, b"startup model").unwrap();
+        std::fs::write(&other, b"other model").unwrap();
+        let state = AppState {
+            models_dir: temp.path().to_path_buf(),
+            distributed_model_sha256: Some(
+                crate::receipt::sha256_file_hex_cached(&startup).unwrap(),
+            ),
+            ..AppState::default()
+        };
+
+        enforce_distributed_model_sha256(&state, &startup).unwrap();
+        enforce_distributed_model_sha256(&state, &same_bytes).unwrap();
+        let err = enforce_distributed_model_sha256(&state, &other)
+            .expect_err("a coordinator must not switch away from its worker's model");
+        assert!(err.to_string().contains("pinned to the model"));
+
+        let response = load_model(
+            State(state),
+            Json(LoadModelRequest {
+                path: other,
+                id: None,
+                replace: true,
+                set_active: None,
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -8870,6 +8956,7 @@ async fn load_model_from_path_with_activation(
     // Resolution runs BEFORE the idempotent fast path so a repeated relative
     // request compares equal to the resolved path the first load stored.
     let path = resolve_request_model_path(&state.models_dir, path)?;
+    enforce_distributed_model_sha256(state, &path)?;
     // Idempotent fast path: the same id already loaded from the same file
     // returns the existing record instead of re-running the full load pipeline
     // (an 8 GB row re-reads the whole file for its receipt otherwise; repeat

--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -2,6 +2,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -17,10 +18,24 @@ use crate::tensor::{CpuTensor, Q4KRepack8Cell, RuntimeDType, TensorShape};
 pub const HANDSHAKE_VERSION: u32 = 1;
 
 const HANDSHAKE_MAGIC: u32 = 0xCA9E_0001;
+const HANDSHAKE_IO_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_DISTRIBUTED_TOKEN_BYTES: usize = 4 * 1024;
 
 /// A handshake is a few hundred bytes. The cap exists so a hostile or confused peer
 /// cannot make the other side allocate on a length it chose.
 const MAX_HANDSHAKE_BYTES: u32 = 64 * 1024;
+
+fn engine_build_identity() -> String {
+    let commit = crate::receipt::camelid_commit();
+    if commit == "unknown" {
+        return env!("CARGO_PKG_VERSION").to_string();
+    }
+    if crate::receipt::camelid_version().ends_with("-dirty") {
+        format!("{commit}+dirty")
+    } else {
+        commit
+    }
+}
 
 /// What a node asserts about itself when a distributed connection opens.
 ///
@@ -29,7 +44,7 @@ const MAX_HANDSHAKE_BYTES: u32 = 64 * 1024;
 /// without this exchange two peers running *different* weights or *different* code
 /// connect happily and produce confident, wrong output. Every field below is one way
 /// that can happen.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodeIdentity {
     pub wire_version: u32,
     /// Engine build. Different code can mean different math, so peers must match.
@@ -52,6 +67,23 @@ pub struct NodeIdentity {
     pub token: Option<String>,
 }
 
+impl std::fmt::Debug for NodeIdentity {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("NodeIdentity")
+            .field("wire_version", &self.wire_version)
+            .field("engine_version", &self.engine_version)
+            .field("model_sha256", &self.model_sha256)
+            .field("total_layers", &self.total_layers)
+            .field("hidden_size", &self.hidden_size)
+            .field("worker_layer_start", &self.worker_layer_start)
+            .field("worker_layer_end", &self.worker_layer_end)
+            .field("platform", &self.platform)
+            .field("token_present", &self.token.is_some())
+            .finish()
+    }
+}
+
 impl NodeIdentity {
     /// Build the identity for a node holding `worker_layers` of `model`.
     ///
@@ -71,7 +103,7 @@ impl NodeIdentity {
         })?;
         Ok(Self {
             wire_version: HANDSHAKE_VERSION,
-            engine_version: env!("CARGO_PKG_VERSION").to_string(),
+            engine_version: engine_build_identity(),
             model_sha256,
             total_layers,
             hidden_size,
@@ -153,15 +185,58 @@ impl NodeIdentity {
     }
 }
 
+pub fn validate_distributed_token(
+    token: Option<String>,
+) -> std::result::Result<Option<String>, String> {
+    let Some(token) = token else {
+        return Ok(None);
+    };
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err("distributed token must not be empty".to_string());
+    }
+    if token.len() > MAX_DISTRIBUTED_TOKEN_BYTES {
+        return Err(format!(
+            "distributed token exceeds the {MAX_DISTRIBUTED_TOKEN_BYTES}-byte limit"
+        ));
+    }
+    if token.chars().any(char::is_control) {
+        return Err("distributed token must not contain control characters".to_string());
+    }
+    Ok(Some(token))
+}
+
+pub fn resolve_distributed_token(
+    token: Option<String>,
+    token_file: Option<&Path>,
+) -> std::result::Result<Option<String>, String> {
+    if token.is_some() && token_file.is_some() {
+        return Err(
+            "--distributed-token and --distributed-token-file are mutually exclusive".to_string(),
+        );
+    }
+    let token = match (token, token_file) {
+        (Some(token), None) => Some(token),
+        (None, Some(path)) => Some(std::fs::read_to_string(path).map_err(|err| {
+            format!(
+                "could not read distributed token file {}: {err}",
+                path.display()
+            )
+        })?),
+        (None, None) => None,
+        (Some(_), Some(_)) => unreachable!("conflict handled above"),
+    };
+    validate_distributed_token(token)
+}
+
 /// Compares without an early exit and without leaking the secret's length.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     // Fold length into the result instead of returning early on it.
-    let mut diff = (a.len() ^ b.len()) as u8;
-    let len = a.len().max(b.len());
-    for i in 0..len {
+    let mut diff = a.len() ^ b.len();
+    for i in 0..MAX_DISTRIBUTED_TOKEN_BYTES {
         let x = a.get(i).copied().unwrap_or(0);
         let y = b.get(i).copied().unwrap_or(0);
-        diff |= x ^ y;
+        diff |= usize::from(x ^ y);
     }
     diff == 0
 }
@@ -218,12 +293,18 @@ fn read_frame<R: Read, T: for<'de> Deserialize<'de>>(reader: &mut R) -> std::io:
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))
 }
 
+fn set_handshake_timeouts(stream: &TcpStream, timeout: Option<Duration>) -> std::io::Result<()> {
+    stream.set_read_timeout(timeout)?;
+    stream.set_write_timeout(timeout)
+}
+
 /// Which whole-model tensors a node loads in the `serve-distributed` pipeline.
 ///
 /// Ownership here is a property of the **role**, not of the layer range. A worker's
 /// [`LlamaInferenceSession::forward_worker_layers`] returns a bare hidden state — it
 /// applies neither `output_norm` nor the output projection — so the coordinator always
-/// finalizes the forward pass and needs both ends of the model whatever shard it holds.
+/// finalizes the forward pass and needs both ends of the model while holding the prefix
+/// shard supported by this transport.
 ///
 /// [`crate::inference::LlamaLoadedWeights::load`] instead derives ownership *positionally*,
 /// for a generic pipeline whose LAST stage emits logits. Using that rule here gives a
@@ -246,6 +327,32 @@ impl PipelineRole {
             Self::Worker => (false, false),
         }
     }
+
+    pub fn validate_layer_range(
+        self,
+        layer_start: usize,
+        layer_end: usize,
+        total_layers: usize,
+    ) -> Result<()> {
+        if total_layers < 2 || layer_start >= layer_end || layer_end > total_layers {
+            return Err(BackendError::InvalidModelMetadata(format!(
+                "distributed layer range {layer_start}..{layer_end} cannot partition model layers 0..{total_layers}"
+            )));
+        }
+        match self {
+            Self::Coordinator if layer_start != 0 || layer_end == total_layers => {
+                Err(BackendError::InvalidModelMetadata(format!(
+                    "distributed coordinator must own a non-empty prefix 0..SPLIT below layer {total_layers}, got {layer_start}..{layer_end}"
+                )))
+            }
+            Self::Worker if layer_start == 0 || layer_end != total_layers => {
+                Err(BackendError::InvalidModelMetadata(format!(
+                    "distributed worker must own a non-empty suffix SPLIT..{total_layers}, got {layer_start}..{layer_end}"
+                )))
+            }
+            _ => Ok(()),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -256,7 +363,7 @@ mod pipeline_role_tests {
     /// "simplifies" `tensor_ownership` back to deriving from the layer range, a `0..k`
     /// coordinator silently loses the output head again and every request 503s.
     #[test]
-    fn the_coordinator_owns_both_ends_whatever_shard_it_holds() {
+    fn the_prefix_coordinator_owns_both_ends() {
         assert_eq!(PipelineRole::Coordinator.tensor_ownership(), (true, true));
         assert_eq!(PipelineRole::Worker.tensor_ownership(), (false, false));
 
@@ -272,11 +379,45 @@ mod pipeline_role_tests {
             "a head-shard coordinator must not inherit the positional rule"
         );
     }
+
+    #[test]
+    fn roles_accept_only_a_complete_prefix_suffix_partition() {
+        PipelineRole::Coordinator
+            .validate_layer_range(0, 8, 16)
+            .unwrap();
+        PipelineRole::Worker
+            .validate_layer_range(8, 16, 16)
+            .unwrap();
+
+        for (role, start, end) in [
+            (PipelineRole::Coordinator, 4, 8),
+            (PipelineRole::Coordinator, 0, 16),
+            (PipelineRole::Worker, 0, 8),
+            (PipelineRole::Worker, 8, 15),
+            (PipelineRole::Worker, 8, 17),
+        ] {
+            role.validate_layer_range(start, end, 16)
+                .expect_err("gapped, overlapping, or out-of-bounds partitions must fail");
+        }
+    }
 }
 
 #[cfg(test)]
 mod handshake_tests {
     use super::*;
+
+    fn connect_to_response(response: HandshakeResponse) -> std::io::Result<DistributedClient> {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let _: NodeIdentity = read_frame(&mut stream).unwrap();
+            write_frame(&mut stream, &response).unwrap();
+        });
+        let result = DistributedClient::connect(&addr.to_string(), &identity());
+        server.join().unwrap();
+        result
+    }
 
     fn identity() -> NodeIdentity {
         NodeIdentity {
@@ -375,6 +516,89 @@ mod handshake_tests {
         assert!(identity().admit(&peer, Some("s3cret")).is_ok());
     }
 
+    #[test]
+    fn distributed_tokens_are_non_empty_bounded_and_control_free() {
+        assert_eq!(validate_distributed_token(None).unwrap(), None);
+        assert_eq!(
+            validate_distributed_token(Some("  s3cret  ".to_string())).unwrap(),
+            Some("s3cret".to_string())
+        );
+        assert!(validate_distributed_token(Some("  ".to_string())).is_err());
+        assert!(validate_distributed_token(Some("line\nbreak".to_string())).is_err());
+        assert!(
+            validate_distributed_token(Some("x".repeat(MAX_DISTRIBUTED_TOKEN_BYTES + 1))).is_err()
+        );
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "  from-file\n").unwrap();
+        assert_eq!(
+            resolve_distributed_token(None, Some(file.path())).unwrap(),
+            Some("from-file".to_string())
+        );
+        assert!(resolve_distributed_token(Some("inline".to_string()), Some(file.path())).is_err());
+    }
+
+    #[test]
+    fn node_identity_debug_redacts_the_token() {
+        let identity = identity().with_token(Some("do-not-print-me".to_string()));
+        let debug = format!("{identity:?}");
+        assert!(!debug.contains("do-not-print-me"));
+        assert!(debug.contains("token_present: true"));
+    }
+
+    #[test]
+    fn model_identity_uses_embedded_build_provenance() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let identity = NodeIdentity::for_model(file.path(), 16, 2048, 8..16).unwrap();
+        assert_eq!(identity.engine_version, engine_build_identity());
+        let commit = crate::receipt::camelid_commit();
+        if commit != "unknown" {
+            assert!(identity.engine_version.starts_with(&commit));
+        }
+    }
+
+    #[test]
+    fn a_stalled_handshake_read_times_out() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(addr).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+        set_handshake_timeouts(&server, Some(Duration::from_millis(20))).unwrap();
+
+        let err = read_frame::<_, NodeIdentity>(&mut server).unwrap_err();
+        assert!(matches!(
+            err.kind(),
+            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+        ));
+        drop(client);
+    }
+
+    #[test]
+    fn coordinator_requires_the_accepted_workers_identity() {
+        let err = match connect_to_response(HandshakeResponse {
+            accepted: true,
+            refusal: None,
+            worker: None,
+        }) {
+            Ok(_) => panic!("accepted response without worker identity must fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+
+        let mut worker = identity();
+        worker.model_sha256 = "b".repeat(64);
+        let err = match connect_to_response(HandshakeResponse {
+            accepted: true,
+            refusal: None,
+            worker: Some(worker),
+        }) {
+            Ok(_) => panic!("accepted response with mismatched worker identity must fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("model_sha256"), "{err}");
+    }
+
     /// A token check that ran before the identity check would let a stranger probe which
     /// models a worker holds. Identity is only compared once the peer has authenticated.
     #[test]
@@ -395,6 +619,10 @@ mod handshake_tests {
         assert!(!constant_time_eq(b"abc", b"abcd"));
         assert!(!constant_time_eq(b"", b"a"));
         assert!(constant_time_eq(b"", b""));
+
+        let mut length_wrapping_candidate = b"abc".to_vec();
+        length_wrapping_candidate.extend([0; 256]);
+        assert!(!constant_time_eq(b"abc", &length_wrapping_candidate));
     }
 
     #[test]
@@ -557,6 +785,7 @@ impl DistributedClient {
     pub fn connect(addr: &str, identity: &NodeIdentity) -> std::io::Result<Self> {
         let mut stream = TcpStream::connect(addr)?;
         stream.set_nodelay(true)?;
+        set_handshake_timeouts(&stream, Some(HANDSHAKE_IO_TIMEOUT))?;
         write_frame(&mut stream, identity)?;
         let response: HandshakeResponse = read_frame(&mut stream)?;
         if !response.accepted {
@@ -568,13 +797,24 @@ impl DistributedClient {
                 ),
             ));
         }
-        if let Some(worker) = &response.worker {
-            tracing::info!(
-                worker_platform = %worker.platform,
-                worker_layers = format!("{}..{}", worker.worker_layer_start, worker.worker_layer_end),
-                "distributed handshake accepted"
-            );
+        let worker = response.worker.as_ref().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "worker accepted the distributed handshake without returning its identity",
+            )
+        })?;
+        if let Some(reason) = identity.first_mismatch(worker) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("worker accepted with a mismatched identity: {reason}"),
+            ));
         }
+        tracing::info!(
+            worker_platform = %worker.platform,
+            worker_layers = format!("{}..{}", worker.worker_layer_start, worker.worker_layer_end),
+            "distributed handshake accepted"
+        );
+        set_handshake_timeouts(&stream, None)?;
         Ok(Self {
             stream: Mutex::new(stream),
             addr: addr.to_string(),
@@ -728,6 +968,10 @@ pub fn run_worker_loop_on_listener(
         };
 
         let _ = stream.set_nodelay(true);
+        if let Err(e) = set_handshake_timeouts(&stream, Some(HANDSHAKE_IO_TIMEOUT)) {
+            tracing::warn!(error = %e, "could not arm distributed handshake timeout");
+            continue;
+        }
 
         // Admit before a single activation is read: a peer that disagrees about the model,
         // the build or the split can only produce wrong numbers, and one that cannot
@@ -764,6 +1008,10 @@ pub fn run_worker_loop_on_listener(
             },
         ) {
             tracing::error!(error = %e, "failed to acknowledge the handshake");
+            continue;
+        }
+        if let Err(e) = set_handshake_timeouts(&stream, None) {
+            tracing::error!(error = %e, "could not clear distributed handshake timeout");
             continue;
         }
         tracing::info!(

--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -7,6 +7,62 @@ use crate::error::{BackendError, Result};
 use crate::inference::LlamaInferenceSession;
 use crate::tensor::{CpuTensor, Q4KRepack8Cell, RuntimeDType, TensorShape};
 
+/// Which whole-model tensors a node loads in the `serve-distributed` pipeline.
+///
+/// Ownership here is a property of the **role**, not of the layer range. A worker's
+/// [`LlamaInferenceSession::forward_worker_layers`] returns a bare hidden state — it
+/// applies neither `output_norm` nor the output projection — so the coordinator always
+/// finalizes the forward pass and needs both ends of the model whatever shard it holds.
+///
+/// [`crate::inference::LlamaLoadedWeights::load`] instead derives ownership *positionally*,
+/// for a generic pipeline whose LAST stage emits logits. Using that rule here gives a
+/// `0..k` coordinator no output projection, and every request fails with
+/// `runtime shape mismatch: ... requires rank-2 weight token_embd.weight, got [0]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipelineRole {
+    /// Runs the HTTP API, owns its layer shard plus the embedding and output head.
+    Coordinator,
+    /// Owns its layer shard only.
+    Worker,
+}
+
+impl PipelineRole {
+    /// `(load_embedding, load_output)` for
+    /// [`crate::inference::LlamaLoadedWeights::load_distributed`].
+    pub const fn tensor_ownership(self) -> (bool, bool) {
+        match self {
+            Self::Coordinator => (true, true),
+            Self::Worker => (false, false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod pipeline_role_tests {
+    use super::PipelineRole;
+
+    /// The rule this transport needs is deliberately *not* the positional one. If anyone
+    /// "simplifies" `tensor_ownership` back to deriving from the layer range, a `0..k`
+    /// coordinator silently loses the output head again and every request 503s.
+    #[test]
+    fn the_coordinator_owns_both_ends_whatever_shard_it_holds() {
+        assert_eq!(PipelineRole::Coordinator.tensor_ownership(), (true, true));
+        assert_eq!(PipelineRole::Worker.tensor_ownership(), (false, false));
+
+        // The positional rule `LlamaLoadedWeights::load` applies, restated here: the first
+        // shard owns the embedding, the last shard owns the output head.
+        let total_layers = 16;
+        let head_shard = 0..8;
+        let positional = (head_shard.start == 0, head_shard.end >= total_layers);
+        assert_eq!(positional, (true, false));
+        assert_ne!(
+            PipelineRole::Coordinator.tensor_ownership(),
+            positional,
+            "a head-shard coordinator must not inherit the positional rule"
+        );
+    }
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct DistributedHeader {

--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -1,11 +1,222 @@
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
 
 use crate::error::{BackendError, Result};
 use crate::inference::LlamaInferenceSession;
 use crate::tensor::{CpuTensor, Q4KRepack8Cell, RuntimeDType, TensorShape};
+
+/// Wire version of the `serve-distributed` connect handshake.
+///
+/// Bump on any change to [`NodeIdentity`]'s meaning. Peers require equality, so an old
+/// binary meeting a new one is refused at connect rather than producing wrong numbers
+/// somewhere deep in a forward pass.
+pub const HANDSHAKE_VERSION: u32 = 1;
+
+const HANDSHAKE_MAGIC: u32 = 0xCA9E_0001;
+
+/// A handshake is a few hundred bytes. The cap exists so a hostile or confused peer
+/// cannot make the other side allocate on a length it chose.
+const MAX_HANDSHAKE_BYTES: u32 = 64 * 1024;
+
+/// What a node asserts about itself when a distributed connection opens.
+///
+/// The pipeline ships raw activations between two processes that each hold half a model.
+/// Nothing in the activation stream identifies the model, the build, or the split, so
+/// without this exchange two peers running *different* weights or *different* code
+/// connect happily and produce confident, wrong output. Every field below is one way
+/// that can happen.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeIdentity {
+    pub wire_version: u32,
+    /// Engine build. Different code can mean different math, so peers must match.
+    pub engine_version: String,
+    /// Full-file SHA-256 of the GGUF. This is the model's identity: file length (what a
+    /// weaker handshake might compare) is equal for any two same-size quantisations.
+    pub model_sha256: String,
+    pub total_layers: u32,
+    pub hidden_size: u32,
+    /// The layer range the worker owns, `[start, end)`.
+    pub worker_layer_start: u32,
+    pub worker_layer_end: u32,
+    /// Host platform, e.g. `windows/x86_64`. **Reported, never enforced** — a coordinator
+    /// and worker on different platforms are a supported configuration and have been
+    /// measured producing byte-identical output. Carried so an operator (and a future
+    /// receipt) can see what actually ran.
+    pub platform: String,
+    /// Presented by the coordinator when the worker requires one. Never logged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+}
+
+impl NodeIdentity {
+    /// Build the identity for a node holding `worker_layers` of `model`.
+    ///
+    /// Hashing is served from the on-disk digest cache, so this is a stat on the warm
+    /// path rather than a re-read of the whole GGUF.
+    pub fn for_model(
+        model: &Path,
+        total_layers: u32,
+        hidden_size: u32,
+        worker_layers: std::ops::Range<u32>,
+    ) -> Result<Self> {
+        let model_sha256 = crate::receipt::sha256_file_hex_cached(model).map_err(|err| {
+            BackendError::RuntimeShapeMismatch(format!(
+                "could not hash {} for the distributed handshake: {err}",
+                model.display()
+            ))
+        })?;
+        Ok(Self {
+            wire_version: HANDSHAKE_VERSION,
+            engine_version: env!("CARGO_PKG_VERSION").to_string(),
+            model_sha256,
+            total_layers,
+            hidden_size,
+            worker_layer_start: worker_layers.start,
+            worker_layer_end: worker_layers.end,
+            platform: format!("{}/{}", std::env::consts::OS, std::env::consts::ARCH),
+            token: None,
+        })
+    }
+
+    pub fn with_token(mut self, token: Option<String>) -> Self {
+        self.token = token;
+        self
+    }
+
+    /// The first field on which `self` (the worker's own view) disagrees with the
+    /// `peer` that just connected, named exactly.
+    ///
+    /// `platform` is deliberately absent: see the field's documentation.
+    fn first_mismatch(&self, peer: &Self) -> Option<String> {
+        fn differs<T: PartialEq + std::fmt::Display>(
+            field: &str,
+            worker: &T,
+            coordinator: &T,
+        ) -> Option<String> {
+            (worker != coordinator).then(|| {
+                format!("{field} mismatch: worker has {worker}, coordinator has {coordinator}")
+            })
+        }
+        differs("wire_version", &self.wire_version, &peer.wire_version)
+            .or_else(|| differs("engine_version", &self.engine_version, &peer.engine_version))
+            .or_else(|| differs("model_sha256", &self.model_sha256, &peer.model_sha256))
+            .or_else(|| differs("total_layers", &self.total_layers, &peer.total_layers))
+            .or_else(|| differs("hidden_size", &self.hidden_size, &peer.hidden_size))
+            .or_else(|| {
+                differs(
+                    "worker_layer_start",
+                    &self.worker_layer_start,
+                    &peer.worker_layer_start,
+                )
+            })
+            .or_else(|| {
+                differs(
+                    "worker_layer_end",
+                    &self.worker_layer_end,
+                    &peer.worker_layer_end,
+                )
+            })
+    }
+
+    /// Whether `peer` may drive this node, and why not when it may not.
+    ///
+    /// `required_token` is the worker's configured secret. When set, a coordinator that
+    /// presents nothing or presents the wrong value is refused; the comparison is
+    /// length-independent and constant time so a rejected peer learns nothing about the
+    /// secret from how long the refusal took.
+    pub fn admit(
+        &self,
+        peer: &Self,
+        required_token: Option<&str>,
+    ) -> std::result::Result<(), String> {
+        if let Some(expected) = required_token {
+            match peer.token.as_deref() {
+                Some(presented) if constant_time_eq(expected.as_bytes(), presented.as_bytes()) => {}
+                Some(_) => return Err("authentication failed: token rejected".to_string()),
+                None => {
+                    return Err(
+                        "authentication failed: this worker requires a token and the \
+                         coordinator presented none"
+                            .to_string(),
+                    )
+                }
+            }
+        }
+        match self.first_mismatch(peer) {
+            Some(reason) => Err(reason),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Compares without an early exit and without leaking the secret's length.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    // Fold length into the result instead of returning early on it.
+    let mut diff = (a.len() ^ b.len()) as u8;
+    let len = a.len().max(b.len());
+    for i in 0..len {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// The worker's answer to a connect attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HandshakeResponse {
+    pub accepted: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker: Option<NodeIdentity>,
+}
+
+fn write_frame<W: Write, T: Serialize>(writer: &mut W, value: &T) -> std::io::Result<()> {
+    let body = serde_json::to_vec(value)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    let len = u32::try_from(body.len())
+        .ok()
+        .filter(|n| *n <= MAX_HANDSHAKE_BYTES);
+    let Some(len) = len else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "handshake frame exceeds the maximum size",
+        ));
+    };
+    writer.write_all(&HANDSHAKE_MAGIC.to_le_bytes())?;
+    writer.write_all(&len.to_le_bytes())?;
+    writer.write_all(&body)?;
+    writer.flush()
+}
+
+fn read_frame<R: Read, T: for<'de> Deserialize<'de>>(reader: &mut R) -> std::io::Result<T> {
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic)?;
+    if u32::from_le_bytes(magic) != HANDSHAKE_MAGIC {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "not a Camelid distributed handshake",
+        ));
+    }
+    let mut len_bytes = [0u8; 4];
+    reader.read_exact(&mut len_bytes)?;
+    let len = u32::from_le_bytes(len_bytes);
+    if len > MAX_HANDSHAKE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "handshake frame exceeds the maximum size",
+        ));
+    }
+    let mut body = vec![0u8; len as usize];
+    reader.read_exact(&mut body)?;
+    serde_json::from_slice(&body)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+}
 
 /// Which whole-model tensors a node loads in the `serve-distributed` pipeline.
 ///
@@ -60,6 +271,174 @@ mod pipeline_role_tests {
             positional,
             "a head-shard coordinator must not inherit the positional rule"
         );
+    }
+}
+
+#[cfg(test)]
+mod handshake_tests {
+    use super::*;
+
+    fn identity() -> NodeIdentity {
+        NodeIdentity {
+            wire_version: HANDSHAKE_VERSION,
+            engine_version: "0.5.2".to_string(),
+            model_sha256: "a".repeat(64),
+            total_layers: 16,
+            hidden_size: 2048,
+            worker_layer_start: 8,
+            worker_layer_end: 16,
+            platform: "linux/x86_64".to_string(),
+            token: None,
+        }
+    }
+
+    #[test]
+    fn a_matching_peer_is_admitted() {
+        assert!(identity().admit(&identity(), None).is_ok());
+    }
+
+    /// Each of these is a way two nodes can connect and compute different mathematics.
+    /// The refusal has to name the field, or an operator is left guessing which of two
+    /// machines is the wrong one.
+    #[test]
+    fn every_identity_field_is_refused_by_name() {
+        let mut cases: Vec<(&str, NodeIdentity)> = Vec::new();
+        let mut peer = identity();
+        peer.wire_version += 1;
+        cases.push(("wire_version", peer));
+        let mut peer = identity();
+        peer.engine_version = "0.5.1".to_string();
+        cases.push(("engine_version", peer));
+        let mut peer = identity();
+        peer.model_sha256 = "b".repeat(64);
+        cases.push(("model_sha256", peer));
+        let mut peer = identity();
+        peer.total_layers = 32;
+        cases.push(("total_layers", peer));
+        let mut peer = identity();
+        peer.hidden_size = 4096;
+        cases.push(("hidden_size", peer));
+        let mut peer = identity();
+        peer.worker_layer_start = 7;
+        cases.push(("worker_layer_start", peer));
+        let mut peer = identity();
+        peer.worker_layer_end = 15;
+        cases.push(("worker_layer_end", peer));
+
+        for (field, peer) in cases {
+            let err = identity()
+                .admit(&peer, None)
+                .expect_err("a peer differing in one field must be refused");
+            assert!(
+                err.contains(field),
+                "refusal must name the field; {field} produced: {err}"
+            );
+        }
+    }
+
+    /// A same-size GGUF with different contents is the case a length comparison cannot
+    /// see, and it is the one that silently produces wrong output.
+    #[test]
+    fn a_different_model_of_the_same_size_is_refused() {
+        let mut peer = identity();
+        peer.model_sha256 = "c".repeat(64);
+        let err = identity().admit(&peer, None).unwrap_err();
+        assert!(err.contains("model_sha256"), "{err}");
+    }
+
+    /// Platform difference is a supported configuration: a Windows x86_64 coordinator and
+    /// an ARM64 macOS worker have been measured producing byte-identical output. Refusing
+    /// it would break a working cluster.
+    #[test]
+    fn a_different_platform_is_reported_not_refused() {
+        let mut peer = identity();
+        peer.platform = "macos/aarch64".to_string();
+        assert!(identity().admit(&peer, None).is_ok());
+    }
+
+    #[test]
+    fn a_worker_with_a_token_refuses_a_coordinator_without_one() {
+        let err = identity().admit(&identity(), Some("s3cret")).unwrap_err();
+        assert!(err.contains("requires a token"), "{err}");
+    }
+
+    #[test]
+    fn a_wrong_token_is_refused() {
+        let peer = identity().with_token(Some("wrong".to_string()));
+        let err = identity().admit(&peer, Some("s3cret")).unwrap_err();
+        assert!(err.contains("token rejected"), "{err}");
+    }
+
+    #[test]
+    fn the_right_token_is_admitted() {
+        let peer = identity().with_token(Some("s3cret".to_string()));
+        assert!(identity().admit(&peer, Some("s3cret")).is_ok());
+    }
+
+    /// A token check that ran before the identity check would let a stranger probe which
+    /// models a worker holds. Identity is only compared once the peer has authenticated.
+    #[test]
+    fn authentication_is_decided_before_identity_is_revealed() {
+        let mut peer = identity();
+        peer.model_sha256 = "d".repeat(64);
+        let err = identity().admit(&peer, Some("s3cret")).unwrap_err();
+        assert!(
+            err.contains("authentication failed"),
+            "an unauthenticated peer must not learn about model identity, got: {err}"
+        );
+    }
+
+    #[test]
+    fn constant_time_eq_matches_only_identical_bytes() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+        assert!(!constant_time_eq(b"", b"a"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn a_frame_round_trips() {
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &identity()).unwrap();
+        let back: NodeIdentity = read_frame(&mut buf.as_slice()).unwrap();
+        assert_eq!(back, identity());
+    }
+
+    #[test]
+    fn a_frame_without_the_magic_is_rejected() {
+        let buf = vec![0u8; 8];
+        let err = read_frame::<_, NodeIdentity>(&mut buf.as_slice()).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("not a Camelid distributed handshake"));
+    }
+
+    /// The length prefix is attacker-chosen, so it is bounded before it is allocated.
+    #[test]
+    fn an_oversized_declared_length_is_rejected_before_allocating() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&HANDSHAKE_MAGIC.to_le_bytes());
+        buf.extend_from_slice(&u32::MAX.to_le_bytes());
+        let err = read_frame::<_, NodeIdentity>(&mut buf.as_slice()).unwrap_err();
+        assert!(err.to_string().contains("maximum size"), "{err}");
+    }
+
+    #[test]
+    fn the_bind_policy_matches_the_http_servers_rule() {
+        let loopback: SocketAddr = "127.0.0.1:5005".parse().unwrap();
+        let public: SocketAddr = "0.0.0.0:5005".parse().unwrap();
+
+        assert!(check_worker_bind_policy(&loopback, false, false).is_ok());
+        assert!(check_worker_bind_policy(&public, true, false).is_ok());
+        assert!(check_worker_bind_policy(&public, false, true).is_ok());
+
+        let err = check_worker_bind_policy(&public, false, false).unwrap_err();
+        assert!(
+            err.contains("refusing unauthenticated non-loopback"),
+            "{err}"
+        );
+        assert!(err.contains("CAMELID_DISTRIBUTED_TOKEN"), "{err}");
     }
 }
 
@@ -170,9 +549,32 @@ pub struct DistributedClient {
 }
 
 impl DistributedClient {
-    pub fn connect(addr: &str) -> std::io::Result<Self> {
-        let stream = TcpStream::connect(addr)?;
+    /// Open a connection and complete the identity handshake.
+    ///
+    /// A worker that disagrees about the model, the build, or the split refuses here, so a
+    /// misconfigured pair fails at startup with a named field instead of producing plausible
+    /// wrong output for the life of the process.
+    pub fn connect(addr: &str, identity: &NodeIdentity) -> std::io::Result<Self> {
+        let mut stream = TcpStream::connect(addr)?;
         stream.set_nodelay(true)?;
+        write_frame(&mut stream, identity)?;
+        let response: HandshakeResponse = read_frame(&mut stream)?;
+        if !response.accepted {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "worker {addr} refused the distributed handshake: {}",
+                    response.refusal.as_deref().unwrap_or("no reason given")
+                ),
+            ));
+        }
+        if let Some(worker) = &response.worker {
+            tracing::info!(
+                worker_platform = %worker.platform,
+                worker_layers = format!("{}..{}", worker.worker_layer_start, worker.worker_layer_end),
+                "distributed handshake accepted"
+            );
+        }
         Ok(Self {
             stream: Mutex::new(stream),
             addr: addr.to_string(),
@@ -261,9 +663,45 @@ impl DistributedClient {
 pub static DISTRIBUTED_CLIENT: OnceLock<DistributedClient> = OnceLock::new();
 pub static DISTRIBUTED_RANGE: OnceLock<(usize, usize)> = OnceLock::new();
 
-pub fn run_worker_loop(addr: &str, session: LlamaInferenceSession) -> anyhow::Result<()> {
+/// Refuse an unauthenticated worker listener that faces the network.
+///
+/// This mirrors the rule the HTTP server already applies in [`crate::api::server`]:
+/// loopback stays frictionless, and exposing the port requires either a token or an
+/// explicit acknowledgement. The worker port deserves at least that much — it accepts raw
+/// activations and spends this machine's CPU on them, with no request logging and no
+/// per-request authorization behind it.
+pub fn check_worker_bind_policy(
+    addr: &SocketAddr,
+    has_token: bool,
+    allow_unauthenticated_remote: bool,
+) -> std::result::Result<(), String> {
+    if addr.ip().is_loopback() || has_token || allow_unauthenticated_remote {
+        return Ok(());
+    }
+    Err(format!(
+        "refusing unauthenticated non-loopback distributed worker listener {addr}; set \
+         --distributed-token/CAMELID_DISTRIBUTED_TOKEN or explicitly acknowledge the risk \
+         with --allow-unauthenticated-remote"
+    ))
+}
+
+pub fn run_worker_loop(
+    addr: &str,
+    session: LlamaInferenceSession,
+    identity: NodeIdentity,
+    required_token: Option<String>,
+    allow_unauthenticated_remote: bool,
+) -> anyhow::Result<()> {
     let listener = TcpListener::bind(addr)?;
-    run_worker_loop_on_listener(listener, session)
+    let bound = listener.local_addr()?;
+    if let Err(reason) = check_worker_bind_policy(
+        &bound,
+        required_token.is_some(),
+        allow_unauthenticated_remote,
+    ) {
+        anyhow::bail!(reason);
+    }
+    run_worker_loop_on_listener(listener, session, identity, required_token)
 }
 
 /// Serve the worker protocol on an already-bound listener.
@@ -275,6 +713,8 @@ pub fn run_worker_loop(addr: &str, session: LlamaInferenceSession) -> anyhow::Re
 pub fn run_worker_loop_on_listener(
     listener: TcpListener,
     mut session: LlamaInferenceSession,
+    identity: NodeIdentity,
+    required_token: Option<String>,
 ) -> anyhow::Result<()> {
     tracing::info!(addr = ?listener.local_addr(), "Distributed Worker TCP server listening");
 
@@ -288,7 +728,48 @@ pub fn run_worker_loop_on_listener(
         };
 
         let _ = stream.set_nodelay(true);
-        tracing::info!("Worker accepted connection from coordinator");
+
+        // Admit before a single activation is read: a peer that disagrees about the model,
+        // the build or the split can only produce wrong numbers, and one that cannot
+        // authenticate has no business spending this machine's CPU.
+        let peer: NodeIdentity = match read_frame(&mut stream) {
+            Ok(peer) => peer,
+            Err(e) => {
+                tracing::warn!(error = %e, "rejected a connection that did not open with a handshake");
+                continue;
+            }
+        };
+        if let Err(reason) = identity.admit(&peer, required_token.as_deref()) {
+            tracing::warn!(%reason, "refused a distributed coordinator");
+            let _ = write_frame(
+                &mut stream,
+                &HandshakeResponse {
+                    accepted: false,
+                    refusal: Some(reason),
+                    worker: None,
+                },
+            );
+            continue;
+        }
+        if let Err(e) = write_frame(
+            &mut stream,
+            &HandshakeResponse {
+                accepted: true,
+                refusal: None,
+                // Never echo a credential back, whatever this node was configured with.
+                worker: Some(NodeIdentity {
+                    token: None,
+                    ..identity.clone()
+                }),
+            },
+        ) {
+            tracing::error!(error = %e, "failed to acknowledge the handshake");
+            continue;
+        }
+        tracing::info!(
+            coordinator_platform = %peer.platform,
+            "Worker accepted connection from coordinator"
+        );
 
         loop {
             let mut header_buf = [0u8; 16];

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4547,7 +4547,8 @@ impl LlamaInferenceSession {
             if let Some(range) = &self.weights.layer_range {
                 if !range.contains(&layer_idx) {
                     if let Some(client) = crate::distributed::DISTRIBUTED_CLIENT.get() {
-                        let _worker_response = client.forward_to_worker(
+                        // Prefill only warms KV; this returns timings, so the reply is unused.
+                        client.forward_to_worker(
                             &hidden,
                             true,
                             token_ids.len(),
@@ -4794,13 +4795,13 @@ impl LlamaInferenceSession {
             if let Some(range) = &self.weights.layer_range {
                 if !range.contains(&layer_idx) {
                     if let Some(client) = crate::distributed::DISTRIBUTED_CLIENT.get() {
-                        let worker_response = client.forward_to_worker(
+                        // Prefill only warms KV; this returns timings, so the reply is unused.
+                        client.forward_to_worker(
                             &hidden,
                             true,
                             token_ids.len(),
                             self.kv_cache.position,
                         )?;
-                        hidden = worker_response;
                         break;
                     } else {
                         continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1957,13 +1957,15 @@ async fn main() -> anyhow::Result<()> {
                     layer_start,
                     layer_end
                 );
+                let (load_embedding, load_output) =
+                    camelid::distributed::PipelineRole::Worker.tensor_ownership();
                 let weights = camelid::inference::LlamaLoadedWeights::load_distributed(
                     &store,
                     &binding,
                     layer_start,
                     layer_end,
-                    false,
-                    false,
+                    load_embedding,
+                    load_output,
                 )?;
 
                 tracing::info!("Worker weights loaded successfully. Initializing session.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -936,9 +936,17 @@ enum Command {
         threads: Option<usize>,
         /// Shared secret the coordinator must present to this worker. Required before a
         /// worker will bind a non-loopback address, unless the risk is explicitly
-        /// acknowledged with --allow-unauthenticated-remote.
-        #[arg(long, env = "CAMELID_DISTRIBUTED_TOKEN")]
+        /// acknowledged with --allow-unauthenticated-remote. Prefer the file option on
+        /// shared machines so the secret is not present in the process command line.
+        #[arg(
+            long,
+            env = "CAMELID_DISTRIBUTED_TOKEN",
+            conflicts_with = "distributed_token_file"
+        )]
         distributed_token: Option<String>,
+        /// Read the distributed shared secret from a text file.
+        #[arg(long, env = "CAMELID_DISTRIBUTED_TOKEN_FILE")]
+        distributed_token_file: Option<PathBuf>,
         #[command(flatten)]
         server: ServerPolicyArgs,
     },
@@ -1904,9 +1912,15 @@ async fn main() -> anyhow::Result<()> {
             model,
             threads,
             distributed_token,
+            distributed_token_file,
             server,
         } => {
             configure_rayon_threads(threads)?;
+            let distributed_token = camelid::distributed::resolve_distributed_token(
+                distributed_token,
+                distributed_token_file.as_deref(),
+            )
+            .map_err(anyhow::Error::msg)?;
 
             let parts: Vec<&str> = layer_range.split("..").collect();
             anyhow::ensure!(
@@ -1929,6 +1943,11 @@ async fn main() -> anyhow::Result<()> {
 
                 let gguf = camelid::gguf::read_metadata(&model)?;
                 let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
+                camelid::distributed::PipelineRole::Coordinator.validate_layer_range(
+                    layer_start,
+                    layer_end,
+                    config.block_count as usize,
+                )?;
                 let identity = camelid::distributed::NodeIdentity::for_model(
                     &model,
                     config.block_count,
@@ -1936,6 +1955,7 @@ async fn main() -> anyhow::Result<()> {
                     (layer_end as u32)..(config.block_count),
                 )?
                 .with_token(distributed_token.clone());
+                let distributed_model_sha256 = identity.model_sha256.clone();
 
                 tracing::info!(worker_addr = %worker_addr_str, "Coordinator connecting to worker");
                 let client =
@@ -1952,7 +1972,10 @@ async fn main() -> anyhow::Result<()> {
                 api::serve(
                     addr,
                     threads,
-                    Some(api::StartupModel::explicit(model)),
+                    Some(api::StartupModel::distributed(
+                        model,
+                        distributed_model_sha256,
+                    )),
                     false,
                     false,
                     None,
@@ -1966,6 +1989,11 @@ async fn main() -> anyhow::Result<()> {
                     DenseLaneWindowedForward::CpuDenseOnly,
                 )?;
                 let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
+                camelid::distributed::PipelineRole::Worker.validate_layer_range(
+                    layer_start,
+                    layer_end,
+                    config.block_count as usize,
+                )?;
                 let binding = camelid::model::LlamaTensorBinding::bind(&gguf, &config)?;
                 let store = camelid::tensor::TensorStore::open(&model, &gguf);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -934,6 +934,11 @@ enum Command {
         /// Override Rayon worker threads
         #[arg(long, env = "CAMELID_THREADS")]
         threads: Option<usize>,
+        /// Shared secret the coordinator must present to this worker. Required before a
+        /// worker will bind a non-loopback address, unless the risk is explicitly
+        /// acknowledged with --allow-unauthenticated-remote.
+        #[arg(long, env = "CAMELID_DISTRIBUTED_TOKEN")]
+        distributed_token: Option<String>,
         #[command(flatten)]
         server: ServerPolicyArgs,
     },
@@ -1898,6 +1903,7 @@ async fn main() -> anyhow::Result<()> {
             layer_range,
             model,
             threads,
+            distributed_token,
             server,
         } => {
             configure_rayon_threads(threads)?;
@@ -1921,8 +1927,19 @@ async fn main() -> anyhow::Result<()> {
                     anyhow::anyhow!("--worker-addr is required in coordinator mode")
                 })?;
 
+                let gguf = camelid::gguf::read_metadata(&model)?;
+                let config = camelid::model::LlamaModelConfig::from_gguf(&gguf)?;
+                let identity = camelid::distributed::NodeIdentity::for_model(
+                    &model,
+                    config.block_count,
+                    config.embedding_length,
+                    (layer_end as u32)..(config.block_count),
+                )?
+                .with_token(distributed_token.clone());
+
                 tracing::info!(worker_addr = %worker_addr_str, "Coordinator connecting to worker");
-                let client = camelid::distributed::DistributedClient::connect(&worker_addr_str)?;
+                let client =
+                    camelid::distributed::DistributedClient::connect(&worker_addr_str, &identity)?;
                 camelid::distributed::DISTRIBUTED_CLIENT
                     .set(client)
                     .map_err(|_| anyhow::anyhow!("Failed to set global distributed client lock"))?;
@@ -1969,6 +1986,12 @@ async fn main() -> anyhow::Result<()> {
                 )?;
 
                 tracing::info!("Worker weights loaded successfully. Initializing session.");
+                let identity = camelid::distributed::NodeIdentity::for_model(
+                    &model,
+                    config.block_count,
+                    config.embedding_length,
+                    (layer_start as u32)..(layer_end as u32),
+                )?;
                 let session = camelid::inference::LlamaInferenceSession::new(config, weights)?;
 
                 let addr_str = addr.to_string();
@@ -1976,7 +1999,13 @@ async fn main() -> anyhow::Result<()> {
                 unsafe {
                     pthread_set_qos_class_self_np(0x09, 0); // QOS_CLASS_BACKGROUND (forces network I/O onto E-cores)
                 }
-                camelid::distributed::run_worker_loop(&addr_str, session)?;
+                camelid::distributed::run_worker_loop(
+                    &addr_str,
+                    session,
+                    identity,
+                    distributed_token,
+                    server.allow_unauthenticated_remote,
+                )?;
             } else {
                 anyhow::bail!("Invalid role: {role}. Must be 'coordinator' or 'worker'");
             }

--- a/tests/distributed_tests.rs
+++ b/tests/distributed_tests.rs
@@ -4,12 +4,12 @@ use tempfile::tempdir;
 use camelid::{
     distributed::{
         run_network_benchmark_worker_on_listener, run_worker_loop_on_listener, DistributedClient,
-        DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE,
+        PipelineRole, DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE,
     },
     gguf::read_metadata,
     inference::{LlamaInferenceSession, LlamaLoadedWeights},
     model::{LlamaModelConfig, LlamaTensorBinding},
-    tensor::TensorStore,
+    tensor::{CpuTensor, TensorStore},
 };
 
 /// Bind loopback on an OS-assigned free port.
@@ -176,6 +176,69 @@ fn pipeline_load_puts_output_weights_on_last_node() {
         "last node loads output_norm"
     );
     last.validate_dense_shapes(&config).unwrap();
+}
+
+/// Regression for defect D1. `serve-distributed` computes logits on the **coordinator** —
+/// `run_worker_loop`'s `forward_worker_layers` returns a bare hidden state, applying
+/// neither `output_norm` nor the output projection — so a coordinator holding a head shard
+/// must still own the output head. That is what `PipelineRole::Coordinator` encodes, and
+/// what `test_distributed_pipeline_parallel_inference` above has always assumed.
+///
+/// The shipped API loader instead derived ownership positionally through
+/// `LlamaLoadedWeights::load`, which reserves the output head for the LAST shard (see
+/// `pipeline_load_puts_output_weights_on_last_node`, correct for that other topology).
+/// The second half here is the negative control: it reproduces in-process the exact
+/// failure that mismatch produced over HTTP.
+#[test]
+fn distributed_coordinator_head_shard_owns_the_output_head() {
+    let dir = tempdir().unwrap();
+    let model_path = dir.path().join("tiny_model.gguf");
+    write_tiny_llama_gguf(&model_path);
+    let gguf = read_metadata(&model_path).unwrap();
+    let binding =
+        LlamaTensorBinding::bind(&gguf, &LlamaModelConfig::from_gguf(&gguf).unwrap()).unwrap();
+    let store = TensorStore::open(&model_path, &gguf);
+
+    // Shaped like a hidden state the worker hands back: [seq, hidden].
+    let from_worker = CpuTensor::from_f32("wire_activation", vec![1, 8], vec![0.0; 8]).unwrap();
+
+    let (load_embedding, load_output) = PipelineRole::Coordinator.tensor_ownership();
+    let coordinator =
+        LlamaLoadedWeights::load_distributed(&store, &binding, 0, 1, load_embedding, load_output)
+            .unwrap();
+    let coordinator =
+        LlamaInferenceSession::new(LlamaModelConfig::from_gguf(&gguf).unwrap(), coordinator)
+            .unwrap();
+    let logits = coordinator
+        .forward_final_norm_and_logits(&from_worker)
+        .expect("a coordinator owning the output head can finalize the forward pass");
+    assert_eq!(logits.shape.dims, vec![1, 16], "[seq, vocab]");
+
+    let positional = LlamaLoadedWeights::load(&store, &binding, Some(0..1)).unwrap();
+    assert_eq!(
+        positional.output_norm.shape.dims,
+        vec![0],
+        "positional ownership leaves a head shard without output_norm"
+    );
+    assert_eq!(
+        positional.output.as_ref().map(|o| o.shape.dims.clone()),
+        Some(vec![0]),
+        "positional ownership leaves a head shard without the output projection"
+    );
+    let positional =
+        LlamaInferenceSession::new(LlamaModelConfig::from_gguf(&gguf).unwrap(), positional)
+            .unwrap();
+    let err = positional
+        .forward_final_norm_and_logits(&from_worker)
+        .expect_err("positional ownership cannot finalize; this was the shipped defect");
+    // Which check trips first depends on the finalize path and on whether the model ties
+    // its output to the embedding; the served 1B model reported the projection
+    // (`token_embd.weight, got [0]`), this untied fixture reports the norm. Both are the
+    // same missing output head, so assert the empty shape rather than one message.
+    assert!(
+        err.to_string().contains("[0]"),
+        "expected a missing-output-head shape error, got: {err}"
+    );
 }
 
 fn write_tiny_llama_gguf(path: &Path) {

--- a/tests/distributed_tests.rs
+++ b/tests/distributed_tests.rs
@@ -4,7 +4,7 @@ use tempfile::tempdir;
 use camelid::{
     distributed::{
         run_network_benchmark_worker_on_listener, run_worker_loop_on_listener, DistributedClient,
-        PipelineRole, DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE,
+        NodeIdentity, PipelineRole, DISTRIBUTED_CLIENT, DISTRIBUTED_RANGE,
     },
     gguf::read_metadata,
     inference::{LlamaInferenceSession, LlamaLoadedWeights},
@@ -56,8 +56,10 @@ fn test_distributed_pipeline_parallel_inference() {
     // coordinator below can connect immediately.
     let listener = bind_ephemeral();
     let worker_addr = listener.local_addr().unwrap().to_string();
+    let worker_identity = NodeIdentity::for_model(&model_path, 2, 8, 1..2).unwrap();
     let _worker_handle = std::thread::spawn(move || {
-        if let Err(e) = run_worker_loop_on_listener(listener, worker_session) {
+        if let Err(e) = run_worker_loop_on_listener(listener, worker_session, worker_identity, None)
+        {
             // Surface the worker's own failure. Without this the only symptom is
             // an unexplained EOF on the coordinator's read.
             eprintln!("distributed worker loop exited with error: {e:#}");
@@ -65,7 +67,8 @@ fn test_distributed_pipeline_parallel_inference() {
     });
 
     // 2. Coordinator Setup (Loads layer 0..1)
-    let client = DistributedClient::connect(&worker_addr).unwrap();
+    let coordinator_identity = NodeIdentity::for_model(&model_path, 2, 8, 1..2).unwrap();
+    let client = DistributedClient::connect(&worker_addr, &coordinator_identity).unwrap();
     let _ = DISTRIBUTED_CLIENT.set(client);
     let _ = DISTRIBUTED_RANGE.set((0, 1));
 
@@ -241,9 +244,50 @@ fn distributed_coordinator_head_shard_owns_the_output_head() {
     );
 }
 
+/// The handshake has to hold over a real socket, not just as a pure comparison: a
+/// coordinator carrying a different model must be refused at connect, before it can ship a
+/// single activation, and the worker must stay up to serve the next caller.
+#[test]
+fn a_coordinator_with_a_different_model_is_refused_over_the_wire() {
+    let dir = tempdir().unwrap();
+    let model_path = dir.path().join("tiny_model.gguf");
+    write_tiny_llama_gguf(&model_path);
+    let gguf = read_metadata(&model_path).unwrap();
+    let config = LlamaModelConfig::from_gguf(&gguf).unwrap();
+    let binding = LlamaTensorBinding::bind(&gguf, &config).unwrap();
+    let store = TensorStore::open(&model_path, &gguf);
+    let (load_embedding, load_output) = PipelineRole::Worker.tensor_ownership();
+    let weights =
+        LlamaLoadedWeights::load_distributed(&store, &binding, 1, 2, load_embedding, load_output)
+            .unwrap();
+    let session = LlamaInferenceSession::new(config, weights).unwrap();
+
+    let listener = bind_ephemeral();
+    let worker_addr = listener.local_addr().unwrap().to_string();
+    let worker_identity = NodeIdentity::for_model(&model_path, 2, 8, 1..2).unwrap();
+    std::thread::spawn(move || {
+        let _ = run_worker_loop_on_listener(listener, session, worker_identity, None);
+    });
+
+    let mut impostor = NodeIdentity::for_model(&model_path, 2, 8, 1..2).unwrap();
+    impostor.model_sha256 = "0".repeat(64);
+    let err = match DistributedClient::connect(&worker_addr, &impostor) {
+        Err(err) => err,
+        Ok(_) => panic!("a coordinator holding a different model must not be admitted"),
+    };
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert!(err.to_string().contains("model_sha256"), "{err}");
+
+    // The worker survived the refusal and still serves a legitimate coordinator.
+    let honest = NodeIdentity::for_model(&model_path, 2, 8, 1..2).unwrap();
+    DistributedClient::connect(&worker_addr, &honest)
+        .expect("a refusal must not take the worker down");
+}
+
 fn write_tiny_llama_gguf(path: &Path) {
     // 2 layers, tiny dimensions: hidden=8, vocab=16, ffn=16, heads=2, kv_heads=2
     // We have exactly 21 tensors: token_embedding, output_norm, output + 9 tensors per layer (18 total) = 21 tensors.
+    // 2 layers, tiny dimensions: hidden=8, vocab=16, ffn=16, heads=2, kv_heads=2
     let mut b = header(21, 13);
 
     // Model hparams metadata


### PR DESCRIPTION
> **Stacked on #594.** Review this PR's two commits after `68c67322b`.

## Summary

`serve-distributed` peers now authenticate and establish the model, build, dimensions, and exact split before any activation moves. The coordinator remains pinned to that model for the life of the worker connection.

Before this change, different models/builds/splits connected and could produce plausible wrong output. Any reachable peer could also consume worker compute.

## Identity contract

The versioned handshake carries:

```rust
NodeIdentity {
    wire_version,
    engine_version,       // full embedded commit SHA (+dirty), version fallback outside Git
    model_sha256,         // full-file digest
    total_layers,
    hidden_size,
    worker_layer_start,
    worker_layer_end,
    platform,             // reported, deliberately not enforced
    token,
}
```

Both sides validate the accepted identity. The coordinator rejects an `accepted:true` response that omits or contradicts the worker identity. Local range validation requires the supported complete partition: coordinator `0..SPLIT`, worker `SPLIT..total_layers`. The coordinator's API is pinned to the handshake model SHA, so `/api/models/load`, `/models/load`, and on-demand loads cannot switch only one half of the pipeline; a different GGUF fails closed before `replace:true` can release the valid model.

Build identity uses the embedded full commit SHA rather than `CARGO_PKG_VERSION`, which cannot distinguish different `0.5.2` commits. The SHA is stable across full and shallow clones; dirty builds carry `+dirty`. Builds made outside a Git checkout fall back to the package version.

## Authentication

Workers accept a shared secret through either:

- `--distributed-token` / `CAMELID_DISTRIBUTED_TOKEN`
- `--distributed-token-file` / `CAMELID_DISTRIBUTED_TOKEN_FILE` (preferred on shared machines)

Secrets are trimmed, non-empty, control-free, and capped at 4 KiB. Debug output reports only whether a token exists.

The review found and fixed a real authentication bypass: the original comparator truncated `(expected.len() ^ presented.len())` to `u8`. The correct token plus 256 NUL bytes therefore authenticated. Length accounting now remains `usize`, and comparison always executes the fixed 4 KiB budget.

Authentication runs before identity comparison, so an unauthenticated peer cannot probe the worker's model. Non-loopback workers still require a token unless `--allow-unauthenticated-remote` explicitly acknowledges the risk.

Handshake reads/writes have a 10-second inactivity timeout, cleared after admission, so a silent unauthenticated socket cannot hold the serial accept loop forever while long model steps remain unaffected.

## Validation

Local gates on `b8f026b8`:

- `cargo test -j 2 --lib`: **1445 passed, 0 failed, 71 ignored**
- `cargo test -j 2 --test distributed_tests`: **5 passed, 0 failed**
- distributed unit namespace: **31 passed, 0 failed**
- handshake unit module after final hardening: **18 passed, 0 failed**
- `cargo clippy -j 2 --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `git diff --check`: clean

Negative controls cover the 256-NUL token bypass, empty/oversized/control-character tokens, token-file conflict and trimming, secret redaction, stalled handshake reads, forged accepted responses, mismatched model/build/split fields, incomplete layer partitions, and post-handshake model switching (including `replace:true`).

The existing real-binary parity evidence remains unchanged: matching and token-authenticated pairs produce the same output SHA as the single-node reference; wrong splits and wrong/missing tokens are refused before activation exchange.

## Scope and limits

- No transport encryption. Activations and the pre-shared token cross the link in cleartext; use a trusted/private network.
- No token rotation or session key exchange.
- `platform` is reported but not compared so measured heterogeneous Windows/x86_64 and macOS/ARM64 pairs remain possible.
- Applies only to `serve-distributed`; the legacy and Gemma 4 transports are unchanged.
- A source-archive build without embedded Git provenance falls back to package version identity.
