### PR TITLE
fix: make the CLI's own pull example resolve, and the UI agree with it on file sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,15 @@ jobs:
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:catalog-activation
 
+      # Keeps the UI's size formatting on the same decimal convention as
+      # src/catalog.rs. These drifted apart once already: the formatter divided
+      # by 1024 while printing KB/MB/GB, so one GGUF read "3.4 GB" from the CLI
+      # and "3.2 GB" in the Models page. Pure module check, so it does not need
+      # the dist build the browser smokes depend on.
+      - name: Frontend byte-units smoke
+        if: ${{ !cancelled() }}
+        run: npm run smoke:byte-units
+
       # Covers frontend/src/lib/firstRunActivation.js and lib/modelActivation.js:
       # which model a fresh install is offered (supported_* rows only, fit-filtered,
       # smallest first) and the inspect -> load -> readiness protocol behind the one

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "smoke:contrast": "node scripts/contrast-check.mjs",
     "capture:views": "node scripts/capture-views.mjs",
     "smoke:markdown": "node scripts/markdown-smoke.mjs",
+    "smoke:byte-units": "node scripts/byte-units-smoke.mjs",
     "smoke:flow": "node scripts/flow-visual-smoke.mjs"
   },
   "dependencies": {

--- a/frontend/scripts/byte-units-smoke.mjs
+++ b/frontend/scripts/byte-units-smoke.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/* The UI and the CLI must not disagree about how big a file is.
+ *
+ * `formatBytes` divided by 1024 while labelling the result KB/MB/GB, so every
+ * size in the UI was a binary magnitude wearing an SI name. The same GGUF read
+ * "3.4 GB" from `camelid pull` and "3.2 GB" on the Models page, and the second
+ * number is what a user compares against the Hub's listing and their own disk.
+ *
+ * This pins the formatter to the same decimal convention `src/catalog.rs` uses
+ * (`bytes as f64 / 1e9`, rendered `{:.1} GB`) and checks it against the real
+ * catalog sizes rather than invented ones, so a future edit that reintroduces
+ * 1024 fails here instead of shipping two numbers for one file.
+ *
+ * Pure module test -- no browser, no dist build required.
+ */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+import { formatBytes } from '../src/lib/formatters.js'
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url))
+
+/* What the Rust side prints for a GB-scale row: `{:.1} GB` over bytes / 1e9. */
+function rustGb(bytes) {
+  return `${(bytes / 1e9).toFixed(1)} GB`
+}
+
+/* Real catalog rows, so this cannot pass against a convenient fixture. */
+const supportedModels = readFileSync(
+  resolve(scriptDir, '../src/lib/supportedModels.js'),
+  'utf8',
+)
+const sizes = [...supportedModels.matchAll(/size_bytes:\s*(\d+)/g)].map((m) => Number(m[1]))
+assert.ok(sizes.length >= 2, `expected several catalog sizes, found ${sizes.length}`)
+
+for (const bytes of sizes) {
+  if (bytes < 1e9) continue // only GB-scale rows are directly comparable
+  const ui = formatBytes(bytes)
+  const cli = rustGb(bytes)
+  assert.equal(
+    ui,
+    cli,
+    `UI and CLI disagree for ${bytes} bytes: UI "${ui}" vs CLI "${cli}". ` +
+      'formatBytes must divide by 1000 to match the SI labels it prints.',
+  )
+}
+
+/* Exact boundaries, independent of the catalog contents. */
+assert.equal(formatBytes(0), '0 B')
+assert.equal(formatBytes(999), '999 B')
+assert.equal(formatBytes(1000), '1.0 KB')
+assert.equal(formatBytes(1_000_000), '1.0 MB')
+assert.equal(formatBytes(1_000_000_000), '1.0 GB')
+assert.equal(formatBytes(null), '—')
+assert.equal(formatBytes(undefined), '—')
+
+/* The regression itself: 1024-based maths would render this 3.2 GB. */
+assert.equal(formatBytes(3_421_898_816), '3.4 GB')
+
+console.log(`byte-units smoke OK (${sizes.length} catalog sizes checked)`)

--- a/frontend/src/lib/formatters.js
+++ b/frontend/src/lib/formatters.js
@@ -38,13 +38,23 @@ export function formatHistoryDate(value) {
   return date.toLocaleDateString([], { month: 'short', day: 'numeric' })
 }
 
