### PR TITLE
feat(fabric): record what the proxy is actually doing

### DIFF
--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -634,6 +634,7 @@ fn route_error(error: RouteError) -> Response {
 }
 
 fn forward_error(error: ForwardError) -> Response {
+    let message = error.to_string();
     // The node was reachable but refused unsupported input: that is the
     // caller's mistake, not the upstream's, so it is a 400 not a 502/503.
     let status = match &error {
@@ -642,7 +643,15 @@ fn forward_error(error: ForwardError) -> Response {
         | ForwardError::Transport { .. }
         | ForwardError::Json { .. } => StatusCode::BAD_GATEWAY,
     };
-    error_response(status, &error.to_string())
+    let label = error.label().map(str::to_string);
+    let mut response = error_response(status, &message);
+    // The node that failed rides on the answer for the same reason [`tag`] puts
+    // the node that served there: placement is read back off the response, so a
+    // failure that does not carry its node is one nobody can attribute.
+    if let Some(label) = label {
+        insert(response.headers_mut(), "x-camelid-fabric-node", &label);
+    }
+    response
 }
 
 fn error_response(status: StatusCode, message: &str) -> Response {
@@ -769,7 +778,7 @@ mod tests {
                             reason: RouteReason::LeastLoaded,
                             affinity_lost: None,
                         };
-                        tag(response.headers_mut(), &decision);
+                        tag(response.headers_mut(), &decision, 1);
                     }
                     response
                 }),
@@ -822,13 +831,17 @@ mod tests {
             auth: ClientAuth::resolve(Some("s3cret".to_string()), None).expect("a key resolves"),
             ..open_config()
         };
-        let written = logged(
-            router(Fabric::new(Vec::new()), config),
-            get_request("/v1/models"),
-        )
-        .await;
+        let mut refused = get_request("/v1/models");
+        // Actually presented, so the assertion below is about a credential that
+        // reached the middleware rather than one that was never sent.
+        refused.headers_mut().insert(
+            "authorization",
+            HeaderValue::from_static("Bearer presented-9f3a"),
+        );
+        let written = logged(router(Fabric::new(Vec::new()), config), refused).await;
         assert!(written.contains("status=401"), "{written}");
-        // The credential itself must never reach the log.
+        // No request header reaches the log, and one of them is the client's key.
+        assert!(!written.contains("presented-9f3a"), "{written}");
         assert!(!written.contains("s3cret"), "{written}");
     }
 
@@ -855,6 +868,34 @@ mod tests {
             served.is_empty(),
             "a served request must not warn: {served}"
         );
+    }
+
+    /// A node that could not be reached is the failure most worth attributing,
+    /// and it is the one an operator is reading WARN to find. The error already
+    /// carries the label, so a line that cannot name the node is a line that
+    /// sends them to a packet capture anyway.
+    #[tokio::test]
+    async fn a_failure_to_reach_a_node_records_which_node() {
+        let app = Router::new()
+            .route(
+                "/v1/chat/completions",
+                post(|| async {
+                    forward_error(ForwardError::Transport {
+                        label: "node-a".to_string(),
+                        detail: "connection refused".to_string(),
+                    })
+                }),
+            )
+            .layer(middleware::from_fn(access_log));
+
+        let written = logged_at(
+            tracing::Level::WARN,
+            app,
+            request(serde_json::json!({ "model": "m" })),
+        )
+        .await;
+        assert!(written.contains("status=502"), "{written}");
+        assert!(written.contains("node=\"node-a\""), "{written}");
     }
 
     /// A query string can carry anything a client puts there, and the path

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -33,6 +33,10 @@
 //!   unless a key is configured or the risk is acknowledged explicitly.
 //! * Authentication is all-or-nothing: there is one key, it is not per-client,
 //!   and nothing here revokes or rotates it while the proxy is running.
+//! * Every request is recorded through `tracing` at INFO, and a failure at
+//!   WARN, which means nothing is written unless `RUST_LOG` asks for it — the
+//!   same as the rest of this binary. `RUST_LOG=camelid=info` is the whole
+//!   access log; `RUST_LOG=camelid=warn` narrows it to what failed.
 //! * A node that becomes ready, or loads a different model, is routed to only
 //!   once the current observation expires. A node that *stops* answering is not
 //!   waited on: the request that finds it gone is placed on another node
@@ -49,13 +53,14 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{DefaultBodyLimit, State};
+use axum::extract::{DefaultBodyLimit, Request, State};
 use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{middleware, Json, Router};
@@ -137,8 +142,6 @@ struct ServerState {
 
 /// Build the router without binding a socket, so tests can drive it directly.
 pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
-    // Applied last, so it is the outermost layer: an unauthenticated request is
-    // refused before anything here reads its body or observes the fabric.
     let auth = config.auth.inner.clone();
     Router::new()
         .route("/v1/chat/completions", post(chat_completions))
@@ -150,10 +153,87 @@ pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
             fabric: Arc::new(fabric),
             config,
         })
