### PR TITLE
feat(fabric): give the proxy a health endpoint of its own

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -47,7 +47,8 @@
 //! A `session_start` with no matching `session_exit` means the process did not
 //! leave through that path. Be precise about what that does and does not say:
 //! `camelid serve` installs no signal handler (there is no `ctrl_c` or
-//! `with_graceful_shutdown` anywhere in the engine), so an ordinary Ctrl-C ends
+//! `with_graceful_shutdown` in its path — `fabric serve` has one, but that is a
+//! different command in a different process), so an ordinary Ctrl-C ends
 //! the process exactly as abruptly as an out-of-memory kill, and the two are
 //! recorded identically — which is to say, not at all. Read a missing exit
 //! record as "did not fail on the way out", never as evidence of a kill.

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -43,6 +43,11 @@
 //! * A stop (Ctrl-C, or SIGTERM where there is one) closes the listener and
 //!   lets the requests already in flight finish, bounded by `forward_timeout`.
 //!   A kill still drops them: this covers being asked to stop, not being shot.
+//! * `/v1/health` answers readiness, not liveness — a 503 from it means "no
+//!   node is ready", never "restart me". It is also the one route a client
+//!   reaches without a key, because the engine's shared `authenticate` keeps
+//!   `/v1/health` public; it therefore names the fabric's nodes and models only
+//!   when this proxy is bound to loopback.
 //! * A node that becomes ready, or loads a different model, is routed to only
 //!   once the current observation expires. A node that *stops* answering is not
 //!   waited on: the request that finds it gone is placed on another node
@@ -142,6 +147,15 @@ pub struct ServeConfig {
     pub forward_timeout: Duration,
     /// What a client must present to be served at all.
     pub auth: ClientAuth,
+    /// The address this proxy listens on.
+    ///
+    /// Read only to decide whether `/v1/health` may name the fabric's members:
+    /// a loopback listener cannot be reached from off the machine.
+    /// [`serve_on_until`] overwrites this with the address the listener
+    /// actually bound, so the value the disclosure rule sees can never be a
+    /// caller's guess. It is set there rather than in [`serve_on`] because
+    /// every serving path goes through it, including the injected-stop seam.
+    pub bound: SocketAddr,
 }
 
 #[derive(Clone)]
@@ -158,6 +172,7 @@ pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
     Router::new()
         .route("/v1/chat/completions", post(chat_completions))
         .route("/v1/models", get(models))
+        .route("/v1/health", get(health))
         // Without this, axum's 2 MiB default would refuse conversations the
         // node behind the proxy accepts.
         .layer(DefaultBodyLimit::max(DEFAULT_MAX_REQUEST_BODY_BYTES))
@@ -361,9 +376,14 @@ pub async fn serve_on(
 pub async fn serve_on_until(
     listener: tokio::net::TcpListener,
     fabric: Fabric,
-    config: ServeConfig,
+    mut config: ServeConfig,
     stop: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {
+    // The listener is the only authority on what was actually bound, and the
+    // health disclosure rule turns on it. It is set here rather than in
+    // `serve_on` so that a caller entering through this seam cannot skip it.
+    config.bound = listener.local_addr()?;
+
     let drain = config.forward_timeout;
     // The peer address is only available to a service built this way, and the
     // access log is the only thing that reads it.
@@ -422,6 +442,110 @@ async fn stop_requested() {
         () = interrupt => {}
         () = terminate => {}
     }
+}
+
+/// Report whether this proxy can route a request right now.
+///
+/// A load balancer needs one address to ask "should I send you traffic", and
+/// the proxy had none: `/v1/health` matched no route, so a probe got a bodyless
+/// 404 whatever the fabric was actually doing.
+///
+/// **This is readiness, not liveness.** It answers 503 while no node is ready,
+/// which is the right answer to "send me traffic" and the wrong one to "should
+/// I restart you" — restarting a proxy cannot bring a node back. Wire it to a
+/// readiness probe. Liveness is the `ok` in the body, which is true whenever
+/// this code runs at all.
+///
+/// The answer comes from the same observation placement uses, so a probe every
+/// second does not become a probe of every node every second: inside the
+/// freshness window a health check costs the fabric no traffic.
+async fn health(State(state): State<ServerState>) -> Response {
+    let fabric = Arc::clone(&state.fabric);
+    // Observing is blocking socket I/O against every node, same as a dispatch.
+    let snapshots = match tokio::task::spawn_blocking(move || fabric.observe()).await {
+        Ok(snapshots) => snapshots,
+        Err(join_error) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("could not observe the fabric: {join_error}"),
+            )
+        }
+    };
+
+    let (status, body) = health_report(&snapshots, state.config.bound.ip().is_loopback());
+    (status, Json(body)).into_response()
+}
+
+/// Build the health answer.
+///
+/// Ready means at least one node is ready, which is exactly what placement
+/// needs: with one, some request can be served; with none, every request is
+/// refused, and saying otherwise would invite traffic this proxy cannot serve.
+///
+/// `disclose_detail` decides whether anything beyond that verdict is included,
+/// and is false unless the listener is loopback. This route is **not** behind
+/// [`ClientAuth`]: the engine's shared `authenticate` keeps `/v1/health` public
+/// so a probe needs no credential, and reusing that check means inheriting the
+/// rule. An anonymous caller can therefore read whatever is here, which makes
+/// the contents a disclosure decision rather than a formatting one:
+///
+/// * the node list is every label and address in the fabric;
+/// * the model list is the answer `/v1/models` gives, and that route *is*
+///   behind the key, so publishing it here would hand it out through a side
+///   door;
+/// * off-box callers get the verdict and nothing else, which is all a load
+///   balancer reads anyway.
+///
+/// [`crate::api`] withholds its own `executable` and `listen_addr` on the same
+/// fact, for the same reason.
+///
+/// Deliberately not shaped like a node's health: there is no `engine` field and
+/// the service name differs, so nothing can mistake a proxy for something that
+/// generates. A proxy has no single `active_model_id` to report anyway.
+///
+/// Kept pure so both rules are covered by unit tests rather than by starting a
+/// server and guessing which branch ran.
+fn health_report(snapshots: &[fabric::NodeSnapshot], disclose_detail: bool) -> (StatusCode, Value) {
+    let summary = fabric::FabricSummary::of(snapshots);
+    let ready = summary.ready > 0;
+
+    let mut body = serde_json::json!({
+        "ok": true,
+        "service": "camelid-fabric",
+        "version": env!("CARGO_PKG_VERSION"),
+        "build": crate::receipt::camelid_version(),
+        "ready": ready,
+    });
+
+    if disclose_detail {
+        if let Some(object) = body.as_object_mut() {
+            object.insert(
+                "nodes".to_string(),
+                serde_json::json!({
+                    "total": summary.total(),
+                    "ready": summary.ready,
+                    "not_ready": summary.not_ready,
+                    "unreachable": summary.unreachable,
+                }),
+            );
+            object.insert(
+                "models".to_string(),
+                serde_json::json!(fabric::servable_models(snapshots)),
+            );
+            // The shape `fabric status --json` already prints, so an operator
+            // reading both is not learning two vocabularies for one fact.
+            if let Ok(detail) = serde_json::to_value(snapshots) {
+                object.insert("node_detail".to_string(), detail);
+            }
+        }
+    }
+
+    let status = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (status, body)
 }
 
 /// List every model the fabric can currently route to.
