### PR TITLE
runnable: admit Q8_0 weights on the qwen3.5 resident Metal lane

### DIFF
--- a/qa/ornith/G-PARITY-qwen35-metal-macos.md
+++ b/qa/ornith/G-PARITY-qwen35-metal-macos.md
@@ -1,0 +1,97 @@
+# ORNITH 9B — G-PARITY receipt, resident Metal lane (qwen35 vs llama.cpp acd79d6)
+
+**Gate:** G-PARITY — greedy token-identical vs the pinned llama.cpp oracle
+(`first_divergent_generated_token_index = -1`). **Result: PASS (4/4 prompts).**
+**Date:** 2026-08-06 · **Platform:** macOS 26.6 (25G72) arm64, Apple M4, 16 GB.
+**Camelid lane:** runnable → **resident Metal graph** (`qwen35`), wire mode
+(`CAMELID_METAL_F32Y=1`, `CAMELID_METAL_WIRE=1`), rustc 1.95.0, `--release`.
+**Oracle:** llama.cpp `acd79d6` (build 9632) — **reused, not re-run**; see Method.
+**Model:** `ornith-1.0-9b-Q8_0.gguf` (arch `qwen35`).
+
+Companion to `G-PARITY-qwen35-vs-llamacpp.md`, which certified the same gate on
+Windows x86_64 CPU. This one covers a different lane on a different platform.
+
+## Method (isolates the model forward from tokenization)
+
+Same method and the same four prompt token-ID arrays as the Windows receipt, so the
+two are directly comparable:
+
+```
+[[3710,369,279,6511,314,9338,30],
+ [727,73111,1393,1590],
+ [760,13600,314,3882,369],
+ [2427,310,4097,25,220,16,11,220,17,11,220,18,11]]
+```
+
+Greedy, `n_predict=20`, via the existing `ornith_qwen35_parity_gen` harness.
+
+**The oracle was not re-run for this receipt.** The reference token IDs are the ones
+already pinned in `G-PARITY-qwen35-vs-llamacpp.md` from the llama.cpp `acd79d6` run.
+That is the point of a pinned oracle — this receipt asks whether a *new Camelid lane*
+reproduces it, not whether llama.cpp is still self-consistent. Anyone re-certifying the
+oracle itself should start from the Windows receipt's method section.
+
+**The resident lane was confirmed engaged, not assumed.** `ornith_qwen35_parity_gen`
+exits 0 and prints plausible token IDs even when the Metal lane declines and falls back
+to CPU decode, so the run is only valid if stderr carries:
+
+```
+[qwen35] full Metal resident graph active (packed weights, attention,
+         gated-delta recurrence, FFN, logits, GPU greedy, and request sampling)
+```
+
+and does **not** carry `using hybrid fallback`. Both were checked for this run.
+
+## Results — generated token IDs, Metal resident lane vs pinned oracle
+
+| # | prompt | tokens | match |
+|---|--------|--------|-------|
+| 0 | `What is the capital of France?` | `[271,760,6511,314,9338,369,11751,13,271,3710,369,279,6511,314,9564,30,271,760,6511,314]` | ✅ identical |
+| 1 | `def fibonacci(n):` | `[198,262,413,307,2564,220,15,25,198,285,460,2958,198,262,4265,307,606,220,16,25]` | ✅ identical |
+| 2 | `The opposite of hot is` | `[8981,13,271,248068,198,90700,8340,25,271,16,13,220,2972,2014,53983,279,5952,64700,198,262]` | ✅ identical |
+| 3 | `Count to five: 1, 2, 3,` | `[220,19,11,220,20,13,4543,11,1092,3905,1727,30,271,760,1727,1324,303,279,8240,369]` | ✅ identical |
+
+All four token-identical → `first_divergent_generated_token_index = -1`. Byte-for-byte
+equal to the Windows CPU receipt's IDs, so CPU and Metal agree with each other as well
+as with the oracle.
+
+## What this earns
+
+- The **resident Metal lane** reproduces the pinned oracle for `qwen35` Q8_0 on Apple
+  Silicon. The gated-delta-net recurrence, causal conv1d, GQA head-repeat, state
+  orientation, partial NEOX mRoPE and gated attention are all correct **as executed on
+  the GPU**, not only in the CPU reference.
+- Admitting GGUF `Q8_0` into the resident lane with no repack does not perturb the
+  forward. Same 34-byte wire blocks, same argmax trajectory, all four prompts.
+- A macOS arm64 data point for a gate that previously existed only on Windows x86_64.
+
+This is lane/platform evidence for an existing row. It is **not** a support-contract
+change and claims nothing about rows outside `qwen35` Q8_0.
+
+## Caveats
+
+- **Not a benchmark.** No warmup, and load time is inside the wall clock, so the
+  numbers here are not comparable to `bench-generate` figures. For reference only: this
+  run took 14.7 s end to end; the same harness on the CPU hybrid lane took 221.8 s. A
+  cold process also pays one-time Metal pipeline compilation, which lands inside the
+  first prefill — see the `--warmup` note in the PR discussion.
+- **Wire mode must be set explicitly under the test harness.** `CAMELID_METAL_F32Y`
+  and `CAMELID_METAL_WIRE` default off; only the CLI turns them on via
+  `apply_default_fast_stack`. A bare `cargo test` therefore does *not* exercise this
+  lane, and wire-page weights require it.
+- **Known deviation carried from G-LOAD:** BPE pre-tokenizer `qwen35` is implemented as
+  qwen2's single-digit split, with `\p{M}` combining-mark folding deferred. The parity
+  method feeds token IDs, so this does not affect the model-forward result here.
+
+## Reproduce
+
+```sh
+CAMELID_ORNITH_GGUF=/path/to/ornith-1.0-9b-Q8_0.gguf \
+CAMELID_METAL_F32Y=1 CAMELID_METAL_WIRE=1 \
+CAMELID_PARITY_TOKENS='[[3710,369,279,6511,314,9338,30],[727,73111,1393,1590],[760,13600,314,3882,369],[2427,310,4097,25,220,16,11,220,17,11,220,18,11]]' \
+CAMELID_PARITY_NPREDICT=20 \
+cargo test --release --lib ornith_qwen35_parity_gen -- --ignored --nocapture
+```
+
+Check stderr for `full Metal resident graph active` before trusting the IDs. To produce
+the CPU control from the same binary, add `CAMELID_QWEN35_METAL=0`.

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -25214,6 +25214,120 @@ mod tests {
         }
     }
 
