### PR TITLE
feat(fabric): place the engine's other inference routes, not only chat

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -131,6 +131,31 @@ Request bodies are bounded at the same 16 MiB default the node itself uses. A st
 relayed as it arrives; `fabric run`, which returns one complete answer, refuses `stream: true` with
 400 instead.
 
+### What the proxy serves
+
+It places the engine's stateless inference routes, and answers discovery for the whole fabric:
+
+| Route | Behaviour |
+| --- | --- |
+| `POST /v1/chat/completions` | Placed on a node serving the model named in the body. |
+| `POST /v1/completions` | Same. |
+| `POST /v1/embeddings` | Same. |
+| `POST /v1/rerank`, `POST /v1/reranking` | Same. |
+| `GET /v1/models` | The union of what every ready node is serving. |
+| `GET /v1/models/{model}` | 200 exactly when a request naming that model would be placed. |
+
+A route is placed only if any node serving the named model could answer it, because the client cannot
+tell which node it reached and must not need to. That rules out the Responses and Conversations APIs:
+they keep their items in a SQLite store on the node that served the request, so a follow-up landing on
+another node would find nothing. Those routes are refused with **501** and a reason rather than
+half-supported — send them to a node directly, where they work as documented. Any other route is a
+**404** naming what is served, so a client can tell a wrong route from a wrong model. Both refusals
+are behind the client key, if one is configured: an unauthenticated caller gets a 401 and learns
+nothing about the fabric.
+
+`stream: true` is read from the request rather than assumed from the route, so a client that sets it
+on a route with nothing to stream still gets that route's complete answer instead of an empty stream.
+
 ## Mixtral diagnostic gate
 
 The checked Mixtral 8×7B Q8 row has one-token evidence, but its longer continuation parity gate is

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -43,6 +43,11 @@
 //! * A stop (Ctrl-C, or SIGTERM where there is one) closes the listener and
 //!   lets the requests already in flight finish, bounded by `forward_timeout`.
 //!   A kill still drops them: this covers being asked to stop, not being shot.
+//! * `/v1/health` answers readiness, not liveness — a 503 from it means "no
+//!   node is ready", never "restart me". It is also the one route a client
+//!   reaches without a key, because the engine's shared `authenticate` keeps
+//!   `/v1/health` public; it therefore names the fabric's nodes and models only
+//!   when this proxy is bound to loopback.
 //! * A node that becomes ready, or loads a different model, is routed to only
 //!   once the current observation expires. A node that *stops* answering is not
 //!   waited on: the request that finds it gone is placed on another node
@@ -142,6 +147,15 @@ pub struct ServeConfig {
     pub forward_timeout: Duration,
     /// What a client must present to be served at all.
     pub auth: ClientAuth,
+    /// The address this proxy listens on.
+    ///
+    /// Read only to decide whether `/v1/health` may name the fabric's members:
+    /// a loopback listener cannot be reached from off the machine.
+    /// [`serve_on_until`] overwrites this with the address the listener
+    /// actually bound, so the value the disclosure rule sees can never be a
+    /// caller's guess. It is set there rather than in [`serve_on`] because
+    /// every serving path goes through it, including the injected-stop seam.
+    pub bound: SocketAddr,
 }
 
 #[derive(Clone)]
@@ -158,6 +172,7 @@ pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
     Router::new()
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/models", get(models))
+        .route("/v1/health", get(health))
         // Without this, axum's 2 MiB default would refuse conversations the
         // node behind the proxy accepts.
         .layer(DefaultBodyLimit::max(DEFAULT_MAX_REQUEST_BODY_BYTES))
@@ -361,9 +376,14 @@ pub async fn serve_on(
 pub async fn serve_on_until(
     listener: tokio::net::TcpListener,
     fabric: Fabric,
-    config: ServeConfig,
+    mut config: ServeConfig,
     stop: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {
+    // The listener is the only authority on what was actually bound, and the
+    // health disclosure rule turns on it. It is set here rather than in
+    // `serve_on` so that a caller entering through this seam cannot skip it.
+    config.bound = listener.local_addr()?;
+
     let drain = config.forward_timeout;
     // The peer address is only available to a service built this way, and the
     // access log is the only thing that reads it.
@@ -422,6 +442,110 @@ async fn stop_requested() {
         () = interrupt => {}
         () = terminate => {}
     }
+}
+
+/// Report whether this proxy can route a request right now.
+///
+/// A load balancer needs one address to ask "should I send you traffic", and
+/// the proxy had none: `/v1/health` matched no route, so a probe got a bodyless
+/// 404 whatever the fabric was actually doing.
+///
+/// **This is readiness, not liveness.** It answers 503 while no node is ready,
+/// which is the right answer to "send me traffic" and the wrong one to "should
+/// I restart you" — restarting a proxy cannot bring a node back. Wire it to a
+/// readiness probe. Liveness is the `ok` in the body, which is true whenever
+/// this code runs at all.
+///
+/// The answer comes from the same observation placement uses, so a probe every
+/// second does not become a probe of every node every second: inside the
+/// freshness window a health check costs the fabric no traffic.
+async fn health(State(state): State<ServerState>) -> Response {
+    let fabric = Arc::clone(&state.fabric);
+    // Observing is blocking socket I/O against every node, same as a dispatch.
+    let snapshots = match tokio::task::spawn_blocking(move || fabric.observe()).await {
+        Ok(snapshots) => snapshots,
+        Err(join_error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("could not observe the fabric: {join_error}"),
+            )
+        }
+    };
+
+    let (status, body) = health_report(&snapshots, state.config.bound.ip().is_loopback());
+    (status, Json(body)).into_response()
+}
+
+/// Build the health answer.
+///
+/// Ready means at least one node is ready, which is exactly what placement
+/// needs: with one, some request can be served; with none, every request is
+/// refused, and saying otherwise would invite traffic this proxy cannot serve.
+///
+/// `disclose_detail` decides whether anything beyond that verdict is included,
+/// and is false unless the listener is loopback. This route is **not** behind
+/// [`ClientAuth`]: the engine's shared `authenticate` keeps `/v1/health` public
+/// so a probe needs no credential, and reusing that check means inheriting the
+/// rule. An anonymous caller can therefore read whatever is here, which makes
+/// the contents a disclosure decision rather than a formatting one:
+///
+/// * the node list is every label and address in the fabric;
+/// * the model list is the answer `/v1/models` gives, and that route *is*
+///   behind the key, so publishing it here would hand it out through a side
+///   door;
+/// * off-box callers get the verdict and nothing else, which is all a load
+///   balancer reads anyway.
+///
+/// [`crate::api`] withholds its own `executable` and `listen_addr` on the same
+/// fact, for the same reason.
+///
+/// Deliberately not shaped like a node's health: there is no `engine` field and
+/// the service name differs, so nothing can mistake a proxy for something that
+/// generates. A proxy has no single `active_model_id` to report anyway.
+///
+/// Kept pure so both rules are covered by unit tests rather than by starting a
+/// server and guessing which branch ran.
+fn health_report(snapshots: &[fabric::NodeSnapshot], disclose_detail: bool) -> (StatusCode, Value) {
+    let summary = fabric::FabricSummary::of(snapshots);
+    let ready = summary.ready > 0;
+
+    let mut body = serde_json::json!({
+        "ok": true,
+        "service": "camelid-fabric",
+        "version": env!("CARGO_PKG_VERSION"),
+        "build": crate::receipt::camelid_version(),
+        "ready": ready,
+    });
+
+    if disclose_detail {
+        if let Some(object) = body.as_object_mut() {
+            object.insert(
+                "nodes".to_string(),
+                serde_json::json!({
+                    "total": summary.total(),
+                    "ready": summary.ready,
+                    "not_ready": summary.not_ready,
+                    "unreachable": summary.unreachable,
+                }),
+            );
+            object.insert(
+                "models".to_string(),
+                serde_json::json!(fabric::servable_models(snapshots)),
+            );
+            // The shape `fabric status --json` already prints, so an operator
+            // reading both is not learning two vocabularies for one fact.
+            if let Ok(detail) = serde_json::to_value(snapshots) {
+                object.insert("node_detail".to_string(), detail);
+            }
+        }
+    }
+
+    let status = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, body)
 }
 
 /// List every model the fabric can currently route to.
