### PR TITLE
Fix Metal model-switch fit preflight

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6389,12 +6389,17 @@ fn fit_preload_message(
     if verdict == crate::fit::FitVerdict::InsufficientFreeMemory {
         let free_gb = hw.host_ram_free_bytes as f64 / 1e9;
         let total_gb = hw.host_ram_total_bytes as f64 / 1e9;
+        let footprint_gb = footprint.footprint_bytes() as f64 / 1e9;
+        let usable_gb = crate::fit::usable_host_ram_bytes(hw).unwrap_or(0) as f64 / 1e9;
         return Some((
             "host_memory_unavailable",
             format!(
-                "This model (~{size_gb:.1} GB) fits this machine, but only ~{free_gb:.1} GB \
-                 of ~{total_gb:.1} GB memory is free right now. Close some applications \
-                 and retry, or set CAMELID_SKIP_FIT_CHECK=1 to attempt the load anyway."
+                "This model's ~{size_gb:.1} GB file fits this machine, but its estimated \
+                 in-memory footprint is ~{footprint_gb:.1} GB including weights, KV cache, \
+                 and scratch space. Only ~{free_gb:.1} GB of ~{total_gb:.1} GB memory is free \
+                 right now; after Camelid's safety reserve, ~{usable_gb:.1} GB is usable. \
+                 Close some applications and retry, or set \
+                 CAMELID_SKIP_FIT_CHECK=1 to attempt the load anyway."
             ),
         ));
     }
@@ -6414,8 +6419,9 @@ fn fit_preload_message(
 
 /// Env + filesystem wrapper around [`fit_preload_message`]. Probes **live** host
 /// memory and computes an **exact** footprint from the GGUF's real dimensions
-/// (weights + KV at a normal-use context + a bounded scratch margin) whenever the
-/// header parses, falling back to the coarse size pad otherwise. Returns a typed
+/// (weights + KV + a bounded scratch margin) whenever the header parses. Resident
+/// Metal uses its real on-demand initial KV allocation; CPU/CUDA retain the normal-
+/// use advisory context. Falls back to the coarse size pad otherwise. Returns a typed
 /// 422 only on a load-refusing verdict ([`crate::fit::FitVerdict::refuses_load`]);
 /// `None` (proceed unchanged) on the `CAMELID_SKIP_FIT_CHECK=1` override, a
 /// missing/zero-size file, or any `Fits*`/`Unknown` verdict — a fail-fast
@@ -6427,6 +6433,62 @@ fn fit_preload_message(
 /// else (including unset) keeps the preflight on.
 fn fit_check_skipped(raw: Option<&str>) -> bool {
     raw.map(str::trim) == Some("1")
+}
+
+fn preload_env_flag_enabled(raw: Option<&str>) -> bool {
+    raw.is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// The load guard must model the lane this process will actually use. The CLI
+/// fast stack explicitly arms resident Metal before the API starts; embedders and
+/// deterministic mode keep the CPU/advisory policy.
+fn metal_resident_preload_enabled(hw: &crate::capability::HardwareProfile) -> bool {
+    hw.metal_available
+        && hw.metal_unified_memory
+        && !crate::inference::deterministic_mode_enabled()
+        && preload_env_flag_enabled(
+            std::env::var("CAMELID_METAL_RESIDENT_DECODE")
+                .ok()
+                .as_deref(),
+        )
+}
+
+/// Pure arithmetic half of the exact preload policy. Resident Metal allocates KV
+/// in 512-position chunks on demand, so requiring a full 4K cache before the model
+/// can even load is a false refusal. Longer prompts/conversations remain protected
+/// by the runtime's authoritative KV growth guard.
+fn exact_preload_footprint(
+    size: u64,
+    dims: crate::fit::ModelDims,
+    hw: &crate::capability::HardwareProfile,
+    metal_resident: bool,
+    metal_kv_dtype: crate::fit::KvDtype,
+) -> crate::fit::FitInputs {
+    let (context_tokens, kv_dtype, scratch_bytes) = if metal_resident {
+        (
+            crate::fit::METAL_INITIAL_KV_CONTEXT_TOKENS,
+            metal_kv_dtype,
+            crate::fit::METAL_INITIAL_ACTIVATION_SCRATCH_BYTES,
+        )
+    } else if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
+        (
+            crate::fit::ADVISORY_CONTEXT_TOKENS,
+            crate::fit::KvDtype::F16,
+            crate::fit::ACTIVATION_SCRATCH_BYTES,
+        )
+    } else {
+        (
+            crate::fit::ADVISORY_CONTEXT_TOKENS,
+            crate::fit::KvDtype::F32,
+            crate::fit::ACTIVATION_SCRATCH_BYTES,
+        )
+    };
+    crate::fit::exact_footprint_with_scratch(size, dims, context_tokens, kv_dtype, scratch_bytes)
 }
 
 fn fit_preload_guard(
@@ -6443,19 +6505,28 @@ fn fit_preload_guard(
     // Live probe (not the cached startup snapshot): free VRAM/RAM shift as other
     // apps run or a model is already loaded, and this decision must reflect *now*.
     let hw = crate::capability::HardwareProfile::detect();
-    // Exact footprint from the GGUF's real dims when the header parses; else the pad.
-    let footprint = match crate::fit_dims::dims_from_gguf_file(path) {
-        Some(dims) => {
-            // KV is stored f16 on the GPU-resident path, f32 on the CPU path.
-            let kv_dtype = if hw.cuda_available && hw.cuda_vram_free_bytes > 0 {
-                crate::fit::KvDtype::F16
-            } else {
-                crate::fit::KvDtype::F32
-            };
-            crate::fit::exact_footprint(size, dims, crate::fit::ADVISORY_CONTEXT_TOKENS, kv_dtype)
-        }
-        None => crate::fit::advisory_footprint(size),
-    };
+    // Parse once: dimensions and the projection tensor types both live in the GGUF
+    // header. The latter selects the same F16/F32 default as resident Metal.
+    let parsed = crate::gguf::read_metadata(path).ok();
+    let footprint = parsed
+        .as_ref()
+        .and_then(|gguf| {
+            let dims = crate::fit_dims::dims_from_gguf(gguf)?;
+            let metal_resident = metal_resident_preload_enabled(&hw);
+            let metal_kv_dtype = crate::fit::metal_resident_kv_dtype_for_gguf(
+                gguf,
+                std::env::var("CAMELID_METAL_KV_DTYPE").ok().as_deref(),
+                std::env::var("CAMELID_METAL_KV16").ok().as_deref(),
+            );
+            Some(exact_preload_footprint(
+                size,
+                dims,
+                &hw,
+                metal_resident,
+                metal_kv_dtype,
+            ))
+        })
+        .unwrap_or_else(|| crate::fit::advisory_footprint(size));
     let (code, message) = fit_preload_message(&hw, &footprint, size, reclaim)?;
     Some(api_error(
         StatusCode::UNPROCESSABLE_ENTITY,
@@ -27542,6 +27613,67 @@ mod catalog_fit_tests {
     }
 
     #[test]
+    fn resident_metal_preload_uses_the_initial_f16_cache_for_bonsai_4b() {
+        let mut hw = host(false, 0, 8 * GIB, 1_503_000_000);
+        hw.metal_available = true;
+        hw.metal_unified_memory = true;
+        let size = 572_270_624; // exact Bonsai-4B-Q1_0.gguf row
+        let dims = crate::fit::ModelDims {
+            layers: 36,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+
+        // Regression: the old policy treated a Metal host as CPU-only and demanded
+        // a full 4096-position F32 cache before load, producing the confusing
+        // "0.6 GB model / 1.6 GB free" refusal on this 8 GiB Mac.
+        let old = crate::fit::exact_footprint(
+            size,
+            dims,
+            crate::fit::ADVISORY_CONTEXT_TOKENS,
+            crate::fit::KvDtype::F32,
+        );
+        assert!(super::fit_preload_message(&hw, &old, size, None).is_some());
+
+        let metal = super::exact_preload_footprint(size, dims, &hw, true, crate::fit::KvDtype::F16);
+        assert_eq!(
+            metal,
+            crate::fit::exact_footprint_with_scratch(
+                size,
+                dims,
+                crate::fit::METAL_INITIAL_KV_CONTEXT_TOKENS,
+                crate::fit::KvDtype::F16,
+                crate::fit::METAL_INITIAL_ACTIVATION_SCRATCH_BYTES,
+            )
+        );
+        assert!(
+            super::fit_preload_message(&hw, &metal, size, None).is_none(),
+            "the real initial Metal allocation fits the live-memory scenario"
+        );
+    }
+
+    #[test]
+    fn non_metal_preload_keeps_the_normal_use_context_policy() {
+        let hw = host(false, 0, 8 * GIB, 6 * GIB);
+        let dims = crate::fit::ModelDims {
+            layers: 36,
+            kv_heads: 8,
+            head_dim: 128,
+        };
+        let actual =
+            super::exact_preload_footprint(GIB, dims, &hw, false, crate::fit::KvDtype::F16);
+        assert_eq!(
+            actual,
+            crate::fit::exact_footprint(
+                GIB,
+                dims,
+                crate::fit::ADVISORY_CONTEXT_TOKENS,
+                crate::fit::KvDtype::F32,
+            )
+        );
+    }
+
+    #[test]
     fn load_request_replace_defaults_to_false_for_existing_api_clients() {
         // Back-compat: a body without `replace` must not start evicting models.
         let req: super::LoadModelRequest =
@@ -27696,6 +27828,9 @@ mod catalog_fit_tests {
         assert_eq!(code, "host_memory_unavailable");
         assert!(msg.contains("free right now"), "{msg}");
         assert!(msg.contains("Close some applications"), "{msg}");
+        assert!(msg.contains("estimated in-memory footprint"), "{msg}");
+        assert!(msg.contains("safety reserve"), "{msg}");
+        assert!(msg.contains("usable"), "{msg}");
         assert!(!msg.contains("larger than this machine"), "{msg}");
         // The override is still offered, exactly as for the too-large case.
         assert!(msg.contains("CAMELID_SKIP_FIT_CHECK=1"), "{msg}");

--- a/src/fit.rs
+++ b/src/fit.rs
@@ -156,7 +156,7 @@ impl FitInputs {
 /// - Unprobed RAM: the KV guard fails *open* (unbounded); the advisor abstains here
 ///   with `None` (surfaced as [`FitVerdict::Unknown`]) rather than assert a capacity
 ///   it cannot measure.
-fn usable_host_ram_bytes(hw: &HardwareProfile) -> Option<u64> {
+pub(crate) fn usable_host_ram_bytes(hw: &HardwareProfile) -> Option<u64> {
     if hw.host_ram_total_bytes == 0 {
         return None;
     }
@@ -321,6 +321,76 @@ impl KvDtype {
     }
 }
 
+/// Whether a resident Metal projection type selects the parity-qualified F16
+/// primary KV cache. Keep this predicate shared with the runtime's loaded-weight
+/// decision (`inference/metal_resident.rs`) so the preload advisor cannot size a
+/// Q1/Q2/K-quant model as F32 while the engine actually builds an F16 cache.
+pub(crate) fn metal_f16_kv_tensor_type(tensor_type: crate::gguf::GgufTensorType) -> bool {
+    matches!(
+        tensor_type,
+        crate::gguf::GgufTensorType::Q4K
+            | crate::gguf::GgufTensorType::Q6K
+            | crate::gguf::GgufTensorType::Q1_0
+            | crate::gguf::GgufTensorType::Q2_0G64
+            | crate::gguf::GgufTensorType::Q2_0G128
+            | crate::gguf::GgufTensorType::Pq2_0
+    )
+}
+
+/// True for the per-layer dense projections inspected by
+/// `inference::metal_resident::weights_use_kquant`. Tensor names are available in
+/// the GGUF header, so preload can mirror that runtime decision without loading or
+/// expanding the weights.
+fn is_dense_projection_name(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix("blk.") else {
+        return false;
+    };
+    let Some((layer, role)) = rest.split_once('.') else {
+        return false;
+    };
+    if layer.is_empty() || !layer.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    matches!(
+        role,
+        "attn_q.weight"
+            | "attn_k.weight"
+            | "attn_v.weight"
+            | "attn_output.weight"
+            | "ffn_gate.weight"
+            | "ffn_up.weight"
+            | "ffn_down.weight"
+    )
+}
+
+/// Resolve the resident Metal KV width from a parsed local GGUF header and the
+/// same operator overrides consumed by the runtime. `q8` is conservatively sized
+/// as F16 because [`KvDtype`] has no block-overhead representation and two bytes
+/// per element is still an upper bound for the quantized cache.
+pub(crate) fn metal_resident_kv_dtype_for_gguf(
+    gguf: &crate::gguf::GgufFile,
+    explicit_dtype: Option<&str>,
+    legacy_kv16: Option<&str>,
+) -> KvDtype {
+    match explicit_dtype.map(str::trim).map(str::to_ascii_lowercase) {
+        Some(value) if matches!(value.as_str(), "f32" | "float32") => return KvDtype::F32,
+        Some(value) if matches!(value.as_str(), "f16" | "half" | "q8" | "q8_0") => {
+            return KvDtype::F16
+        }
+        _ => {}
+    }
+    if legacy_kv16.is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true")) {
+        return KvDtype::F16;
+    }
+    if gguf.tensors.iter().any(|tensor| {
+        is_dense_projection_name(&tensor.name) && metal_f16_kv_tensor_type(tensor.tensor_type)
+    }) {
+        KvDtype::F16
+    } else {
+        KvDtype::F32
+    }
+}
+
 /// The architecture dimensions the KV-cache size depends on. Read from GGUF
 /// metadata (`block_count`, `attention.head_count_kv`, `head_dim`) — never guessed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -347,6 +417,18 @@ impl ModelDims {
 /// fixed, realistic length rather than the theoretical max. The runtime's own KV
 /// predict-and-abort guard governs longer conversations.
 pub const ADVISORY_CONTEXT_TOKENS: u64 = 4096;
+
+/// The resident Metal cache's minimum allocation quantum. A fresh decode grows
+/// on demand from 512 positions rather than materializing the advisory 4K context
+/// at load time. Preload admission sizes this initial allocation; the runtime KV
+/// budget remains authoritative as a conversation grows beyond it.
+pub const METAL_INITIAL_KV_CONTEXT_TOKENS: u64 = 512;
+
+/// Measured resident-Metal load/first-token scratch reserve. On the 4B Q1 row,
+/// building the engine plus its initial KV cache raises RSS by ~177 MiB; 256 MiB
+/// leaves meaningful driver/fragmentation headroom without applying the generic
+/// 512 MiB CPU/CUDA allowance twice to unified memory.
+pub const METAL_INITIAL_ACTIVATION_SCRATCH_BYTES: u64 = 256 * 1024 * 1024;
 
 /// Coarse, bounded allowance for activations + framework scratch beyond weights
 /// and KV. Small next to weights/KV for single-sequence decode; a fixed margin
@@ -375,8 +457,27 @@ pub fn exact_footprint(
     context_tokens: u64,
     kv: KvDtype,
 ) -> FitInputs {
-    let kv_and_scratch =
-        kv_bytes(dims, context_tokens, kv).saturating_add(ACTIVATION_SCRATCH_BYTES);
+    exact_footprint_with_scratch(
+        weight_bytes,
+        dims,
+        context_tokens,
+        kv,
+        ACTIVATION_SCRATCH_BYTES,
+    )
+}
+
+/// Exact footprint with a lane-specific scratch allowance. Preload uses this for
+/// resident Metal, whose unified-memory engine has a measured smaller initial
+/// allocation; all existing callers retain [`ACTIVATION_SCRATCH_BYTES`] through
+/// [`exact_footprint`].
+pub(crate) fn exact_footprint_with_scratch(
+    weight_bytes: u64,
+    dims: ModelDims,
+    context_tokens: u64,
+    kv: KvDtype,
+    scratch_bytes: u64,
+) -> FitInputs {
+    let kv_and_scratch = kv_bytes(dims, context_tokens, kv).saturating_add(scratch_bytes);
     FitInputs {
         weight_bytes,
         kv_bytes_at_ctx: kv_and_scratch,
@@ -678,6 +779,77 @@ mod tests {
         assert_eq!(
             kv_bytes(d, 100, KvDtype::F16) * 2,
             kv_bytes(d, 100, KvDtype::F32)
+        );
+    }
+
+    fn gguf_with_projection(
+        name: &str,
+        tensor_type: crate::gguf::GgufTensorType,
+    ) -> crate::gguf::GgufFile {
+        crate::gguf::GgufFile {
+            path: std::path::PathBuf::from("synthetic.gguf"),
+            version: 3,
+            tensor_count: 1,
+            metadata_count: 0,
+            alignment: 32,
+            data_start_offset: 0,
+            metadata: std::collections::BTreeMap::new(),
+            tensors: vec![crate::gguf::GgufTensorDescriptor {
+                name: name.to_string(),
+                dimensions: vec![128, 128],
+                tensor_type,
+                relative_offset: 0,
+                absolute_offset: 0,
+                n_bytes: 0,
+            }],
+        }
+    }
+
+    #[test]
+    fn metal_kv_dtype_tracks_the_projection_quant_not_an_unrelated_tensor() {
+        let q1_projection =
+            gguf_with_projection("blk.0.attn_q.weight", crate::gguf::GgufTensorType::Q1_0);
+        assert_eq!(
+            metal_resident_kv_dtype_for_gguf(&q1_projection, None, None),
+            KvDtype::F16
+        );
+
+        let q1_embedding =
+            gguf_with_projection("token_embd.weight", crate::gguf::GgufTensorType::Q1_0);
+        assert_eq!(
+            metal_resident_kv_dtype_for_gguf(&q1_embedding, None, None),
+            KvDtype::F32
+        );
+
+        let q8_projection =
+            gguf_with_projection("blk.0.attn_q.weight", crate::gguf::GgufTensorType::Q8_0);
+        assert_eq!(
+            metal_resident_kv_dtype_for_gguf(&q8_projection, None, None),
+            KvDtype::F32
+        );
+    }
+
+    #[test]
+    fn metal_kv_dtype_honors_runtime_overrides_conservatively() {
+        let q1 = gguf_with_projection("blk.0.ffn_down.weight", crate::gguf::GgufTensorType::Q1_0);
+        assert_eq!(
+            metal_resident_kv_dtype_for_gguf(&q1, Some("f32"), None),
+            KvDtype::F32
+        );
+
+        let q8 = gguf_with_projection("blk.0.ffn_down.weight", crate::gguf::GgufTensorType::Q8_0);
+        assert_eq!(
+            metal_resident_kv_dtype_for_gguf(&q8, Some("f16"), None),
+            KvDtype::F16
+        );
+        assert_eq!(
+            metal_resident_kv_dtype_for_gguf(&q8, Some("q8"), None),
+            KvDtype::F16,
+            "F16 is a safe upper bound for block-quantized KV"
+        );
+        assert_eq!(
+            metal_resident_kv_dtype_for_gguf(&q8, None, Some("true")),
+            KvDtype::F16
         );
     }
 

--- a/src/fit_dims.rs
+++ b/src/fit_dims.rs
@@ -476,7 +476,7 @@ pub fn dims_from_gguf_file(path: &Path) -> Option<ModelDims> {
 
 /// Map a parsed GGUF's metadata to dense-Llama KV dims, or `None` for a
 /// non-dense/unknown architecture or implausible values.
-fn dims_from_gguf(gguf: &crate::gguf::GgufFile) -> Option<ModelDims> {
+pub(crate) fn dims_from_gguf(gguf: &crate::gguf::GgufFile) -> Option<ModelDims> {
     let config = crate::model::LlamaModelConfig::from_gguf(gguf).ok()?;
     let dims = crate::model::DenseLlamaDims::from_config(&config).ok()?;
     let dims = ModelDims {

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -122,17 +122,8 @@ pub(super) fn prefix_cache_setting_enables(raw: Option<&str>) -> bool {
 /// models re-decides.
 pub(super) fn weights_use_kquant(weights: &super::LlamaLoadedWeights) -> bool {
     let is_kquant = |t: &CpuTensor| {
-        matches!(
-            t.source_type,
-            Some(
-                GgufTensorType::Q4K
-                    | GgufTensorType::Q6K
-                    | GgufTensorType::Q1_0
-                    | GgufTensorType::Q2_0G64
-                    | GgufTensorType::Q2_0G128
-                    | GgufTensorType::Pq2_0
-            )
-        )
+        t.source_type
+            .is_some_and(crate::fit::metal_f16_kv_tensor_type)
     };
     weights.layers.iter().any(|l| {
         is_kquant(&l.attention_q)


### PR DESCRIPTION
## Summary

- make preload admission use the resident Metal lane's actual initial KV allocation
- keep CPU and CUDA preload policies unchanged
- share Metal quantization/KV-width detection with the runtime
- report file size, estimated in-memory footprint, free memory, and usable memory in fit errors

## Root cause

On Apple Silicon, the preload guard treated Metal as the CPU path. It budgeted an F32 KV cache for the full 4096-token advisory context plus the generic scratch allowance. Switching from Bonsai-8B to the 0.6 GB Bonsai-4B therefore produced a false refusal even though Metal initially allocates only 512 KV positions and uses F16 KV for the Q1 model.

## Impact

Bonsai-8B → Bonsai-4B switching now succeeds on the affected 8 GB Mac without `CAMELID_SKIP_FIT_CHECK`. Longer prompts remain protected by the runtime KV growth guard.

## Validation

- `cargo test --all-targets`
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --all -- --check`
- focused fit/catalog regression tests
- release sidecar build
- live installed-app Bonsai-8B → Bonsai-4B switch
- one-token chat generation through the Metal resident backend