### PR TITLE
feat(fabric): add and remove a machine without restarting the proxy

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -185,6 +185,39 @@ fabric: could not reload client keys: <why>. The previous set of 2 clients is st
 revocation written here has NOT taken effect.
 ```
 
+### Adding and removing a machine while it runs
+
+`--node` is read once at startup, so changing the fabric means restarting the proxy — which drops
+whatever everyone else has in flight. `--nodes-file <PATH>` puts the set in a file instead and
+re-reads it as it changes:
+
+```
+# the machines I place on
+desktop=192.0.2.10:8181
+laptop=192.0.2.11:8181
+```
+
+One `LABEL=HOST[:PORT]` per line, exactly the syntax `--node` takes, parsed by the same code. Blank
+lines and whole-line `#` comments are ignored, so a machine can be taken out for an hour by
+commenting it rather than deleting what you wrote. It conflicts with `--node`, because "which
+machines am I placing on" must have one answer.
+
+Adding a line makes that machine placeable; removing one stops it being placed on. Neither restarts
+the proxy, and **neither disturbs a request already running on the machine you removed** — that
+request is answered by the node it was placed on, and only new placements see the new set.
+
+The file is re-read at most once a second, and only when its size or modification time has changed.
+A change is only acted on if the set actually differs, so saving the file without editing it costs
+nothing.
+
+Two refusals are deliberate. A file that cannot be read, is not valid, or **names no nodes at all**
+is refused at startup rather than started on an empty fabric, which would answer every request with
+503 while looking as though it had started. And if a *re-read* fails the same way, the previous set
+stays in force and a warning is logged — a file is usually replaced by writing a new one and renaming
+it over the old, so a read landing mid-swap sees a partial or empty file, and emptying the fabric on
+that would turn an ordinary edit into a total outage. The cost is that a change written into a broken
+file has not taken effect, and the warning is the only thing that says so.
+
 The proxy re-probes its nodes at most once per `--observation-max-age-ms` (500 by default) rather
 than once per request. Inside that window its view can be wrong, so a request placed on a node that
 has gone since is placed again on another node serving the same model, up to `--max-forward-attempts`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -213,10 +213,24 @@ nothing.
 Two refusals are deliberate. A file that cannot be read, is not valid, or **names no nodes at all**
 is refused at startup rather than started on an empty fabric, which would answer every request with
 503 while looking as though it had started. And if a *re-read* fails the same way, the previous set
-stays in force and a warning is logged — a file is usually replaced by writing a new one and renaming
-it over the old, so a read landing mid-swap sees a partial or empty file, and emptying the fabric on
-that would turn an ordinary edit into a total outage. The cost is that a change written into a broken
-file has not taken effect, and the warning is the only thing that says so.
+stays in force — a file is usually replaced by writing a new one and renaming it over the old, so a
+read landing mid-swap sees a partial or empty file, and emptying the fabric on that would turn an
+ordinary edit into a total outage.
+
+That fallback has a cost worth stating plainly: **a change written into a file that does not parse,
+or deleting the node file altogether, does not change anything.** The previously loaded set goes on
+being placed on until the file is readable again or the proxy is restarted — and a restart refuses to
+come up at all while the file is unusable. A machine you meant to take out is still taking requests.
+So the proxy prints to stderr when a re-read starts failing, and again when it recovers, rather than
+relying on `RUST_LOG` being set:
+
+```
+fabric: could not reload the node file: <why>. The previous set of 2 machines is still being
+placed on, so a change written here has NOT taken effect.
+```
+
+It is printed once each way, not once per re-read, so a file left broken does not emit a line a
+second for as long as it stays that way.
 
 The proxy re-probes its nodes at most once per `--observation-max-age-ms` (500 by default) rather
 than once per request. Inside that window its view can be wrong, so a request placed on a node that

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod client_keys;
 pub mod forward;
 pub(crate) mod http;
 pub mod node;
+pub(crate) mod nodes;
 pub mod policy;
 pub mod probe;
 pub mod server;
@@ -42,6 +43,7 @@ pub use node::{
     parse_fabric, parse_node_spec, NodeReady, NodeSnapshot, NodeSpec, NodeSpecParseError,
     NodeStatus, DEFAULT_NODE_PORT,
 };
