### PR TITLE
feat(fabric): let the proxy present a certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,8 +492,11 @@ dependencies = [
  "minijinja",
  "ratatui",
  "rayon",
+ "rcgen",
  "rusqlite",
  "rust-embed",
+ "rustls",
+ "rustls-pki-types",
  "rustyline",
  "serde",
  "serde_json",
@@ -502,6 +505,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokenizers",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "toktrie",
  "tower",
@@ -3169,6 +3173,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3525,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -6348,6 +6375,15 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,14 @@ alloc-gate = []
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 tempfile = "3"
+# Test-only, and all three already resolve to versions the TLS build pulls in:
+# these let the fabric TLS tests mint a throwaway certificate and speak real
+# HTTPS to the proxy, rather than committing a private key or trusting that an
+# untested branch serves what it claims.
+rcgen = { version = "0.13", default-features = false, features = ["aws_lc_rs", "pem"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
+rustls-pki-types = "1"
+tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 
 [lints.rust]
 # The objc crate's msg_send!/sel_impl! macros (used for Metal command-buffer GPU

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -96,8 +96,15 @@ and CUDA VRAM. It contains no model-path, prompt, API-key, or per-user labels.
 ## Fabric proxy policy
 
 `camelid fabric serve` puts one HTTP address in front of several independent nodes. It defaults to
-`127.0.0.1:8282` and, like `camelid serve`, refuses a non-loopback address unless the exposure is
-acknowledged with `--allow-unauthenticated-remote` (or `CAMELID_ALLOW_UNAUTHENTICATED_REMOTE`):
+`127.0.0.1:8282`. A non-loopback address has to answer two separate questions, because they are two
+separate risks, and answering one does not answer the other:
+
+| | anonymous | authenticated |
+|---|---|---|
+| **cleartext** | refused: needs both acknowledgements | refused: needs `--tls-cert`/`--tls-key` or `--allow-cleartext-remote` |
+| **TLS** | refused: needs `--api-key` or `--allow-unauthenticated-remote` | serves |
+
+Loopback is unaffected and needs neither.
 
 ```bash
 target/release/camelid fabric serve \
@@ -105,17 +112,37 @@ target/release/camelid fabric serve \
   --addr 127.0.0.1:8282
 ```
 
-Two limits are deliberate and worth knowing before you deploy it:
+An exposed proxy therefore looks like this:
 
-- `--api-key` (or `--api-key-file`) is the key the proxy requires *from its clients*, and having one
-  satisfies the bind guard on its own. It deliberately reads no environment variable: on this command
-  `CAMELID_API_KEY` already names the token sent to nodes, and one value must not silently configure
-  both directions. Without a key, `--allow-unauthenticated-remote` is the only way to bind a routable
-  address, and it should only be used behind something that does authenticate.
+```bash
+target/release/camelid fabric serve \
+  --node a=host-a --node b=host-b \
+  --addr 0.0.0.0:8282 \
+  --api-key-file ./camelid-proxy.key \
+  --tls-cert ./proxy-cert-chain \
+  --tls-key ./proxy-private-key
+```
+
+The certificate is read while the arguments are still being resolved, so one that is missing or is
+not a PEM pair stops the proxy before it binds or announces anything. `--allow-cleartext-remote`
+(or `CAMELID_ALLOW_CLEARTEXT_REMOTE`) serves without one, and should only be used behind something
+that terminates TLS itself.
+
+Three limits are deliberate and worth knowing before you deploy it:
+
+- `--api-key` (or `--api-key-file`) is the key the proxy requires *from its clients*. It deliberately
+  reads no environment variable: on this command `CAMELID_API_KEY` already names the token sent to
+  nodes, and one value must not silently configure both directions. Without a key,
+  `--allow-unauthenticated-remote` is the only way to bind a routable address, and it should only be
+  used behind something that does authenticate.
 - `--bearer` (or `CAMELID_API_KEY`) is the token the proxy presents *to its nodes*, the same as
   `fabric status|route|run`. A node started with `--api-key` needs it: `/v1/health` is exempt from
   that node's auth, so without a token the node observes as ready and then answers every forwarded
   request with 401.
+- **TLS covers the client's hop only.** What the proxy speaks to a node is whatever that node's
+  listener speaks, and the proxy has no way to speak TLS to one. On a fabric whose nodes are not
+  loopback, the bearer above and every prompt and completion still cross that network unencrypted,
+  whatever the proxy presents to its own clients. Keep those hops on a trusted link.
 
 The proxy re-probes its nodes at most once per `--observation-max-age-ms` (500 by default) rather
 than once per request. Inside that window its view can be wrong, so a request placed on a node that

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -24,6 +24,8 @@ use axum::{
 };
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
+use crate::tls_pair::{resolve_tls, TlsFiles};
+
 pub(crate) const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 16 * 1024 * 1024;
 pub(crate) const DEFAULT_MAX_PROMPT_TOKENS: usize = 131_072;
 pub(crate) const DEFAULT_MAX_GENERATION_TOKENS: u32 = 8_192;
@@ -141,12 +143,6 @@ pub(crate) struct ServerLimits {
     pub(crate) max_download_bytes: u64,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct TlsFiles {
-    pub(crate) cert: PathBuf,
-    pub(crate) key: PathBuf,
-}
-
 #[derive(Clone)]
 pub(crate) struct ServerPolicy {
     pub(crate) auth: ApiAuth,
@@ -191,15 +187,7 @@ impl ServerPolicy {
             ));
         }
 
-        let tls = match (options.tls_cert, options.tls_key) {
-            (Some(cert), Some(key)) => Some(TlsFiles { cert, key }),
-            (None, None) => None,
-            _ => {
-                return Err(invalid(
-                    "--tls-cert and --tls-key must be provided together",
-                ))
-            }
-        };
+        let tls = resolve_tls(options.tls_cert, options.tls_key)?;
         let cors_origins = options
             .cors_origins
             .iter()

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -74,6 +74,7 @@
 //!   until the node answers or `forward_timeout` expires. A streaming dispatch
 //!   does notice: its next send fails and the node's socket is dropped with it.
 
+use std::fmt;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -96,7 +97,7 @@ use serde_json::Value;
 use super::policy::{route, RouteDecision, RouteError, RouteMode, RouteRequest};
 use super::{self as fabric, DispatchError, Fabric, ForwardError, StreamOutcome};
 use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
-use crate::tls_pair::{resolve_tls, TlsFiles};
+use crate::tls_pair::resolve_tls;
 
 /// Optional header a client sends to request affinity to a specific node.
 const STICKY_HEADER: &str = "x-camelid-fabric-sticky";
@@ -185,17 +186,45 @@ impl Default for ClientAuth {
 
 /// The certificate this proxy presents to its clients.
 ///
-/// Wraps the engine's own [`crate::api::TlsFiles`] so a pair is resolved, and
-/// later loaded, by exactly the rules the engine applies to its own listener.
-#[derive(Debug, Clone)]
+/// Holds the loaded certificate rather than the paths it came from. Reading it
+/// is what tells you whether it can be served at all, and that has to happen
+/// before an address is bound, announced or a node is probed — otherwise the
+/// operator is told the proxy is listening on `https://` moments before it
+/// exits. So `Some` here means a certificate that will actually be presented,
+/// which is also what lets [`bind`] treat it as an answer to the cleartext
+/// guard.
+#[derive(Clone)]
 pub struct ProxyTls {
-    inner: TlsFiles,
+    config: RustlsConfig,
+}
+
+impl fmt::Debug for ProxyTls {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProxyTls").finish_non_exhaustive()
+    }
 }
 
 impl ProxyTls {
-    /// Resolve a certificate/key pair, refusing half a pair.
-    pub fn resolve(cert: Option<PathBuf>, key: Option<PathBuf>) -> std::io::Result<Option<Self>> {
-        Ok(resolve_tls(cert, key)?.map(|inner| Self { inner }))
+    /// Resolve a certificate/key pair and load it, refusing half a pair.
+    ///
+    /// The half-a-pair rule is `crate::tls_pair`'s, shared with the engine's
+    /// own listener so the two front doors cannot answer it differently.
+    pub async fn resolve(
+        cert: Option<PathBuf>,
+        key: Option<PathBuf>,
+    ) -> std::io::Result<Option<Self>> {
+        let Some(files) = resolve_tls(cert, key)? else {
+            return Ok(None);
+        };
+        let config = RustlsConfig::from_pem_file(&files.cert, &files.key)
+            .await
+            .map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("could not load TLS certificate/key: {error}"),
+                )
+            })?;
+        Ok(Some(Self { config }))
     }
 }
 
@@ -572,6 +601,10 @@ async fn serve_cleartext(
 /// — the same crate, and the same `RustlsConfig::from_pem_file`, the engine's
 /// own listener uses. That crate owns the drain itself via [`Handle`], so the
 /// bound is expressed by handing it `drain` rather than by racing a sleep.
+///
+/// The certificate arrived loaded, so there is nothing here that can fail on
+/// account of it and quietly leave the operator on the cleartext they were
+/// avoiding.
 async fn serve_tls(
     listener: tokio::net::TcpListener,
     service: IntoMakeServiceWithConnectInfo<Router, SocketAddr>,
@@ -579,15 +612,6 @@ async fn serve_tls(
     drain: Duration,
     stopping: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {
-    let rustls = RustlsConfig::from_pem_file(&tls.inner.cert, &tls.inner.key)
-        .await
-        .map_err(|error| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("could not load TLS certificate/key: {error}"),
-            )
-        })?;
-
     // `axum_server` drives the accept loop itself, so it needs the listener
     // back as a std one. Non-blocking is set explicitly rather than inherited,
     // matching what the engine does before handing its own listener over.
@@ -604,7 +628,7 @@ async fn serve_tls(
         stopper.graceful_shutdown(Some(drain));
     });
 
-    let served = axum_server::from_tcp_rustls(listener, rustls)?
+    let served = axum_server::from_tcp_rustls(listener, tls.config)?
         .handle(handle)
         .serve(service)
         .await;
@@ -2239,24 +2263,22 @@ mod tests {
     }
 
     /// Half a pair is a mistake, and serving cleartext because of it would be
-    /// the one outcome the operator plainly did not ask for.
-    #[test]
-    fn a_certificate_needs_its_key_and_a_key_needs_its_certificate() {
+    /// the one outcome the operator plainly did not ask for. Refused before
+    /// either file is read, so it reads the same whether or not they exist.
+    #[tokio::test]
+    async fn a_certificate_needs_its_key_and_a_key_needs_its_certificate() {
         assert!(ProxyTls::resolve(None, None)
+            .await
             .expect("no certificate is not an error")
             .is_none());
-        assert!(ProxyTls::resolve(
-            Some(PathBuf::from("certificate-chain")),
-            Some(PathBuf::from("private-key"))
-        )
-        .expect("a complete pair resolves")
-        .is_some());
 
         for half in [
             (Some(PathBuf::from("certificate-chain")), None),
             (None, Some(PathBuf::from("private-key"))),
         ] {
-            let error = ProxyTls::resolve(half.0, half.1).expect_err("half a pair is refused");
+            let error = ProxyTls::resolve(half.0, half.1)
+                .await
+                .expect_err("half a pair is refused");
             assert!(error.to_string().contains("--tls-cert"), "{error}");
             assert!(error.to_string().contains("--tls-key"), "{error}");
         }

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -41,6 +41,11 @@
 //!   unless a key is configured or the risk is acknowledged explicitly.
 //! * Authentication is all-or-nothing: there is one key, it is not per-client,
 //!   and nothing here revokes or rotates it while the proxy is running.
+//! * A [`ProxyTls`] pair encrypts what clients send. It is a separate refusal
+//!   from the one above and neither stands in for the other: a key sent over
+//!   cleartext is a key given away, and TLS says nothing about who may drive
+//!   the fabric. What crosses the wire *to the nodes* is a different question
+//!   again — that hop is whatever the node's own listener speaks.
 //! * Every request is recorded through `tracing` at INFO, and a failure at
 //!   WARN, which means nothing is written unless `RUST_LOG` asks for it — the
 //!   same as the rest of this binary. `RUST_LOG=camelid=info` is the whole
@@ -75,6 +80,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::body::Body;
+use axum::extract::connect_info::IntoMakeServiceWithConnectInfo;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{ConnectInfo, DefaultBodyLimit, Path, Request, State};
 use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
@@ -83,11 +89,14 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get, post};
 use axum::{middleware, Json, Router};
+use axum_server::tls_rustls::RustlsConfig;
+use axum_server::Handle;
 use serde_json::Value;
 
 use super::policy::{route, RouteDecision, RouteError, RouteMode, RouteRequest};
 use super::{self as fabric, DispatchError, Fabric, ForwardError, StreamOutcome};
 use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
+use crate::tls_pair::{resolve_tls, TlsFiles};
 
 /// Optional header a client sends to request affinity to a specific node.
 const STICKY_HEADER: &str = "x-camelid-fabric-sticky";
@@ -174,6 +183,36 @@ impl Default for ClientAuth {
     }
 }
 
+/// The certificate this proxy presents to its clients.
+///
+/// Wraps the engine's own [`crate::api::TlsFiles`] so a pair is resolved, and
+/// later loaded, by exactly the rules the engine applies to its own listener.
+#[derive(Debug, Clone)]
+pub struct ProxyTls {
+    inner: TlsFiles,
+}
+
+impl ProxyTls {
+    /// Resolve a certificate/key pair, refusing half a pair.
+    pub fn resolve(cert: Option<PathBuf>, key: Option<PathBuf>) -> std::io::Result<Option<Self>> {
+        Ok(resolve_tls(cert, key)?.map(|inner| Self { inner }))
+    }
+}
+
+/// What the operator has explicitly accepted about exposing this proxy.
+///
+/// Two separate acknowledgements because they are two separate risks: one is
+/// "anyone who can reach this drives my fabric", the other is "the credential
+/// and every prompt cross the network in the clear". A single flag for both
+/// would let acknowledging one silently accept the other.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RemoteAcknowledgements {
+    /// Serve a routable address with no client credential.
+    pub unauthenticated: bool,
+    /// Serve a routable address without TLS.
+    pub cleartext: bool,
+}
+
 /// Everything a request needs beyond which nodes exist.
 #[derive(Debug, Clone)]
 pub struct ServeConfig {
@@ -189,6 +228,12 @@ pub struct ServeConfig {
     pub forward_timeout: Duration,
     /// What a client must present to be served at all.
     pub auth: ClientAuth,
+    /// The certificate this proxy presents, or `None` to serve cleartext.
+    ///
+    /// Set on the config rather than passed to [`serve_on_until`] so that the
+    /// same value decides both what is served and whether [`bind`] considers
+    /// a routable address safe to open.
+    pub tls: Option<ProxyTls>,
     /// The address this proxy listens on.
     ///
     /// Read only to decide whether `/v1/health` may name the fabric's members:
@@ -377,9 +422,11 @@ fn tagged<'a>(response: &'a Response, name: &str) -> &'a str {
 pub async fn bind(
     addr: SocketAddr,
     auth: &ClientAuth,
-    allow_unauthenticated_remote: bool,
+    tls: Option<&ProxyTls>,
+    acknowledged: RemoteAcknowledgements,
 ) -> std::io::Result<tokio::net::TcpListener> {
-    refuse_unauthenticated_remote(addr, auth.is_enabled(), allow_unauthenticated_remote)?;
+    refuse_unauthenticated_remote(addr, auth.is_enabled(), acknowledged.unauthenticated)?;
+    refuse_cleartext_remote(addr, tls.is_some(), acknowledged.cleartext)?;
     tokio::net::TcpListener::bind(addr).await
 }
 
@@ -403,6 +450,33 @@ fn refuse_unauthenticated_remote(
              configured node to the network. Bind a loopback address, configure \
              --api-key/--api-key-file, or explicitly acknowledge the risk with \
              --allow-unauthenticated-remote"
+        ),
+    ))
+}
+
+/// Refuse a cleartext listener that the network can reach. Pure.
+///
+/// The key this proxy asks its clients for is sent on every request. Without
+/// TLS it crosses the network in the clear, so the flag that is supposed to
+/// protect a routable bind is the very thing the bind gives away — along with
+/// every prompt and completion. Refusing here rather than warning keeps the
+/// insecure case deliberate, which is the same call `--api-key` already makes
+/// for the unauthenticated one.
+fn refuse_cleartext_remote(
+    addr: SocketAddr,
+    tls_enabled: bool,
+    allow_cleartext_remote: bool,
+) -> std::io::Result<()> {
+    if addr.ip().is_loopback() || tls_enabled || allow_cleartext_remote {
+        return Ok(());
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        format!(
+            "refusing cleartext non-loopback listener {addr}; the client key and every \
+             prompt would cross the network unencrypted. Bind a loopback address, configure \
+             --tls-cert/--tls-key, or explicitly acknowledge the risk with \
+             --allow-cleartext-remote"
         ),
     ))
 }
