### PR TITLE
Fix model actions and add runtime memory analytics

### DIFF
--- a/frontend/scripts/ui-regression-smoke.mjs
+++ b/frontend/scripts/ui-regression-smoke.mjs
@@ -117,6 +117,8 @@ const systemViewSource = read('../src/views/SystemView.jsx')
 const modelsViewSource = read('../src/views/ModelsView.jsx')
 const topBarSource = read('../src/components/TopBar.jsx')
 const analyticsViewSource = read('../src/views/AnalyticsView.jsx')
+const runtimeMemoryPanelSource = read('../src/components/analytics/RuntimeMemoryPanel.jsx')
+const runtimeMemoryHookSource = read('../src/hooks/useRuntimeMemory.js')
 const capabilitiesSource = read('../src/lib/capabilities.js')
 const streamParserSource = read('../src/lib/chatCompletionStream.js')
 const evidenceChipSource = read('../src/components/ui/EvidenceChip.jsx')
@@ -136,6 +138,7 @@ const tokensCss = read('../src/styles/tokens.css')
 const evidenceCss = read('../src/styles/evidence.css')
 const chatCss = read('../src/styles/chat.css')
 const uiCss = read('../src/styles/ui.css')
+const viewsCss = read('../src/styles/views.css')
 const statusSheets = ['../src/styles/ui.css', '../src/styles/shell.css', '../src/styles/chat.css', '../src/styles/views.css', '../src/styles/cluster.css', '../src/styles/observatory.css']
   .map((path) => [path, read(path)])
 
