### PR TITLE
feat(fabric): authenticate to nodes with a bearer token

### DIFF
--- a/src/fabric/forward.rs
+++ b/src/fabric/forward.rs
@@ -109,10 +109,15 @@ pub fn error_message(body: &Value) -> Option<&str> {
 }
 
 /// Send one request to one node.
+///
+/// `bearer` is required by any node started with an API key: `/v1/health` is
+/// exempt from the server's auth but `/v1/chat/completions` is not, so without
+/// it this is the call that comes back 401.
 pub fn forward(
     spec: &NodeSpec,
     path: &str,
     body: &Value,
+    bearer: Option<&str>,
     timeout: Duration,
 ) -> Result<Forwarded, ForwardError> {
     reject_streaming(body)?;
@@ -129,6 +134,7 @@ pub fn forward(
         "POST",
         path,
         Some(&encoded),
+        bearer,
         timeout,
         MAX_RESPONSE_BYTES,
     )
@@ -190,6 +196,7 @@ mod tests {
             &spec("a", 1),
             "/v1/chat/completions",
             &body,
+            None,
             Duration::from_millis(200),
         )
         .expect_err("refused");
@@ -235,6 +242,7 @@ mod tests {
             &spec("windows", 1),
             "/v1/chat/completions",
             &chat_request("m", "hi", 4),
+            None,
             Duration::from_millis(400),
         )
         .expect_err("port 1 is closed");

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -25,6 +25,8 @@ pub(crate) enum HttpError {
     Io(String),
     Malformed(String),
     TooLarge(usize),
+    /// The request could not be written safely; refused before any socket work.
+    InvalidRequest(String),
 }
 
 impl std::fmt::Display for HttpError {
@@ -35,6 +37,7 @@ impl std::fmt::Display for HttpError {
             Self::Io(detail) => write!(f, "connection failed: {detail}"),
             Self::Malformed(detail) => write!(f, "malformed HTTP response: {detail}"),
             Self::TooLarge(limit) => write!(f, "response exceeded {limit} bytes"),
+            Self::InvalidRequest(detail) => write!(f, "cannot build request: {detail}"),
         }
     }
 }
@@ -185,21 +188,68 @@ fn connect_any(addrs: &[SocketAddr], deadline: Instant) -> Result<TcpStream, Htt
     })))
 }
 