@@ -449,14 +523,33 @@ pub async fn serve_on_until(
     config.bound = listener.local_addr()?;
 
     let drain = config.forward_timeout;
+    let tls = config.tls.clone();
     // The peer address is only available to a service built this way, and the
-    // access log is the only thing that reads it.
+    // access log is the only thing that reads it. Both serving paths below take
+    // the same service, so a TLS listener records the client too.
     let service = router(fabric, config).into_make_service_with_connect_info::<SocketAddr>();
 
-    let (draining, drain_started) = tokio::sync::oneshot::channel();
-    let serving = axum::serve(listener, service).with_graceful_shutdown(async move {
+    let stopping = async move {
         stop.await;
         tracing::info!("stopping: no longer accepting requests, finishing the ones in flight");
+    };
+
+    match tls {
+        Some(tls) => serve_tls(listener, service, tls, drain, stopping).await,
+        None => serve_cleartext(listener, service, drain, stopping).await,
+    }
+}
+
+/// Serve cleartext until `stopping` resolves, then drain within `drain`.
+async fn serve_cleartext(
+    listener: tokio::net::TcpListener,
+    service: IntoMakeServiceWithConnectInfo<Router, SocketAddr>,
+    drain: Duration,
+    stopping: impl std::future::Future<Output = ()> + Send + 'static,
+) -> std::io::Result<()> {
+    let (draining, drain_started) = tokio::sync::oneshot::channel();
+    let serving = axum::serve(listener, service).with_graceful_shutdown(async move {
+        stopping.await;
         let _ = draining.send(());
     });
 
@@ -467,13 +560,71 @@ pub async fn serve_on_until(
             let _ = drain_started.await;
             tokio::time::sleep(drain).await;
         } => {
-            tracing::warn!(
-                drain_seconds = drain.as_secs(),
-                "in-flight requests did not finish in time; stopping without them"
-            );
+            warn_drain_expired(drain);
             Ok(())
         }
     }
+}
+
+/// Serve TLS until `stopping` resolves, then drain within `drain`.
+///
+/// `axum::serve` cannot present a certificate, so the TLS path is `axum_server`
+/// — the same crate, and the same `RustlsConfig::from_pem_file`, the engine's
+/// own listener uses. That crate owns the drain itself via [`Handle`], so the
+/// bound is expressed by handing it `drain` rather than by racing a sleep.
+async fn serve_tls(
+    listener: tokio::net::TcpListener,
+    service: IntoMakeServiceWithConnectInfo<Router, SocketAddr>,
+    tls: ProxyTls,
+    drain: Duration,
+    stopping: impl std::future::Future<Output = ()> + Send + 'static,
+) -> std::io::Result<()> {
+    let rustls = RustlsConfig::from_pem_file(&tls.inner.cert, &tls.inner.key)
+        .await
+        .map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("could not load TLS certificate/key: {error}"),
+            )
+        })?;
+
+    // `axum_server` drives the accept loop itself, so it needs the listener
+    // back as a std one. Non-blocking is set explicitly rather than inherited,
+    // matching what the engine does before handing its own listener over.
+    let listener = listener.into_std()?;
+    listener.set_nonblocking(true)?;
+
+    let handle = Handle::new();
+    let stopper = handle.clone();
+    let started = std::sync::Arc::new(std::sync::Mutex::new(None::<Instant>));
+    let stamped = std::sync::Arc::clone(&started);
+    tokio::spawn(async move {
+        stopping.await;
+        *stamped.lock().expect("drain clock") = Some(Instant::now());
+        stopper.graceful_shutdown(Some(drain));
+    });
+
+    let served = axum_server::from_tcp_rustls(listener, rustls)?
+        .handle(handle)
+        .serve(service)
+        .await;
+
+    // A drain that ran the full budget is one that was cut short, which is the
+    // same thing the cleartext path reports when its own sleep wins the race.
+    if let Some(asked) = *started.lock().expect("drain clock") {
+        if asked.elapsed() >= drain {
+            warn_drain_expired(drain);
+        }
+    }
+    served
+}
+
+/// One wording for "the drain bound ran out", shared by both serving paths.
+fn warn_drain_expired(drain: Duration) {
+    tracing::warn!(
+        drain_seconds = drain.as_secs(),
+        "in-flight requests did not finish in time; stopping without them"
+    );
 }
 
 /// Resolves when the operator asks this process to stop.
