### PR TITLE
perf(inference): carry the Q4_K owner's group scale in its widening madd

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -20202,6 +20202,32 @@ fn x86_kquant_matmul_owner_vnni_enabled() -> bool {
     }
 }
 
+/// The 256-bit `vpdpbusd` inner, default OFF: the AVX2 inner carries the group
+/// scale inside its widening `madd_epi16`, and measured faster than
+/// `vpdpbusd` + `mullo_epi32` at both shapes tried — 1.19x at in_dim 2048 and
+/// 1.17x at 8192 in isolation, 1.09x on 1B Q4_K_M prefill, on an i9-14900HX.
+/// Retained behind `CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256=1` because that
+/// comparison has only been made on one microarchitecture; dispatch is
+/// bit-identical either way. Resolved once like its siblings, with the same
+/// bypass so an A/B sweep is not pinned to whichever arm ran first.
+#[cfg(target_arch = "x86_64")]
+fn x86_kquant_matmul_owner_avxvnni256_enabled() -> bool {
+    #[cfg(test)]
+    {
+        q8_0_env_flag_enabled_default_off("CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256")
+    }
+    #[cfg(not(test))]
+    {
+        if q8_runtime::bench_uncached_runtime_plan() {
+            return q8_0_env_flag_enabled_default_off("CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256");
+        }
+        static ENABLED: OnceLock<bool> = OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            q8_0_env_flag_enabled_default_off("CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256")
+        })
+    }
+}
+
 /// Shared-base output pointer for the K-quant owner's rayon tasks. Tasks
 /// partition the output-channel dimension into disjoint chunks — no two tasks
 /// ever write the same (row, channel) cell despite the shared base pointer.