@@ -804,7 +928,7 @@ fn error_response(status: StatusCode, message: &str) -> Response {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fabric::node::NodeSpec;
+    use crate::fabric::node::{NodeReady, NodeSnapshot, NodeSpec, NodeStatus};
     use crate::fabric::policy::RouteReason;
     use tower::ServiceExt;
 
@@ -840,7 +964,39 @@ mod tests {
             mode: RouteMode::Throughput,
             forward_timeout: Duration::from_millis(200),
             auth: ClientAuth::none(),
+            bound: "127.0.0.1:8490".parse().expect("loopback address"),
         }
+    }
+
+    /// A proxy on an address the network can reach. Integration tests always
+    /// bind loopback, so this is the only place the redacted branch is reached.
+    fn exposed_config() -> ServeConfig {
+        ServeConfig {
+            bound: "203.0.113.7:8490".parse().expect("routable address"),
+            ..open_config()
+        }
+    }
+
+    fn snapshot(label: &str, status: NodeStatus) -> NodeSnapshot {
+        NodeSnapshot {
+            spec: NodeSpec {
+                label: label.to_string(),
+                host: "192.0.2.10".to_string(),
+                port: 8181,
+            },
+            status,
+            latency: Some(Duration::from_millis(3)),
+        }
+    }
+
+    fn ready_status(model: &str) -> NodeStatus {
+        NodeStatus::Ready(NodeReady {
+            active_model_id: Some(model.to_string()),
+            backend: "llama".to_string(),
+            version: "0.6.1".to_string(),
+            in_flight: 0,
+            waiting: 0,
+        })
     }
 
     fn proxy(fabric: Fabric) -> Router {
@@ -1156,6 +1312,123 @@ mod tests {
         let written = logged(proxy(Fabric::new(Vec::new())), get_request("/v1/models")).await;
         assert!(written.contains("fabric request"), "{written}");
         assert!(written.contains("client=\"-\""), "{written}");
+    }
+
+    /// Ready means "placement can succeed", which is exactly one ready node.
+    #[test]
+    fn health_is_ready_when_one_node_can_serve() {
+        let snapshots = vec![
+            snapshot("a", ready_status("llama-3b")),
+            snapshot(
+                "b",
+                NodeStatus::Unreachable {
+                    reason: "cannot connect".to_string(),
+                },
+            ),
+        ];
+        let (status, body) = health_report(&snapshots, true);
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["ok"], serde_json::json!(true));
+        assert_eq!(body["ready"], serde_json::json!(true));
+        assert_eq!(body["nodes"]["total"], serde_json::json!(2));
+        assert_eq!(body["nodes"]["ready"], serde_json::json!(1));
+        assert_eq!(body["nodes"]["unreachable"], serde_json::json!(1));
+        assert_eq!(body["models"], serde_json::json!(["llama-3b"]));
+    }
+
+    /// A proxy with nothing to route to must not invite traffic. `ok` stays
+    /// true through it: the process is fine, its fabric is not, and restarting
+    /// this process would fix nothing.
+    #[test]
+    fn health_refuses_traffic_when_no_node_is_ready() {
+        let snapshots = vec![snapshot(
+            "a",
+            NodeStatus::NotReady {
+                reason: "no model loaded".to_string(),
+            },
+        )];
+        let (status, body) = health_report(&snapshots, true);
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["ok"], serde_json::json!(true));
+        assert_eq!(body["ready"], serde_json::json!(false));
+        assert_eq!(body["models"], serde_json::json!([]));
+    }
+
+    /// The verdict itself does not depend on who is asking; only the detail does.
+    #[test]
+    fn the_readiness_verdict_is_the_same_off_box() {
+        let snapshots = vec![snapshot("a", ready_status("llama-3b"))];
+        let (disclosed, _) = health_report(&snapshots, true);
+        let (withheld, body) = health_report(&snapshots, false);
+        assert_eq!(disclosed, withheld);
+        assert_eq!(body["ready"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn a_loopback_listener_may_name_the_fabric() {
+        let snapshots = vec![snapshot("a", ready_status("llama-3b"))];
+        let (_, body) = health_report(&snapshots, true);
+        let detail = body["node_detail"].as_array().expect("node detail");
+        assert_eq!(detail.len(), 1);
+        assert_eq!(detail[0]["spec"]["label"], serde_json::json!("a"));
+        assert_eq!(detail[0]["spec"]["host"], serde_json::json!("192.0.2.10"));
+    }
+
+    /// This route needs no key, because the engine's shared `authenticate`
+    /// keeps `/v1/health` public. So an exposed proxy answers anyone, and what
+    /// it answers must not include every node's address.
+    #[test]
+    fn an_exposed_listener_does_not_name_the_fabric() {
+        let snapshots = vec![snapshot("a", ready_status("llama-3b"))];
+        let (_, body) = health_report(&snapshots, false);
+        assert!(body.get("node_detail").is_none(), "{body}");
+        assert!(body.get("nodes").is_none(), "{body}");
+        assert!(!body.to_string().contains("192.0.2.10"), "{body}");
+    }
+
+    /// `/v1/models` is behind the key and has a test saying an unauthenticated
+    /// caller must not learn what is served. Health needs no key, so listing
+    /// models here off-box would give that same answer away through a side door.
+    #[test]
+    fn an_exposed_listener_does_not_list_the_models() {
+        let snapshots = vec![snapshot("a", ready_status("private-model"))];
+        let (_, body) = health_report(&snapshots, false);
+        assert!(body.get("models").is_none(), "{body}");
+        assert!(!body.to_string().contains("private-model"), "{body}");
+    }
+
+    /// Proves the route reads the bound address rather than merely that the
+    /// pure function can redact. Integration tests all bind loopback, so the
+    /// exposed branch has no other end-to-end coverage.
+    #[tokio::test]
+    async fn only_a_loopback_listener_names_the_fabric_on_the_route() {
+        let exposed = router(Fabric::new(Vec::new()), exposed_config())
+            .oneshot(get_request("/v1/health"))
+            .await
+            .expect("router answers");
+        let (_, exposed_body) = read_json(exposed).await;
+        assert!(exposed_body.get("node_detail").is_none(), "{exposed_body}");
+
+        let loopback = proxy(Fabric::new(Vec::new()))
+            .oneshot(get_request("/v1/health"))
+            .await
+            .expect("router answers");
+        let (_, loopback_body) = read_json(loopback).await;
+        assert_eq!(loopback_body["node_detail"], serde_json::json!([]));
+    }
+
+    /// An empty fabric is not a broken proxy, but it cannot take traffic.
+    #[tokio::test]
+    async fn the_health_route_refuses_an_empty_fabric() {
+        let response = proxy(Fabric::new(Vec::new()))
+            .oneshot(get_request("/v1/health"))
+            .await
+            .expect("router answers");
+        let (status, body) = read_json(response).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["ready"], serde_json::json!(false));
+        assert_eq!(body["nodes"]["total"], serde_json::json!(0));
+        assert_eq!(body["service"], serde_json::json!("camelid-fabric"));
     }
 
     /// A client points at one address, so that address has to answer what it

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -456,9 +456,17 @@ async fn stop_requested() {
 /// readiness probe. Liveness is the `ok` in the body, which is true whenever
 /// this code runs at all.
 ///
-/// The answer comes from the same observation placement uses, so a probe every
-/// second does not become a probe of every node every second: inside the
-/// freshness window a health check costs the fabric no traffic.
+/// The answer comes from the same observation placement uses, so a health check
+/// taken inside the freshness window costs the fabric no traffic at all.
+/// Outside it this probes every node, exactly as any other request would: at the
+/// 500 ms default a once-a-second check is always past the window and re-probes
+/// every time. A deployment that polls this route therefore wants
+/// `--observation-max-age-ms` at or above its polling interval, or the health
+/// check itself becomes the node traffic that bound exists to remove.
+///
+/// That bound is also the only thing pacing this route, because it is
+/// deliberately outside [`ClientAuth`]: the caller decides how often it is
+/// asked, and with `--observation-max-age-ms 0` every ask probes every node.
 async fn health(State(state): State<ServerState>) -> Response {
     let fabric = Arc::clone(&state.fabric);
     // Observing is blocking socket I/O against every node, same as a dispatch.

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -36,7 +36,13 @@
 //! * Every request is recorded through `tracing` at INFO, and a failure at
 //!   WARN, which means nothing is written unless `RUST_LOG` asks for it — the
 //!   same as the rest of this binary. `RUST_LOG=camelid=info` is the whole
-//!   access log; `RUST_LOG=camelid=warn` narrows it to what failed.
+//!   access log; `RUST_LOG=camelid=warn` narrows it to what failed. Each line
+//!   carries the client it came from and an `x-request-id`, which is also
+//!   answered to the client — the node does not log that id, so it correlates
+//!   a complaint with this proxy's line, not with the node's own.
+//! * A stop (Ctrl-C, or SIGTERM where there is one) closes the listener and
+//!   lets the requests already in flight finish, bounded by `forward_timeout`.
+//!   A kill still drops them: this covers being asked to stop, not being shot.
 //! * A node that becomes ready, or loads a different model, is routed to only
 //!   once the current observation expires. A node that *stops* answering is not
 //!   waited on: the request that finds it gone is placed on another node
@@ -57,7 +63,7 @@ use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{DefaultBodyLimit, Request, State};
+use axum::extract::{ConnectInfo, DefaultBodyLimit, Request, State};
 use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::Next;
@@ -72,6 +78,12 @@ use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
 
 /// Optional header a client sends to request affinity to a specific node.
 const STICKY_HEADER: &str = "x-camelid-fabric-sticky";
+
+/// The header a request id arrives on, and is answered with.
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+/// Longest inbound request id this proxy will adopt as its own.
+const MAX_REQUEST_ID_LEN: usize = 128;
 
 /// The credential a client must present to this proxy.
 ///
@@ -192,9 +204,15 @@ pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
 async fn access_log(request: Request, next: Next) -> Response {
     let method = request.method().clone();
     let path = request.uri().path().to_string();
+    let client = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(peer)| peer.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let request_id = correlation_id(request.headers());
     let started = Instant::now();
 
-    let response = next.run(request).await;
+    let mut response = next.run(request).await;
 
     let elapsed_ms = started.elapsed().as_millis() as u64;
     let status = response.status();
@@ -209,6 +227,8 @@ async fn access_log(request: Request, next: Next) -> Response {
             node,
             reason,
             elapsed_ms,
+            client,
+            request_id,
             "fabric request failed"
         );
     } else {
@@ -219,11 +239,46 @@ async fn access_log(request: Request, next: Next) -> Response {
             node,
             reason,
             elapsed_ms,
+            client,
+            request_id,
             "fabric request"
         );
     }
 
+    // Returned so a client that reports a slow or failed call can name the line
+    // that recorded it, without an operator having to guess from a timestamp.
+    insert(response.headers_mut(), REQUEST_ID_HEADER, &request_id);
     response
+}
+
+/// The id this request is known by, in the log and in the client's answer.
+///
+/// An inbound id is honoured so one assigned upstream survives the hop — but
+/// only after it is checked, because it is written into a log line a client
+/// does not otherwise control. HTTP framing rejects a raw CR or LF before this
+/// sees it, so the reachable problems are the quieter ones: a tab or DEL that
+/// makes a line hard to parse, and a length nothing bounds.
+///
+/// Anything that fails the check gets a fresh id rather than a cleaned-up one.
+/// A sanitised id is no longer the caller's id, so it would correlate with
+/// nothing while still looking as though it did.
+fn correlation_id(headers: &HeaderMap) -> String {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| is_usable_request_id(value))
+        .map(str::to_string)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+}
+
+/// Pure: non-empty, printable, and short enough to belong in a log line.
+///
+/// `is_ascii_graphic` excludes space and every control character, so a value
+/// that passes cannot break the line it is written on.
+fn is_usable_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_REQUEST_ID_LEN
+        && value.bytes().all(|byte| byte.is_ascii_graphic())
 }
 
 /// One of this proxy's own response headers, or `-` when the answer never got
@@ -273,16 +328,100 @@ fn refuse_unauthenticated_remote(
     ))
 }
 