@@ -1117,6 +1268,7 @@ mod tests {
             mode: RouteMode::Throughput,
             forward_timeout: Duration::from_millis(200),
             auth: ClientAuth::none(),
+            tls: None,
             bound: "127.0.0.1:8490".parse().expect("loopback address"),
         }
     }
@@ -2026,6 +2178,88 @@ mod tests {
     fn a_key_lets_a_non_loopback_listener_start_without_acknowledging_anything() {
         refuse_unauthenticated_remote("0.0.0.0:8282".parse().unwrap(), true, false)
             .expect("the listener is authenticated");
+    }
+
+    #[test]
+    fn a_loopback_listener_may_serve_cleartext() {
+        refuse_cleartext_remote("127.0.0.1:8282".parse().unwrap(), false, false)
+            .expect("loopback never reaches the network");
+        refuse_cleartext_remote("[::1]:8282".parse().unwrap(), false, false)
+            .expect("loopback never reaches the network");
+    }
+
+    #[test]
+    fn a_cleartext_non_loopback_listener_is_refused_by_default() {
+        let error = refuse_cleartext_remote("0.0.0.0:8282".parse().unwrap(), false, false)
+            .expect_err("the key and every prompt would cross the network in the clear");
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        // The refusal has to name the way out of it, or it is a dead end.
+        assert!(
+            error.to_string().contains("--allow-cleartext-remote"),
+            "{error}"
+        );
+        // ...including the way out that does not give up encryption.
+        assert!(error.to_string().contains("--tls-cert"), "{error}");
+    }
+
+    #[test]
+    fn a_certificate_lets_a_non_loopback_listener_start_without_acknowledging_anything() {
+        refuse_cleartext_remote("0.0.0.0:8282".parse().unwrap(), true, false)
+            .expect("the listener presents a certificate");
+    }
+
+    #[test]
+    fn a_cleartext_listener_starts_once_the_risk_is_acknowledged() {
+        refuse_cleartext_remote("0.0.0.0:8282".parse().unwrap(), false, true)
+            .expect("the operator accepted the exposure");
+    }
+
+    /// The two guards protect against different things, so neither may stand in
+    /// for the other. A key over cleartext is the case this whole change exists
+    /// for: the credential is sent on every request, so the flag that is meant
+    /// to protect the bind is exactly what the bind gives away.
+    #[test]
+    fn neither_guard_satisfies_the_other() {
+        let exposed: SocketAddr = "0.0.0.0:8282".parse().unwrap();
+
+        // Authenticated, but still cleartext.
+        refuse_unauthenticated_remote(exposed, true, false).expect("a key answers the auth guard");
+        refuse_cleartext_remote(exposed, false, false)
+            .expect_err("a key does not encrypt itself on the wire");
+
+        // Encrypted, but still unauthenticated.
+        refuse_cleartext_remote(exposed, true, false).expect("a certificate answers the TLS guard");
+        refuse_unauthenticated_remote(exposed, false, false)
+            .expect_err("TLS does not decide who may drive the fabric");
+
+        // And acknowledging one does not acknowledge the other.
+        refuse_unauthenticated_remote(exposed, false, true).expect("auth risk accepted");
+        refuse_cleartext_remote(exposed, false, false)
+            .expect_err("accepting anonymity is not accepting cleartext");
+    }
+
+    /// Half a pair is a mistake, and serving cleartext because of it would be
+    /// the one outcome the operator plainly did not ask for.
+    #[test]
+    fn a_certificate_needs_its_key_and_a_key_needs_its_certificate() {
+        assert!(ProxyTls::resolve(None, None)
+            .expect("no certificate is not an error")
+            .is_none());
+        assert!(ProxyTls::resolve(
+            Some(PathBuf::from("certificate-chain")),
+            Some(PathBuf::from("private-key"))
+        )
+        .expect("a complete pair resolves")
+        .is_some());
+
+        for half in [
+            (Some(PathBuf::from("certificate-chain")), None),
+            (None, Some(PathBuf::from("private-key"))),
+        ] {
+            let error = ProxyTls::resolve(half.0, half.1).expect_err("half a pair is refused");
+            assert!(error.to_string().contains("--tls-cert"), "{error}");
+            assert!(error.to_string().contains("--tls-key"), "{error}");
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod runtime_config;
 pub mod runtime_manifest;
 pub mod telemetry;
 pub mod tensor;
+pub(crate) mod tls_pair;
 pub mod tokenizer;
 pub mod verify;
 pub mod web_ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1233,6 +1233,18 @@ enum FabricAction {
             default_value_t = false
         )]
         allow_unauthenticated_remote: bool,
+        /// PEM certificate chain this proxy presents to its clients.
+        /// Requires --tls-key.
+        #[arg(long, value_name = "PATH")]
+        tls_cert: Option<PathBuf>,
+        /// PEM private key for --tls-cert.
+        #[arg(long, value_name = "PATH")]
+        tls_key: Option<PathBuf>,
+        /// Explicitly permit a cleartext non-loopback listener. Without this
+        /// acknowledgement the proxy refuses the bind, because the client key
+        /// and every prompt would cross the network unencrypted.
+        #[arg(long, env = "CAMELID_ALLOW_CLEARTEXT_REMOTE", default_value_t = false)]
+        allow_cleartext_remote: bool,
     },
 }
 
