### PR TITLE
feat(fabric): name the clients this proxy serves, and let one be revoked

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -172,9 +172,18 @@ The name, never the key, is written to every access-log line that client causes,
 Deleting an entry revokes that client without a restart and without disturbing anyone else. The file
 is re-read at most once a second, and only when its size or modification time has changed, so this
 costs nothing per request. If a re-read fails — which is what the moment of an atomic replace looks
-like — the previous set stays in force and a warning is logged, so an ordinary edit cannot become an
-outage. The cost of that choice is real and worth stating: a revocation written into a file that
-does not parse has *not* taken effect, and the warning is the only thing that says so.
+like — the previous set stays in force, so an ordinary edit cannot become an outage.
+
+That fallback has a cost worth stating plainly: **a revocation written into a file that does not
+parse, or deleting the key file altogether, does not revoke anybody.** The previously loaded set goes
+on being served until the file is readable again or the proxy is restarted — and a restart refuses to
+come up at all while the file is unusable. So the proxy prints to stderr when a re-read starts
+failing, and again when it recovers, rather than relying on `RUST_LOG` being set:
+
+```
+fabric: could not reload client keys: <why>. The previous set of 2 clients is still in force, so a
+revocation written here has NOT taken effect.
+```
 
 The proxy re-probes its nodes at most once per `--observation-max-age-ms` (500 by default) rather
 than once per request. Inside that window its view can be wrong, so a request placed on a node that

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -102,7 +102,7 @@ separate risks, and answering one does not answer the other:
 | | anonymous | authenticated |
 |---|---|---|
 | **cleartext** | refused: needs both acknowledgements | refused: needs `--tls-cert`/`--tls-key` or `--allow-cleartext-remote` |
-| **TLS** | refused: needs `--api-key` or `--allow-unauthenticated-remote` | serves |
+| **TLS** | refused: needs `--api-key`, `--client-keys`, or `--allow-unauthenticated-remote` | serves |
 
 Loopback is unaffected and needs neither.
 
@@ -130,11 +130,11 @@ that terminates TLS itself.
 
 Three limits are deliberate and worth knowing before you deploy it:
 
-- `--api-key` (or `--api-key-file`) is the key the proxy requires *from its clients*. It deliberately
-  reads no environment variable: on this command `CAMELID_API_KEY` already names the token sent to
-  nodes, and one value must not silently configure both directions. Without a key,
-  `--allow-unauthenticated-remote` is the only way to bind a routable address, and it should only be
-  used behind something that does authenticate.
+- `--api-key` (or `--api-key-file`, or `--client-keys` below) is the key the proxy requires *from its
+  clients*. It deliberately reads no environment variable: on this command `CAMELID_API_KEY` already
+  names the token sent to nodes, and one value must not silently configure both directions. Without
+  one of them, `--allow-unauthenticated-remote` is the only way to bind a routable address, and it
+  should only be used behind something that does authenticate.
 - `--bearer` (or `CAMELID_API_KEY`) is the token the proxy presents *to its nodes*, the same as
   `fabric status|route|run`. A node started with `--api-key` needs it: `/v1/health` is exempt from
   that node's auth, so without a token the node observes as ready and then answers every forwarded
@@ -143,6 +143,38 @@ Three limits are deliberate and worth knowing before you deploy it:
   listener speaks, and the proxy has no way to speak TLS to one. On a fabric whose nodes are not
   loopback, the bearer above and every prompt and completion still cross that network unencrypted,
   whatever the proxy presents to its own clients. Keep those hops on a trusted link.
+
+### Naming clients, and cutting one off
+
+`--api-key` gives every client the same secret, so the access log can only say that *someone*
+authenticated, and withdrawing access from one client means changing the key for all of them and
+restarting. `--client-keys <PATH>` replaces it with a set of named clients:
+
+```json
+{"clients": [
+  {"name": "laptop", "key": "..."},
+  {"name": "ci",     "key": "..."}
+]}
+```
+
+It conflicts with `--api-key` and `--api-key-file`, because two different answers to "who may call"
+must not be configurable at once. A set answers the *authentication* question in the table above
+exactly as a single key does, and like a single key it answers only that one: an exposed proxy still
+needs a certificate or `--allow-cleartext-remote` as well.
+
+Each key is validated by exactly the rules `--api-key` applies, and a presented credential is read
+from the same two headers (`Authorization: Bearer` or `X-API-Key`) and compared the same way. A set
+is refused at startup — rather than started open — if it is unreadable, is not valid JSON, lists no
+clients, names a client twice, or gives two clients the same key.
+
+The name, never the key, is written to every access-log line that client causes, as `client_name`.
+
+Deleting an entry revokes that client without a restart and without disturbing anyone else. The file
+is re-read at most once a second, and only when its size or modification time has changed, so this
+costs nothing per request. If a re-read fails — which is what the moment of an atomic replace looks
+like — the previous set stays in force and a warning is logged, so an ordinary edit cannot become an
+outage. The cost of that choice is real and worth stating: a revocation written into a file that
+does not parse has *not* taken effect, and the warning is the only thing that says so.
 
 The proxy re-probes its nodes at most once per `--observation-max-age-ms` (500 by default) rather
 than once per request. Inside that window its view can be wrong, so a request placed on a node that

--- a/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
+++ b/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
@@ -27,7 +27,7 @@
   },
   "implementation": {
     "source_file": "src/api/mod.rs",
-    "source_git_blob_sha1": "cb8e118ed45a8606f803a05ace3e39ff00e82bf8",
+    "source_git_blob_sha1": "c74f54dc3cfff63dc86c2529d94cea39132b8600",
     "architecture": "smollm3",
     "renderer": "render_smollm3_production_chat_prompt",
     "public_chokepoints": [

--- a/scripts/hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/hf-qualification-smollm3-chat-parity.mjs
@@ -93,11 +93,11 @@ const GROUNDING_FILES = Object.freeze({
   }),
   runtime_envelope: Object.freeze({
     path: 'qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json',
-    sha256: 'ad62ac8d8763403869475033a89db9c6dee9a6b3492c2f800650e756d120d183',
+    sha256: '3c5d38919bac36a57998b6d7cb3c2bc95d5ed4297bf7d7bda50ad086e0d91fbb',
   }),
 })
 
-const RENDERER_GIT_BLOB_SHA1 = 'cb8e118ed45a8606f803a05ace3e39ff00e82bf8'
+const RENDERER_GIT_BLOB_SHA1 = 'c74f54dc3cfff63dc86c2529d94cea39132b8600'
 const SHAPE_CASE_ID = 'default_think_single_user_generation_prompt'
 const NORMALIZED_PROMPT_UTF8_BYTES = 1_392
 const NORMALIZED_PROMPT_SHA256 = '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1'