+use nodes::NodeSet;
 pub use policy::{
     route, route_reserved, Reservations, RouteDecision, RouteError, RouteMode, RouteReason,
     RouteRequest,
@@ -59,7 +61,12 @@ pub const DEFAULT_MAX_FORWARD_ATTEMPTS: usize = 2;
 /// A configured set of nodes.
 #[derive(Clone)]
 pub struct Fabric {
-    specs: Vec<NodeSpec>,
+    /// The machines this fabric places on.
+    ///
+    /// Shared across clones for the same reason as `reserved`, and one reason
+    /// more: two clones that disagreed about which machines exist would place
+    /// against different fabrics.
+    nodes: NodeSet,
     timeout: Duration,
     bearer: Option<String>,
     /// Requests this fabric has placed and not yet finished.
@@ -68,11 +75,12 @@ pub struct Fabric {
     /// every request, and they have to be counting into the same place or they
     /// cannot see each other.
     reserved: Arc<Mutex<Reservations>>,
-    /// The most recent observation, reused while it is fresh enough.
+    /// The most recent observation, with the node-set generation it was taken
+    /// over, reused while it is fresh enough *and* still describes the set.
     ///
     /// Shared across clones for the same reason as `reserved`: an observation
     /// only one clone can see would be re-taken by every other one.
-    observed: Arc<Mutex<Option<Observation>>>,
+    observed: Arc<Mutex<Option<(u64, Observation)>>>,
     /// How stale a reused observation may be. Zero means never reuse one.
     max_observation_age: Duration,
     /// How many nodes one request may be sent to. One never fails over.
@@ -84,7 +92,7 @@ pub struct Fabric {
 impl std::fmt::Debug for Fabric {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Fabric")
-            .field("specs", &self.specs)
+            .field("nodes", &self.nodes)
             .field("timeout", &self.timeout)
             .field("bearer", &self.bearer.as_ref().map(|_| "[REDACTED]"))
             .field("max_observation_age", &self.max_observation_age)
@@ -95,8 +103,28 @@ impl std::fmt::Debug for Fabric {
 
 impl Fabric {
     pub fn new(specs: Vec<NodeSpec>) -> Self {
+        Self::over(NodeSet::fixed(specs))
+    }
+
+    /// Place on the machines named by a file, re-read as it changes.
+    ///
+    /// Fails rather than starting on an empty fabric: a proxy that silently
+    /// ignored an unreadable node file would refuse every request while
+    /// looking as though it had started correctly.
+    pub fn from_node_file(path: std::path::PathBuf) -> std::io::Result<Self> {
+        Ok(Self::over(NodeSet::from_file(path)?))
+    }
+
+    /// [`Self::from_node_file`] with the staleness bound supplied, so a test
+    /// does not have to wait one out.
+    #[cfg(test)]
+    fn from_node_file_every(path: std::path::PathBuf, interval: Duration) -> std::io::Result<Self> {
+        Ok(Self::over(NodeSet::from_file_every(path, interval)?))
+    }
+
+    fn over(nodes: NodeSet) -> Self {
         Self {
-            specs,
+            nodes,
             timeout: DEFAULT_PROBE_TIMEOUT,
             bearer: None,
             reserved: Arc::new(Mutex::new(Reservations::none())),
@@ -142,12 +170,18 @@ impl Fabric {
         self
     }
 
-    pub fn specs(&self) -> &[NodeSpec] {
-        &self.specs
+    /// The machines this fabric places on, as they stand right now.
+    pub fn specs(&self) -> Vec<NodeSpec> {
+        self.nodes.current().0.to_vec()
+    }
+
+    /// Whether the node set changes without a restart.
+    pub fn is_reloadable(&self) -> bool {
+        self.nodes.is_reloadable()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.specs.is_empty()
+        self.nodes.current().0.is_empty()
     }
 
     /// Observe every node.
@@ -165,8 +199,13 @@ impl Fabric {
     /// observation is a statement about the fabric as it was, and some
     /// refusals are reported to clients as permanent.
     fn observe_reporting_reuse(&self) -> (Vec<NodeSnapshot>, bool) {
+        // Resolved first, and its lock released before the observation lock is
+        // taken: the order is nodes -> observed -> reserved, and no two are
+        // ever held together.
+        let (specs, generation) = self.nodes.current();
+
         if self.max_observation_age.is_zero() {
-            return (self.probe(), false);
+            return (self.probe(&specs), false);
         }
 
         // Refreshing under the lock makes concurrent callers wait for one probe
@@ -174,19 +213,29 @@ impl Fabric {
         // on an expired observation would reproduce exactly the per-request
         // probing this bound exists to remove.
         let mut observed = lock(&self.observed);
-        if let Some(observation) = observed.as_ref() {
-            if observation.is_fresh_at(Instant::now(), self.max_observation_age) {
+        if let Some((taken_over, observation)) = observed.as_ref() {
+            // The generation is checked before the clock. An observation of a
+            // set that has since gained or lost a machine is not stale, it is
+            // about something else: reusing it would place on a node that has
+            // gone, or refuse to place on one that has just arrived, for the
+            // whole of the freshness window.
+            if *taken_over == generation
+                && observation.is_fresh_at(Instant::now(), self.max_observation_age)
+            {
                 return (observation.snapshots().to_vec(), true);
             }
         }
-        let snapshots = self.probe();
-        *observed = Some(Observation::taken_at(snapshots.clone(), Instant::now()));
+        let snapshots = self.probe(&specs);
+        *observed = Some((
+            generation,
+            Observation::taken_at(snapshots.clone(), Instant::now()),
+        ));
         (snapshots, false)
     }
 
-    /// Probe every node, whatever was observed before.
-    fn probe(&self) -> Vec<NodeSnapshot> {
-        probe_fabric(&self.specs, self.bearer.as_deref(), self.timeout)
+    /// Probe every node in `specs`, whatever was observed before.
+    fn probe(&self, specs: &[NodeSpec]) -> Vec<NodeSnapshot> {
+        probe_fabric(specs, self.bearer.as_deref(), self.timeout)
     }
 
     /// Drop the current observation, so the next one is taken fresh.
@@ -1077,6 +1126,104 @@ mod tests {
             ),
             "got {error:?}"
         );
+    }
+
+    /// The whole point of a node file: a machine the operator adds is placed
+    /// on, and one they take away stops being placed on, without a restart.
+    ///
+    /// The observation window here is an hour. That is deliberate — if a
+    /// changed set did not invalidate the observation taken over the old one,
+    /// this fabric would go on describing the old machines for that hour.
+    #[test]
+    fn a_changed_node_set_is_not_answered_from_the_observation_of_the_old_one() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("nodes");
+        // Port 1 is never listening, so every probe settles as Unreachable.
+        // Which labels come back is the whole question; whether they were
+        // reachable is not.
+        std::fs::write(&path, "a=127.0.0.1:1\n").expect("write");
+
+        let fabric = Fabric::from_node_file_every(path.clone(), Duration::ZERO)
+            .expect("load")
+            .with_timeout(Duration::from_millis(50))
+            .with_max_observation_age(Duration::from_secs(3600));
+
+        let labels = |snapshots: &[NodeSnapshot]| -> Vec<String> {
+            snapshots.iter().map(|s| s.label().to_string()).collect()
+        };
+
+        assert_eq!(labels(&fabric.observe()), vec!["a"]);
+
+        std::fs::write(&path, "b=127.0.0.1:1\n").expect("rewrite");
+
+        assert_eq!(
+            labels(&fabric.observe()),
+            vec!["b"],
+            "an observation of the node set as it was must not survive the set changing"
+        );
+    }
+
+    /// A set that has not changed must keep its observation, or every look at
+    /// the file would cost a probe of every node.
+    #[test]
+    fn an_unchanged_node_file_keeps_the_observation_it_already_has() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("nodes");
+        std::fs::write(&path, "a=127.0.0.1:1\n").expect("write");
+
+        let fabric = Fabric::from_node_file_every(path.clone(), Duration::ZERO)
+            .expect("load")
+            .with_timeout(Duration::from_millis(50))
+            .with_max_observation_age(Duration::from_secs(3600));
+
+        let first = fabric.observe();
+        // Rewritten with identical content: the stamp moves, the set does not.
+        std::fs::write(&path, "a=127.0.0.1:1\n").expect("identical rewrite");
+        let second = fabric.observe();
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_eq!(
+            first[0].label(),
+            second[0].label(),
+            "an identical rewrite must not invalidate the observation"
+        );
+    }
+
+    /// Taking a machine away must not disturb what is already running on it:
+    /// reservations are counted by label and released when the placement is
+    /// dropped, whether or not the node is still in the set.
+    #[test]
+    fn removing_a_node_leaves_the_requests_already_placed_on_it_alone() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("nodes");
+        std::fs::write(&path, "a=127.0.0.1:1\nb=127.0.0.1:1\n").expect("write");
+        let fabric = Fabric::from_node_file_every(path.clone(), Duration::ZERO).expect("load");
+
+        // Reserved by hand: placement needs a ready node, and this test is
+        // about the bookkeeping, not about probing.
+        lock(&fabric.reserved).take("a");
+        assert_eq!(fabric.reserved().get("a"), 1);
+
+        std::fs::write(&path, "b=127.0.0.1:1\n").expect("remove a");
+        assert_eq!(fabric.specs().len(), 1, "the set really did shrink");
+
+        assert_eq!(
+            fabric.reserved().get("a"),
+            1,
+            "a request in flight on a removed node must still be counted"
+        );
+        lock(&fabric.reserved).release("a");
+        assert_eq!(
+            fabric.reserved().get("a"),
+            0,
+            "and must still release when it finishes"
+        );
+    }
+
+    #[test]
+    fn a_fixed_fabric_does_not_claim_to_be_reloadable() {
+        assert!(!Fabric::new(Vec::new()).is_reloadable());
     }
 
     #[test]

--- a/src/fabric/nodes.rs
+++ b/src/fabric/nodes.rs
@@ -1,0 +1,449 @@
+//! Which machines this fabric places on, and how that set changes while it runs.
+//!
+//! The node set used to be fixed at construction: `--node` was read once at
+//! startup and never again, so adding a machine or taking one away meant
+//! stopping the proxy — which drops the requests everyone else has in flight,
+//! the exact thing the graceful stop exists to prevent.
+//!
+//! A node file is the set, as a file the operator can edit, diff and back up.
+//! Its syntax is deliberately the same `label=host[:port]` that `--node`
+//! already takes, parsed by [`parse_node_spec`] through [`parse_fabric`], so
+//! there is one answer to "what is a node spec" and one place that answers it.
+
+use std::fs;
+use std::io::{Error, ErrorKind, Result};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
+
+use super::node::{parse_fabric, NodeSpec};
+
+/// How long a loaded set is trusted before the file is looked at again.
+///
+/// A node joining or leaving is only noticed this fast. A second is short
+/// enough that an operator does not wait on it and long enough that a busy
+/// proxy is not stat-ing a file on every placement.
+pub(crate) const DEFAULT_NODE_RELOAD_INTERVAL: Duration = Duration::from_secs(1);
+
+/// What the file looked like when it was last read.
+///
+/// Modification time alone is not enough: a file rewritten within the same
+/// timestamp tick would be missed, and on a removal that means a node that
+/// should have stopped being placed on keeps being placed on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileStamp {
+    modified: Option<SystemTime>,
+    len: u64,
+}
+
+impl FileStamp {
+    fn of(path: &Path) -> Result<Self> {
+        let metadata = fs::metadata(path)?;
+        Ok(Self {
+            modified: metadata.modified().ok(),
+            len: metadata.len(),
+        })
+    }
+}
+
+enum Source {
+    /// Specs given on the command line. They cannot change while the process
+    /// runs, so there is nothing to re-read.
+    Fixed,
+    File {
+        path: PathBuf,
+        interval: Duration,
+    },
+}
+
+struct State {
+    specs: Arc<[NodeSpec]>,
+    stamp: Option<FileStamp>,
+    last_checked: Option<Instant>,
+}
+
+struct Inner {
+    source: Source,
+    state: Mutex<State>,
+    /// Bumped only when the set actually changes, never merely because the
+    /// file was re-read. An observation is valid for the generation it was
+    /// taken in and no other; see [`NodeSet::current`].
+    generation: AtomicU64,
+}
+
+/// The set of nodes a fabric places on.
+///
+/// Cloning shares one set, for the same reason the observation and the
+/// reservations are shared: the resident proxy hands a `Fabric` to every
+/// request, and a set only one clone could see would be re-read by every
+/// other one — and worse, they would disagree about which machines exist.
+#[derive(Clone)]
+pub(crate) struct NodeSet {
+    inner: Arc<Inner>,
+}
+
+impl NodeSet {
+    /// A set that cannot change.
+    pub(crate) fn fixed(specs: Vec<NodeSpec>) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                source: Source::Fixed,
+                state: Mutex::new(State {
+                    specs: Arc::from(specs),
+                    stamp: None,
+                    last_checked: None,
+                }),
+                generation: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    /// A set read from a file, re-read as it changes.
+    pub(crate) fn from_file(path: PathBuf) -> Result<Self> {
+        Self::from_file_every(path, DEFAULT_NODE_RELOAD_INTERVAL)
+    }
+
+    /// [`Self::from_file`] with the staleness bound supplied.
+    ///
+    /// A zero interval re-reads on every look, which is what the tests use so
+    /// a change does not have to be waited out.
+    pub(crate) fn from_file_every(path: PathBuf, interval: Duration) -> Result<Self> {
+        // Loaded once here so an unusable file stops the proxy at startup
+        // rather than at the first request.
+        let specs = load_node_file(&path)?;
+        let stamp = FileStamp::of(&path).ok();
+        Ok(Self {
+            inner: Arc::new(Inner {
+                source: Source::File { path, interval },
+                state: Mutex::new(State {
+                    specs: Arc::from(specs),
+                    stamp,
+                    last_checked: Some(Instant::now()),
+                }),
+                generation: AtomicU64::new(0),
+            }),
+        })
+    }
+
+    /// Whether the set changes without a restart.
+    pub(crate) fn is_reloadable(&self) -> bool {
+        matches!(self.inner.source, Source::File { .. })
+    }
+
+    /// The set as it stands, and the generation it belongs to.
+    ///
+    /// The generation is the point of this method. An observation describes
+    /// the set it was taken over, so one taken before a machine was added or
+    /// removed is not merely stale, it is *about something else*. Callers keep
+    /// the generation alongside the observation and reuse neither across a
+    /// change. Returning it — rather than a "did it change" flag — means a
+    /// caller that only wanted the specs cannot accidentally swallow the
+    /// change and leave the next caller reusing an observation of a set that
+    /// no longer exists.
+    pub(crate) fn current(&self) -> (Arc<[NodeSpec]>, u64) {
+        let Source::File { path, interval } = &self.inner.source else {
+            let state = lock(&self.inner.state);
+            return (Arc::clone(&state.specs), 0);
+        };
+
+        let mut state = lock(&self.inner.state);
+
+        let due = match state.last_checked {
+            Some(checked) if *interval > Duration::ZERO => checked.elapsed() >= *interval,
+            _ => true,
+        };
+        if !due {
+            return (
+                Arc::clone(&state.specs),
+                self.inner.generation.load(Ordering::SeqCst),
+            );
+        }
+        state.last_checked = Some(Instant::now());
+
+        let stamp = FileStamp::of(path).ok();
+        if stamp.is_some() && stamp == state.stamp {
+            return (
+                Arc::clone(&state.specs),
+                self.inner.generation.load(Ordering::SeqCst),
+            );
+        }
+
+        match load_node_file(path) {
+            Ok(specs) => {
+                state.stamp = stamp;
+                // Compared, not assumed: touching a file without changing what
+                // it says must not throw away a usable observation.
+                if specs.as_slice() != &*state.specs {
+                    tracing::info!(
+                        nodes = specs.len(),
+                        path = %path.display(),
+                        "node set reloaded"
+                    );
+                    state.specs = Arc::from(specs);
+                    self.inner.generation.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+            Err(error) => {
+                // The previous set is kept on purpose. A file is often replaced
+                // by writing a new one and renaming it over the old, so a read
+                // that lands mid-swap sees a partial, empty or missing file;
+                // emptying the fabric on that would turn an ordinary edit into
+                // a total outage, because a fabric with no nodes refuses every
+                // request. The cost is that a change written into a *broken*
+                // file does not take effect, which is why this is loud.
+                tracing::warn!(
+                    path = %path.display(),
+                    %error,
+                    "could not reload the node set; the previous one is still in force"
+                );
+            }
+        }
+        (
+            Arc::clone(&state.specs),
+            self.inner.generation.load(Ordering::SeqCst),
+        )
+    }
+}
+
+impl std::fmt::Debug for NodeSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (specs, generation) = {
+            let state = lock(&self.inner.state);
+            (
+                Arc::clone(&state.specs),
+                self.inner.generation.load(Ordering::SeqCst),
+            )
+        };
+        f.debug_struct("NodeSet")
+            .field("specs", &specs)
+            .field("reloadable", &self.is_reloadable())
+            .field("generation", &generation)
+            .finish()
+    }
+}
+
+/// Read and validate a node file.
+///
+/// Blank lines and whole-line `#` comments are skipped, so an operator can
+/// take a machine out by commenting it rather than deleting what they wrote.
+/// Everything else is a spec in `--node` syntax, and duplicate labels are
+/// refused by [`parse_fabric`] exactly as they are on the command line.
+fn load_node_file(path: &Path) -> Result<Vec<NodeSpec>> {
+    let text = fs::read_to_string(path).map_err(|error| {
+        Error::new(
+            error.kind(),
+            format!("could not read node file {}: {error}", path.display()),
+        )
+    })?;
+
+    let lines: Vec<String> = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(str::to_string)
+        .collect();
+
+    let specs = parse_fabric(&lines).map_err(|error| {
+        Error::new(
+            ErrorKind::InvalidData,
+            format!("node file {}: {error}", path.display()),
+        )
+    })?;
+
+    // An empty set is refused rather than served, at startup and on every
+    // reload. A fabric with no nodes answers every request with 503, and the
+    // realistic way to get an empty file is a truncated write rather than a
+    // deliberate one. An operator who wants to serve nothing stops the proxy.
+    if specs.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "node file {} names no nodes; a fabric with no nodes can serve \
+                 nothing, so the proxy will not run on one",
+                path.display()
+            ),
+        ));
+    }
+    Ok(specs)
+}
+
+/// A poisoned lock is not corrupted state: some other request panicked while
+/// holding it. Recover the value rather than spreading the panic.
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &tempfile::TempDir, body: &str) -> PathBuf {
+        let path = dir.path().join("nodes");
+        fs::write(&path, body).expect("write node file");
+        path
+    }
+
+    const TWO: &str = "a=127.0.0.1:8181\nb=127.0.0.1:8182\n";
+
+    fn labels(specs: &[NodeSpec]) -> Vec<String> {
+        specs.iter().map(|spec| spec.label.clone()).collect()
+    }
+
+    #[test]
+    fn a_fixed_set_never_changes() {
+        let set = NodeSet::fixed(parse_fabric(&["a=host".to_string()]).expect("parse"));
+        assert!(!set.is_reloadable());
+        let (first, generation) = set.current();
+        let (again, same) = set.current();
+        assert_eq!(labels(&first), labels(&again));
+        assert_eq!(generation, same);
+    }
+
+    /// The point of the file: a machine joins and starts being placed on,
+    /// without the proxy stopping.
+    #[test]
+    fn a_node_added_to_the_file_joins_the_set() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write(&dir, "a=127.0.0.1:8181\n");
+        let set = NodeSet::from_file_every(path.clone(), Duration::ZERO).expect("load");
+
+        let (before, first_generation) = set.current();
+        assert_eq!(labels(&before), vec!["a"]);
+
+        fs::write(&path, TWO).expect("rewrite");
+
+        let (after, second_generation) = set.current();
+        assert_eq!(labels(&after), vec!["a", "b"]);
+        assert_ne!(
+            first_generation, second_generation,
+            "a changed set must not share a generation with the set it replaced"
+        );
+    }
+
+    #[test]
+    fn a_node_removed_from_the_file_leaves_the_set() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write(&dir, TWO);
+        let set = NodeSet::from_file_every(path.clone(), Duration::ZERO).expect("load");
+        assert_eq!(labels(&set.current().0), vec!["a", "b"]);
+
+        fs::write(&path, "b=127.0.0.1:8182\n").expect("rewrite");
+        assert_eq!(labels(&set.current().0), vec!["b"]);
+    }
+
+    /// Commenting a machine out is how an operator takes it away for an hour
+    /// without losing what they had typed.
+    #[test]
+    fn blank_lines_and_comments_are_not_nodes() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write(
+            &dir,
+            "# my fabric\n\n  a=127.0.0.1:8181  \n\n#b=127.0.0.1:8182\n",
+        );
+        let set = NodeSet::from_file(path).expect("load");
+        assert_eq!(labels(&set.current().0), vec!["a"]);
+    }
+
+    /// A file being replaced is briefly unreadable, and an empty one is very
+    /// likely a truncated write. Neither may empty the fabric.
+    #[test]
+    fn a_broken_or_empty_file_leaves_the_previous_set_in_force() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write(&dir, TWO);
+        let set = NodeSet::from_file_every(path.clone(), Duration::ZERO).expect("load");
+
+        fs::write(&path, "not a spec").expect("corrupt");
+        assert_eq!(labels(&set.current().0), vec!["a", "b"]);
+
+        fs::write(&path, "").expect("truncate");
+        assert_eq!(labels(&set.current().0), vec!["a", "b"]);
+
+        fs::remove_file(&path).expect("remove");
+        assert_eq!(labels(&set.current().0), vec!["a", "b"]);
+
+        // ...and a file that becomes usable again is picked up.
+        fs::write(&path, "c=127.0.0.1:8183\n").expect("restore");
+        assert_eq!(labels(&set.current().0), vec!["c"]);
+    }
+
+    /// Rewriting a file with the same content must not invalidate the
+    /// observation taken over it, or an operator's editor could cost a probe
+    /// of every node for nothing.
+    ///
+    /// Only the identical rewrite is asserted here. A *reordering* is a change
+    /// the generation should also catch, but it cannot be tested this way: the
+    /// reordered text is the same length as the original, so a write landing in
+    /// the same modification-time tick is indistinguishable from no write at
+    /// all, and the test would fail on timing rather than on behaviour. Adding
+    /// and removing are covered above and change the length.
+    #[test]
+    fn rewriting_a_file_without_changing_it_does_not_change_the_generation() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write(&dir, TWO);
+        let set = NodeSet::from_file_every(path.clone(), Duration::ZERO).expect("load");
+        let (_, before) = set.current();
+
+        fs::write(&path, TWO).expect("identical rewrite");
+        let (specs, after) = set.current();
+
+        assert_eq!(labels(&specs), vec!["a", "b"]);
+        assert_eq!(before, after, "an identical rewrite is not a change");
+    }
+
+    #[test]
+    fn a_set_inside_the_bound_is_not_re_read() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write(&dir, "a=127.0.0.1:8181\n");
+        let set = NodeSet::from_file_every(path.clone(), Duration::from_secs(3600)).expect("load");
+
+        fs::write(&path, TWO).expect("rewrite");
+
+        assert_eq!(
+            labels(&set.current().0),
+            vec!["a"],
+            "the file was re-read before its staleness bound had passed"
+        );
+    }
+
+    #[test]
+    fn an_unusable_file_stops_the_proxy_rather_than_emptying_the_fabric() {
+        let dir = tempfile::tempdir().expect("temp dir");
+
+        for (label, body) in [
+            ("no nodes", ""),
+            ("only comments", "# nothing here\n\n"),
+            ("not a spec", "this is not a node\n"),
+            ("duplicate label", "a=127.0.0.1:8181\na=127.0.0.1:8182\n"),
+            ("unbracketed ipv6", "a=::1:8181\n"),
+        ] {
+            let path = write(&dir, body);
+            NodeSet::from_file(path)
+                .err()
+                .unwrap_or_else(|| panic!("{label} was accepted"));
+        }
+
+        NodeSet::from_file(dir.path().join("absent"))
+            .expect_err("a missing file is not an empty fabric");
+    }
+
+    /// Clones share one set, or two requests would disagree about which
+    /// machines exist.
+    #[test]
+    fn a_clone_sees_the_same_set() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write(&dir, "a=127.0.0.1:8181\n");
+        let set = NodeSet::from_file_every(path.clone(), Duration::ZERO).expect("load");
+        let clone = set.clone();
+
+        fs::write(&path, TWO).expect("rewrite");
+        let (seen_by_clone, clone_generation) = clone.current();
+        let (seen_by_original, original_generation) = set.current();
+
+        assert_eq!(labels(&seen_by_clone), vec!["a", "b"]);
+        assert_eq!(labels(&seen_by_original), vec!["a", "b"]);
+        assert_eq!(clone_generation, original_generation);
+    }
+}

