### PR TITLE
feat(fabric): make the proxy safe to restart and its log traceable

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -47,7 +47,8 @@
 //! A `session_start` with no matching `session_exit` means the process did not
 //! leave through that path. Be precise about what that does and does not say:
 //! `camelid serve` installs no signal handler (there is no `ctrl_c` or
-//! `with_graceful_shutdown` anywhere in the engine), so an ordinary Ctrl-C ends
+//! `with_graceful_shutdown` in its path — `fabric serve` has one, but that is a
+//! different command in a different process), so an ordinary Ctrl-C ends
 //! the process exactly as abruptly as an out-of-memory kill, and the two are
 //! recorded identically — which is to say, not at all. Read a missing exit
 //! record as "did not fail on the way out", never as evidence of a kill.

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -36,7 +36,13 @@
 //! * Every request is recorded through `tracing` at INFO, and a failure at
 //!   WARN, which means nothing is written unless `RUST_LOG` asks for it — the
 //!   same as the rest of this binary. `RUST_LOG=camelid=info` is the whole
-//!   access log; `RUST_LOG=camelid=warn` narrows it to what failed.
+//!   access log; `RUST_LOG=camelid=warn` narrows it to what failed. Each line
+//!   carries the client it came from and an `x-request-id`, which is also
+//!   answered to the client — the node does not log that id, so it correlates
+//!   a complaint with this proxy's line, not with the node's own.
+//! * A stop (Ctrl-C, or SIGTERM where there is one) closes the listener and
+//!   lets the requests already in flight finish, bounded by `forward_timeout`.
+//!   A kill still drops them: this covers being asked to stop, not being shot.
 //! * A node that becomes ready, or loads a different model, is routed to only
 //!   once the current observation expires. A node that *stops* answering is not
 //!   waited on: the request that finds it gone is placed on another node
@@ -57,7 +63,7 @@ use std::time::{Duration, Instant};
 
 use axum::body::Body;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{DefaultBodyLimit, Request, State};
+use axum::extract::{ConnectInfo, DefaultBodyLimit, Request, State};
 use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::Next;
@@ -72,6 +78,12 @@ use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
 
 /// Optional header a client sends to request affinity to a specific node.
 const STICKY_HEADER: &str = "x-camelid-fabric-sticky";
+
+/// The header a request id arrives on, and is answered with.
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+/// Longest inbound request id this proxy will adopt as its own.
+const MAX_REQUEST_ID_LEN: usize = 128;
 
 /// The credential a client must present to this proxy.
 ///
@@ -192,9 +204,15 @@ pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
 async fn access_log(request: Request, next: Next) -> Response {
     let method = request.method().clone();
     let path = request.uri().path().to_string();
+    let client = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(peer)| peer.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let request_id = correlation_id(request.headers());
     let started = Instant::now();
 
-    let response = next.run(request).await;
+    let mut response = next.run(request).await;
 
     let elapsed_ms = started.elapsed().as_millis() as u64;
     let status = response.status();
@@ -209,6 +227,8 @@ async fn access_log(request: Request, next: Next) -> Response {
             node,
             reason,
             elapsed_ms,
+            client,
+            request_id,
             "fabric request failed"
         );
     } else {
@@ -219,11 +239,46 @@ async fn access_log(request: Request, next: Next) -> Response {
             node,
             reason,
             elapsed_ms,
+            client,
+            request_id,
             "fabric request"
         );
     }
 
+    // Returned so a client that reports a slow or failed call can name the line
+    // that recorded it, without an operator having to guess from a timestamp.
+    insert(response.headers_mut(), REQUEST_ID_HEADER, &request_id);
     response
