### PR TITLE
feat(fabric): hand a request on when the node it landed on is full

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -107,16 +107,29 @@ target/release/camelid fabric serve \
 
 Two limits are deliberate and worth knowing before you deploy it:
 
-- The proxy has no key of its own, so it authenticates no client. The acknowledgement flag is the
-  only way to bind it to a routable address, and it should only be used behind something that does
-  authenticate.
+- `--api-key` (or `--api-key-file`) is the key the proxy requires *from its clients*, and having one
+  satisfies the bind guard on its own. It deliberately reads no environment variable: on this command
+  `CAMELID_API_KEY` already names the token sent to nodes, and one value must not silently configure
+  both directions. Without a key, `--allow-unauthenticated-remote` is the only way to bind a routable
+  address, and it should only be used behind something that does authenticate.
 - `--bearer` (or `CAMELID_API_KEY`) is the token the proxy presents *to its nodes*, the same as
   `fabric status|route|run`. A node started with `--api-key` needs it: `/v1/health` is exempt from
   that node's auth, so without a token the node observes as ready and then answers every forwarded
   request with 401.
 
-Request bodies are bounded at the same 16 MiB default the node itself uses, and streaming requests
-are refused with 400 rather than half-supported.
+The proxy re-probes its nodes at most once per `--observation-max-age-ms` (500 by default) rather
+than once per request. Inside that window its view can be wrong, so a request placed on a node that
+has gone since is placed again on another node serving the same model, up to `--max-forward-attempts`
+(2 by default) nodes in all. A request is only ever sent twice when the first node was never reached
+and so cannot have started it: a node that accepted the request and then failed, or that failed
+part-way through a stream, ends the request with 502 rather than risking a second generation. Set
+`--max-forward-attempts 1` to fail on the first node instead. Every answer carries
+`x-camelid-fabric-node`, `x-camelid-fabric-reason` and `x-camelid-fabric-attempts`, so a client can
+tell a first-choice placement from a failover.
+
+Request bodies are bounded at the same 16 MiB default the node itself uses. A streaming request is
+relayed as it arrives; `fabric run`, which returns one complete answer, refuses `stream: true` with
+400 instead.
 
 ## Mixtral diagnostic gate
 

--- a/src/fabric/forward.rs
+++ b/src/fabric/forward.rs
@@ -42,6 +42,55 @@ impl Forwarded {
     }
 }
 