--- a/src/fabric/nodes.rs
+++ b/src/fabric/nodes.rs
@@ -28,9 +28,12 @@ pub(crate) const DEFAULT_NODE_RELOAD_INTERVAL: Duration = Duration::from_secs(1)
 
 /// What the file looked like when it was last read.
 ///
-/// Modification time alone is not enough: a file rewritten within the same
-/// timestamp tick would be missed, and on a removal that means a node that
-/// should have stopped being placed on keeps being placed on.
+/// Length as well as modification time, because adding or removing a machine
+/// changes the length and mtime alone can be too coarse to notice a rewrite
+/// within one tick. It narrows that window rather than closing it: an edit of
+/// the same length inside a single tick still looks unchanged. Closing it would
+/// mean reading the file every interval, which is the cost this exists to
+/// avoid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FileStamp {
     modified: Option<SystemTime>,
@@ -61,6 +64,9 @@ struct State {
     specs: Arc<[NodeSpec]>,
     stamp: Option<FileStamp>,
     last_checked: Option<Instant>,
+    /// Whether the last re-read failed, so the notice below is printed once
+    /// per transition rather than once per interval for as long as it lasts.
+    stale: bool,
 }
 
 struct Inner {
@@ -93,6 +99,7 @@ impl NodeSet {
                     specs: Arc::from(specs),
                     stamp: None,
                     last_checked: None,
+                    stale: false,
                 }),
                 generation: AtomicU64::new(0),
             }),