--- a/scripts/test-hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/test-hf-qualification-smollm3-chat-parity.mjs
@@ -114,7 +114,7 @@ assert.deepEqual(TEMPLATE_IDENTITY, {
 assert.equal(GROUNDING_FILES.shape_pack.sha256,
   'd46794448b7c2585d0aa83dfd7bb17d4904c2dcbc048ade1ef68cd3863166de6')
 assert.equal(GROUNDING_FILES.runtime_envelope.sha256,
-  'ad62ac8d8763403869475033a89db9c6dee9a6b3492c2f800650e756d120d183')
+  '3c5d38919bac36a57998b6d7cb3c2bc95d5ed4297bf7d7bda50ad086e0d91fbb')
 assert.equal(LLAMA_PIN.executable_sha256,
   '6c787bf07ac1d7e1bbaa1ee176c3ef0df58ea86494c8c1b1d2d9f4a9176b19ae')
 assert.equal(LLAMA_PIN.server_impl_sha256,
@@ -331,7 +331,7 @@ assert.equal(classifySmolLM3ChatParityError(sharedSmolError).error_code,
 
 const committedGrounding = await inspectGroundings(root)
 assert.equal(committedGrounding.renderer_git_blob_sha1,
-  'cb8e118ed45a8606f803a05ace3e39ff00e82bf8')
+  'c74f54dc3cfff63dc86c2529d94cea39132b8600')
 assert.equal(committedGrounding.shape_case.normalized_prompt_sha256,
   '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1')
 const shapePack = JSON.parse(await readFile(resolve(GROUNDING_FILES.shape_pack.path), 'utf8'))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,7 +43,7 @@ pub use server::ServeOptions;
 pub(crate) use server::DEFAULT_MAX_REQUEST_BODY_BYTES;
 /// Re-exported so another front door authenticates its clients with this
 /// server's check rather than a second implementation of one.
-pub(crate) use server::{authenticate, resolve_api_key, ApiAuth};
+pub(crate) use server::{resolve_api_key, ApiAuth};
 
 use crate::{
     embedding::{

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -118,7 +118,7 @@ impl ApiAuth {
         Some(format!("Authorization: Bearer {key}\r\n"))
     }
 
-    fn accepts(&self, headers: &axum::http::HeaderMap) -> bool {
+    pub(crate) fn accepts(&self, headers: &axum::http::HeaderMap) -> bool {
         let Some(expected) = self.key.as_deref() else {
             return true;
         };
@@ -132,6 +132,41 @@ impl ApiAuth {
         bearer
             .or(api_key)
             .is_some_and(|candidate| constant_time_eq(expected, candidate.as_bytes()))
+    }
+
+    /// Whether `path` is behind the key at all.
+    ///
+    /// An associated function rather than a free one so that anything reusing
+    /// [`ApiAuth`] — the fabric proxy does — applies the same exemptions. The
+    /// health routes are public on purpose: a load balancer has to be able to
+    /// probe a server it holds no credential for.
+    pub(crate) fn route_requires_auth(path: &str) -> bool {
+        !matches!(path, "/health" | "/v1/health" | "/" | "/index.html")
+            && !path.starts_with("/assets/")
+            && !path.starts_with("/favicon")
+    }
+
+    /// The refusal a caller without a usable key gets.
+    ///
+    /// Built here so every front door refuses in the same words, with the same
+    /// challenge header, and none of them names which key would have worked.
+    pub(crate) fn unauthorized() -> Response {
+        let mut response = (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "error": {
+                    "code": "unauthorized",
+                    "message": "provide Authorization: Bearer <key> or X-API-Key",
+                    "type": "authentication_error"
+                }
+            })),
+        )
+            .into_response();
+        response.headers_mut().insert(
+            WWW_AUTHENTICATE,
+            HeaderValue::from_static("Bearer realm=\"camelid\""),
+        );
+        response
     }
 }
 
@@ -239,34 +274,13 @@ pub(crate) async fn authenticate(
     next: Next,
 ) -> Response {
     if request.method() == Method::OPTIONS
-        || !route_requires_auth(request.uri().path())
+        || !ApiAuth::route_requires_auth(request.uri().path())
         || auth.accepts(request.headers())
     {
         return next.run(request).await;
     }
 
-    let mut response = (
-        StatusCode::UNAUTHORIZED,
-        Json(serde_json::json!({
-            "error": {
-                "code": "unauthorized",
-                "message": "provide Authorization: Bearer <key> or X-API-Key",
-                "type": "authentication_error"
-            }
-        })),
-    )
-        .into_response();
-    response.headers_mut().insert(
-        WWW_AUTHENTICATE,
-        HeaderValue::from_static("Bearer realm=\"camelid\""),
-    );
-    response
-}
-
-fn route_requires_auth(path: &str) -> bool {
-    !matches!(path, "/health" | "/v1/health" | "/" | "/index.html")
-        && !path.starts_with("/assets/")
-        && !path.starts_with("/favicon")
+    ApiAuth::unauthorized()
 }
 
 fn parse_bearer(value: &str) -> Option<&str> {

--- a/src/fabric/client_keys.rs
+++ b/src/fabric/client_keys.rs
@@ -1,0 +1,615 @@
+//! Which clients this proxy serves, and how one of them stops being served.
+//!
+//! The proxy shipped with a single key: every client that could reach it held
+//! the same secret, so there was no way to tell two callers apart in a log and
+//! no way to cut one off without cutting off all of them and restarting.
+//!
+//! A key set names its clients. The name is what the access log records — the
+//! key itself never is — and removing an entry from the file revokes that
+//! client without stopping the proxy or disturbing anyone else.
+//!
+//! # What is reused rather than rebuilt
+//!
+//! Nothing here compares secrets. Each client holds the engine's own
+//! [`ApiAuth`], so a presented credential is parsed from the same two headers
+//! and compared with the same constant-time check the engine applies to its
+//! own listener, and keys are validated by the engine's rules through
+//! [`crate::api::resolve_api_key`]. This module decides *who*, never *how*.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::{Error, ErrorKind, Result};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
+
+use axum::http::HeaderMap;
+use serde::Deserialize;
+
+use crate::api::ApiAuth;
+
+/// Longest client name this proxy will accept.
+///
+/// Bounded because the name is written to every log line the client causes.
+const MAX_CLIENT_NAME_BYTES: usize = 64;
+
+/// How long a loaded key set is trusted before the file is looked at again.
+///
+/// Revocation is only as fast as this. A second is short enough that an
+/// operator does not wait on it and long enough that a busy proxy is not
+/// stat-ing a file on every request.
+pub const DEFAULT_KEY_RELOAD_INTERVAL: Duration = Duration::from_secs(1);
+
+/// What the proxy decided about a request's credential.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Admission {
+    /// No key is configured, so the request is served and no client is named.
+    Open,
+    /// A configured client presented its key.
+    Client(Arc<str>),
+    /// A key is required and this request did not present a usable one.
+    Refused,
+}
+
+/// One client, and the name its requests are recorded under.
+#[derive(Clone)]
+struct ClientKey {
+    name: Arc<str>,
+    /// The engine's single-key primitive, one per client: this is what makes
+    /// the comparison here identical to the engine's own.
+    auth: ApiAuth,
+}
+
+/// The on-disk shape of a key set.
+#[derive(Debug, Deserialize)]
+struct KeyFile {
+    clients: Vec<KeyFileEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KeyFileEntry {
+    name: String,
+    key: String,
+}
+
+/// What the file looked like when it was last read.
+///
+/// Modification time alone is not enough: a file rewritten within the same
+/// timestamp tick would be missed, and on a revocation that means a key that
+/// should have stopped working keeps working.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileStamp {
+    modified: Option<SystemTime>,
+    len: u64,
+}
+
+impl FileStamp {
+    fn of(path: &Path) -> Result<Self> {
+        let metadata = fs::metadata(path)?;
+        Ok(Self {
+            modified: metadata.modified().ok(),
+            len: metadata.len(),
+        })
+    }
+}
+
+struct ReloadState {
+    clients: Arc<[ClientKey]>,
+    stamp: Option<FileStamp>,
+    last_checked: Option<Instant>,
+}
+
+enum Source {
+    /// A single key given on the command line or in a one-key file. It cannot
+    /// change while the process runs, so there is nothing to re-read.
+    Fixed(Arc<[ClientKey]>),
+    /// A key set on disk, re-read when it changes.
+    File {
+        path: PathBuf,
+        interval: Duration,
+        state: Mutex<ReloadState>,
+    },
+}
+
+/// The credential a client must present to this proxy.
+#[derive(Clone)]
+pub struct ClientAuth {
+    /// `None` accepts every client, which [`super::server::bind`] only permits
+    /// on a loopback listener or with the risk acknowledged.
+    source: Option<Arc<Source>>,
+}
+
+impl std::fmt::Debug for ClientAuth {
+    /// Never renders a key, and not the names either: this is printed by
+    /// `ServeConfig`'s derive, and who may call is not something to scatter
+    /// through logs.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientAuth")
+            .field("enabled", &self.is_enabled())
+            .field("reloadable", &self.is_reloadable())
+            .finish()
+    }
+}
+
+impl ClientAuth {
+    /// Accept every client.
+    pub fn none() -> Self {
+        Self { source: None }
+    }
+
+    /// Require one key, read from a value or a file.
+    ///
+    /// Fails rather than starting unauthenticated: a proxy that silently
+    /// ignored an unreadable key file would be open to whatever can reach it.
+    pub fn resolve(api_key: Option<String>, api_key_file: Option<PathBuf>) -> Result<Self> {
+        let Some(key) = crate::api::resolve_api_key(api_key, api_key_file)? else {
+            return Ok(Self::none());
+        };
+        Ok(Self {
+            source: Some(Arc::new(Source::Fixed(Arc::from(vec![ClientKey {
+                name: Arc::from("default"),
+                auth: ApiAuth::new(Some(key)),
+            }])))),
+        })
+    }
+
+    /// Require a key from a named set on disk, re-read as it changes.
+    pub fn from_key_file(path: PathBuf) -> Result<Self> {
+        Self::from_key_file_every(path, DEFAULT_KEY_RELOAD_INTERVAL)
+    }
+
+    /// [`Self::from_key_file`] with the staleness bound supplied.
+    ///
+    /// A zero interval re-reads on every request, which is what the tests use
+    /// so a revocation does not have to be waited out.
+    pub fn from_key_file_every(path: PathBuf, interval: Duration) -> Result<Self> {
+        // Loaded once here so an unusable file stops the proxy at startup
+        // rather than at the first request.
+        let clients = load_key_file(&path)?;
+        let stamp = FileStamp::of(&path).ok();
+        Ok(Self {
+            source: Some(Arc::new(Source::File {
+                path,
+                interval,
+                state: Mutex::new(ReloadState {
+                    clients,
+                    stamp,
+                    last_checked: Some(Instant::now()),
+                }),
+            })),
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.source.is_some()
+    }
+
+    /// Whether revoking a client takes effect without a restart.
+    pub fn is_reloadable(&self) -> bool {
+        matches!(self.source.as_deref(), Some(Source::File { .. }))
+    }
+
+    /// How many clients are currently served. Reported at startup, never per
+    /// request.
+    pub fn client_count(&self) -> usize {
+        match self.source.as_deref() {
+            None => 0,
+            Some(Source::Fixed(clients)) => clients.len(),
+            Some(Source::File { state, .. }) => state.lock().expect("client keys").clients.len(),
+        }
+    }
+
+    /// Decide whether `headers` may be served, and by which client's name.
+    pub(crate) fn admit(&self, headers: &HeaderMap) -> Admission {
+        let Some(source) = self.source.as_deref() else {
+            return Admission::Open;
+        };
+        let clients = match source {
+            Source::Fixed(clients) => Arc::clone(clients),
+            Source::File {
+                path,
+                interval,
+                state,
+            } => current_clients(path, *interval, state),
+        };
+        match_client(&clients, headers)
+    }
+}
+
+impl Default for ClientAuth {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+/// The accepting client, compared against every entry.
+///
+/// At most one entry can match, because the loader refuses a set that gives
+/// two clients the same key. Stopping at the first match would therefore save
+/// nothing except comparisons against a handful of remaining keys, while
+/// making the time a decision takes depend on where in the operator's file a
+/// client happens to sit.
+fn match_client(clients: &[ClientKey], headers: &HeaderMap) -> Admission {
+    let mut admitted: Option<Arc<str>> = None;
+    for client in clients {
+        if client.auth.accepts(headers) {
+            admitted = Some(Arc::clone(&client.name));
+        }
+    }
+    admitted.map_or(Admission::Refused, Admission::Client)
+}
+
+/// The key set as it stands, re-reading the file if it may have changed.
+fn current_clients(
+    path: &Path,
+    interval: Duration,
+    state: &Mutex<ReloadState>,
+) -> Arc<[ClientKey]> {
+    let mut state = state.lock().expect("client keys");
+
+    let due = match state.last_checked {
+        Some(checked) if interval > Duration::ZERO => checked.elapsed() >= interval,
+        Some(_) => true,
+        None => true,
+    };
+    if !due {
+        return Arc::clone(&state.clients);
+    }
+    state.last_checked = Some(Instant::now());
+
+    let stamp = FileStamp::of(path).ok();
+    if stamp.is_some() && stamp == state.stamp {
+        return Arc::clone(&state.clients);
+    }
+
+    match load_key_file(path) {
+        Ok(clients) => {
+            if clients.len() != state.clients.len() {
+                tracing::info!(
+                    clients = clients.len(),
+                    path = %path.display(),
+                    "client key set reloaded"
+                );
+            }
+            state.clients = clients;
+            state.stamp = stamp;
+        }
+        Err(error) => {
+            // The previous set is kept on purpose. A key file is often replaced
+            // by writing a new one and renaming it over the old, so a read that
+            // lands mid-swap sees a partial or missing file; refusing every
+            // client on that would turn an ordinary edit into an outage. The
+            // cost is that a revocation written into a *broken* file does not
+            // take effect, which is why this is loud rather than silent.
+            tracing::warn!(
+                path = %path.display(),
+                %error,
+                "could not reload client keys; the previous set is still in force"
+            );
+        }
+    }
+    Arc::clone(&state.clients)
+}
+
+/// Read and validate a key set.
+fn load_key_file(path: &Path) -> Result<Arc<[ClientKey]>> {
+    let text = fs::read_to_string(path).map_err(|error| {
+        Error::new(
+            error.kind(),
+            format!("could not read client key file {}: {error}", path.display()),
+        )
+    })?;
+    let parsed: KeyFile = serde_json::from_str(&text).map_err(|error| {
+        Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "client key file {} is not valid JSON of the form \
+                 {{\"clients\":[{{\"name\":\"...\",\"key\":\"...\"}}]}}: {error}",
+                path.display()
+            ),
+        )
+    })?;
+
+    if parsed.clients.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "client key file {} lists no clients; remove --client-keys to \
+                 serve without authentication, which the bind guard will then \
+                 make you acknowledge",
+                path.display()
+            ),
+        ));
+    }
+
+    let mut names = HashSet::new();
+    let mut keys = HashSet::new();
+    let mut clients = Vec::with_capacity(parsed.clients.len());
+    for entry in parsed.clients {
+        let name = validate_client_name(&entry.name, path)?;
+        // Validated by the engine's own rules, so the two front doors cannot
+        // disagree about what a usable key is.
+        let key = crate::api::resolve_api_key(Some(entry.key), None)?.ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidData,
+                format!("client {name} in {} has no key", path.display()),
+            )
+        })?;
+
+        if !names.insert(name.clone()) {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "client key file {} names {name} more than once; a name has \
+                     to identify one client for a log line to mean anything",
+                    path.display()
+                ),
+            ));
+        }
+        if !keys.insert(key.clone()) {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "client key file {} gives the same key to more than one \
+                     client; revoking either would not revoke the other",
+                    path.display()
+                ),
+            ));
+        }
+
+        clients.push(ClientKey {
+            name: Arc::from(name.as_str()),
+            auth: ApiAuth::new(Some(key)),
+        });
+    }
+    Ok(Arc::from(clients))
+}
+
+/// A name that can be read back out of a log line unambiguously.
+fn validate_client_name(name: &str, path: &Path) -> Result<String> {
+    let trimmed = name.trim();
+    let usable = !trimmed.is_empty()
+        && trimmed.len() <= MAX_CLIENT_NAME_BYTES
+        && trimmed.chars().all(|c| c.is_ascii_graphic());
+    if !usable {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "client key file {} has a name that is empty, longer than \
+                 {MAX_CLIENT_NAME_BYTES} bytes, or not printable ASCII; the \
+                 name is written to every log line that client causes",
+                path.display()
+            ),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn bearer(key: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {key}")).expect("header"),
+        );
+        headers
+    }
+
+    fn write_keys(dir: &tempfile::TempDir, body: &str) -> PathBuf {
+        let path = dir.path().join("clients.json");
+        fs::write(&path, body).expect("write key file");
+        path
+    }
+
+    const TWO_CLIENTS: &str = r#"{"clients":[
+        {"name":"laptop","key":"laptop-secret"},
+        {"name":"ci","key":"ci-secret"}
+    ]}"#;
+
+    #[test]
+    fn no_key_admits_everyone_and_names_nobody() {
+        let auth = ClientAuth::none();
+        assert!(!auth.is_enabled());
+        assert_eq!(auth.admit(&HeaderMap::new()), Admission::Open);
+    }
+
+    #[test]
+    fn each_client_is_admitted_under_its_own_name() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let auth = ClientAuth::from_key_file(write_keys(&dir, TWO_CLIENTS)).expect("load");
+
+        assert_eq!(auth.client_count(), 2);
+        assert_eq!(
+            auth.admit(&bearer("laptop-secret")),
+            Admission::Client(Arc::from("laptop"))
+        );
+        assert_eq!(
+            auth.admit(&bearer("ci-secret")),
+            Admission::Client(Arc::from("ci"))
+        );
+        assert_eq!(auth.admit(&bearer("neither")), Admission::Refused);
+        assert_eq!(auth.admit(&HeaderMap::new()), Admission::Refused);
+    }
+
+    /// The point of naming clients: one stops being served, the rest do not
+    /// notice, and nothing restarts.
+    #[test]
+    fn removing_a_client_revokes_only_that_client() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_keys(&dir, TWO_CLIENTS);
+        let auth = ClientAuth::from_key_file_every(path.clone(), Duration::ZERO).expect("load");
+
+        assert_eq!(
+            auth.admit(&bearer("laptop-secret")),
+            Admission::Client(Arc::from("laptop"))
+        );
+
+        fs::write(&path, r#"{"clients":[{"name":"ci","key":"ci-secret"}]}"#).expect("rewrite");
+
+        assert_eq!(
+            auth.admit(&bearer("laptop-secret")),
+            Admission::Refused,
+            "a removed client is still being served"
+        );
+        assert_eq!(
+            auth.admit(&bearer("ci-secret")),
+            Admission::Client(Arc::from("ci")),
+            "revoking one client disturbed another"
+        );
+    }
+
+    /// A file being replaced is briefly unreadable. Refusing everyone on that
+    /// would turn an ordinary edit into an outage.
+    #[test]
+    fn a_broken_file_leaves_the_previous_set_in_force() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_keys(&dir, TWO_CLIENTS);
+        let auth = ClientAuth::from_key_file_every(path.clone(), Duration::ZERO).expect("load");
+
+        fs::write(&path, "{ not json").expect("corrupt");
+        assert_eq!(
+            auth.admit(&bearer("laptop-secret")),
+            Admission::Client(Arc::from("laptop"))
+        );
+
+        fs::remove_file(&path).expect("remove");
+        assert_eq!(
+            auth.admit(&bearer("ci-secret")),
+            Admission::Client(Arc::from("ci"))
+        );
+
+        // ...and a file that becomes valid again is picked up.
+        fs::write(&path, r#"{"clients":[{"name":"ci","key":"ci-secret"}]}"#).expect("restore");
+        assert_eq!(auth.admit(&bearer("laptop-secret")), Admission::Refused);
+    }
+
+    /// The set is only re-read once the bound has passed, so a busy proxy is
+    /// not stat-ing the file on every request.
+    #[test]
+    fn a_set_inside_the_bound_is_not_re_read() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write_keys(&dir, TWO_CLIENTS);
+        let auth =
+            ClientAuth::from_key_file_every(path.clone(), Duration::from_secs(3600)).expect("load");
+
+        fs::write(&path, r#"{"clients":[{"name":"ci","key":"ci-secret"}]}"#).expect("rewrite");
+
+        assert_eq!(
+            auth.admit(&bearer("laptop-secret")),
+            Admission::Client(Arc::from("laptop")),
+            "the file was re-read before its staleness bound had passed"
+        );
+    }
+
+    #[test]
+    fn an_unusable_set_stops_the_proxy_rather_than_opening_it() {
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        for (label, body) in [
+            ("not json", "{ nope"),
+            ("no clients", r#"{"clients":[]}"#),
+            (
+                "duplicate name",
+                r#"{"clients":[{"name":"a","key":"one"},{"name":"a","key":"two"}]}"#,
+            ),
+            (
+                "shared key",
+                r#"{"clients":[{"name":"a","key":"same"},{"name":"b","key":"same"}]}"#,
+            ),
+            ("empty name", r#"{"clients":[{"name":"   ","key":"one"}]}"#),
+            (
+                "unprintable name",
+                "{\"clients\":[{\"name\":\"a\\tb\",\"key\":\"one\"}]}",
+            ),
+            ("empty key", r#"{"clients":[{"name":"a","key":"  "}]}"#),
+        ] {
+            let path = write_keys(&dir, body);
+            ClientAuth::from_key_file(path)
+                .err()
+                .unwrap_or_else(|| panic!("{label} was accepted"));
+        }
+
+        ClientAuth::from_key_file(dir.path().join("absent.json"))
+            .expect_err("a missing file is not an open proxy");
+    }
+
+    /// A single `--api-key` still works, and gets a name so the log can say
+    /// something other than "-".
+    #[test]
+    fn a_single_key_is_one_client_that_cannot_be_reloaded() {
+        let auth = ClientAuth::resolve(Some("solo-secret".to_string()), None).expect("resolve");
+        assert!(auth.is_enabled());
+        assert!(!auth.is_reloadable());
+        assert_eq!(auth.client_count(), 1);
+        assert_eq!(
+            auth.admit(&bearer("solo-secret")),
+            Admission::Client(Arc::from("default"))
+        );
+        assert_eq!(auth.admit(&bearer("wrong")), Admission::Refused);
+    }
+
+    #[test]
+    fn a_key_set_reports_itself_as_reloadable() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let auth = ClientAuth::from_key_file(write_keys(&dir, TWO_CLIENTS)).expect("load");
+        assert!(auth.is_enabled());
+        assert!(auth.is_reloadable());
+    }
+
+    /// Both front doors read a credential the same way, because both use the
+    /// engine's [`ApiAuth`] to do it.
+    #[test]
+    fn either_header_the_engine_accepts_names_the_same_client() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let auth = ClientAuth::from_key_file(write_keys(&dir, TWO_CLIENTS)).expect("load");
+
+        let mut api_key = HeaderMap::new();
+        api_key.insert("x-api-key", HeaderValue::from_static("ci-secret"));
+
+        assert_eq!(
+            auth.admit(&api_key),
+            Admission::Client(Arc::from("ci")),
+            "X-API-Key must name the same client Authorization: Bearer does"
+        );
+        assert_eq!(auth.admit(&bearer("ci-secret")), auth.admit(&api_key));
+    }
+
+    /// A client is admitted under its own name wherever it sits in the set.
+    #[test]
+    fn a_clients_position_in_the_set_does_not_change_the_answer() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        for (position, body) in [
+            (
+                "first",
+                r#"{"clients":[{"name":"target","key":"target-secret"},
+                    {"name":"b","key":"b-secret"},{"name":"c","key":"c-secret"}]}"#,
+            ),
+            (
+                "middle",
+                r#"{"clients":[{"name":"b","key":"b-secret"},
+                    {"name":"target","key":"target-secret"},{"name":"c","key":"c-secret"}]}"#,
+            ),
+            (
+                "last",
+                r#"{"clients":[{"name":"b","key":"b-secret"},
+                    {"name":"c","key":"c-secret"},{"name":"target","key":"target-secret"}]}"#,
+            ),
+        ] {
+            let auth = ClientAuth::from_key_file(write_keys(&dir, body)).expect("load");
+            assert_eq!(
+                auth.admit(&bearer("target-secret")),
+                Admission::Client(Arc::from("target")),
+                "answered differently when the client was {position} in the set"
+            );
+            assert_eq!(
+                auth.admit(&bearer("absent-secret")),
+                Admission::Refused,
+                "an unknown key was admitted when the target was {position}"
+            );
+        }
+    }
+}

