### PR TITLE
Persist Windows Desktop chats and settings across restarts

### DIFF
--- a/camelid-desktop/README.md
+++ b/camelid-desktop/README.md
@@ -46,6 +46,11 @@ camelid-desktop ──spawns──▶ camelid serve --addr 127.0.0.1:<ephemeral>
 On window close the sidecar is terminated cleanly. On Windows, a **job object** with
 `KILL_ON_JOB_CLOSE` also prevents a desktop crash from orphaning a `camelid` process.
 
+The sidecar receives a new ephemeral port on each launch, so browser-origin storage cannot be
+the desktop app's durable authority. Before React starts, the shell hydrates Camelid-owned UI
+state from `ui-storage-v1.json` in the per-user application-data directory. Writes are mirrored
+there through scoped commands; the regular browser build continues to use `localStorage`.
+
 ## Windows in-place upgrades
 
 The NSIS installer overwrites the files it ships but, like any overwrite-only installer, cannot
@@ -219,5 +224,6 @@ v1 deliberately keeps the native shell thin and ships the engine's real UI as-is
   all chat metrics (e.g. tokens/sec) come from the embedded UI rendering the engine's real
   generation/telemetry events. Nothing in this crate computes or smooths a metric.
 - **Native tray / arbitrary GGUF file-picker are deferred.** The loopback-origin page receives
-  only a scoped native folder chooser for configuring model storage; it does not receive broad
-  filesystem access. Local/catalog model loading still goes through the engine's existing API.
+  a scoped native folder chooser plus Camelid-keyed UI-state commands confined to the app-data
+  directory; it does not receive broad filesystem access. Local/catalog model loading still
+  goes through the engine's existing API.

--- a/camelid-desktop/build.rs
+++ b/camelid-desktop/build.rs
@@ -23,6 +23,9 @@ fn main() {
             "retry_startup",
             "choose_models_directory",
             "reset_models_directory",
+            "read_ui_storage",
+            "set_ui_storage_value",
+            "replace_ui_storage",
         ]));
     tauri_build::try_build(attributes).expect("failed to run tauri-build");
 }

--- a/camelid-desktop/capabilities/sidecar.json
+++ b/camelid-desktop/capabilities/sidecar.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/remote-schema.json",
   "identifier": "sidecar-ui",
-  "description": "Allows the Camelid loopback sidecar UI to call the desktop shell's narrow model-directory commands. No arbitrary filesystem permission is granted: choose_models_directory opens a native scoped folder picker on the Rust side, and reset_models_directory clears the saved preference.",
+  "description": "Allows the Camelid loopback sidecar UI to call narrow model-directory and Camelid-keyed UI-storage commands. No arbitrary filesystem permission is granted: the folder picker is scoped on the Rust side, and UI state is confined to the app-data directory.",
   "windows": ["main"],
   "remote": {
     "urls": ["http://127.0.0.1:*", "http://localhost:*"]
@@ -9,6 +9,9 @@
   "permissions": [
     "core:default",
     "allow-choose-models-directory",
-    "allow-reset-models-directory"
+    "allow-reset-models-directory",
+    "allow-read-ui-storage",
+    "allow-set-ui-storage-value",
+    "allow-replace-ui-storage"
   ]
 }

--- a/camelid-desktop/src/main.rs
+++ b/camelid-desktop/src/main.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
 
 mod engine;
+mod ui_storage;
 
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -17,6 +18,7 @@ use tauri::{Emitter, Manager, State};
 use tauri_plugin_dialog::DialogExt;
 
 use engine::Engine;
+use ui_storage::UiStorageState;
 
 const MODELS_DIRECTORY_PREFERENCE_FILE: &str = "models-directory.json";
 
@@ -270,11 +272,15 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .manage(EngineState::default())
         .manage(StartupState::default())