@@ -120,6 +127,7 @@ impl NodeSet {
                     specs: Arc::from(specs),
                     stamp,
                     last_checked: Some(Instant::now()),
+                    stale: false,
                 }),
                 generation: AtomicU64::new(0),
             }),
@@ -183,6 +191,14 @@ impl NodeSet {
                     state.specs = Arc::from(specs);
                     self.inner.generation.fetch_add(1, Ordering::SeqCst);
                 }
+                if state.stale {
+                    eprintln!(
+                        "fabric: node file {} is readable again; placing on {}",
+                        path.display(),
+                        nodes_phrase(state.specs.len())
+                    );
+                }
+                state.stale = false;
             }
             Err(error) => {
                 // The previous set is kept on purpose. A file is often replaced
@@ -190,13 +206,23 @@ impl NodeSet {
                 // that lands mid-swap sees a partial, empty or missing file;
                 // emptying the fabric on that would turn an ordinary edit into
                 // a total outage, because a fabric with no nodes refuses every
-                // request. The cost is that a change written into a *broken*
-                // file does not take effect, which is why this is loud.
+                // request. The cost is that a change written into a broken or
+                // deleted file does not take effect, so the operator has to
+                // hear about it.
                 tracing::warn!(
                     path = %path.display(),
                     %error,
                     "could not reload the node set; the previous one is still in force"
                 );
+                // Printed, not only traced: `RUST_LOG` is unset on a stock
+                // proxy, so a machine the operator meant to take out would go
+                // on being placed on with nothing said. Once per transition,
+                // because this is re-attempted every interval and a file left
+                // broken would otherwise emit a line a second indefinitely.
+                if !state.stale {
+                    eprintln!("{}", stale_node_set_notice(&error, state.specs.len()));
+                }
+                state.stale = true;
             }
         }
         (
@@ -266,6 +292,28 @@ fn load_node_file(path: &Path) -> Result<Vec<NodeSpec>> {
         ));
     }
     Ok(specs)
