### PR TITLE
feat(fabric): let a client discover what the fabric can serve

### DIFF
--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -198,6 +198,24 @@ impl FabricSummary {
     }
 }
 
+/// Every model the fabric can serve right now, deduplicated and ordered.
+///
+/// Only ready nodes count. A node that is unreachable, or that has no model
+/// loaded, cannot serve one — listing its model would advertise something the
+/// fabric would then refuse.
+///
+/// Kept pure so the listing is covered by a unit test rather than by starting a
+/// server, the same way [`render_status`] is.
+pub fn servable_models(snapshots: &[NodeSnapshot]) -> Vec<String> {
+    let mut models: Vec<String> = snapshots
+        .iter()
+        .filter_map(|snapshot| snapshot.active_model_id().map(str::to_string))
+        .collect();
+    models.sort();
+    models.dedup();
+    models
+}
+
 /// Render a fabric observation as fixed-width text.
 ///
 /// Kept pure so the CLI's output is covered by a unit test rather than by
@@ -302,6 +320,50 @@ mod tests {
             in_flight: 1,
             waiting: 0,
         })
+    }
+
+    #[test]
+    fn the_servable_list_is_the_union_of_ready_nodes() {
+        let snapshots = vec![
+            snapshot("b", ready_status("zeta")),
+            snapshot("a", ready_status("alpha")),
+            // The same model on a second node is one entry, not two.
+            snapshot("c", ready_status("alpha")),
+        ];
+        assert_eq!(servable_models(&snapshots), vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn a_node_that_cannot_serve_is_not_advertised() {
+        let blank = NodeStatus::Ready(NodeReady {
+            active_model_id: None,
+            backend: "llama".to_string(),
+            version: "0.5.4".to_string(),
+            in_flight: 0,
+            waiting: 0,
+        });
+        let snapshots = vec![
+            snapshot("a", ready_status("alpha")),
+            snapshot(
+                "dead",
+                NodeStatus::Unreachable {
+                    reason: "connection refused".to_string(),
+                },
+            ),
+            snapshot(
+                "empty",
+                NodeStatus::NotReady {
+                    reason: "no model loaded".to_string(),
+                },
+            ),
+            snapshot("blank", blank),
+        ];
+        assert_eq!(servable_models(&snapshots), vec!["alpha"]);
+    }
+
+    #[test]
+    fn nothing_ready_lists_nothing_rather_than_failing() {
+        assert!(servable_models(&[]).is_empty());
     }
 
     #[test]

--- a/src/fabric/policy.rs
+++ b/src/fabric/policy.rs
@@ -104,6 +104,13 @@ pub enum RouteError {
         model: String,
         /// What the ready nodes are actually serving.
         serving: Vec<String>,
+        /// Configured nodes that could not be consulted, because they were
+        /// unreachable or reachable but not ready.
+        ///
+        /// This is what separates "the fabric does not serve that model" from
+        /// "the fabric cannot say yet": while any node is unaccounted for, one
+        /// of them may be the node that owns the model.
+        unobserved: usize,
     },
 }
 
@@ -118,15 +125,22 @@ impl std::fmt::Display for RouteError {
                 f,
                 "no node can serve: {unreachable} unreachable, {not_ready} reachable but not ready"
             ),
-            Self::ModelUnavailable { model, serving } => {
-                if serving.is_empty() {
-                    write!(f, "no ready node is serving model `{model}`")
-                } else {
-                    write!(
+            Self::ModelUnavailable {
+                model,
+                serving,
+                unobserved,
+            } => {
+                write!(f, "no ready node is serving model `{model}`")?;
+                if !serving.is_empty() {
+                    write!(f, "; ready nodes serve: {}", serving.join(", "))?;
+                }
+                match unobserved {
+                    0 => Ok(()),
+                    1 => write!(f, "; 1 node could not be consulted, so this may change"),
+                    many => write!(
                         f,
-                        "no ready node is serving model `{model}`; ready nodes serve: {}",
-                        serving.join(", ")
-                    )
+                        "; {many} nodes could not be consulted, so this may change"
+                    ),
                 }
             }
         }
@@ -183,6 +197,7 @@ pub fn route(
                 return Err(RouteError::ModelUnavailable {
                     model: model.to_string(),
                     serving,
+                    unobserved: snapshots.len() - ready.len(),
                 });
             }
             matched
@@ -389,6 +404,7 @@ mod tests {
             Err(RouteError::ModelUnavailable {
                 model: "gemma-27b".to_string(),
                 serving: vec!["llama-3b".to_string(), "qwen-4b".to_string()],
+                unobserved: 0,
             })
         );
     }
@@ -400,6 +416,50 @@ mod tests {
         let nodes = vec![ready("a", None, 99)];
         let decision = route(&nodes, &RouteRequest::new(RouteMode::Throughput)).expect("routes");
         assert_eq!(decision.label, "a");
+    }
+
+    /// A node that never answered may be the one holding the model, so the
+    /// refusal has to record that the fabric could not see the whole picture.
+    /// A caller reads this to tell a permanent refusal from a temporary one.
+    #[test]
+    fn a_refusal_records_the_nodes_it_could_not_consult() {
+        let nodes = vec![
+            ready("up", Some("llama-3b"), 0),
+            unreachable("down"),
+            not_ready("loading"),
+        ];
+        let request = RouteRequest::new(RouteMode::Throughput).with_model(Some("qwen-4b"));
+        match route(&nodes, &request).expect_err("nothing ready serves it") {
+            RouteError::ModelUnavailable { unobserved, .. } => assert_eq!(unobserved, 2),
+            other => panic!("expected ModelUnavailable, got {other:?}"),
+        }
+    }
+
+    /// The control: with every node accounted for, the same refusal is final.
+    #[test]
+    fn a_refusal_from_a_fully_observed_fabric_records_nothing_missing() {
+        let nodes = vec![ready("a", Some("llama-3b"), 0), ready("b", None, 0)];
+        let request = RouteRequest::new(RouteMode::Throughput).with_model(Some("qwen-4b"));
+        match route(&nodes, &request).expect_err("nothing serves it") {
+            RouteError::ModelUnavailable { unobserved, .. } => assert_eq!(unobserved, 0),
+            other => panic!("expected ModelUnavailable, got {other:?}"),
+        }
+    }
+
+    /// The message is what an operator acts on, so it has to say the fabric
+    /// could not see everything rather than implying the model is simply gone.
+    #[test]
+    fn an_incomplete_refusal_says_so_in_its_message() {
+        let nodes = vec![ready("up", Some("llama-3b"), 0), unreachable("down")];
+        let request = RouteRequest::new(RouteMode::Throughput).with_model(Some("qwen-4b"));
+        let message = route(&nodes, &request)
+            .expect_err("nothing ready serves it")
+            .to_string();
+        assert!(message.contains("llama-3b"), "{message}");
+        assert!(
+            message.contains("1 node could not be consulted"),
+            "{message}"
+        );
     }
 
     #[test]
@@ -454,6 +514,7 @@ mod tests {
             Err(RouteError::ModelUnavailable {
                 model: "llama-3b".to_string(),
                 serving: Vec::new(),
+                unobserved: 0,
             })
         );
     }

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -28,7 +28,7 @@ use axum::extract::rejection::JsonRejection;
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde_json::Value;
 