+    /// Resolver gate for the resident `Q8_0` projection. The runnable loader admits
+    /// GGUF `Q8_0` with no repack, so what needs proving is the seam: that
+    /// `ResidentWeightFormat::Q8_0` plus 34-byte wire blocks resolve through the
+    /// production projection encoder — block-count math and the `n_tokens == 1` decode
+    /// vs batched-prefill split — to the scalar decoder's values. The Q8 GEMV kernels
+    /// themselves are covered by `metal_q8_0_ksplit_gemv_matches_cpu_reference`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn metal_q8_0_resident_projection_matches_scalar_decode() {
+        if !detect_metal_device().available {
+            return;
+        }
+        let kernel = metal_linear_kernel().expect("Q8 Metal pipelines");
+        let format = ResidentWeightFormat::Q8_0;
+        let block_elements = format.values_per_block();
+        let block_bytes = format.wire_bytes_per_block();
+
+        // One block per row is the degenerate K-split case (a single live block slot);
+        // eight crosses the stride. 19 rows is odd, so the row-tiling tail guard runs
+        // rather than only SIMD group zero.
+        for blocks_per_row in [1usize, 8] {
+            let input_width = blocks_per_row * block_elements;
+            let rows = 19usize;
+            for n_tokens in [1usize, 2] {
+                let inputs: Vec<f32> = (0..n_tokens * input_width)
+                    .map(|i| (((i * 37 + 11) % 101) as f32 - 50.0) * 0.03125)
+                    .collect();
+
+                let mut wire = vec![0u8; rows * blocks_per_row * block_bytes];
+                for row in 0..rows {
+                    for block_idx in 0..blocks_per_row {
+                        let off = (row * blocks_per_row + block_idx) * block_bytes;
+                        let block = &mut wire[off..off + block_bytes];
+                        let scale = 0.125 + row as f32 * 0.0625 + block_idx as f32 * 0.03125;
+                        block[..2].copy_from_slice(&f32_to_f16_bits(scale).to_le_bytes());
+                        for (i, byte) in block[2..].iter_mut().enumerate() {
+                            let q = ((row * 53 + block_idx * 29 + i * 7) % 255) as i32 - 127;
+                            *byte = (q as i8) as u8;
+                        }
+                    }
+                }
+
+                let row_bytes = blocks_per_row * block_bytes;
+                let mut expected = vec![0.0f32; n_tokens * rows];
+                for row in 0..rows {
+                    let decoded = crate::tensor::decode_q8_0_tensor(
+                        "test",
+                        &wire[row * row_bytes..(row + 1) * row_bytes],
+                        input_width,
+                    )
+                    .unwrap();
+                    for token in 0..n_tokens {
+                        expected[token * rows + row] = decoded
+                            .iter()
+                            .zip(&inputs[token * input_width..(token + 1) * input_width])
+                            .map(|(w, x)| w * x)
+                            .sum();
+                    }
+                }
+
+                let input_buf = kernel.device.new_buffer(
+                    (inputs.len() * 4) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                );
+                let weight_buf = kernel
+                    .device
+                    .new_buffer(wire.len() as u64, MTLResourceOptions::StorageModeShared);
+                let output_buf = kernel.device.new_buffer(
+                    (expected.len() * 4) as u64,
+                    MTLResourceOptions::StorageModeShared,
+                );
+                let scalar = kernel
+                    .device
+                    .new_buffer(12, MTLResourceOptions::StorageModeShared);
+                write_buffer_f32(&input_buf, &inputs);
+                write_buffer_bytes(&weight_buf, &wire);
+                let resident = ResidentLinearWeight {
+                    format,
+                    buffer: weight_buf,
+                    // Page-backed GGUF bytes are 34-byte wire blocks, not the 36-byte
+                    // decoded CPU layout.
+                    q8_wire: true,
+                };
+                let cb = kernel.queue.new_command_buffer();
+                let encoder = cb.new_compute_command_encoder();
+                encode_resident_matmul_f32(
+                    encoder,
+                    kernel,
+                    &mut Vec::new(),
+                    &input_buf,
+                    &resident,
+                    &output_buf,
+                    &scalar,
+                    input_width,
+                    rows,
+                    n_tokens,
+                );
+                encoder.end_encoding();
+                cb.commit();
+                cb.wait_until_completed();
+                let mut got = vec![0.0f32; expected.len()];
+                read_buffer_f32(&output_buf, &mut got);
+                for (i, (&actual, &want)) in got.iter().zip(&expected).enumerate() {
+                    let tolerance = 2.0e-5 * want.abs().max(1.0);
+                    assert!(
+                        (actual - want).abs() <= tolerance,
+                        "Q8_0 blocks_per_row={blocks_per_row} n_tokens={n_tokens} output {i}: \
+                         gpu={actual} cpu={want} tolerance={tolerance}"
+                    );
+                }
+            }
+        }
+    }
+
     /// End-to-end tied-head gate: verifies RMSNorm, no-copy mmap offset binding,
     /// Q8_K activation quantization, Q6_K projection, and final soft-cap against
     /// the established CPU oracles.

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -68,6 +68,22 @@ impl RawMatBytes {
     }
 }
 
