### PR TITLE
perf(inference): widen the Q6_K prefill owner's integer inner

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -20876,9 +20876,47 @@ fn q6_k_owner_rebuild_superblock(block: &[u8], a: &mut [i8; Q6_K_VALUES_PER_BLOC
     }
 }
 
+/// `shuffle_epi8` control that reorders one 16-value scale group so the two
+/// values sharing an `aux32` lane become adjacent: `dst[2m] = src[m]`,
+/// `dst[2m + 1] = src[m + 8]`. A scale group is exactly one 128-bit lane, so
+/// broadcasting these 16 bytes covers both halves of a 32-byte load.
+#[cfg(target_arch = "x86_64")]
+const Q6_K_OWNER_PAIR_PERM: [i8; 16] = [0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15];
+
+/// Q6_K's reference unpack shifts each 6-bit code by `-32`. `maddubs` needs an
+/// unsigned operand, so the kernel adds that shift back and then removes it
+/// again from the activation pair sums.
+#[cfg(target_arch = "x86_64")]
+const Q6_K_OWNER_ZERO_POINT: i8 = 32;
+#[cfg(target_arch = "x86_64")]
+const Q6_K_OWNER_ZERO_POINT_SHIFT: i32 = 5;
+#[cfg(target_arch = "x86_64")]
+const _: () = assert!(Q6_K_OWNER_ZERO_POINT as i32 == 1 << Q6_K_OWNER_ZERO_POINT_SHIFT);
+
 /// Q6_K integer lane dot over a pre-rebuilt superblock: the exact integers of
