### PR TITLE
fix(fabric): stop re-probing every node on every request

### DIFF
--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -29,7 +29,7 @@ pub mod probe;
 pub mod server;
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
@@ -44,7 +44,7 @@ pub use policy::{
     route, route_reserved, Reservations, RouteDecision, RouteError, RouteMode, RouteReason,
     RouteRequest,
 };
-pub use probe::{probe_fabric, probe_node, ProbeError, DEFAULT_PROBE_TIMEOUT};
+pub use probe::{probe_fabric, probe_node, Observation, ProbeError, DEFAULT_PROBE_TIMEOUT};
 
 /// A configured set of nodes.
 #[derive(Clone)]
@@ -58,6 +58,13 @@ pub struct Fabric {
     /// every request, and they have to be counting into the same place or they
     /// cannot see each other.
     reserved: Arc<Mutex<Reservations>>,
+    /// The most recent observation, reused while it is fresh enough.
+    ///
+    /// Shared across clones for the same reason as `reserved`: an observation
+    /// only one clone can see would be re-taken by every other one.
+    observed: Arc<Mutex<Option<Observation>>>,
+    /// How stale a reused observation may be. Zero means never reuse one.
+    max_observation_age: Duration,
 }
 
 /// Hand-written so a token can never reach a log through a derived `Debug`,
@@ -68,6 +75,7 @@ impl std::fmt::Debug for Fabric {
             .field("specs", &self.specs)
             .field("timeout", &self.timeout)
             .field("bearer", &self.bearer.as_ref().map(|_| "[REDACTED]"))
+            .field("max_observation_age", &self.max_observation_age)
             .finish()
     }
 }
@@ -79,11 +87,24 @@ impl Fabric {
             timeout: DEFAULT_PROBE_TIMEOUT,
             bearer: None,
             reserved: Arc::new(Mutex::new(Reservations::none())),
+            observed: Arc::new(Mutex::new(None)),
+            max_observation_age: Duration::ZERO,
         }
     }
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Reuse an observation for up to `max_age` instead of probing again.
+    ///
+    /// A process that makes one request and exits wants the default of zero:
+    /// it has nothing to reuse, and paying for the freshest possible view is
+    /// free. A resident proxy is the opposite — without a bound it probes every
+    /// node on every request. See [`Observation`].
+    pub fn with_max_observation_age(mut self, max_age: Duration) -> Self {
+        self.max_observation_age = max_age;
         self
     }
 
@@ -105,18 +126,61 @@ impl Fabric {
         self.specs.is_empty()
     }
 
-    /// Observe every node once.
+    /// Observe every node.
+    ///
+    /// Probes unless a previous observation is still inside
+    /// [`Fabric::with_max_observation_age`], which defaults to zero — so this
+    /// probes every time until a caller asks for something else.
     pub fn observe(&self) -> Vec<NodeSnapshot> {
+        if self.max_observation_age.is_zero() {
+            return self.probe();
+        }
+
+        // Refreshing under the lock makes concurrent callers wait for one probe
+        // rather than each starting their own. Without that, a burst arriving
+        // on an expired observation would reproduce exactly the per-request
+        // probing this bound exists to remove.
+        let mut observed = lock(&self.observed);
+        if let Some(observation) = observed.as_ref() {
+            if observation.is_fresh_at(Instant::now(), self.max_observation_age) {
+                return observation.snapshots().to_vec();
+            }
+        }
+        let snapshots = self.probe();
+        *observed = Some(Observation::taken_at(snapshots.clone(), Instant::now()));
+        snapshots
+    }
+
+    /// Probe every node, whatever was observed before.
+    fn probe(&self) -> Vec<NodeSnapshot> {
         probe_fabric(&self.specs, self.bearer.as_deref(), self.timeout)
     }
 
