### PR TITLE
feat(fabric): let the proxy require a key from its clients

### DIFF
--- a/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
+++ b/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
@@ -27,7 +27,7 @@
   },
   "implementation": {
     "source_file": "src/api/mod.rs",
-    "source_git_blob_sha1": "681667e2c27a8926c35af836949a5582f19b3a5c",
+    "source_git_blob_sha1": "d26867ac20319c564251db59292e60d51469911d",
     "architecture": "smollm3",
     "renderer": "render_smollm3_production_chat_prompt",
     "public_chokepoints": [

--- a/scripts/hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/hf-qualification-smollm3-chat-parity.mjs
@@ -93,11 +93,11 @@ const GROUNDING_FILES = Object.freeze({
   }),
   runtime_envelope: Object.freeze({
     path: 'qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json',
-    sha256: '51e978d633e4859956ddb7dbfb27c219c538844b0dcf950b8917312b448fcc53',
+    sha256: '9a1ad6fb962a70b2e8bcb732355eedd4003235006350e071750bfe4e6498e4ae',
   }),
 })
 
-const RENDERER_GIT_BLOB_SHA1 = '681667e2c27a8926c35af836949a5582f19b3a5c'
+const RENDERER_GIT_BLOB_SHA1 = 'd26867ac20319c564251db59292e60d51469911d'
 const SHAPE_CASE_ID = 'default_think_single_user_generation_prompt'
 const NORMALIZED_PROMPT_UTF8_BYTES = 1_392
 const NORMALIZED_PROMPT_SHA256 = '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1'

