### PR TITLE
Add API key support to the web UI

### DIFF
--- a/frontend/scripts/ui-regression-smoke.mjs
+++ b/frontend/scripts/ui-regression-smoke.mjs
@@ -134,6 +134,8 @@ const tokenizerPlaygroundSource = read('../src/components/models/TokenizerPlaygr
 const evidenceStatusSource = read('../src/lib/evidenceStatus.js')
 const useThemeSource = read('../src/hooks/useTheme.js')
 const mainSource = read('../src/main.jsx')
+const settingsViewSource = read('../src/views/SettingsView.jsx')
+const apiAuthSource = read('../src/lib/apiAuth.js')
 const tokensCss = read('../src/styles/tokens.css')
 const evidenceCss = read('../src/styles/evidence.css')
 const chatCss = read('../src/styles/chat.css')
@@ -565,6 +567,10 @@ assert.match(tokensCss, /--color-evidence:/, 'tokens must define the bounded-evi
 assert.match(mainSource, /@fontsource-variable\/inter/, 'body font must be self-hosted via Fontsource')
 assert.match(mainSource, /@fontsource\/ibm-plex-mono/, 'mono font must be self-hosted via Fontsource')
 assert.doesNotMatch(mainSource, /fonts\.googleapis|fonts\.gstatic/, 'no third-party font CDN calls')
+assert.match(mainSource, /installApiAuthFetch\(\)/, 'the UI must install authenticated API requests before rendering')
+assert.match(settingsViewSource, /type="password"[\s\S]*Save key/, 'Settings must provide an API-key control for authenticated backends')
+assert.match(apiAuthSource, /requestUrl\.origin !== apiOrigin/, 'API credentials must only be attached to the configured Camelid origin')
+assert.match(apiAuthSource, /headers\.set\('x-api-key', apiKey\)/, 'Camelid requests must include the stored API key')
 assert.match(useThemeSource, /return saved && VALID\.has\(saved\) \? saved : 'dark'/, 'theme preference must default to dark')
 
 /* ---- Brand hygiene across visible UI sources ---- */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -421,6 +421,7 @@ function App() {
               runtime={runtime}
               apiBase={apiBase}
               setApiBase={setApiBase}
+              refreshDashboard={loadDashboard}
               backend={backend}
               showNotice={showNotice}
               themePreference={preference}

--- a/frontend/src/lib/apiAuth.js
+++ b/frontend/src/lib/apiAuth.js
@@ -1,0 +1,39 @@
+export const API_BASE_STORAGE_KEY = 'camelid.apiBase'
+export const API_KEY_STORAGE_KEY = 'camelid.apiKey'
+
+export function getStoredApiKey() {
+  if (typeof window === 'undefined') return ''
+  return window.localStorage.getItem(API_KEY_STORAGE_KEY) || ''
+}
+
+export function setStoredApiKey(value) {
+  if (typeof window === 'undefined') return
+  const next = String(value || '').trim()
+  if (next) window.localStorage.setItem(API_KEY_STORAGE_KEY, next)
+  else window.localStorage.removeItem(API_KEY_STORAGE_KEY)
+}
+
+export function installApiAuthFetch() {
+  if (typeof window === 'undefined' || window.__camelidApiAuthFetchInstalled) return
+  const nativeFetch = window.fetch.bind(window)
+
+  window.fetch = (input, init = {}) => {
+    const apiKey = getStoredApiKey()
+    if (!apiKey) return nativeFetch(input, init)
+
+    try {
+      const requestUrl = new URL(typeof input === 'string' || input instanceof URL ? input : input.url, window.location.href)
+      const configuredBase = window.localStorage.getItem(API_BASE_STORAGE_KEY) || window.location.origin
+      const apiOrigin = new URL(configuredBase, window.location.href).origin
+      if (requestUrl.origin !== apiOrigin) return nativeFetch(input, init)
+
+      const headers = new Headers(init.headers || (typeof Request !== 'undefined' && input instanceof Request ? input.headers : undefined))
+      if (!headers.has('authorization') && !headers.has('x-api-key')) headers.set('x-api-key', apiKey)
+      return nativeFetch(input, { ...init, headers })
+    } catch {
+      return nativeFetch(input, init)
+    }
+  }
+
+  window.__camelidApiAuthFetchInstalled = true
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -9,6 +9,9 @@ import '@fontsource/ibm-plex-mono/400.css'
 import '@fontsource/ibm-plex-mono/500.css'
 import '@fontsource/ibm-plex-mono/600.css'
 import './styles.css'
+import { installApiAuthFetch } from './lib/apiAuth'
+
+installApiAuthFetch()
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/views/SettingsView.jsx
+++ b/frontend/src/views/SettingsView.jsx
@@ -8,6 +8,7 @@ import { CamelidMark } from '../components/ui/CamelidMark'
 import { IconPlay, IconStop, IconCopy, IconCheck, IconServer, IconMonitor, IconSun, IconMoon, IconNetwork, IconChevronRight } from '../components/ui/icons'
 import { copyText } from '../lib/markdown'
 import { getConfiguredMaxTokens, setConfiguredMaxTokens } from '../lib/responseLimits'
+import { getStoredApiKey, setStoredApiKey } from '../lib/apiAuth'
 import { ResponseLengthControl } from '../components/settings/ResponseLengthControl'
 
 const THEME_OPTS = [
@@ -20,6 +21,7 @@ export default function SettingsView({
   runtime,
   apiBase,
   setApiBase,
+  refreshDashboard = null,
   backend,
   showNotice,
   themePreference = 'system',
@@ -35,6 +37,7 @@ export default function SettingsView({
   const { status, command, setCommand, resolvedCommand, starting, start, stop } = backend
   const [copied, setCopied] = useState(false)
   const [apiBaseDraft, setApiBaseDraft] = useState(apiBase || 'http://127.0.0.1:8181')
+  const [apiKeyDraft, setApiKeyDraft] = useState(getStoredApiKey)
   const [showAdvanced, setShowAdvanced] = useState(Boolean(command))
   const [showLogs, setShowLogs] = useState(false)
   const [maxTokens, setMaxTokens] = useState(() => getConfiguredMaxTokens(selectedModel?.id))
@@ -88,6 +91,13 @@ export default function SettingsView({
     if (!next) { showNotice?.('API base cannot be empty.', 'error'); return }
     setApiBase(next)
     showNotice?.(`API base set to ${next.replace(/\/$/, '')}.`, 'success')
+  }
+
+  const handleSaveApiKey = () => {
+    const next = apiKeyDraft.trim()
+    setStoredApiKey(next)
+    showNotice?.(next ? 'API key saved in this browser.' : 'API key cleared.', 'success')
+    refreshDashboard?.()
   }
 
   const handleMaxTokens = (value) => {
@@ -180,6 +190,11 @@ export default function SettingsView({
           <div className="settings-inline">
             <input type="text" value={apiBaseDraft} spellCheck={false} onChange={(e) => setApiBaseDraft(e.target.value)} placeholder="http://127.0.0.1:8181" />
             <Button variant="tonal" onClick={handleSaveApiBase} disabled={apiBaseDraft.trim() === (apiBase || '')}>Save</Button>
+          </div>
+          <p className="settings-help">API key for authenticated LAN or remote backends. It is stored only in this browser.</p>
+          <div className="settings-inline">
+            <input type="password" value={apiKeyDraft} autoComplete="off" spellCheck={false} onChange={(e) => setApiKeyDraft(e.target.value)} placeholder="Optional API key" />
+            <Button variant="tonal" onClick={handleSaveApiKey}>Save key</Button>
           </div>
         </CardBody>
       </Card>


### PR DESCRIPTION
## What changed

- add an API-key password field to Settings for authenticated LAN and remote Camelid servers
- store the key in the current browser and refresh backend discovery after saving
- attach `X-API-Key` automatically to requests sent to the configured Camelid origin
- avoid sending the credential to any other origin
- add UI regression coverage for the setting and origin restriction

## Why

Camelid correctly requires authentication when listening on a non-loopback address, but the web UI could not supply that key. The page loaded over the LAN while protected backend calls returned `401`, making the backend appear offline.

## Impact

A browser on another machine can configure the server address and API key once, then use dashboard discovery, models, chat, Analytics, and other Camelid requests normally.

## Validation

- `npm run build`
- `npm run smoke:ui`
- rebuilt and served Camelid on `0.0.0.0:8181`
- verified protected requests return `401` without a key and `200` with the configured key