### PR TITLE
Fix low-memory chat streaming failures

### DIFF
--- a/docs/perf-deep-dive/METAL_KQUANT_ROADMAP_RESULT.md
+++ b/docs/perf-deep-dive/METAL_KQUANT_ROADMAP_RESULT.md
@@ -50,7 +50,7 @@ cooperative streaming scheduler — see item 5.
 | `CAMELID_METAL_KV_DTYPE` | `f32`, `f16`, `q8` | `f16` for K-quant; `f32` otherwise | Select the resident KV primary representation. The default follows the LOADED MODEL's weights, not the `CAMELID_METAL_KQUANT` gate: a Q8_0 model keeps its F32 cache (and with it the split-K decode attention and the attention-as-matmul prefill, both of which require an F32 primary) even with K-quant admission enabled. |
 | `CAMELID_METAL_KV16` | `0`, `1` | `0` | Legacy alias for `CAMELID_METAL_KV_DTYPE=f16`. |
 | `CAMELID_CONTINUOUS_BATCH_SLOTS` | `1..256` | `2` | Maximum active cooperative streaming sessions. Set `1` for legacy run-to-completion scheduling. |
-| `CAMELID_PREFIX_CACHE_RESIDENT` | `0`, `1` | `1` | Let a GPU-resident session mirror its KV back so the prompt-prefix cache can store it. `0` keeps this lane's CPU KV at zero bytes and accepts a full re-prefill on every repeated prompt. Only ever engages when the round trip is bit-exact (F16 resident primary + non-quantized CPU KV). |
+| `CAMELID_PREFIX_CACHE_RESIDENT` | `0`, `1` | auto (`0` on hosts with ≤8 GiB RAM, otherwise `1`) | Let a GPU-resident session mirror its KV back so the prompt-prefix cache can store it. `0` keeps this lane's CPU KV at zero bytes and accepts a full re-prefill on every repeated prompt. An explicit value overrides the host-memory policy. Only ever engages when the round trip is bit-exact (F16 resident primary + non-quantized CPU KV). |
 
 `--deterministic` forces `CAMELID_METAL_KQUANT=0` and
 `CAMELID_METAL_KV_DTYPE=f32` along with the rest of the GPU-off policy.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2076,6 +2076,16 @@ pub struct ErrorBody {
     pub param: Option<&'static str>,
 }
 
+/// Structured API error metadata retained in a response extension. Streaming
+/// handlers have already committed HTTP/SSE headers when a decode step fails,
+/// so they cannot forward the response body; this copy preserves the original
+/// machine-readable code and actionable message for the SSE error event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ApiErrorDetails {
+    code: String,
+    message: String,
+}
+
 /// The models directory used when `serve` gets no `--models-dir`: the first
 /// existing of `<exe dir>/models` (the shipped layout — `camelid.exe` beside a
 /// `models/` folder, the same precedent `auto_select_model` follows) then