--- a/scripts/test-hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/test-hf-qualification-smollm3-chat-parity.mjs
@@ -114,7 +114,7 @@ assert.deepEqual(TEMPLATE_IDENTITY, {
 assert.equal(GROUNDING_FILES.shape_pack.sha256,
   'd46794448b7c2585d0aa83dfd7bb17d4904c2dcbc048ade1ef68cd3863166de6')
 assert.equal(GROUNDING_FILES.runtime_envelope.sha256,
-  '51e978d633e4859956ddb7dbfb27c219c538844b0dcf950b8917312b448fcc53')
+  '9a1ad6fb962a70b2e8bcb732355eedd4003235006350e071750bfe4e6498e4ae')
 assert.equal(LLAMA_PIN.executable_sha256,
   '6c787bf07ac1d7e1bbaa1ee176c3ef0df58ea86494c8c1b1d2d9f4a9176b19ae')
 assert.equal(LLAMA_PIN.server_impl_sha256,
@@ -331,7 +331,7 @@ assert.equal(classifySmolLM3ChatParityError(sharedSmolError).error_code,
 
 const committedGrounding = await inspectGroundings(root)
 assert.equal(committedGrounding.renderer_git_blob_sha1,
-  '681667e2c27a8926c35af836949a5582f19b3a5c')
+  'd26867ac20319c564251db59292e60d51469911d')
 assert.equal(committedGrounding.shape_case.normalized_prompt_sha256,
   '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1')
 const shapePack = JSON.parse(await readFile(resolve(GROUNDING_FILES.shape_pack.path), 'utf8'))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -41,6 +41,9 @@ pub use server::ServeOptions;
 /// Re-exported so anything else in the crate that fronts this server bounds
 /// request bodies at the same size the server itself does.
 pub(crate) use server::DEFAULT_MAX_REQUEST_BODY_BYTES;
+/// Re-exported so another front door authenticates its clients with this
+/// server's check rather than a second implementation of one.
+pub(crate) use server::{authenticate, resolve_api_key, ApiAuth};
 
 use crate::{
     embedding::{

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -99,6 +99,13 @@ impl fmt::Debug for ApiAuth {
 }
 
 impl ApiAuth {
+    /// Require `key`, or accept every request when it is `None`.
+    pub(crate) fn new(key: Option<String>) -> Self {
+        Self {
+            key: key.map(|key| Arc::<[u8]>::from(key.into_bytes())),
+        }
+    }
+
     pub(crate) fn enabled(&self) -> bool {
         self.key.is_some()
     }
@@ -171,25 +178,7 @@ impl ServerPolicy {
         validate_positive("max generation tokens", options.max_generation_tokens)?;
         validate_positive("max download bytes", options.max_download_bytes)?;
 
-        if options.api_key.is_some() && options.api_key_file.is_some() {
-            return Err(invalid(
-                "--api-key and --api-key-file are mutually exclusive",
-            ));
-        }
-        let key = match (options.api_key, options.api_key_file) {
-            (Some(key), None) => Some(validate_api_key(key)?),
-            (None, Some(path)) => {
-                let key = std::fs::read_to_string(&path).map_err(|error| {
-                    Error::new(
-                        error.kind(),
-                        format!("could not read API key file {}: {error}", path.display()),
-                    )
-                })?;
-                Some(validate_api_key(key)?)
-            }
-            (None, None) => None,
-            (Some(_), Some(_)) => unreachable!("conflict handled above"),
-        };
+        let key = resolve_api_key(options.api_key, options.api_key_file)?;
 
         if !addr.ip().is_loopback() && key.is_none() && !options.allow_unauthenticated_remote {
             return Err(Error::new(
@@ -218,9 +207,7 @@ impl ServerPolicy {
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {
-            auth: ApiAuth {
-                key: key.map(|key| Arc::<[u8]>::from(key.into_bytes())),
-            },
+            auth: ApiAuth::new(key),
             limits: ServerLimits {
                 max_request_body_bytes: options.max_request_body_bytes,
                 max_prompt_tokens: options.max_prompt_tokens,
@@ -324,6 +311,33 @@ fn validate_api_key(key: String) -> Result<String> {
         return Err(invalid("API key must not contain control characters"));
     }
     Ok(key)
+}
+
+/// Resolve the key clients must present, from a value or a file.
+///
+/// Shared with the fabric proxy: two front doors validating the same kind of
+/// secret by two sets of rules is how they end up disagreeing about what a
+/// valid key is.
+pub(crate) fn resolve_api_key(
+    api_key: Option<String>,
+    api_key_file: Option<PathBuf>,
+) -> Result<Option<String>> {
+    match (api_key, api_key_file) {
+        (Some(_), Some(_)) => Err(invalid(
+            "--api-key and --api-key-file are mutually exclusive",
+        )),
+        (Some(key), None) => Ok(Some(validate_api_key(key)?)),
+        (None, Some(path)) => {
+            let key = std::fs::read_to_string(&path).map_err(|error| {
+                Error::new(
+                    error.kind(),
+                    format!("could not read API key file {}: {error}", path.display()),
+                )
+            })?;
+            Ok(Some(validate_api_key(key)?))
+        }
+        (None, None) => Ok(None),
+    }
 }
 
 fn parse_origin(origin: &str) -> Result<HeaderValue> {

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -10,19 +10,31 @@
 //! `stream: true` the node's server-sent events are forwarded byte for byte, so
 //! an event field this proxy has never heard of reaches the client unaltered.
 //!
+//! # Two credentials, in opposite directions
+//!
+//! [`ClientAuth`] is what a client must present to *this* proxy. The bearer the
+//! [`Fabric`] was built with is what this proxy presents to *its nodes*. They
+//! are configured separately and are not interchangeable: a fabric whose nodes
+//! share one key must not thereby accept that key from the network.
+//!
+//! The check itself is [`crate::api::authenticate`] — the engine's, not a
+//! second one. A client sees the same 401 whichever of the two it is talking
+//! to, and there is only one constant-time comparison in the crate to get right.
+//!
 //! # Limits an operator has to know about
 //!
-//! * There is no authentication layer. Anything that can reach this address can
-//!   drive every node in the fabric, so [`bind`] refuses a non-loopback address
-//!   unless the risk is acknowledged explicitly.
-//! * The token this proxy presents to its nodes is the one the fabric was built
-//!   with; it authenticates the proxy to the nodes, never a client to the proxy.
+//! * Without a [`ClientAuth`], anything that can reach this address can drive
+//!   every node in the fabric, so [`bind`] refuses a non-loopback address
+//!   unless a key is configured or the risk is acknowledged explicitly.
+//! * Authentication is all-or-nothing: there is one key, it is not per-client,
+//!   and nothing here revokes or rotates it while the proxy is running.
 //! * A non-streaming dispatch runs on a blocking thread and blocking socket I/O
 //!   is not cancellable, so a client that hangs up leaves its dispatch running
 //!   until the node answers or `forward_timeout` expires. A streaming dispatch
 //!   does notice: its next send fails and the node's socket is dropped with it.
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,15 +45,57 @@ use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
-use axum::{Json, Router};
+use axum::{middleware, Json, Router};
 use serde_json::Value;
 
 use super::policy::{RouteDecision, RouteError, RouteMode, RouteRequest};
 use super::{self as fabric, DispatchError, Fabric, ForwardError, StreamOutcome};
-use crate::api::DEFAULT_MAX_REQUEST_BODY_BYTES;
+use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
 
 /// Optional header a client sends to request affinity to a specific node.
 const STICKY_HEADER: &str = "x-camelid-fabric-sticky";
+
+/// The credential a client must present to this proxy.
+///
+/// Wraps the engine's own [`ApiAuth`] so a key is validated, and later compared,
+/// by exactly the rules the engine applies to its own.
+#[derive(Clone, Debug)]
+pub struct ClientAuth {
+    inner: ApiAuth,
+}
+
+impl ClientAuth {
+    /// Accept every client. Safe only on a loopback listener, which is why
+    /// [`bind`] refuses anything else without an acknowledgement.
+    pub fn none() -> Self {
+        Self {
+            inner: ApiAuth::new(None),
+        }
+    }
+
+    /// Require a key, read from a value or a file.
+    ///
+    /// Fails rather than starting unauthenticated: a proxy that silently
+    /// ignored an unreadable key file would be open to whatever can reach it.
+    pub fn resolve(
+        api_key: Option<String>,
+        api_key_file: Option<PathBuf>,
+    ) -> std::io::Result<Self> {
+        Ok(Self {
+            inner: ApiAuth::new(crate::api::resolve_api_key(api_key, api_key_file)?),
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.inner.enabled()
+    }
+}
+
+impl Default for ClientAuth {
+    fn default() -> Self {
+        Self::none()
+    }
+}
 
 /// Everything a request needs beyond which nodes exist.
 #[derive(Debug, Clone)]
@@ -56,6 +110,8 @@ pub struct ServeConfig {
     /// node sends nothing. A healthy stream resets the second with every token,
     /// so a long generation is never cut short by it.
     pub forward_timeout: Duration,
+    /// What a client must present to be served at all.
+    pub auth: ClientAuth,
 }
 
 #[derive(Clone)]
@@ -68,6 +124,9 @@ struct ServerState {
 
 /// Build the router without binding a socket, so tests can drive it directly.
 pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
+    // Applied last, so it is the outermost layer: an unauthenticated request is
+    // refused before anything here reads its body or observes the fabric.
+    let auth = config.auth.inner.clone();
     Router::new()
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/models", get(models))
@@ -78,6 +137,10 @@ pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
             fabric: Arc::new(fabric),
             config,
         })
+        .layer(middleware::from_fn_with_state(
+            auth,
+            crate::api::authenticate,
+        ))
 }
 
 /// Bind `addr` for the proxy, refusing an exposure the operator did not ask for.
@@ -86,30 +149,32 @@ pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
 /// directly so the guard cannot be skipped by forgetting to call it.
 pub async fn bind(
     addr: SocketAddr,
+    auth: &ClientAuth,
     allow_unauthenticated_remote: bool,
 ) -> std::io::Result<tokio::net::TcpListener> {
-    refuse_unauthenticated_remote(addr, allow_unauthenticated_remote)?;
+    refuse_unauthenticated_remote(addr, auth.is_enabled(), allow_unauthenticated_remote)?;
     tokio::net::TcpListener::bind(addr).await
 }
 
 /// Refuse an unauthenticated listener that the network can reach. Pure.
 ///
-/// This proxy has no auth layer at all, so a routable bind exposes every node
-/// in the fabric, not just this process. `crate::api::server` refuses the same
-/// shape of listener; this mirrors that refusal and its escape hatch.
+/// An unauthenticated routable bind exposes every node in the fabric, not just
+/// this process. `crate::api::server` refuses the same shape of listener on the
+/// same three conditions; this mirrors that refusal and its escape hatch.
 fn refuse_unauthenticated_remote(
     addr: SocketAddr,
+    authenticated: bool,
     allow_unauthenticated_remote: bool,
 ) -> std::io::Result<()> {
-    if addr.ip().is_loopback() || allow_unauthenticated_remote {
+    if addr.ip().is_loopback() || authenticated || allow_unauthenticated_remote {
         return Ok(());
     }
     Err(std::io::Error::new(
         std::io::ErrorKind::PermissionDenied,
         format!(
-            "refusing unauthenticated non-loopback listener {addr}; the fabric proxy has no \
-             authentication of its own, so this would expose every configured node to the \
-             network. Bind a loopback address, or explicitly acknowledge the risk with \
+            "refusing unauthenticated non-loopback listener {addr}; this would expose every \
+             configured node to the network. Bind a loopback address, configure \
+             --api-key/--api-key-file, or explicitly acknowledge the risk with \
              --allow-unauthenticated-remote"
         ),
     ))
@@ -501,14 +566,18 @@ mod tests {
             .expect("valid request")
     }
 
+    /// A proxy that accepts every client. Authentication has its own tests;
+    /// everything else here is about what the proxy does once a request is in.
+    fn open_config() -> ServeConfig {
+        ServeConfig {
+            mode: RouteMode::Throughput,
+            forward_timeout: Duration::from_millis(200),
+            auth: ClientAuth::none(),
+        }
+    }
+
     fn proxy(fabric: Fabric) -> Router {
-        router(
-            fabric,
-            ServeConfig {
-                mode: RouteMode::Throughput,
-                forward_timeout: Duration::from_millis(200),
-            },
-        )
+        router(fabric, open_config())
     }
 
     /// A client points at one address, so that address has to answer what it
@@ -691,13 +760,7 @@ mod tests {
     #[tokio::test]
     async fn an_empty_fabric_answers_503_not_a_hang() {
         let fabric = Fabric::new(Vec::new());
-        let router = router(
-            fabric,
-            ServeConfig {
-                mode: RouteMode::Throughput,
-                forward_timeout: Duration::from_millis(200),
-            },
-        );
+        let router = router(fabric, open_config());
         let response = router
             .oneshot(request(serde_json::json!({ "model": "m" })))
             .await
@@ -721,13 +784,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             port: 1,
         }]);
-        let router = router(
-            fabric,
-            ServeConfig {
-                mode: RouteMode::Throughput,
-                forward_timeout: Duration::from_millis(200),
-            },
-        );
+        let router = router(fabric, open_config());
         let response = router
             .oneshot(request(serde_json::json!({ "model": "m", "stream": true })))
             .await
@@ -740,13 +797,7 @@ mod tests {
     #[tokio::test]
     async fn a_malformed_body_is_rejected_before_it_reaches_the_fabric() {
         let fabric = Fabric::new(Vec::new());
-        let router = router(
-            fabric,
-            ServeConfig {
-                mode: RouteMode::Throughput,
-                forward_timeout: Duration::from_millis(200),
-            },
-        );
+        let router = router(fabric, open_config());
         let bad = axum::http::Request::builder()
             .method("POST")
             .uri("/v1/chat/completions")
@@ -768,13 +819,7 @@ mod tests {
     #[tokio::test]
     async fn a_body_over_the_axum_default_still_reaches_the_fabric() {
         let fabric = Fabric::new(Vec::new());
-        let router = router(
-            fabric,
-            ServeConfig {
-                mode: RouteMode::Throughput,
-                forward_timeout: Duration::from_millis(200),
-            },
-        );
+        let router = router(fabric, open_config());
         let body = serde_json::json!({ "model": "m", "pad": "x".repeat(4 * 1024 * 1024) });
         let response = router.oneshot(request(body)).await.expect("router answers");
         let (status, body) = read_json(response).await;
@@ -787,13 +832,7 @@ mod tests {
     #[tokio::test]
     async fn a_body_over_the_proxy_limit_is_refused_in_the_fabric_error_shape() {
         let fabric = Fabric::new(Vec::new());
-        let router = router(
-            fabric,
-            ServeConfig {
-                mode: RouteMode::Throughput,
-                forward_timeout: Duration::from_millis(200),
-            },
-        );
+        let router = router(fabric, open_config());
         let oversize = crate::api::DEFAULT_MAX_REQUEST_BODY_BYTES + 1024;
         let body = serde_json::json!({ "model": "m", "pad": "x".repeat(oversize) });
         let response = router.oneshot(request(body)).await.expect("router answers");
@@ -804,15 +843,15 @@ mod tests {
 
     #[test]
     fn a_loopback_listener_needs_no_acknowledgement() {
-        refuse_unauthenticated_remote("127.0.0.1:8282".parse().unwrap(), false)
+        refuse_unauthenticated_remote("127.0.0.1:8282".parse().unwrap(), false, false)
             .expect("loopback is not exposed");
-        refuse_unauthenticated_remote("[::1]:8282".parse().unwrap(), false)
+        refuse_unauthenticated_remote("[::1]:8282".parse().unwrap(), false, false)
             .expect("loopback is not exposed");
     }
 
     #[test]
     fn an_unauthenticated_non_loopback_listener_is_refused_by_default() {
-        let error = refuse_unauthenticated_remote("0.0.0.0:8282".parse().unwrap(), false)
+        let error = refuse_unauthenticated_remote("0.0.0.0:8282".parse().unwrap(), false, false)
             .expect_err("every node in the fabric would be exposed");
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
         // The refusal has to name the way out of it, or it is a dead end.
@@ -820,12 +859,44 @@ mod tests {
             error.to_string().contains("--allow-unauthenticated-remote"),
             "{error}"
         );
+        // ...including the way out that does not give up authentication.
+        assert!(error.to_string().contains("--api-key"), "{error}");
     }
 
     #[test]
     fn a_non_loopback_listener_starts_once_the_risk_is_acknowledged() {
-        refuse_unauthenticated_remote("0.0.0.0:8282".parse().unwrap(), true)
+        refuse_unauthenticated_remote("0.0.0.0:8282".parse().unwrap(), false, true)
             .expect("the operator accepted the exposure");
+    }
+
+    /// Requiring a key is what the acknowledgement is an alternative to, so a
+    /// key has to satisfy the guard on its own.
+    #[test]
+    fn a_key_lets_a_non_loopback_listener_start_without_acknowledging_anything() {
+        refuse_unauthenticated_remote("0.0.0.0:8282".parse().unwrap(), true, false)
+            .expect("the listener is authenticated");
+    }
+
+    #[test]
+    fn a_resolved_key_reports_itself_as_enabled() {
+        assert!(!ClientAuth::none().is_enabled());
+        assert!(!ClientAuth::resolve(None, None)
+            .expect("no key is not an error")
+            .is_enabled());
+        assert!(ClientAuth::resolve(Some("k".to_string()), None)
+            .expect("a key resolves")
+            .is_enabled());
+    }
+
+    /// A key that cannot be read has to stop the process, not quietly leave the
+    /// proxy open to whatever can reach it.
+    #[test]
+    fn an_unusable_key_is_an_error_rather_than_an_open_proxy() {
+        ClientAuth::resolve(Some(" ".to_string()), None).expect_err("blank is not a key");
+        ClientAuth::resolve(None, Some(PathBuf::from("no-such-key-file")))
+            .expect_err("an unreadable file is not a key");
+        ClientAuth::resolve(Some("k".to_string()), Some(PathBuf::from("f")))
+            .expect_err("two sources is ambiguous");
     }
 
     /// The sticky header is documented as working whatever default the proxy

--- a/src/main.rs
+++ b/src/main.rs
@@ -1188,6 +1188,17 @@ enum FabricAction {
         /// answers every forwarded request with 401.
         #[arg(long, value_name = "TOKEN")]
         bearer: Option<String>,
+        /// Require this key from clients of the proxy. This is the opposite
+        /// direction to --bearer, and deliberately does NOT read CAMELID_API_KEY:
+        /// on this command that variable already names the token sent to nodes,
+        /// so one value would silently configure both directions.
+        #[arg(long, value_name = "KEY", conflicts_with = "api_key_file")]
+        api_key: Option<String>,
+        /// Read the client key from a text file (surrounding whitespace is
+        /// ignored). Prefer this on a shared machine, so the secret is not in
+        /// the process command line.
+        #[arg(long, value_name = "PATH")]
+        api_key_file: Option<PathBuf>,
         /// Per-node health probe budget.
         #[arg(long, default_value_t = 2000)]
         timeout_ms: u64,
@@ -2968,12 +2979,15 @@ async fn main() -> anyhow::Result<()> {
                 addr,
                 mode,
                 bearer,
+                api_key,
+                api_key_file,
                 timeout_ms,
                 forward_timeout_s,
                 allow_unauthenticated_remote,
             } => {
                 let mode = route_mode(&mode)?;
                 let bearer = fabric_bearer(bearer);
+                let auth = camelid::fabric::server::ClientAuth::resolve(api_key, api_key_file)?;
                 let specs = camelid::fabric::parse_fabric(&nodes)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)
@@ -2983,7 +2997,8 @@ async fn main() -> anyhow::Result<()> {
                 // Bind before announcing, so a refused or already-taken address
                 // never prints a listening line it did not earn.
                 let listener =
-                    camelid::fabric::server::bind(addr, allow_unauthenticated_remote).await?;
+                    camelid::fabric::server::bind(addr, &auth, allow_unauthenticated_remote)
+                        .await?;
                 println!("fabric serve listening on {}", listener.local_addr()?);
                 camelid::fabric::server::serve_on(
                     listener,
@@ -2991,6 +3006,7 @@ async fn main() -> anyhow::Result<()> {
                     camelid::fabric::server::ServeConfig {
                         mode,
                         forward_timeout: std::time::Duration::from_secs(forward_timeout_s),
+                        auth,
                     },
                 )
                 .await?;

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use camelid::fabric::server::{serve_on, ServeConfig};
+use camelid::fabric::server::{serve_on, ClientAuth, ServeConfig};
 use camelid::fabric::{Fabric, NodeSpec, RouteMode};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -358,6 +358,10 @@ fn fabric_of(specs: Vec<NodeSpec>) -> Fabric {
 /// Bind the real proxy on an OS-assigned port and start serving it in the
 /// background, returning the address a client should connect to.
 async fn start_proxy(fabric: Fabric, mode: RouteMode) -> SocketAddr {
+    start_proxy_with_auth(fabric, mode, ClientAuth::none()).await
+}
+
+async fn start_proxy_with_auth(fabric: Fabric, mode: RouteMode, auth: ClientAuth) -> SocketAddr {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind proxy");
@@ -365,6 +369,7 @@ async fn start_proxy(fabric: Fabric, mode: RouteMode) -> SocketAddr {
     let config = ServeConfig {
         mode,
         forward_timeout: FORWARD_TIMEOUT,
+        auth,
     };
     tokio::spawn(async move {
         let _ = serve_on(listener, fabric, config).await;
@@ -1004,4 +1009,135 @@ async fn concurrent_slow_requests_do_not_serialize_on_the_single_worker_thread()
         "four concurrent slow requests took {elapsed:?}; \
          they appear to have serialized on the async runtime"
     );
+}
+
+/// Send one GET over a real socket and return (status, raw body).
+async fn get_raw(addr: SocketAddr, path: &str, extra_headers: &[(&str, &str)]) -> (u16, String) {
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to proxy");
+    let mut request = format!("GET {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n");
+    for (name, value) in extra_headers {
+        request.push_str(&format!("{name}: {value}\r\n"));
+    }
+    request.push_str("\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read response");
+    let text = String::from_utf8_lossy(&raw).into_owned();
+    let header_end = text.find("\r\n\r\n").expect("header terminator");
+    let status: u16 = text[..header_end]
+        .lines()
+        .next()
+        .expect("status line")
+        .split_whitespace()
+        .nth(1)
+        .expect("status code")
+        .parse()
+        .expect("numeric status");
+    (status, text[header_end + 4..].to_string())
+}
+
+fn authenticated(key: &str) -> ClientAuth {
+    ClientAuth::resolve(Some(key.to_string()), None).expect("a key resolves")
+}
+
+/// The whole point of the credential is that an unauthenticated caller cannot
+/// reach the fabric at all. Refusing after placement would still have spent a
+/// probe on every node, and told the caller which of them are up.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unauthenticated_request_never_reaches_a_node() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("node-a")]),
+        RouteMode::Throughput,
+        authenticated("s3cret"),
+    )
+    .await;
+
+    let (status, body, _) =
+        post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
+    assert_eq!(status, 401);
+    assert_eq!(body["error"]["type"], "authentication_error");
+    assert!(
+        node.received().is_empty(),
+        "the node was touched by a request that was never authenticated: {:?}",
+        node.received()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn either_header_the_engine_accepts_is_accepted_here() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("node-a")]),
+        RouteMode::Throughput,
+        authenticated("s3cret"),
+    )
+    .await;
+    let body = serde_json::json!({ "model": "shared-model" });
+
+    let (bearer, _, _) = post_chat(addr, &body, &[("Authorization", "Bearer s3cret")]).await;
+    assert_eq!(bearer, 200, "Authorization: Bearer must be accepted");
+
+    let (api_key, _, _) = post_chat(addr, &body, &[("X-API-Key", "s3cret")]).await;
+    assert_eq!(api_key, 200, "X-API-Key must be accepted");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_wrong_key_is_refused_like_no_key_at_all() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("node-a")]),
+        RouteMode::Throughput,
+        authenticated("s3cret"),
+    )
+    .await;
+
+    let (status, _, _) = post_chat(
+        addr,
+        &serde_json::json!({ "model": "shared-model" }),
+        &[("Authorization", "Bearer wrong")],
+    )
+    .await;
+    assert_eq!(status, 401);
+    assert!(node.received().is_empty(), "{:?}", node.received());
+}
+
+/// Discovery is behind the key too: an unauthenticated caller must not learn
+/// which models the fabric is serving.
+#[tokio::test(flavor = "multi_thread")]
+async fn discovery_does_not_answer_an_unauthenticated_caller() {
+    let node = StubNode::start(StubConfig::ready("private-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("node-a")]),
+        RouteMode::Throughput,
+        authenticated("s3cret"),
+    )
+    .await;
+
+    let (refused, body) = get_raw(addr, "/v1/models", &[]).await;
+    assert_eq!(refused, 401);
+    assert!(!body.contains("private-model"), "{body}");
+
+    let (served, listing) =
+        get_raw(addr, "/v1/models", &[("Authorization", "Bearer s3cret")]).await;
+    assert_eq!(served, 200);
+    assert!(listing.contains("private-model"), "{listing}");
+}
+
+/// A proxy started without a key is unchanged: this is what every other test in
+/// this file relies on, and what a loopback operator gets by default.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_proxy_without_a_key_serves_an_anonymous_client() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("node-a")]), RouteMode::Throughput).await;
+
+    let (status, _, _) =
+        post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
+    assert_eq!(status, 200);
 }


### PR DESCRIPTION
## The problem

`camelid fabric serve` had no authentication of its own. Its module docs said so plainly, and [`bind`](https://github.com/timtoole02/Camelid/blob/main/src/fabric/server.rs) refused any non-loopback address for exactly that reason: nothing stood between the network and every node in the fabric. The proxy was usable on loopback and nowhere else.

The only escape hatch was `--allow-unauthenticated-remote`, which does not make the exposure safe — it just records that you meant it.

## What this does

`fabric serve` now takes `--api-key` / `--api-key-file`, and a configured key satisfies the bind guard on its own. Exposing the proxy no longer requires declaring it unauthenticated.

**The check is the engine's, not a second one.** `crate::api::authenticate` is used behind a `pub(crate)` re-export, the same way this proxy already shares the engine's request body limit. Two consequences worth stating:

- A client sees the same 401, the same `WWW-Authenticate`, and the same accepted headers (`Authorization: Bearer` or `X-API-Key`) whichever front door it is talking to.
- There is still exactly one constant-time comparison in the crate. Writing a second implementation of a credential check is how the two quietly stop agreeing.

Key resolution moved out of `ServerPolicy::resolve` into a shared `resolve_api_key`, so both front doors validate the same kind of secret by the same rules rather than growing their own. That refactor is behaviour-preserving; the engine's own auth tests cover it and are unchanged.

## Two credentials, in opposite directions

They are configured separately and are not interchangeable:

| flag | direction |
|---|---|
| `--bearer` | what this proxy presents **to its nodes** |
| `--api-key` | what a client must present **to this proxy** |

`--api-key` deliberately does **not** read `CAMELID_API_KEY`. On this command that variable already names the node token — `fabric_bearer` reads it directly — so binding it here would let one value silently configure both directions of trust. A fabric whose nodes share a key must not thereby accept that key from the network. The flag's help text says this.

## Refusal happens before placement

The auth layer is applied outermost, so an unauthenticated request is refused before the body is read and before the fabric is observed. That is not a performance detail: refusing *after* placement would spend a probe on every node and let an anonymous caller learn which of them are up.

Both the integration test and the live receipt assert the nodes recorded **zero** requests across every refusal.

A key that cannot be used — blank, unreadable file, two sources at once — stops the process rather than starting a proxy that is open to whatever can reach it.

## Evidence

**Gates:** `cargo fmt --check` clean; `clippy --all-targets -- -D warnings` clean; `fabric::` unit **117**; `api::server` unit **8** (the refactor's regression check); `fabric_serve` **20** (was 15); `fabric_end_to_end` 14; `--bin camelid` 40; `check-public-scrub.sh` exit 0; touched files `i/lf w/lf`; `git diff --check` clean.

**Live receipt**, against the built release binary rather than the test harness:

| case | result |
|---|---|
| `0.0.0.0`, no key, no acknowledgement | exit 1, names **both** `--api-key` and `--allow-unauthenticated-remote`, no listening line |
| `0.0.0.0`, with a key | `fabric serve listening on 0.0.0.0:8490` — no acknowledgement needed |
| chat, no credential | 401 |
| chat, wrong bearer | 401 |
| `GET /v1/models`, no credential | 401, and the model name does not appear in the body |
| **node requests caused by those three refusals** | **0** |
| chat, `Authorization: Bearer` | 200 |
| chat, `X-API-Key` | 200 |
| `GET /v1/models`, with credential | 200, lists the model |
| unreadable `--api-key-file` | exit 1, never listened |
| `--api-key` and `--api-key-file` together | exit 2 |

**Ablations.** Each guarantee removed in turn, and only its own tests fail:

- auth layer removed → the 3 refusal tests fail; both positive controls and all 17 pre-existing `fabric_serve` tests still pass
- bind guard made to ignore the key → only `a_key_lets_a_non_loopback_listener_start_without_acknowledging_anything`, while its acknowledgement sibling still passes
- key resolution made to swallow errors → only `an_unusable_key_is_an_error_rather_than_an_open_proxy`

Six duplicated `ServeConfig` literals in the existing tests collapsed into one `open_config()` helper, so the diff removes more duplication than it adds.

## Limits, stated plainly

- **Authentication is all-or-nothing.** One key, not per-client, with no rotation or revocation while the proxy is running.
- **A proxy started without a key is unchanged**, and that is still the default: loopback stays open, and a non-loopback bind without a key still needs the acknowledgement. This adds an option, it does not tighten an existing deployment.
- **There is no transport encryption here.** A key travels in a header; over a routable network that wants TLS in front, which this does not provide.
- The exemption list the shared check uses (`/v1/health`, `/`, static assets) is the engine's. None of those routes exist on the proxy today, so both registered routes require the key — but a future route named like one of them would inherit the exemption.
- Independent of #656; they touch different parts of `fabric/server.rs` and can land in either order.