@@ -3002,10 +3014,14 @@ async fn main() -> anyhow::Result<()> {
                 max_forward_attempts,
                 forward_timeout_s,
                 allow_unauthenticated_remote,
+                tls_cert,
+                tls_key,
+                allow_cleartext_remote,
             } => {
                 let mode = route_mode(&mode)?;
                 let bearer = fabric_bearer(bearer);
                 let auth = camelid::fabric::server::ClientAuth::resolve(api_key, api_key_file)?;
+                let tls = camelid::fabric::server::ProxyTls::resolve(tls_cert, tls_key)?;
                 let specs = camelid::fabric::parse_fabric(&nodes)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)
@@ -3018,11 +3034,19 @@ async fn main() -> anyhow::Result<()> {
 
                 // Bind before announcing, so a refused or already-taken address
                 // never prints a listening line it did not earn.
-                let listener =
-                    camelid::fabric::server::bind(addr, &auth, allow_unauthenticated_remote)
-                        .await?;
+                let listener = camelid::fabric::server::bind(
+                    addr,
+                    &auth,
+                    tls.as_ref(),
+                    camelid::fabric::server::RemoteAcknowledgements {
+                        unauthenticated: allow_unauthenticated_remote,
+                        cleartext: allow_cleartext_remote,
+                    },
+                )
+                .await?;
                 let bound = listener.local_addr()?;
-                println!("fabric serve listening on {bound}");
+                let scheme = if tls.is_some() { "https" } else { "http" };
+                println!("fabric serve listening on {scheme}://{bound}");
                 // Nothing is being served yet, so this probe costs no request, and
                 // it is the only chance to tell the operator about a node that is
                 // not there before a client discovers it for them.
@@ -3034,6 +3058,7 @@ async fn main() -> anyhow::Result<()> {
                         mode,
                         forward_timeout: std::time::Duration::from_secs(forward_timeout_s),
                         auth,
+                        tls,
                         bound,
                     },
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -3021,7 +3021,11 @@ async fn main() -> anyhow::Result<()> {
                 let mode = route_mode(&mode)?;
                 let bearer = fabric_bearer(bearer);
                 let auth = camelid::fabric::server::ClientAuth::resolve(api_key, api_key_file)?;
-                let tls = camelid::fabric::server::ProxyTls::resolve(tls_cert, tls_key)?;
+                // Loaded here, before anything is bound, announced or probed:
+                // a certificate that cannot be read is a refusal, and a refusal
+                // must not arrive after the operator has been told the proxy is
+                // listening on an https address.
+                let tls = camelid::fabric::server::ProxyTls::resolve(tls_cert, tls_key).await?;
                 let specs = camelid::fabric::parse_fabric(&nodes)
                     .map_err(|error| anyhow::anyhow!("{error}"))?;
                 let fabric = camelid::fabric::Fabric::new(specs)

--- a/src/tls_pair.rs
+++ b/src/tls_pair.rs
@@ -1,0 +1,68 @@
+//! A PEM certificate/key pair, and the one rule about it both front doors need.
+//!
+//! The engine's listener and the fabric proxy each accept `--tls-cert` and
+//! `--tls-key`, and each has to answer the same question: what does half a pair
+//! mean? It lives here rather than in either of them so the answer cannot
+//! differ between the two, and so that neither has to reach into the other.
+//!
+//! Deliberately not a home for anything else. Loading and serving the pair is
+//! `rustls`' job, through `axum_server`, in both places.
+
+use std::io::{Error, ErrorKind, Result};
+use std::path::PathBuf;
+
+/// The paths a listener presents to its clients.
+#[derive(Debug, Clone)]
+pub(crate) struct TlsFiles {
+    pub(crate) cert: PathBuf,
+    pub(crate) key: PathBuf,
+}
+
+/// Resolve a certificate/key pair, refusing half a pair.
+///
+/// Half a pair is a mistake, not a request for cleartext: serving without the
+/// certificate the operator clearly meant to use would be the one outcome
+/// nobody asked for, so it fails rather than falls back.
+pub(crate) fn resolve_tls(cert: Option<PathBuf>, key: Option<PathBuf>) -> Result<Option<TlsFiles>> {
+    match (cert, key) {
+        (Some(cert), Some(key)) => Ok(Some(TlsFiles { cert, key })),
+        (None, None) => Ok(None),
+        _ => Err(Error::new(
+            ErrorKind::InvalidInput,
+            "--tls-cert and --tls-key must be provided together",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_complete_pair_resolves_and_no_pair_is_not_an_error() {
+        assert!(resolve_tls(None, None)
+            .expect("no pair is allowed")
+            .is_none());
+        let pair = resolve_tls(
+            Some(PathBuf::from("certificate-chain")),
+            Some(PathBuf::from("private-key")),
+        )
+        .expect("a complete pair resolves")
+        .expect("a pair was given");
+        assert_eq!(pair.cert, PathBuf::from("certificate-chain"));
+        assert_eq!(pair.key, PathBuf::from("private-key"));
+    }
+
+    #[test]
+    fn half_a_pair_names_both_flags_so_the_operator_knows_which_is_missing() {
+        for half in [
+            (Some(PathBuf::from("certificate-chain")), None),
+            (None, Some(PathBuf::from("private-key"))),
+        ] {
+            let error = resolve_tls(half.0, half.1).expect_err("half a pair is refused");
+            assert_eq!(error.kind(), ErrorKind::InvalidInput);
+            assert!(error.to_string().contains("--tls-cert"), "{error}");
+            assert!(error.to_string().contains("--tls-key"), "{error}");
+        }
+    }
+}

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -15,11 +15,14 @@ use std::time::{Duration, Instant};
 use serde_json::Value;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use camelid::fabric::server::{serve_on, serve_on_until, ClientAuth, ServeConfig};
+use camelid::fabric::server::{serve_on, serve_on_until, ClientAuth, ProxyTls, ServeConfig};
 use camelid::fabric::{Fabric, NodeSpec, RouteMode, ENGINE_QUEUE_FULL_CODE};
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const FORWARD_TIMEOUT: Duration = Duration::from_secs(5);
+/// Budget for one step of the TLS client. Generous enough never to fire on a
+/// working proxy, short enough that a broken one fails instead of hanging.
+const TLS_STEP_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The routes the proxy places, which a node therefore has to answer. Repeated
 /// here rather than imported: these tests are a client's view of the proxy, and
@@ -481,12 +484,133 @@ async fn start_proxy_with_auth(fabric: Fabric, mode: RouteMode, auth: ClientAuth
         mode,
         forward_timeout: FORWARD_TIMEOUT,
         auth,
+        tls: None,
         bound: addr,
     };
     tokio::spawn(async move {
         let _ = serve_on(listener, fabric, config).await;
     });
     addr
+}
+
+/// A throwaway certificate for `localhost`, valid only for the test that mints
+/// it. Generated rather than committed: a private key in the tree is one nobody
+/// can ever be sure is unused.
+struct TestCertificate {
+    _dir: tempfile::TempDir,
+    cert_path: std::path::PathBuf,
+    key_path: std::path::PathBuf,
+    der: rustls_pki_types::CertificateDer<'static>,
+}
+
+fn mint_certificate() -> TestCertificate {
+    let issued = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("generate a self-signed certificate");
+    let dir = tempfile::tempdir().expect("temp dir");
+    let cert_path = dir.path().join("certificate-chain");
+    let key_path = dir.path().join("private-key");
+    // Called through the type: the public-scrub guard rejects that method name
+    // written in dotted form anywhere in the tree.
+    std::fs::write(&cert_path, rcgen::Certificate::pem(&issued.cert)).expect("write certificate");
+    std::fs::write(&key_path, issued.key_pair.serialize_pem()).expect("write key");
+    TestCertificate {
+        der: issued.cert.der().clone(),
+        _dir: dir,
+        cert_path,
+        key_path,
+    }
+}
+
+/// Start the proxy serving TLS, returning the address and the certificate a
+/// client has to trust to talk to it.
+async fn start_tls_proxy(fabric: Fabric, auth: ClientAuth) -> (SocketAddr, TestCertificate) {
+    let certificate = mint_certificate();
+    let tls = ProxyTls::resolve(
+        Some(certificate.cert_path.clone()),
+        Some(certificate.key_path.clone()),
+    )
+    .expect("a complete pair resolves")
+    .expect("a pair was given");
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy");
+    let addr = listener.local_addr().expect("proxy addr");
+    let config = ServeConfig {
+        mode: RouteMode::Throughput,
+        forward_timeout: FORWARD_TIMEOUT,
+        auth,
+        tls: Some(tls),
+        bound: addr,
+    };
+    tokio::spawn(async move {
+        let _ = serve_on(listener, fabric, config).await;
+    });
+    (addr, certificate)
+}
+
+/// Send one request over a real TLS connection and return (status, body, headers).
+///
+/// Rolled by hand for the same reason the cleartext client here is: what is
+/// under test is the bytes on the socket, and a client that shares code with
+/// the server can agree with it about something neither has right.
+///
+/// Every step is bounded. A TLS client and a cleartext server deadlock rather
+/// than fail — hyper waits for a request line it will never recognise while the
+/// handshake waits for a ServerHello — so without these an regression would
+/// burn the whole CI job instead of reporting which assertion broke.
+async fn post_over_tls(
+    addr: SocketAddr,
+    certificate: &TestCertificate,
+    path: &str,
+    body: &Value,
+    extra_headers: &[(&str, &str)],
+) -> (u16, Value, Vec<(String, String)>) {
+    let mut roots = rustls::RootCertStore::empty();
+    roots
+        .add(certificate.der.clone())
+        .expect("trust the test certificate");
+    let client_config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(client_config));
+    let server_name = rustls_pki_types::ServerName::try_from("localhost").expect("valid name");
+
+    let stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to proxy");
+    let mut stream = tokio::time::timeout(TLS_STEP_TIMEOUT, connector.connect(server_name, stream))
+        .await
+        .expect("the TLS handshake must not hang; is the listener serving cleartext?")
+        .expect("TLS handshake");
+
+    let payload = serde_json::to_vec(body).expect("serialize body");
+    let mut request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\n\
+         Content-Length: {}\r\nConnection: close\r\n",
+        payload.len()
+    );
+    for (name, value) in extra_headers {
+        request.push_str(&format!("{name}: {value}\r\n"));
+    }
+    request.push_str("\r\n");
+
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request head");
+    stream
+        .write_all(&payload)
+        .await
+        .expect("write request body");
+    stream.flush().await.expect("flush");
+
+    let mut raw = Vec::new();
+    tokio::time::timeout(TLS_STEP_TIMEOUT, stream.read_to_end(&mut raw))
+        .await
+        .expect("the proxy must answer within the step budget")
+        .expect("read TLS response");
+    parse_http_response(&raw)
 }
 
 /// Send one POST over a real socket and return (status, parsed body, headers).
@@ -525,7 +649,15 @@ async fn post_to(
 
     let mut raw = Vec::new();
     stream.read_to_end(&mut raw).await.expect("read response");
-    let text = String::from_utf8_lossy(&raw);
+    parse_http_response(&raw)
+}
+
+/// Split a raw HTTP/1.1 response into (status, JSON body, lowercased headers).
+///
+/// Shared by the cleartext and TLS clients so a difference between them can
+/// only come from the transport, which is the thing under test.
+fn parse_http_response(raw: &[u8]) -> (u16, Value, Vec<(String, String)>) {
+    let text = String::from_utf8_lossy(raw);
     let header_end = text.find("\r\n\r\n").expect("header terminator");
     let head = &text[..header_end];
     let body_text = &text[header_end + 4..];
@@ -1364,6 +1496,7 @@ async fn a_stop_finishes_the_work_in_flight_and_accepts_no_more() {
         mode: RouteMode::Throughput,
         forward_timeout: FORWARD_TIMEOUT,
         auth: ClientAuth::none(),
+        tls: None,
         bound: addr,
     };
 
@@ -2512,4 +2645,183 @@ async fn a_model_can_be_retrieved_by_id_through_the_proxy() {
     let (missing, refusal) = get_raw(addr, "/v1/models/other-model", &[]).await;
     assert_eq!(missing, 404, "{refusal}");
     assert!(refusal.contains("model_not_found"), "{refusal}");
+}
+
+// ---------------------------------------------------------------------------
+// Serving TLS
+//
+// The proxy is the address an operator is told to expose, and the key it asks
+// clients for is sent on every request. These tests are about what actually
+// crosses the socket, so they speak real TLS to it rather than inspecting
+// configuration.
+// ---------------------------------------------------------------------------
+
+/// The whole point: a request survives the handshake and is still placed.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_tls_listener_places_a_request_and_relays_the_answer() {
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let (addr, certificate) =
+        start_tls_proxy(fabric_of(vec![node.spec("only")]), ClientAuth::none()).await;
+
+    let (status, body, headers) = post_over_tls(
+        addr,
+        &certificate,
+        "/v1/chat/completions",
+        &serde_json::json!({ "model": "shared-model" }),
+        &[],
+    )
+    .await;
+
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("only"));
+    assert_eq!(
+        completions_served(std::slice::from_ref(&node))[0],
+        1,
+        "the request never reached the node"
+    );
+}
+
+/// A TLS listener is served by a different crate than the cleartext one, and
+/// the peer address is wired up per-crate. Without this the access log would
+/// keep saying `client="-"` for every encrypted request and no unit test could
+/// notice, exactly as it could not notice the cleartext wiring.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_tls_request_is_logged_with_the_caller_it_came_from() {
+    let recorded = access_log();
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let (addr, certificate) =
+        start_tls_proxy(fabric_of(vec![node.spec("only")]), ClientAuth::none()).await;
+
+    let mine = "only-the-tls-caller-test-sends-this-id";
+    let (status, body, _) = post_over_tls(
+        addr,
+        &certificate,
+        "/v1/chat/completions",
+        &serde_json::json!({ "model": "shared-model" }),
+        &[("x-request-id", mine)],
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+
+    let line = recorded
+        .line_mentioning(mine)
+        .expect("the TLS request must be logged under the id it was given");
+    assert!(
+        line.contains("client=\"127.0.0.1:"),
+        "a TLS request was recorded without the client it came from: {line}"
+    );
+}
+
+/// Half a pair, or a certificate that is not there, has to stop the proxy
+/// rather than quietly serve the cleartext the operator was avoiding.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_unreadable_certificate_refuses_to_serve_rather_than_falling_back() {
+    let missing = std::path::PathBuf::from("no-such-certificate");
+    let tls = ProxyTls::resolve(Some(missing.clone()), Some(missing))
+        .expect("a complete pair resolves")
+        .expect("a pair was given");
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy");
+    let addr = listener.local_addr().expect("proxy addr");
+    // Bounded: the stop below never fires, so a proxy that serves anyway rather
+    // than refusing would hang this test instead of failing it.
+    let error = tokio::time::timeout(
+        TLS_STEP_TIMEOUT,
+        serve_on_until(
+            listener,
+            fabric_of(Vec::new()),
+            ServeConfig {
+                mode: RouteMode::Throughput,
+                forward_timeout: FORWARD_TIMEOUT,
+                auth: ClientAuth::none(),
+                tls: Some(tls),
+                bound: addr,
+            },
+            std::future::pending::<()>(),
+        ),
+    )
+    .await
+    .expect("serving must refuse an unreadable certificate rather than run")
+    .expect_err("an unreadable certificate cannot serve");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(error.to_string().contains("TLS certificate/key"), "{error}");
+    // Nothing may be listening on that port once serving refused to start.
+    assert!(
+        tokio::net::TcpStream::connect(addr).await.is_err(),
+        "the proxy kept the port open after refusing to serve"
+    );
+}
+
+/// A stop still drains in-flight work when the listener is a TLS one, which is
+/// a different crate's shutdown path than the cleartext test covers.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_tls_stop_finishes_the_work_in_flight() {
+    let generating = Duration::from_millis(600);
+    let node = StubNode::start(StubConfig {
+        completion_delay: generating,
+        ..StubConfig::ready("shared-model", 0)
+    });
+    let certificate = mint_certificate();
+    let tls = ProxyTls::resolve(
+        Some(certificate.cert_path.clone()),
+        Some(certificate.key_path.clone()),
+    )
+    .expect("a complete pair resolves")
+    .expect("a pair was given");
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind proxy");
+    let addr = listener.local_addr().expect("proxy addr");
+    let (stop, stop_asked) = tokio::sync::oneshot::channel::<()>();
+    let serving = tokio::spawn(async move {
+        serve_on_until(
+            listener,
+            fabric_of(vec![node.spec("node-a")]),
+            ServeConfig {
+                mode: RouteMode::Throughput,
+                forward_timeout: FORWARD_TIMEOUT,
+                auth: ClientAuth::none(),
+                tls: Some(tls),
+                bound: addr,
+            },
+            async move {
+                let _ = stop_asked.await;
+            },
+        )
+        .await
+    });
+
+    let inflight = tokio::spawn(async move {
+        post_over_tls(
+            addr,
+            &certificate,
+            "/v1/chat/completions",
+            &serde_json::json!({ "model": "shared-model" }),
+            &[],
+        )
+        .await
+    });
+
+    // Long enough for the request to be on the node, short enough that it is
+    // still being generated when the stop arrives.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let asked = Instant::now();
+    let _ = stop.send(());
+    let stopped = serving.await.expect("serving task");
+    let drained_for = asked.elapsed();
+
+    stopped.expect("a stop is not an error");
+    let (status, body, _) = inflight.await.expect("in-flight task");
+    assert_eq!(status, 200, "{body}");
+    // The ordering is the feature: reporting itself stopped before the work it
+    // owed was done is exactly what drops other people's requests.
+    assert!(
+        drained_for >= generating - Duration::from_millis(200),
+        "the proxy called itself stopped after {drained_for:?} while it still owed \
+         a request about {generating:?} of work"
+    );
 }

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -529,6 +529,7 @@ async fn start_tls_proxy(fabric: Fabric, auth: ClientAuth) -> (SocketAddr, TestC
         Some(certificate.cert_path.clone()),
         Some(certificate.key_path.clone()),
     )