+/// The engine's typed code for a request its bounded queue turned away.
+///
+/// This mirrors the literal `crate::api` uses when it maps its queue-full post
+/// error onto the error envelope. It is duplicated rather than shared because
+/// that module's bytes are pinned by the model-qualification provenance check,
+/// and one constant is not worth reopening it.
+///
+/// Nothing in this crate can catch the two drifting apart — a test would only
+/// be comparing this literal with itself. Only a real engine refusing a real
+/// request can, which is what this was measured against; if the engine ever
+/// renames the code, a saturated fabric silently stops handing work on.
+pub const ENGINE_QUEUE_FULL_CODE: &str = "engine_queue_full";
+
+/// An answer a node gave, which the fabric looks inside before it treats the
+/// request as finished.
+pub trait NodeAnswer {
+    /// The node turned this request away at its queue boundary, so it never
+    /// started the work.
+    ///
+    /// This is the same property [`ForwardError::node_never_received_it`]
+    /// carries for a failure — "another node can safely be asked instead" —
+    /// except that it arrives as a *successful* forward, because a node that
+    /// answers 503 has answered. Nothing else about a 503 implies it: a node
+    /// with no model loaded also refuses with one, and re-sending that would
+    /// just spend another node's time on the same refusal.
+    fn refused_for_backpressure(&self) -> bool;
+}
+
+impl NodeAnswer for Forwarded {
+    fn refused_for_backpressure(&self) -> bool {
+        self.status == 503
+            && self.body.pointer("/error/code").and_then(Value::as_str)
+                == Some(ENGINE_QUEUE_FULL_CODE)
+    }
+}
+
+impl NodeAnswer for StreamOutcome {
+    fn refused_for_backpressure(&self) -> bool {
+        match self {
+            // A refusal arrives buffered, before one event has been relayed, so
+            // the request can still be placed somewhere else.
+            Self::Buffered(answer) => answer.refused_for_backpressure(),
+            // Once the node is streaming it has started generating, and the
+            // head is already on its way to the client.
+            Self::Streaming(_) => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ForwardError {
     /// The node was never reached, so it cannot have run the request.
@@ -343,6 +392,83 @@ mod tests {
             host: "127.0.0.1".to_string(),
             port,
         }
+    }
+
+    fn answered(status: u16, body: Value) -> Forwarded {
+        Forwarded {
+            label: "node-a".to_string(),
+            status,
+            body,
+            elapsed: Duration::from_millis(1),
+        }
+    }
+
+    /// The exact envelope a real engine sends when its bounded queue turns a
+    /// request away: a 503 whose typed code names the queue, not the model.
+    #[test]
+    fn a_queue_full_refusal_is_backpressure() {
+        let answer = answered(
+            503,
+            serde_json::json!({
+                "error": {
+                    "message": "the generation queue is full; retry shortly",
+                    "type": "runtime_unavailable",
+                    "code": ENGINE_QUEUE_FULL_CODE,
+                }
+            }),
+        );
+        assert!(answer.refused_for_backpressure());
+    }
+
+    /// The status alone must not decide it. A node with no model loaded also
+    /// answers 503, and it will answer the same way however many times it is
+    /// asked — re-sending that request costs a second node its time and turns
+    /// one refusal into two.
+    #[test]
+    fn another_kind_of_503_is_not_backpressure() {
+        let answer = answered(
+            503,
+            serde_json::json!({
+                "error": {
+                    "message": "no model is loaded",
+                    "type": "runtime_unavailable",
+                    "code": "model_unavailable",
+                }
+            }),
+        );
+        assert!(!answer.refused_for_backpressure());
+    }
+
+    #[test]
+    fn a_body_without_an_error_is_not_backpressure() {
+        assert!(!answered(503, Value::Null).refused_for_backpressure());
+        assert!(!answered(503, serde_json::json!({ "error": "full" })).refused_for_backpressure());
+        assert!(!answered(503, serde_json::json!({})).refused_for_backpressure());
+    }
+
+    /// A served answer is never re-placed, whatever it happens to contain.
+    #[test]
+    fn a_successful_answer_is_not_backpressure() {
+        let answer = answered(
+            200,
+            serde_json::json!({ "error": { "code": ENGINE_QUEUE_FULL_CODE } }),
+        );
+        assert!(!answer.refused_for_backpressure());
+    }
+
+    /// A streaming request refused this way never became a stream: the node
+    /// answered with one body, so nothing has been relayed and the request can
+    /// still go elsewhere.
+    #[test]
+    fn a_buffered_refusal_on_a_streaming_request_is_backpressure() {
+        let outcome = StreamOutcome::Buffered(answered(
+            503,
+            serde_json::json!({ "error": { "code": ENGINE_QUEUE_FULL_CODE } }),
+        ));
+        assert!(outcome.refused_for_backpressure());
+
+        let served = StreamOutcome::Buffered(answered(200, serde_json::json!({ "choices": [] })));
+        assert!(!served.refused_for_backpressure());
     }
 
     #[test]

--- a/src/fabric/forward.rs
+++ b/src/fabric/forward.rs
@@ -44,7 +44,13 @@ impl Forwarded {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ForwardError {
-    /// The request never completed against that node.
+    /// The node was never reached, so it cannot have run the request.
+    ///
+    /// Held apart from [`ForwardError::Transport`] because that is the whole
+    /// difference between "safe to send somewhere else" and "may already be
+    /// generating"; see [`ForwardError::node_never_received_it`].
+    Unreachable { label: String, detail: String },
+    /// The request never completed against that node, and may have reached it.
     Transport { label: String, detail: String },
     /// The node answered, but not with JSON.
     Json { label: String, detail: String },
@@ -52,9 +58,44 @@ pub enum ForwardError {
     Unsupported(String),
 }
 
+impl ForwardError {
+    /// Whether the node provably never received the request.
+    ///
+    /// Only a caller that has said nothing to its own client on the strength of
+    /// this attempt may act on it: re-sending is safe because the node cannot
+    /// have started, not because the request is idempotent.
+    pub fn node_never_received_it(&self) -> bool {
+        matches!(self, Self::Unreachable { .. })
+    }
+
+    /// Which node failed, when the failure is attributable to one.
+    pub fn label(&self) -> Option<&str> {
+        match self {
+            Self::Unreachable { label, .. }
+            | Self::Transport { label, .. }
+            | Self::Json { label, .. } => Some(label),
+            Self::Unsupported(_) => None,
+        }
+    }
+}
+
+/// Tag an HTTP failure with the node it happened against, keeping the one
+/// distinction a retry depends on.
+fn dial_or_transport(label: &str, error: HttpError) -> ForwardError {
+    let (label, detail) = (label.to_string(), error.to_string());
+    if error.peer_never_received_it() {
+        ForwardError::Unreachable { label, detail }
+    } else {
+        ForwardError::Transport { label, detail }
+    }
+}
+
 impl std::fmt::Display for ForwardError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Unreachable { label, detail } => {
+                write!(f, "node `{label}` could not be reached: {detail}")
+            }
             Self::Transport { label, detail } => {
                 write!(f, "node `{label}` did not answer: {detail}")
             }
@@ -144,10 +185,7 @@ pub fn forward(
         timeout,
         MAX_RESPONSE_BYTES,
     )
-    .map_err(|error: HttpError| ForwardError::Transport {
-        label: spec.label.clone(),
-        detail: error.to_string(),
-    })?;
+    .map_err(|error| dial_or_transport(&spec.label, error))?;
     let elapsed = started.elapsed();
 
     // An empty body is legal for some statuses; represent it as null rather than
@@ -198,6 +236,9 @@ impl std::fmt::Debug for Streaming {
 
 impl Streaming {
     /// The next piece of the body, or `None` at the end of the stream.
+    ///
+    /// Always a `Transport` failure, never `Unreachable`: the node answered to
+    /// get here, so the request cannot be sent anywhere else.
     pub fn next_chunk(&mut self) -> Result<Option<Vec<u8>>, ForwardError> {
         self.stream
             .next_chunk()
@@ -239,6 +280,9 @@ pub fn forward_streaming(
         detail: format!("request body could not be encoded: {error}"),
     })?;
 
+    // Only opening the stream can fail before the node has the request. Once a
+    // head is in, the node is generating, so everything below is `Transport`
+    // whatever the underlying cause was.
     let transport = |error: HttpError| ForwardError::Transport {
         label: spec.label.clone(),
         detail: error.to_string(),
@@ -256,7 +300,7 @@ pub fn forward_streaming(
         idle_timeout,
         MAX_RESPONSE_BYTES,
     )
-    .map_err(transport)?;
+    .map_err(|error| dial_or_transport(&spec.label, error))?;
 
     let head = stream.head().clone();
     // A node that refused, or answered with something other than a stream, has
@@ -373,11 +417,53 @@ mod tests {
         )
         .expect_err("port 1 is closed");
         match &error {
-            ForwardError::Transport { label, .. } => assert_eq!(label, "windows"),
-            other => panic!("expected Transport, got {other:?}"),
+            ForwardError::Unreachable { label, .. } => assert_eq!(label, "windows"),
+            other => panic!("expected Unreachable, got {other:?}"),
         }
         // The message must name the node, or an operator cannot act on it.
         assert!(error.to_string().contains("windows"), "{error}");
+        assert_eq!(error.label(), Some("windows"));
+    }
+
+    #[test]
+    fn a_node_that_was_never_dialled_is_distinguished_from_one_that_was() {
+        // The distinction the whole retry path rests on, taken from the real
+        // dialling code rather than a hand-built variant.
+        let unreached = forward(
+            &spec("gone", 1),
+            "/v1/chat/completions",
+            &chat_request("m", "hi", 4),
+            None,
+            Duration::from_millis(400),
+        )
+        .expect_err("port 1 is closed");
+        assert!(unreached.node_never_received_it(), "{unreached:?}");
+
+        let interrupted = ForwardError::Transport {
+            label: "gone".to_string(),
+            detail: "connection reset".to_string(),
+        };
+        assert!(!interrupted.node_never_received_it());
+
+        // A refusal that never named a node cannot be blamed on one either.
+        let refused = reject_streaming(&json!({ "model": "m", "stream": true }))
+            .expect_err("streaming is unsupported");
+        assert!(!refused.node_never_received_it());
+        assert_eq!(refused.label(), None);
+    }
+
+    #[test]
+    fn a_streaming_open_against_a_closed_port_is_also_never_received() {
+        let error = forward_streaming(
+            &spec("gone", 1),
+            "/v1/chat/completions",
+            &json!({ "model": "m", "stream": true }),
+            None,
+            Duration::from_millis(400),
+            Duration::from_millis(400),
+        )
+        .expect_err("port 1 is closed");
+        assert!(error.node_never_received_it(), "{error:?}");
     }
 
     #[test]

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -34,6 +34,25 @@ pub(crate) enum HttpError {
     InvalidRequest(String),
 }
 
+impl HttpError {
+    /// Whether the peer provably never received any part of the request.
+    ///
+    /// Only resolution and dialling qualify. Every other variant is raised at or
+    /// after the first write, and `write_all` does not say how many bytes left
+    /// the socket, so the request may already be running on the peer. Answering
+    /// "it may have arrived" whenever that is possible is what lets a caller
+    /// re-send elsewhere without risking a second execution.
+    ///
+    /// [`HttpError::InvalidRequest`] is deliberately excluded: nothing was sent,
+    /// but the request is malformed, so another peer would refuse it identically.
+    pub(crate) fn peer_never_received_it(&self) -> bool {
+        match self {
+            Self::Resolve(_) | Self::Connect(_) => true,
+            Self::Io(_) | Self::Malformed(_) | Self::TooLarge(_) | Self::InvalidRequest(_) => false,
+        }
+    }
+}
+
 impl std::fmt::Display for HttpError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -728,6 +747,36 @@ mod tests {
         let error = connect_any(&[dead, dead], Instant::now() + Duration::from_secs(1))
             .expect_err("nothing is listening");
         assert!(matches!(error, HttpError::Connect(_)), "{error:?}");
+    }
+
+    #[test]
+    fn only_a_failure_before_the_first_write_counts_as_never_received() {
+        // Exhaustive on purpose: a new variant must be classified deliberately,
+        // because answering "never received" wrongly permits a second execution.
+        for error in [
+            HttpError::Resolve("no such host".to_string()),
+            HttpError::Connect("refused".to_string()),
+        ] {
+            assert!(error.peer_never_received_it(), "{error:?}");
+        }
+        for error in [
+            HttpError::Io("reset".to_string()),
+            HttpError::Malformed("truncated".to_string()),
+            HttpError::TooLarge(1),
+            HttpError::InvalidRequest("bad token".to_string()),
+        ] {
+            assert!(!error.peer_never_received_it(), "{error:?}");
+        }
+    }
+
+    #[test]
+    fn a_dial_failure_from_a_real_socket_is_classified_as_never_received() {
+        // Not a hand-built variant: this is the error the dialling path actually
+        // produces against a closed port, which is the case failover turns on.
+        let dead = SocketAddr::from(([127, 0, 0, 1], 1));
+        let error = connect_any(&[dead], Instant::now() + Duration::from_secs(1))
+            .expect_err("nothing is listening");
+        assert!(error.peer_never_received_it(), "{error:?}");
     }
 
     #[test]

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -369,8 +369,10 @@ impl Fabric {
     /// [`Fabric::with_max_observation_age`] exists to remove.
     ///
     /// If nowhere else can take it, the node's own refusal is returned rather
-    /// than an error this proxy invented. A client is owed the real answer,
-    /// including its `Retry-After`.
+    /// than an error this proxy invented: the client gets the status and body
+    /// the node sent, its code and message included. Not its headers, though —
+    /// [`Forwarded`] carries none, so the node's `Retry-After` does not survive
+    /// the hop.
     fn send_until_a_node_takes_it<T: NodeAnswer>(
         &self,
         request: &RouteRequest<'_>,
@@ -380,20 +382,22 @@ impl Fabric {
         let mut saturated: Vec<String> = Vec::new();
         let mut first_failure: Option<ForwardError> = None;
         let mut refused: Option<(T, Placement)> = None;
-        let mut attempts = 0;
+        // Nodes actually asked, which is not the attempt number: placement can
+        // run out before an attempt reaches one.
+        let mut asked = 0;
 
         for attempt in 1..=self.max_forward_attempts.max(1) {
-            attempts = attempt;
             let excluded: Vec<String> = gone.iter().chain(saturated.iter()).cloned().collect();
             let placement = match self.place_excluding(request, &excluded) {
                 Ok(placement) => placement,
                 Err(refusal) => {
                     if let Some((value, placement)) = refused {
-                        return Ok(self.settle_for_the_refusal(value, placement, attempts, &gone));
+                        return Ok(self.settle_for_the_refusal(value, placement, asked, &gone));
                     }
                     return Err(self.ran_out_of_nodes(first_failure, refusal));
                 }
             };
+            asked = attempt;
 
             match send(&placement.node.spec) {
                 Ok(value) if value.refused_for_backpressure() => {
@@ -440,7 +444,7 @@ impl Fabric {
         }
 
         if let Some((value, placement)) = refused {
-            return Ok(self.settle_for_the_refusal(value, placement, attempts, &gone));
+            return Ok(self.settle_for_the_refusal(value, placement, asked, &gone));
         }
 
         // The budget ran out with nodes possibly still untried. Say so with the
@@ -507,7 +511,8 @@ pub struct Dispatched {
     pub decision: RouteDecision,
     pub answer: Forwarded,
     /// Nodes this request was sent to, the one that answered included. More
-    /// than one means a node was found gone and the request was placed again.
+    /// than one means a node was found gone, or full, and the request was
+    /// placed again.
     pub attempts: usize,
 }
 

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -46,6 +46,14 @@ pub use policy::{
 };
 pub use probe::{probe_fabric, probe_node, Observation, ProbeError, DEFAULT_PROBE_TIMEOUT};
 
+/// How many nodes one request may be sent to before it fails.
+///
+/// Two means one retry. A request that finds its node gone is still served, and
+/// a fabric where several nodes have gone still fails after a bounded number of
+/// dials rather than walking every node it has. Raise it for a large fabric
+/// where more of that walk is worth paying for; one turns failover off.
+pub const DEFAULT_MAX_FORWARD_ATTEMPTS: usize = 2;
+
 /// A configured set of nodes.
 #[derive(Clone)]
 pub struct Fabric {
@@ -65,6 +73,8 @@ pub struct Fabric {
     observed: Arc<Mutex<Option<Observation>>>,
     /// How stale a reused observation may be. Zero means never reuse one.
     max_observation_age: Duration,
+    /// How many nodes one request may be sent to. One never fails over.
+    max_forward_attempts: usize,
 }
 
 /// Hand-written so a token can never reach a log through a derived `Debug`,
@@ -76,6 +86,7 @@ impl std::fmt::Debug for Fabric {
             .field("timeout", &self.timeout)
             .field("bearer", &self.bearer.as_ref().map(|_| "[REDACTED]"))
             .field("max_observation_age", &self.max_observation_age)
+            .field("max_forward_attempts", &self.max_forward_attempts)
             .finish()
     }
 }
@@ -89,6 +100,7 @@ impl Fabric {
             reserved: Arc::new(Mutex::new(Reservations::none())),
             observed: Arc::new(Mutex::new(None)),
             max_observation_age: Duration::ZERO,
+            max_forward_attempts: DEFAULT_MAX_FORWARD_ATTEMPTS,
         }
     }
 
@@ -105,6 +117,16 @@ impl Fabric {
     /// node on every request. See [`Observation`].
     pub fn with_max_observation_age(mut self, max_age: Duration) -> Self {
         self.max_observation_age = max_age;
+        self
+    }
+
+    /// How many nodes one request may be sent to before it fails.
+    ///
+    /// See [`DEFAULT_MAX_FORWARD_ATTEMPTS`]. One disables failover entirely and
+    /// is the exact behaviour of a fabric that has never heard of it. Zero is
+    /// meaningless — a request must be sent somewhere — and is read as one.
+    pub fn with_max_forward_attempts(mut self, attempts: usize) -> Self {
+        self.max_forward_attempts = attempts.max(1);
         self
     }
 
@@ -177,7 +199,10 @@ impl Fabric {
     /// window costs the one request that discovers it, not every request until
     /// the observation expires.
     fn forget_observation_if_node_vanished(&self, error: &ForwardError) {
-        if matches!(error, ForwardError::Transport { .. }) {
+        if matches!(
+            error,
+            ForwardError::Transport { .. } | ForwardError::Unreachable { .. }
+        ) {
             self.forget_observation();
         }
     }
@@ -187,22 +212,40 @@ impl Fabric {
     /// The returned [`Placement`] counts the request against the chosen node
     /// until it is dropped, so a placement running concurrently can see it.
     pub fn place(&self, request: &RouteRequest<'_>) -> Result<Placement, RouteError> {
+        self.place_excluding(request, &[])
+    }
+
+    /// Choose a node for a request, ignoring nodes already found gone.
+    ///
+    /// `excluded` holds labels this request has already been sent to and could
+    /// not reach. They are dropped from the observation rather than from the
+    /// policy, so placement stays the one pure decision it was.
+    fn place_excluding(
+        &self,
+        request: &RouteRequest<'_>,
+        excluded: &[String],
+    ) -> Result<Placement, RouteError> {
         // Observing is socket I/O against every node. It stays outside the
         // reservation lock: holding that across it would serialise placement on
         // the slowest node, and would deadlock a `Placement` being dropped.
         let (snapshots, reused) = self.observe_reporting_reuse();
 
-        match self.place_observed(snapshots, request) {
+        match self.place_observed(snapshots, request, excluded) {
             // Refusing on a reused observation would settle from memory a
             // question the caller asked about now — and the proxy reports
             // `ModelUnavailable` as a 404 a client is told never to retry. A
             // node that has loaded a model since must not be refused that way,
             // so look again before saying no. This costs a probe only on a
             // request that was about to fail.
-            Err(_) if reused => {
+            //
+            // Not once anything is excluded: by then the caller already holds a
+            // forwarding failure, and that failure — not this refusal — is what
+            // it will report, so a fresh look would buy nothing and would pay a
+            // whole probe round against a node just found to be gone.
+            Err(_) if reused && excluded.is_empty() => {
                 self.forget_observation();
                 let (fresh, _) = self.observe_reporting_reuse();
-                self.place_observed(fresh, request)
+                self.place_observed(fresh, request, excluded)
             }
             settled => settled,
         }
@@ -213,7 +256,13 @@ impl Fabric {
         &self,
         snapshots: Vec<NodeSnapshot>,
         request: &RouteRequest<'_>,
+        excluded: &[String],
     ) -> Result<Placement, RouteError> {
+        let snapshots: Vec<NodeSnapshot> = snapshots
+            .into_iter()
+            .filter(|snapshot| !excluded.iter().any(|label| label == snapshot.label()))
+            .collect();
+
         // Deciding and recording are one step. Split them and two concurrent
         // placements both decide before either records, which is the pile-up
         // this reservation exists to prevent.
@@ -242,28 +291,27 @@ impl Fabric {
     /// Observe, place, and send — the whole path a caller actually wants.
     ///
     /// Returns the placement alongside the answer so a caller can record which
-    /// node served the request and whether affinity held.
+    /// node served the request and whether affinity held. A node that turns out
+    /// to be gone does not fail the request while another can serve it; see
+    /// [`DEFAULT_MAX_FORWARD_ATTEMPTS`].
     pub fn dispatch(
         &self,
         path: &str,
         body: &Value,
         request: &RouteRequest<'_>,
         forward_timeout: Duration,
-    ) -> Result<(RouteDecision, Forwarded), DispatchError> {
+    ) -> Result<Dispatched, DispatchError> {
         // Refuse an unsupported request before spending any probes on it.
         forward::reject_streaming(body)?;
 
-        // Held until this function returns, which is when the request is over.
-        let placement = self.place(request)?;
-        let answer = forward::forward(
-            &placement.node.spec,
-            path,
-            body,
-            self.bearer.as_deref(),
-            forward_timeout,
-        )
-        .inspect_err(|error| self.forget_observation_if_node_vanished(error))?;
-        Ok((placement.decision.clone(), answer))
+        let sent = self.send_until_a_node_takes_it(request, |spec| {
+            forward::forward(spec, path, body, self.bearer.as_deref(), forward_timeout)
+        })?;
+        Ok(Dispatched {
+            decision: sent.placement.decision.clone(),
+            answer: sent.value,
+            attempts: sent.attempts,
+        })
     }
 
     /// Observe, place, and start a streaming request.
@@ -283,19 +331,134 @@ impl Fabric {
         request: &RouteRequest<'_>,
         head_timeout: Duration,
         idle_timeout: Duration,
-    ) -> Result<(StreamOutcome, Placement), DispatchError> {
-        let placement = self.place(request)?;
-        let outcome = forward::forward_streaming(
-            &placement.node.spec,
-            path,
-            body,
-            self.bearer.as_deref(),
-            head_timeout,
-            idle_timeout,
-        )
-        .inspect_err(|error| self.forget_observation_if_node_vanished(error))?;
-        Ok((outcome, placement))
+    ) -> Result<DispatchedStream, DispatchError> {
+        let sent = self.send_until_a_node_takes_it(request, |spec| {
+            forward::forward_streaming(
+                spec,
+                path,
+                body,
+                self.bearer.as_deref(),
+                head_timeout,
+                idle_timeout,
+            )
+        })?;
+        Ok(DispatchedStream {
+            outcome: sent.value,
+            placement: sent.placement,
+            attempts: sent.attempts,
+        })
     }
+
+    /// Place the request and send it, moving on while a node turns out to be
+    /// gone.
+    ///
+    /// `send` must not have told anyone anything on the strength of an attempt
+    /// it reports as failed: this calls it again against another node, which is
+    /// only safe while nothing has been said and — per
+    /// [`ForwardError::node_never_received_it`] — the failed node cannot have
+    /// started the work.
+    fn send_until_a_node_takes_it<T>(
+        &self,
+        request: &RouteRequest<'_>,
+        mut send: impl FnMut(&NodeSpec) -> Result<T, ForwardError>,
+    ) -> Result<Sent<T>, DispatchError> {
+        let mut gone: Vec<String> = Vec::new();
+        let mut first_failure: Option<ForwardError> = None;
+
+        for attempt in 1..=self.max_forward_attempts.max(1) {
+            let placement = match self.place_excluding(request, &gone) {
+                Ok(placement) => placement,
+                // Placement can only run out of nodes on a later attempt
+                // because this request excluded the ones it just found gone.
+                // That first failure is the story worth telling; a refusal
+                // derived from an exclusion this request invented is not.
+                Err(refusal) => {
+                    return Err(self.abandon(first_failure, DispatchError::Route(refusal)))
+                }
+            };
+
+            match send(&placement.node.spec) {
+                Ok(value) => {
+                    // A node this request could not reach was named by the
+                    // current observation, so that observation must not outlive
+                    // the request even though the request itself succeeded.
+                    if !gone.is_empty() {
+                        self.forget_observation();
+                    }
+                    return Ok(Sent {
+                        value,
+                        placement,
+                        attempts: attempt,
+                    });
+                }
+                Err(error) if error.node_never_received_it() => {
+                    gone.push(placement.decision.label.clone());
+                    first_failure.get_or_insert(error);
+                }
+                Err(error) => {
+                    return Err(self.abandon(first_failure, DispatchError::Forward(error)))
+                }
+            }
+        }
+
+        // The budget ran out with nodes possibly still untried. Say so with the
+        // failure that started it, not with a count.
+        let exhausted = first_failure.expect("the budget can only run out after a failure");
+        self.forget_observation();
+        Err(DispatchError::Forward(exhausted))
+    }
+
+    /// Settle on the failure to report once a request has run out of road.
+    ///
+    /// A request that reached this point after finding a node gone reports that
+    /// finding, and its observation is dropped whichever way it ended: the
+    /// observation named a node that is not there.
+    fn abandon(
+        &self,
+        first_failure: Option<ForwardError>,
+        otherwise: DispatchError,
+    ) -> DispatchError {
+        match first_failure {
+            Some(error) => {
+                self.forget_observation();
+                DispatchError::Forward(error)
+            }
+            None => {
+                if let DispatchError::Forward(error) = &otherwise {
+                    self.forget_observation_if_node_vanished(error);
+                }
+                otherwise
+            }
+        }
+    }
+}
+
+/// A request that a node took, and what it cost to get there.
+struct Sent<T> {
+    value: T,
+    placement: Placement,
+    attempts: usize,
+}
+
+/// A complete answer from the node that served the request.
+#[derive(Debug)]
+pub struct Dispatched {
+    pub decision: RouteDecision,
+    pub answer: Forwarded,
+    /// Nodes this request was sent to, the one that answered included. More
+    /// than one means a node was found gone and the request was placed again.
+    pub attempts: usize,
+}
+
+/// A streaming answer, still arriving from the node that took the request.
+#[derive(Debug)]
+pub struct DispatchedStream {
+    pub outcome: StreamOutcome,
+    /// Holds the node reserved; keep it until the last event is read.
+    pub placement: Placement,
+    /// As on [`Dispatched`]. Settled before the first byte is relayed, so it
+    /// can be reported in the response head.
+    pub attempts: usize,
 }
 
 /// A poisoned lock is not corrupted state: some other request panicked while
@@ -701,6 +864,55 @@ mod tests {
                 DispatchError::Route(RouteError::AllNodesUnavailable { .. })
             ),
             "got {error:?}"
+        );
+    }
+
+    #[test]
+    fn a_request_is_never_placed_on_a_node_it_has_already_failed_against() {
+        let fabric = Fabric::new(Vec::new());
+        let snapshots = vec![
+            snapshot("a", ready_status("m")),
+            snapshot("b", ready_status("m")),
+        ];
+        let request = RouteRequest::new(RouteMode::Throughput);
+
+        // Ties break on label, so an unconstrained placement picks `a`; the
+        // exclusion is what moves it, not a difference between the nodes.
+        let first = fabric
+            .place_observed(snapshots.clone(), &request, &[])
+            .expect("a is eligible");
+        assert_eq!(first.decision().label, "a");
+        drop(first);
+
+        let second = fabric
+            .place_observed(snapshots, &request, &["a".to_string()])
+            .expect("b is still eligible");
+        assert_eq!(second.decision().label, "b");
+    }
+
+    #[test]
+    fn excluding_every_node_refuses_rather_than_placing_on_one_anyway() {
+        let fabric = Fabric::new(Vec::new());
+        let snapshots = vec![snapshot("a", ready_status("m"))];
+        let error = fabric
+            .place_observed(
+                snapshots,
+                &RouteRequest::new(RouteMode::Throughput),
+                &["a".to_string()],
+            )
+            .expect_err("nothing is left to place on");
+        assert_eq!(error, RouteError::NoNodesConfigured);
+    }
+
+    #[test]
+    fn a_request_must_always_be_sendable_somewhere() {
+        // Zero attempts would mean a request that is never sent at all, so the
+        // budget floor is part of the contract rather than a caller's problem.
+        let fabric = Fabric::new(Vec::new()).with_max_forward_attempts(0);
+        assert_eq!(fabric.max_forward_attempts, 1);
+        assert_eq!(
+            Fabric::new(Vec::new()).max_forward_attempts,
+            DEFAULT_MAX_FORWARD_ATTEMPTS
         );
     }
 }

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -34,7 +34,8 @@ use std::time::{Duration, Instant};
 use serde_json::Value;
 
 pub use forward::{
-    wants_streaming, ForwardError, Forwarded, StreamOutcome, Streaming, DEFAULT_FORWARD_TIMEOUT,
+    wants_streaming, ForwardError, Forwarded, NodeAnswer, StreamOutcome, Streaming,
+    DEFAULT_FORWARD_TIMEOUT, ENGINE_QUEUE_FULL_CODE,
 };
 pub use node::{
     parse_fabric, parse_node_spec, NodeReady, NodeSnapshot, NodeSpec, NodeSpecParseError,
@@ -350,28 +351,59 @@ impl Fabric {
     }
 
     /// Place the request and send it, moving on while a node turns out to be
-    /// gone.
+    /// gone or too busy to take it.
     ///
     /// `send` must not have told anyone anything on the strength of an attempt
     /// it reports as failed: this calls it again against another node, which is
     /// only safe while nothing has been said and — per
     /// [`ForwardError::node_never_received_it`] — the failed node cannot have
     /// started the work.
-    fn send_until_a_node_takes_it<T>(
+    ///
+    /// A node that answers with a queue-full refusal gets the same treatment
+    /// for the same reason ([`NodeAnswer::refused_for_backpressure`]): it
+    /// rejected the request at its queue boundary rather than running it, so
+    /// another node can be asked. The two are tracked apart because only one of
+    /// them says the observation was wrong — a saturated node is exactly where
+    /// the observation said it was, and re-probing on every refusal would spend
+    /// a probe per request under load, which is the cost
+    /// [`Fabric::with_max_observation_age`] exists to remove.
+    ///
+    /// If nowhere else can take it, the node's own refusal is returned rather
+    /// than an error this proxy invented. A client is owed the real answer,
+    /// including its `Retry-After`.
+    fn send_until_a_node_takes_it<T: NodeAnswer>(
         &self,
         request: &RouteRequest<'_>,
         mut send: impl FnMut(&NodeSpec) -> Result<T, ForwardError>,
     ) -> Result<Sent<T>, DispatchError> {
         let mut gone: Vec<String> = Vec::new();
+        let mut saturated: Vec<String> = Vec::new();
         let mut first_failure: Option<ForwardError> = None;
+        let mut refused: Option<(T, Placement)> = None;
+        let mut attempts = 0;
 
         for attempt in 1..=self.max_forward_attempts.max(1) {
-            let placement = match self.place_excluding(request, &gone) {
+            attempts = attempt;
+            let excluded: Vec<String> = gone.iter().chain(saturated.iter()).cloned().collect();
+            let placement = match self.place_excluding(request, &excluded) {
                 Ok(placement) => placement,
-                Err(refusal) => return Err(self.ran_out_of_nodes(first_failure, refusal)),
+                Err(refusal) => {
+                    if let Some((value, placement)) = refused {
+                        return Ok(self.settle_for_the_refusal(value, placement, attempts, &gone));
+                    }
+                    return Err(self.ran_out_of_nodes(first_failure, refusal));
+                }
             };
 
             match send(&placement.node.spec) {
+                Ok(value) if value.refused_for_backpressure() => {
+                    saturated.push(placement.decision.label.clone());
+                    // The first refusal is the one a client would have received
+                    // before this existed, so it is the one to fall back to.
+                    if refused.is_none() {
+                        refused = Some((value, placement));
+                    }
+                }
                 Ok(value) => {
                     // A node this request could not reach was named by the
                     // current observation, so that observation must not outlive
@@ -407,6 +439,10 @@ impl Fabric {
             }
         }
 
+        if let Some((value, placement)) = refused {
+            return Ok(self.settle_for_the_refusal(value, placement, attempts, &gone));
+        }
+
         // The budget ran out with nodes possibly still untried. Say so with the
         // failure that started it, not with a count.
         let exhausted = first_failure.expect("the budget can only run out after a failure");
@@ -420,6 +456,29 @@ impl Fabric {
     /// excluded the nodes it just found gone. That finding is the story worth
     /// telling; a refusal derived from an exclusion this request invented is
     /// not. The observation is dropped with it: it named a node that is gone.
+    /// Hand back a node's own refusal, the alternatives having been tried.
+    ///
+    /// The observation is dropped only for a node found *gone*, never for a
+    /// saturated one: a full node is exactly where the observation said it was,
+    /// so forgetting here would re-probe the whole fabric once per request for
+    /// as long as it stays busy.
+    fn settle_for_the_refusal<T>(
+        &self,
+        value: T,
+        placement: Placement,
+        attempts: usize,
+        gone: &[String],
+    ) -> Sent<T> {
+        if !gone.is_empty() {
+            self.forget_observation();
+        }
+        Sent {
+            value,
+            placement,
+            attempts,
+        }
+    }
+
     fn ran_out_of_nodes(
         &self,
         first_failure: Option<ForwardError>,

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -368,13 +368,7 @@ impl Fabric {
         for attempt in 1..=self.max_forward_attempts.max(1) {
             let placement = match self.place_excluding(request, &gone) {
                 Ok(placement) => placement,
-                // Placement can only run out of nodes on a later attempt
-                // because this request excluded the ones it just found gone.
-                // That first failure is the story worth telling; a refusal
-                // derived from an exclusion this request invented is not.
-                Err(refusal) => {
-                    return Err(self.abandon(first_failure, DispatchError::Route(refusal)))
-                }
+                Err(refusal) => return Err(self.ran_out_of_nodes(first_failure, refusal)),
             };
 
             match send(&placement.node.spec) {
@@ -395,8 +389,20 @@ impl Fabric {
                     gone.push(placement.decision.label.clone());
                     first_failure.get_or_insert(error);
                 }
+                // The node that took the request is the one that ended it, so
+                // that is what gets reported. An earlier node found gone was
+                // survived — naming it would send an operator to the node the
+                // fabric successfully routed around, and say nothing about the
+                // one actually failing requests.
                 Err(error) => {
-                    return Err(self.abandon(first_failure, DispatchError::Forward(error)))
+                    if gone.is_empty() {
+                        self.forget_observation_if_node_vanished(&error);
+                    } else {
+                        // An observation that named a node now gone must not
+                        // outlive this request, however the request ended.
+                        self.forget_observation();
+                    }
+                    return Err(DispatchError::Forward(error));
                 }
             }
         }
@@ -408,27 +414,23 @@ impl Fabric {
         Err(DispatchError::Forward(exhausted))
     }
 
-    /// Settle on the failure to report once a request has run out of road.
+    /// Settle on the failure to report when placement runs out of nodes.
     ///
-    /// A request that reached this point after finding a node gone reports that
-    /// finding, and its observation is dropped whichever way it ended: the
-    /// observation named a node that is not there.
-    fn abandon(
+    /// Placement can only run out on a later attempt, because this request
+    /// excluded the nodes it just found gone. That finding is the story worth
+    /// telling; a refusal derived from an exclusion this request invented is
+    /// not. The observation is dropped with it: it named a node that is gone.
+    fn ran_out_of_nodes(
         &self,
         first_failure: Option<ForwardError>,
-        otherwise: DispatchError,
+        refusal: RouteError,
     ) -> DispatchError {
         match first_failure {
             Some(error) => {
                 self.forget_observation();
                 DispatchError::Forward(error)
             }
-            None => {
-                if let DispatchError::Forward(error) = &otherwise {
-                    self.forget_observation_if_node_vanished(error);
-                }
-                otherwise
-            }
+            None => DispatchError::Route(refusal),
         }
     }
 }

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -35,7 +35,12 @@
 //!   and nothing here revokes or rotates it while the proxy is running.
 //! * A node that becomes ready, or loads a different model, is routed to only
 //!   once the current observation expires. A node that *stops* answering is not
-//!   waited on: the failed forward drops the observation immediately.
+//!   waited on: the request that finds it gone is placed on another node
+//!   serving the same model, and the observation that named it is dropped.
+//!   That second placement only happens when the first node was never reached;
+//!   a node that took the request and then failed ends it, because this proxy
+//!   cannot know whether it started generating. See
+//!   [`super::DEFAULT_MAX_FORWARD_ATTEMPTS`].
 //! * A non-streaming dispatch runs on a blocking thread and blocking socket I/O
 //!   is not cancellable, so a client that hangs up leaves its dispatch running
 //!   until the node answers or `forward_timeout` expires. A streaming dispatch
@@ -309,10 +314,15 @@ async fn buffered_completion(state: ServerState, body: Value, request: OwnedRequ
     .await;
 
     match outcome {
-        Ok(Ok((decision, answer))) => {
-            let status = StatusCode::from_u16(answer.status).unwrap_or(StatusCode::BAD_GATEWAY);
-            let mut response = (status, Json(answer.body)).into_response();
-            tag(response.headers_mut(), &decision);
+        Ok(Ok(dispatched)) => {
+            let status =
+                StatusCode::from_u16(dispatched.answer.status).unwrap_or(StatusCode::BAD_GATEWAY);
+            let mut response = (status, Json(dispatched.answer.body)).into_response();
+            tag(
+                response.headers_mut(),
+                &dispatched.decision,
+                dispatched.attempts,
+            );
             response
         }
         Ok(Err(DispatchError::Route(error))) => route_error(error),
@@ -331,12 +341,14 @@ async fn buffered_completion(state: ServerState, body: Value, request: OwnedRequ
 enum StreamStart {
     Streaming {
         decision: RouteDecision,
+        attempts: usize,
         status: u16,
         content_type: Option<String>,
     },
     /// The node answered outright instead of streaming.
     Buffered {
         decision: RouteDecision,
+        attempts: usize,
         answer: fabric::Forwarded,
     },
     Failed(DispatchError),
@@ -372,25 +384,33 @@ async fn stream_completion(state: ServerState, body: Value, request: OwnedReques
                 let _ = start_tx.send(StreamStart::Failed(error));
                 return;
             }
-            Ok((StreamOutcome::Buffered(answer), placement)) => {
-                let _ = start_tx.send(StreamStart::Buffered {
-                    decision: placement.decision().clone(),
-                    answer,
-                });
-                return;
-            }
-            Ok((StreamOutcome::Streaming(streaming), placement)) => {
-                let start = StreamStart::Streaming {
-                    decision: placement.decision().clone(),
-                    status: streaming.status,
-                    content_type: streaming.content_type.clone(),
-                };
-                if start_tx.send(start).is_err() {
-                    return;
+            Ok(dispatched) => {
+                let decision = dispatched.placement.decision().clone();
+                let attempts = dispatched.attempts;
+                match dispatched.outcome {
+                    StreamOutcome::Buffered(answer) => {
+                        let _ = start_tx.send(StreamStart::Buffered {
+                            decision,
+                            attempts,
+                            answer,
+                        });
+                        return;
+                    }
+                    StreamOutcome::Streaming(streaming) => {
+                        let start = StreamStart::Streaming {
+                            decision,
+                            attempts,
+                            status: streaming.status,
+                            content_type: streaming.content_type.clone(),
+                        };
+                        if start_tx.send(start).is_err() {
+                            return;
+                        }
+                        // Bound alongside the stream so the node stays reserved
+                        // until the last event is read — however this loop ends.
+                        (streaming, dispatched.placement)
+                    }
                 }
-                // Bound alongside the stream so the node stays reserved until
-                // the last event is read — however this loop ends.
-                (streaming, placement)
             }
         };
 
@@ -423,20 +443,25 @@ async fn stream_completion(state: ServerState, body: Value, request: OwnedReques
         }
     };
 
-    let (decision, status, content_type) = match start {
+    let (decision, attempts, status, content_type) = match start {
         StreamStart::Failed(DispatchError::Route(error)) => return route_error(error),
         StreamStart::Failed(DispatchError::Forward(error)) => return forward_error(error),
-        StreamStart::Buffered { decision, answer } => {
+        StreamStart::Buffered {
+            decision,
+            attempts,
+            answer,
+        } => {
             let status = StatusCode::from_u16(answer.status).unwrap_or(StatusCode::BAD_GATEWAY);
             let mut response = (status, Json(answer.body)).into_response();
-            tag(response.headers_mut(), &decision);
+            tag(response.headers_mut(), &decision, attempts);
             return response;
         }
         StreamStart::Streaming {
             decision,
+            attempts,
             status,
             content_type,
-        } => (decision, status, content_type),
+        } => (decision, attempts, status, content_type),
     };
 
     let stream = async_stream::stream! {
@@ -456,14 +481,17 @@ async fn stream_completion(state: ServerState, body: Value, request: OwnedReques
         insert(out, CONTENT_TYPE, content_type);
     }
     insert(out, CACHE_CONTROL, "no-cache");
-    tag(out, &decision);
+    tag(out, &decision, attempts);
     response
 }
 
 /// Record which node served a request and why, on any answer shape.
-fn tag(headers: &mut HeaderMap, decision: &RouteDecision) {
+fn tag(headers: &mut HeaderMap, decision: &RouteDecision, attempts: usize) {
     insert(headers, "x-camelid-fabric-node", &decision.label);
     insert(headers, "x-camelid-fabric-reason", decision.reason.as_str());
+    // Always sent, so a client reads a failover off the header rather than
+    // inferring one from a header that is only there sometimes.
+    insert(headers, "x-camelid-fabric-attempts", &attempts.to_string());
     if let Some(previous) = &decision.affinity_lost {
         insert(headers, "x-camelid-fabric-affinity-lost", previous);
     }
@@ -530,7 +558,9 @@ fn forward_error(error: ForwardError) -> Response {
     // caller's mistake, not the upstream's, so it is a 400 not a 502/503.
     let status = match &error {
         ForwardError::Unsupported(_) => StatusCode::BAD_REQUEST,
-        ForwardError::Transport { .. } | ForwardError::Json { .. } => StatusCode::BAD_GATEWAY,
+        ForwardError::Unreachable { .. }
+        | ForwardError::Transport { .. }
+        | ForwardError::Json { .. } => StatusCode::BAD_GATEWAY,
     };
     error_response(status, &error.to_string())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1210,6 +1210,14 @@ enum FabricAction {
         /// Set 0 to probe on every request.
         #[arg(long, default_value_t = 500)]
         observation_max_age_ms: u64,
+        /// How many nodes one request may be sent to.
+        ///
+        /// A request placed on a node that has gone since it was last observed
+        /// is placed again on another node that serves the same model, as long
+        /// as that node was never reached, so it cannot have started the work.
+        /// Set 1 to fail the request instead.
+        #[arg(long, default_value_t = camelid::fabric::DEFAULT_MAX_FORWARD_ATTEMPTS)]
+        max_forward_attempts: usize,
         /// Budget for the generation itself, which can legitimately take
         /// minutes. On a streaming request it bounds the wait for the node's
         /// response head and any later gap in which the node sends nothing;
@@ -2991,6 +2999,7 @@ async fn main() -> anyhow::Result<()> {
                 api_key_file,
                 timeout_ms,
                 observation_max_age_ms,
+                max_forward_attempts,
                 forward_timeout_s,
                 allow_unauthenticated_remote,
             } => {
@@ -3004,7 +3013,8 @@ async fn main() -> anyhow::Result<()> {
                     .with_bearer(bearer.as_deref())
                     .with_max_observation_age(std::time::Duration::from_millis(
                         observation_max_age_ms,
-                    ));
+                    ))
+                    .with_max_forward_attempts(max_forward_attempts);
 
                 // Bind before announcing, so a refused or already-taken address
                 // never prints a listening line it did not earn.

--- a/tests/fabric_end_to_end.rs
+++ b/tests/fabric_end_to_end.rs
@@ -438,7 +438,7 @@ fn dispatch_places_and_sends_in_one_call() {
     let beta = StubNode::start(StubConfig::ready("model-beta", 0));
     let fabric = fabric_of(vec![alpha.spec("alpha"), beta.spec("beta")]);
 
-    let (decision, answer) = fabric
+    let dispatched = fabric
         .dispatch(
             "/v1/chat/completions",
             &forward::chat_request("model-beta", "ping", 8),
@@ -447,10 +447,14 @@ fn dispatch_places_and_sends_in_one_call() {
         )
         .expect("beta serves model-beta");
 
-    assert_eq!(decision.label, "beta");
-    assert_eq!(answer.label, "beta");
+    assert_eq!(dispatched.decision.label, "beta");
+    assert_eq!(dispatched.answer.label, "beta");
     assert_eq!(
-        forward::completion_text(&answer.body),
+        dispatched.attempts, 1,
+        "a node that answers first time is one attempt"
+    );
+    assert_eq!(
+        forward::completion_text(&dispatched.answer.body),
         Some("served by model-beta")
     );
     // The request must not have touched the node that does not hold the model.
@@ -487,7 +491,7 @@ fn a_fabric_carrying_the_key_is_served_by_an_authenticated_node() {
     let alpha = StubNode::start(StubConfig::requiring_key("model-alpha", "s3cret"));
     let fabric = fabric_of(vec![alpha.spec("alpha")]).with_bearer(Some("s3cret"));
 
-    let (decision, answer) = fabric
+    let dispatched = fabric
         .dispatch(
             "/v1/chat/completions",
             &forward::chat_request("model-alpha", "ping", 8),
@@ -496,10 +500,10 @@ fn a_fabric_carrying_the_key_is_served_by_an_authenticated_node() {
         )
         .expect("the node accepts our key");
 
-    assert_eq!(decision.label, "alpha");
-    assert_eq!(answer.status, 200);
+    assert_eq!(dispatched.decision.label, "alpha");
+    assert_eq!(dispatched.answer.status, 200);
     assert_eq!(
-        forward::completion_text(&answer.body),
+        forward::completion_text(&dispatched.answer.body),
         Some("served by model-alpha")
     );
 
@@ -556,6 +560,7 @@ fn a_missing_or_wrong_key_arrives_as_a_401_answer_not_a_transport_failure() {
                 &RouteRequest::new(RouteMode::Throughput),
                 FORWARD_TIMEOUT,
             )
+            .map(|dispatched| (dispatched.decision, dispatched.answer))
             .expect("a 401 is the node's answer, not a forwarding failure");
 
         assert_eq!(answer.status, 401);

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use camelid::fabric::server::{serve_on, ClientAuth, ServeConfig};
-use camelid::fabric::{Fabric, NodeSpec, RouteMode};
+use camelid::fabric::{Fabric, NodeSpec, RouteMode, ENGINE_QUEUE_FULL_CODE};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const FORWARD_TIMEOUT: Duration = Duration::from_secs(5);
@@ -98,6 +98,30 @@ impl StubConfig {
         Self {
             completion_delay: delay,
             live_in_flight: Some(Arc::new(AtomicUsize::new(0))),
+            ..Self::ready(model, 0)
+        }
+    }
+
+    /// A node answering exactly what a real engine answers once its bounded
+    /// queue turns a request away: the typed code, the `runtime_unavailable`
+    /// envelope a 503 carries, and the message naming the bound.
+    fn queue_full(model: &str) -> Self {
+        Self::refusing_with(
+            model,
+            ENGINE_QUEUE_FULL_CODE,
+            "the generation queue is full; retry shortly (depth is bounded by CAMELID_QUEUE_DEPTH)",
+        )
+    }
+
+    /// A node refusing with a 503 that is *not* backpressure. A node with no
+    /// model loaded answers one of these, and sending that request on would
+    /// spend another node's time reaching the same refusal.
+    fn refusing_with(model: &str, code: &str, message: &str) -> Self {
+        Self {
+            completion_status: 503,
+            completion: format!(
+                r#"{{"error":{{"message":"{message}","type":"runtime_unavailable","code":"{code}"}}}}"#
+            ),
             ..Self::ready(model, 0)
         }
     }
@@ -1710,5 +1734,142 @@ async fn the_failure_that_ended_the_request_is_the_one_reported() {
         !message.contains("node-a"),
         "node-a was routed around successfully; naming it points at the wrong \
          node: {message}"
+    );
+}
+
+/// A node at its queue bound rejected the request rather than running it, so
+/// another node can still take it. Until now the client got that 503 while a
+/// sibling sat idle — one busy node undoing the reason the fabric exists.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_saturated_node_hands_the_request_to_one_that_is_not() {
+    let nodes = vec![
+        StubNode::start(StubConfig::queue_full("shared-model")),
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+    ];
+    // `a-full` sorts first, so deterministic placement reaches it first.
+    let specs = vec![nodes[0].spec("a-full"), nodes[1].spec("b-ready")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+
+    let (status, body, headers) =
+        post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
+
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("b-ready"));
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("2"));
+    assert_eq!(
+        completions_served(&nodes),
+        vec![1, 1],
+        "the full node was asked once, then the ready one"
+    );
+}
+
+/// Every node full is a real answer, not a proxy failure. The client gets a
+/// node's own refusal, with the code and message it sent, rather than
+/// something this proxy invented on its behalf.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_fabric_that_is_entirely_saturated_returns_a_node_s_own_refusal() {
+    let nodes = vec![
+        StubNode::start(StubConfig::queue_full("shared-model")),
+        StubNode::start(StubConfig::queue_full("shared-model")),
+    ];
+    let specs = vec![nodes[0].spec("a-full"), nodes[1].spec("b-full")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+
+    let (status, body, headers) =
+        post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
+
+    assert_eq!(status, 503);
+    assert_eq!(body["error"]["code"], ENGINE_QUEUE_FULL_CODE);
+    assert_ne!(
+        body["error"]["type"], "fabric_error",
+        "a node answered, so the node's answer is what stands: {body}"
+    );
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("2"));
+    assert_eq!(completions_served(&nodes), vec![1, 1]);
+}
+
+/// The switch that turns off failover turns this off too: one attempt means
+/// the first node's answer is the answer.
+#[tokio::test(flavor = "multi_thread")]
+async fn one_attempt_returns_the_refusal_without_asking_another_node() {
+    let nodes = vec![
+        StubNode::start(StubConfig::queue_full("shared-model")),
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+    ];
+    let specs = vec![nodes[0].spec("a-full"), nodes[1].spec("b-ready")];
+    let addr = start_proxy(fabric_with_attempts(specs, 1), RouteMode::Throughput).await;
+
+    let (status, body, headers) =
+        post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
+
+    assert_eq!(status, 503, "{body}");
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("1"));
+    assert_eq!(
+        completions_served(&nodes),
+        vec![1, 0],
+        "the ready node must not be asked when failover is off"
+    );
+}
+
+/// Only backpressure is re-placed. A node refusing for any other reason has
+/// answered the request; asking a second node would spend its time reaching
+/// the same refusal, and turn one node's 503 into two.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_refusal_that_is_not_backpressure_is_relayed_untouched() {
+    let nodes = vec![
+        StubNode::start(StubConfig::refusing_with(
+            "shared-model",
+            "model_unavailable",
+            "no model is loaded",
+        )),
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+    ];
+    let specs = vec![nodes[0].spec("a-refusing"), nodes[1].spec("b-ready")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+
+    let (status, body, headers) =
+        post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
+
+    assert_eq!(status, 503);
+    assert_eq!(body["error"]["message"], "no model is loaded");
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("1"));
+    assert_eq!(
+        completions_served(&nodes),
+        vec![1, 0],
+        "a refusal that is not backpressure must not be sent on"
+    );
+}
+
+/// A streaming request gets the same treatment, because the refusal arrives
+/// buffered — before one event has been relayed, so nothing has been said.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_saturated_node_hands_a_streaming_request_on_as_well() {
+    let events = [
+        "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}",
+        "data: [DONE]",
+    ];
+    let nodes = [
+        StubNode::start(StubConfig::queue_full("shared-model")),
+        StubNode::start(StubConfig::streaming(
+            "shared-model",
+            &events,
+            Duration::ZERO,
+        )),
+    ];
+    let specs = vec![nodes[0].spec("a-full"), nodes[1].spec("b-ready")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+
+    let (status, headers, pieces) = post_chat_streaming(
+        addr,
+        &serde_json::json!({ "model": "shared-model", "stream": true }),
+    )
+    .await;
+
+    assert_eq!(status, 200);
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("b-ready"));
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("2"));
+    assert!(
+        !pieces.is_empty(),
+        "the replacement node's events must arrive"
     );
 }

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -1788,6 +1788,29 @@ async fn a_fabric_that_is_entirely_saturated_returns_a_node_s_own_refusal() {
     assert_eq!(completions_served(&nodes), vec![1, 1]);
 }
 
+/// The count of nodes asked has to be the count of nodes asked. With one node
+/// and a budget of two, placement runs out before a second node is reached, so
+/// reporting the budget sends an operator looking for a node that was never
+/// contacted.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_lone_saturated_node_is_one_attempt_not_two() {
+    let nodes = vec![StubNode::start(StubConfig::queue_full("shared-model"))];
+    let specs = vec![nodes[0].spec("a-full")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+
+    let (status, body, headers) =
+        post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
+
+    assert_eq!(status, 503, "{body}");
+    assert_eq!(body["error"]["code"], ENGINE_QUEUE_FULL_CODE);
+    assert_eq!(completions_served(&nodes), vec![1]);
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-attempts"),
+        Some("1"),
+        "one node was asked, so the answer must not claim two"
+    );
+}
+
 /// The switch that turns off failover turns this off too: one attempt means
 /// the first node's answer is the answer.
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -1671,3 +1671,44 @@ async fn a_node_dying_mid_stream_is_not_replayed_on_another_node() {
          been given part of the first node's answer"
     );
 }
+
+/// Failing over past a gone node is a recovery, not the reason a request ends.
+/// When the node it moves on to fails it for real, that second failure is what
+/// the operator has to act on: reporting the first sends them to a node the
+/// fabric already routed around, and says nothing about the one that is
+/// actually broken.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_failure_that_ended_the_request_is_the_one_reported() {
+    let a = StubNode::start(StubConfig::ready("shared-model", 0));
+    // `node-b` is reachable and answers, but with a body that is not JSON, so
+    // it fails the request in a way failover must not move past.
+    let b = StubNode::start(StubConfig {
+        completion: "<html>gateway timeout</html>".to_string(),
+        ..StubConfig::ready("shared-model", 0)
+    });
+    let specs = vec![a.spec("node-a"), b.spec("node-b")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+    let body = serde_json::json!({ "model": "shared-model" });
+
+    let (status, _, headers) = post_chat(addr, &body, &[]).await;
+    assert_eq!(status, 200);
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("node-a"));
+
+    let mut a = a;
+    a.stop_listening();
+
+    let (status, refusal, _) = post_chat(addr, &body, &[]).await;
+    assert_eq!(status, 502);
+    let message = refusal["error"]["message"]
+        .as_str()
+        .expect("a message an operator can act on");
+    assert!(
+        message.contains("node-b"),
+        "the node that actually failed the request must be named: {message}"
+    );
+    assert!(
+        !message.contains("node-a"),
+        "node-a was routed around successfully; naming it points at the wrong \
+         node: {message}"
+    );
+}

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -43,6 +43,9 @@ struct StubConfig {
     /// carries exactly this bearer token — the arrangement a node started with
     /// `CAMELID_API_KEY` actually presents to the proxy.
     required_key: Option<String>,
+    /// Hang up on `/v1/chat/completions` after reading the request instead of
+    /// answering it. The node has the request, so nothing may re-send it.
+    hangs_up_on_completion: bool,
     /// Server-sent events answered to a request carrying `"stream": true`,
     /// instead of one JSON body.
     stream_events: Vec<String>,
@@ -79,6 +82,7 @@ impl StubConfig {
             completion_status: 200,
             completion_delay: Duration::ZERO,
             required_key: None,
+            hangs_up_on_completion: false,
             stream_events: Vec::new(),
             stream_gap: Duration::ZERO,
             stream_truncated: false,
@@ -147,6 +151,15 @@ impl StubConfig {
             ..Self::ready(model, 0)
         }
     }
+
+    /// A node that takes the request and then dies without answering, which is
+    /// what a node crashing mid-generation leaves on the wire.
+    fn hanging_up_on_completion(model: &str) -> Self {
+        Self {
+            hangs_up_on_completion: true,
+            ..Self::ready(model, 0)
+        }
+    }
 }
 
 /// A stand-in Camelid node on loopback, identical in shape to the one in
@@ -202,15 +215,23 @@ impl StubNode {
     fn received(&self) -> Vec<Received> {
         self.requests.lock().expect("stub lock").clone()
     }
-}
 
-impl Drop for StubNode {
-    fn drop(&mut self) {
+    /// Stop accepting, releasing the port so it refuses connections the way a
+    /// machine that has gone does. What it already recorded stays readable.
+    fn stop_listening(&mut self) {
         self.shutdown.store(true, Ordering::SeqCst);
+        // Unblocks the accept loop so it observes the flag and drops the
+        // listener; the connection itself is never served.
         let _ = TcpStream::connect(("127.0.0.1", self.port));
         if let Some(thread) = self.thread.take() {
             let _ = thread.join();
         }
+    }
+}
+
+impl Drop for StubNode {
+    fn drop(&mut self) {
+        self.stop_listening();
     }
 }
 
@@ -237,6 +258,13 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
     if authorized && asked_to_stream && !config.stream_events.is_empty() {
         requests.lock().expect("stub lock").push(received);
         serve_event_stream(stream, config);
+        return;
+    }
+
+    if authorized && config.hangs_up_on_completion && received.path == "/v1/chat/completions" {
+        // Recorded first: the point of this stub is that the node did get the
+        // request, whatever the caller ends up seeing.
+        requests.lock().expect("stub lock").push(received);
         return;
     }
 
@@ -1367,4 +1395,279 @@ async fn a_model_loaded_since_the_observation_is_not_refused_as_permanently_abse
         "a permanent refusal was settled from a stale observation: {body}"
     );
     assert_eq!(status, 200, "{body}");
+}
+
+// ---------------------------------------------------------------------------
+// Failing over to another node
+//
+// A node can go between being observed and being sent to. Placement then names
+// a machine that is not there, and without failover the request dies against it
+// even when a sibling is serving the same model. These tests are built on a
+// reused observation because that is the arrangement `fabric serve` runs in,
+// and the window where the fabric's view can be wrong by construction.
+// ---------------------------------------------------------------------------
+
+/// A fabric as `fabric serve` builds one, with an explicit attempt budget so a
+/// test can turn failover off without changing anything else.
+fn fabric_with_attempts(specs: Vec<NodeSpec>, attempts: usize) -> Fabric {
+    fabric_reusing_observations(specs, Duration::from_secs(30)).with_max_forward_attempts(attempts)
+}
+
+/// Two nodes, both serving the model, and a proxy holding one observation of
+/// them. `node-a` wins the label tie-break, so it is where the next request
+/// goes; stopping it is what makes that observation wrong.
+async fn two_nodes_one_of_which_will_vanish(
+    attempts: usize,
+) -> (StubNode, StubNode, SocketAddr, Value) {
+    let a = StubNode::start(StubConfig::ready("shared-model", 0));
+    let b = StubNode::start(StubConfig::ready("shared-model", 0));
+    let specs = vec![a.spec("node-a"), b.spec("node-b")];
+    let addr = start_proxy(fabric_with_attempts(specs, attempts), RouteMode::Throughput).await;
+    let body = serde_json::json!({ "model": "shared-model" });
+
+    let (status, _, headers) = post_chat(addr, &body, &[]).await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-node"),
+        Some("node-a"),
+        "the tie-break must settle on node-a, or stopping it proves nothing"
+    );
+    (a, b, addr, body)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_vanished_node_does_not_fail_a_request_another_node_can_serve() {
+    let (mut a, _b, addr, body) = two_nodes_one_of_which_will_vanish(2).await;
+    let before = completions_served(std::slice::from_ref(&a))[0];
+    a.stop_listening();
+
+    let (status, answer, headers) = post_chat(addr, &body, &[]).await;
+    assert_eq!(status, 200, "a sibling serves the same model: {answer}");
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-node"),
+        Some("node-b"),
+        "the answer must come from the node that is still there"
+    );
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-attempts"),
+        Some("2"),
+        "a failover must be visible to the client that was served by one"
+    );
+    assert_eq!(
+        completions_served(std::slice::from_ref(&a))[0],
+        before,
+        "the vanished node must not have been sent the request twice"
+    );
+}
+
+/// The ablation, run as a test: the same fabric with the budget at one is the
+/// behaviour this change replaces, and it fails the request.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_budget_of_one_fails_the_request_the_way_it_did_before() {
+    let (mut a, b, addr, body) = two_nodes_one_of_which_will_vanish(1).await;
+    a.stop_listening();
+
+    let (status, refusal, _) = post_chat(addr, &body, &[]).await;
+    assert_eq!(status, 502, "{refusal}");
+    assert_eq!(
+        completions_served(std::slice::from_ref(&b))[0],
+        0,
+        "with failover off the sibling must never be asked"
+    );
+}
+
+/// The line the whole design rests on. This node reads the request and then
+/// hangs up, so it may already be generating; that is a different failure from
+/// never having been reached, and it must not be sent anywhere else.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_node_that_took_the_request_is_not_asked_to_run_it_again_elsewhere() {
+    let a = StubNode::start(StubConfig::hanging_up_on_completion("shared-model"));
+    let b = StubNode::start(StubConfig::ready("shared-model", 0));
+    let specs = vec![a.spec("node-a"), b.spec("node-b")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+
+    let (status, refusal, headers) =
+        post_chat(addr, &serde_json::json!({ "model": "shared-model" }), &[]).await;
+
+    assert_eq!(status, 502, "{refusal}");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), None);
+    assert_eq!(
+        completions_served(std::slice::from_ref(&a))[0],
+        1,
+        "the node did receive the request, which is why it may not be re-sent"
+    );
+    assert_eq!(
+        completions_served(std::slice::from_ref(&b))[0],
+        0,
+        "a request that may already be running was sent to a second node"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn failover_stops_at_the_attempt_budget_rather_than_walking_the_fabric() {
+    let labels = ["node-a", "node-b", "node-c"];
+    let mut nodes: Vec<StubNode> = labels
+        .iter()
+        .map(|_| StubNode::start(StubConfig::ready("shared-model", 0)))
+        .collect();
+    let specs: Vec<NodeSpec> = nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| node.spec(labels[index]))
+        .collect();
+
+    // Both proxies take their observation while all three nodes are up, so the
+    // only difference between them is the budget.
+    let bounded = start_proxy(
+        fabric_with_attempts(specs.clone(), 2),
+        RouteMode::Throughput,
+    )
+    .await;
+    let generous = start_proxy(fabric_with_attempts(specs, 3), RouteMode::Throughput).await;
+    let body = serde_json::json!({ "model": "shared-model" });
+    for proxy in [bounded, generous] {
+        let (status, _, headers) = post_chat(proxy, &body, &[]).await;
+        assert_eq!(status, 200);
+        assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("node-a"));
+    }
+
+    // Two of the three go, leaving a node that only a third attempt reaches.
+    nodes[0].stop_listening();
+    nodes[1].stop_listening();
+    let served_by_c = completions_served(&nodes[2..])[0];
+
+    let (status, refusal, _) = post_chat(bounded, &body, &[]).await;
+    assert_eq!(
+        status, 502,
+        "two attempts must not silently become three: {refusal}"
+    );
+    assert_eq!(
+        completions_served(&nodes[2..])[0],
+        served_by_c,
+        "the third node is beyond the budget and must not have been asked"
+    );
+
+    // The positive control: the same situation with room for a third attempt
+    // does reach it, so the refusal above is the budget and not the exclusion.
+    let (status, answer, headers) = post_chat(generous, &body, &[]).await;
+    assert_eq!(status, 200, "{answer}");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("node-c"));
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("3"));
+}
+
+/// A failover proves the observation is wrong, so it must not survive the
+/// request that discovered it — even though that request succeeded. Otherwise
+/// every request in the rest of the window pays the same dial to the same
+/// absent node before being served.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_served_failover_still_drops_the_observation_that_named_the_vanished_node() {
+    let (mut a, b, addr, body) = two_nodes_one_of_which_will_vanish(2).await;
+    a.stop_listening();
+
+    let (status, _, headers) = post_chat(addr, &body, &[]).await;
+    assert_eq!(status, 200);
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("2"));
+
+    let probes_before = completions_served(std::slice::from_ref(&b))[0];
+    let (status, _, headers) = post_chat(addr, &body, &[]).await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-attempts"),
+        Some("1"),
+        "the next request must be placed from a fresh observation, which no \
+         longer names the node that is gone"
+    );
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-node"),
+        Some("node-b"),
+        "and it must go straight to the node that is there"
+    );
+    assert_eq!(
+        completions_served(std::slice::from_ref(&b))[0],
+        probes_before + 1
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_vanished_node_does_not_fail_a_streaming_request() {
+    let events = ["data: one\n\n", "data: [DONE]\n\n"];
+    let mut a = StubNode::start(StubConfig::streaming(
+        "shared-model",
+        &events,
+        Duration::ZERO,
+    ));
+    let b = StubNode::start(StubConfig::streaming(
+        "shared-model",
+        &events,
+        Duration::ZERO,
+    ));
+    let specs = vec![a.spec("node-a"), b.spec("node-b")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+    let body = serde_json::json!({ "model": "shared-model", "stream": true });
+
+    let (status, headers, _) = post_chat_streaming(addr, &body).await;
+    assert_eq!(status, 200);
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("node-a"));
+
+    a.stop_listening();
+
+    let (status, headers, pieces) = post_chat_streaming(addr, &body).await;
+    assert_eq!(status, 200, "the sibling can still stream");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("node-b"));
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("2"));
+    let framed: String = pieces.iter().map(|piece| piece.text.as_str()).collect();
+    assert_eq!(
+        dechunk(&framed),
+        events.concat(),
+        "the failover must relay the sibling's stream verbatim"
+    );
+}
+
+/// The streaming half of the safety rule. Once the head is relayed the client
+/// has been committed to one node's answer, so a node that dies part-way
+/// through must end that stream rather than start a second one somewhere else.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_node_dying_mid_stream_is_not_replayed_on_another_node() {
+    // Two events with a gap, exactly as `a_node_dying_mid_stream_is_not_relayed
+    // _as_a_completed_one` uses: it is what makes the proxy flush the head and
+    // the first event before the node dies, so the client really is committed
+    // to node-a's answer by the time it fails.
+    let gap = Duration::from_millis(150);
+    let a = StubNode::start(StubConfig::dying_mid_stream(
+        "shared-model",
+        &["data: one\n\n", "data: two\n\n"],
+        gap,
+    ));
+    let b = StubNode::start(StubConfig::streaming(
+        "shared-model",
+        &["data: elsewhere\n\n"],
+        gap,
+    ));
+    let specs = vec![a.spec("node-a"), b.spec("node-b")];
+    let addr = start_proxy(fabric_with_attempts(specs, 2), RouteMode::Throughput).await;
+
+    let (status, headers, pieces) = post_chat_streaming(
+        addr,
+        &serde_json::json!({ "model": "shared-model", "stream": true }),
+    )
+    .await;
+
+    assert_eq!(status, 200, "the head arrived before the node died");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("node-a"));
+    assert_eq!(header(&headers, "x-camelid-fabric-attempts"), Some("1"));
+    let framed: String = pieces.iter().map(|piece| piece.text.as_str()).collect();
+    assert!(
+        dechunk(&framed).starts_with("data: one\n\n"),
+        "what the node did produce must still arrive: {framed:?}"
+    );
+    assert!(
+        !framed.ends_with("0\r\n\r\n"),
+        "a truncated stream must not be framed as complete: {framed:?}"
+    );
+    assert_eq!(
+        completions_served(std::slice::from_ref(&b))[0],
+        0,
+        "the request was replayed on a second node after the client had already \
+         been given part of the first node's answer"
+    );
 }


### PR DESCRIPTION
> Stacked on #662 — it owns the retry machinery this extends (`place_excluding`,
> `--max-forward-attempts`, `node_never_received_it`). The diff below carries #662's commit;
> its own change is 3 files, +352/-6.

## The defect

A node at its queue bound rejects a request instead of running it, and answers a typed 503. The
proxy relayed that to the client verbatim — **with a sibling sitting idle**. One busy node
refused work the fabric could plainly have done, which is the opposite of the reason it exists.

Measured against two real engines, one with `CAMELID_QUEUE_DEPTH=1`, eight requests in flight:

| through the proxy | 200 | 503 |
|---|---|---|
| before (`--max-forward-attempts 1`) | 8 | **8** |

Eight of sixteen clients refused while the other node was free.

## Why it is safe to send it somewhere else

#662 established the rule: `ForwardError::node_never_received_it` is true only when nothing was
written to the node, so it cannot have started the work, so another node can be asked.

A queue-full refusal is the same fact arriving by a different route. The node read the request and
turned it away **at the queue boundary** without running it — `crate::api` documents it as "the
bounded queue rejected the job". The work has not happened either way.

It just does not arrive as an error. A node that answers 503 has *answered*, so it comes back as a
successful forward and #662's retry loop never looked at it. `NodeAnswer::refused_for_backpressure`
is the question it now asks. Both dispatch paths go through the same loop, so buffered and
streaming are covered together — and a streaming request qualifies only while the refusal is still
buffered, because once the node is streaming it has started generating and the head is already on
its way to the client.

**Only backpressure is re-placed.** A node refusing for any other reason has answered the request;
sending it on would spend a second node's time reaching the same refusal and turn one node's 503
into two. That is why the *typed code* decides, not the status — a node with no model loaded
answers 503 too.

**Saturated nodes are tracked apart from ones found gone**, because only one of those says the
observation was wrong. A full node is exactly where the observation said it was, so this
deliberately does **not** drop the observation: doing so would re-probe the whole fabric once per
request for as long as it stayed busy, which is the cost #656's freshness bound exists to remove.

**If nowhere else can take it**, the node's own refusal is returned rather than one this proxy
invented — the client is owed the real answer, including its `Retry-After` and the code that
explains it.

## Live receipt: two real machines, real engines

Windows node + Apple M5 Pro across Wi-Fi, the Mac started with `CAMELID_QUEUE_DEPTH=1`.

**A. What a real engine actually answers past its bound** (straight at the Mac, no proxy) — 16
requests, 8 in flight: 3×200, 13×503, and the body is:

```json
{"error":{"message":"the generation queue is full; retry shortly (depth is bounded by CAMELID_QUEUE_DEPTH)",
          "type":"runtime_unavailable","code":"engine_queue_full","param":null}}
```

**B and C — same load, same fabric, one flag:**

| | 200 | 503 | placed on | attempts |
|---|---|---|---|---|
| `--max-forward-attempts 1` | 8 | **8** | mac 12 / win 4 | all 1 |
| `--max-forward-attempts 2` | **16** | **0** | mac 9 / win 7 | 13×1, **3×2** |

Three requests were refused by the saturated Mac and served by Windows instead. The existing kill
switch turns it off.

Section A is also the only thing that can check `ENGINE_QUEUE_FULL_CODE`. The constant is
duplicated rather than shared, because `src/api/mod.rs` is byte-pinned by the model-qualification
provenance check and one constant is not worth reopening it — so no test in this crate can catch
drift, since it would only be comparing the literal with itself. The doc comment says so plainly.

## Tests

5 unit + 5 integration, including the negative controls: a 503 that is *not* backpressure is
relayed untouched and the second node is never asked; a body with no `error` object is not
backpressure; a 200 never is whatever it contains.

| ablation | result |
|---|---|
| `refused_for_backpressure` always false (feature off) | **exactly 5** fail — 2 unit + 3 integration; both negative controls still pass |
| fire on any 503, ignoring the code | **exactly 3** fail — `another_kind_of_503_is_not_backpressure`, `a_body_without_an_error_is_not_backpressure`, `a_refusal_that_is_not_backpressure_is_relayed_untouched` |

The second is the one worth reading: it is what stops this from amplifying every node refusal into
two.

## Gates

`fmt --check` 0 · `clippy --all-targets -D warnings` **0** · `--lib fabric::` **132** (127 + 5) ·
`--test fabric_serve` **38** (33 + 5) · `--test fabric_end_to_end` 14 · `--bin camelid` 40 ·
`check-public-scrub.sh` 0 · `git diff --check` 0 · all three files `i/lf w/lf`.

## Limits

* Re-placement costs the client the time already spent on the refusal. That is cheap here because
  a queue-full refusal is immediate, but it is not free.
* The proxy still cannot know a node is full *before* placing on it — `/v1/health` publishes load
  but never the bound, so this is feedback after the fact rather than avoidance. Publishing the
  bound would need the engine's health payload to change, which is a separate and much more
  invasive change.
* A fabric that is uniformly saturated does strictly more work than before: every request now
  tries `--max-forward-attempts` nodes before returning the refusal.
* The typed code is duplicated from `crate::api`; see above.