-/// Serve on an already-bound listener.
+/// Serve on an already-bound listener, until the operator asks it to stop.
 ///
 /// Split from [`bind`] so a caller can read back the real port — which matters
 /// when it asked for port 0 — before it starts serving.
+///
+/// A stop is not a kill. The listener closes so no new request is accepted,
+/// and the ones already in flight are given until `forward_timeout` to finish,
+/// because that is already this proxy's answer to "how long may a request
+/// legitimately take".
+///
+/// That bound is a backstop, and it is worth knowing which requests it is for.
+/// A buffered request cannot outlive it — the same value bounds the forward, so
+/// the request ends first either way. A *stream* can: its idle timeout resets
+/// with every event, so a client reading slowly could otherwise hold the
+/// process open for as long as it kept reading. An orchestrator's own grace
+/// period is usually shorter than either and simply wins.
 pub async fn serve_on(
     listener: tokio::net::TcpListener,
     fabric: Fabric,
     config: ServeConfig,
 ) -> std::io::Result<()> {
-    axum::serve(listener, router(fabric, config)).await
+    serve_on_until(listener, fabric, config, stop_requested()).await
+}
+
+/// [`serve_on`], with the stop supplied rather than taken from the OS.
+///
+/// The signal itself cannot be exercised by a test — a test that raised
+/// SIGTERM would stop the test runner — so what a stop *does* is separated
+/// here from what asks for one. Everything below this line is covered; only
+/// [`stop_requested`] is not, and it is the part with no logic in it.
+pub async fn serve_on_until(
+    listener: tokio::net::TcpListener,
+    fabric: Fabric,
+    config: ServeConfig,
+    stop: impl std::future::Future<Output = ()> + Send + 'static,
+) -> std::io::Result<()> {
+    let drain = config.forward_timeout;
+    // The peer address is only available to a service built this way, and the
+    // access log is the only thing that reads it.
+    let service = router(fabric, config).into_make_service_with_connect_info::<SocketAddr>();
+
+    let (draining, drain_started) = tokio::sync::oneshot::channel();
+    let serving = axum::serve(listener, service).with_graceful_shutdown(async move {
+        stop.await;
+        tracing::info!("stopping: no longer accepting requests, finishing the ones in flight");
+        let _ = draining.send(());
+    });
+
+    tokio::select! {
+        served = serving => served,
+        // The clock starts when the stop is asked for, not when serving began.
+        () = async move {
+            let _ = drain_started.await;
+            tokio::time::sleep(drain).await;
+        } => {
+            tracing::warn!(
+                drain_seconds = drain.as_secs(),
+                "in-flight requests did not finish in time; stopping without them"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Resolves when the operator asks this process to stop.
+///
+/// Ctrl-C is the interactive stop. SIGTERM is what an orchestrator sends first,
+/// and it is the one that matters for a proxy holding other people's in-flight
+/// requests: without a handler it is an immediate kill, and every request being
+/// served at that moment dies with it. Windows has no SIGTERM, and there
+/// `ctrl_c` also covers the console being closed.
+async fn stop_requested() {
+    let interrupt = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut signal) => {
+                signal.recv().await;
+            }
+            // Nothing to wait for, but Ctrl-C must still work, so this arm just
+            // never completes rather than resolving and stopping the server.
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = interrupt => {}
+        () = terminate => {}
+    }
 }
 
 /// List every model the fabric can currently route to.
@@ -752,6 +891,22 @@ mod tests {
         app: Router,
         request: axum::http::Request<axum::body::Body>,
     ) -> String {
+        logged_answer_at(level, app, request).await.0
+    }
+
+    /// The log and the answer together, for the fields that appear in both.
+    async fn logged_answer(
+        app: Router,
+        request: axum::http::Request<axum::body::Body>,
+    ) -> (String, Response) {
+        logged_answer_at(tracing::Level::INFO, app, request).await
+    }
+
+    async fn logged_answer_at(
+        level: tracing::Level,
+        app: Router,
+        request: axum::http::Request<axum::body::Body>,
+    ) -> (String, Response) {
         let captured = Captured::default();
         let subscriber = tracing_subscriber::fmt()
             .with_writer(captured.clone())
@@ -759,9 +914,9 @@ mod tests {
             .with_ansi(false)
             .finish();
         let guard = tracing::subscriber::set_default(subscriber);
-        let _ = app.oneshot(request).await.expect("router answers");
+        let response = app.oneshot(request).await.expect("router answers");
         drop(guard);
-        captured.text()
+        (captured.text(), response)
     }
 
     /// A router whose answer carries whatever the fabric would have tagged, so
@@ -909,6 +1064,98 @@ mod tests {
         .await;
         assert!(written.contains("path=/v1/models"), "{written}");
         assert!(!written.contains("s3cret"), "{written}");
+    }
+
+    /// An id assigned upstream has to survive the hop, or the two sides of a
+    /// load balancer describe the same request by different names.
+    #[tokio::test]
+    async fn an_id_the_client_supplied_is_the_one_used() {
+        let mut request = get_request("/v1/models");
+        request
+            .headers_mut()
+            .insert(REQUEST_ID_HEADER, HeaderValue::from_static("abc-123"));
+
+        let (written, response) = logged_answer(proxy(Fabric::new(Vec::new())), request).await;
+        assert!(written.contains("request_id=\"abc-123\""), "{written}");
+        assert_eq!(
+            response.headers().get(REQUEST_ID_HEADER).unwrap(),
+            "abc-123",
+            "the client has to be told which id its request was recorded under"
+        );
+    }
+
+    /// Without one there is nothing to quote in a complaint, so the proxy makes
+    /// one rather than logging a dash.
+    #[tokio::test]
+    async fn a_request_with_no_id_is_given_one() {
+        let (written, response) =
+            logged_answer(proxy(Fabric::new(Vec::new())), get_request("/v1/models")).await;
+        let issued = response
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .expect("an id is always answered")
+            .to_str()
+            .expect("printable");
+        assert!(!issued.is_empty() && issued != "-", "{issued}");
+        assert!(
+            written.contains(issued),
+            "the answer's id must be the logged one: {written}"
+        );
+    }
+
+    /// The id is written into a line the client does not otherwise control, so
+    /// an unusable one is replaced outright — not trimmed into something that
+    /// still looks like the caller's id but no longer is.
+    #[tokio::test]
+    async fn an_unusable_id_is_replaced_rather_than_cleaned_up() {
+        let mut request = get_request("/v1/models");
+        request.headers_mut().insert(
+            REQUEST_ID_HEADER,
+            HeaderValue::from_static("has space and\ttab"),
+        );
+
+        let (written, response) = logged_answer(proxy(Fabric::new(Vec::new())), request).await;
+        assert!(!written.contains("has space"), "{written}");
+        assert!(
+            !written.contains('\t'),
+            "a tab would break the line: {written}"
+        );
+        let issued = response.headers().get(REQUEST_ID_HEADER).expect("an id");
+        assert_ne!(issued, "has space and\ttab");
+    }
+
+    #[test]
+    fn what_counts_as_a_usable_id() {
+        assert!(is_usable_request_id("9f3a-1b2c"));
+        assert!(is_usable_request_id(&"a".repeat(MAX_REQUEST_ID_LEN)));
+
+        assert!(!is_usable_request_id(""), "nothing to correlate on");
+        assert!(!is_usable_request_id(&"a".repeat(MAX_REQUEST_ID_LEN + 1)));
+        assert!(!is_usable_request_id("has space"));
+        assert!(!is_usable_request_id("has\ttab"));
+        assert!(!is_usable_request_id("has\u{7f}del"));
+    }
+
+    /// Who made the request is half of an access log. The service that supplies
+    /// it is only built in [`serve_on_until`], so the middleware has to keep
+    /// working without it — every test that drives the router directly, and
+    /// every one of them would otherwise fail.
+    #[tokio::test]
+    async fn the_client_is_recorded_when_the_service_supplies_one() {
+        let mut request = get_request("/v1/models");
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([192, 0, 2, 10], 51234))));
+
+        let written = logged(proxy(Fabric::new(Vec::new())), request).await;
+        assert!(written.contains("client=\"192.0.2.10:51234\""), "{written}");
+    }
+
+    #[tokio::test]
+    async fn a_request_with_no_client_information_still_records_a_line() {
+        let written = logged(proxy(Fabric::new(Vec::new())), get_request("/v1/models")).await;
+        assert!(written.contains("fabric request"), "{written}");
+        assert!(written.contains("client=\"-\""), "{written}");
     }
 
     /// A client points at one address, so that address has to answer what it

