### PR TITLE
Say it plainly when a model loads, and let the desktop app restart its engine

### DIFF
--- a/frontend/scripts/offline-banner-smoke.mjs
+++ b/frontend/scripts/offline-banner-smoke.mjs
@@ -93,7 +93,7 @@ const origin = `http://127.0.0.1:${server.address().port}`
 const browser = await launchBrowser({ purpose: 'the offline banner smoke', headless: 'new' })
 const pageErrors = []
 
-async function openBanner({ clipboard = 'ok', storage = {}, platform = null } = {}) {
+async function openBanner({ clipboard = 'ok', storage = {}, platform = null, desktopShell = null } = {}) {
   const page = await browser.newPage()
   page.on('pageerror', (error) => pageErrors.push(String(error)))
   // Nothing may leave the harness. One scenario points the app at an engine on
@@ -108,12 +108,26 @@ async function openBanner({ clipboard = 'ok', storage = {}, platform = null } = 
   // copyText() calls navigator.clipboard.writeText. Drive all three real shapes:
   // present and working, ABSENT (what a non-secure context gives you, e.g. a
   // plain-http LAN address), and present but rejecting (permission denied).
-  await page.evaluateOnNewDocument((mode, seed, platformOverride) => {
+  await page.evaluateOnNewDocument((mode, seed, platformOverride, desktopShell) => {
     window.__copied = []
     /* The banner's wording is platform-aware: only Windows users are told to run
        camelid.exe. Scenarios that assert that phrasing must say which platform
        they are standing on rather than inheriting the runner's. */
     if (platformOverride) Object.defineProperty(navigator, 'platform', { configurable: true, value: platformOverride })
+    /* Desktop shell stub: the banner detects Tauri by window.__TAURI__.core.invoke
+       and, inside the app, offers to restart the sidecar itself. Record the
+       commands so the scenario can prove which one it calls. */
+    if (desktopShell) {
+      window.__invoked = []
+      window.__TAURI__ = {
+        core: {
+          invoke: (cmd) => {
+            window.__invoked.push(cmd)
+            return desktopShell === 'failing' ? Promise.reject(new Error('nope')) : Promise.resolve()
+          },
+        },
+      }
+    }
     // Pages share the browser profile, so a key seeded by an earlier scenario
     // would survive into the next one and silently test the wrong thing.
     window.localStorage.clear()
@@ -132,7 +146,7 @@ async function openBanner({ clipboard = 'ok', storage = {}, platform = null } = 
         },
       },
     })
-  }, clipboard, storage, platform)
+  }, clipboard, storage, platform, desktopShell)
   // NOT networkidle2: one scenario points the app at an engine on another host,
   // whose probe never settles, and the banner does not depend on it.
   await page.goto(origin, { waitUntil: 'domcontentloaded' })
@@ -217,6 +231,50 @@ try {
     assert.match(macBanner.text, /served by the engine/i)
     assert.match(macBanner.text, /Start the Camelid app again|re-run the command/i)
   })
+  await page.close()
+
+  /* ---- Scenario 1c: inside Camelid Desktop. The app supervises the engine as a
+     sidecar, so it can restart it in place; telling the reader to quit and
+     reopen was handing them a chore the app could do itself. ---- */
+  resetStub()
+  page = await openBanner({ desktopShell: 'ok' })
+  let desktopBanner = await page.evaluate(readBanner)
+  check('the desktop app offers to restart the engine itself', () => {
+    assert.ok(desktopBanner.buttons.some((label) => label.includes('Restart engine')),
+      `expected a restart action, got ${JSON.stringify(desktopBanner.buttons)}`)
+    assert.equal(/Quit and reopen/i.test(desktopBanner.text), false,
+      'quit-and-reopen must not be the first thing offered when the app can restart the engine')
+  })
+  check('the desktop restart reassures that nothing is lost', () => {
+    assert.match(desktopBanner.text, /models and settings are untouched/i)
+  })
+  check('the desktop app never shows terminal or executable instructions', () => {
+    assert.equal(/camelid\.exe|cargo run|serve\b/i.test(desktopBanner.text), false,
+      `desktop guidance leaked a terminal instruction: ${desktopBanner.text}`)
+  })
+  await clickBannerButton(page, 'Restart engine')
+  check('restarting calls the engine-restart command, not a page reload', async () => {
+    const invoked = await page.evaluate(() => window.__invoked || [])
+    assert.deepEqual(invoked, ['retry_startup'], `unexpected commands: ${JSON.stringify(invoked)}`)
+  })
+  await page.close()
+
+  /* Only once a restart has actually failed is quit-and-reopen the honest advice. */
+  resetStub()
+  page = await openBanner({ desktopShell: 'failing' })
+  await clickBannerButton(page, 'Restart engine')
+  await page.waitForFunction(() => /Quit and reopen/i.test(document.querySelector('.backend-banner')?.textContent || ''), { timeout: 5000 })
+  desktopBanner = await page.evaluate(readBanner)
+  check('a failed restart falls back to quit-and-reopen', () => {
+    assert.match(desktopBanner.text, /would not restart/i)
+    assert.match(desktopBanner.text, /Quit and reopen Camelid Desktop/i)
+  })
+  await page.close()
+
+  /* Restore the packaged Windows context: Scenario 1 continues below. */
+  resetStub()
+  page = await openBanner({ platform: 'Win32' })
+  banner = await page.evaluate(readBanner)
   check('the retired dead-end sentence is gone', () => {
     assert.equal(banner.text.includes(RETIRED_COPY), false)
   })