@@ -357,6 +360,9 @@ assert.match(downloadedModelsViewSource, /unloadLocalModel\(\{ apiBase: spine\.b
 assert.match(downloadedModelsViewSource, /isActive \? spine\.current\?\.id : entry\.filename/, 'an auto-loaded active card must unload by its registry id even when GGUF metadata named it differently')
 assert.match(downloadedModelsViewSource, /spine\.loadedModelIds\.has\(entry\.filename\)/, 'card actions must use the full resident registry, including non-active sidecars')
 assert.match(downloadedModelsViewSource, />\s*Load\s*<\/Button>[\s\S]*>\s*Unload\s*<\/Button>/, 'every downloaded model card must expose both Load and Unload controls')
+assert.match(viewsCss, /\.downloaded-model \.cxv-card__foot\s*\{[^}]*flex-direction:\s*column/, 'downloaded-model metadata and actions must occupy separate footer rows')
+assert.match(viewsCss, /\.downloaded-model \.cxv-card__actions\s*\{[^}]*display:\s*grid[^}]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*160px\)\)[^}]*width:\s*100%[^}]*min-width:\s*0/, 'downloaded-model actions must use a bounded two-column grid instead of overflowing into adjacent cards')
+assert.match(viewsCss, /\.downloaded-model \.cxv-card__actions \.cxv-danger\s*\{\s*grid-column:\s*2/, 'downloaded-model Delete actions must stay aligned to the lower-right grid cell')
 
 /* ---- Model management (Phase 3) ---- */
 assert.match(modelInspectorSource, /not support evidence/, 'the model inspector must label its contents as descriptive, not support evidence')
@@ -516,6 +522,11 @@ assert.match(appSource, /camelid:open-ledger/, 'the app shell must listen for le
 
 /* ---- Analytics ---- */
 assert.match(analyticsViewSource, /displayCapabilityId\(feature\.id\)/, 'Analytics view should not render raw provider-scoped API feature ids')
+assert.match(analyticsViewSource, /<RuntimeMemoryPanel apiBase=\{apiBase\}/, 'Analytics must render live runtime memory from the configured Camelid API')
+assert.match(runtimeMemoryHookSource, /api\/runtime\/memory/, 'runtime memory must come from the backend rather than browser estimates')
+assert.match(runtimeMemoryHookSource, /api\/runtime\/kv-cache\/purge/, 'the KV purge control must call the dedicated cache-only endpoint')
+assert.match(runtimeMemoryPanelSource, /Model weights[\s\S]*KV cache/, 'Analytics runtime cards must show model and KV-cache memory')
+assert.match(runtimeMemoryPanelSource, /Purge KV cache/, 'Analytics runtime cards must provide a KV-cache purge action')
 
 /* ---- TopBar (re-baselined to the Evidence Chip gate) ---- */
 assert.match(topBarSource, /getChatGateState\(capabilities, selectedModel, runtime\)/, 'TopBar must derive its support claim from the shared chat gate')

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -349,7 +349,7 @@ function App() {
           )}
 
           {tab === 'analytics' && (
-            <AnalyticsView conversations={conversations} models={models} runtime={runtime} capabilities={dashboard?.capabilities} />
+            <AnalyticsView apiBase={apiBase} conversations={conversations} models={models} runtime={runtime} capabilities={dashboard?.capabilities} />
           )}
 
           {tab === 'history' && (

--- a/frontend/src/components/analytics/RuntimeMemoryPanel.jsx
+++ b/frontend/src/components/analytics/RuntimeMemoryPanel.jsx
@@ -1,0 +1,95 @@
+import { useRuntimeMemory } from '../../hooks/useRuntimeMemory'
+import { formatBytes } from '../../lib/formatters'
+import { Button } from '../ui/Button'
+import { Notice } from '../ui/Notice'
+import { IconMemory, IconRefresh, IconTrash } from '../ui/icons'
+
+function memoryValue(value, loading) {
+  if (loading && value === undefined) return '…'
+  return formatBytes(value)
+}
+
+export function RuntimeMemoryPanel({ apiBase }) {
+  const { memory, loading, purging, error, notice, refresh, purge, clearNotice } = useRuntimeMemory(apiBase)
+  const modelCount = memory?.models?.length || 0
+  const cacheEntries = Number(memory?.kv_cache_entries || 0)
+
+  return (
+    <section className="cxv-card cxv-panel a-memory">
+      <div className="a-memory__head">
+        <div>
+          <div className="cxv-section__head"><h2>Runtime memory</h2><span className="cxv-section__count">live · refreshes every 5s</span></div>
+          <p className="cxv-sub">Current Camelid process memory, loaded-model weight estimates, and retained prompt KV cache.</p>
+        </div>
+        <div className="a-memory__actions">
+          <Button
+            variant="outline"
+            size="sm"
+            icon={<IconRefresh size={15} />}
+            onClick={() => refresh()}
+            loading={loading}
+          >
+            Refresh
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            icon={<IconTrash size={16} />}
+            onClick={purge}
+            loading={purging}
+            disabled={loading || purging || cacheEntries === 0}
+            title={cacheEntries ? 'Release retained prompt KV-cache entries' : 'KV cache is empty'}
+          >
+            Purge KV cache
+          </Button>
+        </div>
+      </div>
+
+      {error ? <Notice notice={error} tone="error" /> : null}
+      {notice ? <Notice notice={notice} tone="success" onDismiss={clearNotice} /> : null}
+
+      <div className="cxv-stat-grid a-memory__stats">
+        <div className="cxv-stat">
+          <span>Camelid memory</span>
+          <strong>{memoryValue(memory?.process_resident_bytes, loading)}</strong>
+          <small>current process footprint</small>
+        </div>
+        <div className="cxv-stat">
+          <span>Model weights</span>
+          <strong>{memoryValue(memory?.model_weight_bytes_estimate, loading)}</strong>
+          <small>{modelCount} loaded {modelCount === 1 ? 'model' : 'models'} · estimated</small>
+        </div>
+        <div className="cxv-stat">
+          <span>KV cache</span>
+          <strong>{memoryValue(memory?.kv_cache_bytes, loading)}</strong>
+          <small>{cacheEntries} of {memory?.kv_cache_capacity || 0} retained entries</small>
+        </div>
+      </div>
+
+      <div className="a-memory__models">
+        <div className="a-memory__models-head">
+          <strong>Loaded models</strong>
+          <span>weights estimate · retained KV</span>
+        </div>
+        {memory?.models?.length ? memory.models.map((model) => (
+          <article className="a-memory__model" key={model.id}>
+            <div className="a-memory__model-name">
+              <IconMemory size={16} />
+              <strong title={model.id}>{model.id}</strong>
+              {model.active ? <span className="cxv-tag cxv-tag--ready">Active</span> : null}
+            </div>
+            <div className="a-memory__model-metrics">
+              <span><small>Weights</small><strong>{formatBytes(model.weight_bytes_estimate)}</strong></span>
+              <span><small>KV cache</small><strong>{formatBytes(model.kv_cache_bytes)}</strong></span>
+              <span><small>Cached tokens</small><strong>{model.cached_tokens?.toLocaleString() || '0'}</strong></span>
+            </div>
+          </article>
+        )) : (
+          <p className="a-memory__empty">{loading ? 'Reading loaded models…' : 'No models are loaded.'}</p>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default RuntimeMemoryPanel

--- a/frontend/src/hooks/useRuntimeMemory.js
+++ b/frontend/src/hooks/useRuntimeMemory.js
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const REFRESH_INTERVAL_MS = 5000
+
+export function useRuntimeMemory(apiBase = '') {
+  const base = String(apiBase || '').replace(/\/$/, '')
+  const [memory, setMemory] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [purging, setPurging] = useState(false)
+  const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
+
+  const refresh = useCallback(async ({ quiet = false } = {}) => {
+    if (!quiet) setLoading(true)
+    try {
+      const response = await fetch(`${base}/api/runtime/memory`)
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body?.error?.message || `memory request failed (HTTP ${response.status})`)
+      setMemory(body)
+      setError('')
+      return body
+    } catch (err) {
+      setError(String(err?.message || err))
+      return null
+    } finally {
+      if (!quiet) setLoading(false)
+    }
+  }, [base])
+
+  const purge = useCallback(async () => {
+    if (purging) return
+    setPurging(true)
+    setNotice('')
+    setError('')
+    try {
+      const response = await fetch(`${base}/api/runtime/kv-cache/purge`, { method: 'POST' })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body?.error?.message || `KV-cache purge failed (HTTP ${response.status})`)
+      setNotice(body.purged_entries
+        ? `Purged ${body.purged_entries} KV-cache ${body.purged_entries === 1 ? 'entry' : 'entries'}.`
+        : 'KV cache was already empty.')
+      await refresh({ quiet: true })
+    } catch (err) {
+      setError(String(err?.message || err))
+    } finally {
+      setPurging(false)
+    }
+  }, [base, purging, refresh])
+
+  useEffect(() => {
+    refresh()
+    const timer = window.setInterval(() => refresh({ quiet: true }), REFRESH_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [refresh])
+
+  return { memory, loading, purging, error, notice, refresh, purge, clearNotice: () => setNotice('') }
+}
+
+export default useRuntimeMemory

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -488,12 +488,19 @@
   box-shadow: inset 3px 0 0 var(--color-ready), var(--shadow-1);
 }
 .downloaded-model__tags { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: var(--space-1); }
-.downloaded-model .cxv-card__foot { align-items: flex-end; flex-wrap: wrap; }
-.downloaded-model .cxv-card__actions {
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  margin-left: auto;
+.downloaded-model .cxv-card__foot {
+  align-items: stretch;
+  flex-direction: column;
 }
+.downloaded-model .cxv-card__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 160px));
+  width: 100%;
+  min-width: 0;
+  justify-content: flex-end;
+}
+.downloaded-model .cxv-card__actions .cx-btn { width: 100%; }
+.downloaded-model .cxv-card__actions .cxv-danger { grid-column: 2; }
 .downloaded-empty {
   display: flex;
   flex-direction: column;
@@ -510,8 +517,6 @@
 @media (max-width: 640px) {
   .downloaded-active { align-items: stretch; flex-direction: column; }
   .downloaded-storage__next { grid-template-columns: 1fr; gap: var(--space-1); }
-  .downloaded-model .cxv-card__foot { align-items: stretch; flex-direction: column; }
-  .downloaded-model .cxv-card__actions { justify-content: flex-end; margin-left: 0; }
 }
 
 /* ---- cxv: forms ---- */
@@ -541,6 +546,34 @@
 /* ---- cxv: panel (section card) ---- */
 .cxv-panel { display: flex; flex-direction: column; gap: var(--space-4); padding: var(--space-6); }
 .cxv-panel:hover { box-shadow: var(--shadow-1); border-color: var(--color-border-soft); }
+
+/* ---- Analytics: runtime memory ---- */
+.a-memory { gap: var(--space-5); }
+.a-memory__head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-4); }
+.a-memory__head > div:first-child { min-width: 0; }
+.a-memory__head .cxv-sub { margin-top: var(--space-1); }
+.a-memory__actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: var(--space-2); flex: none; }
+.a-memory__stats { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.a-memory__models { display: flex; flex-direction: column; border-top: 1px solid var(--color-border-soft); }
+.a-memory__models-head { display: flex; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) 0; color: var(--color-text-faint); font-size: var(--text-xs); }
+.a-memory__models-head strong { color: var(--color-text-muted); font-weight: 650; }
+.a-memory__model { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: var(--space-4); padding: var(--space-3) 0; border-top: 1px solid var(--color-border-soft); }
+.a-memory__model-name { display: flex; align-items: center; gap: var(--space-2); min-width: 0; color: var(--color-text-muted); }
+.a-memory__model-name strong { overflow: hidden; color: var(--color-text); font-size: var(--text-sm); font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
+.a-memory__model-metrics { display: grid; grid-template-columns: repeat(3, minmax(92px, 1fr)); gap: var(--space-5); }
+.a-memory__model-metrics > span { display: flex; flex-direction: column; align-items: flex-end; gap: 1px; }
+.a-memory__model-metrics small { color: var(--color-text-faint); font-size: var(--text-xs); }
+.a-memory__model-metrics strong { color: var(--color-text); font-size: var(--text-sm); font-variant-numeric: tabular-nums; }
+.a-memory__empty { padding: var(--space-5) 0 var(--space-2); color: var(--color-text-muted); font-size: var(--text-sm); text-align: center; }
+
+@media (max-width: 760px) {
+  .a-memory__head { flex-direction: column; }
+  .a-memory__actions { justify-content: flex-start; }
+  .a-memory__stats { grid-template-columns: 1fr; }
+  .a-memory__model { grid-template-columns: 1fr; }
+  .a-memory__model-metrics { grid-template-columns: repeat(3, 1fr); gap: var(--space-3); }
+  .a-memory__model-metrics > span { align-items: flex-start; }
+}
 
 /* ---- Analytics: leaderboard ---- */
 .a-lead { display: flex; flex-direction: column; gap: var(--space-4); }

--- a/frontend/src/views/AnalyticsView.jsx
+++ b/frontend/src/views/AnalyticsView.jsx
@@ -5,6 +5,7 @@ import { isRunnableModel } from '../lib/modelState'
 import { EmptyState } from '../components/ui/EmptyState'
 import { StatusDot } from '../components/ui/StatusDot'
 import { IconAnalytics, IconChart } from '../components/ui/icons'
+import { RuntimeMemoryPanel } from '../components/analytics/RuntimeMemoryPanel'
 
 function startOfDay(date) { const next = new Date(date); next.setHours(0, 0, 0, 0); return next }
 function dayKey(date) { return startOfDay(date).toISOString().slice(0, 10) }
@@ -20,7 +21,7 @@ function summarizeGuardedTargets(targets = []) {
   return guarded.slice(0, 3).map((target) => `${target.id}: ${formatCapabilityStatus(target.status)}`).join(' · ')
 }
 
-export default function AnalyticsView({ conversations, models, runtime, capabilities }) {
+export default function AnalyticsView({ apiBase, conversations, models, runtime, capabilities }) {
   const now = new Date()
   const sevenDays = Array.from({ length: 7 }, (_, index) => {
     const date = new Date(now)
@@ -109,6 +110,8 @@ export default function AnalyticsView({ conversations, models, runtime, capabili
         <div className="cxv-stat"><span>Avg speed</span><strong>{averageReplyRate ? formatRate(averageReplyRate).replace(' tokens/sec', '') : '—'}</strong><small>{averageReplyRate ? 'tokens/sec out' : 'after first reply'}</small></div>
         <div className="cxv-stat"><span>Chat-ready</span><strong>{chatReadyModels}</strong><small>{runtime?.generation_ready ? 'runtime is green' : 'load a local GGUF'}</small></div>
       </div>
+
+      <RuntimeMemoryPanel apiBase={apiBase} />
 
       <div className="cxv-grid cxv-grid--two">
         <section className="cxv-card cxv-panel">

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -300,7 +300,7 @@ fn metric_gauge(out: &mut String, name: &str, help: &str, value: impl ToString) 
 }
 
 #[cfg(target_os = "linux")]
-fn current_process_rss_bytes() -> Option<u64> {
+pub(super) fn current_process_rss_bytes() -> Option<u64> {
     let status = std::fs::read_to_string("/proc/self/status").ok()?;
     let line = status.lines().find(|line| line.starts_with("VmRSS:"))?;
     let kib = line.split_whitespace().nth(1)?.parse::<u64>().ok()?;
@@ -308,7 +308,7 @@ fn current_process_rss_bytes() -> Option<u64> {
 }
 
 #[cfg(windows)]
-fn current_process_rss_bytes() -> Option<u64> {
+pub(super) fn current_process_rss_bytes() -> Option<u64> {
     use windows_sys::Win32::System::{
         ProcessStatus::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS},
         Threading::GetCurrentProcess,
@@ -329,8 +329,21 @@ fn current_process_rss_bytes() -> Option<u64> {
     (ok != 0).then_some(counters.WorkingSetSize as u64)
 }
 
-#[cfg(not(any(target_os = "linux", windows)))]
-fn current_process_rss_bytes() -> Option<u64> {
+#[cfg(target_os = "macos")]
+pub(super) fn current_process_rss_bytes() -> Option<u64> {
+    let mut info: libc::rusage_info_v2 = unsafe { std::mem::zeroed() };
+    let result = unsafe {
+        libc::proc_pid_rusage(
+            std::process::id() as libc::c_int,
+            libc::RUSAGE_INFO_V2,
+            &mut info as *mut libc::rusage_info_v2 as *mut libc::rusage_info_t,
+        )
+    };
+    (result == 0 && info.ri_phys_footprint > 0).then_some(info.ri_phys_footprint)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+pub(super) fn current_process_rss_bytes() -> Option<u64> {
     None
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -578,6 +578,32 @@ pub struct Q8RuntimeHealth {
 }
 
 #[derive(Debug, Serialize)]
+pub struct RuntimeMemoryResponse {
+    pub process_resident_bytes: Option<u64>,
+    pub model_weight_bytes_estimate: u64,
+    pub kv_cache_bytes: u64,
+    pub kv_cache_entries: usize,
+    pub kv_cache_capacity: usize,
+    pub models: Vec<RuntimeModelMemory>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RuntimeModelMemory {
+    pub id: String,
+    pub active: bool,
+    pub weight_bytes_estimate: u64,
+    pub kv_cache_bytes: u64,
+    pub kv_cache_entries: usize,
+    pub cached_tokens: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PurgeKvCacheResponse {
+    pub purged_entries: usize,
+    pub released_bytes_estimate: u64,
+}
+
+#[derive(Debug, Serialize)]
 pub struct CapabilitiesResponse {
     pub engine: &'static str,
     pub gguf_metadata: bool,
@@ -2298,6 +2324,8 @@ fn router_with_state_and_policy(state: AppState, policy: server::ServerPolicy) -
         .route("/v1/health", get(health))
         .route("/api/capabilities", get(capabilities))
         .route("/api/runtime/gpu", get(gpu_runtime).post(set_gpu_runtime))
+        .route("/api/runtime/memory", get(runtime_memory))
+        .route("/api/runtime/kv-cache/purge", post(purge_kv_cache))
         .route("/api/telemetry/stream", get(telemetry_stream))
         .route("/execution-plan", get(execution_plan))
         .route("/api/execution-plan", get(execution_plan))
@@ -3001,6 +3029,77 @@ async fn health_registry_snapshot(state: &AppState) -> HealthResponse {
         executable: loopback_executable_path(state.serve_addr),
         listen_addr: (state.serve_addr.ip().is_loopback()).then(|| state.serve_addr.to_string()),
     }
+}
+
+#[derive(Debug)]
+struct KvCacheEntryMemory {
+    model_id: String,
+    bytes: u64,
+    tokens: usize,
+}
+
+fn kv_cache_memory_snapshot(state: &AppState) -> (Vec<KvCacheEntryMemory>, usize) {
+    let Ok(pool) = state.cached_prompt_prefix.lock() else {
+        return (Vec::new(), 0);
+    };
+    let entries = pool
+        .entries
+        .iter()
+        .map(|entry| KvCacheEntryMemory {
+            model_id: entry.cached.model_id.clone(),
+            bytes: entry.cached.session.kv_cache_allocated_bytes(),
+            tokens: entry.cached.token_ids.len(),
+        })
+        .collect();
+    (entries, pool.capacity)
+}
+
+async fn runtime_memory(State(state): State<AppState>) -> Json<RuntimeMemoryResponse> {
+    let (kv_entries, kv_cache_capacity) = kv_cache_memory_snapshot(&state);
+    let kv_cache_bytes = kv_entries.iter().map(|entry| entry.bytes).sum();
+    let active_model_id = state.active_model_id.read().await.clone();
+    let loaded_models = state.loaded_models.read().await;
+    let mut models = loaded_models
+        .values()
+        .map(|model| {
+            let model_cache: Vec<_> = kv_entries
+                .iter()
+                .filter(|entry| entry.model_id == model.id)
+                .collect();
+            RuntimeModelMemory {
+                id: model.id.clone(),
+                active: active_model_id.as_ref() == Some(&model.id),
+                weight_bytes_estimate: std::fs::metadata(&model.path)
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0),
+                kv_cache_bytes: model_cache.iter().map(|entry| entry.bytes).sum(),
+                kv_cache_entries: model_cache.len(),
+                cached_tokens: model_cache.iter().map(|entry| entry.tokens).sum(),
+            }
+        })
+        .collect::<Vec<_>>();
+    models.sort_by(|left, right| left.id.cmp(&right.id));
+    let model_weight_bytes_estimate = models.iter().map(|model| model.weight_bytes_estimate).sum();
+
+    Json(RuntimeMemoryResponse {
+        process_resident_bytes: metrics::current_process_rss_bytes(),
+        model_weight_bytes_estimate,
+        kv_cache_bytes,
+        kv_cache_entries: kv_entries.len(),
+        kv_cache_capacity,
+        models,
+    })
+}
+
+async fn purge_kv_cache(State(state): State<AppState>) -> Json<PurgeKvCacheResponse> {
+    let (entries, _) = kv_cache_memory_snapshot(&state);
+    let released_bytes_estimate = entries.iter().map(|entry| entry.bytes).sum();
+    let purged_entries = entries.len();
+    clear_prompt_prefix_cache(&state);
+    Json(PurgeKvCacheResponse {
+        purged_entries,
+        released_bytes_estimate,
+    })
 }
 
 /// `/health` while a model transition holds the registries: every field that
@@ -18381,6 +18480,20 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn runtime_memory_reports_empty_state_and_purge_is_idempotent() {
+        let state = AppState::default();
+        let Json(memory) = runtime_memory(State(state.clone())).await;
+        assert_eq!(memory.model_weight_bytes_estimate, 0);
+        assert_eq!(memory.kv_cache_bytes, 0);
+        assert_eq!(memory.kv_cache_entries, 0);
+        assert!(memory.models.is_empty());
+
+        let Json(purged) = purge_kv_cache(State(state)).await;
+        assert_eq!(purged.purged_entries, 0);
+        assert_eq!(purged.released_bytes_estimate, 0);
+    }
 
     #[test]
     fn streaming_error_preserves_the_structured_api_failure() {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2650,6 +2650,13 @@ impl LlamaInferenceSession {
         self.kv_cache.position
     }
 
+    /// Bytes currently allocated by this session's CPU-side K/V history.
+    /// Used by the local runtime-memory endpoint to report retained prompt-cache
+    /// cost without exposing cache contents.
+    pub fn kv_cache_allocated_bytes(&self) -> u64 {
+        self.kv_cache.allocated_bytes()
+    }
+
     /// Positions still available before the context limit.
     pub fn remaining_context(&self) -> usize {
         self.kv_cache


### PR DESCRIPTION
## What changed

- align downloaded-model actions in a bounded two-column grid so controls stay inside each card
- add live Analytics cards for Camelid process memory, loaded-model weight estimates, and retained KV-cache usage
- show per-model weight, KV-cache, cached-token, and active-model details
- add a cache-only purge action that releases retained prompt KV entries without unloading model weights
- add macOS process-footprint reporting and regression coverage

## Why

Downloaded-model action controls could overflow into adjacent cards, and Analytics did not expose the runtime memory cost of Camelid, loaded models, or retained prompt KV cache.

## Impact

Operators can now see the major runtime memory components in one place and safely purge retained KV cache when needed.

## Validation

- `npm run build`
- `node scripts/ui-regression-smoke.mjs`
- `cargo test --offline --locked runtime_memory_reports_empty_state_and_purge_is_idempotent`
- live local verification against a loaded Bonsai-8B model