--- a/src/main.rs
+++ b/src/main.rs
@@ -3021,7 +3021,8 @@ async fn main() -> anyhow::Result<()> {
                 let listener =
                     camelid::fabric::server::bind(addr, &auth, allow_unauthenticated_remote)
                         .await?;
-                println!("fabric serve listening on {}", listener.local_addr()?);
+                let bound = listener.local_addr()?;
+                println!("fabric serve listening on {bound}");
                 // Nothing is being served yet, so this probe costs no request, and
                 // it is the only chance to tell the operator about a node that is
                 // not there before a client discovers it for them.
@@ -3033,6 +3034,7 @@ async fn main() -> anyhow::Result<()> {
                         mode,
                         forward_timeout: std::time::Duration::from_secs(forward_timeout_s),
                         auth,
+                        bound,
                     },
                 )
                 .await?;

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -8,14 +8,14 @@
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use camelid::fabric::server::{serve_on, ClientAuth, ServeConfig};
+use camelid::fabric::server::{serve_on, serve_on_until, ClientAuth, ServeConfig};
 use camelid::fabric::{Fabric, NodeSpec, RouteMode, ENGINE_QUEUE_FULL_CODE};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -1222,6 +1222,155 @@ async fn discovery_does_not_answer_an_unauthenticated_caller() {
         get_raw(addr, "/v1/models", &[("Authorization", "Bearer s3cret")]).await;
     assert_eq!(served, 200);
     assert!(listing.contains("private-model"), "{listing}");
+}
+
+/// A `tracing` sink a test can read back, so the access log can be asserted as
+/// an operator actually reads it rather than by calling the middleware directly.
+#[derive(Clone)]
+struct AccessLog(Arc<Mutex<Vec<u8>>>);
+
+impl AccessLog {
+    /// The line mentioning `needle`. Every test in this binary shares one sink,
+    /// so a caller has to look for something only it could have sent.
+    fn line_mentioning(&self, needle: &str) -> Option<String> {
+        let captured = self.0.lock().expect("access log");
+        String::from_utf8_lossy(&captured)
+            .lines()
+            .find(|line| line.contains(needle))
+            .map(str::to_string)
+    }
+}
+
+impl Write for AccessLog {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("access log").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Install the capturing subscriber, once: a global default can only be set
+/// once per process, and these tests share one.
+fn access_log() -> AccessLog {
+    static CAPTURED: OnceLock<AccessLog> = OnceLock::new();
+    CAPTURED
+        .get_or_init(|| {
+            let sink = AccessLog(Arc::new(Mutex::new(Vec::new())));
+            let writer = sink.clone();
+            tracing_subscriber::fmt()
+                .with_writer(move || writer.clone())
+                .with_max_level(tracing::Level::INFO)
+                // Both off so the assertions match on the text an operator
+                // greps, not on escape codes or a timestamp.
+                .with_ansi(false)
+                .without_time()
+                .init();
+            sink
+        })
+        .clone()
+}
+
+/// The access log is the only place this proxy says who called and which
+/// request it was. Both are supplied by the serving stack rather than by the
+/// middleware, so neither is proven by calling the middleware directly.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_request_is_logged_with_the_caller_and_the_id_it_was_given() {
+    let recorded = access_log();
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("node-a")]), RouteMode::Throughput).await;
+
+    let mine = "only-this-test-sends-this-id";
+    let body = serde_json::json!({ "model": "shared-model" });
+    let (status, answered, headers) = post_chat(addr, &body, &[("x-request-id", mine)]).await;
+
+    assert_eq!(status, 200, "{answered}");
+    assert_eq!(
+        header(&headers, "x-request-id"),
+        Some(mine),
+        "the id a client sent must come back to it, or it cannot quote it"
+    );
+
+    let line = recorded
+        .line_mentioning(mine)
+        .expect("the request must be logged under the id it was given");
+    assert!(
+        line.contains("127.0.0.1:"),
+        "the line must name the caller, not `-`: {line}"
+    );
+}
+
+/// Being asked to stop is not the same as being killed. A proxy holds other
+/// people's requests, and dropping them on a deploy turns a routine restart
+/// into a client-visible failure.
+///
+/// The load-bearing claim is an *ordering* one: the stop must not complete
+/// until the work in flight has. Asserting only that the request got its answer
+/// would prove nothing here, because a connection axum has already accepted is
+/// served on its own task and finishes either way while this process lives — it
+/// is the caller returning early, and the process exiting under it, that loses
+/// the request. So this measures how long the stop took to report itself done.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_stop_finishes_the_work_in_flight_and_accepts_no_more() {
+    let generating = Duration::from_millis(600);
+    let node = StubNode::start(StubConfig {
+        completion_delay: generating,
+        ..StubConfig::ready("shared-model", 0)
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy");
+    let addr = listener.local_addr().expect("proxy addr");
+    let fabric = fabric_of(vec![node.spec("node-a")]);
+    let config = ServeConfig {
+        mode: RouteMode::Throughput,
+        forward_timeout: FORWARD_TIMEOUT,
+        auth: ClientAuth::none(),
+    };
+
+    let (stop, stop_asked) = tokio::sync::oneshot::channel::<()>();
+    let serving = tokio::spawn(async move {
+        serve_on_until(listener, fabric, config, async move {
+            let _ = stop_asked.await;
+        })
+        .await
+    });
+
+    let body = serde_json::json!({ "model": "shared-model" });
+    let inflight = tokio::spawn(async move { post_chat(addr, &body, &[]).await });
+
+    // Long enough for the request to be on the node, short enough that it is
+    // still there when the stop arrives.
+    let settle = Duration::from_millis(200);
+    tokio::time::sleep(settle).await;
+    let asked_at = Instant::now();
+    let _ = stop.send(());
+
+    serving
+        .await
+        .expect("the server joins")
+        .expect("a stop is not a failure");
+    let took = asked_at.elapsed();
+
+    // The request still had most of its generation left when the stop landed.
+    let still_owed = generating - settle;
+    assert!(
+        took >= still_owed / 2,
+        "the proxy called itself stopped after {took:?}, while it still owed a \
+         request about {still_owed:?} of work"
+    );
+
+    let (status, answered, _) = inflight.await.expect("the in-flight request joins");
+    assert_eq!(
+        status, 200,
+        "a request already on a node must be finished, not dropped: {answered}"
+    );
+    assert!(
+        tokio::net::TcpStream::connect(addr).await.is_err(),
+        "a stopped proxy must not still be taking work"
+    );
 }
 
 /// A proxy started without a key is unchanged: this is what every other test in

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -464,6 +464,7 @@ async fn start_proxy_with_auth(fabric: Fabric, mode: RouteMode, auth: ClientAuth
         mode,
         forward_timeout: FORWARD_TIMEOUT,
         auth,
+        bound: addr,
     };
     tokio::spawn(async move {
         let _ = serve_on(listener, fabric, config).await;
@@ -1328,6 +1329,7 @@ async fn a_stop_finishes_the_work_in_flight_and_accepts_no_more() {
         mode: RouteMode::Throughput,
         forward_timeout: FORWARD_TIMEOUT,
         auth: ClientAuth::none(),
+        bound: addr,
     };
 
     let (stop, stop_asked) = tokio::sync::oneshot::channel::<()>();
@@ -1383,6 +1385,133 @@ async fn a_proxy_without_a_key_serves_an_anonymous_client() {
     let (status, _, _) =
         post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
     assert_eq!(status, 200);
+}
+
+/// A load balancer needs one address to ask whether to send traffic here. Until
+/// this route existed the answer was a bodyless 404 whatever the fabric was
+/// doing, so nothing could tell a working proxy from a useless one.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_reports_ready_while_a_node_can_serve() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("node-a")]), RouteMode::Throughput).await;
+
+    let (status, body) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(status, 200, "{body}");
+    let parsed: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(parsed["ok"], serde_json::json!(true));
+    assert_eq!(parsed["ready"], serde_json::json!(true));
+    assert_eq!(parsed["nodes"]["ready"], serde_json::json!(1));
+    assert_eq!(parsed["models"], serde_json::json!(["shared-model"]));
+    // The test binds loopback, so the fabric may be named.
+    assert_eq!(parsed["node_detail"][0]["spec"]["label"], "node-a");
+}
+
+/// A spec for a port nothing listens on. Binding and dropping proves the port
+/// was free and is now closed; a hardcoded number proves neither.
+async fn closed_port_spec(label: &str) -> NodeSpec {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind a free port");
+    let addr = listener.local_addr().expect("port");
+    drop(listener);
+    NodeSpec {
+        label: label.to_string(),
+        host: addr.ip().to_string(),
+        port: addr.port(),
+    }
+}
+
+/// Ready is "some request can be served", not "every node is well". A fabric
+/// with one node down still takes traffic, and a proxy that reported itself
+/// unhealthy here would take a whole fabric out of rotation over one node.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_stays_ready_while_any_node_can_serve() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let specs = vec![node.spec("node-a"), closed_port_spec("node-gone").await];
+    let addr = start_proxy(fabric_of(specs), RouteMode::Throughput).await;
+
+    let (status, body) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(status, 200, "{body}");
+    let parsed: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(parsed["ready"], serde_json::json!(true));
+    assert_eq!(parsed["nodes"]["ready"], serde_json::json!(1));
+    assert_eq!(parsed["nodes"]["unreachable"], serde_json::json!(1));
+}
+
+/// The status code has to change, not just a field in the body: a load balancer
+/// acts on the code alone. A proxy with nothing behind it must stop inviting
+/// traffic it can only refuse.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_stops_inviting_traffic_when_no_node_answers() {
+    let specs = vec![closed_port_spec("node-gone").await];
+    let addr = start_proxy(fabric_of(specs), RouteMode::Throughput).await;
+
+    let (status, body) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(status, 503, "{body}");
+    let parsed: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(parsed["ready"], serde_json::json!(false));
+    // Liveness is unchanged: this process is fine, its fabric is not, and
+    // restarting this process would not bring a node back.
+    assert_eq!(parsed["ok"], serde_json::json!(true));
+    assert_eq!(parsed["nodes"]["unreachable"], serde_json::json!(1));
+    assert_eq!(parsed["models"], serde_json::json!([]));
+}
+
+/// Health needs no key even on a proxy that requires one everywhere else: the
+/// engine's shared `authenticate` keeps `/v1/health` public so a probe can run
+/// without credentials, and this proxy reuses that check rather than writing a
+/// second one. `/v1/models` stays behind the key, and the contrast is the point
+/// — it is why the health body withholds the fabric's detail off-box, which the
+/// unit tests cover because this test can only bind loopback.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_answers_a_probe_that_carries_no_key() {
+    let node = StubNode::start(StubConfig::ready("private-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("node-a")]),
+        RouteMode::Throughput,
+        authenticated("s3cret"),
+    )
+    .await;
+
+    let (health, body) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(health, 200, "a probe with no key must still get an answer");
+    let parsed: Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(parsed["ready"], serde_json::json!(true));
+
+    let (models, listing) = get_raw(addr, "/v1/models", &[]).await;
+    assert_eq!(models, 401, "discovery stays behind the key");
+    assert!(!listing.contains("private-model"), "{listing}");
+
+    let (chat, _, _) = post_chat(addr, &serde_json::json!({ "model": "private-model" }), &[]).await;
+    assert_eq!(chat, 401, "generation stays behind the key");
+}
+
+/// A load balancer polls this route forever. If each poll re-probed the fabric,
+/// adding a health check would multiply node traffic by the polling rate, which
+/// is exactly the cost the freshness bound exists to remove.
+#[tokio::test(flavor = "multi_thread")]
+async fn repeated_health_checks_share_one_observation() {
+    let nodes = vec![
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+    ];
+    let specs = vec![nodes[0].spec("node-a"), nodes[1].spec("node-b")];
+    let addr = start_proxy(
+        fabric_reusing_observations(specs, Duration::from_secs(30)),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    for _ in 0..5 {
+        let (status, _) = get_raw(addr, "/v1/health", &[]).await;
+        assert_eq!(status, 200);
+    }
+
+    assert_eq!(
+        health_probes(&nodes),
+        nodes.len(),
+        "five health checks should share one observation, one probe per node"
+    );
 }
 
 /// The proxy observes the fabric before every placement. Without a freshness

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -1514,6 +1514,36 @@ async fn repeated_health_checks_share_one_observation() {
     );
 }
 