--- a/frontend/src/components/layout/BackendBanner.jsx
+++ b/frontend/src/components/layout/BackendBanner.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { Button } from '../ui/Button'
 import { StatusDot } from '../ui/StatusDot'
-import { IconPlay, IconCopy, IconCheck, IconSettings } from '../ui/icons'
+import { IconPlay, IconCopy, IconCheck, IconRefresh, IconSettings } from '../ui/icons'
 import { copyText } from '../../lib/markdown'
+import { isDesktopShell } from '../../lib/desktopShell'
 
 /* Shown on the copy button when the engine never told us where it lives.
 
@@ -38,11 +39,7 @@ function readEnginePath() {
 
 /* Inside Camelid Desktop the sidecar engine is bundled and supervised by the
    shell — terminal restart commands are wrong there, so the banner switches to
-   app-level guidance instead. Same detection as DownloadedModelsView. */
-function isDesktopShell() {
-  if (typeof window === 'undefined') return false
-  return Boolean(window.__TAURI__?.core?.invoke)
-}
+   app-level guidance instead. Detection lives in lib/desktopShell. */
 
 /* `camelid.exe` / "unzipped" phrasing is only right on Windows. The stored
    engine path is the most reliable signal (it names the machine the engine is
@@ -134,6 +131,23 @@ export function BackendBanner({ backend, apiBase, onOpenSettings }) {
   // there would be the same class of lie this whole change is removing.
   const [copyState, setCopyState] = useState('idle')
   const copyResetRef = useRef(null)
+  const [restarting, setRestarting] = useState(false)
+  /* Only after a restart actually fails do we fall back to "quit and reopen".
+     Leading with it, as this banner used to, hands the reader a chore for
+     something the app can do itself. */
+  const [restartFailed, setRestartFailed] = useState(false)
+
+  const handleRestartEngine = async () => {
+    setRestarting(true)
+    setRestartFailed(false)
+    try {
+      await window.__TAURI__.core.invoke('retry_startup')
+    } catch {
+      setRestartFailed(true)
+    } finally {
+      setRestarting(false)
+    }
+  }
 
   useEffect(() => () => { if (copyResetRef.current) window.clearTimeout(copyResetRef.current) }, [])
 
