### PR TITLE
ci(frontend): give the puppeteer smokes a launch they can survive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,15 +389,24 @@ jobs:
         run: npm ci
 
       - name: Build frontend
+        id: build
         run: npm run build
 
+      # Every smoke below carries this. The smokes are independent of each other,
+      # so stopping at the first failure only hides the rest: a red gate then
+      # takes one round trip per broken smoke to fully diagnose. Guarding on the
+      # build keeps that from turning a broken build into a wall of identical
+      # "missing dist" errors, and the job still fails on any smoke failure.
       - name: Frontend support-contract smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:model-state
 
       - name: Frontend model-lanes smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:model-lanes
 
       - name: Frontend catalog activation smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:catalog-activation
 
       # Covers frontend/src/lib/firstRunActivation.js and lib/modelActivation.js:
@@ -406,6 +415,7 @@ jobs:
       # click. Also asserts the shipped ledger row and the shipped catalog id still
       # join, which is what makes the offer derived rather than hard-coded.
       - name: Frontend first-run activation smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:first-run
 
       # Component-level: mounts the real first-run card in a browser against a
@@ -414,6 +424,7 @@ jobs:
       # re-download it) and cancelling when the backend disagrees that anything was
       # cancelled (404 mid-start, 409 after completion, unreadable probes).
       - name: Frontend first-run card component smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:first-run-card
 
       # Component-level: the offline banner is the only surface a user sees when
@@ -422,6 +433,7 @@ jobs:
       # packaged build can never regress to offering a control it cannot honour,
       # and the dev-server one-click Start keeps working.
       - name: Frontend offline banner smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:offline-banner
 
       # Covers frontend/src/lib/catalogBrowse.js: fit labels/details, the
@@ -429,24 +441,31 @@ jobs:
       # script shipped with the lane but was never wired here, so none of that
       # logic was gated.
       - name: Frontend catalog browse smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:catalog-browse
 
       - name: Frontend catalog companion download smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:catalog-companion
 
       - name: Frontend model deletion smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:model-deletion
 
       - name: Frontend 3B exact-row closure smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:3b-closure
 
       - name: Frontend integration smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:integration
 
       - name: Workspace logic smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:workspace
 
       - name: Workspace read-only visual smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           set -euo pipefail
           npm run preview > /tmp/camelid-workspace-preview.log 2>&1 &
@@ -460,6 +479,7 @@ jobs:
           npm run smoke:workspace-visual
 
       - name: Frontend UI regression smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:ui
 
   # ---------------------------------------------------------------------------