+/* Decimal units, matching the labels. This divided by 1024 while printing KB/MB/GB,
+   so every size in the UI was a binary magnitude wearing an SI name -- and the CLI,
+   which uses `/1e9`, disagreed with the UI about the same file:
+
+     Llama-3.2-3B-Instruct-Q8_0.gguf   CLI "3.4 GB"   UI "3.2 GB"
+
+   Two numbers for one file is worse than either convention being wrong, and the
+   catalog literals, the Hub's own listing and `camelid pull` are all decimal, so
+   the UI was the outlier. Dividing by 1000 makes the labels honest and the two
+   surfaces agree. Sizes shown in the UI go up slightly; nothing downloads more. */
 export function formatBytes(value) {
   if (value === null || value === undefined) return '—'
   const units = ['B', 'KB', 'MB', 'GB']
   let size = Number(value)
   let unit = 0
-  while (size >= 1024 && unit < units.length - 1) {
-    size /= 1024
+  while (size >= 1000 && unit < units.length - 1) {
+    size /= 1000
     unit += 1
   }
   return `${size.toFixed(size >= 100 || unit === 0 ? 0 : 1)} ${units[unit]}`

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -10,6 +10,25 @@ use std::path::{Path, PathBuf};
 
 use crate::api::{curated_catalog, CatalogItem};
 
+/// The id shown to users as the worked example of `camelid pull`.
+///
+/// This is a constant, and covered by a test, because the previous example was
+/// a bare `llama32_3b` that stopped resolving the moment the Q4_K_M and Q5_K_M
+/// rows joined the catalog: the fragment then named three different multi-GB
+/// downloads and `resolve` correctly refused to guess. The catalog listing and
+/// `--help` both kept printing it, so the CLI spent several releases telling
+/// people to run a command that could only ever error. Nothing failed, because
+/// nothing checked that the advice the CLI gives is advice the CLI accepts.
+///
+/// Quant-qualified so it stays unique as more quantizations of the same model
+/// are certified.
+///
+/// `every_pull_example_in_the_source_resolves` is the real guard: it scans the
+/// crate for `camelid pull <id>` in any string or comment and requires each id
+/// to resolve. That covers `--help`, whose text clap reads textually from doc
+/// attributes and so cannot be built from this constant.
+pub const PULL_EXAMPLE: &str = "3b_instruct_q8";
+
 /// Entry point for the `Pull` subcommand. With no `query`, prints the catalog;
 /// otherwise resolves `query` to exactly one row and downloads it into
 /// `models_dir`.
@@ -18,7 +37,7 @@ pub fn run_pull(query: Option<&str>, models_dir: &Path) -> anyhow::Result<()> {
 
     let Some(query) = query else {
         print_catalog(&entries);
-        eprintln!("\nDownload one with:  camelid pull <id>   (e.g. camelid pull llama32_3b)");
+        eprintln!("\nDownload one with:  camelid pull <id>   (e.g. camelid pull {PULL_EXAMPLE})");
         return Ok(());
     };
 
@@ -292,6 +311,103 @@ mod tests {
         let entries = curated_catalog();
         let item = resolve(&entries, "3b-instruct-q8").unwrap();
         assert_eq!(item.catalog_id, "llama32_3b_instruct_q8_0");
+    }
+
+    /// The CLI must not advertise a command that the CLI rejects.
+    ///
+    /// `a_family_fragment_spanning_several_quants_refuses_to_guess` below
+    /// asserts that `llama32_3b` is ambiguous -- and for several releases that
+    /// was exactly the id the catalog footer and `--help` told people to run.
+    /// Both tests passed the whole time, because nothing tied the printed
+    /// example to the resolver. This is that tie.
+    #[test]
+    fn example_id_actually_resolves() {
+        let entries = curated_catalog();
+        let item = resolve(&entries, PULL_EXAMPLE).unwrap_or_else(|err| {
+            panic!("PULL_EXAMPLE ({PULL_EXAMPLE}) must resolve, but `camelid pull {PULL_EXAMPLE}` would fail: {err}")
+        });
+        assert_eq!(item.catalog_id, "llama32_3b_instruct_q8_0");
+    }
+
+    /// Every `camelid pull <id>` written anywhere in the crate must resolve.
+    ///
+    /// The constant above only guards the catalog footer. `--help` cannot use
+    /// it -- clap reads doc attributes textually and drops anything that is not
+    /// already a string literal -- so its example is a hand-written literal and
+    /// would drift again on the next catalog change. Scanning the source catches
+    /// that copy, and every other one: comments, strings, help text alike.
+    #[test]
+    fn every_pull_example_in_the_source_resolves() {
+        let entries = curated_catalog();
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+
+        fn rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            for entry in std::fs::read_dir(dir)
+                .expect("readable source dir")
+                .flatten()
+            {
+                let path = entry.path();
+                if path.is_dir() {
+                    rs_files(&path, out);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    out.push(path);
+                }
+            }
+        }
+
+        let mut files = Vec::new();
+        rs_files(&root, &mut files);
+        assert!(
+            !files.is_empty(),
+            "found no .rs files under {}",
+            root.display()
+        );
+
+        let mut checked = 0usize;
+        let mut broken = Vec::new();
+
+        for file in &files {
+            let text = std::fs::read_to_string(file).expect("readable source file");
+            for (lineno, line) in text.lines().enumerate() {
+                let mut rest = line;
+                while let Some(at) = rest.find("camelid pull ") {
+                    let tail = &rest[at + "camelid pull ".len()..];
+                    // Stop at the first character that cannot be part of an id.
+                    let id: String = tail
+                        .chars()
+                        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+                        .collect();
+                    rest = &tail[id.len().min(tail.len())..];
+
+                    // `camelid pull <id>` and `camelid pull` alone are usage
+                    // syntax, not examples.
+                    if id.is_empty() {
+                        continue;
+                    }
+                    checked += 1;
+                    if resolve(&entries, &id).is_err() {
+                        broken.push(format!(
+                            "{}:{} -> `camelid pull {}`",
+                            file.file_name().unwrap_or_default().to_string_lossy(),
+                            lineno + 1,
+                            id
+                        ));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            checked > 0,
+            "scanned {} files but found no examples",
+            files.len()
+        );
+        assert!(
+            broken.is_empty(),
+            "these `camelid pull` examples name ids that do not resolve, so the \
+             command as printed would fail:\n  {}",
+            broken.join("\n  ")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1441,7 +1441,13 @@ enum Command {
     /// Download a supported model (a known-good Q8_0 GGUF) into ./models.
     ///
     /// Run with no argument to list the catalog. Accepts a catalog id or a
-    /// fragment of the name, e.g. `camelid pull llama32_3b`.
+    /// fragment of the name, e.g. `camelid pull 3b_instruct_q8`.
+    //
+    // The id here is a plain literal because clap reads doc attributes
+    // textually and silently drops anything that is not already a string
+    // literal, so it cannot be spliced in from a constant. It is kept honest by
+    // `catalog::tests::every_pull_example_in_the_source_resolves`, which scans
+    // for this pattern and requires every id it finds to resolve.
     Pull {
         /// Catalog id or name fragment to download. Omit to list all models.
         model: Option<String>,


### PR DESCRIPTION
Two places where Camelid printed something it did not itself accept. Both
were found while recording a demo video: the video shows the CLI and the
Models page, and the two disagreed on screen.

## The `camelid pull` example could only ever error

The catalog footer and `pull --help` both advertised `camelid pull
llama32_3b`. That id stopped resolving when the Q4_K_M and Q5_K_M rows
were certified — the fragment now names three different multi-GB
downloads, so `resolve` refuses to guess:

```
$ camelid pull llama32_3b
Error: "llama32_3b" matches several models (llama32_3b_instruct_q8_0,
llama_3_2_3b_instruct_q4_k_m, llama_3_2_3b_instruct_q5_k_m); be more specific
```

Both now use the quant-qualified `3b_instruct_q8`, matching the README.

The reason this survived several releases is the interesting part.
`a_family_fragment_spanning_several_quants_refuses_to_guess` asserts
that `llama32_3b` is ambiguous, and it passed the whole time — it was
documenting the resolver behaving correctly while two other files told
users to run the exact command it rejects. Nothing connected the advice
the CLI prints to the input the CLI accepts.

`every_pull_example_in_the_source_resolves` closes that: it scans the
crate for `camelid pull <id>` in any string, comment or doc attribute
and requires each id to resolve, naming file and line for any that
would not. Verified by reverting each site in turn:

```
these `camelid pull` examples name ids that do not resolve, so the
command as printed would fail:
  main.rs:1444 -> `camelid pull llama32_3b`
```

A shared constant could not cover `--help`: clap reads doc attributes
textually and silently drops anything that is not already a string
literal, so that example has to be hand-written. Scanning covers it
anyway, along with every future copy.

## The UI and CLI disagreed about file sizes

`formatBytes` divided by 1024 while labelling the result KB/MB/GB, so
every size in the web UI was a binary magnitude wearing an SI name:

| file | CLI | UI |
|---|---|---|
| `Llama-3.2-3B-Instruct-Q8_0.gguf` | 3.4 GB | 3.2 GB |
| `tinyllama-1.1b-chat-v1.0.Q8_0.gguf` | 1.2 GB | 1.1 GB |

Two numbers for one file is worse than either convention being wrong on
its own. The catalog literals, the Hub's file listing and `camelid pull`
are all decimal, so the UI was the outlier — and the UI figure is the one
a user checks against the Hub page and their free disk space. Dividing by
1000 makes the labels honest and the surfaces agree. Displayed sizes go
up slightly; nothing downloads more than before.

`smoke:byte-units` formats the real catalog sizes from
`supportedModels.js` and requires each GB-scale row to match what
`src/catalog.rs` would print, plus fixed boundary cases. On the old
implementation it fails with exactly the mismatch that motivated this:

```
UI and CLI disagree for 3422709216 bytes: UI "3.2 GB" vs CLI "3.4 GB".
```

It is a pure module check, so unlike the browser smokes it needs no dist
build and runs even when the build step is skipped.

## Verification

Full local gate set on Windows:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -D warnings` — clean
- `cargo test --lib` — 1680 passed, 0 failed
- `scripts/check-public-scrub.sh` — exit 0
- `npm run build` — succeeds
- `npm run smoke:byte-units` — 26 catalog sizes checked

Both new guards were confirmed to fail on the pre-fix code before being
accepted, not just to pass on the fixed code.
