### PR TITLE
feat(fabric): place whole requests across independent Camelid nodes

### DIFF
--- a/src/fabric/forward.rs
+++ b/src/fabric/forward.rs
@@ -1,0 +1,264 @@
+//! Forwarding a placed request to the node that will serve it.
+//!
+//! Placement ([`super::policy`]) chooses a node; this sends the request there and
+//! brings the answer back. The whole point of the fabric is that this happens
+//! once per request rather than once per token, so a node's own generation loop
+//! never waits on the network.
+//!
+//! Streaming is deliberately out of scope for this path. An SSE response is a
+//! different response shape and a different cancellation story; rather than
+//! half-support it, a streaming request is refused with a reason.
+
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+use super::http::{self, HttpError};
+use super::node::NodeSpec;
+
+/// Generation can legitimately take minutes, so this is far longer than a probe
+/// budget. It exists to bound a wedged node, not to bound a slow model.
+pub const DEFAULT_FORWARD_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// A completion body is far larger than a health body but still bounded.
+const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+/// The node's answer, tagged with which node produced it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Forwarded {
+    pub label: String,
+    /// The node's HTTP status. A node answering 503 is a real answer, not a
+    /// forwarding failure, so it arrives here rather than as an error.
+    pub status: u16,
+    pub body: Value,
+    pub elapsed: Duration,
+}
+
+impl Forwarded {
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ForwardError {
+    /// The request never completed against that node.
+    Transport { label: String, detail: String },
+    /// The node answered, but not with JSON.
+    Json { label: String, detail: String },
+    /// Refused before sending; see [`reject_streaming`].
+    Unsupported(String),
+}
+
+impl std::fmt::Display for ForwardError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport { label, detail } => {
+                write!(f, "node `{label}` did not answer: {detail}")
+            }
+            Self::Json { label, detail } => {
+                write!(f, "node `{label}` returned an unreadable body: {detail}")
+            }
+            Self::Unsupported(detail) => write!(f, "{detail}"),
+        }
+    }
+}
+
+impl std::error::Error for ForwardError {}
+
+/// Refuse a streaming request rather than mis-parse an SSE body as JSON. Pure.
+pub fn reject_streaming(body: &Value) -> Result<(), ForwardError> {
+    if body.get("stream").and_then(Value::as_bool) == Some(true) {
+        return Err(ForwardError::Unsupported(
+            "the fabric does not forward streaming requests yet; \
+             send the request without `stream: true`"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Build a minimal OpenAI-shaped chat request. Pure.
+pub fn chat_request(model: &str, prompt: &str, max_tokens: u32) -> Value {
+    json!({
+        "model": model,
+        "messages": [{ "role": "user", "content": prompt }],
+        "max_tokens": max_tokens,
+        "stream": false,
+    })
+}
+
+/// Pull the assistant text out of a chat completion body. Pure.
+///
+/// Returns `None` rather than a placeholder so a caller can tell "the node
+/// answered with no content" from "the node said nothing useful".
+pub fn completion_text(body: &Value) -> Option<&str> {
+    body.get("choices")?
+        .as_array()?
+        .first()?
+        .get("message")?
+        .get("content")?
+        .as_str()
+}
+
+/// Read an engine error message out of a non-2xx body, if it carries one. Pure.
+pub fn error_message(body: &Value) -> Option<&str> {
+    body.get("error")
+        .and_then(|error| error.get("message").or(Some(error)))
+        .and_then(Value::as_str)
+}
+
+/// Send one request to one node.
+pub fn forward(
+    spec: &NodeSpec,
+    path: &str,
+    body: &Value,
+    timeout: Duration,
+) -> Result<Forwarded, ForwardError> {
+    reject_streaming(body)?;
+
+    let encoded = serde_json::to_vec(body).map_err(|error| ForwardError::Json {
+        label: spec.label.clone(),
+        detail: format!("request body could not be encoded: {error}"),
+    })?;
+
+    let started = Instant::now();
+    let response = http::request(
+        &spec.host,
+        spec.port,
+        "POST",
+        path,
+        Some(&encoded),
+        timeout,
+        MAX_RESPONSE_BYTES,
+    )
+    .map_err(|error: HttpError| ForwardError::Transport {
+        label: spec.label.clone(),
+        detail: error.to_string(),
+    })?;
+    let elapsed = started.elapsed();
+
+    // An empty body is legal for some statuses; represent it as null rather than
+    // failing, so the status still reaches the caller.
+    let parsed = if response.body.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice::<Value>(&response.body).map_err(|error| ForwardError::Json {
+            label: spec.label.clone(),
+            detail: error.to_string(),
+        })?
+    };
+
+    Ok(Forwarded {
+        label: spec.label.clone(),
+        status: response.status,
+        body: parsed,
+        elapsed,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(label: &str, port: u16) -> NodeSpec {
+        NodeSpec {
+            label: label.to_string(),
+            host: "127.0.0.1".to_string(),
+            port,
+        }
+    }
+
+    #[test]
+    fn a_chat_request_carries_the_model_prompt_and_no_streaming() {
+        let request = chat_request("llama-3b", "hello", 16);
+        assert_eq!(request["model"], "llama-3b");
+        assert_eq!(request["messages"][0]["role"], "user");
+        assert_eq!(request["messages"][0]["content"], "hello");
+        assert_eq!(request["max_tokens"], 16);
+        assert_eq!(request["stream"], false);
+    }
+
+    #[test]
+    fn a_streaming_request_is_refused_before_a_socket_is_opened() {
+        let body = json!({ "model": "m", "stream": true });
+        let error = reject_streaming(&body).expect_err("streaming is unsupported");
+        assert!(matches!(error, ForwardError::Unsupported(_)));
+
+        // Port 1 is closed; a transport error here would prove we tried to send.
+        let error = forward(
+            &spec("a", 1),
+            "/v1/chat/completions",
+            &body,
+            Duration::from_millis(200),
+        )
+        .expect_err("refused");
+        assert!(
+            matches!(error, ForwardError::Unsupported(_)),
+            "must refuse before dialling, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn a_non_streaming_request_is_allowed_through() {
+        assert!(reject_streaming(&json!({ "model": "m" })).is_ok());
+        assert!(reject_streaming(&json!({ "model": "m", "stream": false })).is_ok());
+    }
+
+    #[test]
+    fn completion_text_reads_the_first_choice() {
+        let body = json!({
+            "choices": [{ "message": { "role": "assistant", "content": "hi there" } }]
+        });
+        assert_eq!(completion_text(&body), Some("hi there"));
+    }
+
+    #[test]
+    fn completion_text_is_none_rather_than_a_placeholder_when_absent() {
+        assert_eq!(completion_text(&json!({})), None);
+        assert_eq!(completion_text(&json!({ "choices": [] })), None);
+        assert_eq!(completion_text(&json!({ "choices": [{}] })), None);
+    }
+
+    #[test]
+    fn an_engine_error_message_is_extracted_for_reporting() {
+        let body = json!({ "error": { "message": "engine queue full" } });
+        assert_eq!(error_message(&body), Some("engine queue full"));
+
+        let flat = json!({ "error": "bad request" });
+        assert_eq!(error_message(&flat), Some("bad request"));
+    }
+
+    #[test]
+    fn a_dead_node_reports_which_node_failed() {
+        let error = forward(
+            &spec("windows", 1),
+            "/v1/chat/completions",
+            &chat_request("m", "hi", 4),
+            Duration::from_millis(400),
+        )
+        .expect_err("port 1 is closed");
+        match &error {
+            ForwardError::Transport { label, .. } => assert_eq!(label, "windows"),
+            other => panic!("expected Transport, got {other:?}"),
+        }
+        // The message must name the node, or an operator cannot act on it.
+        assert!(error.to_string().contains("windows"), "{error}");
+    }
+
+    #[test]
+    fn a_success_status_is_distinguished_from_an_engine_refusal() {
+        let ok = Forwarded {
+            label: "a".to_string(),
+            status: 200,
+            body: Value::Null,
+            elapsed: Duration::ZERO,
+        };
+        let refused = Forwarded {
+            status: 503,
+            ..ok.clone()
+        };
+        assert!(ok.is_success());
+        assert!(!refused.is_success());
+    }
+}

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -11,8 +11,12 @@
 //! health probe nor a request forward should depend on.
 
 use std::io::{Read, Write};
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::{Duration, Instant};
+
+/// Never spend the whole budget dialling; a forward budget is minutes long and
+/// a node that has not accepted in five seconds is not about to.
+const CONNECT_ATTEMPT_CAP: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum HttpError {
@@ -57,17 +61,14 @@ fn find_header_end(raw: &[u8]) -> Option<HeaderSplit> {
 }
 
 fn parse_status_line(line: &str) -> Result<u16, HttpError> {
-    let mut parts = line.split(' ');
-    let version = parts
-        .next()
-        .ok_or_else(|| HttpError::Malformed("no status line".to_string()))?;
-    if !version.starts_with("HTTP/") {
+    if !line.starts_with("HTTP/") {
         return Err(HttpError::Malformed(format!(
             "status line does not start with HTTP/: {line}"
         )));
     }
-    let code = parts
-        .next()
+    let code = line
+        .split(' ')
+        .nth(1)
         .ok_or_else(|| HttpError::Malformed("status line has no code".to_string()))?;
     code.parse::<u16>()
         .map_err(|_| HttpError::Malformed(format!("status code `{code}` is not a number")))
@@ -155,6 +156,35 @@ pub(crate) fn parse_response(raw: &[u8], max_body: usize) -> Result<HttpResponse
     Ok(HttpResponse { status, body })
 }
 
+/// Connect to the first address that accepts.
+///
+/// A fabric member is usually named rather than numbered, and one name commonly
+/// resolves to several addresses — typically an AAAA ahead of an A. Trying only
+/// the first would report a healthy node as offline whenever its leading address
+/// is unroutable, so every address gets a turn until the deadline runs out.
+fn connect_any(addrs: &[SocketAddr], deadline: Instant) -> Result<TcpStream, HttpError> {
+    let mut last: Option<String> = None;
+    for (index, addr) in addrs.iter().enumerate() {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        // Share what is left between the addresses still untried, so one that
+        // black-holes instead of refusing cannot starve the ones behind it.
+        let untried = (addrs.len() - index) as u32;
+        let attempt = (remaining / untried)
+            .min(CONNECT_ATTEMPT_CAP)
+            .max(Duration::from_millis(1));
+        match TcpStream::connect_timeout(addr, attempt) {
+            Ok(stream) => return Ok(stream),
+            Err(error) => last = Some(format!("{addr}: {error}")),
+        }
+    }
+    Err(HttpError::Connect(last.unwrap_or_else(|| {
+        "no address accepted a connection within the timeout".to_string()
+    })))
+}
+
 /// Perform one request/response round trip against a node.
 ///
 /// `timeout` bounds the whole exchange, not each socket operation, so a peer
@@ -171,18 +201,17 @@ pub(crate) fn request(
     let deadline = Instant::now() + timeout;
     let authority = format!("{host}:{port}");
 
-    let addr = authority
+    let addrs: Vec<SocketAddr> = authority
         .to_socket_addrs()
         .map_err(|error| HttpError::Resolve(error.to_string()))?
-        .next()
-        .ok_or_else(|| HttpError::Resolve("host resolved to no addresses".to_string()))?;
+        .collect();
+    if addrs.is_empty() {
+        return Err(HttpError::Resolve(
+            "host resolved to no addresses".to_string(),
+        ));
+    }
 
-    // Connecting must not consume the whole budget; leave time to actually talk.
-    let connect_timeout = timeout
-        .min(Duration::from_secs(5))
-        .max(Duration::from_millis(1));
-    let mut stream = TcpStream::connect_timeout(&addr, connect_timeout)
-        .map_err(|error| HttpError::Connect(error.to_string()))?;
+    let mut stream = connect_any(&addrs, deadline)?;
     // Short socket reads keep the loop responsive to the overall deadline; one
     // long read timeout would overshoot it on a stalled peer.
     stream
@@ -240,8 +269,29 @@ pub(crate) fn request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::TcpListener;
 
     const LIMIT: usize = 1024 * 1024;
+
+    #[test]
+    fn a_dead_leading_address_does_not_hide_a_live_one() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("binds");
+        let live = listener.local_addr().expect("has an address");
+        // Port 1 is closed; it stands in for an unroutable AAAA ahead of the A.
+        let dead = SocketAddr::from(([127, 0, 0, 1], 1));
+
+        let stream = connect_any(&[dead, live], Instant::now() + Duration::from_secs(2))
+            .expect("the second address accepts");
+        assert_eq!(stream.peer_addr().expect("connected"), live);
+    }
+
+    #[test]
+    fn every_address_failing_reports_the_last_failure() {
+        let dead = SocketAddr::from(([127, 0, 0, 1], 1));
+        let error = connect_any(&[dead, dead], Instant::now() + Duration::from_secs(1))
+            .expect_err("nothing is listening");
+        assert!(matches!(error, HttpError::Connect(_)), "{error:?}");
+    }
 
     #[test]
     fn a_content_length_body_is_read_exactly() {

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -1,0 +1,370 @@
+//! Minimal blocking HTTP/1.1 client shared by the fabric's probe and forward
+//! paths.
+//!
+//! Response parsing is pure over byte slices, so the awkward parts — chunked
+//! bodies, truncated frames, a node that answers 500 — are tested without a
+//! server. Only [`request`] touches a socket.
+//!
+//! This deliberately does not reuse `chat::client`: that module is private to
+//! `chat`, is keyed on a resolved `SocketAddr` where fabric members are named
+//! hosts, and carries SSE, bearer auth and tool-call handling that neither a
+//! health probe nor a request forward should depend on.
+
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HttpError {
+    Resolve(String),
+    Connect(String),
+    Io(String),
+    Malformed(String),
+    TooLarge(usize),
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Resolve(detail) => write!(f, "cannot resolve host: {detail}"),
+            Self::Connect(detail) => write!(f, "cannot connect: {detail}"),
+            Self::Io(detail) => write!(f, "connection failed: {detail}"),
+            Self::Malformed(detail) => write!(f, "malformed HTTP response: {detail}"),
+            Self::TooLarge(limit) => write!(f, "response exceeded {limit} bytes"),
+        }
+    }
+}
+
+/// Status line plus body of an HTTP/1.1 response.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct HttpResponse {
+    pub(crate) status: u16,
+    pub(crate) body: Vec<u8>,
+}
+
+struct HeaderSplit {
+    headers_end: usize,
+    body_start: usize,
+}
+
+fn find_header_end(raw: &[u8]) -> Option<HeaderSplit> {
+    raw.windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|at| HeaderSplit {
+            headers_end: at,
+            body_start: at + 4,
+        })
+}
+
+fn parse_status_line(line: &str) -> Result<u16, HttpError> {
+    let mut parts = line.split(' ');
+    let version = parts
+        .next()
+        .ok_or_else(|| HttpError::Malformed("no status line".to_string()))?;
+    if !version.starts_with("HTTP/") {
+        return Err(HttpError::Malformed(format!(
+            "status line does not start with HTTP/: {line}"
+        )));
+    }
+    let code = parts
+        .next()
+        .ok_or_else(|| HttpError::Malformed("status line has no code".to_string()))?;
+    code.parse::<u16>()
+        .map_err(|_| HttpError::Malformed(format!("status code `{code}` is not a number")))
+}
+
+/// Decode `Transfer-Encoding: chunked`.
+fn dechunk(mut rest: &[u8], max_body: usize) -> Result<Vec<u8>, HttpError> {
+    let mut out = Vec::new();
+    loop {
+        let line_end = rest
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .ok_or_else(|| HttpError::Malformed("chunk size line unterminated".to_string()))?;
+        let size_text = std::str::from_utf8(&rest[..line_end])
+            .map_err(|_| HttpError::Malformed("chunk size is not UTF-8".to_string()))?;
+        // A chunk extension (`1a;name=value`) is legal and ignorable.
+        let size_text = size_text.split(';').next().unwrap_or("").trim();
+        let size = usize::from_str_radix(size_text, 16).map_err(|_| {
+            HttpError::Malformed(format!("chunk size `{size_text}` is not hexadecimal"))
+        })?;
+        rest = &rest[line_end + 2..];
+        if size == 0 {
+            return Ok(out);
+        }
+        if out.len() + size > max_body {
+            return Err(HttpError::TooLarge(max_body));
+        }
+        if rest.len() < size + 2 {
+            return Err(HttpError::Malformed("chunk body truncated".to_string()));
+        }
+        out.extend_from_slice(&rest[..size]);
+        rest = &rest[size + 2..];
+    }
+}
+
+/// Parse a whole HTTP/1.1 response. Pure; see the tests at the bottom.
+pub(crate) fn parse_response(raw: &[u8], max_body: usize) -> Result<HttpResponse, HttpError> {
+    let split = find_header_end(raw)
+        .ok_or_else(|| HttpError::Malformed("no header terminator".to_string()))?;
+    let head = std::str::from_utf8(&raw[..split.headers_end])
+        .map_err(|_| HttpError::Malformed("headers are not UTF-8".to_string()))?;
+
+    let mut lines = head.split("\r\n");
+    let status_line = lines
+        .next()
+        .ok_or_else(|| HttpError::Malformed("empty response".to_string()))?;
+    let status = parse_status_line(status_line)?;
+
+    let mut chunked = false;
+    let mut content_length: Option<usize> = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match name.as_str() {
+            "transfer-encoding" => chunked = value.to_ascii_lowercase().contains("chunked"),
+            "content-length" => content_length = value.parse::<usize>().ok(),
+            _ => {}
+        }
+    }
+
+    let rest = &raw[split.body_start..];
+    let body = if chunked {
+        dechunk(rest, max_body)?
+    } else if let Some(len) = content_length {
+        if len > max_body {
+            return Err(HttpError::TooLarge(max_body));
+        }
+        if rest.len() < len {
+            return Err(HttpError::Malformed(format!(
+                "body truncated: expected {len} bytes, got {}",
+                rest.len()
+            )));
+        }
+        rest[..len].to_vec()
+    } else {
+        rest.to_vec()
+    };
+
+    if body.len() > max_body {
+        return Err(HttpError::TooLarge(max_body));
+    }
+    Ok(HttpResponse { status, body })
+}
+
+/// Perform one request/response round trip against a node.
+///
+/// `timeout` bounds the whole exchange, not each socket operation, so a peer
+/// that dribbles bytes forever still fails on schedule.
+pub(crate) fn request(
+    host: &str,
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&[u8]>,
+    timeout: Duration,
+    max_body: usize,
+) -> Result<HttpResponse, HttpError> {
+    let deadline = Instant::now() + timeout;
+    let authority = format!("{host}:{port}");
+
+    let addr = authority
+        .to_socket_addrs()
+        .map_err(|error| HttpError::Resolve(error.to_string()))?
+        .next()
+        .ok_or_else(|| HttpError::Resolve("host resolved to no addresses".to_string()))?;
+
+    // Connecting must not consume the whole budget; leave time to actually talk.
+    let connect_timeout = timeout
+        .min(Duration::from_secs(5))
+        .max(Duration::from_millis(1));
+    let mut stream = TcpStream::connect_timeout(&addr, connect_timeout)
+        .map_err(|error| HttpError::Connect(error.to_string()))?;
+    // Short socket reads keep the loop responsive to the overall deadline; one
+    // long read timeout would overshoot it on a stalled peer.
+    stream
+        .set_read_timeout(Some(Duration::from_millis(100)))
+        .map_err(|error| HttpError::Io(error.to_string()))?;
+    stream
+        .set_write_timeout(Some(timeout))
+        .map_err(|error| HttpError::Io(error.to_string()))?;
+
+    let mut head = format!("{method} {path} HTTP/1.1\r\nHost: {authority}\r\nAccept: application/json\r\nConnection: close\r\n");
+    if let Some(body) = body {
+        head.push_str("Content-Type: application/json\r\n");
+        head.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+    head.push_str("\r\n");
+
+    stream
+        .write_all(head.as_bytes())
+        .map_err(|error| HttpError::Io(error.to_string()))?;
+    if let Some(body) = body {
+        stream
+            .write_all(body)
+            .map_err(|error| HttpError::Io(error.to_string()))?;
+    }
+
+    let mut raw = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        if Instant::now() >= deadline {
+            return Err(HttpError::Io("request exceeded its deadline".to_string()));
+        }
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => {
+                raw.extend_from_slice(&chunk[..read]);
+                if raw.len() > max_body {
+                    return Err(HttpError::TooLarge(max_body));
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                continue
+            }
+            Err(error) => return Err(HttpError::Io(error.to_string())),
+        }
+    }
+
+    parse_response(&raw, max_body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LIMIT: usize = 1024 * 1024;
+
+    #[test]
+    fn a_content_length_body_is_read_exactly() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello-trailing-garbage";
+        let response = parse_response(raw, LIMIT).expect("parses");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, b"hello");
+    }
+
+    #[test]
+    fn a_chunked_body_is_reassembled() {
+        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
+        assert_eq!(
+            parse_response(raw, LIMIT).expect("parses").body,
+            b"hello world"
+        );
+    }
+
+    #[test]
+    fn chunk_extensions_are_ignored() {
+        let raw =
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5;name=value\r\nhello\r\n0\r\n\r\n";
+        assert_eq!(parse_response(raw, LIMIT).expect("parses").body, b"hello");
+    }
+
+    #[test]
+    fn a_body_without_framing_headers_is_read_to_end() {
+        let raw = b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n{}";
+        assert_eq!(parse_response(raw, LIMIT).expect("parses").body, b"{}");
+    }
+
+    #[test]
+    fn header_names_are_matched_case_insensitively() {
+        let raw = b"HTTP/1.1 200 OK\r\ncOnTeNt-LeNgTh: 2\r\n\r\nok";
+        assert_eq!(parse_response(raw, LIMIT).expect("parses").body, b"ok");
+    }
+
+    #[test]
+    fn a_non_http_greeting_is_refused_rather_than_guessed_at() {
+        let raw = b"SSH-2.0-OpenSSH_9.0\r\n\r\n";
+        assert!(matches!(
+            parse_response(raw, LIMIT),
+            Err(HttpError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn a_response_with_no_header_terminator_is_refused() {
+        assert!(matches!(
+            parse_response(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n", LIMIT),
+            Err(HttpError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn a_truncated_body_is_refused_rather_than_silently_short() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 99\r\n\r\nshort";
+        assert!(matches!(
+            parse_response(raw, LIMIT),
+            Err(HttpError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn a_truncated_chunk_is_refused() {
+        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n9\r\nshort\r\n";
+        assert!(matches!(
+            parse_response(raw, LIMIT),
+            Err(HttpError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn an_oversized_content_length_is_refused_before_allocating() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 99999999\r\n\r\n";
+        assert_eq!(parse_response(raw, LIMIT), Err(HttpError::TooLarge(LIMIT)));
+    }
+
+    #[test]
+    fn an_oversized_chunked_body_is_refused_mid_stream() {
+        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
+        assert_eq!(parse_response(raw, 2), Err(HttpError::TooLarge(2)));
+    }
+
+    #[test]
+    fn a_non_200_is_reported_with_its_code() {
+        let raw = b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n";
+        assert_eq!(parse_response(raw, LIMIT).expect("parses").status, 503);
+    }
+
+    #[test]
+    fn a_closed_port_reports_connect_failure_not_a_panic() {
+        let error = request(
+            "127.0.0.1",
+            1,
+            "GET",
+            "/v1/health",
+            None,
+            Duration::from_millis(500),
+            LIMIT,
+        )
+        .expect_err("port 1 is closed");
+        assert!(
+            matches!(error, HttpError::Connect(_) | HttpError::Io(_)),
+            "unexpected: {error:?}"
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_host_reports_a_resolve_failure() {
+        let error = request(
+            "camelid-fabric-host-that-does-not-exist.invalid",
+            8181,
+            "GET",
+            "/v1/health",
+            None,
+            Duration::from_millis(500),
+            LIMIT,
+        )
+        .expect_err("`.invalid` never resolves");
+        assert!(
+            matches!(error, HttpError::Resolve(_)),
+            "unexpected: {error:?}"
+        );
+    }
+}

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -72,6 +72,23 @@ impl Fabric {
         probe_fabric(&self.specs, self.timeout)
     }
 
+    /// Observe every node once and choose one for a request.
+    ///
+    /// The chosen node's snapshot comes back with the decision so a caller can
+    /// read what that node is already serving before it builds a request body.
+    pub fn place(
+        &self,
+        request: &RouteRequest<'_>,
+    ) -> Result<(RouteDecision, NodeSnapshot), RouteError> {
+        let snapshots = self.observe();
+        let decision = route(&snapshots, request)?;
+        let chosen = snapshots
+            .into_iter()
+            .find(|snapshot| snapshot.label() == decision.label)
+            .expect("placement returns a label it was given");
+        Ok((decision, chosen))
+    }
+
     /// Observe, place, and send — the whole path a caller actually wants.
     ///
     /// Returns the placement alongside the answer so a caller can record which
@@ -86,15 +103,8 @@ impl Fabric {
         // Refuse an unsupported request before spending any probes on it.
         forward::reject_streaming(body)?;
 
-        let snapshots = self.observe();
-        let decision = route(&snapshots, request)?;
-        let spec = snapshots
-            .iter()
-            .find(|snapshot| snapshot.label() == decision.label)
-            .map(|snapshot| snapshot.spec.clone())
-            .ok_or(DispatchError::Route(RouteError::NoNodesConfigured))?;
-
-        let answer = forward::forward(&spec, path, body, forward_timeout)?;
+        let (decision, chosen) = self.place(request)?;
+        let answer = forward::forward(&chosen.spec, path, body, forward_timeout)?;
         Ok((decision, answer))
     }
 }

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -17,15 +17,21 @@
 //! # Shape
 //!
 //! * [`node`] — identity and observed state.
-//! * [`probe`] — the only socket work.
+//! * [`probe`] — turning `/v1/health` into a routing fact.
 //! * [`policy`] — pure placement decisions; the correctness of the fabric.
+//! * [`forward`] — sending a placed request to the node that will serve it.
 
+pub mod forward;
+pub(crate) mod http;
 pub mod node;
 pub mod policy;
 pub mod probe;
 
 use std::time::Duration;
 
+use serde_json::Value;
+
+pub use forward::{ForwardError, Forwarded, DEFAULT_FORWARD_TIMEOUT};
 pub use node::{
     parse_fabric, parse_node_spec, NodeReady, NodeSnapshot, NodeSpec, NodeSpecParseError,
     NodeStatus, DEFAULT_NODE_PORT,
@@ -64,6 +70,64 @@ impl Fabric {
     /// Observe every node once.
     pub fn observe(&self) -> Vec<NodeSnapshot> {
         probe_fabric(&self.specs, self.timeout)
+    }
+
+    /// Observe, place, and send — the whole path a caller actually wants.
+    ///
+    /// Returns the placement alongside the answer so a caller can record which
+    /// node served the request and whether affinity held.
+    pub fn dispatch(
+        &self,
+        path: &str,
+        body: &Value,
+        request: &RouteRequest<'_>,
+        forward_timeout: Duration,
+    ) -> Result<(RouteDecision, Forwarded), DispatchError> {
+        // Refuse an unsupported request before spending any probes on it.
+        forward::reject_streaming(body)?;
+
+        let snapshots = self.observe();
+        let decision = route(&snapshots, request)?;
+        let spec = snapshots
+            .iter()
+            .find(|snapshot| snapshot.label() == decision.label)
+            .map(|snapshot| snapshot.spec.clone())
+            .ok_or(DispatchError::Route(RouteError::NoNodesConfigured))?;
+
+        let answer = forward::forward(&spec, path, body, forward_timeout)?;
+        Ok((decision, answer))
+    }
+}
+
+/// Why a dispatch did not produce an answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchError {
+    /// No node could take the request.
+    Route(RouteError),
+    /// A node was chosen, but the request did not complete against it.
+    Forward(ForwardError),
+}
+
+impl std::fmt::Display for DispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Route(error) => write!(f, "{error}"),
+            Self::Forward(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for DispatchError {}
+
+impl From<RouteError> for DispatchError {
+    fn from(error: RouteError) -> Self {
+        Self::Route(error)
+    }
+}
+
+impl From<ForwardError> for DispatchError {
+    fn from(error: ForwardError) -> Self {
+        Self::Forward(error)
     }
 }
 
@@ -252,5 +316,70 @@ mod tests {
         let fabric = Fabric::new(Vec::new());
         assert!(fabric.is_empty());
         assert!(fabric.observe().is_empty());
+    }
+
+    #[test]
+    fn dispatch_refuses_a_streaming_request_before_probing_anything() {
+        // The node here is unreachable on purpose: if dispatch probed first, this
+        // would surface as a routing failure instead of the streaming refusal.
+        let fabric = Fabric::new(vec![NodeSpec {
+            label: "dead".to_string(),
+            host: "127.0.0.1".to_string(),
+            port: 1,
+        }]);
+        let body = serde_json::json!({ "model": "m", "stream": true });
+        let error = fabric
+            .dispatch(
+                "/v1/chat/completions",
+                &body,
+                &RouteRequest::new(RouteMode::Throughput),
+                Duration::from_millis(200),
+            )
+            .expect_err("streaming is unsupported");
+        assert!(
+            matches!(error, DispatchError::Forward(ForwardError::Unsupported(_))),
+            "got {error:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_on_an_empty_fabric_fails_at_placement_not_transport() {
+        let fabric = Fabric::new(Vec::new());
+        let error = fabric
+            .dispatch(
+                "/v1/chat/completions",
+                &serde_json::json!({ "model": "m" }),
+                &RouteRequest::new(RouteMode::Throughput),
+                Duration::from_millis(200),
+            )
+            .expect_err("no nodes");
+        assert_eq!(error, DispatchError::Route(RouteError::NoNodesConfigured));
+    }
+
+    #[test]
+    fn dispatch_reports_a_dead_node_as_a_placement_failure() {
+        // Every node being unreachable is a routing outcome, not a forward error:
+        // there was never a node to send to.
+        let fabric = Fabric::new(vec![NodeSpec {
+            label: "dead".to_string(),
+            host: "127.0.0.1".to_string(),
+            port: 1,
+        }])
+        .with_timeout(Duration::from_millis(300));
+        let error = fabric
+            .dispatch(
+                "/v1/chat/completions",
+                &serde_json::json!({ "model": "m" }),
+                &RouteRequest::new(RouteMode::Throughput),
+                Duration::from_millis(300),
+            )
+            .expect_err("node is dead");
+        assert!(
+            matches!(
+                error,
+                DispatchError::Route(RouteError::AllNodesUnavailable { .. })
+            ),
+            "got {error:?}"
+        );
     }
 }

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -1,0 +1,256 @@
+//! A fabric of independent Camelid nodes.
+//!
+//! # Why this exists
+//!
+//! Camelid already has a distributed lane (`crate::distributed`) that shards one
+//! model's layers across two machines. It is a *capacity* mechanism: it lets a
+//! model run that fits on neither machine, and it is measurably slower than a
+//! single node, because every generated token crosses the network twice and each
+//! machine idles while the other computes.
+//!
+//! The fabric is the opposite arrangement. Each node owns a whole model and a
+//! whole session; the fabric places *whole requests*. Nothing crosses the network
+//! inside the token loop, so throughput scales with nodes instead of being taxed
+//! by them. It composes with the layer-sharded lane rather than replacing it —
+//! a fabric node may itself be a distributed coordinator.
+//!
+//! # Shape
+//!
+//! * [`node`] — identity and observed state.
+//! * [`probe`] — the only socket work.
+//! * [`policy`] — pure placement decisions; the correctness of the fabric.
+
+pub mod node;
+pub mod policy;
+pub mod probe;
+
+use std::time::Duration;
+
+pub use node::{
+    parse_fabric, parse_node_spec, NodeReady, NodeSnapshot, NodeSpec, NodeSpecParseError,
+    NodeStatus, DEFAULT_NODE_PORT,
+};
+pub use policy::{route, RouteDecision, RouteError, RouteMode, RouteReason, RouteRequest};
+pub use probe::{probe_fabric, probe_node, ProbeError, DEFAULT_PROBE_TIMEOUT};
+
+/// A configured set of nodes.
+#[derive(Debug, Clone)]
+pub struct Fabric {
+    specs: Vec<NodeSpec>,
+    timeout: Duration,
+}
+
+impl Fabric {
+    pub fn new(specs: Vec<NodeSpec>) -> Self {
+        Self {
+            specs,
+            timeout: DEFAULT_PROBE_TIMEOUT,
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn specs(&self) -> &[NodeSpec] {
+        &self.specs
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.specs.is_empty()
+    }
+
+    /// Observe every node once.
+    pub fn observe(&self) -> Vec<NodeSnapshot> {
+        probe_fabric(&self.specs, self.timeout)
+    }
+}
+
+/// Counts of each observed state, for reporting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FabricSummary {
+    pub ready: usize,
+    pub not_ready: usize,
+    pub unreachable: usize,
+}
+
+impl FabricSummary {
+    pub fn of(snapshots: &[NodeSnapshot]) -> Self {
+        let mut summary = Self::default();
+        for snapshot in snapshots {
+            match snapshot.status {
+                NodeStatus::Ready(_) => summary.ready += 1,
+                NodeStatus::NotReady { .. } => summary.not_ready += 1,
+                NodeStatus::Unreachable { .. } => summary.unreachable += 1,
+            }
+        }
+        summary
+    }
+
+    pub fn total(&self) -> usize {
+        self.ready + self.not_ready + self.unreachable
+    }
+}
+
+/// Render a fabric observation as fixed-width text.
+///
+/// Kept pure so the CLI's output is covered by a unit test rather than by
+/// eyeballing a terminal.
+pub fn render_status(snapshots: &[NodeSnapshot]) -> String {
+    if snapshots.is_empty() {
+        return "no nodes configured\n".to_string();
+    }
+
+    let label_width = snapshots
+        .iter()
+        .map(|s| s.label().len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+    let authority_width = snapshots
+        .iter()
+        .map(|s| s.spec.authority().len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{:<label_width$}  {:<authority_width$}  {:<9}  {:<24}  {:<6}  {}\n",
+        "NODE",
+        "ADDRESS",
+        "STATE",
+        "MODEL",
+        "LOAD",
+        "DETAIL",
+        label_width = label_width,
+        authority_width = authority_width,
+    ));
+
+    for snapshot in snapshots {
+        let (state, model, load, detail) = match &snapshot.status {
+            NodeStatus::Ready(ready) => (
+                "ready",
+                ready.active_model_id.as_deref().unwrap_or("-").to_string(),
+                ready.in_flight.to_string(),
+                match snapshot.latency {
+                    Some(latency) => format!("{} · {} ms", ready.backend, latency.as_millis()),
+                    None => ready.backend.clone(),
+                },
+            ),
+            NodeStatus::NotReady { reason } => (
+                "not-ready",
+                "-".to_string(),
+                "-".to_string(),
+                reason.clone(),
+            ),
+            NodeStatus::Unreachable { reason } => {
+                ("offline", "-".to_string(), "-".to_string(), reason.clone())
+            }
+        };
+        out.push_str(&format!(
+            "{:<label_width$}  {:<authority_width$}  {:<9}  {:<24}  {:<6}  {}\n",
+            snapshot.label(),
+            snapshot.spec.authority(),
+            state,
+            model,
+            load,
+            detail,
+            label_width = label_width,
+            authority_width = authority_width,
+        ));
+    }
+
+    let summary = FabricSummary::of(snapshots);
+    out.push_str(&format!(
+        "\n{} node(s): {} ready, {} not ready, {} offline\n",
+        summary.total(),
+        summary.ready,
+        summary.not_ready,
+        summary.unreachable
+    ));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(label: &str, status: NodeStatus) -> NodeSnapshot {
+        NodeSnapshot {
+            spec: NodeSpec {
+                label: label.to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 8181,
+            },
+            status,
+            latency: Some(Duration::from_millis(4)),
+        }
+    }
+
+    fn ready_status(model: &str) -> NodeStatus {
+        NodeStatus::Ready(NodeReady {
+            active_model_id: Some(model.to_string()),
+            backend: "llama".to_string(),
+            version: "0.5.4".to_string(),
+            in_flight: 1,
+            waiting: 0,
+        })
+    }
+
+    #[test]
+    fn an_empty_fabric_renders_a_sentence_not_an_empty_table() {
+        assert_eq!(render_status(&[]), "no nodes configured\n");
+    }
+
+    #[test]
+    fn the_summary_counts_every_state() {
+        let snapshots = vec![
+            snapshot("a", ready_status("llama-3b")),
+            snapshot(
+                "b",
+                NodeStatus::NotReady {
+                    reason: "no model loaded".to_string(),
+                },
+            ),
+            snapshot(
+                "c",
+                NodeStatus::Unreachable {
+                    reason: "cannot connect".to_string(),
+                },
+            ),
+        ];
+        let summary = FabricSummary::of(&snapshots);
+        assert_eq!(summary.ready, 1);
+        assert_eq!(summary.not_ready, 1);
+        assert_eq!(summary.unreachable, 1);
+        assert_eq!(summary.total(), 3);
+    }
+
+    #[test]
+    fn the_table_reports_model_load_and_failure_detail() {
+        let snapshots = vec![
+            snapshot("windows", ready_status("llama-3b")),
+            snapshot(
+                "mac",
+                NodeStatus::Unreachable {
+                    reason: "cannot connect: refused".to_string(),
+                },
+            ),
+        ];
+        let rendered = render_status(&snapshots);
+        assert!(rendered.contains("windows"), "{rendered}");
+        assert!(rendered.contains("llama-3b"), "{rendered}");
+        assert!(rendered.contains("LOAD"), "{rendered}");
+        assert!(rendered.contains("cannot connect: refused"), "{rendered}");
+        assert!(rendered.contains("2 node(s): 1 ready"), "{rendered}");
+    }
+
+    #[test]
+    fn a_fabric_with_no_specs_observes_nothing() {
+        let fabric = Fabric::new(Vec::new());
+        assert!(fabric.is_empty());
+        assert!(fabric.observe().is_empty());
+    }
+}

--- a/src/fabric/node.rs
+++ b/src/fabric/node.rs
@@ -1,0 +1,422 @@
+//! Identity and observed state of one Camelid node in a fabric.
+//!
+//! A node is a whole, independent `camelid serve` process that owns a complete
+//! model and a complete session. The fabric never reaches inside one: the only
+//! thing it learns is what `/v1/health` reports, and the only thing it decides
+//! is which node a whole request goes to. That boundary is what keeps the token
+//! loop free of cross-node traffic.
+
+use std::fmt;
+use std::time::Duration;
+
+use serde::{Serialize, Serializer};
+
+/// Operator-supplied identity of one node.
+///
+/// `host` stays a string rather than a resolved `SocketAddr` because fabric
+/// members are typically named (`workstation.local`), and a name that resolves
+/// late survives a DHCP lease change that a cached address would not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NodeSpec {
+    pub label: String,
+    pub host: String,
+    pub port: u16,
+}
+
+/// Default port for a `camelid serve` process.
+pub const DEFAULT_NODE_PORT: u16 = 8181;
+
+impl NodeSpec {
+    pub fn authority(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+impl fmt::Display for NodeSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.label, self.authority())
+    }
+}
+
+/// Why parsing an operator-supplied node string failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeSpecParseError {
+    Empty,
+    MissingLabel,
+    MissingHost,
+    DuplicateLabel(String),
+    BadPort(String),
+    /// A bare IPv6 literal cannot be told apart from `host:port`, so RFC 3986
+    /// brackets are required rather than guessed at.
+    UnbracketedIpv6(String),
+    MalformedEndpoint(String),
+}
+
+impl fmt::Display for NodeSpecParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "node specification is empty"),
+            Self::MissingLabel => write!(
+                f,
+                "node specification needs a label, as in `windows=127.0.0.1:8181`"
+            ),
+            Self::MissingHost => write!(f, "node specification needs a host"),
+            Self::DuplicateLabel(label) => {
+                write!(f, "node label `{label}` is used more than once")
+            }
+            Self::BadPort(port) => write!(f, "`{port}` is not a valid port"),
+            Self::UnbracketedIpv6(endpoint) => write!(
+                f,
+                "`{endpoint}` looks like an IPv6 address; wrap it in brackets, as in `[::1]:8181`"
+            ),
+            Self::MalformedEndpoint(endpoint) => {
+                write!(f, "`{endpoint}` is not a valid host[:port]")
+            }
+        }
+    }
+}
+
+fn parse_port(raw: &str) -> Result<u16, NodeSpecParseError> {
+    match raw.parse::<u16>() {
+        Ok(port) if port != 0 => Ok(port),
+        _ => Err(NodeSpecParseError::BadPort(raw.to_string())),
+    }
+}
+
+impl std::error::Error for NodeSpecParseError {}
+
+/// Parse one `label=host[:port]` string.
+///
+/// The label is mandatory and not derived from the host: routing decisions,
+/// affinity keys and receipts all quote it, and a host that changes address
+/// must not silently become a different node.
+pub fn parse_node_spec(raw: &str) -> Result<NodeSpec, NodeSpecParseError> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(NodeSpecParseError::Empty);
+    }
+    let (label, endpoint) = raw
+        .split_once('=')
+        .ok_or(NodeSpecParseError::MissingLabel)?;
+    let label = label.trim();
+    let endpoint = endpoint.trim();
+    if label.is_empty() {
+        return Err(NodeSpecParseError::MissingLabel);
+    }
+    if endpoint.is_empty() {
+        return Err(NodeSpecParseError::MissingHost);
+    }
+
+    // A bracketed IPv6 literal owns every colon up to `]`; only a colon after the
+    // bracket introduces a port. Splitting on the last colon instead would read
+    // `[::1]` as host `[:` and port `1]`.
+    let (host, port) = if endpoint.starts_with('[') {
+        let close = endpoint
+            .find(']')
+            .ok_or_else(|| NodeSpecParseError::MalformedEndpoint(endpoint.to_string()))?;
+        let host = &endpoint[..=close];
+        if host.len() <= 2 {
+            return Err(NodeSpecParseError::MissingHost);
+        }
+        match &endpoint[close + 1..] {
+            "" => (host, DEFAULT_NODE_PORT),
+            rest => match rest.strip_prefix(':') {
+                Some(port) => (host, parse_port(port)?),
+                None => return Err(NodeSpecParseError::MalformedEndpoint(endpoint.to_string())),
+            },
+        }
+    } else {
+        match endpoint.rsplit_once(':') {
+            Some((host, port)) => {
+                if host.contains(':') {
+                    return Err(NodeSpecParseError::UnbracketedIpv6(endpoint.to_string()));
+                }
+                (host, parse_port(port)?)
+            }
+            None => (endpoint, DEFAULT_NODE_PORT),
+        }
+    };
+    if host.is_empty() {
+        return Err(NodeSpecParseError::MissingHost);
+    }
+
+    Ok(NodeSpec {
+        label: label.to_string(),
+        host: host.to_string(),
+        port,
+    })
+}
+
+/// Parse a whole fabric, rejecting duplicate labels.
+///
+/// Duplicates are refused rather than de-duplicated: two nodes sharing a label
+/// would make an affinity decision ambiguous, and silently dropping one would
+/// hide a typo that costs the operator a machine.
+pub fn parse_fabric(raws: &[String]) -> Result<Vec<NodeSpec>, NodeSpecParseError> {
+    let mut specs: Vec<NodeSpec> = Vec::with_capacity(raws.len());
+    for raw in raws {
+        let spec = parse_node_spec(raw)?;
+        if specs.iter().any(|existing| existing.label == spec.label) {
+            return Err(NodeSpecParseError::DuplicateLabel(spec.label));
+        }
+        specs.push(spec);
+    }
+    Ok(specs)
+}
+
+/// The generation-relevant subset of `/v1/health` from a node that can serve.
+///
+/// `/v1/health` reports current load but **not** the node's queue bound. The bound
+/// is `CAMELID_QUEUE_DEPTH`, read on the node itself and never serialised — the
+/// field named `engine_queue_depth` is a gauge of jobs in flight, not a capacity.
+/// So the fabric ranks by observed load and never declares a node full: a node
+/// genuinely at its bound answers a typed 503, which is a retry concern rather
+/// than a placement one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NodeReady {
+    pub active_model_id: Option<String>,
+    pub backend: String,
+    pub version: String,
+    /// Jobs accepted and not yet finished, queued plus running
+    /// (`engine_queue_depth`). This is the load signal placement ranks on.
+    pub in_flight: usize,
+    /// Jobs queued but not yet running (`engine_queued_tasks`).
+    pub waiting: usize,
+}
+
+/// What a probe learned about a node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum NodeStatus {
+    /// Answered `/v1/health` and reports it can generate.
+    Ready(NodeReady),
+    /// Answered, but cannot generate — no model loaded, or still warming.
+    NotReady { reason: String },
+    /// Did not answer within the probe budget.
+    Unreachable { reason: String },
+}
+
+impl NodeStatus {
+    pub fn ready(&self) -> Option<&NodeReady> {
+        match self {
+            Self::Ready(ready) => Some(ready),
+            _ => None,
+        }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready(_))
+    }
+}
+
+/// Render a probe duration as whole milliseconds; `Duration`'s own
+/// representation is not a useful thing to hand an operator or a script.
+fn serialize_latency_ms<S: Serializer>(
+    latency: &Option<Duration>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match latency {
+        Some(latency) => serializer.serialize_some(&(latency.as_millis() as u64)),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// One node's spec plus the most recent observation of it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct NodeSnapshot {
+    pub spec: NodeSpec,
+    pub status: NodeStatus,
+    /// Round-trip time of the probe itself. Recorded for reporting only; routing
+    /// deliberately does not rank on it, because one sample of a Wi-Fi RTT is
+    /// noise (measured 3-13 ms across six pings on this fabric).
+    #[serde(rename = "latency_ms", serialize_with = "serialize_latency_ms")]
+    pub latency: Option<Duration>,
+}
+
+impl NodeSnapshot {
+    pub fn label(&self) -> &str {
+        &self.spec.label
+    }
+
+    /// The model this node is currently serving, when it can serve at all.
+    pub fn active_model_id(&self) -> Option<&str> {
+        self.status
+            .ready()
+            .and_then(|ready| ready.active_model_id.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_host_takes_the_default_port() {
+        let spec = parse_node_spec("mac=workstation.local").expect("parses");
+        assert_eq!(spec.label, "mac");
+        assert_eq!(spec.host, "workstation.local");
+        assert_eq!(spec.port, DEFAULT_NODE_PORT);
+    }
+
+    #[test]
+    fn an_explicit_port_overrides_the_default() {
+        let spec = parse_node_spec("win=127.0.0.1:8200").expect("parses");
+        assert_eq!(spec.host, "127.0.0.1");
+        assert_eq!(spec.port, 8200);
+    }
+
+    #[test]
+    fn ipv6_literals_keep_their_colons() {
+        let spec = parse_node_spec("v6=[::1]:8181").expect("parses");
+        assert_eq!(spec.host, "[::1]");
+        assert_eq!(spec.port, 8181);
+
+        let bare = parse_node_spec("v6=[::1]").expect("parses");
+        assert_eq!(bare.host, "[::1]");
+        assert_eq!(bare.port, DEFAULT_NODE_PORT);
+
+        let full = parse_node_spec("v6=[2001:db8::1]:9000").expect("parses");
+        assert_eq!(full.host, "[2001:db8::1]");
+        assert_eq!(full.port, 9000);
+    }
+
+    #[test]
+    fn an_unbracketed_ipv6_is_refused_with_advice_instead_of_misparsed() {
+        // `::1` would otherwise read as host `:` port `1`.
+        assert_eq!(
+            parse_node_spec("v6=::1"),
+            Err(NodeSpecParseError::UnbracketedIpv6("::1".to_string()))
+        );
+        assert_eq!(
+            parse_node_spec("v6=2001:db8::1"),
+            Err(NodeSpecParseError::UnbracketedIpv6(
+                "2001:db8::1".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn a_malformed_bracketed_endpoint_is_refused() {
+        assert_eq!(
+            parse_node_spec("v6=[::1"),
+            Err(NodeSpecParseError::MalformedEndpoint("[::1".to_string()))
+        );
+        assert_eq!(
+            parse_node_spec("v6=[::1]junk"),
+            Err(NodeSpecParseError::MalformedEndpoint(
+                "[::1]junk".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_node_spec("v6=[]"),
+            Err(NodeSpecParseError::MissingHost)
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_tolerated() {
+        let spec = parse_node_spec("  mac = 192.0.2.10:8181  ").expect("parses");
+        assert_eq!(spec.label, "mac");
+        assert_eq!(spec.host, "192.0.2.10");
+    }
+
+    #[test]
+    fn malformed_specs_are_refused_with_a_reason() {
+        assert_eq!(parse_node_spec(""), Err(NodeSpecParseError::Empty));
+        assert_eq!(
+            parse_node_spec("127.0.0.1:8181"),
+            Err(NodeSpecParseError::MissingLabel)
+        );
+        assert_eq!(
+            parse_node_spec("=127.0.0.1"),
+            Err(NodeSpecParseError::MissingLabel)
+        );
+        assert_eq!(
+            parse_node_spec("win="),
+            Err(NodeSpecParseError::MissingHost)
+        );
+        assert_eq!(
+            parse_node_spec("win=host:0"),
+            Err(NodeSpecParseError::BadPort("0".to_string()))
+        );
+        assert_eq!(
+            parse_node_spec("win=host:99999"),
+            Err(NodeSpecParseError::BadPort("99999".to_string()))
+        );
+    }
+
+    #[test]
+    fn duplicate_labels_are_refused_rather_than_deduplicated() {
+        let raws = vec!["a=h1:1".to_string(), "a=h2:2".to_string()];
+        assert_eq!(
+            parse_fabric(&raws),
+            Err(NodeSpecParseError::DuplicateLabel("a".to_string()))
+        );
+    }
+
+    #[test]
+    fn distinct_labels_on_the_same_host_are_allowed() {
+        // Two engines on one box, different ports, is a legitimate fabric.
+        let raws = vec!["a=h:1".to_string(), "b=h:2".to_string()];
+        assert_eq!(parse_fabric(&raws).expect("parses").len(), 2);
+    }
+
+    #[test]
+    fn an_idle_node_reports_no_load() {
+        // Regression: an idle engine reports 0 in flight. An earlier version read
+        // `engine_queue_depth` as a capacity bound and concluded a healthy idle
+        // fabric was full, refusing every request.
+        let idle = NodeReady {
+            active_model_id: Some("llama-3b".to_string()),
+            backend: "llama".to_string(),
+            version: "0.5.4".to_string(),
+            in_flight: 0,
+            waiting: 0,
+        };
+        assert_eq!(idle.in_flight, 0);
+    }
+
+    #[test]
+    fn a_snapshot_serializes_with_a_flat_state_tag_and_millisecond_latency() {
+        let snapshot = NodeSnapshot {
+            spec: NodeSpec {
+                label: "windows".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 8181,
+            },
+            status: NodeStatus::Ready(NodeReady {
+                active_model_id: Some("llama-3b".to_string()),
+                backend: "llama".to_string(),
+                version: "0.5.4".to_string(),
+                in_flight: 1,
+                waiting: 0,
+            }),
+            latency: Some(Duration::from_millis(7)),
+        };
+        let value = serde_json::to_value(&snapshot).expect("serializes");
+        assert_eq!(value["status"]["state"], "ready");
+        assert_eq!(value["status"]["active_model_id"], "llama-3b");
+        assert_eq!(value["status"]["in_flight"], 1);
+        assert_eq!(value["latency_ms"], 7);
+        assert_eq!(value["spec"]["label"], "windows");
+    }
+
+    #[test]
+    fn an_offline_snapshot_serializes_its_reason_and_a_null_latency() {
+        let snapshot = NodeSnapshot {
+            spec: NodeSpec {
+                label: "mac".to_string(),
+                host: "192.0.2.10".to_string(),
+                port: 8181,
+            },
+            status: NodeStatus::Unreachable {
+                reason: "cannot connect".to_string(),
+            },
+            latency: None,
+        };
+        let value = serde_json::to_value(&snapshot).expect("serializes");
+        assert_eq!(value["status"]["state"], "unreachable");
+        assert_eq!(value["status"]["reason"], "cannot connect");
+        assert!(value["latency_ms"].is_null());
+    }
+}

--- a/src/fabric/policy.rs
+++ b/src/fabric/policy.rs
@@ -1,0 +1,435 @@
+//! Routing policy: which node receives a whole request.
+//!
+//! Every function here is pure. The fabric's correctness lives in this file, so
+//! it is deliberately separated from the socket work in [`super::probe`] and can
+//! be tested exhaustively against hand-built snapshots with no network, no
+//! server and no model.
+//!
+//! Two properties are load-bearing and each has a test that fails without it:
+//!
+//! * **Selection is deterministic.** Ties break on label, so an operator's dry
+//!   run predicts what the fabric will actually do.
+//! * **Affinity degrades, never fails.** A warm prefix is an optimisation; when
+//!   the node holding it dies the request still gets served, and the decision
+//!   records that affinity was lost rather than silently pretending it held.
+
+use super::node::{NodeSnapshot, NodeStatus};
+
+/// How to choose among eligible nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteMode {
+    /// Spread independent requests over the least-loaded nodes.
+    Throughput,
+    /// Prefer the node that last served this session so its prompt prefix and KV
+    /// cache stay warm, falling back to [`RouteMode::Throughput`] when it cannot.
+    Affinity,
+}
+
+/// What the caller is asking the fabric to place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RouteRequest<'a> {
+    pub mode: RouteMode,
+    /// Required model id. `None` means any ready node will do.
+    pub model: Option<&'a str>,
+    /// Label of the node that served this session previously, if any.
+    pub sticky: Option<&'a str>,
+}
+
+impl<'a> RouteRequest<'a> {
+    pub fn new(mode: RouteMode) -> Self {
+        Self {
+            mode,
+            model: None,
+            sticky: None,
+        }
+    }
+
+    pub fn with_model(mut self, model: Option<&'a str>) -> Self {
+        self.model = model;
+        self
+    }
+
+    pub fn with_sticky(mut self, sticky: Option<&'a str>) -> Self {
+        self.sticky = sticky;
+        self
+    }
+}
+
+/// How the winning node was chosen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteReason {
+    /// The session's previous node is still eligible.
+    Affinity,
+    /// Exactly one node was eligible.
+    OnlyCandidate,
+    /// Fewest queued jobs among the eligible nodes.
+    LeastLoaded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDecision {
+    pub label: String,
+    pub reason: RouteReason,
+    /// Previous node's label when affinity was requested but could not be
+    /// honoured. Reported so a caller can tell a warm hit from a cold re-prefill.
+    pub affinity_lost: Option<String>,
+}
+
+/// Why no node could take the request. Every variant carries enough detail to
+/// act on without re-probing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteError {
+    NoNodesConfigured,
+    AllNodesUnavailable {
+        unreachable: usize,
+        not_ready: usize,
+    },
+    ModelUnavailable {
+        model: String,
+        /// What the ready nodes are actually serving.
+        serving: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for RouteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoNodesConfigured => write!(f, "no nodes configured"),
+            Self::AllNodesUnavailable {
+                unreachable,
+                not_ready,
+            } => write!(
+                f,
+                "no node can serve: {unreachable} unreachable, {not_ready} reachable but not ready"
+            ),
+            Self::ModelUnavailable { model, serving } => {
+                if serving.is_empty() {
+                    write!(f, "no ready node is serving model `{model}`")
+                } else {
+                    write!(
+                        f,
+                        "no ready node is serving model `{model}`; ready nodes serve: {}",
+                        serving.join(", ")
+                    )
+                }
+            }
+        }
+    }
+}
+
+impl std::error::Error for RouteError {}
+
+/// One eligible node reduced to the fields selection actually uses.
+struct Candidate<'a> {
+    label: &'a str,
+    in_flight: usize,
+}
+
+/// Choose a node for one request.
+pub fn route(
+    snapshots: &[NodeSnapshot],
+    request: &RouteRequest<'_>,
+) -> Result<RouteDecision, RouteError> {
+    if snapshots.is_empty() {
+        return Err(RouteError::NoNodesConfigured);
+    }
+
+    let ready: Vec<&NodeSnapshot> = snapshots
+        .iter()
+        .filter(|snapshot| snapshot.status.is_ready())
+        .collect();
+
+    if ready.is_empty() {
+        let unreachable = snapshots
+            .iter()
+            .filter(|s| matches!(s.status, NodeStatus::Unreachable { .. }))
+            .count();
+        return Err(RouteError::AllNodesUnavailable {
+            unreachable,
+            not_ready: snapshots.len() - unreachable,
+        });
+    }
+
+    let serving_model: Vec<&NodeSnapshot> = match request.model {
+        Some(model) => {
+            let matched: Vec<&NodeSnapshot> = ready
+                .iter()
+                .copied()
+                .filter(|snapshot| snapshot.active_model_id() == Some(model))
+                .collect();
+            if matched.is_empty() {
+                let mut serving: Vec<String> = ready
+                    .iter()
+                    .filter_map(|s| s.active_model_id().map(str::to_string))
+                    .collect();
+                serving.sort();
+                serving.dedup();
+                return Err(RouteError::ModelUnavailable {
+                    model: model.to_string(),
+                    serving,
+                });
+            }
+            matched
+        }
+        None => ready,
+    };
+
+    // Every ready node serving the model is eligible. The fabric cannot tell
+    // whether a node is at its bound — `/v1/health` publishes load, not capacity
+    // — so it ranks by load and lets a genuinely full node answer its own 503.
+    let candidates: Vec<Candidate<'_>> = serving_model
+        .iter()
+        .filter_map(|snapshot| {
+            snapshot.status.ready().map(|ready| Candidate {
+                label: snapshot.label(),
+                in_flight: ready.in_flight,
+            })
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return Err(RouteError::AllNodesUnavailable {
+            unreachable: 0,
+            not_ready: serving_model.len(),
+        });
+    }
+
+    if request.mode == RouteMode::Affinity {
+        if let Some(sticky) = request.sticky {
+            if let Some(hit) = candidates.iter().find(|c| c.label == sticky) {
+                return Ok(RouteDecision {
+                    label: hit.label.to_string(),
+                    reason: RouteReason::Affinity,
+                    affinity_lost: None,
+                });
+            }
+        }
+    }
+
+    // Ties break on label so a dry run predicts the real decision.
+    let chosen = candidates
+        .iter()
+        .min_by(|a, b| {
+            a.in_flight
+                .cmp(&b.in_flight)
+                .then_with(|| a.label.cmp(b.label))
+        })
+        .expect("candidates is non-empty");
+
+    let reason = if candidates.len() == 1 {
+        RouteReason::OnlyCandidate
+    } else {
+        RouteReason::LeastLoaded
+    };
+
+    let affinity_lost = request
+        .sticky
+        .filter(|sticky| request.mode == RouteMode::Affinity && *sticky != chosen.label)
+        .map(str::to_string);
+
+    Ok(RouteDecision {
+        label: chosen.label.to_string(),
+        reason,
+        affinity_lost,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fabric::node::{NodeReady, NodeSpec, NodeStatus};
+
+    fn spec(label: &str) -> NodeSpec {
+        NodeSpec {
+            label: label.to_string(),
+            host: "127.0.0.1".to_string(),
+            port: 8181,
+        }
+    }
+
+    fn ready(label: &str, model: Option<&str>, in_flight: usize) -> NodeSnapshot {
+        NodeSnapshot {
+            spec: spec(label),
+            status: NodeStatus::Ready(NodeReady {
+                active_model_id: model.map(str::to_string),
+                backend: "llama".to_string(),
+                version: "0.5.4".to_string(),
+                in_flight,
+                waiting: in_flight.saturating_sub(1),
+            }),
+            latency: None,
+        }
+    }
+
+    fn unreachable(label: &str) -> NodeSnapshot {
+        NodeSnapshot {
+            spec: spec(label),
+            status: NodeStatus::Unreachable {
+                reason: "connection refused".to_string(),
+            },
+            latency: None,
+        }
+    }
+
+    fn not_ready(label: &str) -> NodeSnapshot {
+        NodeSnapshot {
+            spec: spec(label),
+            status: NodeStatus::NotReady {
+                reason: "no model loaded".to_string(),
+            },
+            latency: None,
+        }
+    }
+
+    #[test]
+    fn an_empty_fabric_is_refused_distinctly_from_a_dead_one() {
+        assert_eq!(
+            route(&[], &RouteRequest::new(RouteMode::Throughput)),
+            Err(RouteError::NoNodesConfigured)
+        );
+    }
+
+    #[test]
+    fn a_dead_fabric_reports_how_it_died() {
+        let nodes = vec![unreachable("a"), not_ready("b"), unreachable("c")];
+        assert_eq!(
+            route(&nodes, &RouteRequest::new(RouteMode::Throughput)),
+            Err(RouteError::AllNodesUnavailable {
+                unreachable: 2,
+                not_ready: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn an_unreachable_node_is_never_selected() {
+        let nodes = vec![unreachable("a"), ready("b", None, 0)];
+        let decision =
+            route(&nodes, &RouteRequest::new(RouteMode::Throughput)).expect("b can serve");
+        assert_eq!(decision.label, "b");
+        assert_eq!(decision.reason, RouteReason::OnlyCandidate);
+    }
+
+    #[test]
+    fn a_wholly_idle_fabric_routes() {
+        // Regression: `engine_queue_depth` is a load gauge, not a capacity bound.
+        // Reading it as a bound made two healthy idle nodes both look "full" and
+        // every request was refused. Verified against two live nodes.
+        let nodes = vec![ready("windows", None, 0), ready("mac", None, 0)];
+        let decision = route(&nodes, &RouteRequest::new(RouteMode::Throughput))
+            .expect("an idle fabric must be routable");
+        assert_eq!(decision.label, "mac", "ties break on label");
+    }
+
+    #[test]
+    fn the_least_loaded_eligible_node_wins() {
+        let nodes = vec![
+            ready("a", None, 3),
+            ready("b", None, 1),
+            ready("c", None, 2),
+        ];
+        let decision = route(&nodes, &RouteRequest::new(RouteMode::Throughput)).expect("routes");
+        assert_eq!(decision.label, "b");
+        assert_eq!(decision.reason, RouteReason::LeastLoaded);
+    }
+
+    #[test]
+    fn ties_break_on_label_so_a_dry_run_predicts_the_real_decision() {
+        let forward = vec![ready("zulu", None, 1), ready("alpha", None, 1)];
+        let reversed = vec![ready("alpha", None, 1), ready("zulu", None, 1)];
+        let request = RouteRequest::new(RouteMode::Throughput);
+        assert_eq!(route(&forward, &request).expect("routes").label, "alpha");
+        assert_eq!(route(&reversed, &request).expect("routes").label, "alpha");
+    }
+
+    #[test]
+    fn a_model_request_only_matches_a_node_actually_serving_it() {
+        let nodes = vec![
+            ready("a", Some("llama-3b"), 0),
+            ready("b", Some("qwen-4b"), 0),
+        ];
+        let request = RouteRequest::new(RouteMode::Throughput).with_model(Some("qwen-4b"));
+        assert_eq!(route(&nodes, &request).expect("routes").label, "b");
+    }
+
+    #[test]
+    fn a_missing_model_names_what_the_fabric_does_serve() {
+        let nodes = vec![
+            ready("a", Some("llama-3b"), 0),
+            ready("b", Some("qwen-4b"), 0),
+        ];
+        let request = RouteRequest::new(RouteMode::Throughput).with_model(Some("gemma-27b"));
+        assert_eq!(
+            route(&nodes, &request),
+            Err(RouteError::ModelUnavailable {
+                model: "gemma-27b".to_string(),
+                serving: vec!["llama-3b".to_string(), "qwen-4b".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn a_busy_node_still_receives_work_when_it_is_the_only_one() {
+        // The fabric cannot know a node's bound, so it must not invent one and
+        // refuse. A genuinely full node answers its own 503.
+        let nodes = vec![ready("a", None, 99)];
+        let decision = route(&nodes, &RouteRequest::new(RouteMode::Throughput)).expect("routes");
+        assert_eq!(decision.label, "a");
+    }
+
+    #[test]
+    fn affinity_keeps_a_session_on_its_warm_node_even_when_busier() {
+        let nodes = vec![ready("warm", None, 3), ready("idle", None, 0)];
+        let request = RouteRequest::new(RouteMode::Affinity).with_sticky(Some("warm"));
+        let decision = route(&nodes, &request).expect("routes");
+        assert_eq!(decision.label, "warm");
+        assert_eq!(decision.reason, RouteReason::Affinity);
+        assert_eq!(decision.affinity_lost, None);
+    }
+
+    #[test]
+    fn affinity_degrades_instead_of_failing_when_the_warm_node_dies() {
+        let nodes = vec![unreachable("warm"), ready("idle", None, 0)];
+        let request = RouteRequest::new(RouteMode::Affinity).with_sticky(Some("warm"));
+        let decision = route(&nodes, &request).expect("falls back rather than failing");
+        assert_eq!(decision.label, "idle");
+        assert_eq!(decision.affinity_lost.as_deref(), Some("warm"));
+    }
+
+    #[test]
+    fn affinity_degrades_when_the_warm_node_no_longer_holds_the_model() {
+        let nodes = vec![
+            ready("warm", Some("llama-3b"), 0),
+            ready("other", Some("qwen-4b"), 5),
+        ];
+        let request = RouteRequest::new(RouteMode::Affinity)
+            .with_sticky(Some("warm"))
+            .with_model(Some("qwen-4b"));
+        let decision = route(&nodes, &request).expect("routes");
+        assert_eq!(decision.label, "other");
+        assert_eq!(decision.affinity_lost.as_deref(), Some("warm"));
+    }
+
+    #[test]
+    fn throughput_mode_ignores_a_sticky_hint_entirely() {
+        let nodes = vec![ready("warm", None, 3), ready("idle", None, 0)];
+        let request = RouteRequest::new(RouteMode::Throughput).with_sticky(Some("warm"));
+        let decision = route(&nodes, &request).expect("routes");
+        assert_eq!(decision.label, "idle");
+        // Affinity was never requested, so nothing was lost.
+        assert_eq!(decision.affinity_lost, None);
+    }
+
+    #[test]
+    fn a_node_with_no_model_cannot_satisfy_a_model_request() {
+        let nodes = vec![ready("a", None, 0)];
+        let request = RouteRequest::new(RouteMode::Throughput).with_model(Some("llama-3b"));
+        assert_eq!(
+            route(&nodes, &request),
+            Err(RouteError::ModelUnavailable {
+                model: "llama-3b".to_string(),
+                serving: Vec::new(),
+            })
+        );
+    }
+}

--- a/src/fabric/probe.rs
+++ b/src/fabric/probe.rs
@@ -1,27 +1,19 @@
-//! Probing a node's `/v1/health` over HTTP/1.1.
+//! Probing a node's `/v1/health`.
 //!
-//! This is the only file in the fabric that touches a socket. The response
-//! parsing is split out as pure functions over byte slices so the awkward parts
-//! — chunked bodies, truncated frames, a node that answers 500 — are tested
-//! without a server.
-//!
-//! It does not reuse `chat::client`: that module is private to `chat`, is keyed
-//! on a resolved `SocketAddr` (fabric members are named hosts), and carries SSE,
-//! bearer auth and tool-call handling that a health probe must not depend on.
-//! The overlap is one request/response round trip, and duplicating that is
-//! cheaper than widening a shipped module's boundary.
+//! Everything here turns one HTTP response into a routing fact. The socket work
+//! lives in [`super::http`]; [`classify`] is pure and owns the decision about
+//! what "ready" means.
 
-use std::io::{Read, Write};
-use std::net::{TcpStream, ToSocketAddrs};
 use std::time::{Duration, Instant};
 
 use serde::Deserialize;
 
+use super::http::{self, HttpError};
 use super::node::{NodeReady, NodeSnapshot, NodeSpec, NodeStatus};
 
-/// Refuse a body larger than this. A health response is a few KiB; anything at
-/// this size means we are not talking to a Camelid engine.
-const MAX_BODY_BYTES: usize = 1024 * 1024;
+/// Refuse a health body larger than this. A health response is a few KiB;
+/// anything at this size means we are not talking to a Camelid engine.
+const MAX_HEALTH_BYTES: usize = 1024 * 1024;
 
 /// Default probe budget. Wi-Fi RTT on this fabric was measured at 3-13 ms, so
 /// two seconds is generous for a healthy node and still fails a dead one fast.
@@ -29,11 +21,7 @@ pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProbeError {
-    Resolve(String),
-    Connect(String),
-    Io(String),
-    Malformed(String),
-    TooLarge,
+    Transport(String),
     Status(u16),
     Json(String),
 }
@@ -41,14 +29,16 @@ pub enum ProbeError {
 impl std::fmt::Display for ProbeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Resolve(detail) => write!(f, "cannot resolve host: {detail}"),
-            Self::Connect(detail) => write!(f, "cannot connect: {detail}"),
-            Self::Io(detail) => write!(f, "connection failed: {detail}"),
-            Self::Malformed(detail) => write!(f, "malformed HTTP response: {detail}"),
-            Self::TooLarge => write!(f, "response exceeded {MAX_BODY_BYTES} bytes"),
+            Self::Transport(detail) => write!(f, "{detail}"),
             Self::Status(code) => write!(f, "health endpoint answered HTTP {code}"),
             Self::Json(detail) => write!(f, "health payload was not readable: {detail}"),
         }
+    }
+}
+
+impl From<HttpError> for ProbeError {
+    fn from(error: HttpError) -> Self {
+        Self::Transport(error.to_string())
     }
 }
 
@@ -73,130 +63,6 @@ struct HealthPayload {
     engine_queued_tasks: usize,
     #[serde(default)]
     engine_queue_depth: usize,
-}
-
-/// Status line plus body of an HTTP/1.1 response.
-#[derive(Debug, PartialEq, Eq)]
-struct HttpResponse {
-    status: u16,
-    body: Vec<u8>,
-}
-
-/// Parse a whole HTTP/1.1 response. Pure; see the tests at the bottom.
-fn parse_http_response(raw: &[u8]) -> Result<HttpResponse, ProbeError> {
-    let split = find_header_end(raw)
-        .ok_or_else(|| ProbeError::Malformed("no header terminator".to_string()))?;
-    let head = std::str::from_utf8(&raw[..split.headers_end])
-        .map_err(|_| ProbeError::Malformed("headers are not UTF-8".to_string()))?;
-
-    let mut lines = head.split("\r\n");
-    let status_line = lines
-        .next()
-        .ok_or_else(|| ProbeError::Malformed("empty response".to_string()))?;
-    let status = parse_status_line(status_line)?;
-
-    let mut chunked = false;
-    let mut content_length: Option<usize> = None;
-    for line in lines {
-        let Some((name, value)) = line.split_once(':') else {
-            continue;
-        };
-        let name = name.trim().to_ascii_lowercase();
-        let value = value.trim();
-        match name.as_str() {
-            "transfer-encoding" => {
-                chunked = value.to_ascii_lowercase().contains("chunked");
-            }
-            "content-length" => {
-                content_length = value.parse::<usize>().ok();
-            }
-            _ => {}
-        }
-    }
-
-    let rest = &raw[split.body_start..];
-    let body = if chunked {
-        dechunk(rest)?
-    } else if let Some(len) = content_length {
-        if len > MAX_BODY_BYTES {
-            return Err(ProbeError::TooLarge);
-        }
-        if rest.len() < len {
-            return Err(ProbeError::Malformed(format!(
-                "body truncated: expected {len} bytes, got {}",
-                rest.len()
-            )));
-        }
-        rest[..len].to_vec()
-    } else {
-        rest.to_vec()
-    };
-
-    if body.len() > MAX_BODY_BYTES {
-        return Err(ProbeError::TooLarge);
-    }
-    Ok(HttpResponse { status, body })
-}
-
-struct HeaderSplit {
-    headers_end: usize,
-    body_start: usize,
-}
-
-fn find_header_end(raw: &[u8]) -> Option<HeaderSplit> {
-    raw.windows(4)
-        .position(|w| w == b"\r\n\r\n")
-        .map(|at| HeaderSplit {
-            headers_end: at,
-            body_start: at + 4,
-        })
-}
-
-fn parse_status_line(line: &str) -> Result<u16, ProbeError> {
-    let mut parts = line.split(' ');
-    let version = parts
-        .next()
-        .ok_or_else(|| ProbeError::Malformed("no status line".to_string()))?;
-    if !version.starts_with("HTTP/") {
-        return Err(ProbeError::Malformed(format!(
-            "status line does not start with HTTP/: {line}"
-        )));
-    }
-    let code = parts
-        .next()
-        .ok_or_else(|| ProbeError::Malformed("status line has no code".to_string()))?;
-    code.parse::<u16>()
-        .map_err(|_| ProbeError::Malformed(format!("status code `{code}` is not a number")))
-}
-
-/// Decode `Transfer-Encoding: chunked`.
-fn dechunk(mut rest: &[u8]) -> Result<Vec<u8>, ProbeError> {
-    let mut out = Vec::new();
-    loop {
-        let line_end = rest
-            .windows(2)
-            .position(|w| w == b"\r\n")
-            .ok_or_else(|| ProbeError::Malformed("chunk size line unterminated".to_string()))?;
-        let size_text = std::str::from_utf8(&rest[..line_end])
-            .map_err(|_| ProbeError::Malformed("chunk size is not UTF-8".to_string()))?;
-        // A chunk extension (`1a;name=value`) is legal and ignorable.
-        let size_text = size_text.split(';').next().unwrap_or("").trim();
-        let size = usize::from_str_radix(size_text, 16).map_err(|_| {
-            ProbeError::Malformed(format!("chunk size `{size_text}` is not hexadecimal"))
-        })?;
-        rest = &rest[line_end + 2..];
-        if size == 0 {
-            return Ok(out);
-        }
-        if out.len() + size > MAX_BODY_BYTES {
-            return Err(ProbeError::TooLarge);
-        }
-        if rest.len() < size + 2 {
-            return Err(ProbeError::Malformed("chunk body truncated".to_string()));
-        }
-        out.extend_from_slice(&rest[..size]);
-        rest = &rest[size + 2..];
-    }
 }
 
 /// Turn a successful health payload into a routing status. Pure.
@@ -225,60 +91,15 @@ fn classify(payload: &HealthPayload) -> NodeStatus {
 }
 
 fn read_health(spec: &NodeSpec, timeout: Duration) -> Result<HealthPayload, ProbeError> {
-    let deadline = Instant::now() + timeout;
-    let authority = spec.authority();
-
-    let addr = authority
-        .to_socket_addrs()
-        .map_err(|error| ProbeError::Resolve(error.to_string()))?
-        .next()
-        .ok_or_else(|| ProbeError::Resolve("host resolved to no addresses".to_string()))?;
-
-    let mut stream = TcpStream::connect_timeout(&addr, timeout)
-        .map_err(|error| ProbeError::Connect(error.to_string()))?;
-    // Short socket reads keep the loop responsive to the overall deadline; a
-    // single long read timeout would overshoot it on a stalled peer.
-    stream
-        .set_read_timeout(Some(Duration::from_millis(100)))
-        .map_err(|error| ProbeError::Io(error.to_string()))?;
-    stream
-        .set_write_timeout(Some(timeout))
-        .map_err(|error| ProbeError::Io(error.to_string()))?;
-
-    let request = format!(
-        "GET /v1/health HTTP/1.1\r\nHost: {authority}\r\nAccept: application/json\r\nConnection: close\r\n\r\n"
-    );
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|error| ProbeError::Io(error.to_string()))?;
-
-    let mut raw = Vec::new();
-    let mut chunk = [0_u8; 4096];
-    loop {
-        if Instant::now() >= deadline {
-            return Err(ProbeError::Io("probe exceeded its deadline".to_string()));
-        }
-        match stream.read(&mut chunk) {
-            Ok(0) => break,
-            Ok(read) => {
-                raw.extend_from_slice(&chunk[..read]);
-                if raw.len() > MAX_BODY_BYTES {
-                    return Err(ProbeError::TooLarge);
-                }
-            }
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
-                ) =>
-            {
-                continue
-            }
-            Err(error) => return Err(ProbeError::Io(error.to_string())),
-        }
-    }
-
-    let response = parse_http_response(&raw)?;
+    let response = http::request(
+        &spec.host,
+        spec.port,
+        "GET",
+        "/v1/health",
+        None,
+        timeout,
+        MAX_HEALTH_BYTES,
+    )?;
     if response.status != 200 {
         return Err(ProbeError::Status(response.status));
     }
@@ -349,87 +170,6 @@ mod tests {
             engine_queued_tasks: 1,
             engine_queue_depth: 4,
         }
-    }
-
-    #[test]
-    fn a_content_length_body_is_read_exactly() {
-        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello-trailing-garbage";
-        let response = parse_http_response(raw).expect("parses");
-        assert_eq!(response.status, 200);
-        assert_eq!(response.body, b"hello");
-    }
-
-    #[test]
-    fn a_chunked_body_is_reassembled() {
-        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
-        let response = parse_http_response(raw).expect("parses");
-        assert_eq!(response.body, b"hello world");
-    }
-
-    #[test]
-    fn chunk_extensions_are_ignored() {
-        let raw =
-            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5;name=value\r\nhello\r\n0\r\n\r\n";
-        assert_eq!(parse_http_response(raw).expect("parses").body, b"hello");
-    }
-
-    #[test]
-    fn a_body_without_framing_headers_is_read_to_end() {
-        let raw = b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n{}";
-        assert_eq!(parse_http_response(raw).expect("parses").body, b"{}");
-    }
-
-    #[test]
-    fn header_names_are_matched_case_insensitively() {
-        let raw = b"HTTP/1.1 200 OK\r\ncOnTeNt-LeNgTh: 2\r\n\r\nok";
-        assert_eq!(parse_http_response(raw).expect("parses").body, b"ok");
-    }
-
-    #[test]
-    fn a_non_http_greeting_is_refused_rather_than_guessed_at() {
-        let raw = b"SSH-2.0-OpenSSH_9.0\r\n\r\n";
-        assert!(matches!(
-            parse_http_response(raw),
-            Err(ProbeError::Malformed(_))
-        ));
-    }
-
-    #[test]
-    fn a_response_with_no_header_terminator_is_refused() {
-        assert!(matches!(
-            parse_http_response(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n"),
-            Err(ProbeError::Malformed(_))
-        ));
-    }
-
-    #[test]
-    fn a_truncated_body_is_refused_rather_than_silently_short() {
-        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 99\r\n\r\nshort";
-        assert!(matches!(
-            parse_http_response(raw),
-            Err(ProbeError::Malformed(_))
-        ));
-    }
-
-    #[test]
-    fn a_truncated_chunk_is_refused() {
-        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n9\r\nshort\r\n";
-        assert!(matches!(
-            parse_http_response(raw),
-            Err(ProbeError::Malformed(_))
-        ));
-    }
-
-    #[test]
-    fn an_oversized_content_length_is_refused_before_allocating() {
-        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 99999999\r\n\r\n";
-        assert_eq!(parse_http_response(raw), Err(ProbeError::TooLarge));
-    }
-
-    #[test]
-    fn a_non_200_is_reported_with_its_code() {
-        let raw = b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n";
-        assert_eq!(parse_http_response(raw).expect("parses").status, 503);
     }
 
     #[test]

--- a/src/fabric/probe.rs
+++ b/src/fabric/probe.rs
@@ -1,0 +1,510 @@
+//! Probing a node's `/v1/health` over HTTP/1.1.
+//!
+//! This is the only file in the fabric that touches a socket. The response
+//! parsing is split out as pure functions over byte slices so the awkward parts
+//! — chunked bodies, truncated frames, a node that answers 500 — are tested
+//! without a server.
+//!
+//! It does not reuse `chat::client`: that module is private to `chat`, is keyed
+//! on a resolved `SocketAddr` (fabric members are named hosts), and carries SSE,
+//! bearer auth and tool-call handling that a health probe must not depend on.
+//! The overlap is one request/response round trip, and duplicating that is
+//! cheaper than widening a shipped module's boundary.
+
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+
+use super::node::{NodeReady, NodeSnapshot, NodeSpec, NodeStatus};
+
+/// Refuse a body larger than this. A health response is a few KiB; anything at
+/// this size means we are not talking to a Camelid engine.
+const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// Default probe budget. Wi-Fi RTT on this fabric was measured at 3-13 ms, so
+/// two seconds is generous for a healthy node and still fails a dead one fast.
+pub const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeError {
+    Resolve(String),
+    Connect(String),
+    Io(String),
+    Malformed(String),
+    TooLarge,
+    Status(u16),
+    Json(String),
+}
+
+impl std::fmt::Display for ProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Resolve(detail) => write!(f, "cannot resolve host: {detail}"),
+            Self::Connect(detail) => write!(f, "cannot connect: {detail}"),
+            Self::Io(detail) => write!(f, "connection failed: {detail}"),
+            Self::Malformed(detail) => write!(f, "malformed HTTP response: {detail}"),
+            Self::TooLarge => write!(f, "response exceeded {MAX_BODY_BYTES} bytes"),
+            Self::Status(code) => write!(f, "health endpoint answered HTTP {code}"),
+            Self::Json(detail) => write!(f, "health payload was not readable: {detail}"),
+        }
+    }
+}
+
+/// The subset of `/v1/health` the fabric routes on.
+///
+/// Every field but `ok` defaults, so a node running a newer or older engine that
+/// renames an unrelated field still probes successfully instead of dropping out
+/// of the fabric.
+#[derive(Debug, Clone, Deserialize)]
+struct HealthPayload {
+    #[serde(default)]
+    ok: bool,
+    #[serde(default)]
+    generation_ready: bool,
+    #[serde(default)]
+    active_model_id: Option<String>,
+    #[serde(default)]
+    backend: String,
+    #[serde(default)]
+    version: String,
+    #[serde(default)]
+    engine_queued_tasks: usize,
+    #[serde(default)]
+    engine_queue_depth: usize,
+}
+
+/// Status line plus body of an HTTP/1.1 response.
+#[derive(Debug, PartialEq, Eq)]
+struct HttpResponse {
+    status: u16,
+    body: Vec<u8>,
+}
+
+/// Parse a whole HTTP/1.1 response. Pure; see the tests at the bottom.
+fn parse_http_response(raw: &[u8]) -> Result<HttpResponse, ProbeError> {
+    let split = find_header_end(raw)
+        .ok_or_else(|| ProbeError::Malformed("no header terminator".to_string()))?;
+    let head = std::str::from_utf8(&raw[..split.headers_end])
+        .map_err(|_| ProbeError::Malformed("headers are not UTF-8".to_string()))?;
+
+    let mut lines = head.split("\r\n");
+    let status_line = lines
+        .next()
+        .ok_or_else(|| ProbeError::Malformed("empty response".to_string()))?;
+    let status = parse_status_line(status_line)?;
+
+    let mut chunked = false;
+    let mut content_length: Option<usize> = None;
+    for line in lines {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim().to_ascii_lowercase();
+        let value = value.trim();
+        match name.as_str() {
+            "transfer-encoding" => {
+                chunked = value.to_ascii_lowercase().contains("chunked");
+            }
+            "content-length" => {
+                content_length = value.parse::<usize>().ok();
+            }
+            _ => {}
+        }
+    }
+
+    let rest = &raw[split.body_start..];
+    let body = if chunked {
+        dechunk(rest)?
+    } else if let Some(len) = content_length {
+        if len > MAX_BODY_BYTES {
+            return Err(ProbeError::TooLarge);
+        }
+        if rest.len() < len {
+            return Err(ProbeError::Malformed(format!(
+                "body truncated: expected {len} bytes, got {}",
+                rest.len()
+            )));
+        }
+        rest[..len].to_vec()
+    } else {
+        rest.to_vec()
+    };
+
+    if body.len() > MAX_BODY_BYTES {
+        return Err(ProbeError::TooLarge);
+    }
+    Ok(HttpResponse { status, body })
+}
+
+struct HeaderSplit {
+    headers_end: usize,
+    body_start: usize,
+}
+
+fn find_header_end(raw: &[u8]) -> Option<HeaderSplit> {
+    raw.windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|at| HeaderSplit {
+            headers_end: at,
+            body_start: at + 4,
+        })
+}
+
+fn parse_status_line(line: &str) -> Result<u16, ProbeError> {
+    let mut parts = line.split(' ');
+    let version = parts
+        .next()
+        .ok_or_else(|| ProbeError::Malformed("no status line".to_string()))?;
+    if !version.starts_with("HTTP/") {
+        return Err(ProbeError::Malformed(format!(
+            "status line does not start with HTTP/: {line}"
+        )));
+    }
+    let code = parts
+        .next()
+        .ok_or_else(|| ProbeError::Malformed("status line has no code".to_string()))?;
+    code.parse::<u16>()
+        .map_err(|_| ProbeError::Malformed(format!("status code `{code}` is not a number")))
+}
+
+/// Decode `Transfer-Encoding: chunked`.
+fn dechunk(mut rest: &[u8]) -> Result<Vec<u8>, ProbeError> {
+    let mut out = Vec::new();
+    loop {
+        let line_end = rest
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .ok_or_else(|| ProbeError::Malformed("chunk size line unterminated".to_string()))?;
+        let size_text = std::str::from_utf8(&rest[..line_end])
+            .map_err(|_| ProbeError::Malformed("chunk size is not UTF-8".to_string()))?;
+        // A chunk extension (`1a;name=value`) is legal and ignorable.
+        let size_text = size_text.split(';').next().unwrap_or("").trim();
+        let size = usize::from_str_radix(size_text, 16).map_err(|_| {
+            ProbeError::Malformed(format!("chunk size `{size_text}` is not hexadecimal"))
+        })?;
+        rest = &rest[line_end + 2..];
+        if size == 0 {
+            return Ok(out);
+        }
+        if out.len() + size > MAX_BODY_BYTES {
+            return Err(ProbeError::TooLarge);
+        }
+        if rest.len() < size + 2 {
+            return Err(ProbeError::Malformed("chunk body truncated".to_string()));
+        }
+        out.extend_from_slice(&rest[..size]);
+        rest = &rest[size + 2..];
+    }
+}
+
+/// Turn a successful health payload into a routing status. Pure.
+fn classify(payload: &HealthPayload) -> NodeStatus {
+    if !payload.ok {
+        return NodeStatus::NotReady {
+            reason: "engine reported not ok".to_string(),
+        };
+    }
+    if !payload.generation_ready {
+        let reason = match &payload.active_model_id {
+            Some(model) => format!("model `{model}` loaded but not ready to generate"),
+            None => "no model loaded".to_string(),
+        };
+        return NodeStatus::NotReady { reason };
+    }
+    NodeStatus::Ready(NodeReady {
+        active_model_id: payload.active_model_id.clone(),
+        backend: payload.backend.clone(),
+        version: payload.version.clone(),
+        // `engine_queue_depth` is a gauge of jobs in flight, not a bound; see
+        // the note on `NodeReady`.
+        in_flight: payload.engine_queue_depth,
+        waiting: payload.engine_queued_tasks,
+    })
+}
+
+fn read_health(spec: &NodeSpec, timeout: Duration) -> Result<HealthPayload, ProbeError> {
+    let deadline = Instant::now() + timeout;
+    let authority = spec.authority();
+
+    let addr = authority
+        .to_socket_addrs()
+        .map_err(|error| ProbeError::Resolve(error.to_string()))?
+        .next()
+        .ok_or_else(|| ProbeError::Resolve("host resolved to no addresses".to_string()))?;
+
+    let mut stream = TcpStream::connect_timeout(&addr, timeout)
+        .map_err(|error| ProbeError::Connect(error.to_string()))?;
+    // Short socket reads keep the loop responsive to the overall deadline; a
+    // single long read timeout would overshoot it on a stalled peer.
+    stream
+        .set_read_timeout(Some(Duration::from_millis(100)))
+        .map_err(|error| ProbeError::Io(error.to_string()))?;
+    stream
+        .set_write_timeout(Some(timeout))
+        .map_err(|error| ProbeError::Io(error.to_string()))?;
+
+    let request = format!(
+        "GET /v1/health HTTP/1.1\r\nHost: {authority}\r\nAccept: application/json\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| ProbeError::Io(error.to_string()))?;
+
+    let mut raw = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    loop {
+        if Instant::now() >= deadline {
+            return Err(ProbeError::Io("probe exceeded its deadline".to_string()));
+        }
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => {
+                raw.extend_from_slice(&chunk[..read]);
+                if raw.len() > MAX_BODY_BYTES {
+                    return Err(ProbeError::TooLarge);
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                continue
+            }
+            Err(error) => return Err(ProbeError::Io(error.to_string())),
+        }
+    }
+
+    let response = parse_http_response(&raw)?;
+    if response.status != 200 {
+        return Err(ProbeError::Status(response.status));
+    }
+    serde_json::from_slice::<HealthPayload>(&response.body)
+        .map_err(|error| ProbeError::Json(error.to_string()))
+}
+
+/// Probe one node. Never fails: an unreachable node is a routing fact, not an
+/// error the caller has to handle separately.
+pub fn probe_node(spec: &NodeSpec, timeout: Duration) -> NodeSnapshot {
+    let started = Instant::now();
+    match read_health(spec, timeout) {
+        Ok(payload) => NodeSnapshot {
+            spec: spec.clone(),
+            status: classify(&payload),
+            latency: Some(started.elapsed()),
+        },
+        Err(error) => NodeSnapshot {
+            spec: spec.clone(),
+            status: NodeStatus::Unreachable {
+                reason: error.to_string(),
+            },
+            latency: None,
+        },
+    }
+}
+
+/// Probe every node concurrently, one thread each.
+///
+/// Sequential probing would make a fabric's status cost the sum of its timeouts,
+/// so a single dead node would stall the view of every live one.
+pub fn probe_fabric(specs: &[NodeSpec], timeout: Duration) -> Vec<NodeSnapshot> {
+    if specs.is_empty() {
+        return Vec::new();
+    }
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = specs
+            .iter()
+            .map(|spec| scope.spawn(move || probe_node(spec, timeout)))
+            .collect();
+        handles
+            .into_iter()
+            .zip(specs)
+            .map(|(handle, spec)| {
+                handle.join().unwrap_or_else(|_| NodeSnapshot {
+                    spec: spec.clone(),
+                    status: NodeStatus::Unreachable {
+                        reason: "probe thread panicked".to_string(),
+                    },
+                    latency: None,
+                })
+            })
+            .collect()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(ok: bool, ready: bool, model: Option<&str>) -> HealthPayload {
+        HealthPayload {
+            ok,
+            generation_ready: ready,
+            active_model_id: model.map(str::to_string),
+            backend: "llama".to_string(),
+            version: "0.5.4".to_string(),
+            engine_queued_tasks: 1,
+            engine_queue_depth: 4,
+        }
+    }
+
+    #[test]
+    fn a_content_length_body_is_read_exactly() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello-trailing-garbage";
+        let response = parse_http_response(raw).expect("parses");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, b"hello");
+    }
+
+    #[test]
+    fn a_chunked_body_is_reassembled() {
+        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
+        let response = parse_http_response(raw).expect("parses");
+        assert_eq!(response.body, b"hello world");
+    }
+
+    #[test]
+    fn chunk_extensions_are_ignored() {
+        let raw =
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5;name=value\r\nhello\r\n0\r\n\r\n";
+        assert_eq!(parse_http_response(raw).expect("parses").body, b"hello");
+    }
+
+    #[test]
+    fn a_body_without_framing_headers_is_read_to_end() {
+        let raw = b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n{}";
+        assert_eq!(parse_http_response(raw).expect("parses").body, b"{}");
+    }
+
+    #[test]
+    fn header_names_are_matched_case_insensitively() {
+        let raw = b"HTTP/1.1 200 OK\r\ncOnTeNt-LeNgTh: 2\r\n\r\nok";
+        assert_eq!(parse_http_response(raw).expect("parses").body, b"ok");
+    }
+
+    #[test]
+    fn a_non_http_greeting_is_refused_rather_than_guessed_at() {
+        let raw = b"SSH-2.0-OpenSSH_9.0\r\n\r\n";
+        assert!(matches!(
+            parse_http_response(raw),
+            Err(ProbeError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn a_response_with_no_header_terminator_is_refused() {
+        assert!(matches!(
+            parse_http_response(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n"),
+            Err(ProbeError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn a_truncated_body_is_refused_rather_than_silently_short() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 99\r\n\r\nshort";
+        assert!(matches!(
+            parse_http_response(raw),
+            Err(ProbeError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn a_truncated_chunk_is_refused() {
+        let raw = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n9\r\nshort\r\n";
+        assert!(matches!(
+            parse_http_response(raw),
+            Err(ProbeError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn an_oversized_content_length_is_refused_before_allocating() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: 99999999\r\n\r\n";
+        assert_eq!(parse_http_response(raw), Err(ProbeError::TooLarge));
+    }
+
+    #[test]
+    fn a_non_200_is_reported_with_its_code() {
+        let raw = b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n";
+        assert_eq!(parse_http_response(raw).expect("parses").status, 503);
+    }
+
+    #[test]
+    fn a_ready_engine_becomes_a_routable_node() {
+        let status = classify(&payload(true, true, Some("llama-3b")));
+        let ready = status.ready().expect("ready");
+        assert_eq!(ready.active_model_id.as_deref(), Some("llama-3b"));
+        assert_eq!(ready.in_flight, 4);
+        assert_eq!(ready.waiting, 1);
+    }
+
+    #[test]
+    fn an_idle_engine_is_routable_rather_than_read_as_full() {
+        // Regression: an idle node reports 0/0. Reading `engine_queue_depth` as a
+        // capacity bound made a healthy idle fabric look saturated.
+        let idle = HealthPayload {
+            ok: true,
+            generation_ready: true,
+            active_model_id: Some("llama-3b".to_string()),
+            backend: "llama".to_string(),
+            version: "0.5.4".to_string(),
+            engine_queued_tasks: 0,
+            engine_queue_depth: 0,
+        };
+        let status = classify(&idle);
+        assert!(status.is_ready());
+        assert_eq!(status.ready().expect("ready").in_flight, 0);
+    }
+
+    #[test]
+    fn a_loaded_but_unready_engine_names_the_model_it_is_warming() {
+        let status = classify(&payload(true, false, Some("llama-3b")));
+        match status {
+            NodeStatus::NotReady { reason } => assert!(reason.contains("llama-3b"), "{reason}"),
+            other => panic!("expected NotReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_engine_with_no_model_is_not_ready_and_says_so() {
+        match classify(&payload(true, false, None)) {
+            NodeStatus::NotReady { reason } => assert_eq!(reason, "no model loaded"),
+            other => panic!("expected NotReady, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_engine_reporting_not_ok_is_never_routable() {
+        assert!(!classify(&payload(false, true, Some("llama-3b"))).is_ready());
+    }
+
+    #[test]
+    fn a_health_payload_missing_optional_fields_still_parses() {
+        // A node on a different engine version must not drop out of the fabric
+        // because an unrelated field was renamed.
+        let parsed: HealthPayload =
+            serde_json::from_str(r#"{"ok":true,"generation_ready":true}"#).expect("parses");
+        assert!(classify(&parsed).is_ready());
+    }
+
+    #[test]
+    fn probing_an_empty_fabric_does_no_work() {
+        assert!(probe_fabric(&[], DEFAULT_PROBE_TIMEOUT).is_empty());
+    }
+
+    #[test]
+    fn an_unroutable_address_becomes_unreachable_not_an_error() {
+        // Port 1 on loopback is closed; this exercises the real socket path.
+        let spec = NodeSpec {
+            label: "dead".to_string(),
+            host: "127.0.0.1".to_string(),
+            port: 1,
+        };
+        let snapshot = probe_node(&spec, Duration::from_millis(500));
+        assert!(matches!(snapshot.status, NodeStatus::Unreachable { .. }));
+        assert_eq!(snapshot.label(), "dead");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod distributed;
 pub mod embedding;
 pub mod error;
 pub mod execution_plan;
+pub mod fabric;
 pub mod fit;
 pub mod fit_dims;
 pub mod gait;

--- a/src/main.rs
+++ b/src/main.rs
@@ -814,6 +814,15 @@ fn resolved_gpu_switch(gpu: GpuMode, deterministic: bool) -> Option<bool> {
     }
 }
 
+/// Parse the `--mode` flag shared by `fabric route` and `fabric run`.
+fn route_mode(raw: &str) -> anyhow::Result<camelid::fabric::RouteMode> {
+    match raw {
+        "throughput" => Ok(camelid::fabric::RouteMode::Throughput),
+        "affinity" => Ok(camelid::fabric::RouteMode::Affinity),
+        other => anyhow::bail!("unknown mode `{other}`; expected `throughput` or `affinity`"),
+    }
+}
+
 /// Actions over a fabric of independent Camelid nodes.
 ///
 /// A fabric places whole requests on nodes that each own a complete model and
@@ -2383,13 +2392,7 @@ async fn main() -> anyhow::Result<()> {
                 timeout_ms,
                 json,
             } => {
-                let mode = match mode.as_str() {
-                    "throughput" => camelid::fabric::RouteMode::Throughput,
-                    "affinity" => camelid::fabric::RouteMode::Affinity,
-                    other => {
-                        anyhow::bail!("unknown mode `{other}`; expected `throughput` or `affinity`")
-                    }
-                };
+                let mode = route_mode(&mode)?;
                 let specs = camelid::fabric::parse_fabric(&nodes)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)
@@ -2434,29 +2437,18 @@ async fn main() -> anyhow::Result<()> {
                 forward_timeout_s,
                 json,
             } => {
-                let mode = match mode.as_str() {
-                    "throughput" => camelid::fabric::RouteMode::Throughput,
-                    "affinity" => camelid::fabric::RouteMode::Affinity,
-                    other => {
-                        anyhow::bail!("unknown mode `{other}`; expected `throughput` or `affinity`")
-                    }
-                };
+                let mode = route_mode(&mode)?;
                 let specs = camelid::fabric::parse_fabric(&nodes)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)
                     .with_timeout(std::time::Duration::from_millis(timeout_ms));
 
-                let snapshots = fabric.observe();
                 let request = camelid::fabric::RouteRequest::new(mode)
                     .with_model(model.as_deref())
                     .with_sticky(sticky.as_deref());
-                let decision = camelid::fabric::route(&snapshots, &request)
+                let (decision, chosen) = fabric
+                    .place(&request)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
-
-                let chosen = snapshots
-                    .iter()
-                    .find(|snapshot| snapshot.label() == decision.label)
-                    .ok_or_else(|| anyhow::anyhow!("placement named an unknown node"))?;
 
                 // The request must name a model. Prefer the operator's choice,
                 // otherwise use whatever the chosen node has loaded.

--- a/src/main.rs
+++ b/src/main.rs
@@ -856,6 +856,35 @@ enum FabricAction {
         #[arg(long)]
         json: bool,
     },
+    /// Send one chat request through the fabric and print the answer.
+    ///
+    /// Placement, then forward: the request crosses the network once, not once
+    /// per token.
+    Run {
+        #[arg(long = "node", required = true, value_name = "LABEL=HOST[:PORT]")]
+        nodes: Vec<String>,
+        /// The user message to send.
+        #[arg(long)]
+        prompt: String,
+        #[arg(long, default_value = "throughput")]
+        mode: String,
+        /// Require a node serving this exact model id. When omitted, the fabric
+        /// picks a node and uses whatever that node has loaded.
+        #[arg(long)]
+        model: Option<String>,
+        #[arg(long)]
+        sticky: Option<String>,
+        #[arg(long, default_value_t = 64)]
+        max_tokens: u32,
+        /// Per-node health probe budget.
+        #[arg(long, default_value_t = 2000)]
+        timeout_ms: u64,
+        /// Budget for the generation itself, which can legitimately take minutes.
+        #[arg(long, default_value_t = 300)]
+        forward_timeout_s: u64,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -2392,6 +2421,102 @@ async fn main() -> anyhow::Result<()> {
                              this request re-prefills on a cold node"
                         );
                     }
+                }
+            }
+            FabricAction::Run {
+                nodes,
+                prompt,
+                mode,
+                model,
+                sticky,
+                max_tokens,
+                timeout_ms,
+                forward_timeout_s,
+                json,
+            } => {
+                let mode = match mode.as_str() {
+                    "throughput" => camelid::fabric::RouteMode::Throughput,
+                    "affinity" => camelid::fabric::RouteMode::Affinity,
+                    other => {
+                        anyhow::bail!("unknown mode `{other}`; expected `throughput` or `affinity`")
+                    }
+                };
+                let specs = camelid::fabric::parse_fabric(&nodes)
+                    .map_err(|error| anyhow::anyhow!("{error}"))?;
+                let fabric = camelid::fabric::Fabric::new(specs)
+                    .with_timeout(std::time::Duration::from_millis(timeout_ms));
+
+                let snapshots = fabric.observe();
+                let request = camelid::fabric::RouteRequest::new(mode)
+                    .with_model(model.as_deref())
+                    .with_sticky(sticky.as_deref());
+                let decision = camelid::fabric::route(&snapshots, &request)
+                    .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+                let chosen = snapshots
+                    .iter()
+                    .find(|snapshot| snapshot.label() == decision.label)
+                    .ok_or_else(|| anyhow::anyhow!("placement named an unknown node"))?;
+
+                // The request must name a model. Prefer the operator's choice,
+                // otherwise use whatever the chosen node has loaded.
+                let model_id = match model {
+                    Some(model) => model,
+                    None => chosen
+                        .active_model_id()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "node `{}` reports no active model; pass --model",
+                                decision.label
+                            )
+                        })?
+                        .to_string(),
+                };
+
+                let body = camelid::fabric::forward::chat_request(&model_id, &prompt, max_tokens);
+                let answer = camelid::fabric::forward::forward(
+                    &chosen.spec,
+                    "/v1/chat/completions",
+                    &body,
+                    std::time::Duration::from_secs(forward_timeout_s),
+                )
+                .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "node": answer.label,
+                            "reason": format!("{:?}", decision.reason),
+                            "affinity_lost": decision.affinity_lost,
+                            "model": model_id,
+                            "status": answer.status,
+                            "elapsed_ms": answer.elapsed.as_millis() as u64,
+                            "body": answer.body,
+                        }))?
+                    );
+                } else {
+                    println!(
+                        "[{} · {:?} · {} · {} ms]",
+                        answer.label,
+                        decision.reason,
+                        model_id,
+                        answer.elapsed.as_millis()
+                    );
+                    match camelid::fabric::forward::completion_text(&answer.body) {
+                        Some(text) => println!("{text}"),
+                        None => println!("(no completion text; HTTP {})", answer.status),
+                    }
+                }
+
+                if !answer.is_success() {
+                    let detail = camelid::fabric::forward::error_message(&answer.body)
+                        .unwrap_or("no message");
+                    anyhow::bail!(
+                        "node `{}` answered HTTP {}: {detail}",
+                        answer.label,
+                        answer.status
+                    );
                 }
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -814,6 +814,50 @@ fn resolved_gpu_switch(gpu: GpuMode, deterministic: bool) -> Option<bool> {
     }
 }
 
+/// Actions over a fabric of independent Camelid nodes.
+///
+/// A fabric places whole requests on nodes that each own a complete model and
+/// session, so nothing crosses the network inside the token loop. This is the
+/// throughput complement to `serve-distributed`, which shards one model's layers
+/// across machines and is slower than a single node by construction.
+#[derive(Debug, Subcommand)]
+enum FabricAction {
+    /// Probe every node once and report what the fabric can serve.
+    Status {
+        /// A node, as `LABEL=HOST[:PORT]`. Repeat for each node.
+        #[arg(long = "node", required = true, value_name = "LABEL=HOST[:PORT]")]
+        nodes: Vec<String>,
+        /// Per-node probe budget. Nodes are probed concurrently, so this bounds
+        /// the whole command, not each node in turn.
+        #[arg(long, default_value_t = 2000)]
+        timeout_ms: u64,
+        /// Emit the observation as JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show which node a request would be placed on, without sending it.
+    ///
+    /// Placement is deterministic, so this dry run predicts the real decision.
+    Route {
+        #[arg(long = "node", required = true, value_name = "LABEL=HOST[:PORT]")]
+        nodes: Vec<String>,
+        /// `throughput` spreads independent requests; `affinity` keeps a session
+        /// on the node whose prefix and KV cache are already warm.
+        #[arg(long, default_value = "throughput")]
+        mode: String,
+        /// Only consider nodes serving this exact model id.
+        #[arg(long)]
+        model: Option<String>,
+        /// Label of the node that served this session previously.
+        #[arg(long)]
+        sticky: Option<String>,
+        #[arg(long, default_value_t = 2000)]
+        timeout_ms: u64,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Start the local HTTP API server.
@@ -1143,6 +1187,11 @@ enum Command {
         /// Amount of megabytes to stream for throughput testing (default: 100 MB)
         #[arg(long, default_value_t = 100)]
         bandwidth_mb: usize,
+    },
+    /// Inspect and route across a fabric of independent Camelid nodes.
+    Fabric {
+        #[command(subcommand)]
+        action: FabricAction,
     },
     /// Inspect GGUF metadata and tensor descriptors.
     Inspect { path: PathBuf },
@@ -2280,6 +2329,72 @@ async fn main() -> anyhow::Result<()> {
                 anyhow::bail!("Invalid role: {role}. Must be 'coordinator' or 'worker'");
             }
         }
+        Command::Fabric { action } => match action {
+            FabricAction::Status {
+                nodes,
+                timeout_ms,
+                json,
+            } => {
+                let specs = camelid::fabric::parse_fabric(&nodes)
+                    .map_err(|error| anyhow::anyhow!("{error}"))?;
+                let fabric = camelid::fabric::Fabric::new(specs)
+                    .with_timeout(std::time::Duration::from_millis(timeout_ms));
+                let snapshots = fabric.observe();
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&snapshots)?);
+                } else {
+                    print!("{}", camelid::fabric::render_status(&snapshots));
+                }
+            }
+            FabricAction::Route {
+                nodes,
+                mode,
+                model,
+                sticky,
+                timeout_ms,
+                json,
+            } => {
+                let mode = match mode.as_str() {
+                    "throughput" => camelid::fabric::RouteMode::Throughput,
+                    "affinity" => camelid::fabric::RouteMode::Affinity,
+                    other => {
+                        anyhow::bail!("unknown mode `{other}`; expected `throughput` or `affinity`")
+                    }
+                };
+                let specs = camelid::fabric::parse_fabric(&nodes)
+                    .map_err(|error| anyhow::anyhow!("{error}"))?;
+                let fabric = camelid::fabric::Fabric::new(specs)
+                    .with_timeout(std::time::Duration::from_millis(timeout_ms));
+                let snapshots = fabric.observe();
+                let request = camelid::fabric::RouteRequest::new(mode)
+                    .with_model(model.as_deref())
+                    .with_sticky(sticky.as_deref());
+
+                // A fabric that cannot place the request is a failure the caller
+                // must see in the exit code, not only in the text.
+                let decision = camelid::fabric::route(&snapshots, &request)
+                    .map_err(|error| anyhow::anyhow!("{error}"))?;
+
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "label": decision.label,
+                            "reason": format!("{:?}", decision.reason),
+                            "affinity_lost": decision.affinity_lost,
+                        }))?
+                    );
+                } else {
+                    println!("route -> {} ({:?})", decision.label, decision.reason);
+                    if let Some(previous) = &decision.affinity_lost {
+                        println!(
+                            "note: affinity to `{previous}` could not be honoured; \
+                             this request re-prefills on a cold node"
+                        );
+                    }
+                }
+            }
+        },
         Command::Inspect { path } => {
             let gguf = read_metadata(path)?;
             println!("{}", serde_json::to_string_pretty(&gguf)?);

--- a/tests/fabric_end_to_end.rs
+++ b/tests/fabric_end_to_end.rs
@@ -1,0 +1,438 @@
+//! End-to-end fabric behaviour against stub nodes.
+//!
+//! The two-machine runs that validated this feature needed real engines, real
+//! models and a real network, so they cannot run in CI. These tests stand in
+//! two HTTP nodes on loopback that answer `/v1/health` and
+//! `/v1/chat/completions` from canned data, which makes the same paths — model
+//! scoped placement, affinity, forwarding, failure — reproducible anywhere.
+//!
+//! They also assert what the fabric *sends*, not only what it does with the
+//! reply. Nothing else covers the request side.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use camelid::fabric::{
+    forward, parse_node_spec, route, Fabric, NodeSpec, RouteError, RouteMode, RouteReason,
+    RouteRequest,
+};
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+const FORWARD_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One request the stub actually received.
+#[derive(Debug, Clone)]
+struct Received {
+    method: String,
+    path: String,
+    body: String,
+}
+
+#[derive(Clone)]
+struct StubConfig {
+    /// Body served from `/v1/health`.
+    health: String,
+    /// Body served from `/v1/chat/completions`.
+    completion: String,
+    completion_status: u16,
+}
+
+impl StubConfig {
+    fn ready(model: &str, in_flight: usize) -> Self {
+        Self {
+            health: format!(
+                r#"{{"ok":true,"generation_ready":true,"active_model_id":"{model}",
+                    "backend":"llama","version":"0.5.4",
+                    "engine_queued_tasks":0,"engine_queue_depth":{in_flight}}}"#
+            ),
+            completion: format!(
+                r#"{{"choices":[{{"message":{{"role":"assistant","content":"served by {model}"}}}}]}}"#
+            ),
+            completion_status: 200,
+        }
+    }
+
+    fn not_ready() -> Self {
+        Self {
+            health: r#"{"ok":true,"generation_ready":false,"active_model_id":null}"#.to_string(),
+            completion: "{}".to_string(),
+            completion_status: 200,
+        }
+    }
+
+    fn refusing(model: &str) -> Self {
+        Self {
+            completion: r#"{"error":{"message":"engine queue full"}}"#.to_string(),
+            completion_status: 503,
+            ..Self::ready(model, 0)
+        }
+    }
+}
+
+/// A stand-in Camelid node on loopback.
+struct StubNode {
+    port: u16,
+    shutdown: Arc<AtomicBool>,
+    requests: Arc<Mutex<Vec<Received>>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl StubNode {
+    fn start(config: StubConfig) -> Self {
+        // Port 0 lets the OS pick, so tests never collide with each other or
+        // with a real engine on 8181.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_requests = Arc::clone(&requests);
+        let thread = std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                if thread_shutdown.load(Ordering::SeqCst) {
+                    break;
+                }
+                let Ok(mut stream) = stream else { continue };
+                serve_once(&mut stream, &config, &thread_requests);
+            }
+        });
+
+        Self {
+            port,
+            shutdown,
+            requests,
+            thread: Some(thread),
+        }
+    }
+
+    fn spec(&self, label: &str) -> NodeSpec {
+        NodeSpec {
+            label: label.to_string(),
+            host: "127.0.0.1".to_string(),
+            port: self.port,
+        }
+    }
+
+    fn received(&self) -> Vec<Received> {
+        self.requests.lock().expect("stub lock").clone()
+    }
+}
+
+impl Drop for StubNode {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        // Unblock the accept() the worker is parked in.
+        let _ = TcpStream::connect(("127.0.0.1", self.port));
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<Received>>) {
+    let Some(received) = read_request(stream) else {
+        return;
+    };
+
+    let (status, body) = match received.path.as_str() {
+        "/v1/health" => (200_u16, config.health.clone()),
+        "/v1/chat/completions" => (config.completion_status, config.completion.clone()),
+        _ => (404, "{}".to_string()),
+    };
+
+    // Record only after deciding, so a malformed request never poisons the log.
+    requests.lock().expect("stub lock").push(received);
+
+    let response = format!(
+        "HTTP/1.1 {status} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+fn read_request(stream: &mut TcpStream) -> Option<Received> {
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
+
+    let mut raw = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    // Read until the headers are complete, then until Content-Length is met.
+    loop {
+        let read = stream.read(&mut chunk).ok()?;
+        if read == 0 {
+            break;
+        }
+        raw.extend_from_slice(&chunk[..read]);
+
+        let Some(header_end) = find_header_end(&raw) else {
+            continue;
+        };
+        let head = String::from_utf8_lossy(&raw[..header_end]).to_string();
+        let expected = content_length(&head).unwrap_or(0);
+        if raw.len() >= header_end + 4 + expected {
+            let body = String::from_utf8_lossy(&raw[header_end + 4..]).to_string();
+            let mut parts = head.lines().next()?.split_whitespace();
+            return Some(Received {
+                method: parts.next()?.to_string(),
+                path: parts.next()?.to_string(),
+                body,
+            });
+        }
+    }
+    None
+}
+
+fn find_header_end(raw: &[u8]) -> Option<usize> {
+    raw.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn content_length(head: &str) -> Option<usize> {
+    head.lines()
+        .find(|line| line.to_ascii_lowercase().starts_with("content-length:"))
+        .and_then(|line| line.split(':').nth(1))
+        .and_then(|value| value.trim().parse().ok())
+}
+
+/// A port that nothing listens on.
+fn dead_spec(label: &str) -> NodeSpec {
+    NodeSpec {
+        label: label.to_string(),
+        host: "127.0.0.1".to_string(),
+        port: 9,
+    }
+}
+
+fn fabric_of(specs: Vec<NodeSpec>) -> Fabric {
+    Fabric::new(specs).with_timeout(PROBE_TIMEOUT)
+}
+
+#[test]
+fn a_two_node_fabric_reports_both_models() {
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let beta = StubNode::start(StubConfig::ready("model-beta", 0));
+    let fabric = fabric_of(vec![alpha.spec("alpha"), beta.spec("beta")]);
+
+    let snapshots = fabric.observe();
+    assert_eq!(snapshots.len(), 2);
+    assert_eq!(snapshots[0].active_model_id(), Some("model-alpha"));
+    assert_eq!(snapshots[1].active_model_id(), Some("model-beta"));
+}
+
+#[test]
+fn placement_is_scoped_to_the_node_actually_serving_the_model() {
+    // The live two-machine run proved this; the stubs make it reproducible.
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let beta = StubNode::start(StubConfig::ready("model-beta", 0));
+    let fabric = fabric_of(vec![alpha.spec("alpha"), beta.spec("beta")]);
+    let snapshots = fabric.observe();
+
+    let to_alpha = route(
+        &snapshots,
+        &RouteRequest::new(RouteMode::Throughput).with_model(Some("model-alpha")),
+    )
+    .expect("alpha serves it");
+    assert_eq!(to_alpha.label, "alpha");
+
+    let to_beta = route(
+        &snapshots,
+        &RouteRequest::new(RouteMode::Throughput).with_model(Some("model-beta")),
+    )
+    .expect("beta serves it");
+    assert_eq!(to_beta.label, "beta");
+}
+
+#[test]
+fn an_unserved_model_is_refused_naming_what_the_fabric_does_serve() {
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let fabric = fabric_of(vec![alpha.spec("alpha")]);
+
+    let error = route(
+        &fabric.observe(),
+        &RouteRequest::new(RouteMode::Throughput).with_model(Some("model-absent")),
+    )
+    .expect_err("nothing serves it");
+
+    match error {
+        RouteError::ModelUnavailable { model, serving } => {
+            assert_eq!(model, "model-absent");
+            assert_eq!(serving, vec!["model-alpha".to_string()]);
+        }
+        other => panic!("expected ModelUnavailable, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_node_that_is_not_ready_is_never_placed_on() {
+    let warming = StubNode::start(StubConfig::not_ready());
+    let ready = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let fabric = fabric_of(vec![warming.spec("warming"), ready.spec("ready")]);
+
+    let decision = route(&fabric.observe(), &RouteRequest::new(RouteMode::Throughput))
+        .expect("one node can serve");
+    assert_eq!(decision.label, "ready");
+    assert_eq!(decision.reason, RouteReason::OnlyCandidate);
+}
+
+#[test]
+fn the_least_loaded_node_wins_and_a_dead_peer_does_not_stall_the_view() {
+    let busy = StubNode::start(StubConfig::ready("model-alpha", 5));
+    let idle = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let fabric = fabric_of(vec![
+        dead_spec("dead"),
+        busy.spec("busy"),
+        idle.spec("idle"),
+    ]);
+
+    let snapshots = fabric.observe();
+    assert_eq!(snapshots.len(), 3, "every node is reported, dead included");
+
+    let decision =
+        route(&snapshots, &RouteRequest::new(RouteMode::Throughput)).expect("two nodes can serve");
+    assert_eq!(decision.label, "idle");
+    assert_eq!(decision.reason, RouteReason::LeastLoaded);
+}
+
+#[test]
+fn affinity_holds_on_a_live_node_and_degrades_on_a_dead_one() {
+    let warm = StubNode::start(StubConfig::ready("model-alpha", 3));
+    let cold = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let fabric = fabric_of(vec![warm.spec("warm"), cold.spec("cold")]);
+    let snapshots = fabric.observe();
+
+    let held = route(
+        &snapshots,
+        &RouteRequest::new(RouteMode::Affinity).with_sticky(Some("warm")),
+    )
+    .expect("warm is alive");
+    assert_eq!(held.label, "warm");
+    assert_eq!(held.reason, RouteReason::Affinity);
+    assert_eq!(held.affinity_lost, None);
+
+    // Same fabric, but the session's node is not in it at all.
+    let degraded = route(
+        &snapshots,
+        &RouteRequest::new(RouteMode::Affinity).with_sticky(Some("vanished")),
+    )
+    .expect("degrades rather than failing");
+    assert_eq!(degraded.label, "cold");
+    assert_eq!(degraded.affinity_lost.as_deref(), Some("vanished"));
+}
+
+#[test]
+fn forwarding_sends_a_well_formed_request_and_returns_the_answer() {
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let spec = alpha.spec("alpha");
+
+    let body = forward::chat_request("model-alpha", "ping", 8);
+    let answer = forward::forward(&spec, "/v1/chat/completions", &body, FORWARD_TIMEOUT)
+        .expect("stub answers");
+
+    assert!(answer.is_success());
+    assert_eq!(answer.label, "alpha");
+    assert_eq!(
+        forward::completion_text(&answer.body),
+        Some("served by model-alpha")
+    );
+
+    // The request side: a health probe, then the completion carrying our body.
+    let seen = alpha.received();
+    let completion = seen
+        .iter()
+        .find(|request| request.path == "/v1/chat/completions")
+        .expect("the completion reached the node");
+    assert_eq!(completion.method, "POST");
+
+    let sent: serde_json::Value =
+        serde_json::from_str(&completion.body).expect("we send valid JSON");
+    assert_eq!(sent["model"], "model-alpha");
+    assert_eq!(sent["messages"][0]["content"], "ping");
+    assert_eq!(sent["stream"], false);
+}
+
+#[test]
+fn an_engine_refusal_is_the_nodes_answer_not_a_transport_failure() {
+    let refusing = StubNode::start(StubConfig::refusing("model-alpha"));
+    let spec = refusing.spec("refusing");
+
+    let answer = forward::forward(
+        &spec,
+        "/v1/chat/completions",
+        &forward::chat_request("model-alpha", "ping", 8),
+        FORWARD_TIMEOUT,
+    )
+    .expect("a 503 is an answer, not an error");
+
+    assert!(!answer.is_success());
+    assert_eq!(answer.status, 503);
+    assert_eq!(
+        forward::error_message(&answer.body),
+        Some("engine queue full")
+    );
+}
+
+#[test]
+fn dispatch_places_and_sends_in_one_call() {
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 4));
+    let beta = StubNode::start(StubConfig::ready("model-beta", 0));
+    let fabric = fabric_of(vec![alpha.spec("alpha"), beta.spec("beta")]);
+
+    let (decision, answer) = fabric
+        .dispatch(
+            "/v1/chat/completions",
+            &forward::chat_request("model-beta", "ping", 8),
+            &RouteRequest::new(RouteMode::Throughput).with_model(Some("model-beta")),
+            FORWARD_TIMEOUT,
+        )
+        .expect("beta serves model-beta");
+
+    assert_eq!(decision.label, "beta");
+    assert_eq!(answer.label, "beta");
+    assert_eq!(
+        forward::completion_text(&answer.body),
+        Some("served by model-beta")
+    );
+    // The request must not have touched the node that does not hold the model.
+    assert!(
+        alpha
+            .received()
+            .iter()
+            .all(|request| request.path == "/v1/health"),
+        "alpha should only have been probed, never sent the completion"
+    );
+}
+
+#[test]
+fn dispatch_refuses_streaming_before_touching_the_network() {
+    // Every node is dead: if dispatch probed first this would be a routing
+    // failure, so seeing the streaming refusal proves the order.
+    let fabric = fabric_of(vec![dead_spec("dead")]);
+    let error = fabric
+        .dispatch(
+            "/v1/chat/completions",
+            &serde_json::json!({ "model": "m", "stream": true }),
+            &RouteRequest::new(RouteMode::Throughput),
+            Duration::from_millis(300),
+        )
+        .expect_err("streaming is unsupported");
+    assert!(
+        error.to_string().contains("streaming"),
+        "unexpected: {error}"
+    );
+}
+
+#[test]
+fn an_operator_node_string_drives_a_real_placement() {
+    // Proves the parsed CLI form reaches a live node, not just the struct form.
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let spec = parse_node_spec(&format!("alpha=127.0.0.1:{}", alpha.port)).expect("parses");
+
+    let fabric = fabric_of(vec![spec]);
+    let decision = route(&fabric.observe(), &RouteRequest::new(RouteMode::Throughput))
+        .expect("the parsed node serves");
+    assert_eq!(decision.label, "alpha");
+}


### PR DESCRIPTION
## What

Adds `src/fabric`: a scheduler that places **whole requests** on Camelid nodes that each own a complete model and a complete session, plus a `camelid fabric` CLI to observe, dry-run and send.

Nothing crosses the network inside the token loop, so throughput scales with nodes instead of being taxed by them.

## Why this is not `serve-distributed`

The existing distributed lane shards one model's layers across machines. It is a **capacity** mechanism — it runs a model that fits on neither machine — and it is latency-additive by construction: every generated token crosses the wire twice and each machine idles while the other computes.

The fabric is the complementary arrangement, for **throughput and heterogeneity**. The two compose: a fabric node may itself be a distributed coordinator.

```
serve-distributed :  one model,  N machines,  N hops per token
fabric            :  N models,   N machines,  0 hops per token
```

## Shape

| File | Role |
| --- | --- |
| `fabric/node.rs` | Identity, observed state, `label=host[:port]` parsing |
| `fabric/policy.rs` | **Pure** placement decisions — no I/O |
| `fabric/probe.rs` | Turning `/v1/health` into a routing fact |
| `fabric/http.rs` | Minimal blocking HTTP/1.1, shared by probe and forward |
| `fabric/forward.rs` | Sending a placed request to the node that serves it |
| `fabric/mod.rs` | `Fabric`, `dispatch`, summary, rendering |

The correctness of the fabric lives in `policy.rs`, which is pure and therefore testable exhaustively with no server, no model and no network.

Routing reads `/v1/health` alone — it already carries `active_model_id` and load — so placement costs one GET per node, and nodes are probed concurrently so a single dead node cannot stall the view of live ones.

## Two load-bearing properties

Each has a test that fails without it.

**Placement is deterministic.** Ties break on label, so `camelid fabric route` predicts what the fabric will actually do.

**Affinity degrades, never fails.** A warm prefix is an optimisation; when the node holding it dies the request is still served, and the decision reports `affinity_lost` so a caller can tell a warm hit from a cold re-prefill.

## Deliberate limits, stated rather than half-supported

- **Streaming is refused.** An SSE body is a different response shape and a different cancellation story. `reject_streaming` runs before a socket is opened, and a test proves the refusal beats the dial.
- **A node answering 503 is an answer, not a failure.** It arrives as a `Forwarded` with its status; only a request that never completed is a `ForwardError`, and that error names the node so an operator can act on it.
- **Node capacity is not modelled.** `/v1/health` publishes current load but never the queue bound — `engine_queue_depth` is a gauge of jobs in flight, and the real limit (`CAMELID_QUEUE_DEPTH`) is read on the node and not serialised. An earlier revision read that field as a bound and refused to route to a **fully idle two-node fabric**. The fabric now ranks on observed load and lets a genuinely full node answer its own 503.

`chat::client` is deliberately not reused: it is private to `chat`, is keyed on a resolved `SocketAddr` where fabric members are named hosts, and carries SSE, bearer auth and tool-call handling that a health probe must not depend on.

## Verification

**Two real machines** — Windows RTX 4060 and a Mac M5 Pro over Wi-Fi, running engines **0.5.4 and 0.5.0** respectively, so version skew is covered by the lenient health payload. Status, throughput placement on an idle fabric, affinity honoured, affinity degrading to a live node, typed refusal for an unserved model, and malformed and duplicate node specs refused before any I/O.

**Two different models** — `Llama 3.2 1B Instruct` on GPU and `Qwen3 4B Instruct Awq` on CPU. Model-scoped placement chose the right node in both directions and real completions came back from both (743 ms and 42934 ms, the latter CPU-bound). A request with no `--model` picked the least-loaded node and used that node's model. An unserved model was refused naming both models the fabric does serve.

**Reproducibly, in CI** — `tests/fabric_end_to_end.rs` stands in two HTTP nodes on loopback, so all of the above runs with no model, no GPU and no second machine. Those tests also assert the **request** side (the fabric sends `POST /v1/chat/completions` with valid JSON carrying model, prompt and `stream:false`) and that placement is exclusive (after a model-scoped dispatch, the node that does not hold the model shows only a health probe).

## Gates

- 11 integration tests, 63 fabric unit tests
- Full lib suite **1632 passed / 0 failed** / 84 ignored
- `clippy --all-targets -- -D warnings` clean
- `rustfmt --check` clean
- `scripts/check-public-scrub.sh` clean
- All new files LF; `git diff --check` clean

## Not in this PR

No streaming. No probe caching or background refresh — every command re-probes. No operator-declared node capacity. No HTTP front door: `fabric run` sends one request from the CLI, and a resident proxy that clients point at is the natural next slice, built on the same `dispatch`.