-    /// Observe every node once and choose one for a request.
+    /// Drop the current observation, so the next one is taken fresh.
+    fn forget_observation(&self) {
+        *lock(&self.observed) = None;
+    }
+
+    /// A node that did not answer may be gone, and an observation that has
+    /// already proved wrong must not be reused for the rest of its window.
+    ///
+    /// This is what keeps the freshness bound honest: a node dying inside the
+    /// window costs the one request that discovers it, not every request until
+    /// the observation expires.
+    fn forget_observation_if_node_vanished(&self, error: &ForwardError) {
+        if matches!(error, ForwardError::Transport { .. }) {
+            self.forget_observation();
+        }
+    }
+
+    /// Observe the fabric and choose a node for a request.
     ///
     /// The returned [`Placement`] counts the request against the chosen node
     /// until it is dropped, so a placement running concurrently can see it.
     pub fn place(&self, request: &RouteRequest<'_>) -> Result<Placement, RouteError> {
-        // Probing is socket I/O against every node. It stays outside the lock:
-        // holding one across it would serialise placement on the slowest node.
+        // Observing is socket I/O against every node. It stays outside the
+        // reservation lock: holding that across it would serialise placement on
+        // the slowest node, and would deadlock a `Placement` being dropped.
         let snapshots = self.observe();
 
         // Deciding and recording are one step. Split them and two concurrent
@@ -166,7 +230,8 @@ impl Fabric {
             body,
             self.bearer.as_deref(),
             forward_timeout,
-        )?;
+        )
+        .inspect_err(|error| self.forget_observation_if_node_vanished(error))?;
         Ok((placement.decision.clone(), answer))
     }
 
@@ -196,15 +261,16 @@ impl Fabric {
             self.bearer.as_deref(),
             head_timeout,
             idle_timeout,
-        )?;
+        )
+        .inspect_err(|error| self.forget_observation_if_node_vanished(error))?;
         Ok((outcome, placement))
     }
 }
 