--- a/src/fabric/client_keys.rs
+++ b/src/fabric/client_keys.rs
@@ -74,9 +74,12 @@ struct KeyFileEntry {
 
 /// What the file looked like when it was last read.
 ///
-/// Modification time alone is not enough: a file rewritten within the same
-/// timestamp tick would be missed, and on a revocation that means a key that
-/// should have stopped working keeps working.
+/// Length as well as modification time, because a revocation usually shortens
+/// the file and mtime alone can be too coarse to notice a rewrite within one
+/// tick. It narrows that window rather than closing it: a key swapped for one
+/// of the same length inside a single tick still looks unchanged. Closing it
+/// would mean reading the file every interval, which is the cost this exists
+/// to avoid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FileStamp {
     modified: Option<SystemTime>,
@@ -97,6 +100,9 @@ struct ReloadState {
     clients: Arc<[ClientKey]>,
     stamp: Option<FileStamp>,
     last_checked: Option<Instant>,
+    /// Whether the last re-read failed, so the notice below is printed once
+    /// per transition rather than once per request.
+    stale: bool,
 }
 
 enum Source {
@@ -175,6 +181,7 @@ impl ClientAuth {
                     clients,
                     stamp,
                     last_checked: Some(Instant::now()),
+                    stale: false,
                 }),
             })),
         })