@@ -804,7 +928,7 @@ fn error_response(status: StatusCode, message: &str) -> Response {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fabric::node::NodeSpec;
+    use crate::fabric::node::{NodeReady, NodeSnapshot, NodeSpec, NodeStatus};
     use crate::fabric::policy::RouteReason;
     use tower::ServiceExt;
 
@@ -840,7 +964,39 @@ mod tests {
             mode: RouteMode::Throughput,
             forward_timeout: Duration::from_millis(200),
             auth: ClientAuth::none(),
+            bound: "127.0.0.1:8490".parse().expect("loopback address"),
         }
+    }
+
+    /// A proxy on an address the network can reach. Integration tests always
+    /// bind loopback, so this is the only place the redacted branch is reached.
+    fn exposed_config() -> ServeConfig {
+        ServeConfig {
+            bound: "203.0.113.7:8490".parse().expect("routable address"),
+            ..open_config()
+        }
+    }
+
+    fn snapshot(label: &str, status: NodeStatus) -> NodeSnapshot {
+        NodeSnapshot {
+            spec: NodeSpec {
+                label: label.to_string(),
+                host: "192.0.2.10".to_string(),
+                port: 8181,
+            },
+            status,
+            latency: Some(Duration::from_millis(3)),
+        }
+    }
+
+    fn ready_status(model: &str) -> NodeStatus {
+        NodeStatus::Ready(NodeReady {
+            active_model_id: Some(model.to_string()),
+            backend: "llama".to_string(),
+            version: "0.6.1".to_string(),
+            in_flight: 0,
+            waiting: 0,
+        })
     }
 
     fn proxy(fabric: Fabric) -> Router {
@@ -1156,6 +1312,123 @@ mod tests {
         let written = logged(proxy(Fabric::new(Vec::new())), get_request("/v1/models")).await;
         assert!(written.contains("fabric request"), "{written}");
         assert!(written.contains("client=\"-\""), "{written}");
+    }
+
+    /// Ready means "placement can succeed", which is exactly one ready node.
+    #[test]
+    fn health_is_ready_when_one_node_can_serve() {
+        let snapshots = vec![
+            snapshot("a", ready_status("llama-3b")),
+            snapshot(
+                "b",
+                NodeStatus::Unreachable {
+                    reason: "cannot connect".to_string(),
+                },
+            ),
+        ];
+        let (status, body) = health_report(&snapshots, true);
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["ok"], serde_json::json!(true));
+        assert_eq!(body["ready"], serde_json::json!(true));
+        assert_eq!(body["nodes"]["total"], serde_json::json!(2));
+        assert_eq!(body["nodes"]["ready"], serde_json::json!(1));
+        assert_eq!(body["nodes"]["unreachable"], serde_json::json!(1));
+        assert_eq!(body["models"], serde_json::json!(["llama-3b"]));
+    }
+
+    /// A proxy with nothing to route to must not invite traffic. `ok` stays
+    /// true through it: the process is fine, its fabric is not, and restarting
+    /// this process would fix nothing.
+    #[test]
+    fn health_refuses_traffic_when_no_node_is_ready() {
+        let snapshots = vec![snapshot(
+            "a",
+            NodeStatus::NotReady {
+                reason: "no model loaded".to_string(),
+            },
+        )];
+        let (status, body) = health_report(&snapshots, true);
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["ok"], serde_json::json!(true));
+        assert_eq!(body["ready"], serde_json::json!(false));
+        assert_eq!(body["models"], serde_json::json!([]));
+    }
+
+    /// The verdict itself does not depend on who is asking; only the detail does.
+    #[test]
+    fn the_readiness_verdict_is_the_same_off_box() {
+        let snapshots = vec![snapshot("a", ready_status("llama-3b"))];
+        let (disclosed, _) = health_report(&snapshots, true);
+        let (withheld, body) = health_report(&snapshots, false);
+        assert_eq!(disclosed, withheld);
+        assert_eq!(body["ready"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn a_loopback_listener_may_name_the_fabric() {
+        let snapshots = vec![snapshot("a", ready_status("llama-3b"))];
+        let (_, body) = health_report(&snapshots, true);
+        let detail = body["node_detail"].as_array().expect("node detail");
+        assert_eq!(detail.len(), 1);
+        assert_eq!(detail[0]["spec"]["label"], serde_json::json!("a"));
+        assert_eq!(detail[0]["spec"]["host"], serde_json::json!("192.0.2.10"));
+    }
+
+    /// This route needs no key, because the engine's shared `authenticate`
+    /// keeps `/v1/health` public. So an exposed proxy answers anyone, and what
+    /// it answers must not include every node's address.
+    #[test]
+    fn an_exposed_listener_does_not_name_the_fabric() {
+        let snapshots = vec![snapshot("a", ready_status("llama-3b"))];
+        let (_, body) = health_report(&snapshots, false);
+        assert!(body.get("node_detail").is_none(), "{body}");
+        assert!(body.get("nodes").is_none(), "{body}");
+        assert!(!body.to_string().contains("192.0.2.10"), "{body}");
+    }
+
+    /// `/v1/models` is behind the key and has a test saying an unauthenticated
+    /// caller must not learn what is served. Health needs no key, so listing
+    /// models here off-box would give that same answer away through a side door.
+    #[test]
+    fn an_exposed_listener_does_not_list_the_models() {
+        let snapshots = vec![snapshot("a", ready_status("private-model"))];
+        let (_, body) = health_report(&snapshots, false);
+        assert!(body.get("models").is_none(), "{body}");
+        assert!(!body.to_string().contains("private-model"), "{body}");
+    }
+
+    /// Proves the route reads the bound address rather than merely that the
+    /// pure function can redact. Integration tests all bind loopback, so the
+    /// exposed branch has no other end-to-end coverage.
+    #[tokio::test]
+    async fn only_a_loopback_listener_names_the_fabric_on_the_route() {
+        let exposed = router(Fabric::new(Vec::new()), exposed_config())
+            .oneshot(get_request("/v1/health"))
+            .await
+            .expect("router answers");
+        let (_, exposed_body) = read_json(exposed).await;
+        assert!(exposed_body.get("node_detail").is_none(), "{exposed_body}");
+
+        let loopback = proxy(Fabric::new(Vec::new()))
+            .oneshot(get_request("/v1/health"))
+            .await
+            .expect("router answers");
+        let (_, loopback_body) = read_json(loopback).await;
+        assert_eq!(loopback_body["node_detail"], serde_json::json!([]));
+    }
+
+    /// An empty fabric is not a broken proxy, but it cannot take traffic.
+    #[tokio::test]
+    async fn the_health_route_refuses_an_empty_fabric() {
+        let response = proxy(Fabric::new(Vec::new()))
+            .oneshot(get_request("/v1/health"))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["ready"], serde_json::json!(false));
+        assert_eq!(body["nodes"]["total"], serde_json::json!(0));
+        assert_eq!(body["service"], serde_json::json!("camelid-fabric"));
     }
 
     /// A client points at one address, so that address has to answer what it

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -456,9 +456,17 @@ async fn stop_requested() {
 /// readiness probe. Liveness is the `ok` in the body, which is true whenever
 /// this code runs at all.
 ///
-/// The answer comes from the same observation placement uses, so a probe every
-/// second does not become a probe of every node every second: inside the
-/// freshness window a health check costs the fabric no traffic.
+/// The answer comes from the same observation placement uses, so a health check
+/// taken inside the freshness window costs the fabric no traffic at all.
+/// Outside it this probes every node, exactly as any other request would: at the
+/// 500 ms default a once-a-second check is always past the window and re-probes
+/// every time. A deployment that polls this route therefore wants
+/// `--observation-max-age-ms` at or above its polling interval, or the health
+/// check itself becomes the node traffic that bound exists to remove.
+///
+/// That bound is also the only thing pacing this route, because it is
+/// deliberately outside [`ClientAuth`]: the caller decides how often it is
+/// asked, and with `--observation-max-age-ms 0` every ask probes every node.
 async fn health(State(state): State<ServerState>) -> Response {
     let fabric = Arc::clone(&state.fabric);
     // Observing is blocking socket I/O against every node, same as a dispatch.

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -10,6 +10,14 @@
 //! `stream: true` the node's server-sent events are forwarded byte for byte, so
 //! an event field this proxy has never heard of reaches the client unaltered.
 //!
+//! # What it serves
+//!
+//! The engine's stateless inference routes ([`PLACED_ROUTES`]) plus discovery
+//! over the whole fabric. A route earns its place there by being answerable by
+//! any node serving the model the request names — which the Responses and
+//! Conversations APIs are not, so they are refused with a reason rather than
+//! placed. Anything else is a 404 that names what is served.
+//!
 //! Unlike the CLI, this process serves many requests, so it reuses a fabric
 //! observation for a bounded time instead of probing every node on every one.
 //! The bound is set by whoever builds the [`Fabric`]; see
@@ -68,16 +76,16 @@ use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{ConnectInfo, DefaultBodyLimit, Request, State};
+use axum::extract::{ConnectInfo, DefaultBodyLimit, Path, Request, State};
 use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{any, get, post};
 use axum::{middleware, Json, Router};
 use serde_json::Value;
 
-use super::policy::{RouteDecision, RouteError, RouteMode, RouteRequest};
+use super::policy::{route, RouteDecision, RouteError, RouteMode, RouteRequest};
 use super::{self as fabric, DispatchError, Fabric, ForwardError, StreamOutcome};
 use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
 
@@ -89,6 +97,40 @@ const REQUEST_ID_HEADER: &str = "x-request-id";
 
 /// Longest inbound request id this proxy will adopt as its own.
 const MAX_REQUEST_ID_LEN: usize = 128;
+
+/// The engine routes this proxy places on a node.
+///
+/// Every one of them is a pure function of its own request body and the model
+/// that body names: nothing in the answer depends on which node produced it, so
+/// any node serving that model may. That is what makes placing them legitimate,
+/// and it is the property a route has to have to be added here.
+///
+/// This list is the single source of truth. The router is built from it, and so
+/// is the refusal a client gets for a route that is not on it, so the two cannot
+/// drift apart.
+const PLACED_ROUTES: [&str; 5] = [
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/rerank",
+    "/v1/reranking",
+];
+
+/// Engine routes that answer from state held by one node.
+///
+/// The Responses and Conversations APIs keep their items in a SQLite store on
+/// the node that served the request. Placing them would appear to work and then
+/// lose a conversation the moment a follow-up landed on a different node, so
+/// they are refused here rather than half-supported. A client that needs them
+/// can talk to a node directly, where they work exactly as documented.
+const NODE_LOCAL_ROUTES: [&str; 6] = [
+    "/v1/responses",
+    "/v1/responses/:id",
+    "/v1/conversations",
+    "/v1/conversations/:id",
+    "/v1/conversations/:id/items",
+    "/v1/conversations/:id/items/:item_id",
+];
 
 /// The credential a client must present to this proxy.
 ///
@@ -169,10 +211,32 @@ struct ServerState {
 /// Build the router without binding a socket, so tests can drive it directly.
 pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
     let auth = config.auth.inner.clone();
-    Router::new()
-        .route("/v1/chat/completions", post(chat_completions))
+
+    let placed = PLACED_ROUTES.iter().fold(Router::new(), |router, path| {
+        let path = *path;
+        router.route(
+            path,
+            post(
+                move |state: State<ServerState>,
+                      headers: HeaderMap,
+                      payload: std::result::Result<Json<Value>, JsonRejection>| async move {
+                    place_and_forward(state, path, headers, payload).await
+                },
+            ),
+        )
+    });
+    let refusals = NODE_LOCAL_ROUTES
+        .iter()
+        .fold(placed, |router, path| router.route(path, any(node_local)));
+
+    refusals
         .route("/v1/models", get(models))
+        .route("/v1/models/:model", get(model))
         .route("/v1/health", get(health))
+        // A client that reaches an address it was told is OpenAI-compatible has
+        // to be able to tell "wrong route" from "wrong model", and axum's own
+        // 404 carries no body at all.
+        .fallback(unknown_route)
         // Without this, axum's 2 MiB default would refuse conversations the
         // node behind the proxy accepts.
         .layer(DefaultBodyLimit::max(DEFAULT_MAX_REQUEST_BODY_BYTES))
@@ -582,21 +646,89 @@ async fn models(State(state): State<ServerState>) -> Response {
 
     let data: Vec<Value> = super::servable_models(&snapshots)
         .into_iter()
-        .map(|id| {
-            serde_json::json!({
-                "id": id,
-                "object": "model",
-                "created": 0,
-                "owned_by": "camelid",
-            })
-        })
+        .map(|id| model_object(&id))
         .collect();
 
     Json(serde_json::json!({ "object": "list", "data": data })).into_response()
 }
 
-async fn chat_completions(
+/// Answer for one model id, the way an SDK's `models.retrieve` asks.
+///
+/// The verdict comes from placement itself rather than from a second rule about
+/// what is servable: a model is retrievable here exactly when a request naming
+/// it would be placed. That also inherits the distinction placement already
+/// makes — a model no ready node serves is a settled 404, but only once every
+/// node has been consulted; while any is unaccounted for the refusal can still
+/// clear, so it stays a retryable 503.
+async fn model(Path(id): Path<String>, State(state): State<ServerState>) -> Response {
+    let fabric = Arc::clone(&state.fabric);
+    let snapshots = match tokio::task::spawn_blocking(move || fabric.observe()).await {
+        Ok(snapshots) => snapshots,
+        Err(join_error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("could not observe the fabric: {join_error}"),
+            )
+        }
+    };
+
+    match route(
+        &snapshots,
+        &RouteRequest::new(RouteMode::Throughput).with_model(Some(&id)),
+    ) {
+        Ok(_) => Json(model_object(&id)).into_response(),
+        Err(error) => route_error(error),
+    }
+}
+
+/// One model, in the shape a node answers with. Pure.
+fn model_object(id: &str) -> Value {
+    serde_json::json!({
+        "id": id,
+        "object": "model",
+        "created": 0,
+        "owned_by": "camelid",
+    })
+}
+
+/// Refuse a route whose answer lives on one node.
+///
+/// A 501 rather than a 404: the route exists and a node implements it, so
+/// "not here" with the reason is more use to a client than "no such thing".
+async fn node_local() -> Response {
+    error_response(
+        StatusCode::NOT_IMPLEMENTED,
+        "the Responses and Conversations APIs keep their state on the node that served the \
+         request, so this proxy does not place them: a follow-up could land on another node and \
+         find nothing. Send these to a node directly. This proxy serves the stateless routes and \
+         model discovery",
+    )
+}
+
+/// Answer a route this proxy does not serve, naming the ones it does.
+async fn unknown_route() -> Response {
+    error_response(
+        StatusCode::NOT_FOUND,
+        &format!(
+            "this fabric proxy does not serve that route; it serves {}, and GET /v1/models, \
+             GET /v1/models/{{model}} and GET /v1/health",
+            PLACED_ROUTES
+                .iter()
+                .map(|path| format!("POST {path}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    )
+}
+
+/// Place one request on a node and relay its answer.
+///
+/// `path` is the matched route, not anything taken from the request line, so
+/// what reaches a node is one of [`PLACED_ROUTES`] and nothing a client can
+/// steer. The body is relayed unread beyond the two fields placement needs.
+async fn place_and_forward(
     State(state): State<ServerState>,
+    path: &'static str,
     headers: HeaderMap,
     payload: std::result::Result<Json<Value>, JsonRejection>,
 ) -> Response {
@@ -618,10 +750,13 @@ async fn chat_completions(
         .map(str::to_string);
     let request = OwnedRequest { model, sticky };
 
+    // Asked for by the request, not by the route: `stream: true` is meaningful
+    // on the generation routes and meaningless on the rest, and a node that has
+    // nothing to stream answers with a body, which the streaming path relays.
     if fabric::wants_streaming(&body) {
-        return stream_completion(state, body, request).await;
+        return stream_completion(state, path, body, request).await;
     }
-    buffered_completion(state, body, request).await
+    buffered_completion(state, path, body, request).await
 }
 
 /// The parts of a [`RouteRequest`] that outlive the borrow of the request body,
@@ -647,7 +782,12 @@ impl OwnedRequest {
     }
 }
 
-async fn buffered_completion(state: ServerState, body: Value, request: OwnedRequest) -> Response {
+async fn buffered_completion(
+    state: ServerState,
+    path: &'static str,
+    body: Value,
+    request: OwnedRequest,
+) -> Response {
     // Fabric::dispatch is synchronous socket I/O (probes every node, then
     // forwards) and can legitimately run for the whole forward_timeout — up to
     // minutes for a real generation. Running it directly on an async worker
@@ -656,7 +796,7 @@ async fn buffered_completion(state: ServerState, body: Value, request: OwnedRequ
     // tokio's much larger blocking pool instead.
     let outcome = tokio::task::spawn_blocking(move || {
         state.fabric.dispatch(
-            "/v1/chat/completions",
+            path,
             &body,
             &request.as_route(state.config.mode),
             state.config.forward_timeout,
@@ -712,7 +852,12 @@ enum StreamStart {
 /// generation in memory.
 const STREAM_CHANNEL_DEPTH: usize = 32;
 
-async fn stream_completion(state: ServerState, body: Value, request: OwnedRequest) -> Response {
+async fn stream_completion(
+    state: ServerState,
+    path: &'static str,
+    body: Value,
+    request: OwnedRequest,
+) -> Response {
     let (start_tx, start_rx) = tokio::sync::oneshot::channel::<StreamStart>();
     let (chunk_tx, mut chunk_rx) =
         tokio::sync::mpsc::channel::<Result<Vec<u8>, String>>(STREAM_CHANNEL_DEPTH);
@@ -723,7 +868,7 @@ async fn stream_completion(state: ServerState, body: Value, request: OwnedReques
     // there, and the socket to the node is dropped as soon as it is not.
     tokio::task::spawn_blocking(move || {
         let outcome = state.fabric.dispatch_streaming(
-            "/v1/chat/completions",
+            path,
             &body,
             &request.as_route(state.config.mode),
             state.config.forward_timeout,
@@ -1439,6 +1584,87 @@ mod tests {
         assert_eq!(body["service"], serde_json::json!("camelid-fabric"));
     }
 
+    /// The 404 is built from the route table, so this can only fail if the two
+    /// are ever allowed to drift — which is the whole reason the table exists.
+    #[tokio::test]
+    async fn an_unserved_route_names_every_route_that_is_served() {
+        let response = proxy(Fabric::new(Vec::new()))
+            .oneshot(get_request("/v1/no-such-thing"))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["error"]["type"], "fabric_error");
+        let message = body["error"]["message"].as_str().expect("a message");
+        for path in PLACED_ROUTES {
+            assert!(
+                message.contains(path),
+                "`{path}` is missing from: {message}"
+            );
+        }
+        assert!(message.contains("/v1/models"), "{message}");
+        assert!(message.contains("/v1/health"), "{message}");
+    }
+
+    /// A route is either placed or refused as node-local, never both: the two
+    /// tables are what axum builds its router from, and registering one path
+    /// twice is a panic at startup rather than a test failure here.
+    #[test]
+    fn no_route_is_both_placed_and_node_local() {
+        for placed in PLACED_ROUTES {
+            assert!(
+                !NODE_LOCAL_ROUTES.contains(&placed),
+                "`{placed}` is in both tables"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_node_local_route_is_refused_with_its_reason_rather_than_placed() {
+        // An empty fabric: a placed route would refuse with a routing error, so
+        // a 501 here proves the refusal happens before any placement at all.
+        let response = proxy(Fabric::new(Vec::new()))
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/v1/responses")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::new(
+                        serde_json::json!({ "model": "m" }).to_string(),
+                    ))
+                    .expect("valid request"),
+            )
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(body["error"]["type"], "fabric_error");
+        let message = body["error"]["message"].as_str().expect("a message");
+        assert!(
+            message.contains("state") && message.contains("node"),
+            "the refusal has to say why, not just no: {message}"
+        );
+    }
+
+    /// Every method, not just the one an SDK happens to use first: a GET of a
+    /// stored response is as node-local as the POST that created it.
+    #[tokio::test]
+    async fn a_node_local_route_is_refused_on_every_method() {
+        for uri in ["/v1/responses/resp_1", "/v1/conversations/conv_1/items"] {
+            let response = proxy(Fabric::new(Vec::new()))
+                .oneshot(get_request(uri))
+                .await
+                .expect("router answers");
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_IMPLEMENTED,
+                "GET {uri} should be refused as node-local"
+            );
+        }
+    }
+
     /// A client points at one address, so that address has to answer what it
     /// can serve. This used to 404, which left every model picker empty.
     #[tokio::test]
@@ -1477,6 +1703,72 @@ mod tests {
         assert_eq!(data[0]["id"], "llama-3b");
         assert_eq!(data[0]["object"], "model");
         assert_eq!(data[0]["owned_by"], "camelid");
+    }
+
+    /// `models.retrieve` on an SDK. The answer is the same object the list
+    /// carries, so a client that found a model in one can look it up in the
+    /// other and get something it recognises.
+    #[tokio::test]
+    async fn a_served_model_can_be_retrieved_on_its_own() {
+        let node = StubModelNode::start("llama-3b");
+        let fabric = Fabric::new(vec![node.spec("only")]).with_timeout(Duration::from_secs(2));
+        let response = proxy(fabric)
+            .oneshot(get_request("/v1/models/llama-3b"))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["id"], "llama-3b");
+        assert_eq!(body["object"], "model");
+        assert_eq!(body["owned_by"], "camelid");
+    }
+
+    /// Retrieval and placement must not be able to disagree: a model this
+    /// answers 200 for is one a request naming it would be placed on, because
+    /// both ask the same question of the same observation.
+    #[tokio::test]
+    async fn retrieving_an_unserved_model_refuses_exactly_as_placing_it_would() {
+        let node = StubModelNode::start("llama-3b");
+        let fabric = Fabric::new(vec![node.spec("only")]).with_timeout(Duration::from_secs(2));
+        let response = proxy(fabric)
+            .oneshot(get_request("/v1/models/no-such-model"))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["error"]["code"], "model_not_found");
+        assert_eq!(body["error"]["param"], "model");
+        let message = body["error"]["message"].as_str().expect("a message");
+        assert!(message.contains("llama-3b"), "{message}");
+    }
+
+    /// And it inherits the other half of that distinction too: while a node is
+    /// unaccounted for, "not found" is not settled and must stay retryable.
+    #[tokio::test]
+    async fn retrieving_a_model_while_a_node_is_down_stays_retryable() {
+        let node = StubModelNode::start("llama-3b");
+        let fabric = Fabric::new(vec![
+            node.spec("up"),
+            // Port 1 is closed, so this node is observed as unreachable.
+            NodeSpec {
+                label: "down".to_string(),
+                host: "127.0.0.1".to_string(),
+                port: 1,
+            },
+        ])
+        .with_timeout(Duration::from_millis(500));
+        let response = proxy(fabric)
+            .oneshot(get_request("/v1/models/no-such-model"))
+            .await
+            .expect("router answers");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "a node that could not be consulted may be the one that owns it"
+        );
     }
 
     /// A model this fabric does not serve will not appear by asking again, and

--- a/src/main.rs
+++ b/src/main.rs
@@ -3021,7 +3021,8 @@ async fn main() -> anyhow::Result<()> {
                 let listener =
                     camelid::fabric::server::bind(addr, &auth, allow_unauthenticated_remote)
                         .await?;
-                println!("fabric serve listening on {}", listener.local_addr()?);
+                let bound = listener.local_addr()?;
+                println!("fabric serve listening on {bound}");
                 // Nothing is being served yet, so this probe costs no request, and
                 // it is the only chance to tell the operator about a node that is
                 // not there before a client discovers it for them.
@@ -3033,6 +3034,7 @@ async fn main() -> anyhow::Result<()> {
                         mode,
                         forward_timeout: std::time::Duration::from_secs(forward_timeout_s),
                         auth,
+                        bound,
                     },
                 )
                 .await?;

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -464,6 +464,7 @@ async fn start_proxy_with_auth(fabric: Fabric, mode: RouteMode, auth: ClientAuth
         mode,
         forward_timeout: FORWARD_TIMEOUT,
         auth,
+        bound: addr,
     };
     tokio::spawn(async move {
         let _ = serve_on(listener, fabric, config).await;
@@ -1328,6 +1329,7 @@ async fn a_stop_finishes_the_work_in_flight_and_accepts_no_more() {
         mode: RouteMode::Throughput,
         forward_timeout: FORWARD_TIMEOUT,
         auth: ClientAuth::none(),
+        bound: addr,
     };
 
     let (stop, stop_asked) = tokio::sync::oneshot::channel::<()>();
@@ -1383,6 +1385,133 @@ async fn a_proxy_without_a_key_serves_an_anonymous_client() {
     let (status, _, _) =
         post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
     assert_eq!(status, 200);
+}
+
+/// A load balancer needs one address to ask whether to send traffic here. Until
+/// this route existed the answer was a bodyless 404 whatever the fabric was
+/// doing, so nothing could tell a working proxy from a useless one.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_reports_ready_while_a_node_can_serve() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("node-a")]), RouteMode::Throughput).await;
+
+    let (status, body) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(status, 200, "{body}");
+    let parsed: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(parsed["ok"], serde_json::json!(true));
+    assert_eq!(parsed["ready"], serde_json::json!(true));
+    assert_eq!(parsed["nodes"]["ready"], serde_json::json!(1));
+    assert_eq!(parsed["models"], serde_json::json!(["shared-model"]));
+    // The test binds loopback, so the fabric may be named.
+    assert_eq!(parsed["node_detail"][0]["spec"]["label"], "node-a");
+}
+
+/// A spec for a port nothing listens on. Binding and dropping proves the port
+/// was free and is now closed; a hardcoded number proves neither.
+async fn closed_port_spec(label: &str) -> NodeSpec {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind a free port");
+    let addr = listener.local_addr().expect("port");
+    drop(listener);
+    NodeSpec {
+        label: label.to_string(),
+        host: addr.ip().to_string(),
+        port: addr.port(),
+    }
+}
+
+/// Ready is "some request can be served", not "every node is well". A fabric
+/// with one node down still takes traffic, and a proxy that reported itself
+/// unhealthy here would take a whole fabric out of rotation over one node.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_stays_ready_while_any_node_can_serve() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let specs = vec![node.spec("node-a"), closed_port_spec("node-gone").await];
+    let addr = start_proxy(fabric_of(specs), RouteMode::Throughput).await;
+
+    let (status, body) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(status, 200, "{body}");
+    let parsed: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(parsed["ready"], serde_json::json!(true));
+    assert_eq!(parsed["nodes"]["ready"], serde_json::json!(1));
+    assert_eq!(parsed["nodes"]["unreachable"], serde_json::json!(1));
+}
+
+/// The status code has to change, not just a field in the body: a load balancer
+/// acts on the code alone. A proxy with nothing behind it must stop inviting
+/// traffic it can only refuse.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_stops_inviting_traffic_when_no_node_answers() {
+    let specs = vec![closed_port_spec("node-gone").await];
+    let addr = start_proxy(fabric_of(specs), RouteMode::Throughput).await;
+
+    let (status, body) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(status, 503, "{body}");
+    let parsed: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(parsed["ready"], serde_json::json!(false));
+    // Liveness is unchanged: this process is fine, its fabric is not, and
+    // restarting this process would not bring a node back.
+    assert_eq!(parsed["ok"], serde_json::json!(true));
+    assert_eq!(parsed["nodes"]["unreachable"], serde_json::json!(1));
+    assert_eq!(parsed["models"], serde_json::json!([]));
+}
+
+/// Health needs no key even on a proxy that requires one everywhere else: the
+/// engine's shared `authenticate` keeps `/v1/health` public so a probe can run
+/// without credentials, and this proxy reuses that check rather than writing a
+/// second one. `/v1/models` stays behind the key, and the contrast is the point
+/// — it is why the health body withholds the fabric's detail off-box, which the
+/// unit tests cover because this test can only bind loopback.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_answers_a_probe_that_carries_no_key() {
+    let node = StubNode::start(StubConfig::ready("private-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("node-a")]),
+        RouteMode::Throughput,
+        authenticated("s3cret"),
+    )
+    .await;
+
+    let (health, body) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(health, 200, "a probe with no key must still get an answer");
+    let parsed: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(parsed["ready"], serde_json::json!(true));
+
+    let (models, listing) = get_raw(addr, "/v1/models", &[]).await;
+    assert_eq!(models, 401, "discovery stays behind the key");
+    assert!(!listing.contains("private-model"), "{listing}");
+
+    let (chat, _, _) = post_chat(addr, &serde_json::json!({ "model": "private-model" }), &[]).await;
+    assert_eq!(chat, 401, "generation stays behind the key");
+}
+
+/// A load balancer polls this route forever. If each poll re-probed the fabric,
+/// adding a health check would multiply node traffic by the polling rate, which
+/// is exactly the cost the freshness bound exists to remove.
+#[tokio::test(flavor = "multi_thread")]
+async fn repeated_health_checks_share_one_observation() {
+    let nodes = vec![
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+    ];
+    let specs = vec![nodes[0].spec("node-a"), nodes[1].spec("node-b")];
+    let addr = start_proxy(
+        fabric_reusing_observations(specs, Duration::from_secs(30)),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    for _ in 0..5 {
+        let (status, _) = get_raw(addr, "/v1/health", &[]).await;
+        assert_eq!(status, 200);
+    }
+
+    assert_eq!(
+        health_probes(&nodes),
+        nodes.len(),
+        "five health checks should share one observation, one probe per node"
+    );
 }
 
 /// The proxy observes the fabric before every placement. Without a freshness

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -21,6 +21,18 @@ use camelid::fabric::{Fabric, NodeSpec, RouteMode, ENGINE_QUEUE_FULL_CODE};
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const FORWARD_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// The routes the proxy places, which a node therefore has to answer. Repeated
+/// here rather than imported: these tests are a client's view of the proxy, and
+/// a test that read the same constant the router is built from could not notice
+/// a route quietly leaving it.
+const PLACED_ROUTES: [&str; 5] = [
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/embeddings",
+    "/v1/rerank",
+    "/v1/reranking",
+];
+
 /// One request a stub received: enough to say which route it was, what
 /// credential the proxy presented on it, and what it asked for.
 #[derive(Debug, Clone)]
@@ -299,7 +311,7 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
                 .to_string(),
         ),
         "/v1/health" => (200_u16, health_body(config)),
-        "/v1/chat/completions" => {
+        path if PLACED_ROUTES.contains(&path) => {
             // Counted for exactly as long as the node is working on it.
             let busy = config.live_in_flight.as_ref().map(|count| {
                 count.fetch_add(1, Ordering::SeqCst);
@@ -437,16 +449,21 @@ fn health_probes(nodes: &[StubNode]) -> usize {
         .sum()
 }
 
-fn completions_served(nodes: &[StubNode]) -> Vec<usize> {
+/// Requests each node received on one route.
+fn served_on(nodes: &[StubNode], path: &str) -> Vec<usize> {
     nodes
         .iter()
         .map(|node| {
             node.received()
                 .iter()
-                .filter(|received| received.path == "/v1/chat/completions")
+                .filter(|received| received.path == path)
                 .count()
         })
         .collect()
+}
+
+fn completions_served(nodes: &[StubNode]) -> Vec<usize> {
+    served_on(nodes, "/v1/chat/completions")
 }
 
 /// Bind the real proxy on an OS-assigned port and start serving it in the
@@ -478,12 +495,22 @@ async fn post_chat(
     body: &Value,
     extra_headers: &[(&str, &str)],
 ) -> (u16, Value, Vec<(String, String)>) {
+    post_to(addr, "/v1/chat/completions", body, extra_headers).await
+}
+
+/// The same, on any route, for the ones that are not chat.
+async fn post_to(
+    addr: SocketAddr,
+    path: &str,
+    body: &Value,
+    extra_headers: &[(&str, &str)],
+) -> (u16, Value, Vec<(String, String)>) {
     let mut stream = tokio::net::TcpStream::connect(addr)
         .await
         .expect("connect to proxy");
     let payload = body.to_string();
     let mut request = format!(
-        "POST /v1/chat/completions HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n",
+        "POST {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n",
         payload.len()
     );
     for (name, value) in extra_headers {
@@ -697,12 +724,20 @@ async fn post_chat_streaming(
     addr: SocketAddr,
     body: &Value,
 ) -> (u16, Vec<(String, String)>, Vec<Piece>) {
+    post_streaming(addr, "/v1/chat/completions", body).await
+}
+
+async fn post_streaming(
+    addr: SocketAddr,
+    path: &str,
+    body: &Value,
+) -> (u16, Vec<(String, String)>, Vec<Piece>) {
     let mut stream = tokio::net::TcpStream::connect(addr)
         .await
         .expect("connect to proxy");
     let payload = body.to_string();
     let request = format!(
-        "POST /v1/chat/completions HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        "POST {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
         payload.len()
     );
     stream
@@ -2205,4 +2240,276 @@ async fn a_saturated_node_hands_a_streaming_request_on_as_well() {
         !pieces.is_empty(),
         "the replacement node's events must arrive"
     );
+}
+
+// ---------------------------------------------------------------------------
+// The routes the proxy serves
+//
+// A client pointed at this address expects an OpenAI-compatible surface, not
+// only chat. These tests are that client's view: what reaches a node, what is
+// refused and why, and what an unauthenticated caller is allowed to learn.
+// ---------------------------------------------------------------------------
+
+/// A body that is recognisably this route's, so the assertion that the node got
+/// it back cannot pass on a body some other route sent.
+fn body_for(path: &str) -> Value {
+    let marker = format!("body for {path}");
+    match path {
+        "/v1/chat/completions" => {
+            serde_json::json!({ "model": "shared-model", "messages": [{ "role": "user", "content": marker }] })
+        }
+        "/v1/embeddings" => serde_json::json!({ "model": "shared-model", "input": marker }),
+        "/v1/rerank" | "/v1/reranking" => {
+            serde_json::json!({ "model": "shared-model", "query": marker, "documents": ["a", "b"] })
+        }
+        _ => serde_json::json!({ "model": "shared-model", "prompt": marker }),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn every_placed_route_reaches_a_node_with_its_path_and_body_intact() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("only")]), RouteMode::Throughput).await;
+
+    for path in PLACED_ROUTES {
+        let sent = body_for(path);
+        let (status, _, headers) = post_to(addr, path, &sent, &[]).await;
+        assert_eq!(status, 200, "{path} was not served");
+        assert_eq!(
+            header(&headers, "x-camelid-fabric-node"),
+            Some("only"),
+            "{path} was answered without being placed"
+        );
+
+        let arrived: Vec<Received> = node
+            .received()
+            .into_iter()
+            .filter(|received| received.path == path)
+            .collect();
+        assert_eq!(
+            arrived.len(),
+            1,
+            "{path} did not reach the node exactly once"
+        );
+        // Byte-for-byte: the proxy reads `model` and `stream` out of the body
+        // and must relay everything else, including fields it has never heard
+        // of, exactly as the client wrote them.
+        assert_eq!(
+            serde_json::from_str::<Value>(&arrived[0].body).expect("json body"),
+            sent,
+            "{path} arrived with a body the client did not send"
+        );
+    }
+}
+
+/// Placement is model-scoped on every route, not just the one it was written
+/// for: a node that does not hold the model must never see the request.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_placed_route_other_than_chat_is_still_scoped_to_the_serving_node() {
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let beta = StubNode::start(StubConfig::ready("model-beta", 0));
+    let addr = start_proxy(
+        fabric_of(vec![alpha.spec("alpha"), beta.spec("beta")]),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    let (status, _, headers) = post_to(
+        addr,
+        "/v1/embeddings",
+        &serde_json::json!({ "model": "model-beta", "input": "hello" }),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, 200);
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("beta"));
+    assert!(
+        alpha
+            .received()
+            .iter()
+            .all(|received| received.path == "/v1/health"),
+        "alpha holds a different model and should only have been probed: {:?}",
+        alpha.received()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_completions_stream_is_relayed_like_a_chat_one() {
+    let events = ["data: one\n\n", "data: [DONE]\n\n"];
+    let node = StubNode::start(StubConfig::streaming(
+        "shared-model",
+        &events,
+        Duration::ZERO,
+    ));
+    let addr = start_proxy(fabric_of(vec![node.spec("only")]), RouteMode::Throughput).await;
+
+    let (status, headers, pieces) = post_streaming(
+        addr,
+        "/v1/completions",
+        &serde_json::json!({ "model": "shared-model", "prompt": "hi", "stream": true }),
+    )
+    .await;
+
+    assert_eq!(status, 200);
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("only"));
+    assert_eq!(header(&headers, "content-type"), Some("text/event-stream"));
+    let framed: String = pieces.iter().map(|piece| piece.text.as_str()).collect();
+    assert_eq!(dechunk(&framed), events.concat());
+    assert_eq!(
+        served_on(std::slice::from_ref(&node), "/v1/completions")[0],
+        1
+    );
+}
+
+/// `stream: true` is a property of the request, not of the route. A route that
+/// has nothing to stream answers with a body instead, and that answer has to
+/// reach the client as an answer rather than as an empty stream.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_route_that_cannot_stream_still_answers_a_client_that_asks_it_to() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("only")]), RouteMode::Throughput).await;
+
+    let (status, body, headers) = post_to(
+        addr,
+        "/v1/embeddings",
+        &serde_json::json!({ "model": "shared-model", "input": "hi", "stream": true }),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, 200);
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("only"));
+    assert!(
+        body.get("choices").is_some(),
+        "the node's complete answer must reach the client verbatim: {body}"
+    );
+}
+
+/// Refused before placement, so the fabric is not even observed: this proxy
+/// declines these routes on principle, not because no node could take them.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_node_local_route_is_refused_without_touching_a_node() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("only")]), RouteMode::Throughput).await;
+
+    let (status, body, _) = post_to(
+        addr,
+        "/v1/responses",
+        &serde_json::json!({ "model": "shared-model", "input": "hi" }),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, 501, "{body}");
+    assert_eq!(body["error"]["type"], "fabric_error");
+    assert!(
+        node.received().is_empty(),
+        "a refusal on principle must not cost a probe: {:?}",
+        node.received()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unserved_route_is_refused_with_the_ones_that_are_served() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("only")]), RouteMode::Throughput).await;
+
+    let (status, body, _) = post_to(
+        addr,
+        "/v1/audio/speech",
+        &serde_json::json!({ "model": "shared-model" }),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, 404, "{body}");
+    assert_eq!(body["error"]["type"], "fabric_error");
+    let message = body["error"]["message"].as_str().expect("a message");
+    assert!(message.contains("/v1/embeddings"), "{message}");
+    assert!(message.contains("/v1/health"), "{message}");
+    assert!(node.received().is_empty(), "{:?}", node.received());
+}
+
+/// The route table is not public. An unauthenticated caller learns that it is
+/// unauthenticated and nothing else — the same reasoning that keeps model names
+/// out of a 401 from `/v1/models`.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unauthenticated_caller_is_refused_before_learning_the_route_table() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("only")]),
+        RouteMode::Throughput,
+        authenticated("s3cret"),
+    )
+    .await;
+
+    let (unknown, body) = get_raw(addr, "/v1/audio/speech", &[]).await;
+    assert_eq!(unknown, 401);
+    assert!(
+        !body.contains("/v1/embeddings"),
+        "the 401 leaked the route table: {body}"
+    );
+
+    let (refused, _, _) = post_to(
+        addr,
+        "/v1/embeddings",
+        &serde_json::json!({ "model": "shared-model", "input": "hi" }),
+        &[],
+    )
+    .await;
+    assert_eq!(refused, 401, "every placed route is behind the key");
+    assert!(node.received().is_empty(), "{:?}", node.received());
+
+    let (served, _, _) = post_to(
+        addr,
+        "/v1/embeddings",
+        &serde_json::json!({ "model": "shared-model", "input": "hi" }),
+        &[("Authorization", "Bearer s3cret")],
+    )
+    .await;
+    assert_eq!(served, 200, "the key still opens the new routes");
+}
+
+/// The body limit and the JSON rejection shape are properties of the handler
+/// every placed route shares, so they must hold on a route that was added
+/// after they were written.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_malformed_body_on_a_new_route_is_refused_in_the_fabric_shape() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("only")]), RouteMode::Throughput).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to proxy");
+    let payload = "this is not json";
+    let request = format!(
+        "POST /v1/rerank HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).await.expect("read response");
+    let text = String::from_utf8_lossy(&raw);
+
+    assert!(text.starts_with("HTTP/1.1 400"), "{text}");
+    assert!(text.contains("fabric_error"), "{text}");
+    assert!(node.received().is_empty(), "{:?}", node.received());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_model_can_be_retrieved_by_id_through_the_proxy() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("only")]), RouteMode::Throughput).await;
+
+    let (found, body) = get_raw(addr, "/v1/models/shared-model", &[]).await;
+    assert_eq!(found, 200, "{body}");
+    assert!(body.contains("\"id\":\"shared-model\""), "{body}");
+
+    let (missing, refusal) = get_raw(addr, "/v1/models/other-model", &[]).await;
+    assert_eq!(missing, 404, "{refusal}");
+    assert!(refusal.contains("model_not_found"), "{refusal}");
 }

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -1514,6 +1514,36 @@ async fn repeated_health_checks_share_one_observation() {
     );
 }
 
+/// The other half of that bound, and the half an operator actually has to set
+/// something for: reuse lasts exactly as long as the window. A deployment
+/// polling this route more slowly than `--observation-max-age-ms` re-probes
+/// every node on every check — at the 500 ms default, a once-a-second probe
+/// does that every time.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_health_check_past_the_window_observes_the_fabric_again() {
+    let nodes = vec![StubNode::start(StubConfig::ready("shared-model", 0))];
+    let specs = vec![nodes[0].spec("node-a")];
+    let addr = start_proxy(
+        fabric_reusing_observations(specs, Duration::from_millis(50)),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    let (first, _) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(first, 200);
+    let after_first = health_probes(&nodes);
+
+    // Comfortably past the window, so this is not a race with the clock.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (second, _) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(second, 200);
+    assert!(
+        health_probes(&nodes) > after_first,
+        "an expired observation must be taken again rather than reused"
+    );
+}
+
 /// The proxy observes the fabric before every placement. Without a freshness
 /// bound that is a `/v1/health` per node per request: measured at exactly 2 per
 /// request against two nodes, and 2.0 s per request when one node black-holes,


### PR DESCRIPTION
> Stacked on #662 (`feat/fabric-failover`). Both touch the same handlers in `src/fabric/server.rs`, so this is one commit on top of that branch rather than a conflict waiting to happen. Review or merge #662 first; the commit here is `2ac97152` and stands alone once it lands.

## The gap

The proxy answered two routes. The engine serves four real inference routes plus discovery:

| engine route | proxy, before |
| --- | --- |
| `POST /v1/chat/completions` | placed |
| `POST /v1/completions` | **bodyless 404 from axum** |
| `POST /v1/embeddings` | **bodyless 404** |
| `POST /v1/rerank`, `/v1/reranking` | **bodyless 404** |
| `GET /v1/models` | aggregated |
| `GET /v1/models/{model}` | **bodyless 404** |

So an address advertised as OpenAI-compatible answered `models.list` but not `models.retrieve`, and served chat but not completions or embeddings — with nothing in the body to say whether the route or the model was wrong.

## What this does

Places all four inference routes and adds `GET /v1/models/{model}`. Every one of those bodies carries `model`, so placement, affinity, the attempt budget, the body limit and the streaming decision are the ones chat already had — the handler is shared, not copied.

Measured on the built binary (`v0.6.1-125-g2ac971520`) against a stub node:

```
placed routes:
  POST /v1/chat/completions   -> 200 node=node-a reached-node=1 body-verbatim=true
  POST /v1/completions        -> 200 node=node-a reached-node=1 body-verbatim=true
  POST /v1/embeddings         -> 200 node=node-a reached-node=1 body-verbatim=true
  POST /v1/rerank             -> 200 node=node-a reached-node=1 body-verbatim=true
  POST /v1/reranking          -> 200 node=node-a reached-node=1 body-verbatim=true

refusals:
  POST /v1/responses             -> 501  the Responses and Conversations APIs keep their state...
  GET  /v1/conversations/c1/items -> 501  (same, on every method)
  POST /v1/audio/speech          -> 404
    this fabric proxy does not serve that route; it serves POST /v1/chat/completions,
    POST /v1/completions, POST /v1/embeddings, POST /v1/rerank, POST /v1/reranking,
    and GET /v1/models and GET /v1/models/{model}

discovery:
  GET /v1/models               -> 200 {"object":"list","data":[{"id":"receipt-model",...}]}
  GET /v1/models/receipt-model -> 200 {"id":"receipt-model","object":"model",...}
  GET /v1/models/not-loaded    -> 404 code=model_not_found
```

## What earns a route its place

That any node serving the model the request names could answer it. The client cannot tell which node it reached and must not need to.

That rules out the **Responses and Conversations** APIs. They keep their items in a SQLite store on the node that served the request (`src/api/responses_store.rs`), so placing them would appear to work and then lose a conversation the moment a follow-up landed elsewhere. They are refused with **501 and the reason**, on every method, rather than half-supported — a stored response is as node-local as the POST that created it. Anything else is a **404 naming what is served**.

Both refusals sit inside the client-key layer: an unauthenticated caller gets a 401 and learns nothing about the fabric, which is the same reasoning that keeps model names out of a 401 from `/v1/models`.

## Design notes

- **One table, two uses.** `PLACED_ROUTES` is what the router is folded from *and* what the 404 message is written from, so a route cannot be registered and unadvertised, or advertised and unregistered.
- **The path is not client-controlled.** Each route is registered with its own `&'static str`; nothing is read from the request line, so no query string or encoded segment can steer what reaches a node.
- **Retrieval and placement cannot disagree.** `GET /v1/models/{model}` answers from `policy::route` on the same observation, so a 200 there is a promise that a request naming that model would be placed. It inherits the distinction #654 introduced for free: a settled 404 when every node was consulted, a retryable 503 while one is unaccounted for.
- **`stream: true` stays a property of the request, not of the route.** A client that sets it on a route with nothing to stream gets that route's complete answer relayed, because a non-streaming answer already comes back as `StreamOutcome::Buffered`. There is a test for that rather than a rule against it.

## Validation

| gate | result |
| --- | --- |
| `cargo test --lib` | 1844 passed / 0 failed / 86 ignored |
| `cargo test --lib fabric::` | 134 passed (127 + 7 new) |
| `cargo test --test fabric_serve` | 41 passed (32 + 9 new) |
| `cargo test --test fabric_end_to_end` | 14 passed |
| `cargo test --bin camelid` | 40 passed |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | 0 warnings |
| `scripts/check-public-scrub.sh` | exit 0 |
| `git diff --check`, `git ls-files --eol` | clean, all 3 files `i/lf w/lf` |

### Ablations

Each applied to the committed tree, suites re-run, then reverted; `git diff` empty afterwards each time.

| ablation | result |
| --- | --- |
| register only `/v1/chat/completions` | **exactly the 6** tests that exercise the new routes fail; 35 pass, including every pre-existing chat, streaming, auth and failover test |
| drop the node-local refusals | **exactly 3** fail (1 integration, 2 unit), and the failure output shows `/v1/responses` falling through to the generic 404 |
| drop the unknown-route fallback | **exactly 2** fail |
| let model retrieval answer 200 without consulting placement | **exactly 3** fail, including the one that pins the retryable-vs-settled distinction |

### New tests

Integration, over real sockets: every placed route arrives with its path and a **byte-for-byte** body (a field the proxy has never heard of has to survive); a non-chat route is still scoped to the node serving the model; `/v1/completions` streams; `/v1/embeddings` with `stream: true` still answers; the node-local refusal costs not even a probe; an unserved route names the served ones; an unauthenticated caller cannot read the route table and cannot reach a node on a new route; a malformed body on a new route is refused in the fabric error shape.

Unit: the 404 message names every entry in the table; the two tables do not overlap; node-local routes are refused on every method; a model can be retrieved, an unserved one is refused exactly as placing it would be, and a fabric with an unreachable node stays retryable.

## Not covered

Still loopback only — no cross-machine evidence, unchanged from #651/#652/#662. `/v1/messages` is not registered: the engine refuses it as unsupported, and this proxy's 404 names the alternatives, which is more use than relaying that refusal.