+}
+
+/// What an operator is told when a re-read fails. Pure, so it is tested rather
+/// than eyeballed.
+///
+/// It has to say the change did not happen: the file and the set being placed
+/// on no longer agree, and the file is the one the operator is looking at. A
+/// machine they meant to take out is still taking requests.
+fn stale_node_set_notice(error: &Error, nodes: usize) -> String {
+    format!(
+        "fabric: could not reload the node file: {error}. The previous set of {} \
+         is still being placed on, so a change written here has NOT taken effect.",
+        nodes_phrase(nodes)
+    )
+}
+
+fn nodes_phrase(count: usize) -> String {
+    if count == 1 {
+        "1 machine".to_string()
+    } else {
+        format!("{count} machines")
+    }
 }
 
 /// A poisoned lock is not corrupted state: some other request panicked while
@@ -391,6 +439,24 @@ mod tests {
 
         assert_eq!(labels(&specs), vec!["a", "b"]);
         assert_eq!(before, after, "an identical rewrite is not a change");
+    }
+
+    /// Keeping the previous set is only safe if the operator is told, and
+    /// `RUST_LOG` is unset on a stock proxy, so the notice is printed. It has
+    /// to say the change did not happen: a machine they meant to take out is
+    /// still taking requests, and "could not reload" alone reads like a retry
+    /// that will sort itself out.
+    #[test]
+    fn the_notice_says_the_change_has_not_taken_effect() {
+        let error = Error::new(ErrorKind::InvalidData, "nodes: needs a label");
+        let notice = stale_node_set_notice(&error, 2);
+        assert!(notice.contains("nodes: needs a label"), "{notice}");
+        assert!(notice.contains("previous set of 2 machines"), "{notice}");
+        assert!(notice.contains("NOT taken effect"), "{notice}");
+        assert!(
+            stale_node_set_notice(&error, 1).contains("previous set of 1 machine "),
+            "one machine is not '1 machines'"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1175,8 +1175,21 @@ enum FabricAction {
     /// default and refuses a routable address unless the exposure is
     /// acknowledged explicitly.
     Serve {
-        #[arg(long = "node", required = true, value_name = "LABEL=HOST[:PORT]")]
+        #[arg(
+            long = "node",
+            required_unless_present = "nodes_file",
+            conflicts_with = "nodes_file",
+            value_name = "LABEL=HOST[:PORT]"
+        )]
         nodes: Vec<String>,
+        /// Read the nodes from a file instead, one `LABEL=HOST[:PORT]` per
+        /// line, and re-read it as it changes.
+        ///
+        /// Blank lines and whole-line `#` comments are ignored. Editing the
+        /// file adds or removes a machine without restarting the proxy, so
+        /// doing so does not drop the requests already in flight.
+        #[arg(long, value_name = "PATH")]
+        nodes_file: Option<PathBuf>,
         #[arg(long, default_value = "127.0.0.1:8282")]
         addr: SocketAddr,
         /// Default placement mode; a client can still request affinity to a
@@ -1385,6 +1398,38 @@ mod fabric_command_tests {
             ] {
                 Cli::try_parse_from(&argv).unwrap_or_else(|_| panic!("{argv:?} must parse"));
             }
+        });
+    }
+
+    /// The node set has one source. Allowing both would leave "which machines
+    /// am I actually placing on" with two answers, and the file is the one
+    /// that can change underneath.
+    #[test]
+    fn the_nodes_come_from_a_file_or_from_flags_but_never_both() {
+        on_cli_test_stack(|| {
+            Cli::try_parse_from([
+                "camelid",
+                "fabric",
+                "serve",
+                "--node",
+                "a=127.0.0.1",
+                "--nodes-file",
+                "nodes.txt",
+            ])
+            .expect_err("--node with --nodes-file was accepted");
+
+            // Either alone parses, so the guard is the combination — and
+            // --node is no longer required now that a file can supply them.
+            for argv in [
+                vec!["camelid", "fabric", "serve", "--node", "a=127.0.0.1"],
+                vec!["camelid", "fabric", "serve", "--nodes-file", "nodes.txt"],
+            ] {
+                Cli::try_parse_from(&argv).unwrap_or_else(|_| panic!("{argv:?} must parse"));
+            }
+
+            // Neither is still a refusal: a proxy with no nodes serves nothing.
+            Cli::try_parse_from(["camelid", "fabric", "serve"])
+                .expect_err("serve with no nodes at all was accepted");
         });
     }
 }