+/// The other half of that bound, and the half an operator actually has to set
+/// something for: reuse lasts exactly as long as the window. A deployment
+/// polling this route more slowly than `--observation-max-age-ms` re-probes
+/// every node on every check — at the 500 ms default, a once-a-second probe
+/// does that every time.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_health_check_past_the_window_observes_the_fabric_again() {
+    let nodes = vec![StubNode::start(StubConfig::ready("shared-model", 0))];
+    let specs = vec![nodes[0].spec("node-a")];
+    let addr = start_proxy(
+        fabric_reusing_observations(specs, Duration::from_millis(50)),
+        RouteMode::Throughput,
+    )
+    .await;
+
+    let (first, _) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(first, 200);
+    let after_first = health_probes(&nodes);
+
+    // Comfortably past the window, so this is not a race with the clock.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let (second, _) = get_raw(addr, "/v1/health", &[]).await;
+    assert_eq!(second, 200);
+    assert!(
+        health_probes(&nodes) > after_first,
+        "an expired observation must be taken again rather than reused"
+    );
+}
+
 /// The proxy observes the fabric before every placement. Without a freshness
 /// bound that is a `/v1/health` per node per request: measured at exactly 2 per
 /// request against two nodes, and 2.0 s per request when one node black-holes,


### PR DESCRIPTION
## The gap