+        .manage(UiStorageState::default())
         .invoke_handler(tauri::generate_handler![
             startup_snapshot,
             retry_startup,
             choose_models_directory,
-            reset_models_directory
+            reset_models_directory,
+            ui_storage::read_ui_storage,
+            ui_storage::set_ui_storage_value,
+            ui_storage::replace_ui_storage
         ])
         .setup(|app| {
             let handle = app.handle().clone();

--- a/camelid-desktop/src/ui_storage.rs
+++ b/camelid-desktop/src/ui_storage.rs
@@ -1,0 +1,329 @@
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tauri::{Manager, State};
+
+const UI_STORAGE_FILE: &str = "ui-storage-v1.json";
+const UI_STORAGE_TEMP_FILE: &str = "ui-storage-v1.json.tmp";
+const UI_STORAGE_VERSION: u32 = 1;
+const MAX_KEY_BYTES: usize = 256;
+const MAX_VALUE_BYTES: usize = 32 * 1024 * 1024;
+const MAX_DOCUMENT_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Default)]
+struct UiStorageInner {
+    loaded: bool,
+    initialized: bool,
+    values: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default)]
+pub struct UiStorageState(Mutex<UiStorageInner>);
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct UiStorageDocument {
+    version: u32,
+    values: BTreeMap<String, String>,
+}
+
+#[derive(serde::Serialize)]
+struct UiStorageDocumentRef<'a> {
+    version: u32,
+    values: &'a BTreeMap<String, String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct UiStorageSnapshot {
+    version: u32,
+    initialized: bool,
+    values: BTreeMap<String, String>,
+}
+
+fn storage_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join(UI_STORAGE_FILE)
+}
+
+fn temp_storage_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join(UI_STORAGE_TEMP_FILE)
+}
+
+fn validate_entry(key: &str, value: &str) -> Result<(), String> {
+    if !key.starts_with("camelid") {
+        return Err("desktop UI storage only accepts Camelid-owned keys".to_string());
+    }
+    if key.is_empty() || key.len() > MAX_KEY_BYTES {
+        return Err(format!(
+            "desktop UI storage keys must be between 1 and {MAX_KEY_BYTES} bytes"
+        ));
+    }
+    if value.len() > MAX_VALUE_BYTES {
+        return Err(format!(
+            "desktop UI storage values may not exceed {MAX_VALUE_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_values(values: &BTreeMap<String, String>) -> Result<(), String> {
+    for (key, value) in values {
+        validate_entry(key, value)?;
+    }
+    Ok(())
+}
+
+fn decode_document(bytes: &[u8], path: &Path) -> Result<UiStorageDocument, String> {
+    let document: UiStorageDocument = serde_json::from_slice(bytes)
+        .map_err(|err| format!("{} is invalid: {err}", path.display()))?;
+    if document.version != UI_STORAGE_VERSION {
+        return Err(format!(
+            "{} uses unsupported UI storage version {}",
+            path.display(),
+            document.version
+        ));
+    }
+    validate_values(&document.values)?;
+    Ok(document)
+}
+
+fn load_document(app_data_dir: &Path) -> Result<(bool, BTreeMap<String, String>), String> {
+    let path = storage_path(app_data_dir);
+    match fs::read(&path) {
+        Ok(bytes) => return decode_document(&bytes, &path).map(|document| (true, document.values)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(format!("could not read {}: {err}", path.display())),
+    }
+
+    // On Windows replacing an existing file requires unlinking it first. If the
+    // process stopped in that tiny interval, the complete, synced temporary file
+    // is still the durable authority and can be recovered here.
+    let temp_path = temp_storage_path(app_data_dir);
+    match fs::read(&temp_path) {
+        Ok(bytes) => {
+            let document = decode_document(&bytes, &temp_path)?;
+            replace_file(&temp_path, &path)?;
+            Ok((true, document.values))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok((false, BTreeMap::new())),
+        Err(err) => Err(format!("could not read {}: {err}", temp_path.display())),
+    }
+}
+
+fn replace_file(temp_path: &Path, path: &Path) -> Result<(), String> {
+    #[cfg(windows)]
+    if path.exists() {
+        fs::remove_file(path)
+            .map_err(|err| format!("could not replace {}: {err}", path.display()))?;
+    }
+
+    fs::rename(temp_path, path).map_err(|err| {
+        format!(
+            "could not move {} into {}: {err}",
+            temp_path.display(),
+            path.display()
+        )
+    })
+}
+
+fn write_document(app_data_dir: &Path, values: &BTreeMap<String, String>) -> Result<(), String> {
+    validate_values(values)?;
+    fs::create_dir_all(app_data_dir)
+        .map_err(|err| format!("could not create {}: {err}", app_data_dir.display()))?;
+
+    let bytes = serde_json::to_vec_pretty(&UiStorageDocumentRef {
+        version: UI_STORAGE_VERSION,
+        values,
+    })
+    .map_err(|err| format!("could not encode desktop UI storage: {err}"))?;
+    if bytes.len() > MAX_DOCUMENT_BYTES {
+        return Err(format!(
+            "desktop UI storage may not exceed {MAX_DOCUMENT_BYTES} bytes"
+        ));
+    }
+
+    let temp_path = temp_storage_path(app_data_dir);
+    let path = storage_path(app_data_dir);
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&temp_path)
+        .map_err(|err| format!("could not create {}: {err}", temp_path.display()))?;
+    file.write_all(&bytes)
+        .and_then(|_| file.sync_all())
+        .map_err(|err| format!("could not save {}: {err}", temp_path.display()))?;
+    drop(file);
+    replace_file(&temp_path, &path)
+}
+
+impl UiStorageState {
+    fn with_loaded<T>(
+        &self,
+        app_data_dir: &Path,
+        operation: impl FnOnce(&mut UiStorageInner) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let mut inner = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !inner.loaded {
+            let (initialized, values) = load_document(app_data_dir)?;
+            inner.loaded = true;
+            inner.initialized = initialized;
+            inner.values = values;
+        }
+        operation(&mut inner)
+    }
+
+    fn snapshot(&self, app_data_dir: &Path) -> Result<UiStorageSnapshot, String> {
+        self.with_loaded(app_data_dir, |inner| {
+            Ok(UiStorageSnapshot {
+                version: UI_STORAGE_VERSION,
+                initialized: inner.initialized,
+                values: inner.values.clone(),
+            })
+        })
+    }
+
+    fn set_value(
+        &self,
+        app_data_dir: &Path,
+        key: String,
+        value: Option<String>,
+    ) -> Result<(), String> {
+        if let Some(value) = value.as_deref() {
+            validate_entry(&key, value)?;
+        } else if !key.starts_with("camelid") || key.len() > MAX_KEY_BYTES {
+            return Err("desktop UI storage only accepts Camelid-owned keys".to_string());
+        }
+
+        self.with_loaded(app_data_dir, |inner| {
+            let mut next = inner.values.clone();
+            if let Some(value) = value {
+                next.insert(key, value);
+            } else {
+                next.remove(&key);
+            }
+            write_document(app_data_dir, &next)?;
+            inner.initialized = true;
+            inner.values = next;
+            Ok(())
+        })
+    }
+
+    fn replace_values(
+        &self,
+        app_data_dir: &Path,
+        values: BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        validate_values(&values)?;
+        self.with_loaded(app_data_dir, |inner| {
+            write_document(app_data_dir, &values)?;
+            inner.initialized = true;
+            inner.values = values;
+            Ok(())
+        })
+    }
+}
+
+fn app_data_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map_err(|err| format!("could not resolve Camelid application data: {err}"))
+}
+
+#[tauri::command]
+pub async fn read_ui_storage(
+    app: tauri::AppHandle,
+    state: State<'_, UiStorageState>,
+) -> Result<UiStorageSnapshot, String> {
+    state.snapshot(&app_data_dir(&app)?)
+}
+
+#[tauri::command]
+pub async fn set_ui_storage_value(
+    app: tauri::AppHandle,
+    state: State<'_, UiStorageState>,
+    key: String,
+    value: Option<String>,
+) -> Result<(), String> {
+    state.set_value(&app_data_dir(&app)?, key, value)
+}
+
+#[tauri::command]
+pub async fn replace_ui_storage(
+    app: tauri::AppHandle,
+    state: State<'_, UiStorageState>,
+    values: BTreeMap<String, String>,
+) -> Result<(), String> {
+    state.replace_values(&app_data_dir(&app)?, values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{storage_path, UiStorageState};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn desktop_state_survives_a_fresh_webview_origin() {
+        let root = tempfile::tempdir().unwrap();
+        let first_launch = UiStorageState::default();
+        first_launch
+            .set_value(
+                root.path(),
+                "camelid-theme".to_string(),
+                Some("light".to_string()),
+            )
+            .unwrap();
+        first_launch
+            .set_value(
+                root.path(),
+                "camelid.conversations".to_string(),
+                Some("[{\"id\":\"chat-1\"}]".to_string()),
+            )
+            .unwrap();
+
+        // A new state instance models a desktop restart whose WebView has a
+        // different ephemeral-port origin and therefore a fresh localStorage.
+        let second_launch = UiStorageState::default();
+        let snapshot = second_launch.snapshot(root.path()).unwrap();
+        assert!(snapshot.initialized);
+        assert_eq!(snapshot.values["camelid-theme"], "light");
+        assert_eq!(
+            snapshot.values["camelid.conversations"],
+            "[{\"id\":\"chat-1\"}]"
+        );
+    }
+
+    #[test]
+    fn initialized_empty_storage_does_not_resurrect_stale_origin_values() {
+        let root = tempfile::tempdir().unwrap();
+        let first_launch = UiStorageState::default();
+        first_launch
+            .replace_values(root.path(), BTreeMap::new())
+            .unwrap();
+
+        let second_launch = UiStorageState::default();
+        let snapshot = second_launch.snapshot(root.path()).unwrap();
+        assert!(snapshot.initialized);
+        assert!(snapshot.values.is_empty());
+        assert!(storage_path(root.path()).is_file());
+    }
+
+    #[test]
+    fn desktop_storage_rejects_non_camelid_keys() {
+        let root = tempfile::tempdir().unwrap();
+        let state = UiStorageState::default();
+        let error = state
+            .set_value(
+                root.path(),
+                "unrelated-key".to_string(),
+                Some("value".to_string()),
+            )
+            .unwrap_err();
+        assert!(error.contains("Camelid-owned"));
+        assert!(!storage_path(root.path()).exists());
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "smoke:first-run": "node scripts/first-run-activation-smoke.mjs",
     "smoke:first-run-card": "node scripts/first-run-card-smoke.mjs",
     "smoke:offline-banner": "node scripts/offline-banner-smoke.mjs",
+    "smoke:desktop-storage": "node scripts/desktop-storage-smoke.mjs",
     "smoke:catalog-browse": "node scripts/catalog-browse-smoke.mjs",
     "smoke:model-families": "node scripts/model-families-smoke.mjs",
     "smoke:catalog-companion": "node scripts/catalog-companion-smoke.mjs",

--- a/frontend/scripts/desktop-storage-smoke.mjs
+++ b/frontend/scripts/desktop-storage-smoke.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+
+class MemoryStorage {
+  constructor(seed = {}) {
+    this.values = new Map(Object.entries(seed))
+  }
+
+  get length() { return this.values.size }
+  key(index) { return [...this.values.keys()][index] ?? null }
+  getItem(key) { return this.values.has(String(key)) ? this.values.get(String(key)) : null }
+  setItem(key, value) { this.values.set(String(key), String(value)) }
+  removeItem(key) { this.values.delete(String(key)) }
+  clear() { this.values.clear() }
+}
+
+class FullStorage extends MemoryStorage {
+  setItem() { throw new Error('quota exceeded') }
+}
+
+const nativeDocument = { initialized: false, values: {} }
+const invoke = async (command, args = {}) => {
+  if (command === 'read_ui_storage') {
+    return { version: 1, initialized: nativeDocument.initialized, values: { ...nativeDocument.values } }
+  }
+  if (command === 'replace_ui_storage') {
+    nativeDocument.initialized = true
+    nativeDocument.values = { ...args.values }
+    return
+  }
+  if (command === 'set_ui_storage_value') {
+    nativeDocument.initialized = true
+    if (args.value === null) delete nativeDocument.values[args.key]
+    else nativeDocument.values[args.key] = args.value
+    return
+  }
+  throw new Error(`unexpected command: ${command}`)
+}
+
+function installWindow(storage, withDesktop = true) {
+  globalThis.window = {
+    localStorage: storage,
+    ...(withDesktop ? { __TAURI__: { core: { invoke } } } : {}),
+  }
+}
+
+// Launch one is served from one ephemeral port and starts with that origin's
+// empty browser storage.
+installWindow(new MemoryStorage())
+const firstLaunch = await import('../src/lib/appStorage.js?desktop-launch=one')
+await firstLaunch.hydrateAppStorage()
+firstLaunch.appStorage.setItem('camelid-theme', 'light')
+firstLaunch.appStorage.setItem('camelid.conversations', '[{"id":"chat-653"}]')
+await firstLaunch.flushAppStorage()
+
+// Launch two models a different port: its localStorage is unrelated and empty,
+// but hydration must restore the native document before app state initializes.
+const secondOrigin = new MemoryStorage()
+installWindow(secondOrigin)
+const secondLaunch = await import('../src/lib/appStorage.js?desktop-launch=two')
+await secondLaunch.hydrateAppStorage()
+assert.equal(secondLaunch.appStorage.getItem('camelid-theme'), 'light')
+assert.equal(secondLaunch.appStorage.getItem('camelid.conversations'), '[{"id":"chat-653"}]')
+
+// Native state remains readable when the WebView origin cache is full and
+// cannot accept the hydrated conversation payload.
+installWindow(new FullStorage())
+const fullOriginLaunch = await import('../src/lib/appStorage.js?desktop-launch=full-origin')
+await fullOriginLaunch.hydrateAppStorage()
+assert.equal(fullOriginLaunch.appStorage.getItem('camelid-theme'), 'light')
+assert.equal(fullOriginLaunch.appStorage.getItem('camelid.conversations'), '[{"id":"chat-653"}]')
+
+// Once initialized, an empty native document is authoritative. A coincidentally
+// reused port must not resurrect values deleted during a previous launch.
+secondLaunch.appStorage.clear()
+await secondLaunch.flushAppStorage()
+const staleOrigin = new MemoryStorage({ 'camelid-theme': 'dark', 'camelid.conversations': '[{"id":"stale"}]' })
+installWindow(staleOrigin)
+const thirdLaunch = await import('../src/lib/appStorage.js?desktop-launch=three')
+await thirdLaunch.hydrateAppStorage()
+assert.equal(thirdLaunch.appStorage.getItem('camelid-theme'), null)
+assert.equal(thirdLaunch.appStorage.getItem('camelid.conversations'), null)
+
+// The normal browser build remains a direct localStorage fallback.
+const browserOrigin = new MemoryStorage()
+installWindow(browserOrigin, false)
+const browserLaunch = await import('../src/lib/appStorage.js?browser-launch')
+await browserLaunch.hydrateAppStorage()
+browserLaunch.appStorage.setItem('camelid-theme', 'system')
+assert.equal(browserOrigin.getItem('camelid-theme'), 'system')
+
+console.log('desktop storage smoke: PASS')

--- a/frontend/scripts/offline-banner-smoke.mjs
+++ b/frontend/scripts/offline-banner-smoke.mjs
@@ -122,6 +122,12 @@ async function openBanner({ clipboard = 'ok', storage = {}, platform = null, des
       window.__TAURI__ = {
         core: {
           invoke: (cmd) => {
+            if (cmd === 'read_ui_storage') {
+              return Promise.resolve({ version: 1, initialized: false, values: {} })
+            }
+            if (cmd === 'replace_ui_storage' || cmd === 'set_ui_storage_value') {
+              return Promise.resolve()
+            }
             window.__invoked.push(cmd)
             return desktopShell === 'failing' ? Promise.reject(new Error('nope')) : Promise.resolve()
           },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import { ConfirmDialog } from './components/ui/ConfirmDialog'
 import { isFirstRunHost } from './lib/firstRunActivation'
 import { formatPreview, formatSidebarDate } from './lib/formatters'
 import { hasOverlayTitleBar } from './lib/desktopShell'
+import { appStorage } from './lib/appStorage.js'
 import { useDashboardData } from './hooks/useDashboardData'
 import { useBackendLauncher } from './hooks/useBackendLauncher'
 import { useNotice } from './hooks/useNotice'
@@ -43,7 +44,7 @@ function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     if (DEMO_UI) return true
     if (typeof window === 'undefined') return false
-    return window.localStorage.getItem('camelid.sidebarCollapsed') === 'true'
+    return appStorage.getItem('camelid.sidebarCollapsed') === 'true'
   })
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const [isMobile, setIsMobile] = useState(
@@ -91,7 +92,7 @@ function App() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    window.localStorage.setItem('camelid.sidebarCollapsed', String(sidebarCollapsed))
+    appStorage.setItem('camelid.sidebarCollapsed', String(sidebarCollapsed))
   }, [sidebarCollapsed])
 
   // Deep-link the active tab via the URL hash (e.g. #library) — shareable and
@@ -136,8 +137,8 @@ function App() {
     const executable = runtime?.executable
     if (!executable || typeof window === 'undefined') return
     try {
-      window.localStorage.setItem(ENGINE_PATH_STORAGE_KEY, executable)
-      if (runtime?.listen_addr) window.localStorage.setItem(ENGINE_ADDR_STORAGE_KEY, runtime.listen_addr)
+      appStorage.setItem(ENGINE_PATH_STORAGE_KEY, executable)
+      if (runtime?.listen_addr) appStorage.setItem(ENGINE_ADDR_STORAGE_KEY, runtime.listen_addr)
     } catch { /* private mode */ }
   }, [runtime?.executable, runtime?.listen_addr])
 

--- a/frontend/src/components/chat/ChatControls.jsx
+++ b/frontend/src/components/chat/ChatControls.jsx
@@ -6,19 +6,20 @@ import {
   loadSavedSamplingParams,
   saveSamplingParams,
 } from '../../lib/samplingContract'
+import { appStorage } from '../../lib/appStorage.js'
 
 const SYSTEM_PROMPT_STORAGE_KEY = 'camelid.systemPrompt'
 const SYSTEM_PROMPT_PRESETS_KEY = 'camelid.systemPromptPresets'
 
 const readStoredPrompt = () => {
   if (typeof window === 'undefined') return ''
-  return window.localStorage.getItem(SYSTEM_PROMPT_STORAGE_KEY) || ''
+  return appStorage.getItem(SYSTEM_PROMPT_STORAGE_KEY) || ''
 }
 
 const readPresets = () => {
   if (typeof window === 'undefined') return []
   try {
-    const saved = JSON.parse(window.localStorage.getItem(SYSTEM_PROMPT_PRESETS_KEY) || '[]')
+    const saved = JSON.parse(appStorage.getItem(SYSTEM_PROMPT_PRESETS_KEY) || '[]')
     return Array.isArray(saved) ? saved.filter((p) => p?.name && typeof p.content === 'string') : []
   } catch {
     return []
@@ -49,11 +50,11 @@ export function ChatControls({ capabilities, modelId, onClose }) {
 
   const persistPrompt = (value) => {
     setSystemPrompt(value)
-    if (typeof window !== 'undefined') window.localStorage.setItem(SYSTEM_PROMPT_STORAGE_KEY, value)
+    if (typeof window !== 'undefined') appStorage.setItem(SYSTEM_PROMPT_STORAGE_KEY, value)
   }
   const persistPresets = (next) => {
     setPresets(next)
-    if (typeof window !== 'undefined') window.localStorage.setItem(SYSTEM_PROMPT_PRESETS_KEY, JSON.stringify(next))
+    if (typeof window !== 'undefined') appStorage.setItem(SYSTEM_PROMPT_PRESETS_KEY, JSON.stringify(next))
   }
   const savePreset = () => {
     const name = presetName.trim()

--- a/frontend/src/components/layout/BackendBanner.jsx
+++ b/frontend/src/components/layout/BackendBanner.jsx
@@ -4,6 +4,7 @@ import { StatusDot } from '../ui/StatusDot'
 import { IconPlay, IconCopy, IconCheck, IconRefresh, IconSettings } from '../ui/icons'
 import { copyText } from '../../lib/markdown'
 import { isDesktopShell } from '../../lib/desktopShell'
+import { appStorage } from '../../lib/appStorage.js'
 
 /* Shown on the copy button when the engine never told us where it lives.
 
@@ -27,7 +28,7 @@ const DEFAULT_ADDR = '127.0.0.1:8181'
 function readStored(key) {
   if (typeof window === 'undefined') return ''
   try {
-    return (window.localStorage.getItem(key) || '').trim()
+    return (appStorage.getItem(key) || '').trim()
   } catch {
     return ''
   }

--- a/frontend/src/hooks/useBackendLauncher.js
+++ b/frontend/src/hooks/useBackendLauncher.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { backendProcStatus, launchBackend, stopBackend } from '../lib/devBackend'
+import { appStorage } from '../lib/appStorage.js'
 
 const CMD_KEY = 'camelid.launchCommand'
 // Bare values that don't resolve on most PATHs — treat as "auto-detect" instead of a real override.
@@ -7,9 +8,9 @@ const NON_OVERRIDES = new Set(['', 'camelid', 'camelid serve'])
 
 function readCommand() {
   if (typeof window === 'undefined') return ''
-  const saved = (window.localStorage.getItem(CMD_KEY) || '').trim()
+  const saved = (appStorage.getItem(CMD_KEY) || '').trim()
   if (NON_OVERRIDES.has(saved)) {
-    if (saved) window.localStorage.removeItem(CMD_KEY) // migrate the old broken default
+    if (saved) appStorage.removeItem(CMD_KEY) // migrate the old broken default
     return ''
   }
   return saved
@@ -37,8 +38,8 @@ export function useBackendLauncher({ showNotice, loadDashboard } = {}) {
   const setCommand = useCallback((value) => {
     setCommandState(value)
     if (typeof window === 'undefined') return
-    if (value.trim()) window.localStorage.setItem(CMD_KEY, value)
-    else window.localStorage.removeItem(CMD_KEY)
+    if (value.trim()) appStorage.setItem(CMD_KEY, value)
+    else appStorage.removeItem(CMD_KEY)
   }, [])
 
   const start = useCallback(async () => {

--- a/frontend/src/hooks/useClusterTopology.js
+++ b/frontend/src/hooks/useClusterTopology.js
@@ -4,6 +4,7 @@ import {
   specsToNodePatch, summarizeCluster, validateTopology,
 } from '../lib/clusterModel'
 import { discoverDevices, fetchNodeTelemetry, probeNode } from '../lib/devCluster'
+import { appStorage } from '../lib/appStorage.js'
 
 const DEFAULT_PORT = { ssh: 22, winrm: 5985, agent: 8181, manual: null }
 
@@ -44,11 +45,11 @@ export function useClusterTopology({ showNotice } = {}) {
         // Accept a single import object or an array of them (each tracked by import_id).
         const imports = Array.isArray(data) ? data : (Array.isArray(data.imports) ? data.imports : [data])
         let done = []
-        try { done = JSON.parse(window.localStorage.getItem('camelid.clusterImports') || '[]') } catch { /* noop */ }
+        try { done = JSON.parse(appStorage.getItem('camelid.clusterImports') || '[]') } catch { /* noop */ }
         const fresh = imports.filter((imp) => imp && imp.import_id && !done.includes(imp.import_id))
         if (!fresh.length) return
         setTopology((prev) => fresh.reduce((acc, imp) => mergeImport(acc, imp), prev))
-        try { window.localStorage.setItem('camelid.clusterImports', JSON.stringify([...done, ...fresh.map((i) => i.import_id)])) } catch { /* noop */ }
+        try { appStorage.setItem('camelid.clusterImports', JSON.stringify([...done, ...fresh.map((i) => i.import_id)])) } catch { /* noop */ }
         const added = fresh.reduce((n, imp) => n + (imp.nodes?.length || 0), 0)
         pushEvent('ok', `Applied ${fresh.length} cluster import(s) — ${added} node entr${added === 1 ? 'y' : 'ies'}.`)
       })

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -7,6 +7,7 @@ import { loadLocalModelForChat, modelFilenameFromPath } from '../lib/modelActiva
 import { readStreamingChatCompletion } from '../lib/chatCompletionStream'
 import { NEW_CHAT_SENTINEL, resolveSelectedConversation, shouldCreateConversationForSend } from '../lib/chatState'
 import { normalizeStoredConversations } from '../lib/conversationStorage.js'
+import { appStorage } from '../lib/appStorage.js'
 import { getRuntimeRequestModelId, isExternalModel, modelRuntimeIdMatches } from '../lib/modelState'
 import { contractSamplingOverrides } from '../lib/samplingContract'
 import { executionRuntimeFields } from '../lib/executionPlan'
@@ -44,23 +45,23 @@ const DEFAULT_API_BASE = defaultApiBase()
 
 function getInitialTab() {
   if (typeof window === 'undefined') return 'chat'
-  const saved = window.localStorage.getItem(TAB_STORAGE_KEY)
+  const saved = appStorage.getItem(TAB_STORAGE_KEY)
   return saved && VALID_TABS.has(saved) ? saved : 'chat'
 }
 
 function getInitialConversationId() {
   if (typeof window === 'undefined') return null
-  return window.localStorage.getItem(SELECTED_CONVERSATION_STORAGE_KEY) || null
+  return appStorage.getItem(SELECTED_CONVERSATION_STORAGE_KEY) || null
 }
 
 function getInitialModelId() {
   if (typeof window === 'undefined') return ''
-  return window.localStorage.getItem(SELECTED_MODEL_STORAGE_KEY) || ''
+  return appStorage.getItem(SELECTED_MODEL_STORAGE_KEY) || ''
 }
 
 function getApiBase() {
   if (typeof window === 'undefined') return DEFAULT_API_BASE
-  return window.localStorage.getItem(API_BASE_STORAGE_KEY) || DEFAULT_API_BASE
+  return appStorage.getItem(API_BASE_STORAGE_KEY) || DEFAULT_API_BASE
 }
 
 function normalizeApiBase(value) {
@@ -70,10 +71,10 @@ function normalizeApiBase(value) {
 function readJsonStorage(key, fallback) {
   if (typeof window === 'undefined') return fallback
   try {
-    const saved = window.localStorage.getItem(key)
+    const saved = appStorage.getItem(key)
     return saved ? JSON.parse(saved) : fallback
   } catch {
-    window.localStorage.removeItem(key)
+    appStorage.removeItem(key)
     return fallback
   }
 }
@@ -81,7 +82,7 @@ function readJsonStorage(key, fallback) {
 function writeJsonStorage(key, value) {
   if (typeof window === 'undefined') return
   try {
-    window.localStorage.setItem(key, JSON.stringify(value))
+    appStorage.setItem(key, JSON.stringify(value))
   } catch {
     // Image attachments can exhaust a browser's small localStorage quota.
     // Keep the live in-memory conversation and request working; persistence
@@ -139,7 +140,7 @@ const DEFAULT_CHAT_MAX_TOKENS = 8192
 
 function getConfiguredMaxTokens() {
   if (typeof window === 'undefined') return DEFAULT_CHAT_MAX_TOKENS
-  const value = Number.parseInt(window.localStorage.getItem(MAX_TOKENS_STORAGE_KEY) || '', 10)
+  const value = Number.parseInt(appStorage.getItem(MAX_TOKENS_STORAGE_KEY) || '', 10)
   return Number.isFinite(value) && value >= 256 ? value : DEFAULT_CHAT_MAX_TOKENS
 }
 
@@ -153,7 +154,7 @@ const SYSTEM_PROMPT_STORAGE_KEY = 'camelid.systemPrompt'
 
 function getConfiguredSystemPrompt() {
   if (typeof window === 'undefined') return ''
-  return String(window.localStorage.getItem(SYSTEM_PROMPT_STORAGE_KEY) || '').trim()
+  return String(appStorage.getItem(SYSTEM_PROMPT_STORAGE_KEY) || '').trim()
 }
 
 function applyLocalChatPolicy(messages) {
@@ -886,19 +887,19 @@ export function useDashboardData({ showNotice, clearNotice }) {
 
   useEffect(() => {
     if (typeof window === 'undefined' || !VALID_TABS.has(tab)) return
-    window.localStorage.setItem(TAB_STORAGE_KEY, tab)
+    appStorage.setItem(TAB_STORAGE_KEY, tab)
   }, [tab])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    if (!selectedConversationId) window.localStorage.removeItem(SELECTED_CONVERSATION_STORAGE_KEY)
-    else window.localStorage.setItem(SELECTED_CONVERSATION_STORAGE_KEY, selectedConversationId)
+    if (!selectedConversationId) appStorage.removeItem(SELECTED_CONVERSATION_STORAGE_KEY)
+    else appStorage.setItem(SELECTED_CONVERSATION_STORAGE_KEY, selectedConversationId)
   }, [selectedConversationId])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    if (!selectedModelId) window.localStorage.removeItem(SELECTED_MODEL_STORAGE_KEY)
-    else window.localStorage.setItem(SELECTED_MODEL_STORAGE_KEY, selectedModelId)
+    if (!selectedModelId) appStorage.removeItem(SELECTED_MODEL_STORAGE_KEY)
+    else appStorage.setItem(SELECTED_MODEL_STORAGE_KEY, selectedModelId)
   }, [selectedModelId])
 
   const conversations = localConversations.length ? localConversations : dashboard?.conversations || []
@@ -1888,7 +1889,7 @@ export function useDashboardData({ showNotice, clearNotice }) {
     setApiBase: (value) => {
       const next = normalizeApiBase(value)
       setApiBaseState(next)
-      if (typeof window !== 'undefined') window.localStorage.setItem(API_BASE_STORAGE_KEY, next)
+      if (typeof window !== 'undefined') appStorage.setItem(API_BASE_STORAGE_KEY, next)
     },
   }
 }

--- a/frontend/src/hooks/useTheme.js
+++ b/frontend/src/hooks/useTheme.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { appStorage } from '../lib/appStorage.js'
 
 const STORAGE_KEY = 'camelid-theme'
 const VALID = new Set(['system', 'light', 'dark'])
@@ -10,7 +11,7 @@ export const THEME_ORDER = ['dark', 'light', 'system']
    'system' and 'light' remain one toggle away. */
 function readPreference() {
   if (typeof window === 'undefined') return 'dark'
-  const saved = window.localStorage.getItem(STORAGE_KEY)
+  const saved = appStorage.getItem(STORAGE_KEY)
   return saved && VALID.has(saved) ? saved : 'dark'
 }
 
@@ -64,7 +65,7 @@ export function useTheme() {
   useEffect(() => {
     applyPreference(preference)
     if (typeof window !== 'undefined') {
-      window.localStorage.setItem(STORAGE_KEY, preference)
+      appStorage.setItem(STORAGE_KEY, preference)
     }
     if (preference !== 'system') {
       setResolved(preference)

--- a/frontend/src/lib/apiAuth.js
+++ b/frontend/src/lib/apiAuth.js
@@ -1,16 +1,18 @@
+import { appStorage } from './appStorage.js'
+
 export const API_BASE_STORAGE_KEY = 'camelid.apiBase'
 export const API_KEY_STORAGE_KEY = 'camelid.apiKey'
 
 export function getStoredApiKey() {
   if (typeof window === 'undefined') return ''
-  return window.localStorage.getItem(API_KEY_STORAGE_KEY) || ''
+  return appStorage.getItem(API_KEY_STORAGE_KEY) || ''
 }
 
 export function setStoredApiKey(value) {
   if (typeof window === 'undefined') return
   const next = String(value || '').trim()
-  if (next) window.localStorage.setItem(API_KEY_STORAGE_KEY, next)
-  else window.localStorage.removeItem(API_KEY_STORAGE_KEY)
+  if (next) appStorage.setItem(API_KEY_STORAGE_KEY, next)
+  else appStorage.removeItem(API_KEY_STORAGE_KEY)
 }
 
 export function installApiAuthFetch() {
@@ -23,7 +25,7 @@ export function installApiAuthFetch() {
 
     try {
       const requestUrl = new URL(typeof input === 'string' || input instanceof URL ? input : input.url, window.location.href)
-      const configuredBase = window.localStorage.getItem(API_BASE_STORAGE_KEY) || window.location.origin
+      const configuredBase = appStorage.getItem(API_BASE_STORAGE_KEY) || window.location.origin
       const apiOrigin = new URL(configuredBase, window.location.href).origin
       if (requestUrl.origin !== apiOrigin) return nativeFetch(input, init)
 

--- a/frontend/src/lib/appStorage.js
+++ b/frontend/src/lib/appStorage.js
@@ -1,0 +1,154 @@
+const CAMELID_STORAGE_PREFIX = 'camelid'
+
+let desktopInvoke = null
+let desktopValues = null
+let hydrated = false
+let persistenceTail = Promise.resolve()
+let persistenceWarningShown = false
+
+function browserStorage() {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function isCamelidKey(key) {
+  return String(key).startsWith(CAMELID_STORAGE_PREFIX)
+}
+
+function readCamelidEntries(storage) {
+  const entries = {}
+  if (!storage) return entries
+  try {
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index)
+      if (!key || !isCamelidKey(key)) continue
+      const value = storage.getItem(key)
+      if (value !== null) entries[key] = value
+    }
+  } catch {
+    // Browser storage remains best-effort in privacy-restricted contexts.
+  }
+  return entries
+}
+
+function replaceBrowserCamelidEntries(storage, values) {
+  if (!storage) return
+  try {
+    for (const key of Object.keys(readCamelidEntries(storage))) storage.removeItem(key)
+    for (const [key, value] of Object.entries(values)) storage.setItem(key, String(value))
+  } catch {
+    // The native document is still authoritative in Desktop even if the
+    // current WebView origin refuses its local compatibility cache.
+  }
+}
+
+function warnPersistenceFailure(error) {
+  if (persistenceWarningShown || typeof console === 'undefined') return
+  persistenceWarningShown = true
+  console.warn('Camelid Desktop could not persist UI settings.', error)
+}
+
+function queueDesktopWrite(command, args) {
+  if (!desktopInvoke) return
+  persistenceTail = persistenceTail
+    .then(() => desktopInvoke(command, args))
+    .catch((error) => warnPersistenceFailure(error))
+}
+
+/**
+ * Hydrate the current ephemeral WebView origin before React reads any settings.
+ * The native app-data document is canonical after its first initialization;
+ * the first launch alone imports any existing Camelid localStorage values.
+ */
+export async function hydrateAppStorage() {
+  if (hydrated || typeof window === 'undefined') return
+  hydrated = true
+  const invoke = window.__TAURI__?.core?.invoke
+  if (!invoke) return
+
+  const storage = browserStorage()
+  try {
+    const snapshot = await invoke('read_ui_storage')
+    desktopInvoke = invoke
+    const persisted = snapshot?.values && typeof snapshot.values === 'object'
+      ? snapshot.values
+      : {}
+
+    if (snapshot?.initialized) {
+      desktopValues = new Map(Object.entries(persisted).map(([key, value]) => [key, String(value)]))
+      replaceBrowserCamelidEntries(storage, persisted)
+    } else {
+      const imported = readCamelidEntries(storage)
+      await invoke('replace_ui_storage', { values: imported })
+      desktopValues = new Map(Object.entries(imported))
+    }
+  } catch (error) {
+    desktopInvoke = null
+    desktopValues = null
+    warnPersistenceFailure(error)
+  }
+}
+
+export const appStorage = {
+  getItem(key) {
+    const normalizedKey = String(key)
+    if (desktopValues && isCamelidKey(normalizedKey)) {
+      return desktopValues.get(normalizedKey) ?? null
+    }
+    try {
+      return browserStorage()?.getItem(normalizedKey) ?? null
+    } catch {
+      return null
+    }
+  },
+
+  setItem(key, value) {
+    const normalizedKey = String(key)
+    const normalizedValue = String(value)
+    if (desktopValues && isCamelidKey(normalizedKey)) {
+      desktopValues.set(normalizedKey, normalizedValue)
+    }
+    try {
+      browserStorage()?.setItem(normalizedKey, normalizedValue)
+    } catch {
+      // Preserve the existing best-effort browser behavior.
+    }
+    if (isCamelidKey(normalizedKey)) {
+      queueDesktopWrite('set_ui_storage_value', { key: normalizedKey, value: normalizedValue })
+    }
+  },
+
+  removeItem(key) {
+    const normalizedKey = String(key)
+    if (desktopValues && isCamelidKey(normalizedKey)) {
+      desktopValues.delete(normalizedKey)
+    }
+    try {
+      browserStorage()?.removeItem(normalizedKey)
+    } catch {
+      // Preserve the existing best-effort browser behavior.
+    }
+    if (isCamelidKey(normalizedKey)) {
+      queueDesktopWrite('set_ui_storage_value', { key: normalizedKey, value: null })
+    }
+  },
+
+  clear() {
+    desktopValues?.clear()
+    try {
+      browserStorage()?.clear()
+    } catch {
+      // Preserve the existing best-effort browser behavior.
+    }
+    queueDesktopWrite('replace_ui_storage', { values: {} })
+  },
+}
+
+// Exposed for deterministic smoke coverage and callers that need a durability barrier.
+export function flushAppStorage() {
+  return persistenceTail
+}

--- a/frontend/src/lib/clusterModel.js
+++ b/frontend/src/lib/clusterModel.js
@@ -3,6 +3,8 @@
    future backend. Persisted client-side (localStorage), like conversations and
    memories. Local-only: machines sharing compute/memory/workers/model-serving. */
 
+import { appStorage } from './appStorage.js'
+
 export const STORAGE_KEY = 'camelid.clusterTopology'
 
 export const NODE_TYPES = [
@@ -134,7 +136,7 @@ export function normalizeTopology(raw) {
 export function loadTopology() {
   if (typeof window === 'undefined') return emptyTopology()
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
+    const raw = appStorage.getItem(STORAGE_KEY)
     return raw ? normalizeTopology(JSON.parse(raw)) : emptyTopology()
   } catch {
     return emptyTopology()
@@ -144,7 +146,7 @@ export function loadTopology() {
 export function saveTopology(topology) {
   if (typeof window === 'undefined') return
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...topology, updated_at: nowIso() }))
+    appStorage.setItem(STORAGE_KEY, JSON.stringify({ ...topology, updated_at: nowIso() }))
   } catch { /* quota / private mode — keep in-memory */ }
 }
 

--- a/frontend/src/lib/responseLimits.js
+++ b/frontend/src/lib/responseLimits.js
@@ -7,6 +7,7 @@
    UI renders those indicators ABSENT, never estimated client-side. */
 
 import { findCompatibilityHint, isExactCompatibilityHint } from './capabilities.js'
+import { appStorage } from './appStorage.js'
 
 export const MAX_RESPONSE_TOKENS = 1000000
 export const MIN_RESPONSE_TOKENS = 1
@@ -209,21 +210,21 @@ const MAX_TOKENS_KEY = 'camelid.maxTokens'
 
 export function hasExplicitMaxTokensSetting(modelId = '') {
   if (typeof window === 'undefined' || !modelId) return false
-  const value = Number.parseInt(window.localStorage.getItem(`${MAX_TOKENS_KEY}.${modelId}`) || '', 10)
+  const value = Number.parseInt(appStorage.getItem(`${MAX_TOKENS_KEY}.${modelId}`) || '', 10)
   return Number.isFinite(value) && value >= MIN_RESPONSE_TOKENS
 }
 
 export function getConfiguredMaxTokens(modelId = '') {
   if (typeof window === 'undefined') return 8192
-  const perModel = modelId ? Number.parseInt(window.localStorage.getItem(`${MAX_TOKENS_KEY}.${modelId}`) || '', 10) : NaN
+  const perModel = modelId ? Number.parseInt(appStorage.getItem(`${MAX_TOKENS_KEY}.${modelId}`) || '', 10) : NaN
   if (Number.isFinite(perModel) && perModel >= MIN_RESPONSE_TOKENS) return perModel
-  const legacy = Number.parseInt(window.localStorage.getItem(MAX_TOKENS_KEY) || '', 10)
+  const legacy = Number.parseInt(appStorage.getItem(MAX_TOKENS_KEY) || '', 10)
   return Number.isFinite(legacy) && legacy >= 256 ? legacy : 8192
 }
 
 export function setConfiguredMaxTokens(modelId, value) {
   if (typeof window === 'undefined') return
   const clamped = Math.min(Math.max(Math.round(value), MIN_RESPONSE_TOKENS), MAX_RESPONSE_TOKENS)
-  if (modelId) window.localStorage.setItem(`${MAX_TOKENS_KEY}.${modelId}`, String(clamped))
-  else window.localStorage.setItem(MAX_TOKENS_KEY, String(clamped))
+  if (modelId) appStorage.setItem(`${MAX_TOKENS_KEY}.${modelId}`, String(clamped))
+  else appStorage.setItem(MAX_TOKENS_KEY, String(clamped))
 }

--- a/frontend/src/lib/samplingContract.js
+++ b/frontend/src/lib/samplingContract.js
@@ -10,6 +10,8 @@
    control is guarded; see frontend/design-evidence/BACKEND_ASKS.md for the requested
    row shape. */
 
+import { appStorage } from './appStorage.js'
+
 import { isSupportedCapabilityStatus } from './capabilities.js'
 
 export const SAMPLING_PARAMS = [
@@ -37,7 +39,7 @@ const PARAM_STORAGE_PREFIX = 'camelid.samplingParams.'
 export function loadSavedSamplingParams(modelId) {
   if (typeof window === 'undefined' || !modelId) return {}
   try {
-    const saved = window.localStorage.getItem(`${PARAM_STORAGE_PREFIX}${modelId}`)
+    const saved = appStorage.getItem(`${PARAM_STORAGE_PREFIX}${modelId}`)
     return saved ? JSON.parse(saved) : {}
   } catch {
     return {}
@@ -46,7 +48,7 @@ export function loadSavedSamplingParams(modelId) {
 
 export function saveSamplingParams(modelId, params) {
   if (typeof window === 'undefined' || !modelId) return
-  window.localStorage.setItem(`${PARAM_STORAGE_PREFIX}${modelId}`, JSON.stringify(params || {}))
+  appStorage.setItem(`${PARAM_STORAGE_PREFIX}${modelId}`, JSON.stringify(params || {}))
 }
 
 /* Request overrides: only parameters whose exact contract row is supported

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,11 +10,20 @@ import '@fontsource/ibm-plex-mono/500.css'
 import '@fontsource/ibm-plex-mono/600.css'
 import './styles.css'
 import { installApiAuthFetch } from './lib/apiAuth'
+import { hydrateAppStorage } from './lib/appStorage.js'
 
-installApiAuthFetch()
+async function startApp() {
+  // Camelid Desktop serves this UI from a new loopback port after each restart.
+  // Restore the app-owned storage document before any hook reads origin-scoped
+  // localStorage; the regular browser build resolves this immediately.
+  await hydrateAppStorage()
+  installApiAuthFetch()
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+  ReactDOM.createRoot(document.getElementById('root')).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  )
+}
+
+startApp()

--- a/frontend/src/views/InferenceObservatoryView.jsx
+++ b/frontend/src/views/InferenceObservatoryView.jsx
@@ -8,6 +8,7 @@ import { getChatGateState } from '../lib/chatGate'
 import { EvidenceChip } from '../components/ui/EvidenceChip'
 import { IconChevronRight, IconObservatory } from '../components/ui/icons'
 import { fmtMs, fmtRate } from '../components/observatory/format'
+import { appStorage } from '../lib/appStorage.js'
 
 /* Observatory (Phase 6.1 — "The Flow Bench"): inference rendered as liquid.
    The centerpiece canvas and the instrument rail consume the SAME lifecycle
@@ -23,7 +24,7 @@ const RENDERERS = ['flowbench', 'neuralfield']
 
 function initialRenderer() {
   try {
-    const stored = window.localStorage.getItem(RENDERER_KEY)
+    const stored = appStorage.getItem(RENDERER_KEY)
     return RENDERERS.includes(stored) ? stored : 'neuralfield'
   } catch {
     return 'neuralfield'
@@ -43,7 +44,7 @@ export default function InferenceObservatoryView({ apiBase, runtime = null, sele
   const pickRenderer = (mode) => {
     setRenderer(mode)
     try {
-      window.localStorage.setItem(RENDERER_KEY, mode)
+      appStorage.setItem(RENDERER_KEY, mode)
     } catch { /* persistence is best-effort */ }
   }
 

--- a/frontend/src/views/SettingsView.jsx
+++ b/frontend/src/views/SettingsView.jsx
@@ -10,6 +10,7 @@ import { IconPlay, IconStop, IconCopy, IconCheck, IconServer, IconSettings, Icon
 import { copyText } from '../lib/markdown'
 import { getConfiguredMaxTokens, setConfiguredMaxTokens } from '../lib/responseLimits'
 import { getStoredApiKey, setStoredApiKey } from '../lib/apiAuth'
+import { appStorage } from '../lib/appStorage.js'
 import { ResponseLengthControl } from '../components/settings/ResponseLengthControl'
 
 const THEME_OPTS = [
@@ -106,7 +107,7 @@ export default function SettingsView({
     setMaxTokens(value)
     setConfiguredMaxTokens(selectedModel?.id || '', value)
     // keep the legacy global key as the fallback for other models
-    if (typeof window !== 'undefined') window.localStorage.setItem('camelid.maxTokens', String(value))
+    if (typeof window !== 'undefined') appStorage.setItem('camelid.maxTokens', String(value))
   }
 
   const statusTone = online ? 'ready' : status.running ? 'warn' : 'offline'

--- a/frontend/src/views/WorkspaceView.jsx
+++ b/frontend/src/views/WorkspaceView.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import { findCompatibilityHint } from '../lib/capabilities'
+import { appStorage } from '../lib/appStorage.js'
 import {
   browseWorkspaceFolders,
   cancelWorkspaceSession,
@@ -56,7 +57,7 @@ const SPLITTER_PX = 10
 const MAX_RENDERED_TURNS = 100
 
 function initialSetupPercent() {
-  const saved = Number.parseFloat(window.localStorage.getItem('camelid.workspaceSetupPercent') || '')
+  const saved = Number.parseFloat(appStorage.getItem('camelid.workspaceSetupPercent') || '')
   return Number.isFinite(saved) ? saved : DEFAULT_SETUP_PERCENT
 }
 
@@ -284,7 +285,7 @@ function ContextInspector({ budget, timing, runtimeContext, compaction, busy, di
 }
 
 export default function WorkspaceView({ apiBase, capabilities, selectedModel, runtime, setTab }) {
-  const [workspacePath, setWorkspacePath] = useState(() => window.localStorage.getItem('camelid.workspacePath') || '')
+  const [workspacePath, setWorkspacePath] = useState(() => appStorage.getItem('camelid.workspacePath') || '')
   const [goal, setGoal] = useState('')
   const [followUp, setFollowUp] = useState('')
   const [savedThreads, setSavedThreads] = useState([])
@@ -415,7 +416,7 @@ export default function WorkspaceView({ apiBase, capabilities, selectedModel, ru
   }, [apiBase, workspacePath, selectedThreadId, session])
 
   useEffect(() => {
-    if (workspacePath) window.localStorage.setItem('camelid.workspacePath', workspacePath)
+    if (workspacePath) appStorage.setItem('camelid.workspacePath', workspacePath)
   }, [workspacePath])
 
   useEffect(() => {
@@ -424,7 +425,7 @@ export default function WorkspaceView({ apiBase, capabilities, selectedModel, ru
   }, [apiBase, session])
 
   useEffect(() => {
-    window.localStorage.setItem('camelid.workspaceSetupPercent', String(setupPercent))
+    appStorage.setItem('camelid.workspaceSetupPercent', String(setupPercent))
   }, [setupPercent])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- persist Camelid-owned Desktop UI state in a versioned app-data document
- hydrate that state before React initializes, while preserving normal localStorage behavior in browser builds
- route conversations, theme, and other saved UI settings through the shared storage adapter
- add regression coverage for restarts across different ephemeral loopback ports and for a full WebView storage quota

## Root cause

Camelid Desktop starts its sidecar on an ephemeral loopback port and navigates the WebView to that origin. Browser localStorage is scoped by origin, including the port, so each restart could receive a fresh storage namespace even though the native models-directory preference continued to persist separately.

## User impact

Chats, theme choice, memories, selected model/tab, response settings, and other Camelid UI preferences now survive Desktop restarts without replacing the collision-resistant ephemeral-port design. The browser-served UI continues to use localStorage directly.

## Validation

- `cargo test -p camelid-desktop` (25 tests passed)
- `cargo clippy -p camelid-desktop --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run build`
- `npm run smoke:desktop-storage`
- `npm run smoke:ui`
- `npm run smoke:offline-banner`
- relevant model, workspace, integration, streaming, capability, markdown, and catalog smokes

The existing `smoke:ghost-moe-execution` baseline also fails on current `main`: the runtime projection includes `gemma4_ghost_catalog_managed: null` while that smoke's expected object omits the field. This PR does not touch that path.

Addresses #653.
