### PR TITLE
chore(release): bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump only: `0.6.0` → `0.6.1`. No functional change in this PR.

Patch release: a hotfix for a support-label regression that shipped in v0.6.0, plus the UI
polish pass and two desktop/UX defects found while verifying it.

## What ships in 0.6.1

**Fixes the v0.6.0 regression**
- #634 — a hash pin no longer relabels a file nobody has hashed. v0.6.0 widened one predicate in
  `classify_model_lane_with_verified_sha256`, and because `/api/models/local` calls it with
  `verified_sha256: None`, **13 curated models read "Experimental"** in the models library —
  including Llama-3.2-3B-Instruct and every Bonsai row. Wrong-bytes protection still fails closed
  at load, where the digest is already computed.

**UI polish (#633)**
- Design-review pass across the frontend and desktop app: grouped navigation, refreshed tokens
  and view layouts, new desktop icons, streaming playback smoothing.
- Sidebar layout fix: grouping the rail into four labelled sections added ~166px, pushing the whole
  `SYSTEM` group below the fold at 1440x900 (the label missed the cut by **one pixel**). Reclaimed
  the section label's doubled padding and added the end-fade already used on the collapsed rail;
  the 20px section rhythm is unchanged.
- **Desktop Retry button fixed.** `retry_startup` was registered in `generate_handler!` and wired
  to the splash's Retry button but authorized in neither `build.rs` nor `capabilities/default.json`,
  so clicking Retry erased the error diagnostics and then died in the Tauri ACL — stranding the
  user on a permanent spinner on the screen they reach *after* the engine failed to start.

**New**
- #619 — `camelid fabric serve`, a resident HTTP proxy across a fabric of independent nodes.

**CI**
- #631 — puppeteer smokes survive a slow Chrome launch (the flake that reddened the v0.6.0 gate).

## Known issue, not fixed here

During streaming, auto-follow releases only on a *gesture* (`wheel`/`touchmove`/`keydown`).
Dragging the scrollbar emits `scroll` and nothing else, so those users stay pinned to the bottom
and "Jump to latest" never appears. v0.6.0 released on any scroll past 260px. Wheel, touch and
keyboard users are unaffected. A one-line fix exists but was reverted rather than shipped
unverified — see the discussion on #633.

## Release checklist
- [x] 4 files, 5 insertions, 5 deletions
- [ ] CI green on this PR (authoritative release-tree signal)
- [ ] Merge, then lightweight tag `v0.6.1` on the merge commit
- [ ] `release.yml` publishes 11 assets
- [ ] Shipped binary verified against real GGUFs via `/api/models/local`