@@ -3063,6 +3108,7 @@ async fn main() -> anyhow::Result<()> {
             }
             FabricAction::Serve {
                 nodes,
+                nodes_file,
                 addr,
                 mode,
                 bearer,
@@ -3089,15 +3135,19 @@ async fn main() -> anyhow::Result<()> {
                 // must not arrive after the operator has been told the proxy is
                 // listening on an https address.
                 let tls = camelid::fabric::server::ProxyTls::resolve(tls_cert, tls_key).await?;
-                let specs = camelid::fabric::parse_fabric(&nodes)
-                    .map_err(|error| anyhow::anyhow!("{error}"))?;
-                let fabric = camelid::fabric::Fabric::new(specs)
-                    .with_timeout(std::time::Duration::from_millis(timeout_ms))
-                    .with_bearer(bearer.as_deref())
-                    .with_max_observation_age(std::time::Duration::from_millis(
-                        observation_max_age_ms,
-                    ))
-                    .with_max_forward_attempts(max_forward_attempts);
+                // Same reason: a node file that cannot be read is a refusal,
+                // and it has to arrive before the listening line.
+                let fabric = match nodes_file {
+                    Some(path) => camelid::fabric::Fabric::from_node_file(path)?,
+                    None => camelid::fabric::Fabric::new(
+                        camelid::fabric::parse_fabric(&nodes)
+                            .map_err(|error| anyhow::anyhow!("{error}"))?,
+                    ),
+                }
+                .with_timeout(std::time::Duration::from_millis(timeout_ms))
+                .with_bearer(bearer.as_deref())
+                .with_max_observation_age(std::time::Duration::from_millis(observation_max_age_ms))
+                .with_max_forward_attempts(max_forward_attempts);
 
                 // Bind before announcing, so a refused or already-taken address
                 // never prints a listening line it did not earn.
@@ -3122,6 +3172,15 @@ async fn main() -> anyhow::Result<()> {
                         "serving {} named clients; editing the key file revokes \
                          a client without a restart",
                         auth.client_count()
+                    );
+                }
+                // The startup report below names the nodes, but not that the
+                // set can still change — which is the one thing an operator
+                // cannot tell by looking at it.
+                if fabric.is_reloadable() {
+                    println!(
+                        "watching the node file; editing it adds or removes a \
+                         machine without a restart"
                     );
                 }
                 // Nothing is being served yet, so this probe costs no request, and

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -1044,6 +1044,193 @@ async fn a_client_can_pin_a_node_even_when_the_proxy_defaults_to_throughput() {
     assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("alpha"));
 }
 