@@ -264,31 +271,67 @@ fn current_clients(
 
     match load_key_file(path) {
         Ok(clients) => {
-            if clients.len() != state.clients.len() {
-                tracing::info!(
-                    clients = clients.len(),
-                    path = %path.display(),
-                    "client key set reloaded"
+            tracing::info!(
+                clients = clients.len(),
+                path = %path.display(),
+                "client key set reloaded"
+            );
+            if state.stale {
+                eprintln!(
+                    "fabric: client keys reloaded from {}; now serving {}",
+                    path.display(),
+                    clients_phrase(clients.len())
                 );
             }
             state.clients = clients;
             state.stamp = stamp;
+            state.stale = false;
         }
         Err(error) => {
             // The previous set is kept on purpose. A key file is often replaced
             // by writing a new one and renaming it over the old, so a read that
             // lands mid-swap sees a partial or missing file; refusing every
             // client on that would turn an ordinary edit into an outage. The
-            // cost is that a revocation written into a *broken* file does not
-            // take effect, which is why this is loud rather than silent.
+            // cost is that a revocation written into a broken or deleted file
+            // has not taken effect, so the operator has to hear about it.
             tracing::warn!(
                 path = %path.display(),
                 %error,
                 "could not reload client keys; the previous set is still in force"
             );
+            // Printed, not only traced: `RUST_LOG` is unset on a stock proxy,
+            // so a revocation that has silently not happened would otherwise
+            // be invisible to the operator who just wrote it. Once per
+            // transition, so a file left broken does not fill the terminal.
+            if !state.stale {
+                eprintln!("{}", stale_key_set_notice(&error, state.clients.len()));
+            }
+            state.stale = true;
         }
     }
     Arc::clone(&state.clients)
+}
+
+/// What an operator is told when a re-read fails. Pure, so it is tested rather
+/// than eyeballed.
+///
+/// It has to say the revocation did not happen, because that is the whole
+/// consequence: the file on disk and the set being enforced no longer agree,
+/// and the file is the one the operator is looking at.
+fn stale_key_set_notice(error: &Error, clients: usize) -> String {
+    format!(
+        "fabric: could not reload client keys: {error}. The previous set of {} \
+         is still in force, so a revocation written here has NOT taken effect.",
+        clients_phrase(clients)
+    )
+}
+
+fn clients_phrase(count: usize) -> String {
+    if count == 1 {
+        "1 client".to_string()
+    } else {
+        format!("{count} clients")
+    }
 }
 
 /// Read and validate a key set.
@@ -376,8 +419,8 @@ fn validate_client_name(name: &str, path: &Path) -> Result<String> {
             ErrorKind::InvalidData,
             format!(
                 "client key file {} has a name that is empty, longer than \
-                 {MAX_CLIENT_NAME_BYTES} bytes, or not printable ASCII; the \
-                 name is written to every log line that client causes",
+                 {MAX_CLIENT_NAME_BYTES} bytes, or not printable ASCII without \
+                 spaces; the name is written to every log line that client causes",
                 path.display()
             ),
         ));
@@ -485,6 +528,26 @@ mod tests {
         // ...and a file that becomes valid again is picked up.
         fs::write(&path, r#"{"clients":[{"name":"ci","key":"ci-secret"}]}"#).expect("restore");
         assert_eq!(auth.admit(&bearer("laptop-secret")), Admission::Refused);
+    }
+
+    /// The previous set staying in force is only safe if the operator is told,
+    /// and `RUST_LOG` is unset on a stock proxy, so the notice is printed. It
+    /// has to say the revocation did not happen; "could not reload" alone
+    /// reads like a retry that will sort itself out.
+    #[test]
+    fn the_notice_says_the_revocation_has_not_taken_effect() {
+        let error = Error::new(ErrorKind::InvalidData, "clients.json is not valid JSON");
+        let notice = stale_key_set_notice(&error, 2);
+        assert!(
+            notice.contains("clients.json is not valid JSON"),
+            "{notice}"
+        );
+        assert!(notice.contains("previous set of 2 clients"), "{notice}");
+        assert!(notice.contains("NOT taken effect"), "{notice}");
+        assert!(
+            stale_key_set_notice(&error, 1).contains("previous set of 1 client "),
+            "one client is not '1 clients'"
+        );
     }
 
     /// The set is only re-read once the bound has passed, so a busy proxy is

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -21,6 +21,7 @@
 //! * [`policy`] — pure placement decisions; the correctness of the fabric.
 //! * [`forward`] — sending a placed request to the node that will serve it.
 
+pub(crate) mod client_keys;
 pub mod forward;
 pub(crate) mod http;
 pub mod node;

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -94,6 +94,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 use serde_json::Value;
 
+use super::client_keys::Admission;
 use super::policy::{route, RouteDecision, RouteError, RouteMode, RouteRequest};
 use super::{self as fabric, DispatchError, Fabric, ForwardError, StreamOutcome};
 use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
@@ -144,45 +145,10 @@ const NODE_LOCAL_ROUTES: [&str; 6] = [
 
 /// The credential a client must present to this proxy.
 ///
-/// Wraps the engine's own [`ApiAuth`] so a key is validated, and later compared,
-/// by exactly the rules the engine applies to its own.
-#[derive(Clone, Debug)]
-pub struct ClientAuth {
-    inner: ApiAuth,
-}
-
-impl ClientAuth {
-    /// Accept every client. Safe only on a loopback listener, which is why
-    /// [`bind`] refuses anything else without an acknowledgement.
-    pub fn none() -> Self {
-        Self {
-            inner: ApiAuth::new(None),
-        }
-    }
-
-    /// Require a key, read from a value or a file.
-    ///
-    /// Fails rather than starting unauthenticated: a proxy that silently
-    /// ignored an unreadable key file would be open to whatever can reach it.
-    pub fn resolve(
-        api_key: Option<String>,
-        api_key_file: Option<PathBuf>,
-    ) -> std::io::Result<Self> {
-        Ok(Self {
-            inner: ApiAuth::new(crate::api::resolve_api_key(api_key, api_key_file)?),
-        })
-    }
-
-    pub fn is_enabled(&self) -> bool {
-        self.inner.enabled()
-    }
-}
-
-impl Default for ClientAuth {
-    fn default() -> Self {
-        Self::none()
-    }
-}
+/// Re-exported from [`super::client_keys`], which owns what a key set is and
+/// when it is re-read; this module only decides what a refusal looks like on
+/// the wire.
+pub use super::client_keys::ClientAuth;
 
 /// The certificate this proxy presents to its clients.
 ///
@@ -284,7 +250,7 @@ struct ServerState {
 
 /// Build the router without binding a socket, so tests can drive it directly.
 pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
-    let auth = config.auth.inner.clone();
+    let auth = config.auth.clone();
 
     let placed = PLACED_ROUTES.iter().fold(Router::new(), |router, path| {
         let path = *path;
@@ -320,13 +286,50 @@ pub fn router(fabric: Fabric, config: ServeConfig) -> Router {
         })
         // Wraps every route: an unauthenticated request is refused before
         // anything below reads its body or observes the fabric.
-        .layer(middleware::from_fn_with_state(
-            auth,
-            crate::api::authenticate,
-        ))
+        .layer(middleware::from_fn_with_state(auth, client_auth))
         // Outermost, so a request refused above is still recorded.
         .layer(middleware::from_fn(access_log))
 }
+
+/// Refuse a request that presents no key this proxy knows, and name the client
+/// that presented one it does.
+///
+/// The proxy has its own layer rather than the engine's `authenticate` because
+/// it now holds a *set* of keys, and a single-key middleware cannot say which
+/// of them answered. Everything security-bearing is still the engine's: the
+/// header parsing and constant-time comparison come from [`ApiAuth`], the
+/// exemption for the health routes from [`ApiAuth::route_requires_auth`], and
+/// the refusal itself from [`ApiAuth::unauthorized`], so a refusal here is
+/// word-for-word the one the engine gives.
+///
+/// The admitted name is attached to the *response* rather than the request,
+/// because the only thing that reads it — [`access_log`] — wraps this layer and
+/// has already given the request away by the time an answer exists.
+async fn client_auth(State(auth): State<ClientAuth>, request: Request, next: Next) -> Response {
+    let exempt = request.method() == axum::http::Method::OPTIONS
+        || !ApiAuth::route_requires_auth(request.uri().path());
+
+    let admitted = if exempt {
+        None
+    } else {
+        match auth.admit(request.headers()) {
+            Admission::Refused => return ApiAuth::unauthorized(),
+            Admission::Open => None,
+            Admission::Client(name) => Some(name),
+        }
+    };
+
+    let mut response = next.run(request).await;
+    if let Some(name) = admitted {
+        response.extensions_mut().insert(AdmittedClient(name));
+    }
+    response
+}
+
+/// The name of the client a request was admitted under, carried from the
+/// authentication layer out to the access log.
+#[derive(Clone)]
+struct AdmittedClient(Arc<str>);
 
 /// Record one line per request, whatever the outcome.
 ///
@@ -371,6 +374,13 @@ async fn access_log(request: Request, next: Next) -> Response {
     let status = response.status();
     let node = tagged(&response, "x-camelid-fabric-node");
     let reason = tagged(&response, "x-camelid-fabric-reason");
+    // The name, never the key. "-" covers both an unauthenticated proxy and a
+    // request that was refused, which the status already tells them apart.
+    let client_name = response
+        .extensions()
+        .get::<AdmittedClient>()
+        .map_or("-", |AdmittedClient(name)| name.as_ref())
+        .to_string();
 
     if status.is_server_error() {
         tracing::warn!(
@@ -381,6 +391,7 @@ async fn access_log(request: Request, next: Next) -> Response {
             reason,
             elapsed_ms,
             client,
+            client_name,
             request_id,
             "fabric request failed"
         );
@@ -393,6 +404,7 @@ async fn access_log(request: Request, next: Next) -> Response {
             reason,
             elapsed_ms,
             client,
+            client_name,
             request_id,
             "fabric request"
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1245,6 +1245,14 @@ enum FabricAction {
         /// and every prompt would cross the network unencrypted.
         #[arg(long, env = "CAMELID_ALLOW_CLEARTEXT_REMOTE", default_value_t = false)]
         allow_cleartext_remote: bool,
+        /// JSON file naming the clients this proxy serves, of the form
+        /// {"clients":[{"name":"...","key":"..."}]}.
+        ///
+        /// Each client gets its own key, and the name is what the access log
+        /// records. Removing an entry revokes that client without a restart
+        /// and without disturbing the others.
+        #[arg(long, value_name = "PATH", conflicts_with_all = ["api_key", "api_key_file"])]
+        client_keys: Option<PathBuf>,
     },
 }
 
@@ -1325,6 +1333,57 @@ mod fabric_command_tests {
                     other => panic!("expected a fabric command, got {other:?}"),
                 };
                 assert_eq!(bearer.as_deref(), Some("s3cret"), "{argv:?}");
+            }
+        });
+    }
+
+    /// Two answers to "who may call" must not be configurable at once. A key
+    /// set is the one that can revoke, so silently letting a stray `--api-key`
+    /// win would leave an operator believing a client had been cut off.
+    #[test]
+    fn a_client_key_set_cannot_be_combined_with_a_single_key() {
+        on_cli_test_stack(|| {
+            for conflicting in [
+                vec!["--api-key", "s3cret"],
+                vec!["--api-key-file", "some.key"],
+            ] {
+                let mut argv = vec![
+                    "camelid",
+                    "fabric",
+                    "serve",
+                    "--node",
+                    "a=127.0.0.1",
+                    "--client-keys",
+                    "clients.json",
+                ];
+                argv.extend(conflicting.iter().copied());
+                Cli::try_parse_from(&argv)
+                    .err()
+                    .unwrap_or_else(|| panic!("{argv:?} was accepted"));
+            }
+
+            // Each on its own still parses, so the guard is the combination.
+            for argv in [
+                vec![
+                    "camelid",
+                    "fabric",
+                    "serve",
+                    "--node",
+                    "a=127.0.0.1",
+                    "--client-keys",
+                    "clients.json",
+                ],
+                vec![
+                    "camelid",
+                    "fabric",
+                    "serve",
+                    "--node",
+                    "a=127.0.0.1",
+                    "--api-key",
+                    "s3cret",
+                ],
+            ] {
+                Cli::try_parse_from(&argv).unwrap_or_else(|_| panic!("{argv:?} must parse"));
             }
         });
     }
@@ -3017,10 +3076,14 @@ async fn main() -> anyhow::Result<()> {
                 tls_cert,
                 tls_key,
                 allow_cleartext_remote,
+                client_keys,
             } => {
                 let mode = route_mode(&mode)?;
                 let bearer = fabric_bearer(bearer);
-                let auth = camelid::fabric::server::ClientAuth::resolve(api_key, api_key_file)?;
+                let auth = match client_keys {
+                    Some(path) => camelid::fabric::server::ClientAuth::from_key_file(path)?,
+                    None => camelid::fabric::server::ClientAuth::resolve(api_key, api_key_file)?,
+                };
                 // Loaded here, before anything is bound, announced or probed:
                 // a certificate that cannot be read is a refusal, and a refusal
                 // must not arrive after the operator has been told the proxy is
@@ -3051,6 +3114,16 @@ async fn main() -> anyhow::Result<()> {
                 let bound = listener.local_addr()?;
                 let scheme = if tls.is_some() { "https" } else { "http" };
                 println!("fabric serve listening on {scheme}://{bound}");
+                // A key set is the only thing here an operator can get subtly
+                // wrong without being told: a file that parsed but named one
+                // client when they meant three looks exactly like success.
+                if auth.is_reloadable() {
+                    println!(
+                        "serving {} named clients; editing the key file revokes \
+                         a client without a restart",
+                        auth.client_count()
+                    );
+                }
                 // Nothing is being served yet, so this probe costs no request, and
                 // it is the only chance to tell the operator about a node that is
                 // not there before a client discovers it for them.

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -1471,6 +1471,137 @@ async fn a_request_is_logged_with_the_caller_and_the_id_it_was_given() {
     );
 }
 
+/// A key set lives in a file, so these tests write one and hand over its path.
+fn client_keys(dir: &tempfile::TempDir, body: &str) -> std::path::PathBuf {
+    let path = dir.path().join("clients.json");
+    std::fs::write(&path, body).expect("write client key file");
+    path
+}
+
+const TWO_CLIENTS: &str = r#"{"clients":[
+    {"name":"laptop","key":"laptop-secret"},
+    {"name":"ci","key":"ci-secret"}
+]}"#;
+
+/// How long a revocation is given to take effect before the test calls it
+/// broken. Generous against the one-second reload the proxy ships with, so a
+/// loaded machine does not fail this for being slow.
+const REVOCATION_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn chat_requests(node: &StubNode) -> usize {
+    node.received()
+        .iter()
+        .filter(|request| request.path == "/v1/chat/completions")
+        .count()
+}
+
+/// One key could only tell an operator that *someone* authenticated. A named
+/// set says which client, in the one place they already read.
+#[tokio::test(flavor = "multi_thread")]
+async fn each_client_is_served_and_logged_under_its_own_name() {
+    let recorded = access_log();
+    let dir = tempfile::tempdir().expect("temp dir");
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("node-a")]),
+        RouteMode::Throughput,
+        ClientAuth::from_key_file(client_keys(&dir, TWO_CLIENTS)).expect("load key set"),
+    )
+    .await;
+    let body = serde_json::json!({ "model": "shared-model" });
+
+    for (client, key, id) in [
+        ("laptop", "laptop-secret", "only-this-test-names-laptop"),
+        ("ci", "ci-secret", "only-this-test-names-ci"),
+    ] {
+        let bearer = format!("Bearer {key}");
+        let (status, answered, _) = post_chat(
+            addr,
+            &body,
+            &[("Authorization", &bearer), ("x-request-id", id)],
+        )
+        .await;
+        assert_eq!(status, 200, "{client} was not served: {answered}");
+
+        let line = recorded
+            .line_mentioning(id)
+            .unwrap_or_else(|| panic!("{client}'s request was not logged"));
+        assert!(
+            line.contains(&format!("client_name=\"{client}\"")),
+            "the line must name the client that called: {line}"
+        );
+        assert!(
+            !line.contains(key),
+            "the line must never carry the key itself: {line}"
+        );
+    }
+}
+
+/// The reason for naming clients at all: one of them stops being served, and
+/// nothing else does.
+///
+/// This runs against the reload interval the proxy actually ships with, not a
+/// test-only one, because the claim being made is about the binary an operator
+/// runs. Nothing is restarted between the two halves of this test — the same
+/// listener that served the laptop goes on serving CI after refusing it.
+#[tokio::test(flavor = "multi_thread")]
+async fn revoking_one_client_stops_it_without_a_restart_or_disturbing_the_rest() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = client_keys(&dir, TWO_CLIENTS);
+    let node = StubNode::start(StubConfig::ready("shared-model", 0));
+    let addr = start_proxy_with_auth(
+        fabric_of(vec![node.spec("node-a")]),
+        RouteMode::Throughput,
+        ClientAuth::from_key_file(path.clone()).expect("load key set"),
+    )
+    .await;
+    let body = serde_json::json!({ "model": "shared-model" });
+    let laptop = [("Authorization", "Bearer laptop-secret")];
+    let ci = [("Authorization", "Bearer ci-secret")];
+
+    assert_eq!(post_chat(addr, &body, &laptop).await.0, 200);
+    assert_eq!(post_chat(addr, &body, &ci).await.0, 200);
+    assert_eq!(
+        chat_requests(&node),
+        2,
+        "both clients should have reached the node before the revocation"
+    );
+
+    std::fs::write(&path, r#"{"clients":[{"name":"ci","key":"ci-secret"}]}"#).expect("revoke");
+
+    let started = Instant::now();
+    loop {
+        if post_chat(addr, &body, &laptop).await.0 == 401 {
+            break;
+        }
+        assert!(
+            started.elapsed() < REVOCATION_TIMEOUT,
+            "a revoked client was still being served {:?} after the key file \
+             stopped listing it",
+            started.elapsed()
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Refused, and refused early: the point of the credential is that the
+    // fabric is never touched on behalf of a caller it does not serve.
+    let settled = chat_requests(&node);
+    let (status, refused, _) = post_chat(addr, &body, &laptop).await;
+    assert_eq!(status, 401, "{refused}");
+    assert_eq!(refused["error"]["type"], "authentication_error");
+    assert_eq!(
+        chat_requests(&node),
+        settled,
+        "a revoked client still reached a node"
+    );
+
+    let (still_served, answered, _) = post_chat(addr, &body, &ci).await;
+    assert_eq!(
+        still_served, 200,
+        "revoking one client cut off another: {answered}"
+    );
+}
+
 /// Being asked to stop is not the same as being killed. A proxy holds other
 /// people's requests, and dropping them on a deploy turns a routine restart
 /// into a client-visible failure.


### PR DESCRIPTION
﻿## What this changes

`camelid fabric serve` took a single `--api-key`, so every client that could reach the proxy held the
same secret. Two consequences, both operational:

- the access log could only say that *someone* authenticated, never which client;
- withdrawing access from one client meant changing the key for all of them and restarting the proxy,
  which drops the requests everyone else has in flight.

`--client-keys <PATH>` takes a JSON file that names each client:

```json
{"clients": [
  {"name": "laptop", "key": "..."},
  {"name": "ci",     "key": "..."}
]}
```

The name is what the access log records, as `client_name`; the key never is. Deleting an entry
revokes that client without a restart and without disturbing anyone else.

## What is reused rather than rebuilt

Nothing in `src/fabric/client_keys.rs` compares secrets. Each client holds the engine's own
`ApiAuth`, so a presented credential is read from the same two headers (`Authorization: Bearer` or
`X-API-Key`) and compared with the same constant-time check the engine applies to its own listener,
and keys are validated through `crate::api::resolve_api_key`. The health-route exemption comes from
`ApiAuth::route_requires_auth` and the 401 from `ApiAuth::unauthorized`, both lifted out of the
engine's `authenticate` so the two front doors refuse in identical words. This module decides *who*,
never *how*.

## Two choices worth arguing with

**A re-read that fails keeps the previous set and says so, rather than refusing everyone.** A key file
is usually replaced by writing a new one and renaming it over the old, so a read landing mid-swap
sees a partial or absent file; refusing on that would turn an ordinary edit into an outage. The cost
is real and is stated where an operator will meet it: a revocation written into a file that does not
parse — or deleting the key file altogether — has *not* taken effect, and the previously loaded set
goes on being served until the file is readable again or the proxy restarts. So the proxy prints to
stderr when a re-read starts failing, and again when it recovers, rather than relying on `RUST_LOG`
being set:

```
fabric: could not reload client keys: <why>. The previous set of 2 clients is still in
force, so a revocation written here has NOT taken effect.
```

**An unusable set at startup stops the proxy rather than opening it.** A proxy that silently ignored
an unreadable key file would serve whatever can reach it. Unreadable, invalid JSON, empty, a
duplicated name, or two clients sharing a key are all refused before the listener binds.

## The one line in `src/api/mod.rs`, and the provenance re-pin

Please look at this part first.

The fabric no longer uses the crate-internal re-export of `authenticate`: it now holds a *set*, and a
single-key middleware cannot say which key answered. That re-export existed only for the fabric --
the engine's own router at `src/api/mod.rs:2575` was already calling `server::authenticate` directly
-- so the name is now dead, and CI denies warnings.

Removing a name moves the file's git blob, and `src/api/mod.rs` is pinned by the SmolLM3 chat-parity
qualification. The pin moves from `cb8e118e` to `c74f54dc`, and it is a chain of three files, not one
value:

| file | what changes |
| --- | --- |
| `qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json` | `implementation.source_git_blob_sha1` |
| `scripts/hf-qualification-smollm3-chat-parity.mjs` | `RENDERER_GIT_BLOB_SHA1`, **and** `GROUNDING_FILES.runtime_envelope.sha256` ΓÇö that fixture is itself a pinned grounding, so editing it moves its own digest |
| `scripts/test-hf-qualification-smollm3-chat-parity.mjs` | the same two values |

The new fixture digest was computed with the repo's own `canonicalGitTextBytes`, not an approximation.
Its canonical length is unchanged at 5,578 bytes, which is the check that the edit replaced forty hex
characters and nothing else.

I got this wrong on the first push and CI caught it: I had refreshed only `RENDERER_GIT_BLOB_SHA1`,
because `GROUNDING_FILES` does not list `src/api/mod.rs` and I stopped there. It does not need to ΓÇö
the fixture carries the blob sha1, and the fixture is what is pinned.
`scripts/test-check-model-qualification-roster.mjs` failed on exactly that, which is also the ablation
proving the pin is live rather than vestigial. All **42** `scripts/test-*.mjs` now pass locally, which
is what `ci.yml` runs in the `validation-scripts` job.

## Measurements

Test counts, against `upstream/main` at `d080367b4` (i.e. with #671's TLS work in). No test was
removed or renamed.

| target | before | after |
| --- | --- | --- |
| `--lib fabric::` | 170 | 181 |
| `--test fabric_serve` | 60 | 62 |
| `--test fabric_end_to_end` | 14 | 14 |
| `--bin camelid` | 40 | 41 |

Gates on the commit, clean tree: `cargo fmt --all --check` exit 0 - `cargo clippy --all-targets --
-D warnings` **0 findings** - `check-public-scrub.sh` exit 0 - `git diff --check` exit 0 - all
touched files LF.

Revocation latency is bounded by the re-read interval, which is one second, and the file is only
re-read when its size or modification time has changed. The integration test runs against that
shipped default rather than a test-only one, and asserts the revoked client is refused within 5s.

## Ablations

Every new test was checked against the behaviour it claims to catch. Each row is one edit to the
source, both suites re-run, then reverted; the failures listed are the complete set.

| ablation | unit failures | integration failures |
| --- | --- | --- |
| `current_clients` never re-reads the file | 2: `removing_a_client_revokes_only_that_client`, `a_broken_file_leaves_the_previous_set_in_force` | 1: `revoking_one_client_stops_it_without_a_restart_or_disturbing_the_rest` |
| the admitted name is not attached to the response | 0 (174 pass) | 1: `each_client_is_served_and_logged_under_its_own_name` |
| an unusable set falls back to `ClientAuth::none()` | 1: `an_unusable_set_stops_the_proxy_rather_than_opening_it` | 0 (58 pass) |
| only the first entry in the set is compared | 3 | 2 |
| `conflicts_with_all` dropped from `--client-keys` | 1 (`--bin camelid`): `a_client_key_set_cannot_be_combined_with_a_single_key` | - |

In every row the pre-existing tests all passed, so these are the new tests failing, not collateral.

One test I wrote and then deleted, in case it is worth knowing: an assertion that `match_client` does
not stop at the first match cannot fail, because the loader already refuses two clients sharing a
key, so at most one entry can ever match. The non-short-circuit is still there and the reasoning is
in the doc comment, but the test now asserts something observable instead -- that a client is
admitted under its own name wherever it sits in the set.

## What this does not do

- No per-client concurrency or rate limit. That is deliberate and separate.
- No cross-machine receipt: the second machine was unavailable while this was written. Everything
  above is loopback and in-process on Windows.
- The key set is a file the proxy watches. It is not a general configuration reload.

## Base

Rebased onto `d080367b4`, i.e. on top of #671. Git resolved four of the five overlapping files on its
own; three things it could not, and they are worth a look:

- **A silent compile break.** My commit removed `use std::path::PathBuf` from `src/fabric/server.rs`,
  because moving `ClientAuth::resolve` out made it unused. #671 then added `ProxyTls::resolve`, which
  needs it. Each side is correct alone and the merge is textually clean; the result did not compile.
  Restored the import.
- **#671's own bind-guard table went stale the moment this landed.** It listed `--api-key` or
  `--allow-unauthenticated-remote` as the ways to answer the anonymous question. `--client-keys` is
  now a third, so the table and the first bullet under it are updated.
- **A claim of mine went stale in the other direction.** I had written that a key set "satisfies the
  bind guard". After #671 there are two guards, and a key set answers only one of them. It now says
  so, and says an exposed proxy still needs a certificate or `--allow-cleartext-remote`.

The counts above were re-measured on the rebased commit, not carried over.