+/// Tensor types read into `RawMatBytes::WirePages` rather than an owned `Vec`: those
+/// whose GGUF wire layout is already what the resident Metal kernels read, so the
+/// allocation can be wrapped in place with `newBufferWithBytesNoCopy`. Otherwise
+/// unobservable — `as_slice` is identical either way and `wire_pages` is macOS-only —
+/// at the cost of rounding each tensor up to a page.
+fn wants_page_backing(tt: GgufTensorType) -> bool {
+    matches!(
+        tt,
+        GgufTensorType::Q1_0
+            | GgufTensorType::Q2_0G64
+            | GgufTensorType::Q2_0G128
+            | GgufTensorType::Pq2_0
+            | GgufTensorType::Q8_0
+    )
+}
+
 #[cfg(target_os = "macos")]
 fn log_prism_metal_hybrid_once() {
     static LOGGED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
@@ -539,14 +555,7 @@ impl RunnableModel {
         let load_raw = |f: &mut File, name: &str| -> Result<RawMat> {
             let d = find_tensor(&gguf, name)?;
             let (inf, outf) = mat_dims(d, name)?;
-            let bytes = if matches!(
-                d.tensor_type,
-                GgufTensorType::Q1_0
-                    | GgufTensorType::Q2_0G64
-                    | GgufTensorType::Q2_0G128
-                    | GgufTensorType::Pq2_0
-                    | GgufTensorType::Q8_0
-            ) {
+            let bytes = if wants_page_backing(d.tensor_type) {
                 let byte_len = usize::try_from(d.n_bytes).map_err(|_| {
                     BackendError::InvalidTensorData(format!(
                         "tensor {name} packed byte length {} does not fit usize",
@@ -4411,6 +4420,43 @@ impl RunnableModel {
     }
 }
 
+/// Backing selection is platform-independent — `load_raw` chooses `WirePages` on every
+/// target — so these run everywhere, not just where the resident lane exists.
+#[cfg(test)]
+mod page_backing_selection_tests {
+    use super::*;
+
+    #[test]
+    fn packed_wire_formats_are_page_backed() {
+        // Dropping one returns it to `Owned`, where the resident lane refuses it and
+        // the model falls back to CPU decode with no error.
+        for tt in [
+            GgufTensorType::Q1_0,
+            GgufTensorType::Q2_0G64,
+            GgufTensorType::Q2_0G128,
+            GgufTensorType::Pq2_0,
+            GgufTensorType::Q8_0,
+        ] {
+            assert!(wants_page_backing(tt), "{tt:?} must load into WirePages");
+        }
+    }
+
+    #[test]
+    fn other_formats_keep_ordinary_owned_backing() {
+        // Page-backing costs a page per tensor, so it stays opt-in per format.
+        // K-quants belong here until the resident lane admits them.
+        for tt in [
+            GgufTensorType::F32,
+            GgufTensorType::F16,
+            GgufTensorType::Q4_0,
+            GgufTensorType::Q4K,
+            GgufTensorType::Q6K,
+        ] {
+            assert!(!wants_page_backing(tt), "{tt:?} must stay Owned");
+        }
+    }
+}
+
 /// Resident-Metal admission for Q8_0 projections. These run on any macOS host with no
 /// GGUF and no GPU: they pin the loader-side contract that lets a Q8_0 `qwen35` model
 /// reach the resident lane at all — the format mapping, the page-backing requirement,
@@ -4521,8 +4567,10 @@ mod resident_metal_q8_admission_tests {
 
     #[test]
     fn owned_q8_0_is_refused_instead_of_silently_copied() {
-        // The resident lane wraps the allocation with newBufferWithBytesNoCopy, so a
-        // non-page-aligned `Owned` buffer must fail closed rather than be uploaded.
+        // Variant check only: `Owned` is refused outright, so an ordinary heap tensor
+        // never reaches the resident lane. The page-alignment invariant itself is
+        // `WirePages`' contract, covered by
+        // `metal::tests::wire_mmap_nocopy_buffer_gpu_reads_file_bytes`.
         let m = raw(
             RawMatBytes::owned(q8_0_wire_bytes(Q8_0_BLOCK_VALUES, 1)),
             GgufTensorType::Q8_0,

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -39,7 +39,7 @@ enum RawMatBytes {
     /// their bytes instead of duplicating the largest matrix in the model.
     Owned(Arc<Vec<u8>>),
     /// Page-aligned packed backing. Metal wraps this allocation with
-    /// `newBufferWithBytesNoCopy`, so a Q1/Q2 projection has one resident copy.
+    /// `newBufferWithBytesNoCopy`, so a Q1/Q2 or Q8_0 projection has one resident copy.
     WirePages(Arc<crate::wire_mmap::WirePages>),
 }
 
@@ -4408,6 +4408,135 @@ impl RunnableModel {
             }
         }
         Ok(e)
+    }
+}
+
+/// Resident-Metal admission for Q8_0 projections. These run on any macOS host with no
+/// GGUF and no GPU: they pin the loader-side contract that lets a Q8_0 `qwen35` model
+/// reach the resident lane at all — the format mapping, the page-backing requirement,
+/// and the wire block geometry that makes admitting Q8_0 a no-repack change.
+#[cfg(all(test, target_os = "macos"))]
+mod resident_metal_q8_admission_tests {
+    use super::*;
+    use crate::metal::{ResidentWeightBytes, ResidentWeightFormat};
+    use std::io::Write;
+
+    /// One GGUF `Q8_0` block is an f16 scale followed by 32 int8 quants. The resident
+    /// Metal Q8 GEMV consumes exactly this layout, which is why admitting Q8_0 needs no
+    /// repack. If either side ever diverges from 34/32, these tests are the tripwire.
+    const Q8_0_WIRE_BLOCK_BYTES: usize = 34;
+    const Q8_0_BLOCK_VALUES: usize = 32;
+
+    fn raw(
+        bytes: RawMatBytes,
+        tt: GgufTensorType,
+        in_features: usize,
+        out_features: usize,
+    ) -> RawMat {
+        RawMat {
+            bytes,
+            tt,
+            in_features,
+            out_features,
+        }
+    }
+
+    /// `out_features` rows of `in_features` values each, in Q8_0 wire form.
+    fn q8_0_wire_bytes(in_features: usize, out_features: usize) -> Vec<u8> {
+        let blocks_per_row = in_features / Q8_0_BLOCK_VALUES;
+        (0..out_features * blocks_per_row * Q8_0_WIRE_BLOCK_BYTES)
+            .map(|i| i as u8)
+            .collect()
+    }
+
+    #[test]
+    fn q8_0_maps_to_the_resident_q8_wire_format() {
+        let m = raw(
+            RawMatBytes::owned(q8_0_wire_bytes(Q8_0_BLOCK_VALUES, 1)),
+            GgufTensorType::Q8_0,
+            Q8_0_BLOCK_VALUES,
+            1,
+        );
+        assert_eq!(m.prism_metal_format(), Some(ResidentWeightFormat::Q8_0));
+    }
+
+    #[test]
+    fn prism_low_bit_formats_still_map_unchanged() {
+        for (tt, want) in [
+            (GgufTensorType::Q1_0, ResidentWeightFormat::Q1_0),
+            (GgufTensorType::Q2_0G64, ResidentWeightFormat::Q2_0G64),
+            (GgufTensorType::Q2_0G128, ResidentWeightFormat::Q2_0G128),
+            (GgufTensorType::Pq2_0, ResidentWeightFormat::Q2_0G128),
+        ] {
+            let m = raw(RawMatBytes::owned(vec![0u8; 64]), tt, 128, 1);
+            assert_eq!(m.prism_metal_format(), Some(want), "{tt:?} must still map");
+        }
+    }
+
+    #[test]
+    fn k_quants_are_still_refused_by_the_resident_lane() {
+        // The Q4K/Q6K Metal kernels exist, but this loader does not admit them yet;
+        // admitting one is a separate, separately-evidenced change.
+        for tt in [GgufTensorType::Q4K, GgufTensorType::Q6K] {
+            let m = raw(RawMatBytes::owned(vec![0u8; 256]), tt, 256, 1);
+            assert_eq!(m.prism_metal_format(), None, "{tt:?} must not admit");
+        }
+    }
+
+    #[test]
+    fn page_backed_q8_0_admits_as_a_resident_wire_weight() {
+        let (in_features, out_features) = (Q8_0_BLOCK_VALUES * 2, 3);
+        let wire = q8_0_wire_bytes(in_features, out_features);
+        assert_eq!(
+            wire.len(),
+            out_features * 2 * Q8_0_WIRE_BLOCK_BYTES,
+            "fixture must be an exact number of 34-byte Q8_0 wire blocks"
+        );
+
+        let mut file = tempfile::NamedTempFile::new().expect("temp file");
+        file.write_all(&wire).expect("write wire bytes");
+        file.flush().expect("flush");
+        let pages = crate::wire_mmap::WirePages::read_from_file(file.as_file(), 0, wire.len())
+            .expect("Q8_0 tensors must be page-backable");
+        assert_eq!(
+            pages.bytes(),
+            &wire[..],
+            "page-backing must not alter bytes"
+        );
+
+        let m = raw(
+            RawMatBytes::WirePages(pages),
+            GgufTensorType::Q8_0,
+            in_features,
+            out_features,
+        );
+        match m.prism_metal_weight().expect("page-backed Q8_0 must admit") {
+            ResidentWeightBytes::WirePages { format, pages } => {
+                assert_eq!(format, ResidentWeightFormat::Q8_0);
+                assert_eq!(pages.bytes(), &wire[..]);
+            }
+            _ => panic!("expected page-backed WirePages backing for a Q8_0 projection"),
+        }
+    }
+
+    #[test]
+    fn owned_q8_0_is_refused_instead_of_silently_copied() {
+        // The resident lane wraps the allocation with newBufferWithBytesNoCopy, so a
+        // non-page-aligned `Owned` buffer must fail closed rather than be uploaded.
+        let m = raw(
+            RawMatBytes::owned(q8_0_wire_bytes(Q8_0_BLOCK_VALUES, 1)),
+            GgufTensorType::Q8_0,
+            Q8_0_BLOCK_VALUES,
+            1,
+        );
+        let err = match m.prism_metal_weight() {
+            Ok(_) => panic!("owned Q8_0 must not reach the resident lane"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("not page-backed"),
+            "unexpected error: {err}"
+        );
     }
 }
 

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -68,20 +68,38 @@ impl RawMatBytes {
     }
 }
 
-/// Tensor types read into `RawMatBytes::WirePages` rather than an owned `Vec`: those
-/// whose GGUF wire layout is already what the resident Metal kernels read, so the
-/// allocation can be wrapped in place with `newBufferWithBytesNoCopy`. Otherwise
-/// unobservable — `as_slice` is identical either way and `wire_pages` is macOS-only —
-/// at the cost of rounding each tensor up to a page.
+/// The resident Metal format a GGUF tensor type maps to, or `None` if the resident lane
+/// cannot consume it. Single source of truth: admitting a type here is what makes it
+/// page-backed at load (see [`wants_page_backing`]), so the two cannot drift apart.
+///
+/// Not macOS-gated, because `wants_page_backing` is not: the loader makes the same
+/// backing choice on every target.
+fn resident_metal_format(tt: GgufTensorType) -> Option<crate::metal::ResidentWeightFormat> {
+    match tt {
+        GgufTensorType::Q1_0 => Some(crate::metal::ResidentWeightFormat::Q1_0),
+        GgufTensorType::Q2_0G64 => Some(crate::metal::ResidentWeightFormat::Q2_0G64),
+        GgufTensorType::Q2_0G128 | GgufTensorType::Pq2_0 => {
+            Some(crate::metal::ResidentWeightFormat::Q2_0G128)
+        }
+        // Q8_0 wire blocks (34B: f16 scale + 32 i8) are already the layout the resident
+        // Metal Q8 GEMV consumes, so they need no repack.
+        GgufTensorType::Q8_0 => Some(crate::metal::ResidentWeightFormat::Q8_0),
+        _ => None,
+    }
+}
+
+/// Tensor types read into `RawMatBytes::WirePages` rather than an owned `Vec`, so the
+/// allocation can be wrapped in place with `newBufferWithBytesNoCopy`.
+///
+/// Derived from [`resident_metal_format`] rather than listed again: `prism_metal_weight`
+/// needs a tensor to be *both* page-backed and format-mapped, and when those were two
+/// hand-maintained lists, adding a type to only one left it silently failing the
+/// page-backed check and falling back to CPU decode.
+///
+/// Page-backing is otherwise unobservable — `as_slice` is identical either way and
+/// `wire_pages` is macOS-only — at the cost of rounding each tensor up to a page.
 fn wants_page_backing(tt: GgufTensorType) -> bool {
-    matches!(
-        tt,
-        GgufTensorType::Q1_0
-            | GgufTensorType::Q2_0G64
-            | GgufTensorType::Q2_0G128
-            | GgufTensorType::Pq2_0
-            | GgufTensorType::Q8_0
-    )
+    resident_metal_format(tt).is_some()
 }
 
 #[cfg(target_os = "macos")]
@@ -139,26 +157,11 @@ impl RawMat {
     }
 
     #[cfg(target_os = "macos")]
-    fn prism_metal_format(&self) -> Option<crate::metal::ResidentWeightFormat> {
-        match self.tt {
-            GgufTensorType::Q1_0 => Some(crate::metal::ResidentWeightFormat::Q1_0),
-            GgufTensorType::Q2_0G64 => Some(crate::metal::ResidentWeightFormat::Q2_0G64),
-            GgufTensorType::Q2_0G128 | GgufTensorType::Pq2_0 => {
-                Some(crate::metal::ResidentWeightFormat::Q2_0G128)
-            }
-            // Q8_0 wire blocks (34B: f16 scale + 32 i8) are already the layout the
-            // resident Metal Q8 GEMV consumes, so they need no repack.
-            GgufTensorType::Q8_0 => Some(crate::metal::ResidentWeightFormat::Q8_0),
-            _ => None,
-        }
-    }
-
-    #[cfg(target_os = "macos")]
     fn prism_metal_weight(&self) -> Result<crate::metal::ResidentWeightBytes<'_>> {
         let pages = self.bytes.wire_pages().ok_or_else(|| {
             BackendError::InvalidTensorData("Prism Metal weight is not page-backed".into())
         })?;
-        let format = self.prism_metal_format().ok_or_else(|| {
+        let format = resident_metal_format(self.tt).ok_or_else(|| {
             BackendError::InvalidTensorData(format!(
                 "unsupported Qwen3.5 Metal projection type {:?}",
                 self.tt
@@ -218,7 +221,7 @@ impl RawMat {
         debug_assert_eq!(x.len(), self.in_features);
         #[cfg(target_os = "macos")]
         if let Some(pages) = self.bytes.wire_pages() {
-            if let Some(output) = self.prism_metal_format().and_then(|format| {
+            if let Some(output) = resident_metal_format(self.tt).and_then(|format| {
                 crate::metal::try_prism_wire_matvec_f32(x, pages, format, self.out_features)
             }) {
                 log_prism_metal_hybrid_once();
@@ -357,7 +360,7 @@ impl RawMat {
         let out_f = self.out_features;
         #[cfg(target_os = "macos")]
         if let Some(pages) = self.bytes.wire_pages() {
-            if let Some(output) = self.prism_metal_format().and_then(|format| {
+            if let Some(output) = resident_metal_format(self.tt).and_then(|format| {
                 crate::metal::try_prism_wire_matmul_f32(xs, pages, format, self.out_features)
             }) {
                 log_prism_metal_hybrid_once();
@@ -4420,31 +4423,36 @@ impl RunnableModel {
     }
 }
 
-/// Backing selection is platform-independent — `load_raw` chooses `WirePages` on every
-/// target — so these run everywhere, not just where the resident lane exists.
+/// The resident-format list and the page-backing it drives. Both are platform-
+/// independent — `load_raw` makes the same backing choice on every target — so these
+/// run everywhere, not only where the resident lane exists.
 #[cfg(test)]
-mod page_backing_selection_tests {
+mod resident_format_admission_tests {
     use super::*;
+    use crate::metal::ResidentWeightFormat;
 
     #[test]
-    fn packed_wire_formats_are_page_backed() {
-        // Dropping one returns it to `Owned`, where the resident lane refuses it and
-        // the model falls back to CPU decode with no error.
-        for tt in [
-            GgufTensorType::Q1_0,
-            GgufTensorType::Q2_0G64,
-            GgufTensorType::Q2_0G128,
-            GgufTensorType::Pq2_0,
-            GgufTensorType::Q8_0,
+    fn admitted_types_map_to_a_resident_format_and_page_back() {
+        // One table pins both halves, because page-backing is derived from the mapping.
+        // Dropping an entry returns that type to `Owned`, where the resident lane
+        // refuses it and the model falls back to CPU decode with no error.
+        for (tt, want) in [
+            (GgufTensorType::Q1_0, ResidentWeightFormat::Q1_0),
+            (GgufTensorType::Q2_0G64, ResidentWeightFormat::Q2_0G64),
+            (GgufTensorType::Q2_0G128, ResidentWeightFormat::Q2_0G128),
+            (GgufTensorType::Pq2_0, ResidentWeightFormat::Q2_0G128),
+            (GgufTensorType::Q8_0, ResidentWeightFormat::Q8_0),
         ] {
+            assert_eq!(resident_metal_format(tt), Some(want), "{tt:?} must map");
             assert!(wants_page_backing(tt), "{tt:?} must load into WirePages");
         }
     }
 
     #[test]
-    fn other_formats_keep_ordinary_owned_backing() {
-        // Page-backing costs a page per tensor, so it stays opt-in per format.
-        // K-quants belong here until the resident lane admits them.
+    fn unadmitted_types_neither_map_nor_page_back() {
+        // Page-backing costs a page per tensor, so it stays opt-in. The Q4K/Q6K Metal
+        // kernels exist but this loader does not admit them yet; when one is, adding it
+        // to `resident_metal_format` is the whole change — there is no second list.
         for tt in [
             GgufTensorType::F32,
             GgufTensorType::F16,
@@ -4452,15 +4460,16 @@ mod page_backing_selection_tests {
             GgufTensorType::Q4K,
             GgufTensorType::Q6K,
         ] {
+            assert_eq!(resident_metal_format(tt), None, "{tt:?} must not admit");
             assert!(!wants_page_backing(tt), "{tt:?} must stay Owned");
         }
     }
 }
 
-/// Resident-Metal admission for Q8_0 projections. These run on any macOS host with no
-/// GGUF and no GPU: they pin the loader-side contract that lets a Q8_0 `qwen35` model
-/// reach the resident lane at all — the format mapping, the page-backing requirement,
-/// and the wire block geometry that makes admitting Q8_0 a no-repack change.
+/// The macOS-only half of Q8_0 admission: `prism_metal_weight`'s page-backing
+/// requirement and the wire block geometry that makes admitting Q8_0 a no-repack
+/// change. The format mapping itself is platform-independent and covered above. Runs
+/// on any macOS host with no GGUF and no GPU.
 #[cfg(all(test, target_os = "macos"))]
 mod resident_metal_q8_admission_tests {
     use super::*;
@@ -4493,40 +4502,6 @@ mod resident_metal_q8_admission_tests {
         (0..out_features * blocks_per_row * Q8_0_WIRE_BLOCK_BYTES)
             .map(|i| i as u8)
             .collect()
-    }
-
-    #[test]
-    fn q8_0_maps_to_the_resident_q8_wire_format() {
-        let m = raw(
-            RawMatBytes::owned(q8_0_wire_bytes(Q8_0_BLOCK_VALUES, 1)),
-            GgufTensorType::Q8_0,
-            Q8_0_BLOCK_VALUES,
-            1,
-        );
-        assert_eq!(m.prism_metal_format(), Some(ResidentWeightFormat::Q8_0));
-    }
-
-    #[test]
-    fn prism_low_bit_formats_still_map_unchanged() {
-        for (tt, want) in [
-            (GgufTensorType::Q1_0, ResidentWeightFormat::Q1_0),
-            (GgufTensorType::Q2_0G64, ResidentWeightFormat::Q2_0G64),
-            (GgufTensorType::Q2_0G128, ResidentWeightFormat::Q2_0G128),
-            (GgufTensorType::Pq2_0, ResidentWeightFormat::Q2_0G128),
-        ] {
-            let m = raw(RawMatBytes::owned(vec![0u8; 64]), tt, 128, 1);
-            assert_eq!(m.prism_metal_format(), Some(want), "{tt:?} must still map");
-        }
-    }
-
-    #[test]
-    fn k_quants_are_still_refused_by_the_resident_lane() {
-        // The Q4K/Q6K Metal kernels exist, but this loader does not admit them yet;
-        // admitting one is a separate, separately-evidenced change.
-        for tt in [GgufTensorType::Q4K, GgufTensorType::Q6K] {
-            let m = raw(RawMatBytes::owned(vec![0u8; 256]), tt, 256, 1);
-            assert_eq!(m.prism_metal_format(), None, "{tt:?} must not admit");
-        }
     }
 
     #[test]

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -130,6 +130,9 @@ impl RawMat {
             GgufTensorType::Q2_0G128 | GgufTensorType::Pq2_0 => {
                 Some(crate::metal::ResidentWeightFormat::Q2_0G128)
             }
+            // Q8_0 wire blocks (34B: f16 scale + 32 i8) are already the layout the
+            // resident Metal Q8 GEMV consumes, so they need no repack.
+            GgufTensorType::Q8_0 => Some(crate::metal::ResidentWeightFormat::Q8_0),
             _ => None,
         }
     }
@@ -542,6 +545,7 @@ impl RunnableModel {
                     | GgufTensorType::Q2_0G64
                     | GgufTensorType::Q2_0G128
                     | GgufTensorType::Pq2_0
+                    | GgufTensorType::Q8_0
             ) {
                 let byte_len = usize::try_from(d.n_bytes).map_err(|_| {
                     BackendError::InvalidTensorData(format!(


### PR DESCRIPTION
## What changed

Two type whitelists in `src/runnable/model.rs` now admit `Q8_0`:

1. `load_raw` (~:539) — add `GgufTensorType::Q8_0` to the `matches!` that selects `WirePages` (page-backed) over `RawMatBytes::owned`.
2. `prism_metal_format` (~:126) — add `GgufTensorType::Q8_0 => Some(ResidentWeightFormat::Q8_0)`.

Four lines. No `metal.rs` change, no new kernels, no repack.

## Why

I wanted to run Ornith-1.0-9B (`qwen35`, Q8_0) on the GPU on an Apple Silicon box. Today it is refused by the resident Metal lane and falls back to CPU decode:

```
[qwen35] resident Metal lane failed (invalid tensor data: Prism Metal weight is not page-backed); using hybrid fallback
```

Reading the tree, the Metal side already looked quantization-generic rather than Prism-specific:

- `Qwen35MetalDecode::new` (`metal.rs:16742`) validates geometry only — it never inspects a weight format.
- `encode_resident_matmul_f32` (`metal.rs:12054`) has a first-class `Q8_0` arm at `:12104`.
- `encode_qwen35_ssm_layer` (`metal.rs:18117`) issues all five SSM projections through that same generic dispatcher; the four genuinely SSM-specific kernels operate on f32 activations and never touch a quantized weight.

So the block was the loader, not the kernels. Both gates were scoped to the Prism quants, so `Q8_0` fell through to `owned` and then failed the page-backed check.

Admitting it needs no conversion step: GGUF `Q8_0` on disk (34 B — f16 scale + 32×i8) is already exactly the layout the Metal wire kernel consumes, as `wire_mmap.rs:3-6` notes. Worth adding that `WirePages` is not an mmap but a page-aligned heap allocation filled by one `read_exact_at`, so the 32-byte tensor alignment in GGUF never mattered here. This also follows precedent already in the tree — `src/runnable/vision.rs:1094-1123` page-backs `Q8_0` end-to-end through the same Metal path.

After the change:

```
[qwen35] full Metal resident graph active (packed weights, attention, gated-delta recurrence, FFN, logits, GPU greedy, and request sampling)
```

## Evidence

`bench-generate`, greedy (`--temperature 0`), warm (`--warmup --iterations 2`), `ornith-1.0-9b-Q8_0.gguf` on an M4 MacBook Air 16 GB:

| | before (CPU) | after (Metal resident) |
|---|---|---|
| decode, 5-token prompt | 9.80 tok/s | 11.3–11.5 tok/s |
| decode, 481-token prompt | 4.01–4.11 tok/s | 11.2–11.5 tok/s |
| TTFT, 481-token prompt | 48.5–57.0 s | 36.6 s |
| peak RSS | 8.0–8.2 GB | 4.8–5.2 GB |

**Greedy output is token-for-token identical to the CPU lane** on both the 5-token and the 481-token prompt (32 generated tokens each, token IDs compared directly).

The decode number is worth reading carefully: the Metal lane is context-stable (~11.3 tok/s at both 5 and 481 tokens) while CPU decays with context, so the ratio is ~1.16× at a short prompt and ~2.8× at 481 tokens. The RSS reduction comes from the weights going into Metal no-copy instead of being resident twice.

## Validation

Per `docs/VALIDATION_MATRIX.md`, "Inference/tokenizer/runtime changes" — standard backend gate plus targeted parity artifacts for the affected row:

- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo test --release --lib` — 1630 passed, 0 failed, 24 ignored
- `cargo doc --no-deps` — builds (one pre-existing `invalid_html_tags` warning in `tools/repack_ghost.rs`, untouched here)
- `bash scripts/check-public-scrub.sh` — pass
- Targeted parity: the token-ID comparison above

I could not run the `--all-features` legs locally: that pulls in `cuda`/`cudarc`, which does not build on macOS. Those need CI or a Linux host.

## Docs / compatibility rows

**None changed, deliberately.** Classifying this as **implementation groundwork only** — a lane that already existed now admits a quantization it already had kernels for. It is not a support claim for any row, and I have not touched `README.md`, `COMPATIBILITY.md`, or `STATUS.md`.

## Caveats I want to be upfront about

1. **Prefill is still slow on both lanes** and this PR does not address it — 36.6 s for a 481-token prompt on Metal (~76 ms/token), reproducible across iterations, so it is not shader compilation. Metal improves TTFT only ~1.4× over CPU. The decode numbers should not be read as a prefill claim.
2. **First call in a cold process pays ~15 s of one-time Metal pipeline compilation**, which lands inside the prefill timer. Benchmarks need `--warmup` or the first TTFT is meaningless (I measured 15.8 s cold vs 0.40 s warm on the same 5-token prompt).
3. **Blast radius is wider than `qwen35`, and it is not macOS-gated.** `load_raw` is shared by the whole runnable lane and the page-backing predicate carries no `cfg`, so **every `Q8_0` runnable model page-backs on every target — Linux and Windows included**, not only other macOS models. Same bytes, same size (page-rounded up). It is unobservable off macOS: `RawMatBytes::as_slice()` returns identical bytes for either backing, and `wire_pages()` — the only accessor that distinguishes them — is `#[cfg(target_os = "macos")]`; the CUDA `qwen35` lane already handles `Q8_0` and reads through `as_slice()`. The real off-macOS cost is rounding each tensor allocation up to a page.
4. **`CAMELID_METAL_WIRE=0` with this patch is untested.** `qwen35` passes `q8_wire: true` unconditionally while its weights are genuinely 34-byte wire, so it should stay self-consistent, but I have not exercised that path.
5. **K-quants are still not admitted** (`resident_metal_format` returns `None` for them). The `Q4K`/`Q6K` kernels exist and `CAMELID_METAL_KQUANT` defaults on, so this may be a similar small extension, but it is unverified and belongs in its own PR. Since `07201707` that extension is one arm in one match — page-backing follows from the mapping, so it is no longer possible to admit a type to half the lane.

## Questions

1. **Still open.** Is admitting `Q8_0` here the direction you want, or is the Prism scoping deliberate? This is the only one that needs you.
2. ~~Given caveat 3 — is page-backing every `Q8_0` runnable model acceptable, or would you prefer this scoped to `qwen35`?~~ — I read @karan68's "harmless, but worth stating outright" as the answer: documented rather than narrowed. Caveat 3 above now names the platforms explicitly. Say the word if you'd still rather have it gated; it is a small change.
3. ~~Would you want a macOS-gated resident-vs-CPU parity test in this PR?~~ — added (`metal_q8_0_resident_projection_matches_scalar_decode`), scoped to the resolver seam, since the Q8 GEMV kernels were already covered by `metal_q8_0_ksplit_gemv_matches_cpu_reference`.
4. ~~What evidence bar do you want?~~ — answered with `qa/ornith/G-PARITY-qwen35-metal-macos.md`: token-identical to the pinned llama.cpp `acd79d6` oracle, 4/4.

Happy to restructure or rescope — whichever fits how you want this lane to grow.

🤖 Filed by Claude Code (Fable) on behalf of @heskew

