### PR TITLE
fix(fabric): tell the operator when the proxy cannot reach a node

### DIFF
--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -501,6 +501,59 @@ pub fn render_status(snapshots: &[NodeSnapshot]) -> String {
     out
 }
 
+/// What a starting proxy tells its operator about the fabric behind it.
+///
+/// A proxy that cannot reach a node still starts: the node may be booting, and a
+/// fabric that refuses to come up because one member is late is less available
+/// than the member it is waiting for. But starting silently is worse — with only
+/// a listening line to go on, a node whose name never resolves leaves the proxy
+/// serving at reduced capacity forever with nothing said, and the first symptom
+/// is a latency graph nobody can explain.
+///
+/// So: report, never refuse. Every node that cannot take work is named, with the
+/// address that was tried and the reason it failed, because "which of my nodes,
+/// and why" is the whole question an operator has at that moment.
+///
+/// Kept pure so the wording is covered by a unit test rather than by starting a
+/// server, the same way [`render_status`] is.
+pub fn startup_report(snapshots: &[NodeSnapshot]) -> String {
+    if snapshots.is_empty() {
+        return "fabric: no nodes configured\n".to_string();
+    }
+
+    let summary = FabricSummary::of(snapshots);
+    let models = servable_models(snapshots);
+    let mut out = format!(
+        "fabric: {} of {} nodes ready",
+        summary.ready,
+        summary.total()
+    );
+    if models.is_empty() {
+        out.push_str("; no model is being served\n");
+    } else {
+        out.push_str(&format!("; serving {}\n", models.join(", ")));
+    }
+
+    for snapshot in snapshots {
+        let (state, reason) = match &snapshot.status {
+            NodeStatus::Ready(_) => continue,
+            NodeStatus::NotReady { reason } => ("not ready", reason),
+            NodeStatus::Unreachable { reason } => ("unreachable", reason),
+        };
+        out.push_str(&format!(
+            "  {} ({}) {state}: {reason}\n",
+            snapshot.label(),
+            snapshot.spec.authority(),
+        ));
+    }
+
+    if summary.ready == 0 {
+        out.push_str("fabric: every request will be refused until a node becomes ready\n");
+    }
+
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -617,6 +670,98 @@ mod tests {
         assert!(rendered.contains("LOAD"), "{rendered}");
         assert!(rendered.contains("cannot connect: refused"), "{rendered}");
         assert!(rendered.contains("2 node(s): 1 ready"), "{rendered}");
+    }
+
+    #[test]
+    fn the_startup_report_names_a_node_it_cannot_reach() {
+        let snapshots = vec![
+            snapshot("windows", ready_status("llama-3b")),
+            snapshot(
+                "mac",
+                NodeStatus::Unreachable {
+                    reason: "cannot resolve host: No such host is known. (os error 11001)"
+                        .to_string(),
+                },
+            ),
+        ];
+        let report = startup_report(&snapshots);
+        assert!(report.contains("1 of 2 nodes ready"), "{report}");
+        assert!(report.contains("serving llama-3b"), "{report}");
+        // The label, the address that was tried, and the reason: an operator
+        // cannot act on any two of those three.
+        assert!(
+            report.contains("mac (127.0.0.1:8181) unreachable"),
+            "{report}"
+        );
+        assert!(report.contains("os error 11001"), "{report}");
+        // A node that is doing its job is not worth a line of its own.
+        assert!(!report.contains("windows"), "{report}");
+    }
+
+    #[test]
+    fn a_healthy_fabric_reports_one_line_and_names_no_node() {
+        let snapshots = vec![
+            snapshot("a", ready_status("llama-3b")),
+            snapshot("b", ready_status("llama-3b")),
+        ];
+        assert_eq!(
+            startup_report(&snapshots),
+            "fabric: 2 of 2 nodes ready; serving llama-3b\n"
+        );
+    }
+
+    #[test]
+    fn a_startup_report_says_when_nothing_can_be_served_at_all() {
+        let snapshots = vec![
+            snapshot(
+                "a",
+                NodeStatus::Unreachable {
+                    reason: "cannot connect".to_string(),
+                },
+            ),
+            snapshot(
+                "b",
+                NodeStatus::Unreachable {
+                    reason: "cannot connect".to_string(),
+                },
+            ),
+        ];
+        let report = startup_report(&snapshots);
+        assert!(report.contains("0 of 2 nodes ready"), "{report}");
+        assert!(report.contains("no model is being served"), "{report}");
+        assert!(
+            report.contains("every request will be refused until a node becomes ready"),
+            "{report}"
+        );
+    }
+
+    #[test]
+    fn a_startup_report_separates_answering_late_from_not_answering() {
+        // These are different operator problems: one node is booting, the other
+        // is not there. Collapsing them into "down" sends you to the wrong box.
+        let snapshots = vec![
+            snapshot(
+                "warming",
+                NodeStatus::NotReady {
+                    reason: "no model loaded".to_string(),
+                },
+            ),
+            snapshot(
+                "gone",
+                NodeStatus::Unreachable {
+                    reason: "cannot connect".to_string(),
+                },
+            ),
+        ];
+        let report = startup_report(&snapshots);
+        assert!(
+            report.contains("warming (127.0.0.1:8181) not ready: no model loaded"),
+            "{report}"
+        );
+        assert!(
+            report.contains("gone (127.0.0.1:8181) unreachable: cannot connect"),
+            "{report}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3012,6 +3012,10 @@ async fn main() -> anyhow::Result<()> {
                     camelid::fabric::server::bind(addr, &auth, allow_unauthenticated_remote)
                         .await?;
                 println!("fabric serve listening on {}", listener.local_addr()?);
+                // Nothing is being served yet, so this probe costs no request, and
+                // it is the only chance to tell the operator about a node that is
+                // not there before a client discovers it for them.
+                print!("{}", camelid::fabric::startup_report(&fabric.observe()));
                 camelid::fabric::server::serve_on(
                     listener,
                     fabric,


### PR DESCRIPTION
## The defect

`fabric serve` prints its listening line and nothing else.

Point it at a fabric where one node's name never resolves and the entire startup output is:

```
fabric serve listening on 127.0.0.1:8490
```

stderr is empty. The proxy then serves at reduced capacity indefinitely, and the first symptom
is a latency graph nobody can explain. I hit this for real while taking two-machine evidence for
#663: I mistyped the Mac as a `.local` name that Windows cannot resolve, the proxy came up
happily, every request went to the one remaining node, and nothing anywhere said why.

`fabric status` is already honest about exactly this:

```
NODE   ADDRESS                               STATE      MODEL  LOAD  DETAIL
mac    palanikannans-macbook-pro.local:8181  offline    -      -     cannot resolve host: ... (os error 11001)
win    127.0.0.1:8181                        ready      ...    0     llama · 1 ms

2 node(s): 1 ready, 0 not ready, 1 offline
```

But `status` is the command you run when you already suspect something. `serve` is the one
actually taking traffic, and it was the silent one.

## The change

Probe once after binding and report what the fabric looks like. Two files, +149/-0.

- New `fabric::startup_report(&[NodeSnapshot]) -> String`, a pure function beside `render_status`
  and `servable_models`, so the wording is unit-tested rather than eyeballed in a terminal.
- `fabric serve` calls it once with `fabric.observe()`, after the listening line and before
  `serve_on`.

**Report, never refuse.** A node may still be booting, and a fabric that refuses to come up
because one member is late is less available than the member it is waiting for. This deliberately
does not gain a `--require-all-nodes` flag; the k8s ordering hazard is not worth it.

Every node that cannot take work is named with **the address that was tried and the reason it
failed**, because "which of my nodes, and why" is the entire question an operator has at that
moment. A node that is doing its job gets no line of its own.

Cost: one probe round at startup. Nothing is being served yet, so it costs no request — and
because `observe()` populates the observation cache from #656, it warms the observation the first
request would otherwise have paid for.

## What it prints

Live, on two real machines: a Windows node and an Apple M5 Pro across the LAN.
`BEFORE = camelid v0.6.1-125-g2ac971520` (pre-fix), `AFTER = camelid v0.6.1-124-g86478cd62`.

**Before**, pointed at a fabric with one unresolvable node — this is the entire output, and
stderr was empty:

```
fabric serve listening on 127.0.0.1:8490
```

**After**, same fabric:

```
fabric serve listening on 127.0.0.1:8490
fabric: 1 of 2 nodes ready; serving Llama 3.2 1B Instruct
  mac (palanikannans-macbook-pro.local:8181) unreachable: cannot resolve host: No such host is known. (os error 11001)
```

**After**, both machines actually up — one line, no per-node noise:

```
fabric serve listening on 127.0.0.1:8490
fabric: 2 of 2 nodes ready; serving Llama 3.2 1B Instruct
```

**After**, the Mac engine stopped so the node is down rather than misnamed:

```
fabric: 1 of 2 nodes ready; serving Llama 3.2 1B Instruct
  mac (192.168.29.158:8181) unreachable: cannot connect: 192.168.29.158:8181: connection timed out
```

**After**, nothing ready at all:

```
fabric: 0 of 2 nodes ready; no model is being served
  a (127.0.0.1:9901) unreachable: cannot connect: 127.0.0.1:9901: connection timed out
  b (127.0.0.1:9902) unreachable: cannot connect: 127.0.0.1:9902: connection timed out
fabric: every request will be refused until a node becomes ready
```

One thing worth knowing about that last reason string, since this change is what surfaces it: the
text comes from the probe, and the probe's default budget is `--timeout-ms 2000`. On this host a
*refused* loopback connect takes **~2.06 s** (measured 2062 ms with a raw `TcpClient.Connect`), so
the budget expires first and the probe reports its own timeout. Given `--timeout-ms 3000` the same
node reports the OS answer instead — `cannot connect: 127.0.0.1:9901: No connection could be made
because the target machine actively refused it. (os error 10061)`. Pre-existing, not introduced
here, and not worth changing blind — but "timed out" and "refused" are different diagnoses and it
is a race between two clocks, so it is worth someone's attention.

## Tests

Four unit tests on the pure function:

- `the_startup_report_names_a_node_it_cannot_reach` — the label, the address, and the reason are
  all present, and a healthy node is *not* named
- `a_healthy_fabric_reports_one_line_and_names_no_node` — exact-string assertion on the whole
  report, so a healthy fabric cannot start printing noise
- `a_startup_report_says_when_nothing_can_be_served_at_all`
- `a_startup_report_separates_answering_late_from_not_answering` — "booting" and "not there" are
  different operator problems; collapsing them into "down" sends you to the wrong machine

**Ablation.** Dropping the per-node loop and keeping the summary line fails **exactly 2** tests —
`the_startup_report_names_a_node_it_cannot_reach` and
`a_startup_report_separates_answering_late_from_not_answering` — with 122 passing, including both
positive controls, which do not depend on per-node naming. Tree restored byte-identical
afterwards (`git diff` empty).

## Gates

`cargo fmt --all --check` 0 · `cargo clippy --all-targets -D warnings` **0 warnings** ·
`--lib fabric::` **124** (120 + 4 new) · `--test fabric_serve` 25 · `--test fabric_end_to_end` 14 ·
`--bin camelid` 40 · `scripts/check-public-scrub.sh` 0 · `git diff --check` 0 ·
both files `i/lf w/lf`.

## Limits

- The report is a snapshot of startup, not a health endpoint. A node that dies at minute five is
  still invisible until something asks. The proxy still has no readiness endpoint of its own —
  that is the larger gap this only chips at.
- The probe is blocking and runs on the async runtime before `serve_on`. That matches what
  `fabric status` already does, and at startup nothing else is running, but it does mean the
  listening socket is bound for up to one probe budget before requests are accepted.
- Output goes to stdout with the listening line. It is not structured, and there is no
  `--json` for it.