@@ -15775,6 +15785,9 @@ enum StreamDecodeEvent {
 /// Response-shaped failure, so the engine job can hand the SSE layer
 /// byte-identical error frames without shipping the `Response` across.
 fn stream_error_parts(response: &Response) -> (String, String) {
+    if let Some(details) = response.extensions().get::<ApiErrorDetails>() {
+        return (details.code.clone(), details.message.clone());
+    }
     (
         "stream_error".to_string(),
         format!("stream failed after headers: HTTP {}", response.status()),
@@ -17942,7 +17955,11 @@ fn api_error(
         StatusCode::UNPROCESSABLE_ENTITY => "model_unavailable",
         _ => "invalid_request",
     };
-    (
+    let details = ApiErrorDetails {
+        code: code.to_string(),
+        message: message.clone(),
+    };
+    let mut response = (
         status,
         Json(ErrorEnvelope {
             error: ErrorBody {
@@ -17953,7 +17970,9 @@ fn api_error(
             },
         }),
     )
-        .into_response()
+        .into_response();
+    response.extensions_mut().insert(details);
+    response
 }
 
 fn tokenizer_state_from_result(
@@ -18046,6 +18065,36 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn streaming_error_preserves_the_structured_api_failure() {
+        let response = api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "generation_step_failed",
+            "KV cache budget exceeded; shorten this conversation".to_string(),
+            Some("max_tokens"),
+        );
+
+        assert_eq!(
+            stream_error_parts(&response),
+            (
+                "generation_step_failed".to_string(),
+                "KV cache budget exceeded; shorten this conversation".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn streaming_error_keeps_a_status_fallback_for_foreign_responses() {
+        let response = StatusCode::SERVICE_UNAVAILABLE.into_response();
+        assert_eq!(
+            stream_error_parts(&response),
+            (
+                "stream_error".to_string(),
+                "stream failed after headers: HTTP 503 Service Unavailable".to_string(),
+            )
+        );
+    }
 
     #[test]
     fn chat_image_url_part_preserves_order_and_collects_data_url() {

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -52,23 +52,56 @@ impl MetalSampleRequest {
 pub(super) const MAX_VERIFY_K: usize = 8;
 
 /// Whether `prepare_for_prompt_prefix_cache` may vouch for ANY session — the
-/// prompt-prefix-cache kill switch. Default ON: the alternative is
-/// re-prefilling every repeated or growing chat prompt, which on the resident
-/// lane costs seconds. Set `CAMELID_PREFIX_CACHE_RESIDENT=0` to refuse every
-/// preparation: no session is stored, the CPU KV stays at zero bytes on the
+/// prompt-prefix-cache host-safety gate. Default ON except on hosts with 8 GiB
+/// of physical RAM or less: mirroring and then cloning a long resident prompt
+/// can retain roughly two CPU KV histories in addition to the GPU-resident KV,
+/// which leaves too little unified-memory headroom on those Macs. The explicit
+/// environment value wins in either direction (`0`/`false` disables, any other
+/// value enables) so controlled benchmarks can still choose the tradeoff.
+///
+/// When disabled no session is stored, the CPU KV stays at zero bytes on the
 /// resident lane, and every turn pays the re-prefill. (Historically this gate
 /// sat AFTER the CPU-authoritative early accept, so it only ever suppressed
 /// the resident mirror and did nothing at all for CPU-authoritative sessions
 /// — see `prepare_for_prompt_prefix_cache_gated`.)
+const LOW_MEMORY_PREFIX_CACHE_MAX_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+
 pub(super) fn resident_prefix_cache_mirror_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        prefix_cache_setting_enables(
+        resident_prefix_cache_policy(
             std::env::var("CAMELID_PREFIX_CACHE_RESIDENT")
                 .ok()
                 .as_deref(),
+            prefix_cache_host_ram_bytes(),
         )
     })
+}
+
+/// Keep ordinary unit tests independent of the machine running them. The pure
+/// policy tests below inject both low- and high-memory totals explicitly; only
+/// production binaries consult the live host probe.
+#[cfg(not(test))]
+fn prefix_cache_host_ram_bytes() -> Option<u64> {
+    crate::gait::host_ram_status().map(|(total, _)| total)
+}
+
+#[cfg(test)]
+fn prefix_cache_host_ram_bytes() -> Option<u64> {
+    None
+}
+
+/// Pure policy seam for the process-wide gate above. Unknown RAM preserves the
+/// historical enabled default; a present environment value is an intentional
+/// operator override and therefore wins over the automatic low-memory guard.
+pub(super) fn resident_prefix_cache_policy(
+    raw: Option<&str>,
+    total_ram_bytes: Option<u64>,
+) -> bool {
+    match raw {
+        Some(value) => prefix_cache_setting_enables(Some(value)),
+        None => total_ram_bytes.is_none_or(|total| total > LOW_MEMORY_PREFIX_CACHE_MAX_BYTES),
+    }
 }
 
 /// Pure parse of the `CAMELID_PREFIX_CACHE_RESIDENT` value. Split from the

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -14331,6 +14331,22 @@ fn prefix_cache_env_setting_parses_the_documented_opt_out() {
     assert!(!prefix_cache_setting_enables(Some("FALSE")));
 }
 
+/// An 8 GiB unified-memory host cannot safely retain the resident GPU KV plus
+/// both CPU histories created by mirror-then-clone. Automatic policy refuses
+/// that cache, while preserving both explicit operator overrides and the
+/// historical default when host RAM cannot be measured.
+#[test]
+fn resident_prefix_cache_policy_protects_low_memory_hosts() {
+    use super::metal_resident::resident_prefix_cache_policy;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+    assert!(!resident_prefix_cache_policy(None, Some(8 * GIB)));
+    assert!(resident_prefix_cache_policy(None, Some(16 * GIB)));
+    assert!(resident_prefix_cache_policy(None, None));
+    assert!(resident_prefix_cache_policy(Some("1"), Some(8 * GIB)));
+    assert!(!resident_prefix_cache_policy(Some("0"), Some(16 * GIB)));
+}
+
 /// BOTH halves of the mirror must be lossless. An F16 resident cache round-trips
 /// through an F32/F16 CPU cache exactly, but `--kv-quant q8_0|q4_0` re-quantizes
 /// on the way in — so a quantized CPU KV must refuse regardless of what the GPU


### PR DESCRIPTION
## What changed

- Automatically disable resident prompt-prefix caching on hosts with 8 GiB of RAM or less, avoiding the mirror-and-clone CPU KV duplication that exhausts unified memory during growing chats.
- Keep `CAMELID_PREFIX_CACHE_RESIDENT` as an explicit operator override in either direction.
- Preserve the original structured API error code and message when a decode fails after SSE headers have been committed.
- Add focused regression coverage and document the new memory-aware default.

## Root cause

The resident prompt-prefix path mirrors GPU KV back to CPU and then clones the populated session. On an 8 GiB Apple Silicon host, a growing multi-turn Bonsai-8B prompt can retain roughly two CPU KV histories in addition to resident GPU KV and model buffers. Once generation fails, the streaming adapter discarded the structured backend error and exposed only `stream failed after headers: HTTP 503 Service Unavailable`.

## User impact

Growing chats on 8 GiB Macs now trade prompt-cache latency for memory safety instead of failing after a few turns. If another streaming failure occurs, the UI receives the actionable backend code and message.

## Validation

- `cargo test --lib --quiet`: 1,518 passed, 24 ignored, 0 failed
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `npm run smoke:streaming`
- `npm run smoke:ui`
- `npm run build`
- `cargo build --release`
- Live Apple M3 / 8 GiB test with the exact hash-pinned `Bonsai-8B-Q1_0.gguf`:
  - growing 3-turn transcript, 1,867 prompt tokens, `max_tokens: 8192`, SSE
  - HTTP 200, reply `OK`, stop finish, 2 completion tokens
  - server remained healthy and did not retain the duplicated prompt cache
- Live injected post-header failure emitted `invalid_generation_timeout` plus its original actionable message, then `[DONE]`.