+}
+
+/// The id this request is known by, in the log and in the client's answer.
+///
+/// An inbound id is honoured so one assigned upstream survives the hop — but
+/// only after it is checked, because it is written into a log line a client
+/// does not otherwise control. HTTP framing rejects a raw CR or LF before this
+/// sees it, so the reachable problems are the quieter ones: a tab or DEL that
+/// makes a line hard to parse, and a length nothing bounds.
+///
+/// Anything that fails the check gets a fresh id rather than a cleaned-up one.
+/// A sanitised id is no longer the caller's id, so it would correlate with
+/// nothing while still looking as though it did.
+fn correlation_id(headers: &HeaderMap) -> String {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| is_usable_request_id(value))
+        .map(str::to_string)
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+}
+
+/// Pure: non-empty, printable, and short enough to belong in a log line.
+///
+/// `is_ascii_graphic` excludes space and every control character, so a value
+/// that passes cannot break the line it is written on.
+fn is_usable_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_REQUEST_ID_LEN
+        && value.bytes().all(|byte| byte.is_ascii_graphic())
 }
 
 /// One of this proxy's own response headers, or `-` when the answer never got
@@ -273,16 +328,100 @@ fn refuse_unauthenticated_remote(
     ))
 }
 
-/// Serve on an already-bound listener.
+/// Serve on an already-bound listener, until the operator asks it to stop.
 ///
 /// Split from [`bind`] so a caller can read back the real port — which matters
 /// when it asked for port 0 — before it starts serving.
+///
+/// A stop is not a kill. The listener closes so no new request is accepted,
+/// and the ones already in flight are given until `forward_timeout` to finish,
+/// because that is already this proxy's answer to "how long may a request
+/// legitimately take".
+///
+/// That bound is a backstop, and it is worth knowing which requests it is for.
+/// A buffered request cannot outlive it — the same value bounds the forward, so
+/// the request ends first either way. A *stream* can: its idle timeout resets
+/// with every event, so a client reading slowly could otherwise hold the
+/// process open for as long as it kept reading. An orchestrator's own grace
+/// period is usually shorter than either and simply wins.
 pub async fn serve_on(
     listener: tokio::net::TcpListener,
     fabric: Fabric,
     config: ServeConfig,
 ) -> std::io::Result<()> {
-    axum::serve(listener, router(fabric, config)).await
+    serve_on_until(listener, fabric, config, stop_requested()).await
+}
+
+/// [`serve_on`], with the stop supplied rather than taken from the OS.
+///
+/// The signal itself cannot be exercised by a test — a test that raised
+/// SIGTERM would stop the test runner — so what a stop *does* is separated
+/// here from what asks for one. Everything below this line is covered; only
+/// [`stop_requested`] is not, and it is the part with no logic in it.
+pub async fn serve_on_until(
+    listener: tokio::net::TcpListener,
+    fabric: Fabric,
+    config: ServeConfig,
+    stop: impl std::future::Future<Output = ()> + Send + 'static,
+) -> std::io::Result<()> {
+    let drain = config.forward_timeout;
+    // The peer address is only available to a service built this way, and the
+    // access log is the only thing that reads it.
+    let service = router(fabric, config).into_make_service_with_connect_info::<SocketAddr>();
+
+    let (draining, drain_started) = tokio::sync::oneshot::channel();
+    let serving = axum::serve(listener, service).with_graceful_shutdown(async move {
+        stop.await;
+        tracing::info!("stopping: no longer accepting requests, finishing the ones in flight");
+        let _ = draining.send(());
+    });
+
+    tokio::select! {
+        served = serving => served,
+        // The clock starts when the stop is asked for, not when serving began.
+        () = async move {
+            let _ = drain_started.await;
+            tokio::time::sleep(drain).await;
+        } => {
+            tracing::warn!(
+                drain_seconds = drain.as_secs(),
+                "in-flight requests did not finish in time; stopping without them"
+            );
+            Ok(())
+        }
+    }
+}
+
+/// Resolves when the operator asks this process to stop.
+///
+/// Ctrl-C is the interactive stop. SIGTERM is what an orchestrator sends first,
+/// and it is the one that matters for a proxy holding other people's in-flight
+/// requests: without a handler it is an immediate kill, and every request being
+/// served at that moment dies with it. Windows has no SIGTERM, and there
+/// `ctrl_c` also covers the console being closed.
+async fn stop_requested() {
+    let interrupt = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut signal) => {
+                signal.recv().await;
+            }
+            // Nothing to wait for, but Ctrl-C must still work, so this arm just
+            // never completes rather than resolving and stopping the server.
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = interrupt => {}
+        () = terminate => {}
+    }
 }
 
 /// List every model the fabric can currently route to.
