### PR TITLE
Plain language under every reply, and stop stacking two title bars

### DIFF
--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -18,7 +18,9 @@
         "minHeight": 560,
         "center": true,
         "backgroundColor": "#0e1216",
-        "url": "index.html"
+        "url": "index.html",
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {
@@ -27,7 +29,9 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": [
+      "nsis"
+    ],
     "publisher": "Camelid",
     "category": "DeveloperTool",
     "shortDescription": "Native chat app for the Camelid local inference engine.",

--- a/frontend/scripts/frontend-integration-smoke.mjs
+++ b/frontend/scripts/frontend-integration-smoke.mjs
@@ -740,7 +740,10 @@ try {
      above), so the invariant keeps its teeth. */
   assert.match(neighboringQuantPathChatMarkup, /Llama 3\.2 3B Instruct Q8_0 isn(?:&#x27;|')t verified for chat yet\./, '3B neighboring-quant chat UX should expose runtime-green state without claiming support')
   assert.match(neighboringQuantPathChatMarkup, /data-send-ready="false" title="Choose a verified model to send\."/, '3B neighboring-quant chat UX should name the exact row mismatch instead of showing ready chat')
-  assert.match(neighboringQuantPathChatMarkup, /This model isn(?:&#x27;|')t verified for chat yet\. Pick a verified model to unlock send\./, '3B neighboring-quant chat UX should explain that the loaded artifact quant does not match the support contract row')
+  /* Restored (2026-08): the quant mismatch names both sides again, so a reader
+     one re-download away is told which build to get instead of just "pick a
+     verified model". */
+  assert.match(neighboringQuantPathChatMarkup, /this build is Q4_0 and the verified build is Q8_0/, '3B neighboring-quant chat UX should name the loaded quant and the verified one')
   assert.doesNotMatch(neighboringQuantPathChatMarkup, /Local chat is ready|Message Camelid…|data-send-ready="true"/, '3B neighboring-quant rows must not render the live-chat ready UX')
 
   const backendReadyButUnsupported3BCapabilities = {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { Notice } from './components/ui/Notice'
 import { ConfirmDialog } from './components/ui/ConfirmDialog'
 import { isFirstRunHost } from './lib/firstRunActivation'
 import { formatPreview, formatSidebarDate } from './lib/formatters'
+import { hasOverlayTitleBar } from './lib/desktopShell'
 import { useDashboardData } from './hooks/useDashboardData'
 import { useBackendLauncher } from './hooks/useBackendLauncher'
 import { useNotice } from './hooks/useNotice'
@@ -245,6 +246,10 @@ function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadDashboard])
 
+  /* Above the loading early-return: every hook must run on every render, and
+     the shell this window lives in cannot change while it is open. */
+  const [overlayTitleBar] = useState(hasOverlayTitleBar)
+
   if (!dashboard) {
     return (
       <div className="loading-shell">
@@ -261,10 +266,17 @@ function App() {
     sidebarCollapsed ? 'is-collapsed' : '',
     mobileNavOpen ? 'is-mobile-open' : '',
     DEMO_UI ? 'is-demo' : '',
+    overlayTitleBar ? 'has-overlay-chrome' : '',
   ].filter(Boolean).join(' ')
 
   return (
     <div className={shellClasses}>
+      {/* macOS desktop only: the window draws no title bar of its own, so the
+          traffic lights float over the top-left of our content. This strip is
+          the room they sit in and the surface the window is dragged by —
+          without it the app showed the OS bar stacked above our own header,
+          which is what makes an app look like a web page in a frame. */}
+      {overlayTitleBar && <div className="app-drag-strip" data-tauri-drag-region />}
       {!DEMO_UI && (
         <SidebarRail
           collapsed={!isMobile && sidebarCollapsed}

--- a/frontend/src/components/chat/MessageTurn.jsx
+++ b/frontend/src/components/chat/MessageTurn.jsx
@@ -3,6 +3,8 @@ import { Avatar } from '../ui/Avatar'
 import { EvidenceChip } from '../ui/EvidenceChip'
 import { IconCopy, IconCheck, IconRefresh, IconEdit } from '../ui/icons'
 import { AssistantMarkdown, copyText, hasOpenCodeFence } from '../../lib/markdown'
+import { capabilityStatusLabel } from '../../lib/capabilities'
+import { formatModelLabel } from '../../lib/formatters'
 import { cleanLegacyDemoCapCopy } from '../../lib/conversationStorage'
 import {
   LiveGenerationBadge,
@@ -52,12 +54,22 @@ function MessageMetaFooter({ message }) {
   if (!usage && !ttft && !rate && !message.model_id && !sentAt) return null
   return (
     <footer className="cxturn__meta" aria-label="Generation details (client-measured telemetry)">
-      {message.model_id && <span className="cxturn__meta-item cxturn__meta-model">{message.model_id}</span>}
+      {message.model_id && (
+        <span className="cxturn__meta-item cxturn__meta-model" title={message.model_id}>
+          {formatModelLabel(message.model_id)}
+        </span>
+      )}
       {message.support_row && (
         <EvidenceChip
           status={message.support_row.status}
           state={message.support_row.supported ? 'supported' : null}
-          source={{ rowId: message.support_row.id, detail: 'Row active when this reply was generated.' }}
+          /* Under a reply the status is reassurance, not the record: show the
+             plain verdict and keep the row id and raw status in the popover. */
+          label={capabilityStatusLabel(message.support_row.status)}
+          source={{
+            rowId: message.support_row.id,
+            detail: `Status ${message.support_row.status} — the row active when this reply was generated.`,
+          }}
           size="sm"
         />
       )}
@@ -76,7 +88,9 @@ function MessageMetaFooter({ message }) {
           {usageLabel} <strong>in {usage.prompt_tokens}</strong><span aria-hidden="true"> · </span><strong>out {usage.completion_tokens ?? 0}</strong>
         </span>
       )}
-      {ttft && <span className="cxturn__meta-item" title="Time to first content, measured in this browser">TTFT {ttft}</span>}
+      {/* "TTFT" is the term of art; under a reply it just needs to say what it
+          measures. The abbreviation stays in the tooltip for anyone comparing. */}
+      {ttft && <span className="cxturn__meta-item" title="Time to first content (TTFT), measured in this browser">first token {ttft}</span>}
       {rate && <span className="cxturn__meta-item" title="End-to-end output rate, measured in this browser">{rate}</span>}
       {duration && <span className="cxturn__meta-item" title="Total request duration, measured in this browser">{duration}</span>}
       {sentAt && <time className="cxturn__meta-item" dateTime={message.created_at} title={formatFullTimestamp(message.created_at)}>{sentAt}</time>}

--- a/frontend/src/lib/capabilities.js
+++ b/frontend/src/lib/capabilities.js
@@ -2,6 +2,25 @@ export function formatCapabilityStatus(value) {
   return (value || '').toString().replace(/_/g, ' ')
 }
 
+/* Human rendering of a contract status, for surfaces where the status is a
+   reassurance rather than the subject.
+
+   formatCapabilityStatus only swaps underscores for spaces, so a status token
+   reaches the screen almost verbatim — and the chip styling uppercases it, so
+   `supported_exact_row_smoke` renders under every chat reply as
+   "SUPPORTED EXACT ROW SMOKE". That is the contract's vocabulary, not the
+   reader's. The Compatibility ledger keeps the raw form on purpose (that view
+   exists to show the contract, and the exact token is the content there); the
+   raw id and status also stay one click away in every chip's popover. */
+export function capabilityStatusLabel(value) {
+  const status = String(value || '').toLowerCase()
+  if (!status) return null
+  if (isSupportedCapabilityStatus(status)) return 'Verified'
+  if (status.startsWith('active_validation')) return 'Being verified'
+  if (status.startsWith('planned')) return 'Not verified yet'
+  return 'Not verified'
+}
+
 const GGUF_FILE_TYPE_QUANT_LABELS = {
   0: 'F32',
   1: 'F16',
@@ -42,6 +61,22 @@ const GGUF_FILE_TYPE_QUANT_LABELS = {
   // carry tensor type 41 while their file_type is 40; both Prism Q2 block
   // geometries declare file_type 41 and the backend refines the geometry.
   41: 'Q2_0',
+}
+
+/* Quant values travel through normalizeCapabilityKey, which strips separators so
+   "Q4_0" and "q4-0" compare equal — great for matching, wrong for reading, since
+   the key renders as "Q40". Map a key back to its canonical label before showing
+   it to anyone. Values already carrying a separator are passed through. */
+const CANONICAL_QUANT_BY_KEY = new Map(
+  Object.values(GGUF_FILE_TYPE_QUANT_LABELS).map((label) => [label.replace(/[^A-Z0-9]+/g, ''), label]),
+)
+
+export function displayQuantLabel(value) {
+  const raw = String(value || '').trim()
+  if (!raw) return null
+  const upper = raw.toUpperCase()
+  if (upper.includes('_')) return upper
+  return CANONICAL_QUANT_BY_KEY.get(upper.replace(/[^A-Z0-9]+/g, '')) || upper
 }
 
 export function quantLabelFromGgufFileType(fileType) {

--- a/frontend/src/lib/desktopShell.js
+++ b/frontend/src/lib/desktopShell.js
@@ -1,0 +1,25 @@
+/* Desktop-shell detection, shared so the browser build never pays for it.
+
+   Two different questions get asked about the desktop app and they are not the
+   same: whether we are inside Tauri at all (BackendBanner asks this, to know a
+   page cannot restart its own engine), and whether this window draws its own
+   title bar. Only macOS uses the overlay style, where the traffic lights float
+   over our content instead of sitting in a strip the OS owns — so only macOS
+   needs the window to reserve room for them and provide a drag region. */
+export function isDesktopShell() {
+  if (typeof window === 'undefined') return false
+  return Boolean(window.__TAURI__?.core?.invoke)
+}
+
+export function isMacPlatform() {
+  if (typeof navigator === 'undefined') return false
+  const platform = navigator.userAgentData?.platform || navigator.platform || ''
+  return /mac/i.test(platform)
+}
+
+/* True only where the window chrome is ours to draw. Keep this the single
+   source: styling that assumes the traffic lights are overlapping content must
+   never switch on in the browser build, where there are none. */
+export function hasOverlayTitleBar() {
+  return isDesktopShell() && isMacPlatform()
+}

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -13,6 +13,23 @@
 .camelid-app.is-collapsed { grid-template-columns: var(--rail-collapsed-width) minmax(0, 1fr); }
 .camelid-app.is-demo { grid-template-columns: minmax(0, 1fr); }
 
+/* ---- macOS desktop window chrome ----
+   With the overlay title bar the OS draws no bar of its own, so the traffic
+   lights land on top of whatever occupies the window's top-left — the sidebar
+   brand row. The shell gains one title-bar's worth of room at the top and a
+   transparent strip across it that the window can be dragged by. Only children
+   carrying data-tauri-drag-region drag, so every control below stays clickable.
+   Applied nowhere but the macOS desktop shell; the browser build never sees it. */
+.camelid-app.has-overlay-chrome { padding-top: var(--overlay-titlebar-height); }
+.app-drag-strip {
+  position: fixed;
+  inset: 0 0 auto 0;
+  height: var(--overlay-titlebar-height);
+  z-index: 60;
+  /* Same ground as the shell so the strip reads as window chrome, not a gap. */
+  background: var(--color-canvas);
+}
+
 /* ---- Main column ---- */
 .camelid-main {
   display: flex;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -92,6 +92,9 @@
   /* ---- Layout ---- */
   --sidebar-width: 288px;
   --rail-collapsed-width: 72px;
+  /* Room the macOS traffic lights need when the window draws its own chrome.
+     28px is the standard title-bar height they are positioned against. */
+  --overlay-titlebar-height: 28px;
   --content-max: 768px;
   --content-wide: 1100px;
 

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { getChatGateState } from '../lib/chatGate'
-import { exactArtifactFilenameForRow } from '../lib/capabilities'
+import { displayQuantLabel, exactArtifactFilenameForRow } from '../lib/capabilities'
 import { applyGemma4GhostChatTokenCap, getConfiguredMaxTokens, modelContextLength, validateSendBudget } from '../lib/responseLimits'
 import { CamelidMark } from '../components/ui/CamelidMark'
 import { Avatar } from '../components/ui/Avatar'
@@ -204,9 +204,24 @@ export default function ChatWorkspace({
   const supportBlocked = selectedRuntimeReady && !selectedModelCapabilitySupported
   /* Only set when the row was matched but the loaded GGUF is not its exact
      artifact — the one blocked state with a concrete next step. */
-  const blockedArtifactFilename = selectedChatGate.hint?.kind === 'artifact_mismatch'
-    ? exactArtifactFilenameForRow(selectedChatGate.hint.target)
-    : null
+  /* The two blocked states a reader can actually act on, each named concretely.
+     "Pick a verified model" alone leaves someone who is one file away from
+     working guessing at which file that is. */
+  const blockedSpecifics = (() => {
+    const hint = selectedChatGate.hint
+    if (hint?.kind === 'artifact_mismatch') {
+      const filename = exactArtifactFilenameForRow(hint.target)
+      return filename ? `it requires the exact ${filename} artifact` : null
+    }
+    if (hint?.kind === 'quant_mismatch') {
+      // observedQuant is a match key ("Q40"), not something to show a reader.
+      const verified = displayQuantLabel(hint.target?.quantization)
+      const observed = displayQuantLabel(selectedModel?.quant || hint.observedQuant)
+      if (verified && observed) return `this build is ${observed} and the verified build is ${verified}`
+      if (verified) return `only the ${verified} build is verified`
+    }
+    return null
+  })()
   const selectedRuntimeMatchesLoadedModel = Boolean(selectedChatGate.runtimeLoaded)
   const selectedModelName = selectedModel?.name || selectedModelId || 'No model selected'
   const selectedModelIssue = selectedModel?.load_error || selectedModel?.install_error || ''
@@ -243,11 +258,12 @@ export default function ChatWorkspace({
     : apiUnavailable
       ? 'Keep writing here. Send unlocks again once the local API responds.'
       : supportBlocked
-        /* When the blocker is a near-miss GGUF, naming the file the reader
-           actually needs is far more actionable than "pick a verified model" —
-           they are usually one download away, not one decision away. */
-        ? (blockedArtifactFilename
-            ? `This model isn't verified for chat yet: it requires the exact ${blockedArtifactFilename} artifact. Pick a verified model to unlock send.`
+        /* When the blocker is a near miss — wrong file, or the right model at an
+           unverified quantization — naming it is far more actionable than "pick a
+           verified model": they are usually one download away, not one decision
+           away. */
+        ? (blockedSpecifics
+            ? `This model isn't verified for chat yet: ${blockedSpecifics}. Pick a verified model to unlock send.`
             : "This model isn't verified for chat yet. Pick a verified model to unlock send.")
         : selectedModel
           ? 'Your draft is ready now. Send unlocks as soon as this model is ready.'


### PR DESCRIPTION
## Summary

- **Message footer** — the last surface leaking contract vocabulary, and it sits under *every* assistant reply. Raw GGUF filename and `SUPPORTED EXACT ROW SMOKE` are gone; it now reads "Llama 3.2 1B Instruct IQ4_XS · Verified", and "TTFT" says "first token".
- **Quant mismatch explains itself again** — a near-miss download is told which build it has and which one is verified, instead of only "isn't verified for chat yet".
- **macOS desktop no longer stacks two title bars** — the window uses the Overlay style, and the shell reserves a drag strip so the traffic lights sit in their own room.

## Why this change exists

### The footer

`formatCapabilityStatus()` only replaces underscores with spaces, and the chip styling uppercases its label, so the backend token `supported_exact_row_smoke` reached the screen almost verbatim — under every reply. This is the same defect as the permanent top-bar chip removed in #633, in a higher-traffic spot.

No evidence is lost. `capabilityStatusLabel()` renders the verdict ("Verified" / "Being verified" / "Not verified yet"), and the row id **and** the raw status stay in the chip's popover, one click away. The Compatibility ledger is deliberately untouched — that view exists to show the contract, so the exact token is the content there.

The label map covers every status the shipped ledger actually uses:

| status (count in ledger) | label |
|---|---|
| `supported_exact_row_smoke` (30), `supported_exact_row_embedding`, `supported_current_gate` | Verified |
| `active_validation_blocked_parity` (2), `active_validation_partial_runtime` | Being verified |
| `planned_exact_row_candidate` (7), `planned_phase_10`, `planned_beyond_named_certified_rows` | Not verified yet |

### The quant mismatch

Flagged as a known gap in #633. The hint already carried both quantizations; the copy just wasn't using them. It needed `displayQuantLabel()` — the value on the hint has been through `normalizeCapabilityKey()`, which strips separators for matching, so printing it directly produced **"Q40"** instead of "Q4_0". Caught in review of my own first draft.

### The desktop chrome

The app drew Tauri's title bar above its own branded header — the "website in a frame" tell. This was deliberately deferred from #633 because it only works as a paired change: `titleBarStyle: Overlay` + `hiddenTitle` alone yields a window that cannot be dragged.

The traffic lights land on the window's **top-left**, which is the sidebar's brand row rather than the top bar, so a per-component padding fix would have been wrong. Instead the shell reserves one title-bar of height and lays a transparent `data-tauri-drag-region` strip across it. Only elements carrying that attribute drag, so every control below stays clickable.

`titleBarStyle` and `hiddenTitle` are macOS-only keys and no-ops elsewhere; they live in the base config because Tauri replaces the `windows` array wholesale when merging a platform override, which would have silently dropped the shared window settings.

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [ ] `cargo test --all-targets --all-features` — not run locally; the only Rust-adjacent change is a Tauri config value. Deferred to CI, whose `desktop` job builds the app.
- [x] `cd frontend && npm run build`
- [x] All 18 frontend smokes pass
- [x] `npm run smoke:contrast` — 258/258 AA in both themes
- [x] **Desktop app built and launched**: traffic lights sit in the reserved strip, no second title bar, app header is the only header
- [x] **Browser build confirmed unaffected**, live: no overlay class, no drag strip, `padding-top: 0px`
- [x] Footer verified by rendering `MessageTurn` directly: raw filename absent, raw status absent, clean name present, popover citation intact

Not exercised: physically dragging the window by the strip. The attribute is wired as Tauri documents it and the layout is confirmed, but the drag gesture itself was not performed.

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