@@ -154,8 +168,11 @@ export function BackendBanner({ backend, apiBase, onOpenSettings }) {
         <strong>Camelid engine isn’t running</strong>
         <span>
           {canStart && 'Start it to load a model and chat — no setup needed.'}
-          {!canStart && isLocalEngine && isDesktopApp && (
-            <>The engine that powers Camelid stopped. Quit and reopen Camelid Desktop to restart it.</>
+          {!canStart && isLocalEngine && isDesktopApp && restartFailed && (
+            <>The engine stopped and would not restart. Quit and reopen Camelid Desktop.</>
+          )}
+          {!canStart && isLocalEngine && isDesktopApp && !restartFailed && (
+            <>The engine that powers Camelid stopped. Restart it below — your models and settings are untouched.</>
           )}
           {!canStart && isLocalEngine && !isDesktopApp && enginePath && (
             <>This page is served by the engine, so it can’t restart it. Start it again with <code>{restartCommand}</code>{windowsEngine ? <> — or just run <code>camelid.exe</code> from where you unzipped Camelid</> : null}.</>
@@ -182,6 +199,23 @@ export function BackendBanner({ backend, apiBase, onOpenSettings }) {
             disabled={backend.starting || running}
           >
             {running ? 'Starting…' : 'Start Camelid'}
+          </Button>
+        )}
+        {/* The desktop app owns the engine as a sidecar, so it can restart it in
+            place. It previously told the reader to quit and reopen the app —
+            an instruction for something the app could do itself. The command
+            behind this is the one the splash's Retry already uses: it tears
+            down any half-running sidecar before starting a clean one. */}
+        {!canStart && isLocalEngine && isDesktopApp && (
+          <Button
+            variant="primary"
+            size="sm"
+            icon={<IconRefresh size={16} />}
+            onClick={handleRestartEngine}
+            loading={restarting}
+            disabled={restarting}
+          >
+            {restarting ? 'Restarting…' : 'Restart engine'}
           </Button>
         )}
         {!canStart && isLocalEngine && !isDesktopApp && (

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -432,7 +432,11 @@ function getGuardrailErrorMessage(error, fallback = 'Request failed.') {
   const code = getBackendErrorCode(error)
   if (!isTypedUnsupportedBackendError(code, message)) return message
   const codeCopy = code ? ` (${code})` : ''
-  return `Camelid refused this with a typed guardrail${codeCopy}: ${message}. This is not chat-ready support yet; check /api/capabilities and COMPATIBILITY.md before retrying.`
+  /* This is the message a refused action shows. It is the worst possible place
+     for contract vocabulary: the reader just had something fail and needs to
+     know what to do, not which files the claim came from. The error code is
+     kept — it is the one part worth quoting in a bug report. */
+  return `Camelid can't do this with the current model${codeCopy}: ${message}. This combination isn't verified yet — see the Compatibility page for what is.`
 }
 
 async function fetchJson(pathOrUrl, options = {}) {
@@ -937,7 +941,7 @@ export function useDashboardData({ showNotice, clearNotice }) {
     // chat through the weaker EXPERIMENTAL lane (every turn marked unverified). Only
     // a model that is not generation-ready at all is fully blocked.
     if (!selectedModelRunnable && !selectedModelExperimental) {
-      showNotice('Camelid is not generation-ready for the selected model yet.', 'error')
+      showNotice('The selected model isn’t ready to generate yet.', 'error')
       return
     }
 
@@ -1548,7 +1552,7 @@ export function useDashboardData({ showNotice, clearNotice }) {
       return
     }
     if (modelRuntimeIdMatches(model, runtime) && runtime?.generation_ready) {
-      showNotice('That model is already loaded and generation-ready.', 'success')
+      showNotice('That model is already loaded and ready.', 'success')
       return
     }
 
@@ -1585,9 +1589,9 @@ export function useDashboardData({ showNotice, clearNotice }) {
       showNotice(
         ready
           ? supportedByContract
-            ? 'Model loaded. Camelid reports generation-ready and the /api/capabilities support contract matches this model/quant.'
-            : 'Model loaded and generation-ready, but chat stays guarded until /api/capabilities has an exact supported COMPATIBILITY.md row for this model/quant.'
-          : 'Model loaded, but Camelid does not report generation-ready yet. Check tokenizer/config/tensor readiness.',
+            ? 'Model loaded and verified — you can start chatting.'
+            : 'Model loaded and running, but this build isn’t verified, so chat stays locked. The Compatibility page lists the verified builds.'
+          : 'Model loaded, but it isn’t ready to generate yet. Give it a moment, or check the Models page for details.',
         ready && supportedByContract ? 'success' : 'info',
       )
     } catch (error) {
@@ -1675,9 +1679,9 @@ export function useDashboardData({ showNotice, clearNotice }) {
       showNotice(
         ready
           ? supportedByContract
-            ? 'Local model saved, loaded, generation-ready, and matched to a supported /api/capabilities row.'
-            : 'Local model saved and generation-ready, but chat stays guarded until COMPATIBILITY.md and /api/capabilities explicitly support this model/quant.'
-          : 'Local model saved and loaded, but Camelid still reports generation is not ready.',
+            ? 'Model saved, loaded, and verified — you can start chatting.'
+            : 'Model saved and running, but this build isn’t verified, so chat stays locked. The Compatibility page lists the verified builds.'
+          : 'Model saved and loaded, but it isn’t ready to generate yet.',
         ready && supportedByContract ? 'success' : 'info',
       )
     } catch (error) {

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { getChatGateState } from '../lib/chatGate'
 import { displayQuantLabel, exactArtifactFilenameForRow } from '../lib/capabilities'
+import { formatModelLabel } from '../lib/formatters'
 import { applyGemma4GhostChatTokenCap, getConfiguredMaxTokens, modelContextLength, validateSendBudget } from '../lib/responseLimits'
 import { CamelidMark } from '../components/ui/CamelidMark'
 import { Avatar } from '../components/ui/Avatar'
@@ -444,14 +445,18 @@ export default function ChatWorkspace({
   const runnableModels = models.filter(modelCanChat)
   const waitingModels = models.filter((model) => !modelCanChat(model))
   const selectedPickerModelId = models.some((model) => model.id === selectedModel?.id) ? selectedModel.id : ''
+  /* The picker sat next to a top bar and message footer that both render clean
+     names, while it showed the raw GGUF filename — one model wearing two names
+     in the same view. formatModelLabel passes display names through untouched. */
   const modelOptionLabel = (model) => {
     const gate = getChatGateState(capabilities, model, runtime)
-    if (gate.chatUnlocked) return `${model.name} · Ready`
-    if (gate.chatMode === 'experimental') return `${model.name} · Experimental ready`
-    if (apiUnavailable) return `${model.name} · Not connected`
-    if (gate.runtimeReady) return `${model.name} · Not verified`
-    if (gate.runtimeLoaded) return `${model.name} · Loading`
-    return `${model.name} · Not loaded`
+    const name = formatModelLabel(model.name)
+    if (gate.chatUnlocked) return `${name} · Ready`
+    if (gate.chatMode === 'experimental') return `${name} · Experimental ready`
+    if (apiUnavailable) return `${name} · Not connected`
+    if (gate.runtimeReady) return `${name} · Not verified`
+    if (gate.runtimeLoaded) return `${name} · Loading`
+    return `${name} · Not loaded`
   }
 
   /* Send-time budget check: the response limit is an upper bound the backend


### PR DESCRIPTION
## Summary

- **Model-load notices speak plainly.** The toasts shown right after Load were the last place contract vocabulary reached a reader — every earlier sweep scoped agents to *view* components, and these live in the data hook.
- **The desktop app restarts its own engine** instead of telling you to quit and reopen it.
- **A long-thread stress pass** confirmed the layout holds and surfaced one naming inconsistency in the composer.

## Why this change exists

### The load notices

A successful load announced:

> "Model loaded. Camelid reports generation-ready and the /api/capabilities support contract matches this model/quant."

and a refusal — the message someone reads when something has *just failed* — opened with "Camelid refused this with a typed guardrail" and pointed at two filenames. Five notices now say what happened and what to do. The backend error code is kept, since that is the part worth quoting in a bug report.

### The engine restart

The desktop app supervises the engine as a sidecar, so it can restart it in place, yet the banner said "Quit and reopen Camelid Desktop" — a chore for something the app could do itself. No new backend work was needed: `retry_startup` already exists and already ships, used by the splash's Retry, and it tears down a half-running sidecar before starting a clean one. Quit-and-reopen remains the advice, but only after a restart has actually failed.

### The stress pass

80 messages, 40-line code blocks, tables, and a 200-character unbroken word. The layout held: no sideways page scroll, long words wrap, tables and code scroll inside their own containers. The 60-turn render window is deliberate (Phase 7 windowing) and its "Show 20 earlier messages" affordance works — verified by clicking it and confirming all 80 turns mount and the button retires.

It did surface one real inconsistency: the composer's model picker showed the raw GGUF filename while the top bar and message footer render clean names, so one model wore two names in the same view.

### Something I got wrong

I had flagged `compatibilityHintCopy` as feeding tooltips app-wide and worth rewriting. It isn't: `gate.copy` is computed and bundled but never rendered anywhere. Left alone rather than churned.

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check` (no Rust changes in this branch)
- [ ] `cargo test --all-targets --all-features` — not run locally; no Rust code is touched. Deferred to CI.
- [x] `cd frontend && npm run build`
- [x] All 18 frontend smokes pass
- [x] `npm run smoke:contrast` — 258/258 AA in both themes
- [x] **Five new offline-banner scenarios** cover the desktop path: the restart action appears, quit-and-reopen is *not* offered first, no terminal or `.exe` instruction reaches the desktop shell, clicking invokes exactly `retry_startup`, and a failed restart falls back to quit-and-reopen. Banner smoke is now 29 checks.
- [x] **Verified in the real Tauri app**: built, launched, killed the sidecar, and confirmed the banner renders "Restart engine" with the new copy (not the old dead end)
- [x] Long-thread pass exercised live at 80 messages

Not exercised: physically clicking Restart in the packaged app. Driving a click into the Tauri webview needs macOS assistive access this environment does not have. The button's behaviour is covered by the stubbed scenarios above, and the command it calls is the one the splash already uses in production.

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
