### PR TITLE
Keep models visible when memory is merely busy, not too small

### DIFF
--- a/frontend/scripts/catalog-browse-smoke.mjs
+++ b/frontend/scripts/catalog-browse-smoke.mjs
@@ -249,8 +249,13 @@ function hfFile({ repo = 'unsloth/Phi-4-mini-instruct-GGUF', quant, size, fit = 
     { catalog_id: 'd', fit: 'unknown' },
   ]
   const { runnable, blocked } = partitionCuratedByFit(curated)
-  assert.deepEqual(runnable.map((i) => i.catalog_id), ['a', 'd'], 'unprobed hosts keep their catalog')
-  assert.deepEqual(blocked.map((i) => i.catalog_id), ['b', 'c'])
+  /* Only a PERMANENT refusal folds away. 'c' is insufficient_free_memory: the
+     machine is big enough and the memory is merely busy, which the user can
+     change, so the row stays visible carrying its own amber chip and Re-check
+     button. Folding it away turned a busy machine into a seemingly empty
+     catalog. 'b' is wont_fit, which freeing memory cannot change. */
+  assert.deepEqual(runnable.map((i) => i.catalog_id), ['a', 'c', 'd'], 'a busy machine keeps its catalog visible')
+  assert.deepEqual(blocked.map((i) => i.catalog_id), ['b'], 'only models too big for the machine fold away')
 
   const ghostAlternative = {
     catalog_id: 'ghost',
@@ -268,7 +273,7 @@ function hfFile({ repo = 'unsloth/Phi-4-mini-instruct-GGUF', quant, size, fit = 
   )
   assert.deepEqual(
     partitionCuratedByFit([...curated, ghostAlternative]).runnable.map((i) => i.catalog_id),
-    ['a', 'd', 'ghost'],
+    ['a', 'c', 'd', 'ghost'],
     'a verified Ghost resident set keeps an otherwise-too-large curated model visible as runnable',
   )
   assert.equal(

--- a/frontend/src/components/models/CatalogLaneBrowse.jsx
+++ b/frontend/src/components/models/CatalogLaneBrowse.jsx
@@ -1045,19 +1045,23 @@ export function CatalogLaneBrowse({
         </CatalogGroup>
       ) : (
         <>
+          {/* The list holds everything this machine can run, including rows whose
+              memory is merely occupied right now — each carries its own amber chip
+              and Re-check button, so the state is visible per row instead of
+              hiding the model. Only models too big for the machine fold away. */}
           <CatalogGroup
-            title="Curated — runs on this machine"
+            title="Curated picks"
             marker={null}
             count={curatedRunnable.length}
-            emptyText="No curated model fits the memory free right now. Close some applications, then use Re-check on one of the rows below."
+            emptyText="No curated model matches."
           >
             {curatedRunnable.map((item) => renderRow(item))}
           </CatalogGroup>
           {curatedBlocked.length ? (
             <details className="catalog-collapsed">
               <summary>
-                {curatedBlocked.length} more curated model{curatedBlocked.length === 1 ? '' : 's'} this
-                machine cannot load right now
+                {curatedBlocked.length} model{curatedBlocked.length === 1 ? '' : 's'} too big for this
+                machine
               </summary>
               <div className="catalog-list">{curatedBlocked.map((item) => renderRow(item))}</div>
             </details>

--- a/frontend/src/lib/catalogBrowse.js
+++ b/frontend/src/lib/catalogBrowse.js
@@ -256,11 +256,23 @@ export function partitionByArchSupport(groups) {
 
 /* Split curated rows into what this machine can run and what it cannot, for the
    no-search landing state. Rows with an `unknown` verdict count as runnable: an
-   unprobed host must not have its whole catalog folded away. */
+   unprobed host must not have its whole catalog folded away.
+
+   Only a PERMANENT refusal is folded away. `insufficient_free_memory` means the
+   machine is big enough and the memory is merely in use right now, which changes
+   the moment another app closes — folding those rows away made a busy machine
+   look like a small one. On a host with little free memory that was most of the
+   catalog: measured here, 31 of 33 curated rows collapsed behind a disclosure and
+   the page read as broken. Those rows stay in the list, where they already render
+   an amber chip, the reason, and the Re-check button that re-probes memory live.
+   `wont_fit` is the one refusal freeing memory cannot change, so it still folds. */
 export function partitionCuratedByFit(items) {
+  const permanentlyRefused = (item) => isRefusingFit(item.fit)
+    && !fitIsRecheckable(item.fit)
+    && !ghostMoeFits(item)
   return {
-    runnable: items.filter((item) => !isRefusingFit(item.fit) || ghostMoeFits(item)),
-    blocked: items.filter((item) => isRefusingFit(item.fit) && !ghostMoeFits(item)),
+    runnable: items.filter((item) => !permanentlyRefused(item)),
+    blocked: items.filter(permanentlyRefused),
   }
 }
 


### PR DESCRIPTION
## Summary

- The Models catalog folded away every model it could not load *right now*, including ones whose memory was merely in use — so a busy machine looked like a small one.
- Only a permanent refusal (`wont_fit`) folds away now. Rows refused for `insufficient_free_memory` stay visible, carrying the amber chip, the reason, and the Re-check button the row renderer already provides.
- Group headings now describe what each group actually holds: **Curated picks**, and **N models too big for this machine**.

## Why this change exists

`isRefusingFit()` covers two answers that mean opposite things to a user:

| verdict | meaning | can the user change it? |
|---|---|---|
| `wont_fit` | larger than the whole machine | no — `fitDetail` says "Freeing memory will not help" |
| `insufficient_free_memory` | machine is big enough, memory is in use | yes — `fitDetail` says "Close some applications, then use Re-check" |

`partitionCuratedByFit()` folded both into a collapsed disclosure. On this host — 1.7 GB free of 8 GB — that hid **31 of 33 curated rows** behind a summary reading "cannot load right now", leaving two visible models and a page that read as broken. It also hid the Re-check button, which is the one control that could have fixed the situation, inside the collapsed element.

The distinction was already modelled in the codebase: `fitIsRecheckable()` exists precisely because "only memory pressure is transient". The partition just was not using it.

After the change, the same host shows 19 rows with 14 folded, and each of the 16 memory-pressured rows renders its own Re-check.

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check` (no Rust changes in this branch)
- [ ] `cargo test --all-targets --all-features` — not run locally; no Rust code is touched here. Deferred to CI.
- [x] `cd frontend && npm run build`
- [x] All 18 frontend smokes pass, including `smoke:catalog-browse`, whose partition assertion was updated to pin the new intent (a busy machine keeps its catalog; only too-big models fold)
- [x] `npm run smoke:contrast` — 258/258 AA in both themes
- [x] Verified live against a running engine at 1.7 GB free: 19 visible / 14 folded, 16 Re-check buttons, headings correct

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
