### PR TITLE
chore(release): bump version to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump: `0.5.2` -> `0.5.3`. Four files, five lines.

## What lands here

- #592: PrismML Bonsai text and image support on macOS Metal
- #596: public PrismML model support documentation
- #597: Q1_0 and PrismML Bonsai model support merged to `main`
- #591: startup readiness stabilization

## Validation

- `main` CI at `985c45d9` passed
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `git diff --check`
- root, desktop crate, lockfile, and Tauri versions all report `0.5.3`

Pushing tag `v0.5.3` after merge will trigger the existing signed multi-platform release workflow.