### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump only: `0.5.4` → `0.6.0`. No functional change in this PR.

Minor bump (not patch) — 81 commits since `v0.5.4` add new model architectures, a new
multi-node execution lane, and new Metal/AVX-512 kernels.

## What ships in 0.6.0

**New architectures**
- LFM2 / LFM2.5 hybrid short-conv + GQA bringup (#614), engine lane (#615), Metal (#620)
- qwen3moe bringup (#612)
- gemma4 ghost-MoE on Metal (#602)
- qwen35 Q8 on Metal (#618) — thanks @heskew

**Cluster fabric**
- Whole-request placement across independent nodes, 0 hops/token (#616) — thanks @karan68
- Bearer auth for fabric nodes (#627)

**Performance**
- Q4_K owner scale fold: AVX2 (#617, @karan68) and AVX-512 (#629) — folded inner needs
  no VNNI (avx512f+bw only)
- Q6_K owner maddubs inner (#613) — thanks @karan68
- Ghost-MoE CUDA pinned host expert tier + KV ring (#607)

**Fixes**
- Bonsai CPU lane on Windows — CPU block-dot restored, compile-time `cfg!` no longer
  stands in for a runtime GPU check (#628)
- Bonsai catalog arch split — 4B/8B are `qwen3` (dense), only 27B is `qwen35` (#624)
- Non-catalog SHA256 guard (#625)
- Ornith support-level contradiction (#622)
- Q8 gate tests (#621)

**Docs**
- qwen35 K-quant / Metal truth-sync (#626)
- README discoverability (#604)

## Not included

Open PRs #619 (fabric serve) and #623 (HF pull) are excluded — not on `main` at cut time.

## Release checklist
- [x] 4 files, 5 insertions, 5 deletions
- [ ] CI green on this PR (authoritative release-tree signal)
- [ ] Merge, then lightweight tag `v0.6.0` on the merge commit
- [ ] `release.yml` publishes 9 signed assets
