### PR TITLE
fix(models): a hash pin must not relabel a file nobody has hashed

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21918,10 +21918,14 @@ mod tests {
                 ModelLaneClass::ExperimentalImplemented,
                 "{filename} with replaced bytes must not inherit support by name"
             );
+            // With no digest in hand, a pin says nothing: the row keeps its
+            // ordinary filename/header class. Asserting ExperimentalImplemented
+            // here for every pinned artifact is what locked the v0.6.0 library
+            // regression in behind a green test.
             assert_eq!(
                 classify_model_lane_with_verified_sha256(Some("qwen35"), filename, None),
-                ModelLaneClass::ExperimentalImplemented,
-                "{filename} must remain unverified until the load path supplies its digest"
+                ModelLaneClass::Supported,
+                "{filename} must not be demoted before anyone has hashed it"
             );
         }
         // A curated row with NO recorded digest keeps its filename-only gating.
@@ -21940,6 +21944,92 @@ mod tests {
             ModelLaneClass::Supported,
             "an unpinned curated row stays filename-gated until a digest is captured"
         );
+    }
+
+    /// THE v0.6.0 REGRESSION, reported against the shipped Windows build:
+    /// "llama-3.2-3b instruct is listed as experimental" and Bonsai likewise.
+    ///
+    /// v0.6.0 widened the pre-load gate from `prism_supported_artifact_expected_sha256`
+    /// to `supported_artifact_expected_sha256`, so every row that gained a pin was
+    /// relabelled Experimental in the models library — which calls the classifier
+    /// with `None`, because drawing a badge must never cost a multi-GB rehash.
+    /// Adding a pin is supposed to tighten what happens when the BYTES are wrong,
+    /// never to change how a file the user has not loaded is described.
+    #[test]
+    fn pinning_an_artifact_never_demotes_it_before_its_digest_is_known() {
+        for filename in [
+            "Llama-3.2-3B-Instruct-Q8_0.gguf",
+            "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+            "Llama-3.2-3B-Instruct-Q5_K_M.gguf",
+            "Llama-3.2-1B-Instruct-IQ4_XS.gguf",
+            "gemma-3-1b-it-Q8_0.gguf",
+            "Qwen3-4B-Q4_K_M.gguf",
+            "ornith-1.0-9b-Q8_0.gguf",
+            "ornith-1.0-9b-Q4_K_M.gguf",
+            "ornith-1.0-9b-Q3_K_M.gguf",
+            "gemma-4-E4B-it-NVFP4-mm.gguf",
+            "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+            // The Bonsai rows the owner reported. TQ2_0 flipped in v0.6.0; the
+            // Prism-pinned ones read Experimental for longer than that.
+            "Ternary-Bonsai-4B-TQ2_0.gguf",
+            "Bonsai-4B-Q1_0.gguf",
+            "Bonsai-8B-Q1_0.gguf",
+            "Bonsai-27B-Q1_0.gguf",
+            "Ternary-Bonsai-4B-Q2_0.gguf",
+            "Ternary-Bonsai-4B-PQ2_0.gguf",
+            "Ternary-Bonsai-8B-Q2_0.gguf",
+        ] {
+            assert!(
+                supported_artifact_expected_sha256(filename).is_some(),
+                "precondition: {filename} is hash-pinned"
+            );
+            assert_eq!(
+                classify_model_lane_with_verified_sha256(Some("llama"), filename, None),
+                ModelLaneClass::Supported,
+                "{filename} must read Supported in the models library, not Experimental"
+            );
+            // The pin still does its real job: certified NAME + uncertified BYTES
+            // loses the row's evidence at load, which is where it always mattered.
+            assert_eq!(
+                classify_loaded_model_identity(Some("llama"), filename, &"00".repeat(32)),
+                ModelLaneClass::ExperimentalImplemented,
+                "{filename} with replaced bytes must still be demoted at load time"
+            );
+        }
+    }
+
+    /// The Prism rows (the curated Bonsai artifacts) read "Experimental" in the
+    /// models library from before v0.6.0 through v0.6.0 itself, because they were
+    /// the original hash-pinned set. They now follow the same rule as every other
+    /// row: described by filename/header until someone actually hashes them, and
+    /// fail-closed the moment the bytes are known to be wrong.
+    #[test]
+    fn prism_rows_are_described_by_filename_until_their_bytes_are_known() {
+        for (filename, expected_sha256) in PRISM_SUPPORTED_ARTIFACT_SHA256 {
+            assert_eq!(
+                classify_model_lane_with_verified_sha256(Some("qwen35"), filename, None),
+                ModelLaneClass::Supported,
+                "{filename} must read Supported in the library, not Experimental"
+            );
+            assert_eq!(
+                classify_model_lane_with_verified_sha256(
+                    Some("qwen35"),
+                    filename,
+                    Some(expected_sha256)
+                ),
+                ModelLaneClass::Supported,
+                "{filename} with its certified digest is supported"
+            );
+            assert_eq!(
+                classify_model_lane_with_verified_sha256(
+                    Some("qwen35"),
+                    filename,
+                    Some(&"00".repeat(32))
+                ),
+                ModelLaneClass::ExperimentalImplemented,
+                "{filename} with uncertified bytes must still fail closed at load"
+            );
+        }
     }
 
     #[test]