-/// [`q6_k_wire_row_dot`]'s `aux32` loop (associative — lane/order free), AVX2
-/// body lifted from the in-tree bit-identical `q6_k_wire_row_dot_avx2`.
+/// [`q6_k_wire_row_dot`]'s `aux32` loop (associative — lane/order free), so
+/// this is bit-identical to [`q6_k_owner_aux32_scalar`] and to the per-cell
+/// path by construction.
+///
+/// Two 16-value scale groups per iteration through one `maddubs`, against the
+/// previous kernel's one group per 128-bit load widened to i16. Both operands
+/// are shuffled into pair order in-register, so a `maddubs` pair sum IS one
+/// `aux32` lane's contribution for that group. The stored weight layout is
+/// deliberately left alone: pre-permuting it would save the shuffle here but
+/// turns the scalar twin's contiguous reads into strided ones, which measured
+/// 3.5x slower — and the scalar twin is the only path on non-x86 targets.
+///
+/// The zero point is added back rather than folded with `sign_epi8`. The sign
+/// form is marginally faster and is silently wrong at an activation byte of
+/// `-128`, because negating `-128` wraps; `quantize_q8_k_blocks` cannot emit
+/// that today, but the per-cell path this must match does not depend on it and
+/// neither should this.
+///
+/// Exact-integer envelope, all well inside i16 before the widen: `a + 32` is
+/// `0..=63` and `|q8| ≤ 128`, so a `maddubs` pair is ≤ 16,128 in absolute
+/// value; the zero-point term `32·(q8_lo + q8_hi)` is ≤ 8,192; their difference
+/// is ≤ 24,320 < `i16::MAX`. After the widen a lane value is `|a·q8| ≤ 4064`
+/// per pair member, × `|scale| ≤ 128` over 16 groups ⇒ ≤ 16.6M ≪ `i32::MAX`.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn q6_k_owner_aux32_avx2(
@@ -20887,24 +20925,43 @@ unsafe fn q6_k_owner_aux32_avx2(
     q8: &[i8; Q6_K_VALUES_PER_BLOCK],
 ) -> [i32; 8] {
     use std::arch::x86_64::*;
+    let perm = _mm256_broadcastsi128_si256(_mm_loadu_si128(
+        Q6_K_OWNER_PAIR_PERM.as_ptr() as *const __m128i
+    ));
+    let ones = _mm256_set1_epi8(1);
+    let zero_point = _mm256_set1_epi8(Q6_K_OWNER_ZERO_POINT);
     let mut acc = _mm256_setzero_si256();
-    let aptr = a.as_ptr();
-    let qptr = q8.as_ptr();
-    for (j, &scale) in scales.iter().enumerate().take(16) {
-        let off = j * 16;
-        let a16 = _mm256_cvtepi8_epi16(_mm_loadu_si128(aptr.add(off) as *const __m128i));
-        let q16 = _mm256_cvtepi8_epi16(_mm_loadu_si128(qptr.add(off) as *const __m128i));
-        // 16 i16 products (exact, fit i16); low 128 = products[0..8], high = [8..16]
-        let prod = _mm256_mullo_epi16(a16, q16);
-        let pair = _mm_add_epi16(
-            _mm256_castsi256_si128(prod),
-            _mm256_extracti128_si256(prod, 1),
-        ); // 8 i16 = prod[l] + prod[l+8]
-        let scaled = _mm256_mullo_epi32(
-            _mm256_cvtepi16_epi32(pair),
-            _mm256_set1_epi32(scale as i8 as i32),
+    for group_pair in 0..8 {
+        let off = group_pair * 32;
+        let q = _mm256_shuffle_epi8(
+            _mm256_loadu_si256(q8.as_ptr().add(off) as *const __m256i),
+            perm,
         );
-        acc = _mm256_add_epi32(acc, scaled);
+        // The rebuild leaves `a` in [-32, 31], so this lands in [0, 63].
+        let au = _mm256_add_epi8(
+            _mm256_shuffle_epi8(
+                _mm256_loadu_si256(a.as_ptr().add(off) as *const __m256i),
+                perm,
+            ),
+            zero_point,
+        );
+        let lanes = _mm256_sub_epi16(
+            _mm256_maddubs_epi16(au, q),
+            _mm256_slli_epi16(_mm256_maddubs_epi16(ones, q), Q6_K_OWNER_ZERO_POINT_SHIFT),
+        );
+        let lo = _mm256_cvtepi16_epi32(_mm256_castsi256_si128(lanes));
+        let hi = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(lanes, 1));
+        acc = _mm256_add_epi32(
+            acc,
+            _mm256_mullo_epi32(lo, _mm256_set1_epi32(scales[2 * group_pair] as i8 as i32)),
+        );
+        acc = _mm256_add_epi32(
+            acc,
+            _mm256_mullo_epi32(
+                hi,
+                _mm256_set1_epi32(scales[2 * group_pair + 1] as i8 as i32),
+            ),
+        );
     }
     let mut aux32 = [0i32; 8];
     _mm256_storeu_si256(aux32.as_mut_ptr() as *mut __m256i, acc);

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -4174,6 +4174,67 @@ fn q6_k_owner_prefill_bitwise_matches_block_dot_core() {
     }
 }
 
+/// Natural-order reference for one superblock's `aux32`, written the way
+/// [`q6_k_wire_row_dot`] states it. Without an independent oracle the kernel
+/// and its twin could agree with each other and both be wrong.
+fn q6_k_reference_aux32(a: &[i8; 256], scales: &[u8; 16], q8: &[i8; 256]) -> [i32; 8] {
+    let mut aux32 = [0i32; 8];
+    for (j, &scale) in scales.iter().enumerate().take(16) {
+        let scale = scale as i8 as i32;
+        let off = j * 16;
+        for l in 0..8 {
+            aux32[l] += scale * (q8[off + l] as i32) * (a[off + l] as i32);
+            aux32[l] += scale * (q8[off + 8 + l] as i32) * (a[off + 8 + l] as i32);
+        }
+    }
+    aux32
+}
+
+/// Both owner `aux32` kernels against the natural-order reference loop.
+#[test]
+fn q6_k_owner_aux32_matches_the_reference_lane_loop() {
+    for salt in 0..8usize {
+        let a: [i8; 256] =
+            std::array::from_fn(|i| ((((i * 17 + salt * 5) % 64) as i16) - 32) as i8);
+        // Scale byte 0 is always 0x80 so the i8 extreme (-128) is exercised.
+        let scales: [u8; 16] = std::array::from_fn(|j| {
+            if j == 0 {
+                0x80
+            } else {
+                ((j * 37 + salt * 13) % 256) as u8
+            }
+        });
+        // salt 7 pins the extreme the zero-point form exists to survive: the
+        // faster sign-folded alternative (`maddubs(|a|, sign(a)·q8)`) is
+        // silently wrong at an activation of -128 because negating it wraps.
+        // `quantize_q8_k_blocks` cannot emit -128 today, and this kernel must
+        // not acquire a dependency on that which the per-cell path lacks.
+        let q8: [i8; 256] = std::array::from_fn(|i| {
+            if salt == 7 && i % 3 == 0 {
+                -128
+            } else {
+                (((i * 23 + salt * 11) % 255) as i16 - 127) as i8
+            }
+        });
+
+        let want = q6_k_reference_aux32(&a, &scales, &q8);
+        assert_eq!(
+            q6_k_owner_aux32_scalar(&a, &scales, &q8),
+            want,
+            "scalar aux32 diverged from the reference (salt={salt})"
+        );
+        #[cfg(target_arch = "x86_64")]
+        if std::arch::is_x86_feature_detected!("avx2") {
+            // SAFETY: avx2 confirmed present above.
+            let simd = unsafe { q6_k_owner_aux32_avx2(&a, &scales, &q8) };
+            assert_eq!(
+                simd, want,
+                "avx2 aux32 diverged from the reference (salt={salt})"
+            );
+        }
+    }
+}
+
 /// Scalar-vs-AVX2 twin for the Q6_K owner's lifted integer lane dot.
 #[test]
 fn q6_k_owner_aux32_scalar_matches_avx2() {


### PR DESCRIPTION
# Widen the Q6_K prefill owner's integer inner

The K-quant prefill owner reaches its Q4_K weights through a 256-bit AVX-VNNI kernel (#593), but the Q6_K sibling has **no VNNI inner at any width and never did** — `kquant_avxvnni256_taken` is `0` for every Q6_K matmul. It ran `q6_k_owner_aux32_avx2`, which handles 16 values per iteration through a 128-bit load widened to i16, and which measures **1.02x its own scalar twin**: the hand-written AVX2 kernel was worth nothing.

Q6_K is not a corner case. `Llama-3.2-*-Q4_K_M` carries exactly one Q6_K tensor per layer — half the layers' `attn_v`, half the layers' `ffn_down`, plus the tied `token_embd` — so it is **14.6% of prefill MACs**.

## Why not VNNI

`dpbusd` reduces four *consecutive* bytes into one i32 lane. Q6_K needs a two-wide reduction under a per-16-value scale with eight *separate* lane accumulators, so the shapes do not meet. `maddubs` is the right instruction, and it is plain AVX2 — this lands on **every x86_64 host**, not only the AVX-VNNI ones.

## What changed

One function. The kernel now does two scale groups per iteration: both operands are shuffled into pair order so the two values sharing an `aux32` lane are adjacent, one `maddubs` produces the lane sums, and a second `maddubs` against ones removes the zero point the unsigned operand had to carry.

Two decisions are worth stating, because the faster version of each is wrong.

**The stored weight layout is left exactly as it was.** Pre-permuting it would save the per-cell shuffle and is 1.70x instead of 1.57x — but pair order turns the scalar twin's contiguous reads into stride-2 reads that stop vectorising: measured **22.29 -> 77.61 ns per superblock, 3.48x slower**. The scalar twin is the only path on every non-x86 target, including Apple Silicon, so the shuffle stays in the kernel and the rebuild is untouched.

**The zero point is added back rather than folded in with `sign_epi8`.** The sign form (as used by #598) is 0.9% faster and is silently wrong at an activation byte of `-128`, because negating `-128` wraps. `quantize_q8_k_blocks` cannot emit that today, but the per-cell path this must match does not depend on it and neither should this. `a*q == (a + 32)*q - 32*q` never negates anything.

## Bit identity

Every intermediate is exact integer inside the envelope stated on the kernel, and integer addition is associative, so regrouping cannot move a lane total. The load-bearing f32 shape — 8 lane accumulators, `sums[l] += d * aux32[l]` in lane order, ascending superblocks, final left fold — is untouched, as are the rebuild and the scalar twin.

## Measurements

i9-14900HX, Windows x86_64, AC power, CUDA hidden. Release binaries built from this branch's base (`v0.5.4-13-g304da5ab8`, clean worktree) and from this branch.

**Kernel in isolation**, per superblock including the identical f32 fold: **21.76 -> 13.85 ns = 1.571x**, with the scalar twin unchanged at 22.31 ns. Bit identity checked over 20,000 random and boundary cases including an activation of `-128`.

**Prefill**, 606-token prompt, 5 paired before/after rounds. The owner-off arm is untouched by this change and runs in the same process as the owner arms, so it serves as both a drift control and a per-pair normaliser:

| model | arm | raw | control-normalised |
| --- | --- | --- | --- |
| Llama-3.2-1B-Instruct-Q6_K | `owner_avx2` | 1.141 (5/5) | **1.133** (5/5) |
| Llama-3.2-1B-Instruct-Q6_K | `owner_avxvnni256` | 1.133 (5/5) | **1.142** (5/5) |
| Llama-3.2-1B-Instruct-Q6_K | `off` (control) | 1.039 (3/5) | — |
| Llama-3.2-1B-Instruct-Q4_K_M | `owner_avx2` | 1.031 (5/5) | **1.021** (4/5) |
| Llama-3.2-1B-Instruct-Q4_K_M | `owner_avxvnni256` | 1.058 (4/5) | **1.037** (4/5) |
| Llama-3.2-1B-Instruct-Q4_K_M | `off` (control) | 1.028 (5/5) | — |

Stating the weakness plainly: **in this run the Q4_K_M control itself moved 2.8%**, so the raw Q4_K_M ratios are not separable from drift and only the normalised figures are worth anything there. The Q6_K effect is 13–14% against a control that moved 4%, so it survives either way. Q4_K_M gains less than Q6_K because only 14.6% of its MACs are Q6_K.

## Byte identity on real weights

64 greedy tokens after the same 606-token prompt, both binaries, owner explicitly on (it is still opt-in at this base): **identical token ids and identical text sha256** for each model — Q6_K `641b4526fdf3b738a6f39b1820dc991b`, Q4_K_M `27beb9855204ec9c64533da0ef9fccc3`. Not vacuous: a TTFT of 4.9 s confirms the CPU owner really ran; a GPU lane would be sub-second.

## Negative controls

Each was reproduced before it was trusted. Replacing the pair-order shuffle with the identity permutation, and dropping the zero-point correction, each fail the reference test, the twin test **and** the end-to-end bitwise test. Changing only the shift constant is a compile error, because a static assertion ties it to the zero point.

## Tests

* `q6_k_owner_aux32_matches_the_reference_lane_loop` — both kernels against a natural-order oracle written the way `q6_k_wire_row_dot` states it, including the `-128` activation. Without an independent oracle the kernel and its twin could agree with each other and both be wrong.
* `q6_k_owner_prefill_bitwise_matches_block_dot_core` (existing) — compares the whole owner path against the non-owner per-cell path bit for bit, over `in_dim` 512/768 and `n_rows` 4/5/13/64/67. Needed no change.

## Local gates

`cargo fmt --all -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean; `git diff --check` clean; `cargo test --lib q6_k` 7/7.

`cargo test --lib` on this box reports 1563 passed / 2 failed. The two failures are **not caused by this change**, and it is worth saying how that was established rather than asserting it: they fail deterministically in isolation, so "flaky" was not an acceptable answer. Reverting *only* the changed files to their base content **inside the same checkout and the same target directory** leaves the failures in place, and a fresh worktree at the same base commit passes them. They are a property of that working copy, not of this diff.

There is no aarch64 job in CI; the `rust` matrix's macOS leg is arm64 and covers the scalar twin natively.

## Scope

This does not change any flag, default, or support claim. The K-quant owner remains opt-in at this base; the change makes its Q6_K half faster when it is on, and stacks with #606.