`fabric serve` had no address anything could probe. `/v1/health` matched no route, so a load
balancer or an orchestrator got a **bodyless 404** whatever the fabric was doing — a proxy with
two healthy nodes and a proxy with nothing behind it were indistinguishable from the outside.

This is the first of the remaining production gaps I listed on #663. It is separate from #664
(which reports the fabric once, at startup); this answers the same question at any time, to a
machine.

## Readiness, and why the status code is what it is

`GET /v1/health` answers **200 while at least one node is ready, 503 when none is.**

That threshold is not a preference — it is exactly the condition placement needs. With one ready
node, some request can be served. With none, every request is refused, and a proxy that kept
answering 200 would be inviting traffic it can only turn away. It also means **one node of
several going down does not take the proxy out of rotation**, which is the behaviour you want and
the opposite of what a naive "all nodes healthy" check would do.

**It is readiness, not liveness.** Restarting the proxy cannot bring a node back, so wiring this
status code to a `livenessProbe` would restart a perfectly good process because someone else's
machine is down. The body carries the liveness fact separately as `ok`, which is true whenever
the process answers at all. Both are stated in the module docs and the handler docs.

The answer comes from the observation placement already uses, so a load balancer polling once a
second does **not** become a probe of every node once a second. There is a test for that.

## The part that changed the design