--- a/frontend/scripts/capture-views.mjs
+++ b/frontend/scripts/capture-views.mjs
@@ -8,7 +8,7 @@
 import { createHash } from 'node:crypto'
 import { mkdir, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import puppeteer from 'puppeteer-core'
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const args = new Map()
 for (let i = 2; i < process.argv.length; i += 2) {
@@ -24,17 +24,9 @@ const onlyViews = args.get('views')?.split(',') || null
 const VIEWS = ['chat', 'library', 'api', 'compatibility', 'telemetry', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster', 'observatory']
 const HEIGHTS = { 1440: 900, 1024: 768, 768: 1024, 390: 844 }
 
-const CHROME_PATHS = [
-  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-  '/Applications/Chromium.app/Contents/MacOS/Chromium',
-]
-const { existsSync } = await import('node:fs')
-const executablePath = CHROME_PATHS.find((p) => existsSync(p))
-if (!executablePath) throw new Error('No local Chrome found for capture')
-
 await mkdir(outDir, { recursive: true })
 const captured = []
-const browser = await puppeteer.launch({ executablePath, headless: 'new', args: ['--enable-gpu', '--use-angle=metal', '--ignore-gpu-blocklist'] })
+const browser = await launchBrowser({ purpose: 'the view capture', headless: 'new', args: ['--enable-gpu', '--use-angle=metal', '--ignore-gpu-blocklist'] })
 
 try {
   for (const theme of themes) {

--- a/frontend/scripts/chat-perf-profile.mjs
+++ b/frontend/scripts/chat-perf-profile.mjs
@@ -5,7 +5,7 @@
    and flush count (each flush = one full or partial markdown render).
    Usage: node scripts/chat-perf-profile.mjs --label baseline --out design-evidence/phase-8 */
 import { mkdirSync, writeFileSync } from 'node:fs'
-import puppeteer from 'puppeteer-core'
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const args = new Map()
 for (let i = 2; i < process.argv.length; i += 2) args.set(process.argv[i]?.replace(/^--/, ''), process.argv[i + 1])
@@ -13,7 +13,7 @@ const label = args.get('label') || 'run'
 const out = args.get('out') || 'design-evidence/phase-8'
 mkdirSync(`${out}/${label}-frames`, { recursive: true })
 
-const browser = await puppeteer.launch({ executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', headless: 'new', args: ['--enable-gpu', '--use-angle=metal', '--ignore-gpu-blocklist'] })
+const browser = await launchBrowser({ purpose: 'the chat perf profile', headless: 'new', args: ['--enable-gpu', '--use-angle=metal', '--ignore-gpu-blocklist'] })
 const page = await browser.newPage()
 await page.setViewport({ width: 1440, height: 900 })
 await page.evaluateOnNewDocument(() => {

--- a/frontend/scripts/first-run-card-smoke.mjs
+++ b/frontend/scripts/first-run-card-smoke.mjs
@@ -17,24 +17,13 @@ import { createServer } from 'node:http'
 import { existsSync, readFileSync } from 'node:fs'
 import { extname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import puppeteer from 'puppeteer-core'
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const scriptDir = fileURLToPath(new URL('.', import.meta.url))
 const distDir = resolve(scriptDir, '../dist')
 const ledgerPath = resolve(scriptDir, '../../ledger/camelid-ledger.json')
 
 if (!existsSync(distDir)) throw new Error(`missing ${distDir} -- run "npm run build" first`)
-
-const executablePath = [
-  process.env.PUPPETEER_EXECUTABLE_PATH,
-  'C:/Program Files/Google/Chrome/Application/chrome.exe',
-  'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
-  '/usr/bin/google-chrome',
-  '/usr/bin/google-chrome-stable',
-  '/usr/bin/chromium',
-  '/usr/bin/chromium-browser',
-].filter(Boolean).find(existsSync)
-if (!executablePath) throw new Error('Chrome or Edge is required for the first-run card smoke')
 
 /* The real shipped contract, so the card's supported-row derivation is not a fixture. */
 const ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'))
@@ -188,7 +177,7 @@ const server = createServer(async (req, res) => {
 await new Promise((done) => server.listen(0, '127.0.0.1', done))
 const origin = `http://127.0.0.1:${server.address().port}`
 
-const browser = await puppeteer.launch({ executablePath, headless: 'new' })
+const browser = await launchBrowser({ purpose: 'the first-run card smoke', headless: 'new' })
 const pageErrors = []
 
 async function openCard() {

--- a/frontend/scripts/flow-calibration.mjs
+++ b/frontend/scripts/flow-calibration.mjs
@@ -6,7 +6,7 @@
    traffic. Saves frames + coverage stats for tuning iterations.
    Usage: node scripts/flow-calibration.mjs --out design-evidence/phase-6.2/iterations/iter1 [--theme dark] [--quick] */
 import { mkdirSync } from 'node:fs'
-import puppeteer from 'puppeteer-core'
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const args = new Map()
 for (let i = 2; i < process.argv.length; i += 1) {
@@ -18,7 +18,7 @@ const theme = args.get('theme') || 'dark'
 const quick = args.has('quick')
 mkdirSync(out, { recursive: true })
 
-const browser = await puppeteer.launch({ executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', headless: 'new', args: ['--enable-gpu', '--use-angle=metal', '--ignore-gpu-blocklist'] })
+const browser = await launchBrowser({ purpose: 'the flow calibration', headless: 'new', args: ['--enable-gpu', '--use-angle=metal', '--ignore-gpu-blocklist'] })
 const page = await browser.newPage()
 await page.setViewport({ width: 1440, height: 900 })
 await page.evaluateOnNewDocument((t) => window.localStorage.setItem('camelid-theme', t), theme)

--- a/frontend/scripts/flow-visual-smoke.mjs
+++ b/frontend/scripts/flow-visual-smoke.mjs
@@ -4,7 +4,7 @@
    invisible, not aesthetic targets. Needs backend + dev server + a loaded
    generation-ready model. */
 import assert from 'node:assert/strict'
-import puppeteer from 'puppeteer-core'
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const IDLE_WAIT_MS = Number(process.env.FLOW_SMOKE_IDLE_MS || 60000)
 const lum = ([r, g, b]) => {
@@ -13,7 +13,7 @@ const lum = ([r, g, b]) => {
 }
 const contrast = (a, b) => { const [hi, lo] = lum(a) >= lum(b) ? [lum(a), lum(b)] : [lum(b), lum(a)]; return (hi + 0.05) / (lo + 0.05) }
 
-const browser = await puppeteer.launch({ executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', headless: 'new', args: ['--enable-gpu', '--use-angle=metal', '--ignore-gpu-blocklist'] })
+const browser = await launchBrowser({ purpose: 'the flow visual smoke', headless: 'new', args: ['--enable-gpu', '--use-angle=metal', '--ignore-gpu-blocklist'] })
 
 async function runTheme(theme, withIdleCheck) {
   const page = await browser.newPage()

--- a/frontend/scripts/lib/launch-browser.mjs
+++ b/frontend/scripts/lib/launch-browser.mjs
@@ -1,0 +1,90 @@
+/* Shared Chrome launch for every puppeteer-driven script in this directory.
+ *
+ * Booting Chrome is the one step in these smokes that can fail for reasons that
+ * have nothing to do with the product, and when it does the job log is a
+ * `TimeoutError` from `ChromeLauncher.launch` with no assertion ever having run.
+ * That is indistinguishable from a real regression at a glance, and it reds the
+ * release gate. Three things made it likelier than it needed to be:
+ *
+ *   - puppeteer's default launch timeout is 30s, while the whole first-run-card
+ *     smoke takes ~25s wall-clock on a healthy runner. There was almost no
+ *     headroom for a cold or loaded runner.
+ *   - a single slow boot was fatal; nothing retried it.
+ *   - the CI smokes passed no `args` at all, so Chrome tried to use its sandbox
+ *     on runners where an AppArmor profile restricts unprivileged user
+ *     namespaces, and tried to use a container-sized /dev/shm.
+ *
+ * So the launch -- and ONLY the launch -- gets headroom, a bounded retry and the
+ * standard CI args. Nothing here retries a navigation, a selector or an
+ * assertion: once this returns a browser, every later failure is the product's
+ * and still fails loudly on the first occurrence.
+ */
+import { existsSync } from 'node:fs'
+import puppeteer from 'puppeteer-core'
+
+/* Superset of the per-script lists this replaced, most specific first. The two
+ * env vars come first so a runner or a developer can always force the choice. */
+const CHROME_PATHS = [
+  process.env.PUPPETEER_EXECUTABLE_PATH,
+  process.env.CHROME_PATH,
+  'C:/Program Files/Google/Chrome/Application/chrome.exe',
+  'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  '/usr/bin/google-chrome',
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+]
+
+/* 4x puppeteer's default. Long enough that only a genuinely stuck Chrome hits
+ * it, short enough that a stuck one is still reported inside a job's lifetime. */
+const LAUNCH_TIMEOUT_MS = Number(process.env.CAMELID_LAUNCH_TIMEOUT_MS || 120000)
+const LAUNCH_ATTEMPTS = Number(process.env.CAMELID_LAUNCH_ATTEMPTS || 3)
+
+/* Only under CI. Locally the sandbox stays on, because there it both works and
+ * is worth having. */
+const CI_ARGS = ['--no-sandbox', '--disable-dev-shm-usage']
+
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms))
+
+/** Resolve the browser binary, or throw naming the smoke that needed it. */
+export function resolveChromeExecutable(purpose = 'this smoke') {
+  const executablePath = CHROME_PATHS.filter(Boolean).find(existsSync)
+  if (!executablePath) throw new Error(`Chrome or Edge is required for ${purpose}`)
+  return executablePath
+}
+
+/**
+ * Launch Chrome for a smoke. Accepts everything `puppeteer.launch` does; the
+ * caller's `args` are kept and the CI args are added to them.
+ *
+ * Retries the launch itself up to LAUNCH_ATTEMPTS times. If every attempt
+ * fails the last error is rethrown unchanged, so a browser that genuinely
+ * cannot start still fails the job.
+ */
+export async function launchBrowser({ purpose = 'this smoke', args = [], ...options } = {}) {
+  const executablePath = options.executablePath || resolveChromeExecutable(purpose)
+  const launchArgs = [...args]
+  if (process.env.CI) for (const arg of CI_ARGS) if (!launchArgs.includes(arg)) launchArgs.push(arg)
+
+  let lastError
+  for (let attempt = 1; attempt <= LAUNCH_ATTEMPTS; attempt += 1) {
+    try {
+      return await puppeteer.launch({
+        timeout: LAUNCH_TIMEOUT_MS,
+        ...options,
+        executablePath,
+        args: launchArgs,
+      })
+    } catch (error) {
+      lastError = error
+      if (attempt === LAUNCH_ATTEMPTS) break
+      /* Announce it: a retried launch is still a slow runner worth noticing, and
+       * a green job that needed two attempts should say so in the log. */
+      console.warn(`browser launch attempt ${attempt}/${LAUNCH_ATTEMPTS} failed (${error.message}); retrying`)
+      await sleep(1000 * attempt)
+    }
+  }
+  throw lastError
+}

--- a/frontend/scripts/models-page-shot.mjs
+++ b/frontend/scripts/models-page-shot.mjs
@@ -3,8 +3,7 @@
      node scripts/models-page-shot.mjs --out qa/models-before.png [--url http://127.0.0.1:4175] [--width 1280] */
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import { existsSync } from 'node:fs'
-import puppeteer from 'puppeteer-core'
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const args = new Map()
 for (let i = 2; i < process.argv.length; i += 2) args.set(process.argv[i].replace(/^--/, ''), process.argv[i + 1])
@@ -12,16 +11,8 @@ const url = args.get('url') || 'http://127.0.0.1:4175'
 const out = args.get('out') || 'models-page.png'
 const width = Number(args.get('width') || 1280)
 
-const CHROME_PATHS = [
-  'C:/Program Files/Google/Chrome/Application/chrome.exe',
-  'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
-  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-]
-const executablePath = CHROME_PATHS.find((p) => existsSync(p))
-if (!executablePath) throw new Error('No local Chrome/Edge found')
-
 await mkdir(dirname(out), { recursive: true }).catch(() => {})
-const browser = await puppeteer.launch({ executablePath, headless: 'new' })
+const browser = await launchBrowser({ purpose: 'the models page shot', headless: 'new' })
 try {
   const page = await browser.newPage()
   await page.setViewport({ width, height: 900 })

--- a/frontend/scripts/neural-field-evidence.mjs
+++ b/frontend/scripts/neural-field-evidence.mjs
@@ -14,7 +14,7 @@
 */
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import puppeteer from 'puppeteer-core'
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const MODE = process.argv[2] || 'full'
 const LABEL = process.argv[3] || 'default'
@@ -23,13 +23,12 @@ mkdirSync(OUT, { recursive: true })
 
 const API = 'http://127.0.0.1:8181'
 const APP = 'http://127.0.0.1:4175/#observatory'
-const CHROME = process.env.CHROME_PATH || 'C:/Program Files/Google/Chrome/Application/chrome.exe'
 const PROMPT = 'Explain, in plain language and complete sentences, how a transformer language model turns a prompt into a reply: tokenization, embeddings, the stack of layers with attention and feed-forward blocks, the key-value cache that grows one entry per token, and the final sampling step that picks each next token. Then list five everyday analogies for attention, one per line, and keep going with more detail about each analogy until you run out of room. '.repeat(2)
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
 async function launch(dpr = 1) {
-  const browser = await puppeteer.launch({ executablePath: CHROME, headless: 'new', args: ['--enable-gpu', '--ignore-gpu-blocklist'] })
+  const browser = await launchBrowser({ purpose: 'the neural field evidence capture', headless: 'new', args: ['--enable-gpu', '--ignore-gpu-blocklist'] })
   const page = await browser.newPage()
   await page.setViewport({ width: 1600, height: 900, deviceScaleFactor: dpr })
   await page.evaluateOnNewDocument(() => {

--- a/frontend/scripts/offline-banner-smoke.mjs
+++ b/frontend/scripts/offline-banner-smoke.mjs
@@ -21,23 +21,12 @@ import { createServer } from 'node:http'
 import { existsSync, readFileSync } from 'node:fs'
 import { extname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import puppeteer from 'puppeteer-core'
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const scriptDir = fileURLToPath(new URL('.', import.meta.url))
 const distDir = resolve(scriptDir, '../dist')
 
 if (!existsSync(distDir)) throw new Error(`missing ${distDir} -- run "npm run build" first`)
-
-const executablePath = [
-  process.env.PUPPETEER_EXECUTABLE_PATH,
-  'C:/Program Files/Google/Chrome/Application/chrome.exe',
-  'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
-  '/usr/bin/google-chrome',
-  '/usr/bin/google-chrome-stable',
-  '/usr/bin/chromium',
-  '/usr/bin/chromium-browser',
-].filter(Boolean).find(existsSync)
-if (!executablePath) throw new Error('Chrome or Edge is required for the offline banner smoke')
 
 /* The exact sentence the packaged build used to show. Asserting its ABSENCE is
    what keeps the dead end from coming back. */
@@ -101,7 +90,7 @@ const server = createServer(async (req, res) => {
 await new Promise((done) => server.listen(0, '127.0.0.1', done))
 const origin = `http://127.0.0.1:${server.address().port}`
 
-const browser = await puppeteer.launch({ executablePath, headless: 'new' })
+const browser = await launchBrowser({ purpose: 'the offline banner smoke', headless: 'new' })
 const pageErrors = []
 
 async function openBanner({ clipboard = 'ok', storage = {} } = {}) {

--- a/frontend/scripts/workspace-readonly-visual-smoke.mjs
+++ b/frontend/scripts/workspace-readonly-visual-smoke.mjs
@@ -1,28 +1,16 @@
 #!/usr/bin/env node
 
-import { existsSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { join, resolve } from 'node:path'
-import puppeteer from 'puppeteer-core'
-
-const executablePath = [
-  process.env.PUPPETEER_EXECUTABLE_PATH,
-  'C:/Program Files/Google/Chrome/Application/chrome.exe',
-  'C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe',
-  '/usr/bin/google-chrome',
-  '/usr/bin/google-chrome-stable',
-  '/usr/bin/chromium',
-  '/usr/bin/chromium-browser',
-].filter(Boolean).find(existsSync)
-if (!executablePath) throw new Error('Chrome or Edge is required for Workspace visual smoke')
+import { launchBrowser } from './lib/launch-browser.mjs'
 
 const baseUrl = process.env.CAMELID_CAPTURE_URL || 'http://127.0.0.1:4175'
 const outputDir = process.env.CAMELID_CAPTURE_DIR
   ? resolve(process.env.CAMELID_CAPTURE_DIR)
   : fileURLToPath(new URL('../../target/', import.meta.url))
 await mkdir(outputDir, { recursive: true })
-const browser = await puppeteer.launch({ executablePath, headless: 'new' })
+const browser = await launchBrowser({ purpose: 'the Workspace visual smoke', headless: 'new' })
 const markdownFiles = [
   'CONFIGURATION.md',
   'CONFORMANCE.md',


### PR DESCRIPTION
## What

Extracts the Chrome launch every puppeteer-driven script in `frontend/scripts/` had copied into a single `scripts/lib/launch-browser.mjs`, and hardens it:

- **120s launch timeout** (4x puppeteer's 30s default).
- **Bounded 3-attempt retry around the launch only.**
- **`--no-sandbox` / `--disable-dev-shm-usage`, under `CI` only** — locally the sandbox stays on.

Also puts an `if:` guard on each frontend smoke step so one failure stops skipping every later smoke.

## Why

Booting Chrome is the one step in these smokes that can fail for reasons unrelated to the product. When it does, the log is a `TimeoutError` out of `ChromeLauncher.launch` with no assertion having run — indistinguishable from a real regression at a glance, and it reds `ci-gate`.

Three things made that likelier than it needed to be:

- puppeteer's default launch timeout is 30s, while the whole first-run-card smoke takes **~25s wall-clock on a healthy runner** ([run 31233396587](https://github.com/timtoole02/Camelid/actions/runs/31233396587), 02:25:38 → 02:26:03). Almost no headroom for a cold or loaded runner.
- nothing retried a slow boot.
- the three CI smokes passed **no `args` at all**, so Chrome reached for its sandbox on runners whose AppArmor profile restricts unprivileged user namespaces, and for a container-sized `/dev/shm`. `ubuntu-latest` is now ubuntu-24.04, where that restriction is in force.

## Scope note

Only **three** CI smoke steps actually drive a browser — `smoke:first-run-card`, `smoke:offline-banner`, `smoke:workspace-visual`. The other eleven are pure-Node logic smokes with no puppeteer import. The six non-CI dev/evidence scripts are routed through the same helper for consistency; three of them had a hardcoded macOS Chrome path and now resolve a browser on any platform.

## Assertions are untouched

The retry wraps `puppeteer.launch` and nothing else. Once it returns a browser, every later failure is the product's and still fails on its first occurrence — no retries around navigations, selectors or assertions. When all three attempts fail the last error is rethrown unchanged, so a browser that genuinely cannot start still fails the job.

## Verification

All 14 frontend smokes pass locally against a clean `npm ci` (lockfile unchanged):

```
PASS smoke:model-state      PASS smoke:catalog-companion   PASS smoke:workspace
PASS smoke:model-lanes      PASS smoke:model-deletion      PASS smoke:workspace-visual
PASS smoke:catalog-activation  PASS smoke:3b-closure       PASS smoke:ui
PASS smoke:first-run        PASS smoke:integration
PASS smoke:first-run-card   PASS smoke:catalog-browse      PASS smoke:offline-banner
```

Forcing every launch to fail proves the retry fires and still fails loudly:

```
$ CAMELID_LAUNCH_TIMEOUT_MS=1 npm run smoke:first-run-card
browser launch attempt 1/3 failed (Timed out after 1 ms ...); retrying
browser launch attempt 2/3 failed (Timed out after 1 ms ...); retrying
TimeoutError: Timed out after 1 ms while waiting for the WS endpoint URL to appear in stdout!
SCRIPT_EXIT=1
```

`CI=true` runs pass too, exercising the sandbox args.

## On the reported flake

Worth flagging: I could not find this flake in CI history. Both runs cited for `3fca86d4` **passed** — [31233396587](https://github.com/timtoole02/Camelid/actions/runs/31233396587) (push) and [31233409371](https://github.com/timtoole02/Camelid/actions/runs/31233409371) (pull_request) — and the first-run-card step printed all six `ok` lines in both. The `frontend` job is `success` or `skipped` in every run back to Aug 1; the only recent red was Clippy. So this is prophylaxis against a real and well-understood failure mode, not a fix for an observed regression.