@@ -752,6 +891,22 @@ mod tests {
         app: Router,
         request: axum::http::Request<axum::body::Body>,
     ) -> String {
+        logged_answer_at(level, app, request).await.0
+    }
+
+    /// The log and the answer together, for the fields that appear in both.
+    async fn logged_answer(
+        app: Router,
+        request: axum::http::Request<axum::body::Body>,
+    ) -> (String, Response) {
+        logged_answer_at(tracing::Level::INFO, app, request).await
+    }
+
+    async fn logged_answer_at(
+        level: tracing::Level,
+        app: Router,
+        request: axum::http::Request<axum::body::Body>,
+    ) -> (String, Response) {
         let captured = Captured::default();
         let subscriber = tracing_subscriber::fmt()
             .with_writer(captured.clone())
@@ -759,9 +914,9 @@ mod tests {
             .with_ansi(false)
             .finish();
         let guard = tracing::subscriber::set_default(subscriber);
-        let _ = app.oneshot(request).await.expect("router answers");
+        let response = app.oneshot(request).await.expect("router answers");
         drop(guard);
-        captured.text()
+        (captured.text(), response)
     }
 
     /// A router whose answer carries whatever the fabric would have tagged, so
@@ -909,6 +1064,98 @@ mod tests {
         .await;
         assert!(written.contains("path=/v1/models"), "{written}");
         assert!(!written.contains("s3cret"), "{written}");
+    }
+
+    /// An id assigned upstream has to survive the hop, or the two sides of a
+    /// load balancer describe the same request by different names.
+    #[tokio::test]
+    async fn an_id_the_client_supplied_is_the_one_used() {
+        let mut request = get_request("/v1/models");
+        request
+            .headers_mut()
+            .insert(REQUEST_ID_HEADER, HeaderValue::from_static("abc-123"));
+
+        let (written, response) = logged_answer(proxy(Fabric::new(Vec::new())), request).await;
+        assert!(written.contains("request_id=\"abc-123\""), "{written}");
+        assert_eq!(
+            response.headers().get(REQUEST_ID_HEADER).unwrap(),
+            "abc-123",
+            "the client has to be told which id its request was recorded under"
+        );
+    }
+
+    /// Without one there is nothing to quote in a complaint, so the proxy makes
+    /// one rather than logging a dash.
+    #[tokio::test]
+    async fn a_request_with_no_id_is_given_one() {
+        let (written, response) =
+            logged_answer(proxy(Fabric::new(Vec::new())), get_request("/v1/models")).await;
+        let issued = response
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .expect("an id is always answered")
+            .to_str()
+            .expect("printable");
+        assert!(!issued.is_empty() && issued != "-", "{issued}");
+        assert!(
+            written.contains(issued),
+            "the answer's id must be the logged one: {written}"
+        );
+    }
+
+    /// The id is written into a line the client does not otherwise control, so
+    /// an unusable one is replaced outright — not trimmed into something that
+    /// still looks like the caller's id but no longer is.
+    #[tokio::test]
+    async fn an_unusable_id_is_replaced_rather_than_cleaned_up() {
+        let mut request = get_request("/v1/models");
+        request.headers_mut().insert(
+            REQUEST_ID_HEADER,
+            HeaderValue::from_static("has space and\ttab"),
+        );
+
+        let (written, response) = logged_answer(proxy(Fabric::new(Vec::new())), request).await;
+        assert!(!written.contains("has space"), "{written}");
+        assert!(
+            !written.contains('\t'),
+            "a tab would break the line: {written}"
+        );
+        let issued = response.headers().get(REQUEST_ID_HEADER).expect("an id");
+        assert_ne!(issued, "has space and\ttab");
+    }
+
+    #[test]
+    fn what_counts_as_a_usable_id() {
+        assert!(is_usable_request_id("9f3a-1b2c"));
+        assert!(is_usable_request_id(&"a".repeat(MAX_REQUEST_ID_LEN)));
+
+        assert!(!is_usable_request_id(""), "nothing to correlate on");
+        assert!(!is_usable_request_id(&"a".repeat(MAX_REQUEST_ID_LEN + 1)));
+        assert!(!is_usable_request_id("has space"));
+        assert!(!is_usable_request_id("has\ttab"));
+        assert!(!is_usable_request_id("has\u{7f}del"));
+    }
+
+    /// Who made the request is half of an access log. The service that supplies
+    /// it is only built in [`serve_on_until`], so the middleware has to keep
+    /// working without it — every test that drives the router directly, and
+    /// every one of them would otherwise fail.
+    #[tokio::test]
+    async fn the_client_is_recorded_when_the_service_supplies_one() {
+        let mut request = get_request("/v1/models");
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([192, 0, 2, 10], 51234))));
+
+        let written = logged(proxy(Fabric::new(Vec::new())), request).await;
+        assert!(written.contains("client=\"192.0.2.10:51234\""), "{written}");
+    }
+
+    #[tokio::test]
+    async fn a_request_with_no_client_information_still_records_a_line() {
+        let written = logged(proxy(Fabric::new(Vec::new())), get_request("/v1/models")).await;
+        assert!(written.contains("fabric request"), "{written}");
+        assert!(written.contains("client=\"-\""), "{written}");
     }
 
     /// A client points at one address, so that address has to answer what it

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -8,14 +8,14 @@
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use camelid::fabric::server::{serve_on, ClientAuth, ServeConfig};
+use camelid::fabric::server::{serve_on, serve_on_until, ClientAuth, ServeConfig};
 use camelid::fabric::{Fabric, NodeSpec, RouteMode, ENGINE_QUEUE_FULL_CODE};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -1222,6 +1222,155 @@ async fn discovery_does_not_answer_an_unauthenticated_caller() {
         get_raw(addr, "/v1/models", &[("Authorization", "Bearer s3cret")]).await;
     assert_eq!(served, 200);
     assert!(listing.contains("private-model"), "{listing}");
+}
+
+/// A `tracing` sink a test can read back, so the access log can be asserted as
+/// an operator actually reads it rather than by calling the middleware directly.
+#[derive(Clone)]
+struct AccessLog(Arc<Mutex<Vec<u8>>>);
+
+impl AccessLog {
+    /// The line mentioning `needle`. Every test in this binary shares one sink,
+    /// so a caller has to look for something only it could have sent.
+    fn line_mentioning(&self, needle: &str) -> Option<String> {
+        let captured = self.0.lock().expect("access log");
+        String::from_utf8_lossy(&captured)
+            .lines()
+            .find(|line| line.contains(needle))
+            .map(str::to_string)
+    }
+}
+
+impl Write for AccessLog {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("access log").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Install the capturing subscriber, once: a global default can only be set
+/// once per process, and these tests share one.
+fn access_log() -> AccessLog {
+    static CAPTURED: OnceLock<AccessLog> = OnceLock::new();
+    CAPTURED
+        .get_or_init(|| {
+            let sink = AccessLog(Arc::new(Mutex::new(Vec::new())));
+            let writer = sink.clone();
+            tracing_subscriber::fmt()
+                .with_writer(move || writer.clone())
+                .with_max_level(tracing::Level::INFO)
+                // Both off so the assertions match on the text an operator
+                // greps, not on escape codes or a timestamp.
+                .with_ansi(false)
+                .without_time()
+                .init();
+            sink
+        })
+        .clone()
+}
+
+/// The access log is the only place this proxy says who called and which
+/// request it was. Both are supplied by the serving stack rather than by the
+/// middleware, so neither is proven by calling the middleware directly.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_request_is_logged_with_the_caller_and_the_id_it_was_given() {
+    let recorded = access_log();
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy(fabric_of(vec![node.spec("node-a")]), RouteMode::Throughput).await;
+
+    let mine = "only-this-test-sends-this-id";
+    let body = serde_json::json!({ "model": "shared-model" });
+    let (status, answered, headers) = post_chat(addr, &body, &[("x-request-id", mine)]).await;
+
+    assert_eq!(status, 200, "{answered}");
+    assert_eq!(
+        header(&headers, "x-request-id"),
+        Some(mine),
+        "the id a client sent must come back to it, or it cannot quote it"
+    );
+
+    let line = recorded
+        .line_mentioning(mine)
+        .expect("the request must be logged under the id it was given");
+    assert!(
+        line.contains("127.0.0.1:"),
+        "the line must name the caller, not `-`: {line}"
+    );
+}
+
+/// Being asked to stop is not the same as being killed. A proxy holds other
+/// people's requests, and dropping them on a deploy turns a routine restart
+/// into a client-visible failure.
+///
+/// The load-bearing claim is an *ordering* one: the stop must not complete
+/// until the work in flight has. Asserting only that the request got its answer
+/// would prove nothing here, because a connection axum has already accepted is
+/// served on its own task and finishes either way while this process lives — it
+/// is the caller returning early, and the process exiting under it, that loses
+/// the request. So this measures how long the stop took to report itself done.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_stop_finishes_the_work_in_flight_and_accepts_no_more() {
+    let generating = Duration::from_millis(600);
+    let node = StubNode::start(StubConfig {
+        completion_delay: generating,
+        ..StubConfig::ready("shared-model", 0)
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy");
+    let addr = listener.local_addr().expect("proxy addr");
+    let fabric = fabric_of(vec![node.spec("node-a")]);
+    let config = ServeConfig {
+        mode: RouteMode::Throughput,
+        forward_timeout: FORWARD_TIMEOUT,
+        auth: ClientAuth::none(),
+    };
+
+    let (stop, stop_asked) = tokio::sync::oneshot::channel::<()>();
+    let serving = tokio::spawn(async move {
+        serve_on_until(listener, fabric, config, async move {
+            let _ = stop_asked.await;
+        })
+        .await
+    });
+
+    let body = serde_json::json!({ "model": "shared-model" });
+    let inflight = tokio::spawn(async move { post_chat(addr, &body, &[]).await });
+
+    // Long enough for the request to be on the node, short enough that it is
+    // still there when the stop arrives.
+    let settle = Duration::from_millis(200);
+    tokio::time::sleep(settle).await;
+    let asked_at = Instant::now();
+    let _ = stop.send(());
+
+    serving
+        .await
+        .expect("the server joins")
+        .expect("a stop is not a failure");
+    let took = asked_at.elapsed();
+
+    // The request still had most of its generation left when the stop landed.
+    let still_owed = generating - settle;
+    assert!(
+        took >= still_owed / 2,
+        "the proxy called itself stopped after {took:?}, while it still owed a \
+         request about {still_owed:?} of work"
+    );
+
+    let (status, answered, _) = inflight.await.expect("the in-flight request joins");
+    assert_eq!(
+        status, 200,
+        "a request already on a node must be finished, not dropped: {answered}"
+    );
+    assert!(
+        tokio::net::TcpStream::connect(addr).await.is_err(),
+        "a stopped proxy must not still be taking work"
+    );
 }
 
 /// A proxy started without a key is unchanged: this is what every other test in


### PR DESCRIPTION
## What this is

Three things an operator needs from a resident proxy. They ship together because they share one call site — the `axum::serve` in `serve_on` — not because they are one feature.

**1. A stop is no longer a kill.** Ctrl-C, or SIGTERM where there is one, closes the listener so no new request is accepted, and lets the requests already in flight finish. Today `fabric serve` drops them: every in-flight generation becomes a client-visible failure on an ordinary restart.

**2. Each access-log line names the client it came from.** This needs `ConnectInfo`, which is configured on that same `axum::serve` call.

**3. Each request has an id**, logged and answered to the client, so a complaint can name the line that recorded it.

## The bound on the drain, and who it is for

Draining is bounded by `forward_timeout`, because that is already this proxy's answer to "how long may a request legitimately take" rather than a new number to tune.

Worth being precise about which requests that bound is actually for. A **buffered** request cannot outlive it — the same value bounds the forward, so the request ends first either way. A **stream** can: its idle timeout resets with every event, so a client reading slowly could otherwise hold the process open for as long as it kept reading. An orchestrator's own grace period is usually shorter than either and simply wins.

That is also why the bound has no automated test: it is only reachable on a stream, and a test for it would be a timing race with no useful margin. It is exercised in the live receipt instead.

## Why an inbound id is checked rather than cleaned up

An inbound `x-request-id` is honoured so an id assigned upstream survives the hop. It is validated first, because it lands in a log line the caller does not otherwise control: non-empty, `<= 128` bytes, and every byte `is_ascii_graphic` (which excludes space and every control character).

HTTP framing rejects a raw CR or LF before this ever sees it, so the reachable problems are the quieter ones — a tab or DEL that makes a line hard to parse, and a length nothing bounds. The docs say that rather than claiming to prevent log injection.

Anything failing the check gets a **fresh uuid, not a sanitised value**. A cleaned-up id is no longer the caller's id, so it would correlate with nothing while still looking as though it did.

## What this id does not do

It correlates a complaint with **this proxy's** log line. It does not correlate with the node's, because the engine neither accepts nor emits `x-request-id` — verified, zero occurrences. The module docs say so explicitly so nobody reads "request id" as end-to-end tracing.

## The one new seam

`serve_on` now delegates to `serve_on_until(listener, fabric, config, stop)`, which takes the stop as an argument. `serve_on` passes the real signal handler. Without that seam the shutdown path could only be tested by signalling the test runner itself.

## Tests, and what each one is worth

`fabric::` 143 → **149**, `fabric_serve` 39 → **41**. Every new test was ablated against the defect it claims to catch:

| Ablation | Result |
|---|---|
| `is_usable_request_id` always returns true | **exactly 2** fail: `an_unusable_id_is_replaced_rather_than_cleaned_up`, `what_counts_as_a_usable_id` |
| `into_make_service_with_connect_info` → `into_make_service` | **exactly 1** fails: `a_request_is_logged_with_the_caller_and_the_id_it_was_given` — and **all 149 `fabric::` unit tests still pass** |
| graceful shutdown → abrupt stop | **exactly 1** fails: `a_stop_finishes_the_work_in_flight_and_accepts_no_more` |

Two of those are worth spelling out, because they changed the tests.

**The `ConnectInfo` ablation passes every unit test.** The unit tests put `ConnectInfo` into the request extensions themselves, so they structurally cannot tell whether the server supplies it. Only a request over a real socket can. That is why there is a test which installs a capturing `tracing` subscriber and asserts the actual log line — it is the only thing that holds the wiring in place.

**My first shutdown test was vacuous and passed under its own ablation.** `axum::serve` spawns a task per accepted connection, so dropping the serve future leaves in-flight requests running *inside the test process*; asserting "the request still got a 200" proved nothing. What loses the request in production is the caller returning early and the process exiting under it. The test now asserts the ordering that actually matters — the stop must not report itself complete until in-flight work is — measured on a single task to avoid a cross-task race. Under the ablation it fails with:

> the proxy called itself stopped after **302.1µs**, while it still owed a request about **400ms** of work

A ~1300x separation, so it is not timing-fragile.

## Gates

`cargo fmt --all --check` clean · `cargo clippy --all-targets -- -D warnings` **0 warnings** · `--lib fabric::` **149 pass / 0 fail** · `--test fabric_serve` **41/0** · `--test fabric_end_to_end` **14/0** (unchanged) · `--bin camelid` **40/0** (unchanged) · `scripts/check-public-scrub.sh` exit 0 · `git diff --check` clean · LF endings on all three files.

## Honest gaps

- **`stop_requested()` itself is untested.** It is the thin wrapper that awaits `ctrl_c()` or SIGTERM. A test that raised a real signal would kill the test runner. Everything below it — the drain, the ordering, the refusal of new connections — is tested through `serve_on_until`.
- **The drain bound has no automated test**, for the reason given above.
- **Log lines still only appear when `RUST_LOG` asks for them**, the same as the rest of this binary. `RUST_LOG=camelid=info` is the whole access log. Not changed here.

## Stacking

#666 has merged, so this no longer carries it: it now stands alone on `main` at **3 files, +407/-10**.

Rebased onto `main` (`49114d3f4`). The rebase changed none of its own work -- `git diff` between the pre-rebase and rebased head is empty. Gates were re-run on the rebased **commit** (clean tree), not on a working tree.

Verified with `git merge-tree`: this still **conflicts with #665** in `src/fabric/server.rs` -- one mechanical hunk where both add to the same router/serve region. #665 will be rebased over this one.