I assumed health would sit behind `ClientAuth` like every other route, wrote a test asserting an
unauthenticated probe gets 401 — and it failed. The engine's shared `authenticate` deliberately
keeps health public:

```rust
// src/api/server.rs
!matches!(path, "/health" | "/v1/health" | "/" | "/index.html")
```

with its own test, `router_authenticates_api_routes_but_keeps_health_public`. Since #658 the
proxy reuses that check rather than writing a second security primitive, so it inherits the
exemption. Good: a probe should not need a credential.

But that turns the body into a **disclosure decision**, not a formatting one:

* the node list is every label and address in the fabric — an attacker's target list, and
  `--allow-unauthenticated-remote` puts this route in reach of anyone;
* the model list is the same answer `/v1/models` gives, and that route **is** behind the key, with
  an existing test asserting an unauthenticated caller must not learn what is served. Publishing
  it here would have handed it out through a side door.

So node detail *and* the model list are included **only when the proxy is bound to loopback**.
That mirrors `crate::api`, which withholds its own `executable` and `listen_addr` on exactly the
same fact (`state.serve_addr.ip().is_loopback()`). Off-box callers get the verdict and nothing
else, which is all a load balancer reads.

The gate keys off the **bound** address, and `serve_on` overwrites `ServeConfig.bound` with the
listener's real `local_addr()`, so the value the rule sees cannot be a caller's guess.