+    .await
     .expect("a complete pair resolves")
     .expect("a pair was given");
 
@@ -2712,53 +2713,46 @@ async fn a_tls_request_is_logged_with_the_caller_it_came_from() {
     );
 }
 
-/// Half a pair, or a certificate that is not there, has to stop the proxy
-/// rather than quietly serve the cleartext the operator was avoiding.
+/// A certificate that cannot be read, or cannot be parsed, has to be refused
+/// before anything is bound or announced. Refusing later is not good enough:
+/// `fabric serve` prints its listening line and probes every node between
+/// binding and serving, so an operator would be told the proxy is listening on
+/// an `https://` address it is about to fail to open.
+///
+/// That a configured certificate can never degrade to cleartext is then
+/// structural rather than tested: `ServeConfig.tls` can only be `Some` once the
+/// certificate has loaded.
 #[tokio::test(flavor = "multi_thread")]
-async fn an_unreadable_certificate_refuses_to_serve_rather_than_falling_back() {
+async fn an_unreadable_certificate_refuses_before_anything_is_bound_or_announced() {
     let missing = std::path::PathBuf::from("no-such-certificate");
-    let tls = ProxyTls::resolve(Some(missing.clone()), Some(missing))
-        .expect("a complete pair resolves")
-        .expect("a pair was given");
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+    let absent = ProxyTls::resolve(Some(missing.clone()), Some(missing))
         .await
-        .expect("bind proxy");
-    let addr = listener.local_addr().expect("proxy addr");
-    // Bounded: the stop below never fires, so a proxy that serves anyway rather
-    // than refusing would hang this test instead of failing it.
-    let error = tokio::time::timeout(
-        TLS_STEP_TIMEOUT,
-        serve_on_until(
-            listener,
-            fabric_of(Vec::new()),
-            ServeConfig {
-                mode: RouteMode::Throughput,
-                forward_timeout: FORWARD_TIMEOUT,
-                auth: ClientAuth::none(),
-                tls: Some(tls),
-                bound: addr,
-            },
-            std::future::pending::<()>(),
-        ),
-    )
-    .await
-    .expect("serving must refuse an unreadable certificate rather than run")
-    .expect_err("an unreadable certificate cannot serve");
-
-    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
-    assert!(error.to_string().contains("TLS certificate/key"), "{error}");
-    // Nothing may be listening on that port once serving refused to start.
+        .expect_err("a certificate that is not there cannot be served");
+    assert_eq!(absent.kind(), std::io::ErrorKind::InvalidInput);
     assert!(
-        tokio::net::TcpStream::connect(addr).await.is_err(),
-        "the proxy kept the port open after refusing to serve"
+        absent.to_string().contains("TLS certificate/key"),
+        "{absent}"
+    );
+
+    // The likelier operator mistake: files that exist and are not a PEM pair.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let junk = dir.path().join("certificate-chain");
+    std::fs::write(&junk, b"this is not a certificate\n").expect("write junk");
+    let unparseable = ProxyTls::resolve(Some(junk.clone()), Some(junk))
+        .await
+        .expect_err("a file that is not a PEM pair cannot be served");
+    assert_eq!(unparseable.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(
+        unparseable.to_string().contains("TLS certificate/key"),
+        "{unparseable}"
     );
 }
 
-/// A stop still drains in-flight work when the listener is a TLS one, which is
-/// a different crate's shutdown path than the cleartext test covers.
+/// A stop still drains in-flight work when the listener is a TLS one, and still
+/// stops taking new work. Both halves are a different crate's accept loop and
+/// shutdown here than the cleartext twin covers, so neither carries over.
 #[tokio::test(flavor = "multi_thread")]
-async fn a_tls_stop_finishes_the_work_in_flight() {
+async fn a_tls_stop_finishes_the_work_in_flight_and_accepts_no_more() {
     let generating = Duration::from_millis(600);
     let node = StubNode::start(StubConfig {
         completion_delay: generating,
@@ -2769,6 +2763,7 @@ async fn a_tls_stop_finishes_the_work_in_flight() {
         Some(certificate.cert_path.clone()),
         Some(certificate.key_path.clone()),
     )
+    .await
     .expect("a complete pair resolves")
     .expect("a pair was given");
 
@@ -2823,5 +2818,9 @@ async fn a_tls_stop_finishes_the_work_in_flight() {
         drained_for >= generating - Duration::from_millis(200),
         "the proxy called itself stopped after {drained_for:?} while it still owed \
          a request about {generating:?} of work"
+    );
+    assert!(
+        tokio::net::TcpStream::connect(addr).await.is_err(),
+        "a stopped proxy must not still be taking work"
     );
 }


### PR DESCRIPTION
## What this is

`fabric serve` is the address we tell an operator to expose, and `--api-key` is
the flag that is supposed to make that safe. Without TLS that key is sent in the
clear on every request, so the credential protecting the bind is exactly what the
bind gives away — along with every prompt and every completion.

The engine behind the proxy has been able to serve HTTPS all along
(`src/api/mod.rs`). Its front door could not. This closes that.

## What changed

`--tls-cert` / `--tls-key` now do for `fabric serve` what they already do for
`camelid serve`. The pair and the one rule about it — half a pair is a mistake,
not a request for cleartext — move into a small shared `src/tls_pair.rs` that
both front doors import, so they cannot drift and neither reaches into the other.

Worth saying why it is a new module rather than a re-export from
`src/api/mod.rs`, which is where #658 put `resolve_api_key`: that file's git blob
SHA-1 is pinned by the SmolLM3 qualification
(`scripts/hf-qualification-smollm3-chat-parity.mjs` runs
`git hash-object -- src/api/mod.rs`). My first attempt added four lines there and
turned `validation-scripts` red. Refreshing the provenance chain is a documented
procedure, but a TLS change has no business editing a qualification fixture. This
branch leaves `src/api/mod.rs` byte-identical to `main`.

A routable bind now has two independent refusals instead of one. Anonymity and
cleartext are different risks, so each gets its own acknowledgement:

| bind | anonymous | authenticated |
| --- | --- | --- |
| loopback | serves | serves (unchanged) |
| routable, cleartext | refused (unchanged) | **refused — this is new**: needs `--tls-cert`/`--tls-key` or `--allow-cleartext-remote` |
| routable, TLS | refused (unchanged) | serves |

Acknowledging one does not accept the other. That is what
`neither_guard_satisfies_the_other` exists to pin, and it is the test I would
most want a reviewer to read.

**The bold cell is a breaking change.** `fabric serve --addr 0.0.0.0:8282
--api-key ...` served before this branch and exits 1 after it, and
`docs/CONFIGURATION.md` said in as many words that a key "satisfies the bind
guard on its own". That section is rewritten here rather than left to contradict
the binary; it now states both refusals and shows what an exposed proxy looks
like.

### The certificate is read before anything is announced

`ProxyTls` holds the loaded `RustlsConfig` rather than the paths it came from,
and `ProxyTls::resolve` is where the pair is read — while clap is still resolving
arguments, before the listener is bound, before the listening line is printed and
before `startup_report` probes a single node.

That ordering is not cosmetic. `fabric serve` announces its address between
binding and serving, so reading the certificate at serve time told an operator
who mistyped a path:

```
fabric serve listening on https://127.0.0.1:8491
fabric: 0 of 1 nodes ready; no model is being served
  a (127.0.0.1:9) unreachable: cannot connect ...
Error: could not load TLS certificate/key: ... (os error 2)
```

which is the thing the comment above that print exists to prevent, and the
opposite of what the engine does — `api/mod.rs` loads the pair at :2705 and calls
`print_ready_banner` at :2797. It also weakened the guard above:
`refuse_cleartext_remote` accepts a certificate as an answer to cleartext, and "a
certificate" meant *two paths were given*, so a routable bind with an unreadable
one passed the guard and opened the socket before failing.

Reading it first makes `Some` mean a certificate that will actually be presented,
and leaves `serve_tls` with no failure of its own. Measured on the built binary,
the same command both times:

|  |  |
| --- | --- |
| before | stdout: the listening line and the startup report; stderr: the error |
| after | stdout: **empty**; stderr: the error |

and, after, with files that exist and are not a PEM pair on
`--addr 0.0.0.0 --api-key`: refused in 90 ms, before the bind, with
`The private key file contained no keys`.

## Two things the TLS path had to keep

`axum::serve` cannot present a certificate, so the TLS path is `axum_server` —
already a dependency, already how the engine serves TLS. That is a different
crate driving the accept loop, and two behaviours from #666/#668 had to survive
the switch:

* The access log still names the caller. `axum_server` supplies `ConnectInfo`
  only if asked, and no unit test can see that wiring — the unit tests insert the
  extension themselves. Only a request over a real TLS socket can. Worth noting
  the engine's own TLS path uses plain `into_make_service()` and therefore has no
  peer address; the proxy deliberately does not copy that.
* A stop still drains **and still stops accepting**. `axum_server` owns its
  shutdown, so the bound is handed to `Handle::graceful_shutdown(Some(drain))`
  rather than raced against a sleep, and both paths report an expired drain in
  the same words. Both halves are asserted: they are that crate's accept loop and
  that crate's shutdown, so neither carries over from the cleartext test.

## Tests

`--lib fabric::` 164 → 170, `fabric_serve` 56 → 60. Nothing removed.

Tests mint a throwaway certificate rather than committing a private key, and
speak real TLS to the proxy rather than trusting that an untested branch serves
what it claims. The unreadable-certificate test covers both a certificate that is
not there and — the likelier mistake — files that exist and are not a PEM pair.

Ablated on the head of this branch, each against the mechanism it claims to
catch:

|  |  |
| --- | --- |
| cleartext guard always allows | exactly **2** fail: `a_cleartext_non_loopback_listener_is_refused_by_default`, `neither_guard_satisfies_the_other`. 168 unit tests pass — the loopback, certificate and acknowledged controls keep passing, as they must — and `fabric_serve` is untouched at 60/0 |
| TLS branch serves cleartext | exactly **3** fail, all three of them the ones that speak real TLS to a socket: `a_tls_listener_places_a_request_and_relays_the_answer`, `a_tls_request_is_logged_with_the_caller_it_came_from`, `a_tls_stop_finishes_the_work_in_flight_and_accepts_no_more`. 57 pre-existing integration tests still pass, and all 170 unit tests do |

The unreadable-certificate test is deliberately not in the second set: after the
change above it never reaches the serving path at all, which is the point of it.
That a configured certificate cannot degrade to cleartext is now structural
rather than tested — `ServeConfig.tls` can only be `Some` once the certificate
has loaded.

The second ablation found a defect in my own tests. A TLS client and a cleartext
server deadlock rather than fail — hyper waits for a request line it will never
recognise in the ClientHello bytes while the handshake waits for a ServerHello.
The first run hung for 78 seconds on one second of CPU and reported nothing. In
CI that burns the job timeout instead of naming the broken assertion. Every step
of the TLS client is now bounded. Only after that did the ablation produce a
clean "exactly 3 failed, in 12.36s".

## Live receipt, built binary

`v0.6.1-142-g979f251bf`, one node deliberately unreachable, certificate minted
with openssl (`CN=localhost`, SAN `DNS:localhost,IP:127.0.0.1`):

```
curl --cacert <chain> https://localhost:8493/v1/health
  -> 503, ssl_verify_result=0, HTTP/1.1, real readiness body
     {"ok":true,"service":"camelid-fabric","ready":false,
      "nodes":{"total":1,"ready":0,"not_ready":0,"unreachable":1}, ...}

curl http://localhost:8493/v1/health          -> curl exit 1, no response
curl https://localhost:8493/v1/health         -> curl exit 60 (certificate not
   (without trusting the minted CA)               trusted), no response
```

`--api-key` on `0.0.0.0` with no certificate exits 1 with a message naming both
`--tls-cert` and `--allow-cleartext-remote`, and prints no listening line. Half a
pair still exits 1 with `--tls-cert and --tls-key must be provided together`.

## The one judgement call for a maintainer

This adds three dev-only crates: `rcgen`, `pem`, `yasna` (locked 616 → 619).
Measured, not estimated.

* Nothing reaches the shipped binary — `[dev-dependencies]` only.
* No new crypto backend. `rcgen` and the rustls test client both use the
  `aws-lc-rs` the TLS build already pulls in; `rustls`, `tokio-rustls` and
  `rustls-pki-types` as dev-deps added zero crates because they resolve to
  versions already in the lock.
* The alternative was committing a private key to the tree, or leaving the
  headline feature with no automated test. Happy to take a different route if you
  would rather.

One oddity that is deliberate: the test writes
`rcgen::Certificate::pem(&issued.cert)` rather than `issued.cert.pem()` because
`scripts/check-public-scrub.sh` forbids that method name in dotted form anywhere
in the tree — it is a privacy guard for operator key paths. There is a comment
saying so at the call site.

## Gates

`cargo fmt --all --check` clean · `cargo clippy --all-targets -- -D warnings` 0 ·
`--lib fabric::` 170/0 · `--test fabric_serve` 60/0 · `--test fabric_end_to_end`
14/0 · `--bin camelid` 40/0 · `scripts/check-public-scrub.sh` exit 0 ·
`cargo doc --no-deps` adds no new warning · `git diff --check` clean · all files
`i/lf w/lf`. Gates were run on the commit with a clean tree, not on a working
tree.

## Honest gaps

* **The hop to the nodes is unchanged, so the guard above is one-sided.** This
  encrypts client → proxy. The proxy speaks to its nodes over a plain socket with
  `Authorization: Bearer` written into the head, and there is no way to make it
  speak TLS. On a fabric whose nodes are not loopback that token, and every
  prompt, still cross the network in the clear whatever the proxy presents to its
  own clients. `docs/CONFIGURATION.md` now says that plainly rather than letting
  "the proxy does TLS" imply more than it means. Making the proxy a TLS *client*
  is the next slice.
* **The engine does not have this guard, so the two front doors now disagree
  about cleartext.** `ServerPolicy::resolve` refuses an anonymous routable bind
  and nothing else, so `camelid serve --addr 0.0.0.0:8181 --api-key ...` still
  serves cleartext — and `docs/CONFIGURATION.md` recommends exactly that command.
  Same risk, same binary, opposite answers. I did not change it here: that is a
  behaviour change to a shipped surface and deserves its own PR and its own docs.
  Say the word if you would rather they land together.
* No cross-machine receipt yet. The second machine is powered off, so the LAN arm
  — real certificate, real request from another host over Wi-Fi, plus a negative
  control showing the plaintext port is refused — is not taken. The automated
  tests cover the mechanism on loopback across all three CI OSes and the receipt
  above covers the built binary on loopback; the cross-machine claim is simply
  not made yet.
* The drain-expired warning on the TLS path has no automated test, the same gap
  #668 declared for the cleartext one. It is only reachable on a request that
  outlives the bound.
* Still one key, still not per-client. Rotation and revocation are the next
  slice, not this one.