@@ -61,6 +61,7 @@ struct ServerState {
 pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
     Router::new()
         .route("/v1/chat/completions", post(chat_completions))
+        .route("/v1/models", get(models))
         // Without this, axum's 2 MiB default would refuse conversations the
         // node behind the proxy accepts.
         .layer(DefaultBodyLimit::max(DEFAULT_MAX_REQUEST_BODY_BYTES))
@@ -115,6 +116,45 @@ pub async fn serve_on(
     config: ServeConfig,
 ) -> std::io::Result<()> {
     axum::serve(listener, router(fabric, config)).await
+}
+
+/// List every model the fabric can currently route to.
+///
+/// A client points at one address, so it has to be able to ask that address
+/// what it can serve; the per-node listing is not reachable through the proxy.
+/// The answer is the union across ready nodes, in the same shape a node
+/// answers, minus the per-file `meta`: two nodes can serve one model id from
+/// different files, and there is no honest way to merge that.
+///
+/// No ready node means an empty list rather than an error. "Nothing right now"
+/// is the truthful answer to a discovery question, and a model picker can show
+/// it without special-casing a failure.
+async fn models(State(state): State<ServerState>) -> Response {
+    let fabric = Arc::clone(&state.fabric);
+    // Observing is blocking socket I/O against every node, same as a dispatch.
+    let snapshots = match tokio::task::spawn_blocking(move || fabric.observe()).await {
+        Ok(snapshots) => snapshots,
+        Err(join_error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("could not observe the fabric: {join_error}"),
+            )
+        }
+    };
+
+    let data: Vec<Value> = super::servable_models(&snapshots)
+        .into_iter()
+        .map(|id| {
+            serde_json::json!({
+                "id": id,
+                "object": "model",
+                "created": 0,
+                "owned_by": "camelid",
+            })
+        })
+        .collect();
+
+    Json(serde_json::json!({ "object": "list", "data": data })).into_response()
 }
 
 async fn chat_completions(
@@ -199,7 +239,28 @@ fn rejected_body(rejection: JsonRejection) -> Response {
 }
 
 fn route_error(error: RouteError) -> Response {
-    error_response(StatusCode::SERVICE_UNAVAILABLE, &error.to_string())
+    match &error {
+        // Asking again will not make the model appear, and the nodes themselves
+        // answer 404 `model_not_found` for exactly this. Answering 503 told
+        // clients to retry, so an SDK spent its whole retry budget on a refusal
+        // that could never change.
+        RouteError::ModelUnavailable { .. } => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": {
+                    "message": error.to_string(),
+                    "type": "fabric_error",
+                    "code": "model_not_found",
+                    "param": "model",
+                }
+            })),
+        )
+            .into_response(),
+        // These can genuinely clear on their own, so they stay retryable.
+        RouteError::NoNodesConfigured | RouteError::AllNodesUnavailable { .. } => {
+            error_response(StatusCode::SERVICE_UNAVAILABLE, &error.to_string())
+        }
+    }
 }
 
 fn forward_error(error: ForwardError) -> Response {
@@ -241,6 +302,137 @@ mod tests {
             .await
             .expect("collect body");
         (status, serde_json::from_slice(&bytes).expect("json body"))
+    }
+
+    fn get_request(uri: &str) -> axum::http::Request<axum::body::Body> {
+        axum::http::Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(axum::body::Body::empty())
+            .expect("valid request")
+    }
+
+    fn proxy(fabric: Fabric) -> Router {
+        router(
+            fabric,
+            ServeConfig {
+                mode: RouteMode::Throughput,
+                forward_timeout: Duration::from_millis(200),
+            },
+        )
+    }
+
+    /// A client points at one address, so that address has to answer what it
+    /// can serve. This used to 404, which left every model picker empty.
+    #[tokio::test]
+    async fn the_models_route_answers_a_list_even_with_nothing_to_serve() {
+        let response = proxy(Fabric::new(Vec::new()))
+            .oneshot(get_request("/v1/models"))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["object"], "list");
+        assert_eq!(
+            body["data"].as_array().expect("a data array").len(),
+            0,
+            "nothing ready is an empty list, not an error"
+        );
+    }
+
+    /// A model this fabric does not serve will not appear by asking again, and
+    /// the nodes answer 404 `model_not_found` for it. Answering 503 told
+    /// clients to retry: an OpenAI SDK spent its whole retry budget on a
+    /// permanent refusal.
+    #[tokio::test]
+    async fn an_unservable_model_is_refused_as_not_found_not_as_try_again() {
+        let node = StubModelNode::start("llama-3b");
+        let fabric = Fabric::new(vec![node.spec("only")]).with_timeout(Duration::from_secs(2));
+        let response = proxy(fabric)
+            .oneshot(request(
+                serde_json::json!({ "model": "no-such-model", "messages": [] }),
+            ))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["error"]["code"], "model_not_found");
+        assert_eq!(body["error"]["param"], "model");
+        // The message still names what the fabric *can* serve, which is the
+        // part an operator acts on.
+        let message = body["error"]["message"].as_str().expect("a message");
+        assert!(message.contains("llama-3b"), "{message}");
+    }
+
+    /// A fabric whose nodes are merely unreachable can recover on its own, so
+    /// that refusal stays retryable.
+    #[tokio::test]
+    async fn an_unreachable_fabric_is_still_a_retryable_503() {
+        let fabric = Fabric::new(vec![NodeSpec {
+            label: "dead".to_string(),
+            host: "127.0.0.1".to_string(),
+            port: 1,
+        }])
+        .with_timeout(Duration::from_millis(200));
+        let response = proxy(fabric)
+            .oneshot(request(serde_json::json!({ "model": "m", "messages": [] })))
+            .await
+            .expect("router answers");
+        let (status, _) = read_json(response).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// A node stub answering only `/v1/health`, which is all placement reads.
+    struct StubModelNode {
+        port: u16,
+        shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl StubModelNode {
+        fn start(model: &str) -> Self {
+            use std::io::{Read, Write};
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+            let port = listener.local_addr().expect("addr").port();
+            let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let flag = std::sync::Arc::clone(&shutdown);
+            let body = format!(
+                r#"{{"ok":true,"generation_ready":true,"active_model_id":"{model}","backend":"llama","version":"0.6.1","engine_queued_tasks":0,"engine_queue_depth":0}}"#
+            );
+            std::thread::spawn(move || {
+                for stream in listener.incoming() {
+                    if flag.load(std::sync::atomic::Ordering::SeqCst) {
+                        break;
+                    }
+                    let Ok(mut stream) = stream else { continue };
+                    let mut scratch = [0_u8; 1024];
+                    let _ = stream.read(&mut scratch);
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                }
+            });
+            Self { port, shutdown }
+        }
+
+        fn spec(&self, label: &str) -> NodeSpec {
+            NodeSpec {
+                label: label.to_string(),
+                host: "127.0.0.1".to_string(),
+                port: self.port,
+            }
+        }
+    }
+
+    impl Drop for StubModelNode {
+        fn drop(&mut self) {
+            self.shutdown
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            let _ = std::net::TcpStream::connect(("127.0.0.1", self.port));
+        }
     }
 
     #[tokio::test]

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -244,7 +244,10 @@ fn route_error(error: RouteError) -> Response {
         // answer 404 `model_not_found` for exactly this. Answering 503 told
         // clients to retry, so an SDK spent its whole retry budget on a refusal
         // that could never change.
-        RouteError::ModelUnavailable { .. } => (
+        //
+        // Only when every node answered, though: a node still unaccounted for
+        // may be the one that owns the model, and that refusal can clear.
+        RouteError::ModelUnavailable { unobserved: 0, .. } => (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({
                 "error": {
@@ -257,7 +260,9 @@ fn route_error(error: RouteError) -> Response {
         )
             .into_response(),
         // These can genuinely clear on their own, so they stay retryable.
-        RouteError::NoNodesConfigured | RouteError::AllNodesUnavailable { .. } => {
+        RouteError::ModelUnavailable { .. }
+        | RouteError::NoNodesConfigured
+        | RouteError::AllNodesUnavailable { .. } => {
             error_response(StatusCode::SERVICE_UNAVAILABLE, &error.to_string())
         }
     }
@@ -341,6 +346,27 @@ mod tests {
         );
     }
 
+    /// The empty case above passes just as well against a route that can only
+    /// ever answer nothing, so this is the one that proves it observes.
+    #[tokio::test]
+    async fn the_models_route_lists_what_a_ready_node_is_serving() {
+        let node = StubModelNode::start("llama-3b");
+        let fabric = Fabric::new(vec![node.spec("only")]).with_timeout(Duration::from_secs(2));
+        let response = proxy(fabric)
+            .oneshot(get_request("/v1/models"))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["object"], "list");
+        let data = body["data"].as_array().expect("a data array");
+        assert_eq!(data.len(), 1, "{body}");
+        assert_eq!(data[0]["id"], "llama-3b");
+        assert_eq!(data[0]["object"], "model");
+        assert_eq!(data[0]["owned_by"], "camelid");
+    }
+
     /// A model this fabric does not serve will not appear by asking again, and
     /// the nodes answer 404 `model_not_found` for it. Answering 503 told
     /// clients to retry: an OpenAI SDK spent its whole retry budget on a
@@ -364,6 +390,40 @@ mod tests {
         // part an operator acts on.
         let message = body["error"]["message"].as_str().expect("a message");
         assert!(message.contains("llama-3b"), "{message}");
+    }
+
+    /// The same refusal is *not* final when a node could not be consulted: the
+    /// node that is down may be the one that owns the model, so a 404 would
+    /// tell an SDK to give up on something a retry would find. This is the
+    /// difference between a model that is absent and a fabric that cannot yet
+    /// say.
+    #[tokio::test]
+    async fn a_model_missing_only_because_a_node_is_down_stays_retryable() {
+        let node = StubModelNode::start("llama-3b");
+        let fabric = Fabric::new(vec![
+            node.spec("up"),
+            // Port 1 is closed, so this node is observed as unreachable.
+            NodeSpec {
+                label: "down".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 1,
+            },
+        ])
+        .with_timeout(Duration::from_millis(500));
+
+        let response = proxy(fabric)
+            .oneshot(request(
+                serde_json::json!({ "model": "no-such-model", "messages": [] }),
+            ))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a node that never answered may be the one serving it: {body}"
+        );
     }
 
     /// A fabric whose nodes are merely unreachable can recover on its own, so
@@ -406,8 +466,17 @@ mod tests {
                         break;
                     }
                     let Ok(mut stream) = stream else { continue };
+                    // Read to the end of the head before answering: closing a
+                    // socket that still holds unread bytes is an abortive close
+                    // on Windows, and it discards the reply along with them.
+                    let mut request = Vec::new();
                     let mut scratch = [0_u8; 1024];
-                    let _ = stream.read(&mut scratch);
+                    while !request.windows(4).any(|w| w == b"\r\n\r\n") {
+                        match stream.read(&mut scratch) {
+                            Ok(0) | Err(_) => break,
+                            Ok(read) => request.extend_from_slice(&scratch[..read]),
+                        }
+                    }
                     let response = format!(
                         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                         body.len()

--- a/tests/fabric_end_to_end.rs
+++ b/tests/fabric_end_to_end.rs
@@ -308,9 +308,15 @@ fn an_unserved_model_is_refused_naming_what_the_fabric_does_serve() {
     .expect_err("nothing serves it");
 
     match error {
-        RouteError::ModelUnavailable { model, serving } => {
+        RouteError::ModelUnavailable {
+            model,
+            serving,
+            unobserved,
+        } => {
             assert_eq!(model, "model-absent");
             assert_eq!(serving, vec!["model-alpha".to_string()]);
+            // Every configured node answered, so this refusal is final.
+            assert_eq!(unobserved, 0);
         }
         other => panic!("expected ModelUnavailable, got {other:?}"),
     }


### PR DESCRIPTION
A stock OpenAI client points at one address and asks that address what it can serve before it does anything else. The fabric answered 404, so every model picker came up empty — while the nodes behind it answer that question fine.

I found this by pointing the real OpenAI SDK at `camelid fabric serve` rather than reasoning about it. It also turned up a second thing on the way.

## What a stock client sees today

| step | fabric | a node directly |
|---|---|---|
| `models.list()` | **404, no body** | works |
| chat, non-streaming | ok | ok |
| unknown model | **503** | **404 `model_not_found`** |

## `GET /v1/models`

The proxy now answers with the union of the models its ready nodes report, deduplicated and ordered.

- A node that is unreachable, or that has no model loaded, is left out. Advertising its model would promise something the fabric would then refuse.
- Per-file `meta` is omitted. Two nodes can serve one model id from different files, and there is no honest way to merge that; everything else matches the shape a node answers.
- No ready node gives an empty list rather than an error. "Nothing right now" is the truthful answer to a discovery question, and a picker can show it without special-casing a failure.

`servable_models` is pure, so the listing is covered without starting a server — the same way `render_status` is.

## The fabric contradicted its own nodes on refusals

Asked for a model nothing serves, a node answers `404 model_not_found`. The fabric answered `503`, which means "try again" — so the SDK retried a condition that cannot change.

Measured: **1534 ms with default retries against 6 ms for a single attempt.**

`route_error` now decides by variant:

- **`ModelUnavailable` → 404**, carrying `code: "model_not_found"` and `param: "model"` so a client can act on it. The message still names what the fabric *can* serve, which is the part an operator acts on.
- **`NoNodesConfigured` and `AllNodesUnavailable` → 503**, unchanged. Those can genuinely clear on their own, so they stay retryable.

The match is exhaustive, so a new `RouteError` variant forces this decision rather than defaulting into "retry forever".

## Evidence

**Gates:** `cargo fmt --check` clean; `clippy --all-targets -- -D warnings` clean; `fabric::` unit 88 pass; `fabric_end_to_end` 14; `fabric_serve` 8; `--bin camelid` 40; `check-public-scrub.sh` exit 0; touched files `i/lf w/lf`; `git diff --check` clean.

**Ablations.** Each change reverted in turn fails only its own test:

- dropping the route → `the_models_route_answers_a_list_even_with_nothing_to_serve` fails
- restoring the blanket 503 → `an_unservable_model_is_refused_as_not_found_not_as_try_again` fails with `left: 503, right: 404`

**Real client, real nodes.** The OpenAI SDK against two live engines, the same nodes for both arms, only the proxy differing:

| | `models.list()` | unknown model |
|---|---|---|
| before | `404 NotFoundError` | `503`, 1534 ms of retries |
| after | 2 models, the union across both nodes | `404`, 27 ms, no retries |

Chat is unaffected in both arms.

## Scope

Independent of #651 and #652 — this touches only `observe`, `RouteError` and the router, all of which are on `main` today. It can land in any order relative to those.

The proxy still has no authentication of its own and still binds loopback by default; `/v1/models` is a discovery call over the same surface and does not change that.
