### PR TITLE
fix(chat): drain the whole request in the stream tool-call socket test (Windows RST)

### DIFF
--- a/src/chat/client.rs
+++ b/src/chat/client.rs
@@ -1404,9 +1404,44 @@ mod tests {
         let client = Client::new(listener.local_addr().unwrap());
         let server = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            // Drain the request head so the client's write completes.
-            let mut buf = [0u8; 4096];
-            let _ = std::io::Read::read(&mut stream, &mut buf);
+            // Drain the ENTIRE request — head AND body — before responding.
+            //
+            // The sibling socket tests here stop at `\r\n\r\n` because their
+            // requests are bodyless GETs. This one POSTs JSON, so stopping at the
+            // head leaves the body sitting unread in the receive queue. Closing a
+            // socket with unread data is what makes Windows send an abortive RST
+            // instead of a FIN, and the client then fails the read with
+            // `os error 10054` rather than seeing a clean end of stream. It is a
+            // race — whether the reset beats the client's last read — so it passed
+            // on one CI run and failed on the next with no code change.
+            //
+            // A single `read` is also wrong on its own terms: it can return a
+            // partial request regardless of buffer size.
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            let mut expected_len: Option<usize> = None;
+            loop {
+                let read = stream.read(&mut buffer).unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if expected_len.is_none() {
+                    if let Some(head_end) = find(&request, b"\r\n\r\n") {
+                        let head = String::from_utf8_lossy(&request[..head_end]).to_lowercase();
+                        let body_len = head
+                            .split("content-length:")
+                            .nth(1)
+                            .and_then(|rest| rest.split("\r\n").next())
+                            .and_then(|value| value.trim().parse::<usize>().ok())
+                            .unwrap_or(0);
+                        expected_len = Some(head_end + 4 + body_len);
+                    }
+                }
+                if expected_len.is_some_and(|need| request.len() >= need) {
+                    break;
+                }
+            }
             let body = concat!(
                 "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n",
                 "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,",
@@ -1417,7 +1452,7 @@ mod tests {
             );
             let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
-                 Content-Length: {}\r\n\r\n{body}",
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
                 body.len()
             );
             let _ = std::io::Write::write_all(&mut stream, response.as_bytes());


### PR DESCRIPTION
## Summary

- `chat_stream_surfaces_tool_calls_over_a_socket` turned **main red on the Windows leg** with `os error 10054` (WSAECONNRESET). This is the test, not the product.
- Its fake server read the request once and closed, leaving the POST body unread in the receive queue; Windows answers a close-with-unread-data by sending an abortive RST rather than a FIN.
- Drain head **and** body before responding, and send `Connection: close`.

## Why this change exists

Closing a socket while bytes are still queued unread is what turns a clean FIN into an RST on Windows, and the client then fails its read instead of reaching end of stream. It is a race between that reset and the client's final read — which is exactly why the identical commit passed the Windows leg on [#659](https://github.com/timtoole02/Camelid/pull/659) and failed on main afterwards with no code change in between. A flaky test, not a regression, but it is red now and it is mine.

The sibling socket tests in this file (`workspace_events_stream_authenticated_json_envelopes`) already loop until `\r\n\r\n` and are green on Windows. They get away with stopping at the head because their requests are bodyless GETs; this one POSTs JSON, so the head is not the whole request. The single `read` was also wrong on its own terms — it can return a partial request whatever the buffer size, so the drain is now a loop that honours `Content-Length`.

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] `cargo test --all-targets` — **66 binaries, 2330 passed, 0 failed**, 32 ignored
- [x] The affected test run 25× in a row: 25/25 pass
- [x] Other evidence attached below

**Scope of that claim:** all of the above is macOS. The race only reproduces on Windows, so local runs cannot prove the fix — they only show it is not broken elsewhere. The Windows CI leg on this PR is the actual check. What is verified by reasoning is the mechanism: with the request fully drained there is no unread data at close, so there is no condition for an RST.

Test-only change; no product code touched.

## Public-repo privacy check

- [x] No private hostnames, SSH commands, user home paths, key paths, local validation details, raw SSH stderr, or raw infrastructure failure output are included
- [x] `bash scripts/check-public-scrub.sh`
- [x] `node scripts/audit-evidence-bundle-privacy.mjs --strict`

## Support-contract check

- [x] This PR does not overclaim support
- [x] No support row, envelope, ledger entry, or documented behaviour changes

## Evidence / artifacts

The failing run: `rust (windows-latest)` on main `e50be3db`, `test result: FAILED. 1829 passed; 1 failed` — the single failure being this test, panicking at the client's `.unwrap()` with `An existing connection was forcibly closed by the remote host. (os error 10054)`. macOS and ubuntu `--all-features` passed on the same commit.

## Docs impact

None.