+/// How long a change to the node file is given to take effect before the test
+/// calls it broken. Generous against the one-second re-read the proxy ships
+/// with, so a loaded machine does not fail this for being slow.
+const NODE_RELOAD_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn node_file(dir: &tempfile::TempDir, lines: &[String]) -> std::path::PathBuf {
+    let path = dir.path().join("nodes");
+    std::fs::write(&path, format!("{}\n", lines.join("\n"))).expect("write node file");
+    path
+}
+
+/// The line an operator would write for this stub, in `--node` syntax.
+fn node_line(node: &StubNode, label: &str) -> String {
+    let spec = node.spec(label);
+    format!("{}={}:{}", spec.label, spec.host, spec.port)
+}
+
+/// A proxy whose node set is a file, exactly as `fabric serve --nodes-file`
+/// builds one — including the shipped one-second re-read, not a test-only bound.
+fn fabric_watching(path: std::path::PathBuf) -> Fabric {
+    Fabric::from_node_file(path)
+        .expect("load node file")
+        .with_timeout(PROBE_TIMEOUT)
+}
+
+/// A machine the operator adds is placed on, without the proxy restarting.
+///
+/// Affinity is the instrument: both nodes serve the same model and `alpha`
+/// sorts first, so only an explicit pin can prove `beta` is in the set at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_machine_added_to_the_node_file_starts_being_placed_on() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let nodes = [
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+    ];
+    let path = node_file(&dir, &[node_line(&nodes[0], "alpha")]);
+    let addr = start_proxy(fabric_watching(path.clone()), RouteMode::Affinity).await;
+    let body = serde_json::json!({ "model": "shared-model" });
+    let sticky = [("x-camelid-fabric-sticky", "beta")];
+
+    // beta is not in the set yet, so the pin cannot be honoured.
+    let (status, answered, headers) = post_chat(addr, &body, &sticky).await;
+    assert_eq!(status, 200, "{answered}");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("alpha"));
+    assert_eq!(
+        completions_served(&nodes)[1],
+        0,
+        "a machine that is not in the node file must never be placed on"
+    );
+
+    std::fs::write(
+        &path,
+        format!(
+            "{}\n{}\n",
+            node_line(&nodes[0], "alpha"),
+            node_line(&nodes[1], "beta")
+        ),
+    )
+    .expect("add beta");
+
+    let started = Instant::now();
+    loop {
+        let (status, answered, headers) = post_chat(addr, &body, &sticky).await;
+        assert_eq!(status, 200, "{answered}");
+        if header(&headers, "x-camelid-fabric-node") == Some("beta") {
+            break;
+        }
+        assert!(
+            started.elapsed() < NODE_RELOAD_TIMEOUT,
+            "a machine added to the node file was still not placed on after {:?}",
+            started.elapsed()
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        completions_served(&nodes)[1] > 0,
+        "the added machine served nothing"
+    );
+}
+
+/// A machine the operator takes away stops being placed on, and the rest of
+/// the fabric goes on serving.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_machine_removed_from_the_node_file_stops_being_placed_on() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let nodes = [
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+    ];
+    let path = node_file(
+        &dir,
+        &[node_line(&nodes[0], "alpha"), node_line(&nodes[1], "beta")],
+    );
+    let addr = start_proxy(fabric_watching(path.clone()), RouteMode::Affinity).await;
+    let body = serde_json::json!({ "model": "shared-model" });
+    let sticky = [("x-camelid-fabric-sticky", "beta")];
+
+    let (status, answered, headers) = post_chat(addr, &body, &sticky).await;
+    assert_eq!(status, 200, "{answered}");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("beta"));
+
+    std::fs::write(&path, format!("{}\n", node_line(&nodes[0], "alpha"))).expect("remove beta");
+
+    let started = Instant::now();
+    loop {
+        let (status, answered, headers) = post_chat(addr, &body, &sticky).await;
+        assert_eq!(status, 200, "{answered}");
+        if header(&headers, "x-camelid-fabric-node") == Some("alpha") {
+            break;
+        }
+        assert!(
+            started.elapsed() < NODE_RELOAD_TIMEOUT,
+            "a machine removed from the node file was still placed on after {:?}",
+            started.elapsed()
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Settled: from here the removed machine must receive nothing more, and
+    // the one that is left must still be served.
+    let settled = completions_served(&nodes)[1];
+    let (status, answered, headers) = post_chat(addr, &body, &sticky).await;
+    assert_eq!(status, 200, "{answered}");
+    assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("alpha"));
+    assert_eq!(
+        completions_served(&nodes)[1],
+        settled,
+        "a removed machine was still placed on"
+    );
+}
+
+/// Taking a machine away must not disturb the request already running on it.
+///
+/// The generation outlives the re-read interval on purpose: the second request
+/// proves the removal has actually taken effect while the first is still in
+/// flight, which is the only way this test can claim anything.
+#[tokio::test(flavor = "multi_thread")]
+async fn removing_a_machine_does_not_disturb_the_request_already_running_on_it() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let nodes = [
+        StubNode::start(StubConfig::ready("shared-model", 0)),
+        StubNode::start(StubConfig {
+            completion_delay: Duration::from_millis(2500),
+            ..StubConfig::ready("shared-model", 0)
+        }),
+    ];
+    let path = node_file(
+        &dir,
+        &[node_line(&nodes[0], "alpha"), node_line(&nodes[1], "beta")],
+    );
+    let addr = start_proxy(fabric_watching(path.clone()), RouteMode::Affinity).await;
+
+    let in_flight = tokio::spawn(async move {
+        let body = serde_json::json!({ "model": "shared-model" });
+        post_chat(addr, &body, &[("x-camelid-fabric-sticky", "beta")]).await
+    });
+
+    // Long enough for the request to be placed on beta and forwarded.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    std::fs::write(&path, format!("{}\n", node_line(&nodes[0], "alpha"))).expect("remove beta");
+
+    let body = serde_json::json!({ "model": "shared-model" });
+    let sticky = [("x-camelid-fabric-sticky", "beta")];
+    let started = Instant::now();
+    loop {
+        let (status, answered, headers) = post_chat(addr, &body, &sticky).await;
+        assert_eq!(status, 200, "{answered}");
+        if header(&headers, "x-camelid-fabric-node") == Some("alpha") {
+            break;
+        }
+        assert!(
+            started.elapsed() < NODE_RELOAD_TIMEOUT,
+            "the removal never took effect, so this proves nothing"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let (status, answered, headers) = in_flight.await.expect("the in-flight request panicked");
+    assert_eq!(status, 200, "{answered}");
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-node"),
+        Some("beta"),
+        "a request already running on a removed machine must still be answered by it"
+    );
+}
+
 /// The load-bearing property: the proxy must relay events as they are produced.
 /// If it buffered the body and released it at the end, every piece would arrive
 /// at once, after the whole generation.