## Live receipt, on two real machines

Windows proxy + a Windows node + an Apple M5 Pro node across real Wi-Fi.

**Loopback bind, both machines up — 200:**

```json
{"ok":true,"service":"camelid-fabric","version":"0.6.1","build":"v0.6.1-123-g1a04ff0a4-dirty",
 "ready":true,"nodes":{"total":2,"ready":2,"not_ready":0,"unreachable":0},
 "models":["Llama 3.2 1B Instruct"],
 "node_detail":[{"spec":{"label":"win","host":"127.0.0.1","port":8181},"status":{"state":"ready",...},"latency_ms":1},
                {"spec":{"label":"mac","host":"192.168.29.158","port":8181},"status":{"state":"ready",...},"latency_ms":23}]}
```

**The Mac is killed — still 200, still in rotation:**

```json
{"ready":true,"nodes":{"total":2,"ready":1,"not_ready":0,"unreachable":1}, ...
 {"spec":{"label":"mac",...},"status":{"state":"unreachable","reason":"cannot connect: ..."},"latency_ms":null}}
```

**The last node is killed — 503:**

```json
{"ok":true,...,"ready":false,"nodes":{"total":2,"ready":0,"not_ready":0,"unreachable":2},"models":[]}
```

**Exposed bind (`0.0.0.0` + `--allow-unauthenticated-remote`), the request issued from the Mac
over Wi-Fi with no credential** — this is the case only a second machine can produce:

```
HTTP 200
{"ok":true,"service":"camelid-fabric","version":"0.6.1","build":"v0.6.1-123-g1a04ff0a4-dirty","ready":true}
```

No node list, no addresses, no model names. The same request to the same proxy over loopback
returns the full body above.

For contrast, a **node's** `/v1/health` is a different thing entirely — `{"ok":true,"engine":"camelid",
...,"generation_ready":true,"active_model_id":"Llama 3.2 1B Instruct",...}`. The proxy deliberately
has no `engine` field and a different `service` name, so nothing can mistake one for the other. A
proxy has no single `active_model_id` to report anyway.

## Tests

8 unit + router tests and 5 integration tests over real sockets, including:

* readiness both ways, and that the verdict is identical off-box while the detail is not;
* a partial fabric stays ready;
* a probe with no key is answered while `/v1/models` and `/v1/chat/completions` on the same proxy
  still return 401 — the contrast that justifies the redaction;
* five health checks against two nodes produce exactly two probes.

**Ablations, each isolating one rule:**

| ablation | result |
|---|---|
| disclose detail unconditionally | **exactly 3** fail: both exposure tests + the route-level one |
| status code always 200 | **exactly 3** fail: 2 unit + 1 integration readiness tests |

Tree restored and re-verified green after each.

Note the coverage asymmetry that shaped the test layout: an integration test can only bind
loopback, so it can *never* reach the redacted branch. That branch is covered at the pure-function
and router level, which is why `health_report` is a pure function taking a bool rather than a
`SocketAddr`.

## Gates

`fmt --check` 0 · `clippy --all-targets -D warnings` **0** · `--lib fabric::` **128** (120 + 8) ·
`--test fabric_serve` **30** (25 + 5) · `--test fabric_end_to_end` 14 · `--bin camelid` 40 ·
`--lib api::server` 8 · `check-public-scrub.sh` 0 · `git diff --check` 0 · all three files
`i/lf w/lf`. 3 files, +402/-3.

## Limits

* It is a snapshot, not a subscription: a node that dies is invisible until something asks, and
  the answer may be up to `--observation-max-age-ms` old. The body does not currently say how old.
* No liveness endpoint of its own. If you want one, use TCP connect — do not use this status code.
* Off-box the body is deliberately thin. An operator who wants detail from off the machine should
  use `fabric status`, or an authenticated `/v1/models`, not this.
* Independent of #664 and #663; no conflicts expected, though after #663 merges the "unknown
  route" 404 message should probably start listing `/v1/health` among the served routes.