+        // Wraps every route: an unauthenticated request is refused before
+        // anything below reads its body or observes the fabric.
         .layer(middleware::from_fn_with_state(
             auth,
             crate::api::authenticate,
         ))
+        // Outermost, so a request refused above is still recorded.
+        .layer(middleware::from_fn(access_log))
+}
+
+/// Record one line per request, whatever the outcome.
+///
+/// The proxy announced its address and then said nothing ever again, so an
+/// operator could not answer "is anything reaching this", "which machine served
+/// that", or "what is failing" without a packet capture.
+///
+/// `TraceLayer`, which the engine's router uses, is not enough on its own here:
+/// it can only see HTTP, so it cannot say which node answered — the one fact
+/// this process exists to decide — and it records at DEBUG, below the level an
+/// operator runs.
+///
+/// The placement facts are read back off the response rather than threaded out
+/// of dispatch, because [`tag`] already puts them there for the client, and one
+/// fact with two sources drifts.
+///
+/// Applied outside the authentication layer deliberately: a refused request is
+/// exactly the one worth having a record of, and inside the layer it would be
+/// invisible.
+///
+/// Never recorded: request and response bodies, and every request header — one
+/// of them is the client's key. The query string is dropped for the same
+/// reason, since the path alone identifies the route.
+///
+/// On a streaming answer this measures time to the response head, not to the
+/// final event: the middleware returns once the head is ready while the body is
+/// still being relayed.
+async fn access_log(request: Request, next: Next) -> Response {
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    let started = Instant::now();
+
+    let response = next.run(request).await;
+
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    let status = response.status();
+    let node = tagged(&response, "x-camelid-fabric-node");
+    let reason = tagged(&response, "x-camelid-fabric-reason");
+
+    if status.is_server_error() {
+        tracing::warn!(
+            %method,
+            %path,
+            status = status.as_u16(),
+            node,
+            reason,
+            elapsed_ms,
+            "fabric request failed"
+        );
+    } else {
+        tracing::info!(
+            %method,
+            %path,
+            status = status.as_u16(),
+            node,
+            reason,
+            elapsed_ms,
+            "fabric request"
+        );
+    }
+
+    response
+}
+
+/// One of this proxy's own response headers, or `-` when the answer never got
+/// far enough to have one.
+fn tagged<'a>(response: &'a Response, name: &str) -> &'a str {
+    response
+        .headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("-")
 }
 
 /// Bind `addr` for the proxy, refusing an exposure the operator did not ask for.