### PR DESCRIPTION
﻿## What this changes

`--node` is read once at startup, so changing which machines the fabric places on means stopping the
proxy ΓÇö which drops whatever everyone else has in flight, the exact thing the graceful stop in #668
exists to prevent. A fabric of personal machines changes often, because personal machines sleep, move
network and get rebuilt.

`--nodes-file <PATH>` puts the set in a file and re-reads it as it changes:

```
# the machines I place on
desktop=192.0.2.10:8181
laptop=192.0.2.11:8181
```

One `LABEL=HOST[:PORT]` per line ΓÇö the syntax `--node` already takes, parsed by the same
`parse_node_spec` through the same `parse_fabric`, so there is one answer to "what is a node spec" and
duplicate labels are refused here exactly as they are on the command line. Blank lines and whole-line
`#` comments are skipped, so a machine can be taken out for an hour by commenting it rather than
deleting what you wrote. It conflicts with `--node`, because "which machines am I placing on" must
have one answer.

## The load-bearing part is the observation, not the file

An observation describes the set it was taken over. One taken before a machine was added or removed is
not merely *stale*, it is **about something else**: reusing it would place on a node that has gone, or
refuse to place on one that has just arrived, for the whole of the freshness window (500 ms by
default, and unbounded if an operator raises it).

So the node set carries a **generation**, and an observation is reused only while its generation still
matches. Two details that matter:

- The generation is bumped only when the parsed set actually **differs**, not merely when the file was
  re-read. Saving the file without editing it therefore costs nothing.
- `NodeSet::current` returns the generation rather than a "did it change" flag, so a caller that only
  wanted the specs cannot swallow the change and leave the next caller reusing an observation of a set
  that no longer exists.

Lock order is now **nodes ΓåÆ observed ΓåÆ reserved**, and no two are ever held together; the node set's
lock is released before the observation's is taken.

## Where I deliberately did not follow the plan

The plan this came from said that removing a node "has to drop both" the observation and the
reservations. **Only the first is right, and I did not do the second.**

Reservations count what is actually in flight, keyed by label, and a `Placement` releases by label
when it drops. A request already running on a machine you just removed is still counted while it runs
and still releases when it finishes. Dropping those counts would lose track of real work and let the
next placement over-commit a node that is still busy. There is a test for it, and an integration test
that proves the removed machine still answers the request it was already given.

## Two refusals, both deliberate

- An unusable file ΓÇö unreadable, invalid, or **naming no nodes at all** ΓÇö stops the proxy at startup
  rather than starting it on an empty fabric, which would answer every request with 503 while looking
  as though it had started correctly.
- A *re-read* that fails keeps the previous set. A file is usually replaced by writing a new one and
  renaming it over the old, so a read landing mid-swap sees a partial or empty file; emptying the
  fabric on that would turn an ordinary edit into a total outage. The cost is real and is stated where
  an operator will meet it: a change written into a broken file — or deleting the node file altogether
  — has **not** taken effect, and the machine you meant to take out is still taking requests. So the
  proxy prints to stderr when a re-read starts failing, and again when it recovers, rather than relying
  on `RUST_LOG` being set:

  ```
  fabric: could not reload the node file: <why>. The previous set of 2 machines is still
  being placed on, so a change written here has NOT taken effect.
  ```

  Once each way, not once per re-read. The `tracing::warn!` alongside it stays periodic on purpose:
  it describes a state rather than an event, so a log stream should carry it every interval.

## Measurements

Against `upstream/main` at `d080367b4`. No test was removed or renamed.

| target | before | after |
| --- | --- | --- |
| `--lib fabric::` | 170 | 184 |
| `--test fabric_serve` | 60 | 63 |
| `--test fabric_end_to_end` | 14 | 14 |
| `--bin camelid` | 40 | 41 |

Gates on the commit, clean tree: `cargo fmt --all --check` exit 0 ┬╖ `cargo clippy --all-targets --
-D warnings` **0 findings** ┬╖ `check-public-scrub.sh` exit 0 ┬╖ `git diff --check` exit 0 ┬╖ all touched
files LF.

The integration tests run against the **shipped** one-second re-read interval, not a test-only bound,
and poll to a 5 s ceiling.

## Ablations

Each row is one edit to the source, both suites re-run, then reverted; the failures listed are the
complete set. In every row the pre-existing tests all passed, so these are the new tests failing, not
collateral.

| ablation | unit failures | integration failures |
| --- | --- | --- |
| the node-set generation is ignored when reusing an observation | 1: `a_changed_node_set_is_not_answered_from_the_observation_of_the_old_one` | 0 (63 pass) |
| the file is never re-read | 7 | 3 |
| a file naming no nodes is accepted | 2: `an_unusable_file_stops_the_proxy_rather_than_emptying_the_fabric`, `a_broken_or_empty_file_leaves_the_previous_set_in_force` | 0 (63 pass) |

The first row is the interesting one: it fails **only** the unit test, because the integration tests
use the default observation age of zero and so never reuse one. That is the honest reading ΓÇö the
generation check is invisible to a proxy that re-probes every time, and only bites the configuration
`fabric serve` actually ships (500 ms).

## A flaky test I wrote and removed

An ablation failed one test I had not predicted, and it was my fault, not the ablation's. I had
asserted that *reordering* the file bumps the generation ΓÇö but the reordered text is the **same
length** as the original, so a write landing in the same modification-time tick is indistinguishable
from no write at all, and the assertion failed on timing rather than on behaviour. I removed that half
and said why in the test. Adding and removing change the length and are covered properly.

## What this does not do

- No add/remove **route**. The file is the whole interface. A loopback admin route is a reasonable
  follow-up and deliberately not in this PR.
- `--nodes-file` is on `fabric serve` only. `fabric status|route|run` are one-shot commands where
  "without restarting" means nothing; letting them read the same file is a small, separate convenience.
- No cross-machine receipt: the second machine was unavailable. Everything here is loopback and
  in-process on Windows.

`Fabric::specs()` returns an owned snapshot rather than a borrow ΓÇö with a set that can change there is
no slice to lend. It had **zero callers** repo-wide.

