### PR TITLE
Add qwen3moe (Qwen3-30B-A3B) with streamed Q4_0/Q4_1 experts

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7548,9 +7548,10 @@ fn model_family(gguf: &GgufFile) -> &'static str {
     match gguf.architecture() {
         Some("gemma4") => "gemma4",
         Some("nomic-bert") => "embedding",
-        Some("llama" | "mistral" | "qwen2" | "qwen3" | "smollm3" | "gemma3" | "phi3" | "lfm2") => {
-            "llama-family"
-        }
+        Some(
+            "llama" | "mistral" | "qwen2" | "qwen3" | "qwen3moe" | "smollm3" | "gemma3" | "phi3"
+            | "lfm2",
+        ) => "llama-family",
         Some(_) => "other",
         None => "unknown",
     }
@@ -13630,7 +13631,20 @@ fn estimate_cpu_weight_materialization_bytes(binding: &LlamaTensorBinding) -> cr
                 | GgufTensorType::Q2_0G128
                 | GgufTensorType::Pq2_0
         ) && desc.dimensions.len() == 2;
-        let f32_bytes = if file_backed_q8_linear || wire_resident_kquant || wire_resident_prism {
+        // Rank-3 Q4_0 MoE expert packs stream file-backed unconditionally
+        // (`load_q4_0_file_backed_expert_tensor`): only per-expert slices are
+        // ever dequantized, transiently, at matvec time. Counting them at f32
+        // bytes would refuse every fine-grained Q4_0 MoE (e.g. ~116 GB for a
+        // 30B-A3B pack) that the engine actually runs in a ~2 GB footprint.
+        let file_backed_q4_experts = matches!(
+            desc.tensor_type,
+            GgufTensorType::Q4_0 | GgufTensorType::Q4_1
+        ) && desc.dimensions.len() == 3;
+        let f32_bytes = if file_backed_q8_linear
+            || wire_resident_kquant
+            || wire_resident_prism
+            || file_backed_q4_experts
+        {
             0
         } else {
             element_count.checked_mul(4).ok_or_else(|| {
@@ -18356,8 +18370,21 @@ fn render_chat_prompt_for_tokenization_fallback(
             };
         }
         if is_qwen3_chatml_template(template) {
+            // Non-thinking Qwen3 templates (e.g. Instruct-2507 and qwen3moe
+            // instruct rows) always render the bare assistant generation
+            // prompt: their jinja has no `enable_thinking` branch (they may
+            // still mention <think> for history stripping). Injecting the
+            // empty-think suppression block there is out-of-distribution and
+            // degrades greedy decoding into echo loops, so the think-block
+            // shape is reserved for templates that actually branch on
+            // `enable_thinking`.
+            let thinking_shape = if template.contains("enable_thinking") {
+                enable_thinking
+            } else {
+                true
+            };
             return RenderedPrompt {
-                text: render_qwen3_chatml_prompt(messages, enable_thinking),
+                text: render_qwen3_chatml_prompt(messages, thinking_shape),
                 // Qwen3 has add_bos_token=false; the ChatML template fully
                 // specifies the prompt. Parse specials so <|im_start|>/<|im_end|>
                 // become control token ids (151644/151645), not literal text.
@@ -21601,6 +21628,7 @@ mod tests {
             expert_weights_scale: 1.0,
             expert_weights_norm: true,
             expert_gating_func: 0,
+            expert_feed_forward_length: None,
         };
         let generic_moe = crate::model::MixtralMoeMetadata {
             family_label: "MoE",

--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -759,6 +759,7 @@ pub fn deserialize_tensor<R: Read>(reader: &mut R, name: String) -> std::io::Res
         q8_0_wire_pages: None,
         kquant_wire_pages: None,
         q8_0_split_file_backing: None,
+        q4_0_file_backing: None,
         q4_k_wire_bytes: None,
         q4_k_repack8: Q4KRepack8Cell::default(),
         q5_k_wire_bytes: None,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -744,6 +744,15 @@ impl LlamaLoadedWeights {
         };
         let load_moe_experts = |experts: &LlamaMoeExpertTensors| match experts {
             LlamaMoeExpertTensors::Merged(desc) => match moe_expert_storage {
+                // Q4_0 expert packs stream as raw wire regardless of the
+                // storage mode: they have no resident-Q8 representation, and
+                // the Q8 loader's f32 fallback would materialize tens of GiB.
+                _ if store.descriptor(&desc.name).is_ok_and(|d| {
+                    matches!(d.tensor_type, GgufTensorType::Q4_0 | GgufTensorType::Q4_1)
+                }) =>
+                {
+                    store.load_q4_0_file_backed_expert_tensor(&desc.name)
+                }
                 crate::runtime_config::MoeExpertStorage::FileBacked => {
                     store.load_q8_0_file_backed_tensor(&desc.name)
                 }
@@ -1361,31 +1370,23 @@ impl LlamaLoadedWeights {
                     moe.expert_count as usize,
                     &format!("layer {idx} ffn router"),
                 )?;
+                let expert_ff = moe
+                    .expert_feed_forward_length
+                    .map(|v| v as usize)
+                    .unwrap_or(dims.feed_forward_length);
                 require_tensor_shape(
                     &layer.ffn_gate,
-                    &[
-                        dims.embedding_length,
-                        dims.feed_forward_length,
-                        moe.expert_count as usize,
-                    ],
+                    &[dims.embedding_length, expert_ff, moe.expert_count as usize],
                     &format!("layer {idx} ffn gate experts"),
                 )?;
                 require_tensor_shape(
                     &layer.ffn_up,
-                    &[
-                        dims.embedding_length,
-                        dims.feed_forward_length,
-                        moe.expert_count as usize,
-                    ],
+                    &[dims.embedding_length, expert_ff, moe.expert_count as usize],
                     &format!("layer {idx} ffn up experts"),
                 )?;
                 require_tensor_shape(
                     &layer.ffn_down,
-                    &[
-                        dims.feed_forward_length,
-                        dims.embedding_length,
-                        moe.expert_count as usize,
-                    ],
+                    &[expert_ff, dims.embedding_length, moe.expert_count as usize],
                     &format!("layer {idx} ffn down experts"),
                 )?;
             } else {
@@ -11834,10 +11835,11 @@ fn expert_matrix_view(
     let uses_q8_storage = weight.q8_0_shared_blocks.is_some()
         || weight.q8_0_blocks.is_some()
         || weight.q8_0_file_backing.is_some()
-        || weight.q8_0_split_file_backing.is_some();
+        || weight.q8_0_split_file_backing.is_some()
+        || weight.q4_0_file_backing.is_some();
     if uses_q8_storage && !expert_elements.is_multiple_of(Q8_0_BLOCK_VALUES) {
         return Err(BackendError::RuntimeShapeMismatch(format!(
-            "MoE expert element count {expert_elements} is not Q8_0 block aligned"
+            "MoE expert element count {expert_elements} is not 32-value block aligned"
         )));
     }
     if weight.dim(0)? != input_width || weight.dim(1)? != output_width {
@@ -11850,7 +11852,20 @@ fn expert_matrix_view(
         BackendError::RuntimeShapeMismatch("MoE expert offset overflow".to_string())
     })? / Q8_0_BLOCK_VALUES;
     let block_count = expert_elements / Q8_0_BLOCK_VALUES;
-    let mut tensor = if let Some(split_backings) = &weight.q8_0_split_file_backing {
+    let mut tensor = if let Some(backing) = &weight.q4_0_file_backing {
+        // Streamed Q4_0/Q4_1 expert pack: read this expert's contiguous wire
+        // slice (buffered, so the OS page cache retains hot experts) and
+        // dequantize it transiently. Both nibble formats use 32-value blocks
+        // like Q8_0, so the shared block arithmetic above holds unchanged.
+        let wire = backing.read_wire_blocks(block_offset, block_count)?;
+        let data = match weight.source_type {
+            Some(GgufTensorType::Q4_1) => {
+                crate::tensor::decode_q4_1_tensor(&weight.name, &wire, expert_elements)?
+            }
+            _ => crate::tensor::decode_q4_0_tensor(&weight.name, &wire, expert_elements)?,
+        };
+        CpuTensor::from_f32(name, vec![output_width, input_width], data)?
+    } else if let Some(split_backings) = &weight.q8_0_split_file_backing {
         let backing = split_backings.get(expert_idx).ok_or_else(|| {
             BackendError::RuntimeShapeMismatch(format!(
                 "MoE split expert index {expert_idx} missing from {} split backings",

--- a/src/model.rs
+++ b/src/model.rs
@@ -126,6 +126,7 @@ pub fn is_implemented_architecture(architecture: &str) -> bool {
             | "mistral"
             | "qwen2"
             | "qwen3"
+            | "qwen3moe"
             | "qwen35"
             | "smollm3"
             | "gemma3"
@@ -304,8 +305,8 @@ impl LlamaModelConfig {
     pub fn from_gguf(gguf: &GgufFile) -> Result<Self> {
         let architecture = match gguf.architecture() {
             Some(
-                architecture @ ("llama" | "mistral" | "qwen2" | "qwen3" | "qwen35" | "smollm3"
-                | "gemma3" | "gemma4" | "phi3" | "lfm2"),
+                architecture @ ("llama" | "mistral" | "qwen2" | "qwen3" | "qwen3moe" | "qwen35"
+                | "smollm3" | "gemma3" | "gemma4" | "phi3" | "lfm2"),
             ) => architecture,
             // Gemma 4 MTP/assistant drafter heads ship as a distinct architecture.
             // The tensor map parses (q-only attention layers, per-layer
@@ -512,6 +513,10 @@ pub struct MixtralMoeMetadata {
     pub expert_weights_scale: f32,
     pub expert_weights_norm: bool,
     pub expert_gating_func: u32,
+    /// Per-expert FFN width when it differs from the dense `feed_forward_length`
+    /// (fine-grained MoE like qwen3moe: `{arch}.expert_feed_forward_length`).
+    /// `None` keeps the Mixtral convention of expert width == dense FFN width.
+    pub expert_feed_forward_length: Option<u32>,
 }
 
 impl MixtralMoeMetadata {
@@ -539,6 +544,10 @@ impl MixtralMoeMetadata {
         let expert_gating_func = gguf
             .metadata_u32(&architecture_key(architecture, "expert_gating_func"))
             .unwrap_or(0);
+        let expert_feed_forward_length = gguf.metadata_u32(&architecture_key(
+            architecture,
+            "expert_feed_forward_length",
+        ));
 
         Some(Self {
             family_label,
@@ -547,6 +556,7 @@ impl MixtralMoeMetadata {
             expert_weights_scale,
             expert_weights_norm,
             expert_gating_func,
+            expert_feed_forward_length,
         })
     }
 }
@@ -1240,7 +1250,10 @@ impl Qwen35Metadata {
 /// for phi3). Everything else keeps adjacent even/odd (LLaMA-style permuted
 /// conversions). Pure so the gate is unit-testable.
 fn arch_uses_neox_rope_pairing(architecture: &str) -> bool {
-    matches!(architecture, "qwen2" | "qwen3" | "qwen35" | "phi3")
+    matches!(
+        architecture,
+        "qwen2" | "qwen3" | "qwen3moe" | "qwen35" | "phi3"
+    )
 }
 
 /// NoPE layer step per architecture.
@@ -1453,7 +1466,7 @@ impl LlamaTensorBinding {
         // resident-capable hosts, while the CPU dense forward stays fail-closed
         // for windowed archs (hazard H4).
         let architecture = gguf.architecture().unwrap_or_default();
-        let expects_qk_norm = matches!(architecture, "qwen3" | "command-r" | "gemma3");
+        let expects_qk_norm = matches!(architecture, "qwen3" | "qwen3moe" | "command-r" | "gemma3");
         let forbids_qk_norm = matches!(architecture, "llama" | "mistral" | "qwen2");
         // gemma3's 4-norm "sandwich" structure: an extra RMSNorm on the attention
         // output and on the FFN output, each applied BEFORE its residual add
@@ -1869,23 +1882,27 @@ impl LlamaTensorBinding {
                         moe.expert_count as usize,
                         &format!("layer {idx} ffn router"),
                     )?;
+                    let expert_ff = moe
+                        .expert_feed_forward_length
+                        .map(|v| v as usize)
+                        .unwrap_or(dims.feed_forward_length);
                     validate_moe_expert_tensor_shape(
                         gate_experts,
                         dims.embedding_length,
-                        dims.feed_forward_length,
+                        expert_ff,
                         moe.expert_count as usize,
                         &format!("layer {idx} ffn gate experts"),
                     )?;
                     validate_moe_expert_tensor_shape(
                         up_experts,
                         dims.embedding_length,
-                        dims.feed_forward_length,
+                        expert_ff,
                         moe.expert_count as usize,
                         &format!("layer {idx} ffn up experts"),
                     )?;
                     validate_moe_expert_tensor_shape(
                         down_experts,
-                        dims.feed_forward_length,
+                        expert_ff,
                         dims.embedding_length,
                         moe.expert_count as usize,
                         &format!("layer {idx} ffn down experts"),
@@ -2615,6 +2632,7 @@ mod tests {
         // else — including the other unpermuted-but-unproven archs — must stay
         // on adjacent even/odd until its own row proves the flip.
         assert!(super::arch_uses_neox_rope_pairing("qwen3"));
+        assert!(super::arch_uses_neox_rope_pairing("qwen3moe"));
         assert!(super::arch_uses_neox_rope_pairing("qwen35"));
         assert!(super::arch_uses_neox_rope_pairing("phi3"));
         assert!(super::arch_uses_neox_rope_pairing("qwen2"));
@@ -2638,7 +2656,8 @@ mod tests {
         // mistral3.cpp:137,143. gemma3/gemma4/qwen35 carry per-layer rope BASES
         // or schedules — not skips — and those live in their own metadata.
         for arch in [
-            "llama", "mistral", "qwen2", "qwen3", "qwen35", "gemma3", "gemma4", "phi3", "lfm2",
+            "llama", "mistral", "qwen2", "qwen3", "qwen3moe", "qwen35", "gemma3", "gemma4", "phi3",
+            "lfm2",
         ] {
             assert!(
                 super::arch_no_rope_layer_step(arch).is_none(),
@@ -2662,7 +2681,8 @@ mod tests {
             );
         }
         for arch in [
-            "llama", "mistral", "qwen2", "qwen3", "smollm3", "gemma3", "gemma4", "phi3", "lfm2", "",
+            "llama", "mistral", "qwen2", "qwen3", "qwen3moe", "smollm3", "gemma3", "gemma4",
+            "phi3", "lfm2", "",
         ] {
             assert!(
                 !super::is_runnable_only_arch(arch),
@@ -2795,10 +2815,11 @@ mod tests {
 
     #[test]
     fn implemented_architecture_set_is_exactly_the_from_gguf_accept_arm() {
-        // These nine must stay byte-for-byte in sync with the match arm in
+        // This list must stay byte-for-byte in sync with the match arm in
         // LlamaModelConfig::from_gguf. If you change one, change both.
         for arch in [
-            "llama", "mistral", "qwen2", "qwen3", "smollm3", "gemma3", "gemma4", "phi3", "lfm2",
+            "llama", "mistral", "qwen2", "qwen3", "qwen3moe", "smollm3", "gemma3", "gemma4",
+            "phi3", "lfm2",
         ] {
             assert!(
                 super::is_implemented_architecture(arch),

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1166,6 +1166,98 @@ impl PartialEq for Q8_0FileBacking {
 
 impl Eq for Q8_0FileBacking {}
 
+/// File-backed raw Q4_0 wire storage for a rank-3 streamed MoE expert pack.
+///
+/// Unlike [`Q8_0FileBacking`], the shared handle keeps OS file caching
+/// ENABLED (no `F_NOCACHE`/readahead-off): a fine-grained MoE's routed expert
+/// set cannot be RAM-resident on the hosts this lane targets, and the page
+/// cache retaining recently routed experts between tokens is the streamed
+/// lane's entire performance model.
+#[derive(Debug, Clone)]
+pub struct Q4_0FileBacking {
+    pub path: PathBuf,
+    pub absolute_offset: u64,
+    pub num_blocks: usize,
+    /// 18 for Q4_0, 20 for Q4_1 — the streamed lane serves both nibble
+    /// formats; the tensor's `source_type` picks the dequantizer.
+    pub wire_bytes_per_block: usize,
+    file_handle: Arc<OnceLock<Arc<File>>>,
+}
+
+impl Q4_0FileBacking {
+    pub const WIRE_BYTES_PER_BLOCK: usize = 18;
+
+    pub fn new(
+        path: PathBuf,
+        absolute_offset: u64,
+        num_blocks: usize,
+        wire_bytes_per_block: usize,
+    ) -> Self {
+        Self {
+            path,
+            absolute_offset,
+            num_blocks,
+            wire_bytes_per_block,
+            file_handle: Arc::new(OnceLock::new()),
+        }
+    }
+
+    fn file(&self) -> Result<Arc<File>> {
+        if let Some(file) = self.file_handle.get() {
+            return Ok(file.clone());
+        }
+        let file = File::open(&self.path).map_err(|source| BackendError::Io {
+            path: self.path.clone(),
+            source,
+        })?;
+        let file = Arc::new(file);
+        if self.file_handle.set(file.clone()).is_err() {
+            return Ok(self
+                .file_handle
+                .get()
+                .expect("q4_0 file handle must exist after OnceLock set race")
+                .clone());
+        }
+        Ok(file)
+    }
+
+    /// Read `block_count` contiguous 18-byte Q4_0 wire blocks starting
+    /// `block_offset` blocks into the backing.
+    pub fn read_wire_blocks(&self, block_offset: usize, block_count: usize) -> Result<Vec<u8>> {
+        let end_block = block_offset.checked_add(block_count).ok_or_else(|| {
+            BackendError::RuntimeShapeMismatch("q4_0 file-backed block range overflow".to_string())
+        })?;
+        if end_block > self.num_blocks {
+            return Err(BackendError::RuntimeShapeMismatch(format!(
+                "q4_0 file-backed read blocks {block_offset}..{end_block} exceed backing of {} blocks",
+                self.num_blocks
+            )));
+        }
+        let mut out = vec![0u8; block_count * self.wire_bytes_per_block];
+        let file = self.file()?;
+        let offset = self
+            .absolute_offset
+            .saturating_add((block_offset * self.wire_bytes_per_block) as u64);
+        crate::platform_fs::read_exact_at(&file, &mut out, offset).map_err(|source| {
+            BackendError::Io {
+                path: self.path.clone(),
+                source,
+            }
+        })?;
+        Ok(out)
+    }
+}
+
+impl PartialEq for Q4_0FileBacking {
+    fn eq(&self, other: &Self) -> bool {
+        self.path == other.path
+            && self.absolute_offset == other.absolute_offset
+            && self.num_blocks == other.num_blocks
+    }
+}
+
+impl Eq for Q4_0FileBacking {}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct CpuTensor {
     pub name: String,
@@ -1186,6 +1278,11 @@ pub struct CpuTensor {
     /// `source_type` identifies the K-quant or Prism Q1/Q2 block format.
     pub kquant_wire_pages: Option<std::sync::Arc<crate::wire_mmap::WirePages>>,
     pub q8_0_split_file_backing: Option<Vec<Q8_0FileBacking>>,
+    /// Buffered file backing for a rank-3 Q4_0 MoE expert pack. Per-expert
+    /// wire slices are read and dequantized transiently at matvec time; see
+    /// [`Q4_0FileBacking`] for why this backing deliberately keeps the OS
+    /// page cache enabled.
+    pub q4_0_file_backing: Option<Q4_0FileBacking>,
     /// Q4_K_M super-block wire bytes (144 bytes/super-block, row-major), retained
     /// when the tensor's `source_type` is `Q4K` so the GPU-resident decode path can
     /// repack them into the `q4k_gemv` SoA layout. Populated by the Q4_K load path;
@@ -1426,6 +1523,7 @@ impl Q8_0TensorBlocks {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -1511,6 +1609,7 @@ impl CpuTensor {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -1604,6 +1703,7 @@ impl CpuTensor {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -1651,6 +1751,7 @@ impl CpuTensor {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -1696,6 +1797,44 @@ impl CpuTensor {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
+            q4_k_wire_bytes: None,
+            q4_k_repack8: Q4KRepack8Cell::default(),
+            q5_k_wire_bytes: None,
+            q6_k_wire_bytes: None,
+            q2_k_wire_bytes: None,
+            q3_k_wire_bytes: None,
+            tq2_0_wire_bytes: None,
+            iq4_xs_wire_bytes: None,
+            data: Vec::new(),
+        }
+    }
+
+    /// Descriptor-only rank-3 Q4_0/Q4_1 MoE expert pack: no weight bytes are
+    /// materialized at load; per-expert wire slices stream (buffered) from the
+    /// backing at matvec time and are dequantized transiently.
+    pub fn q4_0_file_backed_experts(
+        name: impl Into<String>,
+        shape: TensorShape,
+        backing: Q4_0FileBacking,
+        source_type: GgufTensorType,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            shape,
+            dtype: RuntimeDType::F32,
+            source_type: Some(source_type),
+            q8_0_blocks: None,
+            q8_0_shared_blocks: None,
+            q8_0_packed_rows4_4x4: None,
+            q8_0_packed_rows4_4x8: None,
+            q8_0_runtime_storage: None,
+            q8_0_file_backing: None,
+            q8_0_wire_mmap: None,
+            q8_0_wire_pages: None,
+            kquant_wire_pages: None,
+            q8_0_split_file_backing: None,
+            q4_0_file_backing: Some(backing),
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -1728,6 +1867,7 @@ impl CpuTensor {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -1760,6 +1900,7 @@ impl CpuTensor {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: Some(backings),
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -4091,6 +4232,7 @@ impl TensorStore {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes,
@@ -4160,6 +4302,7 @@ impl TensorStore {
                 wire_bytes,
             )?),
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -4197,6 +4340,7 @@ impl TensorStore {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -4257,6 +4401,7 @@ impl TensorStore {
                 wire_bytes,
             )?),
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -4294,6 +4439,7 @@ impl TensorStore {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes: None,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -4421,6 +4567,41 @@ impl TensorStore {
 
     pub fn load_q8_0_file_backed_tensor(&self, name: &str) -> Result<CpuTensor> {
         self.load_q8_0_file_backed_tensor_as(name, name)
+    }
+
+    /// Load a rank-3 Q4_0/Q4_1 MoE expert pack as a descriptor-only streamed
+    /// tensor. Refuses other sources rather than falling back to f32
+    /// materialization: a fine-grained MoE pack materialized f32 is tens of
+    /// GiB and must never happen silently.
+    pub fn load_q4_0_file_backed_expert_tensor(&self, name: &str) -> Result<CpuTensor> {
+        let desc = self.descriptor(name)?.clone();
+        let wire_bytes_per_block = match desc.tensor_type {
+            GgufTensorType::Q4_0 => Q4_0_BLOCK_BYTES,
+            GgufTensorType::Q4_1 => Q4_1_BLOCK_BYTES,
+            other => {
+                return Err(BackendError::InvalidTensorData(format!(
+                    "tensor {name} is {other:?}, not Q4_0/Q4_1; the streamed expert loader refuses fallback"
+                )));
+            }
+        };
+        let shape = TensorShape::from_gguf_dims(&desc.dimensions)?;
+        let expected_elements = shape.element_count()?;
+        if expected_elements % 32 != 0 {
+            return Err(BackendError::InvalidTensorData(format!(
+                "tensor {name} nibble-block element count {expected_elements} is not block aligned"
+            )));
+        }
+        Ok(CpuTensor::q4_0_file_backed_experts(
+            name,
+            shape,
+            Q4_0FileBacking::new(
+                self.path.clone(),
+                desc.absolute_offset,
+                expected_elements / 32,
+                wire_bytes_per_block,
+            ),
+            desc.tensor_type,
+        ))
     }
 
     pub fn load_q8_0_file_backed_tensor_as(
@@ -4596,6 +4777,7 @@ impl TensorStore {
             q8_0_wire_pages: None,
             kquant_wire_pages: None,
             q8_0_split_file_backing: None,
+            q4_0_file_backing: None,
             q4_k_wire_bytes,
             q4_k_repack8: Q4KRepack8Cell::default(),
             q5_k_wire_bytes: None,
@@ -6012,7 +6194,11 @@ pub(crate) fn q1_0_to_q8_0_blocks(
     Ok(out)
 }
 
-fn decode_q4_1_tensor(name: &str, bytes: &[u8], expected_elements: usize) -> Result<Vec<f32>> {
+pub(crate) fn decode_q4_1_tensor(
+    name: &str,
+    bytes: &[u8],
+    expected_elements: usize,
+) -> Result<Vec<f32>> {
     let blocks = decode_q4_1_blocks(bytes)
         .map_err(|e| BackendError::InvalidTensorData(format!("{name}: {e}")))?;
     let mut out = Vec::with_capacity(expected_elements);


### PR DESCRIPTION
## What changed

- Accepts `general.architecture = qwen3moe` in the llama-family engine (NEOX rope pairing + per-head QK-norm like qwen3), reusing the existing MoE forward — its top-k-then-softmax routing weights are algebraically identical to qwen3moe's normalized softmax-top-k.
- New `expert_feed_forward_length` metadata carried through both expert-shape validators for fine-grained expert widths (768 vs the dense 6144).
- Rank-3 Q4_0/Q4_1 expert packs load as descriptor-only **streamed** tensors: per-expert wire slices are read with buffered positioned I/O and dequantized transiently at matvec time. The Q8 loader's silent f32 fallback would have materialized ~116 GB for this pack; the streamed loader refuses non-nibble sources instead, and the CPU materialization budget exempts rank-3 nibble expert packs to match (residual estimate ~4.9 GB on the 30B artifact).
- Qwen3 ChatML templates without an `enable_thinking` branch (the Instruct-2507 generation) render the bare assistant generation prompt; the empty-think suppression block is out of those models' training distribution and degraded greedy decoding into echo loops.

## Validation

- Tokenizer ids byte-exact vs the pinned reference on the acceptance prompt.
- 6-token greedy completion parity **exact** vs the pinned reference (CPU, `The capital of France is` → ` Paris. The capital of France`) on Qwen3-30B-A3B-Instruct-2507-Q4_0.
- Coherent chat-template smoke through the experimental serve lane (`generation_ready=true`, no capability rows added — lands in the experimental chat lane by construction).
- Library suite 1616 passed / 0 failed / 24 ignored; `cargo fmt` + `clippy --all-targets -D warnings` clean.

## Notes

This is a correctness-first bring-up: decode streams ~1 GB of expert wire per token, so throughput is storage-bound (measured ~25 s/token with the artifact on a USB-throttled external drive; page cache warms popular experts). The perf phase — ghost-style persistent expert residency for qwen3moe, mirroring the Gemma 4 26B lane — is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)