@@ -577,6 +657,7 @@ fn error_response(status: StatusCode, message: &str) -> Response {
 mod tests {
     use super::*;
     use crate::fabric::node::NodeSpec;
+    use crate::fabric::policy::RouteReason;
     use tower::ServiceExt;
 
     fn request(body: Value) -> axum::http::Request<axum::body::Body> {
@@ -616,6 +697,177 @@ mod tests {
 
     fn proxy(fabric: Fabric) -> Router {
         router(fabric, open_config())
+    }
+
+    /// Collects formatted log output, so these tests assert on what was
+    /// actually written rather than on whether a function was reached.
+    #[derive(Clone, Default)]
+    struct Captured(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl Captured {
+        fn text(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().expect("log buffer")).into_owned()
+        }
+    }
+
+    impl std::io::Write for Captured {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log buffer").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Captured {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Drive one request and return what was logged while it ran.
+    ///
+    /// The subscriber is thread-local, so these tests run on the default
+    /// current-thread runtime: on a multi-threaded one the task can resume on a
+    /// thread that never had the subscriber installed and capture nothing.
+    async fn logged(app: Router, request: axum::http::Request<axum::body::Body>) -> String {
+        logged_at(tracing::Level::INFO, app, request).await
+    }
+
+    async fn logged_at(
+        level: tracing::Level,
+        app: Router,
+        request: axum::http::Request<axum::body::Body>,
+    ) -> String {
+        let captured = Captured::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(captured.clone())
+            .with_max_level(level)
+            .with_ansi(false)
+            .finish();
+        let guard = tracing::subscriber::set_default(subscriber);
+        let _ = app.oneshot(request).await.expect("router answers");
+        drop(guard);
+        captured.text()
+    }
+
+    /// A router whose answer carries whatever the fabric would have tagged, so
+    /// the middleware can be tested without placing anything.
+    fn answering(status: StatusCode, node: Option<&'static str>) -> Router {
+        Router::new()
+            .route(
+                "/v1/chat/completions",
+                post(move || async move {
+                    let mut response = (status, "body").into_response();
+                    if let Some(label) = node {
+                        let decision = RouteDecision {
+                            label: label.to_string(),
+                            reason: RouteReason::LeastLoaded,
+                            affinity_lost: None,
+                        };
+                        tag(response.headers_mut(), &decision);
+                    }
+                    response
+                }),
+            )
+            .layer(middleware::from_fn(access_log))
+    }
+
+    /// The proxy announced its address and then said nothing ever again.
+    #[tokio::test]
+    async fn a_request_is_recorded_with_its_method_path_and_status() {
+        let written = logged(proxy(Fabric::new(Vec::new())), get_request("/v1/models")).await;
+        assert!(written.contains("fabric request"), "{written}");
+        assert!(written.contains("method=GET"), "{written}");
+        assert!(written.contains("path=/v1/models"), "{written}");
+        assert!(written.contains("status=200"), "{written}");
+        assert!(written.contains("elapsed_ms"), "{written}");
+    }
+
+    /// Which machine served a request is the one fact a generic HTTP layer
+    /// cannot know, and the only reason this proxy exists.
+    #[tokio::test]
+    async fn the_node_that_served_a_request_is_recorded() {
+        let written = logged(
+            answering(StatusCode::OK, Some("mac-studio")),
+            request(serde_json::json!({ "model": "m" })),
+        )
+        .await;
+        assert!(written.contains("mac-studio"), "{written}");
+        assert!(written.contains("LeastLoaded"), "{written}");
+    }
+
+    /// An answer that never reached a node still gets a line; it just has no
+    /// node to name, and an empty field would read like a missing one.
+    #[tokio::test]
+    async fn an_answer_that_reached_no_node_records_a_dash() {
+        let written = logged(
+            answering(StatusCode::OK, None),
+            request(serde_json::json!({ "model": "m" })),
+        )
+        .await;
+        assert!(written.contains("node=\"-\""), "{written}");
+        assert!(written.contains("reason=\"-\""), "{written}");
+    }
+
+    /// The log layer sits outside authentication on purpose: a refused request
+    /// is exactly the one worth having a record of.
+    #[tokio::test]
+    async fn a_refused_request_is_still_recorded() {
+        let config = ServeConfig {
+            auth: ClientAuth::resolve(Some("s3cret".to_string()), None).expect("a key resolves"),
+            ..open_config()
+        };
+        let written = logged(
+            router(Fabric::new(Vec::new()), config),
+            get_request("/v1/models"),
+        )
+        .await;
+        assert!(written.contains("status=401"), "{written}");
+        // The credential itself must never reach the log.
+        assert!(!written.contains("s3cret"), "{written}");
+    }
+
+    /// An operator narrowing to failures must still see them, and must not have
+    /// every healthy request in the way.
+    #[tokio::test]
+    async fn a_failure_is_recorded_at_warn_and_a_success_is_not() {
+        let failed = logged_at(
+            tracing::Level::WARN,
+            answering(StatusCode::BAD_GATEWAY, Some("node-a")),
+            request(serde_json::json!({ "model": "m" })),
+        )
+        .await;
+        assert!(failed.contains("fabric request failed"), "{failed}");
+        assert!(failed.contains("status=502"), "{failed}");
+
+        let served = logged_at(
+            tracing::Level::WARN,
+            answering(StatusCode::OK, Some("node-a")),
+            request(serde_json::json!({ "model": "m" })),
+        )
+        .await;
+        assert!(
+            served.is_empty(),
+            "a served request must not warn: {served}"
+        );
+    }
+
+    /// A query string can carry anything a client puts there, and the path
+    /// alone already identifies the route.
+    #[tokio::test]
+    async fn a_query_string_is_not_recorded() {
+        let written = logged(
+            proxy(Fabric::new(Vec::new())),
+            get_request("/v1/models?token=s3cret&x=1"),
+        )
+        .await;
+        assert!(written.contains("path=/v1/models"), "{written}");
+        assert!(!written.contains("s3cret"), "{written}");
     }
 
     /// A client points at one address, so that address has to answer what it

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -1514,7 +1514,9 @@ async fn a_node_that_took_the_request_is_not_asked_to_run_it_again_elsewhere() {
         post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
 
     assert_eq!(status, 502, "{refusal}");
-    assert_eq!(header(&headers, "x-camelid-fabric-node"), None);
+    // The refusal names the node it happened against, so an operator can act on
+    // the one that is actually broken.
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("node-a"));
     assert_eq!(
         completions_served(std::slice::from_ref(&a))[0],
         1,


### PR DESCRIPTION
## The gap

`fabric serve` printed its listening line and then nothing, ever. `src/fabric` contained **no
logging of any kind** — not a `tracing` event, not a `println`. There was no way to answer "is
anything reaching this", "which machine served that request", or "what is failing" without a
packet capture.

This is gap #2 of the production list I put on #663. (#665 answers "can you take traffic" to a
machine; this answers "what did you just do" to a human.)

## What it does

One line per request through `tracing`: INFO normally, WARN on a 5xx.

```
INFO camelid::fabric::server: fabric request method=POST path=/v1/chat/completions status=200 node="mac" reason="LeastLoaded" elapsed_ms=232
WARN camelid::fabric::server: fabric request failed method=POST path=/v1/chat/completions status=503 node="-" reason="-" elapsed_ms=2013
```

`node` and `reason` are the point. They are read back off the response rather than threaded out
of dispatch, because `tag` already puts them there for the client and one fact with two sources
drifts.

**Why not just `TraceLayer`.** The engine's router already uses tower-http's `TraceLayer`
(`src/api/mod.rs:2581`), and reaching for it here was the obvious move. It is not enough on its
own: it can only see HTTP, so it cannot name the node — the one decision this process exists to
make — and it records at DEBUG, below the level an operator actually runs at. I measured that
second point rather than assuming it: two engine nodes served **911 requests** during the #663
throughput run and their logs contain nothing but `[hw]`/`[cuda]` startup lines.

**Placed outside authentication**, deliberately: a refused request is exactly the one worth
having a record of, and inside the layer it would be invisible.

**Off by default.** Nothing is written unless `RUST_LOG` asks, which is how the rest of this
binary already behaves. `RUST_LOG=camelid=info` is the access log; `RUST_LOG=camelid=warn`
narrows it to failures. A proxy started without it behaves exactly as before — shown below.

**Never recorded:** request and response bodies, and every request header, one of which is the
client's key. The query string is dropped for the same reason; the path alone identifies the
route.

## Live receipt, two real machines

A Windows proxy over a Windows node and an Apple M5 Pro node across Wi-Fi.

**A. `RUST_LOG` unset — two requests served, and the proxy is as silent as it was before:**

```
--- stdout (1 lines) ---
fabric serve listening on 127.0.0.1:8490
```

**B. `RUST_LOG=camelid=info` — six requests, six lines, each naming the machine that answered
across the LAN:**

```
INFO ... fabric request method=POST path=/v1/chat/completions status=200 node="mac" reason="LeastLoaded" elapsed_ms=232
INFO ... fabric request method=POST path=/v1/chat/completions status=200 node="mac" reason="LeastLoaded" elapsed_ms=121
INFO ... fabric request method=POST path=/v1/chat/completions status=200 node="mac" reason="LeastLoaded" elapsed_ms=117
... (6 total)
```

**C. `RUST_LOG=camelid=warn` — two healthy requests produce nothing; then every node is killed:**

```
WARN ... fabric request failed method=POST path=/v1/chat/completions status=503 node="-" reason="-" elapsed_ms=2013
```

**D. a refusal is recorded, and the key is not.** With `--api-key`, an unauthenticated request
and then a correct one:

```
INFO ... fabric request method=POST path=/v1/chat/completions status=401 node="-" reason="-" elapsed_ms=0
INFO ... fabric request method=POST path=/v1/chat/completions status=200 node="mac" reason="LeastLoaded" elapsed_ms=200
--- does the key appear anywhere in the log? ---
no: the credential never reaches the log
```

Note `status=401 ... elapsed_ms=0`: the refusal cost nothing and touched no node, which is the
property #658 exists to hold.

## Tests

Six unit tests that assert on **what was actually written**, by installing a capturing
`tracing` subscriber and reading the formatted output back — not by checking that a function was
reached. They run on the default current-thread runtime on purpose: the subscriber is
thread-local, so on a multi-threaded one the task can resume on a thread that never had it
installed and capture nothing.

The middleware is also driven against a synthetic handler that returns the fabric's own headers,
so "the node is recorded" is tested without placing anything.

| ablation | result |
|---|---|
| move the layer inside the auth layer | **exactly 1** fails: `a_refused_request_is_still_recorded` |
| drop the WARN branch | **exactly 1** fails: `a_failure_is_recorded_at_warn_and_a_success_is_not` |

Both restored and re-verified green.

## Gates

`fmt --check` 0 · `clippy --all-targets -D warnings` **0** · `--lib fabric::` **126** (120 + 6) ·
`--test fabric_serve` 25 · `--test fabric_end_to_end` 14 · `--bin camelid` 40 ·
`check-public-scrub.sh` 0 · `git diff --check` 0 · `i/lf w/lf`. One file, +256/-4.

## Limits

* No client address: that needs `ConnectInfo` wiring the proxy does not have today.
* No request id, so a line cannot be correlated with a node's own logs.
* On a streaming answer `elapsed_ms` is time to the response **head**, not to the last event —
  the middleware returns once the head is ready while the body is still relaying.
* One line per request is a lot at high rates; `RUST_LOG=camelid=warn` is the volume control.
* Independent of #664 and #665. All three touch `src/fabric/server.rs` but different regions.