+/// Build the request head. Pure, so the header set — including whether an
+/// `Authorization` line is present at all — is tested without a server.
+///
+/// A bearer token is written into the head verbatim, so one carrying a control
+/// character could append headers of its own. That is refused rather than sent.
+/// Neither the error nor anything else here repeats the token's value.
+fn request_head(
+    method: &str,
+    path: &str,
+    authority: &str,
+    body: Option<&[u8]>,
+    bearer: Option<&str>,
+) -> Result<String, HttpError> {
+    let mut head = format!(
+        "{method} {path} HTTP/1.1\r\nHost: {authority}\r\nAccept: application/json\r\nConnection: close\r\n"
+    );
+    if let Some(token) = bearer {
+        if token.is_empty() {
+            return Err(HttpError::InvalidRequest(
+                "bearer token is empty; pass no token rather than an empty one".to_string(),
+            ));
+        }
+        if token.chars().any(char::is_control) {
+            return Err(HttpError::InvalidRequest(
+                "bearer token contains a control character".to_string(),
+            ));
+        }
+        head.push_str(&format!("Authorization: Bearer {token}\r\n"));
+    }
+    if let Some(body) = body {
+        head.push_str("Content-Type: application/json\r\n");
+        head.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+    head.push_str("\r\n");
+    Ok(head)
+}
+
 /// Perform one request/response round trip against a node.
 ///
 /// `timeout` bounds the whole exchange, not each socket operation, so a peer
 /// that dribbles bytes forever still fails on schedule.
+///
+/// `bearer` is sent as `Authorization: Bearer`, which is what a node started
+/// with an API key requires on every route but `/v1/health`.
+// One more parameter than clippy's threshold; every one of them is a distinct
+// property of a single round trip, so bundling them would only move the list.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn request(
     host: &str,
     port: u16,
     method: &str,
     path: &str,
     body: Option<&[u8]>,
+    bearer: Option<&str>,
     timeout: Duration,
     max_body: usize,
 ) -> Result<HttpResponse, HttpError> {
     let deadline = Instant::now() + timeout;
     let authority = format!("{host}:{port}");
+    // Built before resolving, so a request that cannot be written safely is
+    // refused without touching the network.
+    let head = request_head(method, path, &authority, body, bearer)?;
 
     let addrs: Vec<SocketAddr> = authority
         .to_socket_addrs()
@@ -220,13 +270,6 @@ pub(crate) fn request(
     stream
         .set_write_timeout(Some(timeout))
         .map_err(|error| HttpError::Io(error.to_string()))?;
-
-    let mut head = format!("{method} {path} HTTP/1.1\r\nHost: {authority}\r\nAccept: application/json\r\nConnection: close\r\n");
-    if let Some(body) = body {
-        head.push_str("Content-Type: application/json\r\n");
-        head.push_str(&format!("Content-Length: {}\r\n", body.len()));
-    }
-    head.push_str("\r\n");
 
     stream
         .write_all(head.as_bytes())
@@ -383,12 +426,103 @@ mod tests {
     }
 
     #[test]
+    fn a_bearer_token_becomes_an_authorization_header() {
+        let head = request_head(
+            "POST",
+            "/v1/chat/completions",
+            "node:8181",
+            Some(b"{}"),
+            Some("s3cret"),
+        )
+        .expect("a well-formed token is sendable");
+        assert!(
+            head.contains("\r\nAuthorization: Bearer s3cret\r\n"),
+            "{head}"
+        );
+        // The rest of the head must survive the new line unchanged.
+        assert!(
+            head.starts_with("POST /v1/chat/completions HTTP/1.1\r\n"),
+            "{head}"
+        );
+        assert!(head.contains("\r\nHost: node:8181\r\n"), "{head}");
+        assert!(head.contains("\r\nContent-Length: 2\r\n"), "{head}");
+        assert!(head.ends_with("\r\n\r\n"), "{head}");
+    }
+
+    #[test]
+    fn no_token_means_no_authorization_header_at_all() {
+        // Not an empty one: an unauthenticated node must see the same request it
+        // saw before the fabric learned about bearer tokens.
+        let head = request_head("GET", "/v1/health", "node:8181", None, None).expect("builds");
+        assert!(
+            !head.to_ascii_lowercase().contains("authorization"),
+            "{head}"
+        );
+        assert_eq!(
+            head,
+            "GET /v1/health HTTP/1.1\r\nHost: node:8181\r\nAccept: application/json\r\n\
+             Connection: close\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn a_token_carrying_a_control_character_is_refused_rather_than_written() {
+        // Writing this verbatim would let the token inject headers of its own.
+        // `s3cret` appears in no refusal wording, so finding it in the message
+        // would mean the value leaked rather than merely the word "token".
+        for token in ["s3cret\r\nX-Injected: 1", "s3cret\n", "s3cret\0"] {
+            let error = request_head("GET", "/v1/health", "node:8181", None, Some(token))
+                .expect_err("a control character is not sendable");
+            match &error {
+                HttpError::InvalidRequest(detail) => {
+                    assert!(
+                        !detail.contains("s3cret"),
+                        "the token must not be echoed: {detail}"
+                    )
+                }
+                other => panic!("expected InvalidRequest, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn an_empty_token_is_refused_rather_than_sent_as_a_bare_bearer() {
+        // `Authorization: Bearer ` is rejected by the server anyway; failing here
+        // says why instead of arriving as an unexplained 401.
+        assert!(matches!(
+            request_head("GET", "/v1/health", "node:8181", None, Some("")),
+            Err(HttpError::InvalidRequest(_))
+        ));
+    }
+
+    #[test]
+    fn an_unsendable_token_is_refused_before_a_socket_is_opened() {
+        // Port 1 is closed, so a connect error here would prove we dialled first.
+        let error = request(
+            "127.0.0.1",
+            1,
+            "GET",
+            "/v1/health",
+            None,
+            Some("bad\r\ntoken"),
+            Duration::from_millis(500),
+            LIMIT,
+        )
+        .expect_err("refused");
+        assert!(
+            matches!(error, HttpError::InvalidRequest(_)),
+            "must refuse before dialling, got {error:?}"
+        );
+    }
+
+    #[test]
     fn a_closed_port_reports_connect_failure_not_a_panic() {
         let error = request(
             "127.0.0.1",
             1,
             "GET",
             "/v1/health",
+            None,
             None,
             Duration::from_millis(500),
             LIMIT,
@@ -407,6 +541,7 @@ mod tests {
             8181,
             "GET",
             "/v1/health",
+            None,
             None,
             Duration::from_millis(500),
             LIMIT,

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -40,10 +40,23 @@ pub use policy::{route, RouteDecision, RouteError, RouteMode, RouteReason, Route
 pub use probe::{probe_fabric, probe_node, ProbeError, DEFAULT_PROBE_TIMEOUT};
 
 /// A configured set of nodes.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Fabric {
     specs: Vec<NodeSpec>,
     timeout: Duration,
+    bearer: Option<String>,
+}
+
+/// Hand-written so a token can never reach a log through a derived `Debug`,
+/// the way `ServerPolicyOptions` redacts the key it holds.
+impl std::fmt::Debug for Fabric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Fabric")
+            .field("specs", &self.specs)
+            .field("timeout", &self.timeout)
+            .field("bearer", &self.bearer.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
 }
 
 impl Fabric {
@@ -51,11 +64,22 @@ impl Fabric {
         Self {
             specs,
             timeout: DEFAULT_PROBE_TIMEOUT,
+            bearer: None,
         }
     }
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Authenticate to every node with this bearer token.
+    ///
+    /// Required against a node started with an API key: `/v1/health` is exempt
+    /// from the server's auth, so without a token such a node observes as ready
+    /// and places fine, then answers the request itself with 401.
+    pub fn with_bearer(mut self, bearer: Option<&str>) -> Self {
+        self.bearer = bearer.map(str::to_string);
         self
     }
 
@@ -69,7 +93,7 @@ impl Fabric {
 
     /// Observe every node once.
     pub fn observe(&self) -> Vec<NodeSnapshot> {
-        probe_fabric(&self.specs, self.timeout)
+        probe_fabric(&self.specs, self.bearer.as_deref(), self.timeout)
     }
 
     /// Observe every node once and choose one for a request.
@@ -104,7 +128,13 @@ impl Fabric {
         forward::reject_streaming(body)?;
 
         let (decision, chosen) = self.place(request)?;
-        let answer = forward::forward(&chosen.spec, path, body, forward_timeout)?;
+        let answer = forward::forward(
+            &chosen.spec,
+            path,
+            body,
+            self.bearer.as_deref(),
+            forward_timeout,
+        )?;
         Ok((decision, answer))
     }
 }
@@ -326,6 +356,19 @@ mod tests {
         let fabric = Fabric::new(Vec::new());
         assert!(fabric.is_empty());
         assert!(fabric.observe().is_empty());
+    }
+
+    #[test]
+    fn a_configured_token_is_never_exposed_by_debug() {
+        // A `Fabric` is the kind of thing that ends up in an error context or a
+        // trace line, so the derived `Debug` would have been a leak.
+        let authenticated = format!("{:?}", Fabric::new(Vec::new()).with_bearer(Some("s3cret")));
+        assert!(!authenticated.contains("s3cret"), "{authenticated}");
+        assert!(authenticated.contains("REDACTED"), "{authenticated}");
+
+        // Having no token reads as absent rather than as a redacted one.
+        let open = format!("{:?}", Fabric::new(Vec::new()));
+        assert!(open.contains("bearer: None"), "{open}");
     }
 
     #[test]

--- a/src/fabric/probe.rs
+++ b/src/fabric/probe.rs
@@ -90,13 +90,18 @@ fn classify(payload: &HealthPayload) -> NodeStatus {
     })
 }
 
-fn read_health(spec: &NodeSpec, timeout: Duration) -> Result<HealthPayload, ProbeError> {
+fn read_health(
+    spec: &NodeSpec,
+    bearer: Option<&str>,
+    timeout: Duration,
+) -> Result<HealthPayload, ProbeError> {
     let response = http::request(
         &spec.host,
         spec.port,
         "GET",
         "/v1/health",
         None,
+        bearer,
         timeout,
         MAX_HEALTH_BYTES,
     )?;
@@ -107,11 +112,27 @@ fn read_health(spec: &NodeSpec, timeout: Duration) -> Result<HealthPayload, Prob
         .map_err(|error| ProbeError::Json(error.to_string()))
 }
 
+/// Why a probe left a node unroutable. Pure.
+///
+/// `/v1/health` is exempt from the server's auth today, so a rejected
+/// credential cannot reach here yet. If that exemption is ever tightened, the
+/// bare status would render as "offline" and send an operator hunting a network
+/// fault instead of a missing key, so 401 and 403 say what they mean.
+fn unreachable_reason(error: &ProbeError) -> String {
+    match error {
+        ProbeError::Status(code @ (401 | 403)) => format!(
+            "node rejected the fabric's credentials (HTTP {code}); \
+             pass --bearer or set CAMELID_API_KEY"
+        ),
+        other => other.to_string(),
+    }
+}
+
 /// Probe one node. Never fails: an unreachable node is a routing fact, not an
 /// error the caller has to handle separately.
-pub fn probe_node(spec: &NodeSpec, timeout: Duration) -> NodeSnapshot {
+pub fn probe_node(spec: &NodeSpec, bearer: Option<&str>, timeout: Duration) -> NodeSnapshot {
     let started = Instant::now();
-    match read_health(spec, timeout) {
+    match read_health(spec, bearer, timeout) {
         Ok(payload) => NodeSnapshot {
             spec: spec.clone(),
             status: classify(&payload),
@@ -120,7 +141,7 @@ pub fn probe_node(spec: &NodeSpec, timeout: Duration) -> NodeSnapshot {
         Err(error) => NodeSnapshot {
             spec: spec.clone(),
             status: NodeStatus::Unreachable {
-                reason: error.to_string(),
+                reason: unreachable_reason(&error),
             },
             latency: None,
         },
@@ -131,14 +152,18 @@ pub fn probe_node(spec: &NodeSpec, timeout: Duration) -> NodeSnapshot {
 ///
 /// Sequential probing would make a fabric's status cost the sum of its timeouts,
 /// so a single dead node would stall the view of every live one.
-pub fn probe_fabric(specs: &[NodeSpec], timeout: Duration) -> Vec<NodeSnapshot> {
+pub fn probe_fabric(
+    specs: &[NodeSpec],
+    bearer: Option<&str>,
+    timeout: Duration,
+) -> Vec<NodeSnapshot> {
     if specs.is_empty() {
         return Vec::new();
     }
     std::thread::scope(|scope| {
         let handles: Vec<_> = specs
             .iter()
-            .map(|spec| scope.spawn(move || probe_node(spec, timeout)))
+            .map(|spec| scope.spawn(move || probe_node(spec, bearer, timeout)))
             .collect();
         handles
             .into_iter()
@@ -232,7 +257,7 @@ mod tests {
 
     #[test]
     fn probing_an_empty_fabric_does_no_work() {
-        assert!(probe_fabric(&[], DEFAULT_PROBE_TIMEOUT).is_empty());
+        assert!(probe_fabric(&[], None, DEFAULT_PROBE_TIMEOUT).is_empty());
     }
 
     #[test]
@@ -243,8 +268,30 @@ mod tests {
             host: "127.0.0.1".to_string(),
             port: 1,
         };
-        let snapshot = probe_node(&spec, Duration::from_millis(500));
+        let snapshot = probe_node(&spec, None, Duration::from_millis(500));
         assert!(matches!(snapshot.status, NodeStatus::Unreachable { .. }));
         assert_eq!(snapshot.label(), "dead");
+    }
+
+    #[test]
+    fn a_rejected_credential_names_the_key_rather_than_reading_as_offline() {
+        for code in [401, 403] {
+            let reason = unreachable_reason(&ProbeError::Status(code));
+            assert!(reason.contains("credentials"), "{reason}");
+            assert!(reason.contains("--bearer"), "{reason}");
+            assert!(reason.contains(&code.to_string()), "{reason}");
+        }
+    }
+
+    #[test]
+    fn every_other_probe_failure_keeps_its_own_wording() {
+        assert_eq!(
+            unreachable_reason(&ProbeError::Status(503)),
+            "health endpoint answered HTTP 503"
+        );
+        assert_eq!(
+            unreachable_reason(&ProbeError::Transport("cannot connect".to_string())),
+            "cannot connect"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -823,6 +823,28 @@ fn route_mode(raw: &str) -> anyhow::Result<camelid::fabric::RouteMode> {
     }
 }
 
+/// Resolve the token the fabric authenticates to its nodes with.
+///
+/// Deliberately not `#[arg(env = "CAMELID_API_KEY")]`: clap prints an env var's
+/// current value in `--help`, which would put the token on the terminal.
+fn fabric_bearer(flag: Option<String>) -> Option<String> {
+    resolve_bearer(flag, std::env::var("CAMELID_API_KEY").ok())
+}
+
+/// Choose between an explicit flag and the environment. Pure, so the precedence
+/// is tested without a process-wide variable.
+///
+/// The flag wins; otherwise `CAMELID_API_KEY`, the same variable the server
+/// reads its own key from, so a shell configured for one node needs no second
+/// setting. Trimmed and emptiness-checked the way the server treats its own key,
+/// so a value that arrived with a trailing newline still matches, and an empty
+/// one reads as "no token" rather than becoming a bare `Bearer `.
+fn resolve_bearer(flag: Option<String>, from_env: Option<String>) -> Option<String> {
+    flag.or(from_env)
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
+}
+
 /// Actions over a fabric of independent Camelid nodes.
 ///
 /// A fabric places whole requests on nodes that each own a complete model and
@@ -836,6 +858,11 @@ enum FabricAction {
         /// A node, as `LABEL=HOST[:PORT]`. Repeat for each node.
         #[arg(long = "node", required = true, value_name = "LABEL=HOST[:PORT]")]
         nodes: Vec<String>,
+        /// Bearer token for nodes started with an API key. Falls back to
+        /// CAMELID_API_KEY. Prefer the variable on a shared machine, so the
+        /// secret is not in the process command line.
+        #[arg(long, value_name = "TOKEN")]
+        bearer: Option<String>,
         /// Per-node probe budget. Nodes are probed concurrently, so this bounds
         /// the whole command, not each node in turn.
         #[arg(long, default_value_t = 2000)]
@@ -860,6 +887,10 @@ enum FabricAction {
         /// Label of the node that served this session previously.
         #[arg(long)]
         sticky: Option<String>,
+        /// Bearer token for nodes started with an API key. Falls back to
+        /// CAMELID_API_KEY.
+        #[arg(long, value_name = "TOKEN")]
+        bearer: Option<String>,
         #[arg(long, default_value_t = 2000)]
         timeout_ms: u64,
         #[arg(long)]
@@ -883,6 +914,11 @@ enum FabricAction {
         model: Option<String>,
         #[arg(long)]
         sticky: Option<String>,
+        /// Bearer token for nodes started with an API key. Falls back to
+        /// CAMELID_API_KEY. Without it, a node that requires a key observes as
+        /// ready and then answers this request with 401.
+        #[arg(long, value_name = "TOKEN")]
+        bearer: Option<String>,
         #[arg(long, default_value_t = 64)]
         max_tokens: u32,
         /// Per-node health probe budget.
@@ -894,6 +930,85 @@ enum FabricAction {
         #[arg(long)]
         json: bool,
     },
+}
+
+#[cfg(test)]
+mod fabric_command_tests {
+    use super::*;
+
+    /// The parsed `Cli` is large enough to want more than a test thread's
+    /// default stack, the same reason `workspace_command_tests` does this.
+    fn on_cli_test_stack(test: impl FnOnce() + Send + 'static) {
+        std::thread::Builder::new()
+            .name("fabric-cli-parse-test".into())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(test)
+            .expect("spawn fabric CLI parse test")
+            .join()
+            .expect("fabric CLI parse test panicked");
+    }
+
+    #[test]
+    fn an_explicit_flag_beats_the_environment() {
+        assert_eq!(
+            resolve_bearer(Some("from-flag".into()), Some("from-env".into())),
+            Some("from-flag".to_string())
+        );
+    }
+
+    #[test]
+    fn the_environment_is_the_fallback_not_the_only_source() {
+        assert_eq!(
+            resolve_bearer(None, Some("from-env".into())),
+            Some("from-env".to_string())
+        );
+        assert_eq!(resolve_bearer(None, None), None);
+    }
+
+    #[test]
+    fn a_token_is_trimmed_the_way_the_server_trims_its_own_key() {
+        // A key exported from a file commonly arrives with a trailing newline;
+        // sending that verbatim would never match the server's trimmed key.
+        assert_eq!(
+            resolve_bearer(None, Some("  s3cret\n".into())),
+            Some("s3cret".to_string())
+        );
+    }
+
+    #[test]
+    fn an_empty_or_blank_token_reads_as_no_token() {
+        // `CAMELID_API_KEY=` is set-but-empty; treating it as a token would send
+        // a bare `Bearer ` that the server rejects for a confusing reason.
+        assert_eq!(resolve_bearer(None, Some(String::new())), None);
+        assert_eq!(resolve_bearer(None, Some("   ".into())), None);
+        assert_eq!(resolve_bearer(Some("  ".into()), None), None);
+    }
+
+    #[test]
+    fn every_fabric_subcommand_accepts_a_bearer() {
+        // `run` is the one that 401s without it, but `status` and `route` must
+        // take it too or they would keep predicting what `run` cannot do.
+        on_cli_test_stack(|| {
+            for argv in [
+                vec!["camelid", "fabric", "status"],
+                vec!["camelid", "fabric", "route"],
+                vec!["camelid", "fabric", "run", "--prompt", "hi"],
+            ] {
+                let mut argv = argv;
+                argv.extend(["--node", "a=127.0.0.1", "--bearer", "s3cret"]);
+                let cli = Cli::try_parse_from(&argv).expect("parses");
+                let bearer = match cli.command {
+                    Some(Command::Fabric { action }) => match action {
+                        FabricAction::Status { bearer, .. }
+                        | FabricAction::Route { bearer, .. }
+                        | FabricAction::Run { bearer, .. } => bearer,
+                    },
+                    other => panic!("expected a fabric command, got {other:?}"),
+                };
+                assert_eq!(bearer.as_deref(), Some("s3cret"), "{argv:?}");
+            }
+        });
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -2370,13 +2485,16 @@ async fn main() -> anyhow::Result<()> {
         Command::Fabric { action } => match action {
             FabricAction::Status {
                 nodes,
+                bearer,
                 timeout_ms,
                 json,
             } => {
+                let bearer = fabric_bearer(bearer);
                 let specs = camelid::fabric::parse_fabric(&nodes)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)
-                    .with_timeout(std::time::Duration::from_millis(timeout_ms));
+                    .with_timeout(std::time::Duration::from_millis(timeout_ms))
+                    .with_bearer(bearer.as_deref());
                 let snapshots = fabric.observe();
                 if json {
                     println!("{}", serde_json::to_string_pretty(&snapshots)?);
@@ -2389,14 +2507,17 @@ async fn main() -> anyhow::Result<()> {
                 mode,
                 model,
                 sticky,
+                bearer,
                 timeout_ms,
                 json,
             } => {
+                let bearer = fabric_bearer(bearer);
                 let mode = route_mode(&mode)?;
                 let specs = camelid::fabric::parse_fabric(&nodes)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)
-                    .with_timeout(std::time::Duration::from_millis(timeout_ms));
+                    .with_timeout(std::time::Duration::from_millis(timeout_ms))
+                    .with_bearer(bearer.as_deref());
                 let snapshots = fabric.observe();
                 let request = camelid::fabric::RouteRequest::new(mode)
                     .with_model(model.as_deref())
@@ -2432,16 +2553,19 @@ async fn main() -> anyhow::Result<()> {
                 mode,
                 model,
                 sticky,
+                bearer,
                 max_tokens,
                 timeout_ms,
                 forward_timeout_s,
                 json,
             } => {
+                let bearer = fabric_bearer(bearer);
                 let mode = route_mode(&mode)?;
                 let specs = camelid::fabric::parse_fabric(&nodes)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)
-                    .with_timeout(std::time::Duration::from_millis(timeout_ms));
+                    .with_timeout(std::time::Duration::from_millis(timeout_ms))
+                    .with_bearer(bearer.as_deref());
 
                 let request = camelid::fabric::RouteRequest::new(mode)
                     .with_model(model.as_deref())
@@ -2470,6 +2594,7 @@ async fn main() -> anyhow::Result<()> {
                     &chosen.spec,
                     "/v1/chat/completions",
                     &body,
+                    bearer.as_deref(),
                     std::time::Duration::from_secs(forward_timeout_s),
                 )
                 .map_err(|error| anyhow::anyhow!("{error}"))?;

--- a/tests/fabric_end_to_end.rs
+++ b/tests/fabric_end_to_end.rs
@@ -30,6 +30,17 @@ struct Received {
     method: String,
     path: String,
     body: String,
+    /// Header names lowercased; values verbatim.
+    headers: Vec<(String, String)>,
+}
+
+impl Received {
+    fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(header, _)| header == name)
+            .map(|(_, value)| value.as_str())
+    }
 }
 
 #[derive(Clone)]
@@ -39,6 +50,10 @@ struct StubConfig {
     /// Body served from `/v1/chat/completions`.
     completion: String,
     completion_status: u16,
+    /// When set, every route but `/v1/health` answers 401 unless the request
+    /// carries exactly this bearer token — the arrangement a node started with
+    /// `CAMELID_API_KEY` actually presents to the fabric.
+    required_key: Option<String>,
 }
 
 impl StubConfig {
@@ -53,6 +68,7 @@ impl StubConfig {
                 r#"{{"choices":[{{"message":{{"role":"assistant","content":"served by {model}"}}}}]}}"#
             ),
             completion_status: 200,
+            required_key: None,
         }
     }
 
@@ -61,6 +77,7 @@ impl StubConfig {
             health: r#"{"ok":true,"generation_ready":false,"active_model_id":null}"#.to_string(),
             completion: "{}".to_string(),
             completion_status: 200,
+            required_key: None,
         }
     }
 
@@ -68,6 +85,14 @@ impl StubConfig {
         Self {
             completion: r#"{"error":{"message":"engine queue full"}}"#.to_string(),
             completion_status: 503,
+            ..Self::ready(model, 0)
+        }
+    }
+
+    /// A node with an API key set: health stays open, generation does not.
+    fn requiring_key(model: &str, key: &str) -> Self {
+        Self {
+            required_key: Some(key.to_string()),
             ..Self::ready(model, 0)
         }
     }
@@ -139,7 +164,22 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
         return;
     };
 
+    // Mirrors `route_requires_auth` in the real server: `/v1/health` is exempt,
+    // everything else is gated.
+    let authorized = match &config.required_key {
+        Some(key) => {
+            received.path == "/v1/health"
+                || received.header("authorization") == Some(&format!("Bearer {key}"))
+        }
+        None => true,
+    };
+
     let (status, body) = match received.path.as_str() {
+        _ if !authorized => (
+            401,
+            r#"{"error":{"message":"provide Authorization: Bearer <key> or X-API-Key"}}"#
+                .to_string(),
+        ),
         "/v1/health" => (200_u16, config.health.clone()),
         "/v1/chat/completions" => (config.completion_status, config.completion.clone()),
         _ => (404, "{}".to_string()),
@@ -181,6 +221,7 @@ fn read_request(stream: &mut TcpStream) -> Option<Received> {
                 method: parts.next()?.to_string(),
                 path: parts.next()?.to_string(),
                 body,
+                headers: parse_headers(&head),
             });
         }
     }
@@ -189,6 +230,15 @@ fn read_request(stream: &mut TcpStream) -> Option<Received> {
 
 fn find_header_end(raw: &[u8]) -> Option<usize> {
     raw.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+/// Every header line after the request line, names lowercased for lookup.
+fn parse_headers(head: &str) -> Vec<(String, String)> {
+    head.lines()
+        .skip(1)
+        .filter_map(|line| line.split_once(':'))
+        .map(|(name, value)| (name.trim().to_ascii_lowercase(), value.trim().to_string()))
+        .collect()
 }
 
 fn content_length(head: &str) -> Option<usize> {
@@ -329,7 +379,7 @@ fn forwarding_sends_a_well_formed_request_and_returns_the_answer() {
     let spec = alpha.spec("alpha");
 
     let body = forward::chat_request("model-alpha", "ping", 8);
-    let answer = forward::forward(&spec, "/v1/chat/completions", &body, FORWARD_TIMEOUT)
+    let answer = forward::forward(&spec, "/v1/chat/completions", &body, None, FORWARD_TIMEOUT)
         .expect("stub answers");
 
     assert!(answer.is_success());
@@ -363,6 +413,7 @@ fn an_engine_refusal_is_the_nodes_answer_not_a_transport_failure() {
         &spec,
         "/v1/chat/completions",
         &forward::chat_request("model-alpha", "ping", 8),
+        None,
         FORWARD_TIMEOUT,
     )
     .expect("a 503 is an answer, not an error");
@@ -422,6 +473,116 @@ fn dispatch_refuses_streaming_before_touching_the_network() {
     assert!(
         error.to_string().contains("streaming"),
         "unexpected: {error}"
+    );
+}
+
+#[test]
+fn a_fabric_carrying_the_key_is_served_by_an_authenticated_node() {
+    let alpha = StubNode::start(StubConfig::requiring_key("model-alpha", "s3cret"));
+    let fabric = fabric_of(vec![alpha.spec("alpha")]).with_bearer(Some("s3cret"));
+
+    let (decision, answer) = fabric
+        .dispatch(
+            "/v1/chat/completions",
+            &forward::chat_request("model-alpha", "ping", 8),
+            &RouteRequest::new(RouteMode::Throughput),
+            FORWARD_TIMEOUT,
+        )
+        .expect("the node accepts our key");
+
+    assert_eq!(decision.label, "alpha");
+    assert_eq!(answer.status, 200);
+    assert_eq!(
+        forward::completion_text(&answer.body),
+        Some("served by model-alpha")
+    );
+
+    // Every request carried the token, the probe included. Health is exempt from
+    // the server's auth today, so sending it there buys nothing now — it means
+    // placement keeps working if that exemption is ever tightened.
+    let seen = alpha.received();
+    assert!(
+        seen.iter().any(|request| request.path == "/v1/health"),
+        "the node was probed as well as sent to"
+    );
+    for request in &seen {
+        assert_eq!(
+            request.header("authorization"),
+            Some("Bearer s3cret"),
+            "`{}` went out unauthenticated",
+            request.path
+        );
+    }
+}
+
+#[test]
+fn a_missing_or_wrong_key_arrives_as_a_401_answer_not_a_transport_failure() {
+    // The defect this flag exists for. `/v1/health` is auth-exempt, so an
+    // authenticated node observes as ready and places fine; only the forward is
+    // refused. That refusal is the node answering, so it must reach the caller
+    // with its status rather than as a `Transport` error naming a dead node.
+    let alpha = StubNode::start(StubConfig::requiring_key("model-alpha", "s3cret"));
+
+    let unauthenticated = fabric_of(vec![alpha.spec("alpha")]);
+    let snapshots = unauthenticated.observe();
+    assert_eq!(
+        snapshots[0].active_model_id(),
+        Some("model-alpha"),
+        "health is exempt, so status still reads the node as ready"
+    );
+    assert_eq!(
+        route(&snapshots, &RouteRequest::new(RouteMode::Throughput))
+            .expect("placement succeeds even though the request will not")
+            .label,
+        "alpha"
+    );
+
+    // A wrong key is refused exactly as plainly as no key — and proves the stub
+    // compares the token rather than merely noticing one is present.
+    for fabric in [
+        unauthenticated,
+        fabric_of(vec![alpha.spec("alpha")]).with_bearer(Some("wrong-key")),
+    ] {
+        let (_, answer) = fabric
+            .dispatch(
+                "/v1/chat/completions",
+                &forward::chat_request("model-alpha", "ping", 8),
+                &RouteRequest::new(RouteMode::Throughput),
+                FORWARD_TIMEOUT,
+            )
+            .expect("a 401 is the node's answer, not a forwarding failure");
+
+        assert_eq!(answer.status, 401);
+        assert!(!answer.is_success());
+        assert!(
+            forward::error_message(&answer.body).is_some(),
+            "the refusal must carry a message an operator can act on"
+        );
+    }
+}
+
+#[test]
+fn an_unauthenticated_fabric_sends_no_authorization_header_at_all() {
+    // An open node must see exactly the request it saw before the fabric learned
+    // about tokens — not a header with an empty credential.
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let fabric = fabric_of(vec![alpha.spec("alpha")]);
+
+    fabric
+        .dispatch(
+            "/v1/chat/completions",
+            &forward::chat_request("model-alpha", "ping", 8),
+            &RouteRequest::new(RouteMode::Throughput),
+            FORWARD_TIMEOUT,
+        )
+        .expect("an open node answers");
+
+    let seen = alpha.received();
+    assert!(!seen.is_empty(), "the node was reached");
+    assert!(
+        seen.iter()
+            .all(|request| request.header("authorization").is_none()),
+        "an unconfigured fabric must not send an Authorization header"
     );
 }
 


### PR DESCRIPTION
## What

Threads an optional bearer token through `src/fabric/`, and adds `--bearer` to `camelid fabric {status,route,run}`.

Closes the auth gap recorded in the [#616 review](https://github.com/timtoole02/Camelid/pull/616#pullrequestreview) before merge.

## The defect

`src/fabric/` never sent an `Authorization` or `X-API-Key` header, while `route_requires_auth` in `src/api/server.rs` exempts `/v1/health` and gates everything else. Against a node started with `CAMELID_API_KEY`, the health probe succeeded and the request did not:

```
$ camelid fabric status --node stub=localhost:8199
NODE   ADDRESS         STATE      MODEL                     LOAD    DETAIL
stub   localhost:8199  ready      stub-model                0       llama · 10 ms

$ camelid fabric route --node stub=localhost:8199
route -> stub (OnlyCandidate)

$ camelid fabric run --node stub=localhost:8199 --prompt hello
[stub · OnlyCandidate · stub-model · 6 ms]
(no completion text; HTTP 401)
Error: node `stub` answered HTTP 401: provide Authorization: Bearer <key> or X-API-Key
```

That breaks the property #616 claims for itself — *placement is deterministic, so `fabric route` predicts what the fabric will actually do*. Under auth the dry run predicted a success that could not happen.

It compounds with the server refusing an unauthenticated non-loopback bind without `--allow-unauthenticated-remote`, so the only multi-machine fabric that worked was one where every node was fully unauthenticated on the LAN.

## The change

| File | Change |
| --- | --- |
| `fabric/http.rs` | `request()` takes `bearer: Option<&str>`; head construction extracted to a pure `request_head` |
| `fabric/probe.rs` | Threaded through `read_health`, `probe_node`, `probe_fabric`; 401/403 named rather than rendered as "offline" |
| `fabric/forward.rs` | Threaded through `forward()` — the path that actually 401s |
| `fabric/mod.rs` | `Fabric` gains `bearer` plus a `with_bearer()` builder; passed from `observe`, `place`, `dispatch` |
| `main.rs` | `--bearer <TOKEN>` on all three subcommands, falling back to `CAMELID_API_KEY` |

The probe sends the token even though `/v1/health` is auth-exempt today. It costs nothing now and means placement keeps working if that exemption is ever tightened.

## Three judgement calls worth reviewing

**`Debug` on `Fabric` is hand-written.** The derived one would have printed the token, and a `Fabric` is exactly the sort of value that ends up in an error context. It now redacts, matching how `ServerPolicyOptions` treats the key it holds. Pinned by a test.

**`--bearer` deliberately does not use `#[arg(env = "CAMELID_API_KEY")]`.** clap prints an env-backed argument's *current value* in `--help`, which would put the token on the terminal. The fallback is an explicit `std::env::var` instead, trimmed and emptiness-checked the way the server treats its own key. Confirmed on this branch: with `CAMELID_API_KEY` exported, `fabric run --help` does not echo it — but `serve --help` does, via the pre-existing `env` attribute on `ServerPolicyArgs::api_key`. That is a separate pre-existing leak and is left alone here.

**A control character in a token is refused before a socket is opened.** The token is written into the request head verbatim, so one carrying CRLF could append headers of its own. This adds one `HttpError::InvalidRequest` variant; neither the error nor anything else repeats the value. The trust boundary here is thin — the operator supplies their own key — so this is defence in depth rather than a fix for a reachable attack.

Also, per the review's note that `probe_node` mapped every failure to `Unreachable`: a rejected credential now says so (`node rejected the fabric's credentials (HTTP 401); pass --bearer or set CAMELID_API_KEY`) rather than reading as a dead node. This stops short of a new `NodeStatus` variant — that would change the `--json` contract and ripple through `policy`, `render_status` and `FabricSummary` for a case the health exemption makes unreachable today.

## Verification

**Against a stub node** gating `/v1/chat/completions` exactly as the server does:

| Case | Result |
| --- | --- |
| No token | 401, exit 1 (the reproduction above) |
| `--bearer s3cret` | 200, completion returned |
| `--bearer wrong-key` | 401 surfaced as an answer, not a transport error |
| `CAMELID_API_KEY` set, no flag | 200 — fallback works |
| env `s3cret` + `--bearer wrong-key` | 401 — the flag wins |
| `CAMELID_API_KEY` set, `fabric run --help` | token absent from output |

**Tests.** Unit in `http.rs`: the head carries `Authorization: Bearer ...` with a token and contains no `authorization` at all without one (asserted against the exact head, so an empty `Bearer ` would fail). Integration: `StubNode` now records request headers and has a `requiring_key` mode; a fabric with the right token gets 200 with every request authenticated including the probe, and one with no token — or a wrong one — gets the 401 as a `Forwarded` rather than a `ForwardError`. The right-key and wrong-key cases are mutually validating: neither an always-401 stub nor a presence-only check would pass both.

## Gates

| Gate | Result |
| --- | --- |
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo test --lib fabric::` | 73 passed / 0 failed |
| `cargo test --test fabric_end_to_end` | 14 passed / 0 failed |
| `cargo test --bin camelid fabric_command_tests` | 5 passed / 0 failed |
| `cargo test --lib` (full) | 1656 passed / 0 failed / 84 ignored |
| `bash scripts/check-public-scrub.sh` | clean |
| `git diff --check` | clean |

## Not in this PR

No `X-API-Key` alternative — the server accepts either and `Authorization` is the documented form. No token for `chat`/`serve-distributed`. No per-node tokens: one token covers the fabric, which fits the case where nodes share an operator, and a heterogeneous fabric would want the token in the node spec rather than a flag.