@@ -28404,8 +28494,12 @@ fn supported_compatibility_row_ids() -> &'static std::collections::HashSet<&'sta
 /// 5,629,108,416 B) while the public HuggingFace file of that exact name is a
 /// different imatrix quant (`5720d1f6...`, 5,629,108,704 B) — different weights,
 /// not just different metadata. Classification therefore fails closed to
-/// `ExperimentalImplemented` until the load path has confirmed the digest; see
-/// `supported_artifact_expected_sha256`.
+/// `ExperimentalImplemented` the moment the load path confirms the digest does
+/// not match — see `classify_loaded_model_identity`, which consults the full pin
+/// set. It does NOT pre-emptively demote the row in the filename-only library
+/// view: that view has no digest, and demoting on the mere existence of a pin is
+/// what made every pinned row read "Experimental" in v0.6.0. See
+/// `classify_model_lane_with_verified_sha256` for that boundary.
 const NON_CATALOG_SUPPORTED_ARTIFACTS: &[(&str, &str, &str)] = &[
     // HF pristine upload; local recompute matches the HF LFS oid (9,527,500,992 B).
     (
@@ -28631,23 +28725,37 @@ fn classify_model_lane(architecture: Option<&str>, filename: &str) -> ModelLaneC
     }
 }
 
-/// The hash-pinned support boundary (Prism + every non-catalog allowlist row).
-/// Filename/header-only views (local library and inspect) therefore remain
-/// experimental until the ordinary load path has computed the exact digest;
-/// other established rows retain their existing filename-gated classification.
+/// Classify an artifact for a view that may or may not have its digest.
+///
+/// A hash pin decides what happens when the BYTES are known and WRONG. It is not
+/// evidence about a file nobody has hashed yet, so it must not change how that
+/// file is described. With a digest in hand this defers to
+/// `classify_loaded_model_identity` (certified NAME + uncertified BYTES loses the
+/// row's evidence); without one it falls back to the ordinary filename/header
+/// classification, exactly as an unpinned curated row already does.
+///
+/// The alternative — withholding support until a digest exists — is what shipped
+/// in v0.6.0, and it reads as a support REGRESSION to anyone looking at the
+/// models library, which calls this with `verified_sha256: None` because drawing
+/// a badge must never cost a multi-GB rehash. Every pinned row was relabelled
+/// "Experimental" on sight: Llama-3.2-3B Q8_0/Q4_K_M/Q5_K_M, Llama-3.2-1B
+/// IQ4_XS/Q4_K_M, gemma-3-1b-it, nomic-embed, Qwen3-4B-Q4_K_M, the NVFP4 row, all
+/// three Ornith rows, and Ternary-Bonsai-4B-TQ2_0. The Prism rows had read
+/// "Experimental" this way since before v0.6.0; that is now gone too.
+///
+/// Fail-closed still holds where it does the work — at load, where the digest is
+/// free (`build_loaded_model` already computes it for `LaneIdentity`) and where a
+/// wrong-bytes file would otherwise inherit parity claims, support claims, and
+/// tool capability. No generation ever runs under an unearned supported label.
 fn classify_model_lane_with_verified_sha256(
     architecture: Option<&str>,
     filename: &str,
     verified_sha256: Option<&str>,
 ) -> ModelLaneClass {
-    let class = classify_model_lane(architecture, filename);
-    if class != ModelLaneClass::Supported || supported_artifact_expected_sha256(filename).is_none()
-    {
-        return class;
+    match verified_sha256 {
+        Some(sha256) => classify_loaded_model_identity(architecture, filename, sha256),
+        None => classify_model_lane(architecture, filename),
     }
-    verified_sha256.map_or(ModelLaneClass::ExperimentalImplemented, |sha256| {
-        classify_loaded_model_identity(architecture, filename, sha256)
-    })
 }
 
 /// Classify from the exact bytes. A hash-pinned artifact loaded under its


### PR DESCRIPTION
Fixes a support-label regression shipped in **v0.6.0**, reported against the released
Windows build: Bonsai models and `Llama-3.2-3B-Instruct` both listed as **Experimental**.

## What broke

#625 widened one predicate in `classify_model_lane_with_verified_sha256`:

```rust
// v0.5.4
if class != Supported || prism_supported_artifact_expected_sha256(filename).is_none() {
// v0.6.0
if class != Supported || supported_artifact_expected_sha256(filename).is_none() {
```

`supported_artifact_expected_sha256` resolves three tables (Prism ∪ non-catalog allowlist ∪
the new `CURATED_SUPPORTED_ARTIFACT_SHA256`). `/api/models/local` calls the classifier with
`verified_sha256: None` — it will not rehash a multi-GB file just to draw a badge — so every
row carrying or gaining a pin fell into the `None` arm and was demoted on sight. The same PR
also gave `Ternary-Bonsai-4B-TQ2_0.gguf` a digest, which is why that row flipped too.

`lane_class` is the *only* thing drawing the badge: `laneOf()` in `frontend/src/lib/modelLanes.js`
short-circuits on `lane_class === 'supported'`, and its capabilities-based fallback is
unreachable for local models because `lane_class` is a non-`Option` field always present.

**Rows affected:** Llama-3.2-3B-Instruct Q8_0/Q4_K_M/Q5_K_M · Llama-3.2-1B-Instruct
IQ4_XS/Q4_K_M · gemma-3-1b-it-Q8_0 · nomic-embed-text-v1.5-Q8_0 · Qwen3-4B-Q4_K_M ·
gemma-4-E4B-it-NVFP4-mm · ornith-1.0-9b Q8_0/Q4_K_M/Q3_K_M · Ternary-Bonsai-4B-TQ2_0 —
plus the six Prism Bonsai rows, which had read Experimental this way since before v0.6.0.

## The fix

A pin decides what happens when the BYTES are known and WRONG. It is not evidence about a
file nobody has hashed, so it must not change how that file is described.

```rust
match verified_sha256 {
    Some(sha256) => classify_loaded_model_identity(architecture, filename, sha256),
    None         => classify_model_lane(architecture, filename),
}
```

**Fail-closed is not weakened.** It still holds at load, where the digest is already computed
for `LaneIdentity`, and where a certified NAME carrying uncertified BYTES is demoted so it
cannot inherit the row's parity evidence, support claims, or tool capability. No generation
ever runs under an unearned supported label.

Known tradeoff, accepted deliberately: a same-named file with wrong bytes — the real hazard
for `ornith-1.0-9b-Q4_K_M.gguf`, where the public HF upload differs from the certified
in-house requant — now reads Supported in the library until it is loaded, at which point it
flips to Experimental. That is the same behaviour every unpinned curated row already had.

## Why it shipped

A green test asserted `ExperimentalImplemented` for **every** pinned artifact, so the widened
predicate looked correct. That assertion is rewritten, and two regression tests now name the
affected artifacts directly.

## Verification

End-to-end on real GGUFs, comparing the shipped v0.5.4 and v0.6.0 release binaries against
this build via `/api/models/local`:

| artifact | v0.5.4 | v0.6.0 shipped | this PR |
|---|---|---|---|
| `Llama-3.2-3B-Instruct-Q8_0.gguf` | supported | **experimental** | supported |
| `Ternary-Bonsai-4B-TQ2_0.gguf` | supported | **experimental** | supported |
| `Bonsai-4B/8B/27B-Q1_0.gguf` | experimental | experimental | supported |
| `Ternary-Bonsai-4B-Q2_0 / PQ2_0 / 8B-Q2_0 / 27B-Q2_0` | experimental | experimental | supported |
| `Ternary-Bonsai-27B-mmproj-Q8_0.gguf` | unsupported | unsupported | unsupported |
| `Llama-3.2-1B-Instruct-Q8_0`, `gemma-4-26B_q4_0-it` | supported | supported | supported |

Local gates: `cargo fmt --check` clean · `cargo clippy --all-targets --all-features -D warnings`
exit 0, no warnings · `cargo test --no-fail-fast` 1678 lib tests + all integration binaries,
0 failed · public-scrub clean · ledger-drift passed.