@@ -20443,12 +20469,17 @@ unsafe fn q4_k_owner_weight_row_block_avx512vnni(
 
 /// v6 inner: 256-bit AVX-VNNI sibling of
 /// [`q4_k_owner_weight_row_block_avx512vnni`], for the Alder-Lake-and-later
-/// consumer parts that carry `vpdpbusd` but have AVX-512 fused off — the whole
-/// 12th-gen-onwards Intel client line, which today falls all the way back to
-/// the AVX2 inner. Same algebra as the AVX-512 sibling with the zmm pair split
-/// into two ymm halves: the low nibbles pair with `y.qs[64j..64j+32]` and the
-/// high nibbles with `y.qs[64j+32..64j+64]`, exactly the halves the 64-byte
-/// zmm load covers, so the operand pairing is unchanged.
+/// consumer parts that carry `vpdpbusd` but have AVX-512 fused off. Same
+/// algebra as the AVX-512 sibling with the zmm pair split into two ymm halves:
+/// the low nibbles pair with `y.qs[64j..64j+32]` and the high nibbles with
+/// `y.qs[64j+32..64j+64]`, exactly the halves the 64-byte zmm load covers, so
+/// the operand pairing is unchanged.
+///
+/// Opt-in via `CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256=1`: `vpdpbusd`
+/// returns i32, so the group scale needs a 2-uop `mullo_epi32`, whereas the
+/// AVX2 inner folds the same scale into a widening `madd_epi16` for free and
+/// measured faster here. Kept because that was measured on one
+/// microarchitecture only.
 ///
 /// Bit-identity: every intermediate is exact integer. A `dpbusd` lane is a quad
 /// sum ≤ 4·15·127 = 7620; ×63 scale ≤ 480,060; `vacc` takes 8 adds (4 chunks ×
@@ -20520,12 +20551,19 @@ unsafe fn q4_k_owner_weight_row_block_avxvnni(
 /// q8 lanes are in [-127, 127] (`quantize_q8_k_blocks` uses iscale = -127/max
 /// plus a .min(127) clamp, so -128 is unreachable) ⇒ |maddubs pair| ≤ 2·15·127
 /// = 3810, no i16 saturation (the raw instruction bound would be 3840 at
-/// q8 = -128); madd lane ≤ 7620; × the post-kmask 6-bit scale cap of 63 ⇒
-/// ≤ 480,060; vacc lane over 8 adds ≤ 3.85M; hsum ≤ 30.8M ≈ 1.4% of i32::MAX.
-/// Integer addition is associative, so the per-cell total equals the
-/// per-chunk-hsum path bit for bit. The f32 chain per cell is verbatim
+/// q8 = -128); × the post-kmask 6-bit scale cap of 63 and summed in pairs ⇒
+/// |madd lane| ≤ 480,060; vacc lane over 8 adds ≤ 3.85M; hsum ≤ 30.8M ≈ 1.4%
+/// of i32::MAX. Integer addition is associative, so the per-cell total equals
+/// the per-chunk-hsum path bit for bit. The f32 chain per cell is verbatim
 /// `q4_k_dot_arm` order: per superblock mins-side `(-dmin).mul_add` then
 /// main-side `d.mul_add`, ascending superblocks (i outer, row inner).
+///
+/// The group scale rides in the widening `madd_epi16` instead of a separate
+/// `mullo_epi32`, which is what makes this inner beat `vpdpbusd`: that
+/// instruction hands back i32, so scaling it costs a 2-uop `mullo_epi32`,
+/// while `madd_epi16` reduces AND scales in one 1-uop instruction. This is an
+/// identity, not an associativity argument — `madd(p, ones) * s` and
+/// `madd(p, s)` are both `s·p[2k] + s·p[2k+1]` in every lane.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 #[allow(clippy::too_many_arguments)]
@@ -20541,42 +20579,40 @@ unsafe fn q4_k_owner_weight_row_block_avx2(
 ) {
     use std::arch::x86_64::*;
     let low_mask = _mm256_set1_epi8(0x0f);
-    let ones16 = _mm256_set1_epi16(1);
     for i in 0..superblocks {
         let qs = &w_row[i * Q4_K_WIRE_BYTES_PER_BLOCK + 16..i * Q4_K_WIRE_BYTES_PER_BLOCK + 144];
         let mut low = [_mm256_setzero_si256(); 4];
         let mut high = [_mm256_setzero_si256(); 4];
+        let mut slo = [_mm256_setzero_si256(); 4];
+        let mut shi = [_mm256_setzero_si256(); 4];
+        let sc = &wscales[i];
         for j in 0..4 {
             let q4 = _mm256_loadu_si256(qs.as_ptr().add(j * 32) as *const __m256i);
             low[j] = _mm256_and_si256(q4, low_mask);
             high[j] = _mm256_and_si256(_mm256_srli_epi16(q4, 4), low_mask);
+            slo[j] = _mm256_set1_epi16(sc[2 * j] as i16);
+            shi[j] = _mm256_set1_epi16(sc[2 * j + 1] as i16);
         }
-        let sc = &wscales[i];
-        let mins = &wmins[i];
+        // Mins are per (weight row, superblock), so the widen is hoisted too.
+        let minv = _mm256_cvtepu8_epi32(_mm_loadl_epi64(wmins[i].as_ptr() as *const __m128i));
         for ((blocks, sums), sumf) in preps.iter().zip(sumf_block.iter_mut()) {
             let y = &blocks[i];
             let d = y.d * wd[i];
             let dmin = y.d * wdmin[i];
-            let mut prod: i64 = 0;
-            for g in 0..8 {
-                prod += sums[i][g] as i64 * mins[g] as i64;
-            }
+            // |group sum| ≤ 32·127 = 4064 and the scale ≤ 63, so a lane is
+            // ≤ 256,032 and the total ≤ 2.05M — exact in i32 and in f32.
+            let sumv = _mm256_loadu_si256(sums[i].as_ptr() as *const __m256i);
+            let prod =
+                crate::diffusion_gemma::refmath::hsum_i32_8(_mm256_mullo_epi32(sumv, minv)) as i64;
             *sumf = (-dmin).mul_add(prod as f32, *sumf);
             let q8p = y.qs.as_ptr();
             let mut vacc = _mm256_setzero_si256();
             for j in 0..4 {
                 let q8lo = _mm256_loadu_si256(q8p.add(j * 64) as *const __m256i);
                 let q8hi = _mm256_loadu_si256(q8p.add(j * 64 + 32) as *const __m256i);
-                let slo = _mm256_madd_epi16(_mm256_maddubs_epi16(low[j], q8lo), ones16);
-                let shi = _mm256_madd_epi16(_mm256_maddubs_epi16(high[j], q8hi), ones16);
-                vacc = _mm256_add_epi32(
-                    vacc,
-                    _mm256_mullo_epi32(slo, _mm256_set1_epi32(sc[2 * j] as i32)),
-                );
-                vacc = _mm256_add_epi32(
-                    vacc,
-                    _mm256_mullo_epi32(shi, _mm256_set1_epi32(sc[2 * j + 1] as i32)),
-                );
+                let plo = _mm256_madd_epi16(_mm256_maddubs_epi16(low[j], q8lo), slo[j]);
+                let phi = _mm256_madd_epi16(_mm256_maddubs_epi16(high[j], q8hi), shi[j]);
+                vacc = _mm256_add_epi32(vacc, _mm256_add_epi32(plo, phi));
             }
             let main = crate::diffusion_gemma::refmath::hsum_i32_8(vacc) as i64;
             *sumf = d.mul_add(main as f32, *sumf);
@@ -20621,10 +20657,11 @@ fn q4_k_owner_prefill_tiled(
     #[cfg(not(target_arch = "x86_64"))]
     let use_vnni = false;
     // 256-bit vpdpbusd: same instruction, no AVX-512. Only consulted when the
-    // 512-bit path is unavailable, so an AVX-512 host is completely unaffected.
+    // 512-bit path is unavailable, and now opt-in — see the flag's doc comment.
     #[cfg(target_arch = "x86_64")]
     let use_avxvnni = !use_vnni
         && x86_kquant_matmul_owner_vnni_enabled()
+        && x86_kquant_matmul_owner_avxvnni256_enabled()
         && std::arch::is_x86_feature_detected!("avxvnni")
         && std::arch::is_x86_feature_detected!("avx2");
     #[cfg(not(target_arch = "x86_64"))]

--- a/src/inference/tests.rs
+++ b/src/inference/tests.rs
@@ -2211,6 +2211,7 @@ fn clear_dense_diagnostic_env() {
         "CAMELID_Q8_0_PACKED_4X8_DOT",
         "CAMELID_X86_KQUANT_MATMUL_OWNER",
         "CAMELID_X86_KQUANT_MATMUL_OWNER_VNNI",
+        "CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256",
         "CAMELID_X86_Q6K_AVX2",
         "CAMELID_Q8_0_FILE_READER_BLOCK_DOT",
         "CAMELID_Q8_0_FILE_CACHE_BYTES",
@@ -3854,6 +3855,14 @@ fn q4_k_owner_prefill_bitwise_matches_block_dot_core() {
                      host_vnni={})",
                     q8_owner_avx512vnni_available()
                 );
+                // The 256-bit inner is opt-in, so neither leg may reach it —
+                // without this the non-512 host's legs could silently be
+                // measuring that kernel instead of the AVX2 one.
+                assert_eq!(
+                    telemetry.kquant_owner_avxvnni_taken, 0,
+                    "the 256-bit inner engaged without its opt-in flag \
+                     (n_rows={n_rows}, vnni={vnni})"
+                );
                 std::env::remove_var("CAMELID_X86_KQUANT_MATMUL_OWNER");
                 std::env::remove_var("CAMELID_X86_KQUANT_MATMUL_OWNER_VNNI");
                 assert_eq!(owner.data.len(), base.data.len());
@@ -4097,11 +4106,13 @@ fn q4_k_owner_avxvnni_inner_is_bit_identical() {
 
         std::env::set_var("CAMELID_X86_KQUANT_MATMUL_OWNER", "1");
         std::env::set_var("CAMELID_X86_KQUANT_MATMUL_OWNER_VNNI", "1");
+        std::env::set_var("CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256", "1");
         reset_q8_schedule_telemetry();
         let owned = matmul_rhs_transposed_q4_k_block_dot(&input, &weight, "avxvnni").unwrap();
         let telemetry = snapshot_q8_schedule_telemetry();
         std::env::remove_var("CAMELID_X86_KQUANT_MATMUL_OWNER");
         std::env::remove_var("CAMELID_X86_KQUANT_MATMUL_OWNER_VNNI");
+        std::env::remove_var("CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256");
 
         assert!(
             telemetry.kquant_owner_avxvnni_taken > 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4993,6 +4993,7 @@ fn run_bench_owner_sweep(
         Lane::KQuant => &[
             "CAMELID_X86_KQUANT_MATMUL_OWNER",
             "CAMELID_X86_KQUANT_MATMUL_OWNER_VNNI",
+            "CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256",
             "CAMELID_X86_KQUANT_MATMUL_OWNER_REPACK8",
         ],
     };
@@ -5061,16 +5062,22 @@ fn run_bench_owner_sweep(
     }
 
     // Lane B. The 512-bit inner and the 8-row repack need AVX-512; the 256-bit
-    // inner needs only `vpdpbusd`. Both answer the same env flag, so which one
-    // runs is a property of the host — hence the label is picked from the
-    // host's capabilities, and kernels this CPU cannot reach are not measured.
+    // inner needs only `vpdpbusd`. The 512-bit inner answers the shared VNNI
+    // flag while the 256-bit one is opt-in, so which one runs is a property of
+    // the host — hence the label is picked from the host's capabilities, and
+    // kernels this CPU cannot reach are not measured.
     const KQ_OWNER: &str = "CAMELID_X86_KQUANT_MATMUL_OWNER";
     const KQ_VNNI: &str = "CAMELID_X86_KQUANT_MATMUL_OWNER_VNNI";
+    const KQ_AVXVNNI256: &str = "CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256";
     const KQ_REPACK8: &str = "CAMELID_X86_KQUANT_MATMUL_OWNER_REPACK8";
     let kq_off: SweepConfig = ("off", false, &[(KQ_OWNER, "0")]);
     let kq_avx2: SweepConfig = ("owner_avx2", true, &[(KQ_OWNER, "1"), (KQ_VNNI, "0")]);
     let kq_vnni512: SweepConfig = ("owner_vnni512", true, &[(KQ_OWNER, "1"), (KQ_VNNI, "1")]);
-    let kq_avxvnni: SweepConfig = ("owner_avxvnni256", true, &[(KQ_OWNER, "1"), (KQ_VNNI, "1")]);
+    let kq_avxvnni: SweepConfig = (
+        "owner_avxvnni256",
+        true,
+        &[(KQ_OWNER, "1"), (KQ_VNNI, "1"), (KQ_AVXVNNI256, "1")],
+    );
     let kq_repack8: SweepConfig = (
         "owner_vnni512_repack8",
         true,


### PR DESCRIPTION
# Carry the Q4_K owner's group scale in its widening `madd`

The K-quant prefill owner's AVX2 inner widened its `maddubs` products with `madd_epi16(., ones16)` and then applied the 6-bit group scale with a **separate `mullo_epi32`**. `madd_epi16` can take the scale in place of the ones vector, reducing and scaling in one instruction.

This is an **identity**, not an associativity argument: `madd(p, ones) * s` and `madd(p, s)` are both `s·p[2k] + s·p[2k+1]` in every lane.

The mins side — an 8-wide `i64` **scalar** loop run per (superblock × activation row) — becomes one `mullo_epi32` plus the existing horizontal sum, with the widened mins hoisted per weight row alongside the scales already hoisted there.

Main-side cost drops from **5 uops per 32 values to 3**, and that is what makes plain AVX2 overtake `vpdpbusd`: that instruction returns i32, so scaling its result needs the 2-uop `mullo_epi32`, whereas `madd_epi16` gets the scale for free.

## Consequence: the 256-bit AVX-VNNI inner is no longer the default

It is **kept and reachable** via `CAMELID_X86_KQUANT_MATMUL_OWNER_AVXVNNI256=1`, because it was compared on exactly one microarchitecture. Zen 5 also has AVX-VNNI and was not measured.

**The AVX-512 inners are untouched.** This host has AVX-512 fused off, so the same fold could not be measured there. Both AVX-512 inners have the identical `dpbusd` + `mullo_epi32` shape and the same scalar mins loop, so the fix likely applies — that is an unmeasured follow-up, not a claim.

## Bit identity

Every intermediate stays exact integer inside the envelope the kernel already documented: `|maddubs pair| ≤ 2·15·127 = 3810`, scale `≤ 63` after the kmask unpack, so a madd lane is `≤ 480,060` and the 8-add accumulator `≤ 3.85M` — about 1.4% of `i32::MAX`. The mins side is smaller still: a group sum is `≤ 32·127 = 4064` and the total `≤ 2.05M`, so the `i64` it used was never needed. The load-bearing f32 chain is untouched, verbatim `q4_k_dot_arm` order.

## Kernel in isolation

Per (activation row × weight row) cell. Verbatim in-tree baselines, best of 3, reproduced across three runs. All four variants agree **bit for bit** over the whole output block.

| inner | in_dim 2048 | in_dim 8192 |
| --- | --- | --- |
| in-tree AVX2 | 56.99 ns | 237.28 ns |
| in-tree AVX-VNNI | 43.87 (1.30×) | 188.24 (1.26×) |
| + scale fold | 38.42 (1.48×) | 163.32 (1.45×) |
| + mins SIMD | **37.00 (1.54×)** | **161.26 (1.47×)** |

## Prefill, end to end

i9-14900HX, Windows x86_64, AC power, CUDA hidden. Release binaries from a clean detached worktree at this branch's base (`v0.5.4-32-g7985e1d32`) and from this branch. 606-token prompt, 5 paired rounds, `Llama-3.2-1B-Instruct-Q4_K_M`.

Two arms are controls: `off` disables the owner, and `owner_avxvnni256` runs the kernel this PR does **not** touch — same binaries, same model.

| arm | per-pair before/after ratios |
| --- | --- |
| `owner_avx2` (changed) | 1.1123 1.1891 1.2181 1.2255 1.2240 |
| `owner_avxvnni256` (untouched) | 0.8941 1.0048 0.9915 0.9845 0.9809 |
| `off` (control) | 0.9101 0.9974 0.9283 1.0109 1.0021 |

The changed arm's **worst** pair (1.1123) is above the **best** pair of either control (1.0109, 1.0048) — complete rank separation, 5 observations against 10, no overlap. That, rather than the 1.218× median, is what carries the result: a median can be bought with a lucky run, rank separation cannot.

Comparing the two inners directly on the after binary, the new AVX2 inner beats the 256-bit VNNI one by **1.086× (5/5)**. That is what an AVX-VNNI host gains; a host **without** AVX-VNNI gains the **1.218×**, since the AVX2 inner was already its only path.

Two independent estimates of the Q4_K matmul share of prefill agree: 1.54× kernel → 1.218× end-to-end implies **51%**; 1.186× → 1.086× implies **50%**.

### What is deliberately not claimed

**No 3B end-to-end number.** The 3B sweep was run twice and discarded both times: in the second run the owner-**off** control — which this PR cannot affect — itself spanned **0.486 to 1.330**, so the run cannot separate the change from drift on this box. The kernel probe covers the 3B-relevant shape directly (`in_dim` 8192 is `ffn_down`, 1.47×), and 3B byte identity is reported below, so nothing rests on the discarded runs.

**Negative-control model.** `Llama-3.2-1B-Instruct-Q6_K` holds no Q4_K tensors, and `kquant_avxvnni256_taken` is 0 for it in every arm — confirming the absence rather than assuming it.

## Byte identity on real weights

64 greedy tokens after the same prompt. Identical token ids **and** text sha256 in all six cells — three models × {default, VNNI sub-flag off}.

| model | sha256 (prefix) |
| --- | --- |
| 1B Q4_K_M | `27beb9855204ec9c64533da0` |
| 3B Q4_K_M | `109708da6da2bbdf90976fed` |
| 1B Q6_K | `641b4526fdf3b738a6f39b18` |

The `default` cell is the strong one: the before binary takes the 256-bit VNNI inner there and the after binary takes the new AVX2 inner, so it exercises the kernel rewrite **and** the dispatch change together.

## Negative controls on the tests

Each reproduced before it was trusted; each fails `q4_k_owner_prefill_bitwise_matches_block_dot_core`:

1. scale replaced by ones
2. low/high group scales swapped
3. mins side adds instead of multiplies
4. the 256-bit inner allowed to dispatch without its opt-in flag

(4) is why the test now asserts `kquant_owner_avxvnni_taken == 0` — without it, the AVX2 legs could silently have been measuring the other kernel.

## Gates

`cargo fmt --all -- --check` clean · `git diff --check` clean · `cargo clippy --all-targets -- -D warnings` clean · `cargo test --lib` **1569 passed, 0 failed**.

The existing `q4_k_owner_prefill_bitwise_matches_block_dot_core` compares the owner against the non-owner per-cell path bit for bit over `in_dim` 512/768, `out_dim` 96/40 and `n_rows` 4/5/13/64/67, and needed no change beyond that one assertion. `q4_k_owner_avxvnni_inner_is_bit_identical` now asks for the inner through its new flag.

## Scope

No flag default, support claim or ledger row changes for any user-visible capability. The K-quant owner itself remains opt-in at this base; this makes its Q4_K half faster when it is on.