-/// A poisoned counter is not a corrupted one: some other request panicked while
-/// holding the lock. Recover the map rather than spreading the panic.
-fn lock(reserved: &Mutex<Reservations>) -> std::sync::MutexGuard<'_, Reservations> {
-    reserved
+/// A poisoned lock is not corrupted state: some other request panicked while
+/// holding it. Recover the value rather than spreading the panic.
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -132,8 +132,17 @@ impl Fabric {
     /// [`Fabric::with_max_observation_age`], which defaults to zero — so this
     /// probes every time until a caller asks for something else.
     pub fn observe(&self) -> Vec<NodeSnapshot> {
+        self.observe_reporting_reuse().0
+    }
+
+    /// Observe, and say whether the answer came from a previous observation.
+    ///
+    /// Placement needs that second fact: a refusal decided from a reused
+    /// observation is a statement about the fabric as it was, and some
+    /// refusals are reported to clients as permanent.
+    fn observe_reporting_reuse(&self) -> (Vec<NodeSnapshot>, bool) {
         if self.max_observation_age.is_zero() {
-            return self.probe();
+            return (self.probe(), false);
         }
 
         // Refreshing under the lock makes concurrent callers wait for one probe
@@ -143,12 +152,12 @@ impl Fabric {
         let mut observed = lock(&self.observed);
         if let Some(observation) = observed.as_ref() {
             if observation.is_fresh_at(Instant::now(), self.max_observation_age) {
-                return observation.snapshots().to_vec();
+                return (observation.snapshots().to_vec(), true);
             }
         }
         let snapshots = self.probe();
         *observed = Some(Observation::taken_at(snapshots.clone(), Instant::now()));
-        snapshots
+        (snapshots, false)
     }
 
     /// Probe every node, whatever was observed before.
@@ -181,8 +190,30 @@ impl Fabric {
         // Observing is socket I/O against every node. It stays outside the
         // reservation lock: holding that across it would serialise placement on
         // the slowest node, and would deadlock a `Placement` being dropped.
-        let snapshots = self.observe();
+        let (snapshots, reused) = self.observe_reporting_reuse();
 
+        match self.place_observed(snapshots, request) {
+            // Refusing on a reused observation would settle from memory a
+            // question the caller asked about now — and the proxy reports
+            // `ModelUnavailable` as a 404 a client is told never to retry. A
+            // node that has loaded a model since must not be refused that way,
+            // so look again before saying no. This costs a probe only on a
+            // request that was about to fail.
+            Err(_) if reused => {
+                self.forget_observation();
+                let (fresh, _) = self.observe_reporting_reuse();
+                self.place_observed(fresh, request)
+            }
+            settled => settled,
+        }
+    }
+
+    /// Choose a node from an observation already taken, and reserve it.
+    fn place_observed(
+        &self,
+        snapshots: Vec<NodeSnapshot>,
+        request: &RouteRequest<'_>,
+    ) -> Result<Placement, RouteError> {
         // Deciding and recording are one step. Split them and two concurrent
         // placements both decide before either records, which is the pile-up
         // this reservation exists to prevent.

--- a/src/fabric/probe.rs
+++ b/src/fabric/probe.rs
@@ -181,6 +181,48 @@ pub fn probe_fabric(
     })
 }
 
+/// A fabric observation, and the moment it was taken.
+///
+/// [`super::Fabric::place`] needs an observation before every request. Probing
+/// for each one is exactly right for a CLI invocation, which makes one request
+/// and exits. For the resident proxy it is a `/v1/health` per node per request,
+/// and while any node is black-holing it is the whole probe budget on every
+/// request — measured at 2.0 s each against nodes that answer in 2 ms.
+///
+/// Reusing an observation trades freshness for that cost, so how stale a reused
+/// one may be is a stated bound rather than an implicit one. Pure, so the
+/// decision is tested without sockets and without sleeping.
+///
+/// `taken` is when the probe *completed*. Stamping it at the start would make
+/// an observation that waited out a black-holing node be born already expired,
+/// which is precisely the case this exists for; the price is that the oldest
+/// fact in an observation can be one probe budget older than the bound alone
+/// suggests.
+#[derive(Debug, Clone)]
+pub struct Observation {
+    snapshots: Vec<NodeSnapshot>,
+    taken: Instant,
+}
+
+impl Observation {
+    pub fn taken_at(snapshots: Vec<NodeSnapshot>, taken: Instant) -> Self {
+        Self { snapshots, taken }
+    }
+
+    pub fn snapshots(&self) -> &[NodeSnapshot] {
+        &self.snapshots
+    }
+
+    /// Whether this observation may still be used at `now`.
+    ///
+    /// The bound is exclusive, so a `max_age` of zero reuses nothing. That is
+    /// what a caller wanting the fabric as it is right now asks for, and it is
+    /// the default.
+    pub fn is_fresh_at(&self, now: Instant, max_age: Duration) -> bool {
+        now.saturating_duration_since(self.taken) < max_age
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,5 +335,30 @@ mod tests {
             unreachable_reason(&ProbeError::Transport("cannot connect".to_string())),
             "cannot connect"
         );
+    }
+
+    /// Built by adding to an instant rather than subtracting from `now`, so the
+    /// test states an elapsed time exactly instead of racing the clock.
+    fn observation_aged(elapsed: Duration) -> (Observation, Instant) {
+        let taken = Instant::now();
+        (Observation::taken_at(Vec::new(), taken), taken + elapsed)
+    }
+
+    #[test]
+    fn an_observation_inside_the_bound_is_reusable() {
+        let (observation, now) = observation_aged(Duration::from_millis(499));
+        assert!(observation.is_fresh_at(now, Duration::from_millis(500)));
+    }
+
+    #[test]
+    fn an_observation_at_the_bound_is_not_reusable() {
+        let (observation, now) = observation_aged(Duration::from_millis(500));
+        assert!(!observation.is_fresh_at(now, Duration::from_millis(500)));
+    }
+
+    #[test]
+    fn a_zero_bound_reuses_nothing_not_even_an_observation_just_taken() {
+        let (observation, now) = observation_aged(Duration::ZERO);
+        assert!(!observation.is_fresh_at(now, Duration::ZERO));
     }
 }

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -10,6 +10,11 @@
 //! `stream: true` the node's server-sent events are forwarded byte for byte, so
 //! an event field this proxy has never heard of reaches the client unaltered.
 //!
+//! Unlike the CLI, this process serves many requests, so it reuses a fabric
+//! observation for a bounded time instead of probing every node on every one.
+//! The bound is set by whoever builds the [`Fabric`]; see
+//! [`Fabric::with_max_observation_age`].
+//!
 //! # Limits an operator has to know about
 //!
 //! * There is no authentication layer. Anything that can reach this address can
@@ -17,6 +22,9 @@
 //!   unless the risk is acknowledged explicitly.
 //! * The token this proxy presents to its nodes is the one the fabric was built
 //!   with; it authenticates the proxy to the nodes, never a client to the proxy.
+//! * A node that becomes ready, or loads a different model, is routed to only
+//!   once the current observation expires. A node that *stops* answering is not
+//!   waited on: the failed forward drops the observation immediately.
 //! * A non-streaming dispatch runs on a blocking thread and blocking socket I/O
 //!   is not cancellable, so a client that hangs up leaves its dispatch running
 //!   until the node answers or `forward_timeout` expires. A streaming dispatch

--- a/src/main.rs
+++ b/src/main.rs
@@ -1191,6 +1191,14 @@ enum FabricAction {
         /// Per-node health probe budget.
         #[arg(long, default_value_t = 2000)]
         timeout_ms: u64,
+        /// How long a fabric observation may be reused before the nodes are
+        /// probed again.
+        ///
+        /// Without a bound this probes every node on every request, and one
+        /// node that black-holes adds the whole probe budget to all of them.
+        /// Set 0 to probe on every request.
+        #[arg(long, default_value_t = 500)]
+        observation_max_age_ms: u64,
         /// Budget for the generation itself, which can legitimately take
         /// minutes. On a streaming request it bounds the wait for the node's
         /// response head and any later gap in which the node sends nothing;
@@ -2969,6 +2977,7 @@ async fn main() -> anyhow::Result<()> {
                 mode,
                 bearer,
                 timeout_ms,
+                observation_max_age_ms,
                 forward_timeout_s,
                 allow_unauthenticated_remote,
             } => {
@@ -2978,7 +2987,10 @@ async fn main() -> anyhow::Result<()> {
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
-                    .with_bearer(bearer.as_deref());
+                    .with_bearer(bearer.as_deref())
+                    .with_max_observation_age(std::time::Duration::from_millis(
+                        observation_max_age_ms,
+                    ));
 
                 // Bind before announcing, so a refused or already-taken address
                 // never prints a listening line it did not earn.

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -355,6 +355,37 @@ fn fabric_of(specs: Vec<NodeSpec>) -> Fabric {
     Fabric::new(specs).with_timeout(PROBE_TIMEOUT)
 }
 
+/// A fabric that reuses an observation, as `fabric serve` builds one.
+fn fabric_reusing_observations(specs: Vec<NodeSpec>, max_age: Duration) -> Fabric {
+    fabric_of(specs).with_max_observation_age(max_age)
+}
+
+/// Health probes every node saw. The whole point of a freshness bound is that
+/// this stops growing with the number of client requests.
+fn health_probes(nodes: &[StubNode]) -> usize {
+    nodes
+        .iter()
+        .map(|node| {
+            node.received()
+                .iter()
+                .filter(|received| received.path == "/v1/health")
+                .count()
+        })
+        .sum()
+}
+
+fn completions_served(nodes: &[StubNode]) -> Vec<usize> {
+    nodes
+        .iter()
+        .map(|node| {
+            node.received()
+                .iter()
+                .filter(|received| received.path == "/v1/chat/completions")
+                .count()
+        })
+        .collect()
+}
+
 /// Bind the real proxy on an OS-assigned port and start serving it in the
 /// background, returning the address a client should connect to.
 async fn start_proxy(fabric: Fabric, mode: RouteMode) -> SocketAddr {
@@ -1004,4 +1035,156 @@ async fn concurrent_slow_requests_do_not_serialize_on_the_single_worker_thread()
         "four concurrent slow requests took {elapsed:?}; \
          they appear to have serialized on the async runtime"
     );
+}
+
+/// The proxy observes the fabric before every placement. Without a freshness
+/// bound that is a `/v1/health` per node per request: measured at exactly 2 per
+/// request against two nodes, and 2.0 s per request when one node black-holes,
+/// against nodes answering in 2 ms.
+#[tokio::test(flavor = "multi_thread")]
+async fn requests_inside_the_freshness_window_share_one_observation() {
+    let nodes = vec![
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+    ];
+    let specs = vec![nodes[0].spec("node-a"), nodes[1].spec("node-b")];
+    let addr = start_proxy(
+        fabric_reusing_observations(specs, Duration::from_secs(30)),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    let body = serde_json::json!({ "model": "shared-model" });
+    for _ in 0..4 {
+        let (status, _, _) = post_chat(addr, &body, &[]).await;
+        assert_eq!(status, 200);
+    }
+
+    assert_eq!(
+        health_probes(&nodes),
+        nodes.len(),
+        "four requests should share one observation, one probe per node"
+    );
+    assert_eq!(
+        completions_served(&nodes).iter().sum::<usize>(),
+        4,
+        "every request must still reach a node"
+    );
+}
+
+/// The bound is a bound, not a cache that never expires. Two requests either
+/// side of it must each take their own observation.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_observation_past_the_bound_is_taken_again() {
+    let max_age = Duration::from_millis(50);
+    let nodes = vec![StubNode::start(StubConfig::ready("shared-model", 0))];
+    let specs = vec![nodes[0].spec("node-a")];
+    let addr = start_proxy(
+        fabric_reusing_observations(specs, max_age),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    let body = serde_json::json!({ "model": "shared-model" });
+    let (first, _, _) = post_chat(addr, &body, &[]).await;
+    assert_eq!(first, 200);
+    tokio::time::sleep(max_age * 4).await;
+    let (second, _, _) = post_chat(addr, &body, &[]).await;
+    assert_eq!(second, 200);
+
+    assert_eq!(
+        health_probes(&nodes),
+        2,
+        "a request after the bound must observe the fabric again"
+    );
+}
+
+/// Reusing an observation must not undo the placement fix: these nodes report a
+/// fixed load, so the observation is identical for every request in the burst
+/// and the spreading can only come from the reservations the fabric keeps
+/// itself. Without those, the label tie-break sends the whole burst to one node.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_burst_still_spreads_while_one_observation_is_reused() {
+    const REQUESTS: usize = 12;
+    let labels = ["node-a", "node-b", "node-c"];
+    let nodes: Vec<StubNode> = labels
+        .iter()
+        .map(|_| StubNode::start(StubConfig::slow("shared-model", Duration::from_millis(300))))
+        .collect();
+    let specs = nodes
+        .iter()
+        .enumerate()
+        .map(|(i, node)| node.spec(labels[i]))
+        .collect();
+    let addr = start_proxy(
+        fabric_reusing_observations(specs, Duration::from_secs(30)),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    let body = serde_json::json!({ "model": "shared-model" });
+    let results =
+        futures_util::future::join_all((0..REQUESTS).map(|_| post_chat(addr, &body, &[]))).await;
+    for (status, _, _) in &results {
+        assert_eq!(*status, 200);
+    }
+
+    assert_eq!(
+        health_probes(&nodes),
+        nodes.len(),
+        "the burst must have been placed from a single observation, \
+         or this proves nothing about spreading without a fresh one"
+    );
+
+    let served = completions_served(&nodes);
+    assert_eq!(
+        served.iter().sum::<usize>(),
+        REQUESTS,
+        "every request must reach a node"
+    );
+    let busiest = served.iter().max().copied().unwrap_or(0);
+    assert!(
+        busiest <= REQUESTS / 2,
+        "one node took {busiest} of {REQUESTS}: {served:?}"
+    );
+    assert!(
+        served.iter().all(|count| *count > 0),
+        "a node serving the model was never used: {served:?}"
+    );
+}
+
+/// A node can die inside the freshness window, and an observation naming it as
+/// ready is then wrong. The failed forward must drop that observation, so the
+/// node is refused as unroutable rather than chosen again for the rest of the
+/// window: the request after the failure is a routing refusal (503), not a
+/// second failed forward (502).
+#[tokio::test(flavor = "multi_thread")]
+async fn a_node_that_stops_answering_drops_the_observation_that_named_it() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let specs = vec![node.spec("node-a")];
+    let addr = start_proxy(
+        fabric_reusing_observations(specs, Duration::from_secs(30)),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    let body = serde_json::json!({ "model": "shared-model" });
+    let (served, _, _) = post_chat(addr, &body, &[]).await;
+    assert_eq!(served, 200, "the node answers while it is up");
+
+    drop(node);
+
+    let (after_death, _, _) = post_chat(addr, &body, &[]).await;
+    assert_eq!(
+        after_death, 502,
+        "the observation still named the node, so this request is spent on it"
+    );
+
+    let (next, refusal, _) = post_chat(addr, &body, &[]).await;
+    assert_eq!(
+        next, 503,
+        "the failed forward must have dropped the observation, so this request \
+         observes the fabric again and finds nothing to route to"
+    );
+    assert_eq!(refusal["error"]["type"], "fabric_error");
 }

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -60,6 +60,9 @@ struct StubConfig {
     /// `engine_queue_depth` behaves this way, and a placement test is only
     /// meaningful against a node whose reported load actually moves.
     live_in_flight: Option<Arc<AtomicUsize>>,
+    /// When set, `/v1/health` reports this model rather than the fixed one, so
+    /// a test can load a different model while the proxy is running.
+    live_model: Option<Arc<Mutex<String>>>,
 }
 
 impl StubConfig {
@@ -81,6 +84,7 @@ impl StubConfig {
             stream_truncated: false,
             events_written: Arc::new(AtomicUsize::new(0)),
             live_in_flight: None,
+            live_model: None,
         }
     }
 
@@ -90,6 +94,15 @@ impl StubConfig {
         Self {
             completion_delay: delay,
             live_in_flight: Some(Arc::new(AtomicUsize::new(0))),
+            ..Self::ready(model, 0)
+        }
+    }
+
+    /// A node whose active model can be changed while the proxy is running, the
+    /// way an operator loading a different model changes it.
+    fn with_switchable_model(model: &str) -> Self {
+        Self {
+            live_model: Some(Arc::new(Mutex::new(model.to_string()))),
             ..Self::ready(model, 0)
         }
     }
@@ -262,19 +275,17 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
     let _ = stream.flush();
 }
 
-/// What `/v1/health` answers: the configured body, or one carrying the load the
-/// node is really under when it is tracking that.
+/// What `/v1/health` answers: the configured body, carrying whatever load and
+/// model the node is really reporting when it is tracking those.
 fn health_body(config: &StubConfig) -> String {
-    match &config.live_in_flight {
-        None => config.health.clone(),
-        Some(count) => {
-            let depth = count.load(Ordering::SeqCst);
-            config.health.replace(
-                "\"engine_queue_depth\":0",
-                &format!("\"engine_queue_depth\":{depth}"),
-            )
-        }
+    let mut body: Value = serde_json::from_str(&config.health).expect("stub health is json");
+    if let Some(count) = &config.live_in_flight {
+        body["engine_queue_depth"] = count.load(Ordering::SeqCst).into();
     }
+    if let Some(model) = &config.live_model {
+        body["active_model_id"] = Value::String(model.lock().expect("stub model lock").clone());
+    }
+    body.to_string()
 }
 
 /// Answer with chunked `text/event-stream`, one HTTP chunk per event, exactly
@@ -1187,4 +1198,37 @@ async fn a_node_that_stops_answering_drops_the_observation_that_named_it() {
          observes the fabric again and finds nothing to route to"
     );
     assert_eq!(refusal["error"]["type"], "fabric_error");
+}
+
+/// Reusing an observation may delay routing to a newly loaded model. It must
+/// not turn that delay into a *permanent* refusal: `/v1/chat/completions`
+/// answers 404 `model_not_found` for a model no node serves, and a 404 tells an
+/// OpenAI SDK to stop retrying. Issued from a reused observation, that verdict
+/// is about the fabric as it was, so the fabric has to look again before it
+/// refuses rather than settle the question from memory.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_model_loaded_since_the_observation_is_not_refused_as_permanently_absent() {
+    let config = StubConfig::with_switchable_model("old-model");
+    let model = Arc::clone(config.live_model.as_ref().expect("a switchable node"));
+    let node = StubNode::start(config);
+    // Far longer than the test runs, so nothing here depends on it expiring.
+    let addr = start_proxy(
+        fabric_reusing_observations(vec![node.spec("only")], Duration::from_secs(30)),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    let (served, _, _) = post_chat(addr, &serde_json::json!({ "model": "old-model" }), &[]).await;
+    assert_eq!(served, 200, "the first request takes the observation");
+
+    // The operator loads something else, exactly as `/api/models/load` does.
+    *model.lock().expect("stub model lock") = "new-model".to_string();
+
+    let (status, body, _) =
+        post_chat(addr, &serde_json::json!({ "model": "new-model" }), &[]).await;
+    assert_ne!(
+        status, 404,
+        "a permanent refusal was settled from a stale observation: {body}"
+    );
+    assert_eq!(status, 200, "{body}");
 }


### PR DESCRIPTION
## The problem

The resident proxy observes the fabric before it places anything, and every request took its own observation. For `fabric run` that is right — one request, one process, and paying for the freshest possible view is free. For a proxy serving many requests it is a `/v1/health` per node per request. Probes are joined, so one node that black-holes adds the whole probe budget to every request that follows it.

Measured on today's `main`, against stub nodes answering in 2 ms:

| | before |
|---|---|
| 10 requests over 2 nodes | **20** health probes — exactly 2 per request |
| 8 requests, one node black-holed | **every** request 2002–2021 ms |

And against a real engine with one black-holed node, where the generation itself took ~95 ms:

| | before |
|---|---|
| 6 requests | 2129 / 2349 / 2284 / 2359 / 2379 / 2270 ms |

96% of each request was spent probing a node that was never going to answer.

## What this does

An observation may now be reused for a bounded time.

- **`Observation`** owns the freshness decision and nothing else — snapshots, when they were taken, and whether they may still be used. Pure, so the boundary is tested without sockets and without sleeping. Same split as `Reservations`: the value type lives in its module, the `Mutex` lives on `Fabric`.
- **The default is zero, which reuses nothing.** `fabric status`, `fabric route` and `fabric run` behave exactly as before and never even take the lock. Only `fabric serve` opts in, at 500 ms, via `--observation-max-age-ms`.
- **Refreshing happens under the lock.** Concurrent callers then wait for one probe instead of each starting their own — otherwise a burst arriving on an expired observation would recreate the per-request probing this removes. `observed` and `reserved` are separate mutexes and are never held at the same time, so a `Placement` being dropped cannot deadlock against a probe.

`taken` is stamped when the probe **completes**, not when it starts. Stamping at the start would make an observation that waited out a black-holing node be born already expired — the exact case this exists for. The price, stated in the module docs, is that the oldest fact in an observation can be one probe budget older than the bound alone suggests.

## What makes reuse safe

A forward that fails on transport drops the observation. A node dying inside the window therefore costs the one request that discovers it, not every request until the window ends.

There is a test for it, and it is what the second ablation below removes: the request after the node dies is a routing refusal (`503`) rather than a second failed forward (`502`).

## This does not undo #652

A frozen observation would re-pile a burst onto one node if ranking used only what the nodes report. It does not: `route_reserved` combines a node's reported load with what this fabric has already placed, and only the first of those stops moving between refreshes.

`a_burst_still_spreads_while_one_observation_is_reused` pins that. Its nodes report a **fixed** load, so the spreading can only come from the reservations, and it asserts the probe count as well — otherwise it could pass for the wrong reason.

## Evidence

**Gates:** `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean; `fabric::` unit **117**; `fabric_serve` **19** (was 15); `fabric_end_to_end` 14; `--bin camelid` 40; `check-public-scrub.sh` exit 0; touched files `i/lf w/lf`; `git diff --check` clean.

**Before / after**, same harness, two release binaries differing only by this commit (`v0.6.1-107-g3e6107dfc` and the same with `-dirty`):

| | before | after |
|---|---|---|
| health probes per 10 requests, 2 nodes | 20 | **2** |
| dead-node arm, median | 2012 ms | **2 ms** |
| real engine + dead node, median | 2349 ms | **97 ms** |

In the dead-node arm only the first request still pays the probe (2017 ms); the remaining seven are 1–3 ms.

**Kill switch.** The same binary with `--observation-max-age-ms 0` reproduces the baseline exactly — median 2012 ms, one probe per request. The old behaviour is one flag away, not a rebuild.

**Ablations.** Each guarantee removed in turn, and only its own tests fail:

- reuse removed → the 3 tests that depend on it fail; all 16 pre-existing `fabric_serve` tests still pass
- invalidation removed → **exactly one** test fails, with `left: 502, right: 503`
- freshness made permanent → the expiry test and the two boundary unit tests fail, while the positive control `an_observation_inside_the_bound_is_reusable` keeps passing

## Limits, stated plainly

- **This is a behaviour change for `fabric serve` by default.** A node that becomes ready, or that loads a different model, is routed to only once the current observation expires. A node that *stops* answering is not waited on. `--observation-max-age-ms 0` restores the previous behaviour exactly.
- 500 ms is a judgement, not a measurement. It is short enough to be imperceptible when a node joins and long enough that the probe stops being per-request; nothing here establishes it as optimal.
- Only a failed **dispatch** invalidates. A node that dies part-way through a relayed stream is not covered — that failure happens after the seam, and is left alone rather than half-handled.
- Every measurement is loopback on one host. As with #651 and #652, nothing here is evidence about behaviour over a real network.
