### PR TITLE
feat(fabric): stop a request when the client that asked for it has gone

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -242,6 +242,15 @@ part-way through a stream, ends the request with 502 rather than risking a secon
 `x-camelid-fabric-node`, `x-camelid-fabric-reason` and `x-camelid-fabric-attempts`, so a client can
 tell a first-choice placement from a failover.
 
+A client that hangs up takes its request's work with it. The proxy notices the connection going and
+hangs up on the node in turn, which that node reads as its own client leaving — it stops generating
+within one decode step. So a request nobody is waiting for gives back the node's generation slot
+instead of holding it for the rest of `--forward-timeout-s`, which matters because a node runs one
+generation at a time. It is not instantaneous: the check happens between socket operations, so it
+takes effect within about 100 ms while the proxy is waiting on a node. A probe round already under
+way is not interrupted, but it is bounded by `--timeout-ms` and costs a node a health read rather
+than its generation slot.
+
 Request bodies are bounded at the same 16 MiB default the node itself uses. A streaming request is
 relayed as it arrives; `fabric run`, which returns one complete answer, refuses `stream: true` with
 400 instead.

--- a/src/fabric/cancel.rs
+++ b/src/fabric/cancel.rs
@@ -1,0 +1,101 @@
+//! Whether the work a request asked for is still wanted.
+//!
+//! Placement and forwarding are synchronous socket I/O, and the proxy runs them
+//! on a blocking thread. A blocking thread cannot be aborted from outside —
+//! dropping its `JoinHandle` detaches it rather than stopping it — so the only
+//! way to end that work early is to tell it, and have it agree to look.
+//!
+//! That matters more here than the shape of the code suggests. A Camelid node
+//! executes at most one decode step at a time, so a request nobody is waiting
+//! for does not merely waste a thread in this process: it holds the *node's*
+//! generation slot until the node finishes or `--forward-timeout-s` expires,
+//! and on a two-machine fabric that is half the operator's hardware, spent on
+//! an answer that will be thrown away.
+//!
+//! # What is promised
+//!
+//! A cancelled request stops at the next socket-operation boundary, not
+//! instantly. In practice that is within one read timeout (100 ms) while
+//! waiting for a node to answer, and within one dial attempt while connecting.
+//! Nothing here interrupts a syscall already in progress.
+//!
+//! Cancelling is not a failure of the node it was placed on, and the rest of
+//! the fabric treats it accordingly: the observation the request was placed
+//! from is kept, and the request is never sent to a second node, because there
+//! is nobody left to send an answer to.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// One request's cancellation, shared between whoever waits for the answer and
+/// whoever is producing it.
+///
+/// Cloning shares the same signal rather than copying its state, so a caller
+/// hands a clone to the work and keeps one to fire.
+#[derive(Clone, Debug)]
+pub struct Cancel(Arc<AtomicBool>);
+
+impl Cancel {
+    /// A cancellation for one request, not yet fired.
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    /// A cancellation nothing will ever fire.
+    ///
+    /// For callers with no client to lose: `fabric status|route|run` send one
+    /// request per process and are ended by ending the process, and a health
+    /// probe is already bounded by its own timeout. Saying so at those call
+    /// sites keeps it a decision rather than an omission.
+    pub fn never() -> Self {
+        Self::new()
+    }
+
+    /// Stop wanting the answer. Idempotent, and safe to call from any thread.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    /// Whether the answer has been given up on.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+impl Default for Cancel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fresh_cancellation_has_not_been_fired() {
+        assert!(!Cancel::new().is_cancelled());
+        assert!(!Cancel::never().is_cancelled());
+    }
+
+    #[test]
+    fn a_clone_carries_the_same_signal_rather_than_a_copy_of_it() {
+        let held_by_the_caller = Cancel::new();
+        let handed_to_the_work = held_by_the_caller.clone();
+
+        held_by_the_caller.cancel();
+
+        assert!(
+            handed_to_the_work.is_cancelled(),
+            "the work was not told, so it would run to its own deadline"
+        );
+    }
+
+    #[test]
+    fn firing_twice_is_the_same_as_firing_once() {
+        let cancel = Cancel::new();
+        cancel.cancel();
+        cancel.cancel();
+        assert!(cancel.is_cancelled());
+    }
+}

--- a/src/fabric/cancel.rs
+++ b/src/fabric/cancel.rs
@@ -19,6 +19,13 @@
 //! waiting for a node to answer, and within one dial attempt while connecting.
 //! Nothing here interrupts a syscall already in progress.
 //!
+//! One window is deliberately not covered: a *write* to the node uses the
+//! whole forward budget as its timeout, so a peer that accepts the connection
+//! and then stops reading can hold a send for far longer than either bound
+//! above. It takes a pathological node to reach — request bodies are capped at
+//! 16 MiB and a node reads its request promptly — and shortening it would mean
+//! chunking every write to poll a flag between the pieces.
+//!
 //! Cancelling is not a failure of the node it was placed on, and the rest of
 //! the fabric treats it accordingly: the observation the request was placed
 //! from is kept, and the request is never sent to a second node, because there

--- a/src/fabric/forward.rs
+++ b/src/fabric/forward.rs
@@ -17,6 +17,7 @@ use serde_json::{json, Value};
 
 use super::http::{self, HttpError};
 use super::node::NodeSpec;
+use super::Cancel;
 
 /// Generation can legitimately take minutes, so this is far longer than a probe
 /// budget. It exists to bound a wedged node, not to bound a slow model.
@@ -105,6 +106,12 @@ pub enum ForwardError {
     Json { label: String, detail: String },
     /// Refused before sending; see [`reject_streaming`].
     Unsupported(String),
+    /// Nobody is waiting for this answer any more, so it was not finished.
+    ///
+    /// Held apart from every other variant because it is not a fault of the
+    /// node at all: the observation that placed the request stays good, and
+    /// re-placing it would only produce an answer for a caller that has gone.
+    Cancelled { label: String },
 }
 
 impl ForwardError {
@@ -122,15 +129,22 @@ impl ForwardError {
         match self {
             Self::Unreachable { label, .. }
             | Self::Transport { label, .. }
-            | Self::Json { label, .. } => Some(label),
+            | Self::Json { label, .. }
+            | Self::Cancelled { label } => Some(label),
             Self::Unsupported(_) => None,
         }
     }
 }
 
-/// Tag an HTTP failure with the node it happened against, keeping the one
-/// distinction a retry depends on.
-fn dial_or_transport(label: &str, error: HttpError) -> ForwardError {
+/// Tag an HTTP failure with the node it happened against, keeping the two
+/// distinctions the rest of the fabric acts on: whether the request may be
+/// re-sent, and whether the node is implicated at all.
+fn attribute(label: &str, error: HttpError) -> ForwardError {
+    if matches!(error, HttpError::Cancelled) {
+        return ForwardError::Cancelled {
+            label: label.to_string(),
+        };
+    }
     let (label, detail) = (label.to_string(), error.to_string());
     if error.peer_never_received_it() {
         ForwardError::Unreachable { label, detail }
@@ -152,6 +166,10 @@ impl std::fmt::Display for ForwardError {
                 write!(f, "node `{label}` returned an unreadable body: {detail}")
             }
             Self::Unsupported(detail) => write!(f, "{detail}"),
+            Self::Cancelled { label } => write!(
+                f,
+                "the client that asked for this request had gone, so node `{label}` was not waited for"
+            ),
         }
     }
 }
@@ -209,12 +227,16 @@ pub fn error_message(body: &Value) -> Option<&str> {
 /// `bearer` is required by any node started with an API key: `/v1/health` is
 /// exempt from the server's auth but `/v1/chat/completions` is not, so without
 /// it this is the call that comes back 401.
+///
+/// `cancel` ends the exchange and hangs up on the node, which is what stops it
+/// generating; pass [`Cancel::never`] where nothing can ask for that.
 pub fn forward(
     spec: &NodeSpec,
     path: &str,
     body: &Value,
     bearer: Option<&str>,
     timeout: Duration,
+    cancel: &Cancel,
 ) -> Result<Forwarded, ForwardError> {
     reject_streaming(body)?;
 
@@ -233,8 +255,9 @@ pub fn forward(
         bearer,
         timeout,
         MAX_RESPONSE_BYTES,
+        cancel,
     )
-    .map_err(|error| dial_or_transport(&spec.label, error))?;
+    .map_err(|error| attribute(&spec.label, error))?;
     let elapsed = started.elapsed();
 
     // An empty body is legal for some statuses; represent it as null rather than
@@ -286,15 +309,27 @@ impl std::fmt::Debug for Streaming {
 impl Streaming {
     /// The next piece of the body, or `None` at the end of the stream.
     ///
-    /// Always a `Transport` failure, never `Unreachable`: the node answered to
-    /// get here, so the request cannot be sent anywhere else.
+    /// Never `Unreachable`: the node answered to get here, so the request
+    /// cannot be sent anywhere else. A failure to read is therefore `Transport`
+    /// whatever caused it — except a cancellation, which says nothing about the
+    /// node and must not be recorded against it.
     pub fn next_chunk(&mut self) -> Result<Option<Vec<u8>>, ForwardError> {
         self.stream
             .next_chunk()
-            .map_err(|error| ForwardError::Transport {
-                label: self.label.clone(),
-                detail: error.to_string(),
-            })
+            .map_err(|error| after_the_head(&self.label, error))
+    }
+}
+
+/// Classify a failure raised once a node has already answered with a head.
+fn after_the_head(label: &str, error: HttpError) -> ForwardError {
+    match error {
+        HttpError::Cancelled => ForwardError::Cancelled {
+            label: label.to_string(),
+        },
+        error => ForwardError::Transport {
+            label: label.to_string(),
+            detail: error.to_string(),
+        },
     }
 }
 
@@ -323,19 +358,12 @@ pub fn forward_streaming(
     bearer: Option<&str>,
     head_timeout: Duration,
     idle_timeout: Duration,
+    cancel: &Cancel,
 ) -> Result<StreamOutcome, ForwardError> {
     let encoded = serde_json::to_vec(body).map_err(|error| ForwardError::Json {
         label: spec.label.clone(),
         detail: format!("request body could not be encoded: {error}"),
     })?;
-
-    // Only opening the stream can fail before the node has the request. Once a
-    // head is in, the node is generating, so everything below is `Transport`
-    // whatever the underlying cause was.
-    let transport = |error: HttpError| ForwardError::Transport {
-        label: spec.label.clone(),
-        detail: error.to_string(),
-    };
 
     let started = Instant::now();
     let stream = http::open_stream(
@@ -348,8 +376,9 @@ pub fn forward_streaming(
         head_timeout,
         idle_timeout,
         MAX_RESPONSE_BYTES,
+        cancel,
     )
-    .map_err(|error| dial_or_transport(&spec.label, error))?;
+    .map_err(|error| attribute(&spec.label, error))?;
 
     let head = stream.head().clone();
     // A node that refused, or answered with something other than a stream, has
@@ -357,7 +386,7 @@ pub fn forward_streaming(
     if !(200..300).contains(&head.status) || !head.is_event_stream() {
         let response = stream
             .into_buffered(MAX_RESPONSE_BYTES)
-            .map_err(transport)?;
+            .map_err(|error| after_the_head(&spec.label, error))?;
         let parsed = if response.body.is_empty() {
             Value::Null
         } else {
@@ -494,6 +523,7 @@ mod tests {
             &body,
             None,
             Duration::from_millis(200),
+            &Cancel::never(),
         )
         .expect_err("refused");
         assert!(
@@ -540,6 +570,7 @@ mod tests {
             &chat_request("m", "hi", 4),
             None,
             Duration::from_millis(400),
+            &Cancel::never(),
         )
         .expect_err("port 1 is closed");
         match &error {
@@ -561,6 +592,7 @@ mod tests {
             &chat_request("m", "hi", 4),
             None,
             Duration::from_millis(400),
+            &Cancel::never(),
         )
         .expect_err("port 1 is closed");
         assert!(unreached.node_never_received_it(), "{unreached:?}");
@@ -587,9 +619,42 @@ mod tests {
             None,
             Duration::from_millis(400),
             Duration::from_millis(400),
+            &Cancel::never(),
         )
         .expect_err("port 1 is closed");
         assert!(error.node_never_received_it(), "{error:?}");
+    }
+
+    /// A client leaving is not the node's doing, and the difference is acted on
+    /// twice over: the request is not placed again, and the observation that
+    /// chose the node is kept rather than thrown away as proved wrong.
+    #[test]
+    fn a_request_its_client_gave_up_on_is_not_recorded_against_the_node() {
+        let cancel = Cancel::new();
+        cancel.cancel();
+
+        let error = forward(
+            &spec("windows", 1),
+            "/v1/chat/completions",
+            &chat_request("m", "hi", 4),
+            None,
+            Duration::from_millis(400),
+            &cancel,
+        )
+        .expect_err("the client had gone");
+
+        assert!(
+            matches!(error, ForwardError::Cancelled { .. }),
+            "a client hanging up must not read as a node failure, got {error:?}"
+        );
+        assert!(
+            !error.node_never_received_it(),
+            "re-placing it would answer a client that has gone"
+        );
+        // Named for the same reason every other failure here is: it says which
+        // node just got its generation slot back.
+        assert_eq!(error.label(), Some("windows"));
+        assert!(error.to_string().contains("windows"), "{error}");
     }
 
     #[test]

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -9,10 +9,19 @@
 //! `chat`, is keyed on a resolved `SocketAddr` where fabric members are named
 //! hosts, and carries SSE, bearer auth and tool-call handling that neither a
 //! health probe nor a request forward should depend on.
+//!
+//! Every loop here that can wait on a peer consults its caller's [`Cancel`]
+//! beside its own deadline, and cancellation is checked first, so a request
+//! nobody wants any more is reported as abandoned rather than as a node that
+//! ran out of time. That is what makes a blocking exchange stoppable at all:
+//! the socket is dropped on the way out, which is the only thing that tells a
+//! node to stop generating.
 
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::{Duration, Instant};
+
+use super::cancel::Cancel;
 
 /// Never spend the whole budget dialling; a forward budget is minutes long and
 /// a node that has not accepted in five seconds is not about to.
@@ -32,6 +41,8 @@ pub(crate) enum HttpError {
     TooLarge(usize),
     /// The request could not be written safely; refused before any socket work.
     InvalidRequest(String),
+    /// The caller stopped wanting the answer before it arrived.
+    Cancelled,
 }
 
 impl HttpError {
@@ -45,10 +56,17 @@ impl HttpError {
     ///
     /// [`HttpError::InvalidRequest`] is deliberately excluded: nothing was sent,
     /// but the request is malformed, so another peer would refuse it identically.
+    /// [`HttpError::Cancelled`] is excluded for a different reason again — it
+    /// can be raised before the first write, but re-sending would produce an
+    /// answer for a caller that has already stopped waiting for one.
     pub(crate) fn peer_never_received_it(&self) -> bool {
         match self {
             Self::Resolve(_) | Self::Connect(_) => true,
-            Self::Io(_) | Self::Malformed(_) | Self::TooLarge(_) | Self::InvalidRequest(_) => false,
+            Self::Io(_)
+            | Self::Malformed(_)
+            | Self::TooLarge(_)
+            | Self::InvalidRequest(_)
+            | Self::Cancelled => false,
         }
     }
 }
@@ -62,6 +80,7 @@ impl std::fmt::Display for HttpError {
             Self::Malformed(detail) => write!(f, "malformed HTTP response: {detail}"),
             Self::TooLarge(limit) => write!(f, "response exceeded {limit} bytes"),
             Self::InvalidRequest(detail) => write!(f, "cannot build request: {detail}"),
+            Self::Cancelled => write!(f, "the answer was no longer wanted"),
         }
     }
 }
@@ -337,9 +356,16 @@ pub(crate) fn parse_response(raw: &[u8], max_body: usize) -> Result<HttpResponse
 /// resolves to several addresses — typically an AAAA ahead of an A. Trying only
 /// the first would report a healthy node as offline whenever its leading address
 /// is unroutable, so every address gets a turn until the deadline runs out.
-fn connect_any(addrs: &[SocketAddr], deadline: Instant) -> Result<TcpStream, HttpError> {
+fn connect_any(
+    addrs: &[SocketAddr],
+    deadline: Instant,
+    cancel: &Cancel,
+) -> Result<TcpStream, HttpError> {
     let mut last: Option<String> = None;
     for (index, addr) in addrs.iter().enumerate() {
+        if cancel.is_cancelled() {
+            return Err(HttpError::Cancelled);
+        }
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             break;
@@ -418,7 +444,14 @@ fn connect_and_send(
     bearer: Option<&str>,
     deadline: Instant,
     write_timeout: Duration,
+    cancel: &Cancel,
 ) -> Result<TcpStream, HttpError> {
+    // Before resolving, which is itself a blocking call: a caller that has
+    // already given up costs its node nothing at all, not even a connection.
+    if cancel.is_cancelled() {
+        return Err(HttpError::Cancelled);
+    }
+
     let authority = format!("{host}:{port}");
     // Built before resolving, so a request that cannot be written safely is
     // refused without touching the network.
@@ -434,7 +467,7 @@ fn connect_and_send(
         ));
     }
 
-    let mut stream = connect_any(&addrs, deadline)?;
+    let mut stream = connect_any(&addrs, deadline, cancel)?;
     // Short socket reads keep the caller's loop responsive to its own deadline;
     // one long read timeout would overshoot it on a stalled peer.
     stream
@@ -462,6 +495,9 @@ fn connect_and_send(
 ///
 /// `bearer` is sent as `Authorization: Bearer`, which is what a node started
 /// with an API key requires on every route but `/v1/health`.
+///
+/// `cancel` ends the exchange early and drops the socket with it. Pass
+/// [`Cancel::never`] where there is no client that can go away.
 // One more parameter than clippy's threshold; every one of them is a distinct
 // property of a single round trip, so bundling them would only move the list.
 #[allow(clippy::too_many_arguments)]
@@ -474,6 +510,7 @@ pub(crate) fn request(
     bearer: Option<&str>,
     timeout: Duration,
     max_body: usize,
+    cancel: &Cancel,
 ) -> Result<HttpResponse, HttpError> {
     let deadline = Instant::now() + timeout;
     let mut stream = connect_and_send(
@@ -486,11 +523,17 @@ pub(crate) fn request(
         bearer,
         deadline,
         timeout,
+        cancel,
     )?;
 
     let mut raw = Vec::new();
     let mut chunk = [0_u8; 8192];
     loop {
+        // Before the deadline, so an abandoned request is reported as abandoned
+        // rather than as a node that was too slow.
+        if cancel.is_cancelled() {
+            return Err(HttpError::Cancelled);
+        }
         if Instant::now() >= deadline {
             return Err(HttpError::Io("request exceeded its deadline".to_string()));
         }
@@ -537,6 +580,9 @@ pub(crate) struct ResponseStream {
     /// How long the node may send nothing at all before it counts as wedged.
     idle_timeout: Duration,
     max_chunk: usize,
+    /// Carried rather than passed per call: the stream outlives the call that
+    /// opened it, and every read it does afterwards belongs to the same client.
+    cancel: Cancel,
 }
 
 /// A body that stopped before its framing said it would.
@@ -545,6 +591,9 @@ fn truncated_body() -> HttpError {
 }
 
 /// Send a request and read only its head, leaving the body to be streamed.
+///
+/// `cancel` bounds the wait for that head and is kept by the returned stream,
+/// so it bounds every later read too.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn open_stream(
     host: &str,
@@ -556,6 +605,7 @@ pub(crate) fn open_stream(
     head_timeout: Duration,
     idle_timeout: Duration,
     max_chunk: usize,
+    cancel: &Cancel,
 ) -> Result<ResponseStream, HttpError> {
     let deadline = Instant::now() + head_timeout;
     let mut stream = connect_and_send(
@@ -568,6 +618,7 @@ pub(crate) fn open_stream(
         bearer,
         deadline,
         head_timeout,
+        cancel,
     )?;
 
     let mut raw = Vec::new();
@@ -578,6 +629,11 @@ pub(crate) fn open_stream(
         }
         if raw.len() > MAX_HEAD_BYTES {
             return Err(HttpError::TooLarge(MAX_HEAD_BYTES));
+        }
+        // A head can be a whole prefill away, which is the longest a client is
+        // ever left with nothing to read; leaving is exactly what it does then.
+        if cancel.is_cancelled() {
+            return Err(HttpError::Cancelled);
         }
         if Instant::now() >= deadline {
             return Err(HttpError::Io(
@@ -608,6 +664,7 @@ pub(crate) fn open_stream(
         stream,
         idle_timeout,
         max_chunk,
+        cancel: cancel.clone(),
     })
 }
 
@@ -639,6 +696,9 @@ impl ResponseStream {
         let deadline = Instant::now() + self.idle_timeout;
         let mut scratch = [0_u8; 8192];
         loop {
+            if self.cancel.is_cancelled() {
+                return Err(HttpError::Cancelled);
+            }
             if Instant::now() >= deadline {
                 return Err(HttpError::Io(
                     "node sent nothing before the idle timeout".to_string(),
@@ -675,6 +735,9 @@ impl ResponseStream {
         let deadline = Instant::now() + self.idle_timeout;
         let mut scratch = [0_u8; 8192];
         while self.complete() != Some(true) {
+            if self.cancel.is_cancelled() {
+                return Err(HttpError::Cancelled);
+            }
             if Instant::now() >= deadline {
                 return Err(HttpError::Io(
                     "node sent nothing before the idle timeout".to_string(),
@@ -736,16 +799,24 @@ mod tests {
         // Port 1 is closed; it stands in for an unroutable AAAA ahead of the A.
         let dead = SocketAddr::from(([127, 0, 0, 1], 1));
 
-        let stream = connect_any(&[dead, live], Instant::now() + Duration::from_secs(2))
-            .expect("the second address accepts");
+        let stream = connect_any(
+            &[dead, live],
+            Instant::now() + Duration::from_secs(2),
+            &Cancel::never(),
+        )
+        .expect("the second address accepts");
         assert_eq!(stream.peer_addr().expect("connected"), live);
     }
 
     #[test]
     fn every_address_failing_reports_the_last_failure() {
         let dead = SocketAddr::from(([127, 0, 0, 1], 1));
-        let error = connect_any(&[dead, dead], Instant::now() + Duration::from_secs(1))
-            .expect_err("nothing is listening");
+        let error = connect_any(
+            &[dead, dead],
+            Instant::now() + Duration::from_secs(1),
+            &Cancel::never(),
+        )
+        .expect_err("nothing is listening");
         assert!(matches!(error, HttpError::Connect(_)), "{error:?}");
     }
 
@@ -764,6 +835,10 @@ mod tests {
             HttpError::Malformed("truncated".to_string()),
             HttpError::TooLarge(1),
             HttpError::InvalidRequest("bad token".to_string()),
+            // Cancelling can happen before the first write, so this one is not
+            // classified by what the peer saw: re-sending would spend another
+            // node on an answer nobody is waiting for.
+            HttpError::Cancelled,
         ] {
             assert!(!error.peer_never_received_it(), "{error:?}");
         }
@@ -774,8 +849,12 @@ mod tests {
         // Not a hand-built variant: this is the error the dialling path actually
         // produces against a closed port, which is the case failover turns on.
         let dead = SocketAddr::from(([127, 0, 0, 1], 1));
-        let error = connect_any(&[dead], Instant::now() + Duration::from_secs(1))
-            .expect_err("nothing is listening");
+        let error = connect_any(
+            &[dead],
+            Instant::now() + Duration::from_secs(1),
+            &Cancel::never(),
+        )
+        .expect_err("nothing is listening");
         assert!(error.peer_never_received_it(), "{error:?}");
     }
 
@@ -1093,6 +1172,7 @@ mod tests {
             Some("bad\r\ntoken"),
             Duration::from_millis(500),
             LIMIT,
+            &Cancel::never(),
         )
         .expect_err("refused");
         assert!(
@@ -1112,6 +1192,7 @@ mod tests {
             None,
             Duration::from_millis(500),
             LIMIT,
+            &Cancel::never(),
         )
         .expect_err("port 1 is closed");
         assert!(
@@ -1131,6 +1212,7 @@ mod tests {
             None,
             Duration::from_millis(500),
             LIMIT,
+            &Cancel::never(),
         )
         .expect_err("`.invalid` never resolves");
         assert!(
@@ -1193,8 +1275,185 @@ mod tests {
             Duration::from_secs(10),
             Duration::from_secs(10),
             LIMIT,
+            &Cancel::never(),
         )
         .expect("the canned node answers")
+    }
+
+    /// Accept one connection, consume the whole request, then answer `prelude`
+    /// and say nothing more — a node that has taken the work and is still doing
+    /// it. The connection is held open, so a reader that gives up early can only
+    /// have done so because it chose to.
+    fn working_node(prelude: &'static [u8]) -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("binds");
+        let port = listener.local_addr().expect("has an address").port();
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut request = Vec::new();
+            let mut scratch = [0_u8; 1024];
+            while !request_complete(&request) {
+                match stream.read(&mut scratch) {
+                    Ok(0) | Err(_) => break,
+                    Ok(read) => request.extend_from_slice(&scratch[..read]),
+                }
+            }
+            if !prelude.is_empty() {
+                let _ = stream.write_all(prelude);
+            }
+            // Far longer than any deadline these tests give a reader, so a
+            // reader returning early is never this node giving up.
+            std::thread::sleep(Duration::from_secs(30));
+        });
+        port
+    }
+
+    /// Fire `cancel` shortly, the way a client hanging up mid-request does.
+    fn cancel_shortly(cancel: &Cancel) {
+        let cancel = cancel.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            cancel.cancel();
+        });
+    }
+
+    /// The whole point of the mechanism: a node's answer can legitimately be
+    /// minutes away, so waiting out the deadline is not a bounded cost.
+    #[test]
+    fn a_cancelled_request_stops_reading_rather_than_waiting_out_its_deadline() {
+        let port = working_node(b"");
+        let cancel = Cancel::new();
+        cancel_shortly(&cancel);
+
+        let started = Instant::now();
+        let error = request(
+            "127.0.0.1",
+            port,
+            "POST",
+            "/v1/chat/completions",
+            Some(b"{}"),
+            None,
+            Duration::from_secs(30),
+            LIMIT,
+            &cancel,
+        )
+        .expect_err("the node never answers");
+        let waited = started.elapsed();
+
+        assert_eq!(error, HttpError::Cancelled);
+        assert!(
+            waited < Duration::from_secs(2),
+            "waited {waited:?} of a 30s budget after the client had gone"
+        );
+    }
+
+    /// A caller that has already gone must not cost its node even a connection,
+    /// let alone the generation slot accepting one would commit.
+    #[test]
+    fn a_request_already_given_up_on_never_opens_a_socket() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("binds");
+        let port = listener.local_addr().expect("has an address").port();
+        let cancel = Cancel::new();
+        cancel.cancel();
+
+        let error = request(
+            "127.0.0.1",
+            port,
+            "POST",
+            "/v1/chat/completions",
+            Some(b"{}"),
+            None,
+            Duration::from_secs(30),
+            LIMIT,
+            &cancel,
+        )
+        .expect_err("the caller had already gone");
+
+        assert_eq!(error, HttpError::Cancelled);
+        listener
+            .set_nonblocking(true)
+            .expect("the listener can be polled");
+        assert!(
+            listener.accept().is_err(),
+            "a connection was opened on behalf of a caller that had gone"
+        );
+    }
+
+    /// The head of a streaming answer is a whole prefill away, which is the
+    /// longest a client is ever left with nothing at all to read.
+    #[test]
+    fn a_head_that_has_not_arrived_is_given_up_on_with_its_client() {
+        let port = working_node(b"");
+        let cancel = Cancel::new();
+        cancel_shortly(&cancel);
+
+        let started = Instant::now();
+        let opened = open_stream(
+            "127.0.0.1",
+            port,
+            "POST",
+            "/v1/chat/completions",
+            Some(b"{}"),
+            None,
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+            LIMIT,
+            &cancel,
+        );
+        let waited = started.elapsed();
+
+        // `ResponseStream` owns a socket rather than describing one, so it has
+        // no `Debug` for `expect_err` to print.
+        let Err(error) = opened else {
+            panic!("the node never sent a head, so no stream can have opened");
+        };
+        assert_eq!(error, HttpError::Cancelled);
+        assert!(
+            waited < Duration::from_secs(2),
+            "waited {waited:?} of a 30s budget after the client had gone"
+        );
+    }
+
+    /// Relaying already stops when a send to the client fails, but only once
+    /// the node produces something to send. Between two tokens there is nothing
+    /// to fail on, and that gap is the whole idle timeout wide.
+    #[test]
+    fn a_stream_whose_client_has_gone_stops_between_events() {
+        // `data: one\n\n` is 11 bytes = 0xb; nothing follows it on the wire.
+        let port = working_node(
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+              Transfer-Encoding: chunked\r\n\r\nb\r\ndata: one\n\n\r\n",
+        );
+        let cancel = Cancel::new();
+        let mut stream = open_stream(
+            "127.0.0.1",
+            port,
+            "POST",
+            "/v1/chat/completions",
+            Some(b"{}"),
+            None,
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+            LIMIT,
+            &cancel,
+        )
+        .expect("the head arrives");
+        assert_eq!(
+            stream.next_chunk().expect("the first event arrives"),
+            Some(b"data: one\n\n".to_vec())
+        );
+
+        cancel.cancel();
+        let started = Instant::now();
+        let error = stream.next_chunk().expect_err("the client has gone");
+        let waited = started.elapsed();
+
+        assert_eq!(error, HttpError::Cancelled);
+        assert!(
+            waited < Duration::from_secs(2),
+            "waited {waited:?} of a 30s idle budget after the client had gone"
+        );
     }
 
     /// `parse_response` calls a chunked body that stops early malformed. The

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -20,7 +20,9 @@
 //! * [`probe`] — turning `/v1/health` into a routing fact.
 //! * [`policy`] — pure placement decisions; the correctness of the fabric.
 //! * [`forward`] — sending a placed request to the node that will serve it.
+//! * [`cancel`] — telling that send it is no longer wanted.
 
+pub mod cancel;
 pub(crate) mod client_keys;
 pub mod forward;
 pub(crate) mod http;
@@ -35,6 +37,7 @@ use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
+pub use cancel::Cancel;
 pub use forward::{
     wants_streaming, ForwardError, Forwarded, NodeAnswer, StreamOutcome, Streaming,
     DEFAULT_FORWARD_TIMEOUT, ENGINE_QUEUE_FULL_CODE,
@@ -249,6 +252,11 @@ impl Fabric {
     /// This is what keeps the freshness bound honest: a node dying inside the
     /// window costs the one request that discovers it, not every request until
     /// the observation expires.
+    ///
+    /// A cancelled request is deliberately not one of those: it says nothing
+    /// about the node it was placed on, and dropping the observation for it
+    /// would make every client that hangs up cost the *next* request a full
+    /// probe round.
     fn forget_observation_if_node_vanished(&self, error: &ForwardError) {
         if matches!(
             error,
@@ -351,12 +359,20 @@ impl Fabric {
         body: &Value,
         request: &RouteRequest<'_>,
         forward_timeout: Duration,
+        cancel: &Cancel,
     ) -> Result<Dispatched, DispatchError> {
         // Refuse an unsupported request before spending any probes on it.
         forward::reject_streaming(body)?;
 
         let sent = self.send_until_a_node_takes_it(request, |spec| {
-            forward::forward(spec, path, body, self.bearer.as_deref(), forward_timeout)
+            forward::forward(
+                spec,
+                path,
+                body,
+                self.bearer.as_deref(),
+                forward_timeout,
+                cancel,
+            )
         })?;
         Ok(Dispatched {
             decision: sent.placement.decision.clone(),
@@ -382,6 +398,7 @@ impl Fabric {
         request: &RouteRequest<'_>,
         head_timeout: Duration,
         idle_timeout: Duration,
+        cancel: &Cancel,
     ) -> Result<DispatchedStream, DispatchError> {
         let sent = self.send_until_a_node_takes_it(request, |spec| {
             forward::forward_streaming(
@@ -391,6 +408,7 @@ impl Fabric {
                 self.bearer.as_deref(),
                 head_timeout,
                 idle_timeout,
+                cancel,
             )
         })?;
         Ok(DispatchedStream {
@@ -423,6 +441,10 @@ impl Fabric {
     /// the node sent, its code and message included. Not its headers, though —
     /// [`Forwarded`] carries none, so the node's `Retry-After` does not survive
     /// the hop.
+    ///
+    /// A cancelled attempt ends the whole dispatch on the spot. It is not a
+    /// node failure, so it is neither re-placed nor recorded against the node:
+    /// there is no longer anybody to hand a second node's answer to.
     fn send_until_a_node_takes_it<T: NodeAnswer>(
         &self,
         request: &RouteRequest<'_>,
@@ -1079,6 +1101,7 @@ mod tests {
                 &body,
                 &RouteRequest::new(RouteMode::Throughput),
                 Duration::from_millis(200),
+                &Cancel::never(),
             )
             .expect_err("streaming is unsupported");
         assert!(
@@ -1096,6 +1119,7 @@ mod tests {
                 &serde_json::json!({ "model": "m" }),
                 &RouteRequest::new(RouteMode::Throughput),
                 Duration::from_millis(200),
+                &Cancel::never(),
             )
             .expect_err("no nodes");
         assert_eq!(error, DispatchError::Route(RouteError::NoNodesConfigured));
@@ -1117,6 +1141,7 @@ mod tests {
                 &serde_json::json!({ "model": "m" }),
                 &RouteRequest::new(RouteMode::Throughput),
                 Duration::from_millis(300),
+                &Cancel::never(),
             )
             .expect_err("node is dead");
         assert!(

--- a/src/fabric/probe.rs
+++ b/src/fabric/probe.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 
 use serde::Deserialize;
 
+use super::cancel::Cancel;
 use super::http::{self, HttpError};
 use super::node::{NodeReady, NodeSnapshot, NodeSpec, NodeStatus};
 
@@ -104,6 +105,10 @@ fn read_health(
         bearer,
         timeout,
         MAX_HEALTH_BYTES,
+        // A probe round is already bounded by `timeout` and costs a node a
+        // health read, not a generation slot, so there is nothing here worth
+        // the noise of making cancellable.
+        &Cancel::never(),
     )?;
     if response.status != 200 {
         return Err(ProbeError::Status(response.status));

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -69,6 +69,15 @@
 //!   a node that took the request and then failed ends it, because this proxy
 //!   cannot know whether it started generating. See
 //!   [`super::DEFAULT_MAX_FORWARD_ATTEMPTS`].
+//! * A client that hangs up takes its request's work with it. A dispatch runs
+//!   on a blocking thread and cannot be aborted, so it is told instead: the
+//!   frame that owns the request holds a [`Cancel`], dropping that frame is
+//!   what a client leaving looks like to axum, and the dispatch stops at its
+//!   next socket-operation boundary and hangs up on the node. A node that sees
+//!   its caller go stops generating within one decode step, so this gives back
+//!   the generation slot rather than merely a thread here. What it does not
+//!   cover is a probe round already in flight, which is bounded by `--timeout-ms`
+//!   and costs a node a health read rather than its generation slot.
 //! * A non-streaming dispatch runs on a blocking thread and blocking socket I/O
 //!   is not cancellable, so a client that hangs up leaves its dispatch running
 //!   until the node answers or `forward_timeout` expires. A streaming dispatch
@@ -96,7 +105,7 @@ use serde_json::Value;
 
 use super::client_keys::Admission;
 use super::policy::{route, RouteDecision, RouteError, RouteMode, RouteRequest};
-use super::{self as fabric, DispatchError, Fabric, ForwardError, StreamOutcome};
+use super::{self as fabric, Cancel, DispatchError, Fabric, ForwardError, StreamOutcome};
 use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
 use crate::tls_pair::resolve_tls;
 
@@ -108,6 +117,17 @@ const REQUEST_ID_HEADER: &str = "x-request-id";
 
 /// Longest inbound request id this proxy will adopt as its own.
 const MAX_REQUEST_ID_LEN: usize = 128;
+
+/// What a request that lost its client is answered with.
+///
+/// Not an IANA code: 499 is nginx's, and it is here for the reason nginx has it
+/// — every standard code would claim either that the request succeeded or that
+/// something upstream failed, and neither happened. Nothing on the network
+/// reads it, because the client it describes has gone; what it protects is the
+/// reader of a log or a test, who must not be told a healthy node failed.
+fn client_closed_request() -> StatusCode {
+    StatusCode::from_u16(499).unwrap_or(StatusCode::BAD_GATEWAY)
+}
 
 /// The engine routes this proxy places on a node.
 ///
@@ -953,6 +973,23 @@ struct OwnedRequest {
     sticky: Option<String>,
 }
 
+/// Fires a request's [`Cancel`] when the frame holding it is dropped.
+///
+/// That drop is the only signal this proxy gets that a client has gone: axum
+/// drops the handler future when the connection does, measured here at ~16 ms
+/// after the client's socket closes. Holding one of these for exactly as long
+/// as a client could still read the answer therefore turns "nobody is waiting"
+/// into something the blocking dispatch can see.
+///
+/// It also fires on the way out of a request that was *served*, which costs
+/// nothing: by then the dispatch has already returned its answer.
+struct CancelOnDrop(Cancel);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
+}
 impl OwnedRequest {
     /// A client that names a node is asking for affinity to it, so the header
     /// settles the mode for its own request. Without this the header would be
@@ -975,6 +1012,13 @@ async fn buffered_completion(
     body: Value,
     request: OwnedRequest,
 ) -> Response {
+    let cancel = Cancel::new();
+    // Bound to this frame, which axum drops when the client hangs up. Nothing
+    // else can stop the task below: dropping the `JoinHandle` the await holds
+    // detaches a blocking task rather than aborting it. Named, because binding
+    // to `_` would drop it here and cancel the request before it started.
+    let _client = CancelOnDrop(cancel.clone());
+
     // Fabric::dispatch is synchronous socket I/O (probes every node, then
     // forwards) and can legitimately run for the whole forward_timeout — up to
     // minutes for a real generation. Running it directly on an async worker
@@ -987,6 +1031,7 @@ async fn buffered_completion(
             &body,
             &request.as_route(state.config.mode),
             state.config.forward_timeout,
+            &cancel,
         )
     })
     .await;
@@ -1049,6 +1094,15 @@ async fn stream_completion(
     let (chunk_tx, mut chunk_rx) =
         tokio::sync::mpsc::channel::<Result<Vec<u8>, String>>(STREAM_CHANNEL_DEPTH);
 
+    let cancel = Cancel::new();
+    // Held by this frame only until the head is in; the streaming arm below
+    // moves it into the response body, because that is where the client can
+    // still be lost from. Until then a client leaving is invisible to the
+    // channel below — nothing has been sent on it yet — and the wait for a head
+    // is a whole prefill long.
+    let client = CancelOnDrop(cancel.clone());
+    let dispatch_cancel = cancel.clone();
+
     // Same reasoning as the buffered path: this is blocking socket I/O for the
     // whole life of the generation, so it belongs on the blocking pool. It also
     // owns cancellation — every send below reports whether the client is still
@@ -1060,6 +1114,7 @@ async fn stream_completion(
             &request.as_route(state.config.mode),
             state.config.forward_timeout,
             state.config.forward_timeout,
+            &dispatch_cancel,
         );
 
         let (mut streaming, _placement) = match outcome {
@@ -1148,6 +1203,11 @@ async fn stream_completion(
     };
 
     let stream = async_stream::stream! {
+        // Moved in, so it lives exactly as long as the response body does. A
+        // client that leaves mid-stream is a dropped body, and the guard is
+        // part of the stream's captured state from the moment it is built, so
+        // a body dropped before it is ever polled still fires it.
+        let _client = client;
         while let Some(chunk) = chunk_rx.recv().await {
             yield chunk;
         }
@@ -1242,6 +1302,11 @@ fn forward_error(error: ForwardError) -> Response {
     // caller's mistake, not the upstream's, so it is a 400 not a 502/503.
     let status = match &error {
         ForwardError::Unsupported(_) => StatusCode::BAD_REQUEST,
+        // Nobody is left to read this. It is answered rather than invented as a
+        // gateway failure so that the one thing that *can* still read it — a
+        // test, or a caller of this function that is not the network — is not
+        // told a healthy node failed.
+        ForwardError::Cancelled { .. } => client_closed_request(),
         ForwardError::Unreachable { .. }
         | ForwardError::Transport { .. }
         | ForwardError::Json { .. } => StatusCode::BAD_GATEWAY,
@@ -2344,5 +2409,66 @@ mod tests {
             plain.as_route(RouteMode::Affinity).mode,
             RouteMode::Affinity
         );
+    }
+
+    /// The guard is what turns a dropped frame into something a blocking
+    /// dispatch can see, so its own contract is worth pinning: dropping it
+    /// fires, and holding it does not.
+    #[test]
+    fn dropping_the_guard_is_what_gives_up_on_the_request() {
+        let cancel = Cancel::new();
+        let guard = CancelOnDrop(cancel.clone());
+        assert!(!cancel.is_cancelled(), "holding it must not give up");
+
+        drop(guard);
+        assert!(cancel.is_cancelled());
+    }
+
+    /// The streaming path moves its guard into the response body, so the body's
+    /// lifetime is the request's. A body can be dropped without ever being
+    /// polled — a client that leaves between the head and the first read — and
+    /// a guard created *inside* the generator rather than moved into it would
+    /// never exist to fire. This pins the distinction, which is invisible in
+    /// the source.
+    #[test]
+    fn a_response_body_dropped_before_it_is_read_still_gives_up_on_the_request() {
+        let cancel = Cancel::new();
+        let guard = CancelOnDrop(cancel.clone());
+        let stream = async_stream::stream! {
+            let _client = guard;
+            yield Ok::<Vec<u8>, String>(Vec::new());
+        };
+
+        assert!(!cancel.is_cancelled(), "building it must not give up");
+        drop(stream);
+        assert!(
+            cancel.is_cancelled(),
+            "a body nobody read left the node generating"
+        );
+    }
+
+    /// A client leaving must not be logged, reported, or acted on as a node
+    /// that failed: [`forward_error`] is what the access log reads placement
+    /// back off, and 502 there would blame a healthy machine.
+    #[test]
+    fn a_request_whose_client_left_is_not_answered_as_a_node_failure() {
+        let abandoned = forward_error(ForwardError::Cancelled {
+            label: "node-a".to_string(),
+        });
+        assert_eq!(abandoned.status().as_u16(), 499);
+        assert_eq!(
+            abandoned
+                .headers()
+                .get("x-camelid-fabric-node")
+                .and_then(|value| value.to_str().ok()),
+            Some("node-a")
+        );
+
+        // The control: a node that really did fail still answers 502.
+        let failed = forward_error(ForwardError::Transport {
+            label: "node-a".to_string(),
+            detail: "connection reset".to_string(),
+        });
+        assert_eq!(failed.status(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -75,13 +75,12 @@
 //!   what a client leaving looks like to axum, and the dispatch stops at its
 //!   next socket-operation boundary and hangs up on the node. A node that sees
 //!   its caller go stops generating within one decode step, so this gives back
-//!   the generation slot rather than merely a thread here. What it does not
-//!   cover is a probe round already in flight, which is bounded by `--timeout-ms`
-//!   and costs a node a health read rather than its generation slot.
-//! * A non-streaming dispatch runs on a blocking thread and blocking socket I/O
-//!   is not cancellable, so a client that hangs up leaves its dispatch running
-//!   until the node answers or `forward_timeout` expires. A streaming dispatch
-//!   does notice: its next send fails and the node's socket is dropped with it.
+//!   the generation slot rather than merely a thread here. Mid-relay a stream
+//!   already noticed on its own — its next send to the client fails — so what
+//!   this adds there is the idle gap between two events, and everywhere else
+//!   it is the only mechanism. What it does not cover is a probe round already
+//!   in flight, which is bounded by `--timeout-ms` and costs a node a health
+//!   read rather than its generation slot.
 
 use std::fmt;
 use std::net::SocketAddr;
@@ -123,8 +122,10 @@ const MAX_REQUEST_ID_LEN: usize = 128;
 /// Not an IANA code: 499 is nginx's, and it is here for the reason nginx has it
 /// — every standard code would claim either that the request succeeded or that
 /// something upstream failed, and neither happened. Nothing on the network
-/// reads it, because the client it describes has gone; what it protects is the
-/// reader of a log or a test, who must not be told a healthy node failed.
+/// reads it, because the client it describes has gone, and nor does the access
+/// log, whose own future is dropped with the handler's. What it protects is a
+/// test, and any future caller of [`forward_error`] that is not the network,
+/// from being told a healthy node failed.
 fn client_closed_request() -> StatusCode {
     StatusCode::from_u16(499).unwrap_or(StatusCode::BAD_GATEWAY)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3066,6 +3066,9 @@ async fn main() -> anyhow::Result<()> {
                     &body,
                     bearer.as_deref(),
                     std::time::Duration::from_secs(forward_timeout_s),
+                    // One request per process: this ends when the process does,
+                    // so there is no client that can leave while it runs.
+                    &camelid::fabric::Cancel::never(),
                 )
                 .map_err(|error| anyhow::anyhow!("{error}"))?;
 

--- a/tests/fabric_end_to_end.rs
+++ b/tests/fabric_end_to_end.rs
@@ -17,8 +17,8 @@ use std::thread::JoinHandle;
 use std::time::Duration;
 
 use camelid::fabric::{
-    forward, parse_node_spec, route, Fabric, NodeSpec, RouteError, RouteMode, RouteReason,
-    RouteRequest,
+    forward, parse_node_spec, route, Cancel, DispatchError, Fabric, ForwardError, NodeSpec,
+    RouteError, RouteMode, RouteReason, RouteRequest,
 };
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -385,8 +385,15 @@ fn forwarding_sends_a_well_formed_request_and_returns_the_answer() {
     let spec = alpha.spec("alpha");
 
     let body = forward::chat_request("model-alpha", "ping", 8);
-    let answer = forward::forward(&spec, "/v1/chat/completions", &body, None, FORWARD_TIMEOUT)
-        .expect("stub answers");
+    let answer = forward::forward(
+        &spec,
+        "/v1/chat/completions",
+        &body,
+        None,
+        FORWARD_TIMEOUT,
+        &Cancel::never(),
+    )
+    .expect("stub answers");
 
     assert!(answer.is_success());
     assert_eq!(answer.label, "alpha");
@@ -421,6 +428,7 @@ fn an_engine_refusal_is_the_nodes_answer_not_a_transport_failure() {
         &forward::chat_request("model-alpha", "ping", 8),
         None,
         FORWARD_TIMEOUT,
+        &Cancel::never(),
     )
     .expect("a 503 is an answer, not an error");
 
@@ -444,6 +452,7 @@ fn dispatch_places_and_sends_in_one_call() {
             &forward::chat_request("model-beta", "ping", 8),
             &RouteRequest::new(RouteMode::Throughput).with_model(Some("model-beta")),
             FORWARD_TIMEOUT,
+            &Cancel::never(),
         )
         .expect("beta serves model-beta");
 
@@ -478,6 +487,7 @@ fn dispatch_refuses_streaming_before_touching_the_network() {
             &serde_json::json!({ "model": "m", "stream": true }),
             &RouteRequest::new(RouteMode::Throughput),
             Duration::from_millis(300),
+            &Cancel::never(),
         )
         .expect_err("streaming is unsupported");
     assert!(
@@ -497,6 +507,7 @@ fn a_fabric_carrying_the_key_is_served_by_an_authenticated_node() {
             &forward::chat_request("model-alpha", "ping", 8),
             &RouteRequest::new(RouteMode::Throughput),
             FORWARD_TIMEOUT,
+            &Cancel::never(),
         )
         .expect("the node accepts our key");
 
@@ -559,6 +570,7 @@ fn a_missing_or_wrong_key_arrives_as_a_401_answer_not_a_transport_failure() {
                 &forward::chat_request("model-alpha", "ping", 8),
                 &RouteRequest::new(RouteMode::Throughput),
                 FORWARD_TIMEOUT,
+                &Cancel::never(),
             )
             .map(|dispatched| (dispatched.decision, dispatched.answer))
             .expect("a 401 is the node's answer, not a forwarding failure");
@@ -585,6 +597,7 @@ fn an_unauthenticated_fabric_sends_no_authorization_header_at_all() {
             &forward::chat_request("model-alpha", "ping", 8),
             &RouteRequest::new(RouteMode::Throughput),
             FORWARD_TIMEOUT,
+            &Cancel::never(),
         )
         .expect("an open node answers");
 
@@ -607,4 +620,75 @@ fn an_operator_node_string_drives_a_real_placement() {
     let decision = route(&fabric.observe(), &RouteRequest::new(RouteMode::Throughput))
         .expect("the parsed node serves");
     assert_eq!(decision.label, "alpha");
+}
+
+/// Health probes a node has answered. A freshness bound exists so that this
+/// stops growing with the number of client requests.
+fn health_probes(node: &StubNode) -> usize {
+    node.received()
+        .iter()
+        .filter(|received| received.path == "/v1/health")
+        .count()
+}
+
+/// A client hanging up says nothing about the node its request was placed on.
+///
+/// The fabric drops an observation that has proved wrong, which is what keeps
+/// a freshness bound honest. Counting a cancellation as proof would invert
+/// that: on a fabric working perfectly, every client that leaves would make the
+/// *next* request pay a whole probe round.
+#[test]
+fn a_cancelled_request_leaves_the_observation_that_placed_it_in_force() {
+    let alpha = StubNode::start(StubConfig::ready("model-alpha", 0));
+    let fabric =
+        fabric_of(vec![alpha.spec("alpha")]).with_max_observation_age(Duration::from_secs(30));
+    let body = forward::chat_request("model-alpha", "ping", 8);
+    let request = RouteRequest::new(RouteMode::Throughput);
+
+    fabric
+        .dispatch(
+            "/v1/chat/completions",
+            &body,
+            &request,
+            FORWARD_TIMEOUT,
+            &Cancel::never(),
+        )
+        .expect("the node serves");
+    let after_the_first = health_probes(&alpha);
+    assert!(after_the_first > 0, "the fabric observed the node at all");
+
+    let gone = Cancel::new();
+    gone.cancel();
+    let error = fabric
+        .dispatch(
+            "/v1/chat/completions",
+            &body,
+            &request,
+            FORWARD_TIMEOUT,
+            &gone,
+        )
+        .expect_err("the client had gone");
+    assert!(
+        matches!(
+            error,
+            DispatchError::Forward(ForwardError::Cancelled { .. })
+        ),
+        "got {error:?}"
+    );
+
+    fabric
+        .dispatch(
+            "/v1/chat/completions",
+            &body,
+            &request,
+            FORWARD_TIMEOUT,
+            &Cancel::never(),
+        )
+        .expect("the node still serves");
+
+    assert_eq!(
+        health_probes(&alpha),
+        after_the_first,
+        "the fabric re-probed because a client hung up"
+    );
 }

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -81,6 +81,13 @@ struct StubConfig {
     /// When set, `/v1/health` reports this model rather than the fixed one, so
     /// a test can load a different model while the proxy is running.
     live_model: Option<Arc<Mutex<String>>>,
+    /// How long a placed request is worked on while watching the socket for the
+    /// caller going away. A node with one JSON answer to give has nothing to
+    /// write until it is finished, so unlike `events_written` there is no
+    /// failing write to reveal a hang-up — it has to be looked for.
+    completion_watch: Duration,
+    /// How far into `completion_watch` the caller went away, if it did.
+    caller_left_after: Arc<Mutex<Option<Duration>>>,
 }
 
 impl StubConfig {
@@ -104,6 +111,8 @@ impl StubConfig {
             events_written: Arc::new(AtomicUsize::new(0)),
             live_in_flight: None,
             live_model: None,
+            completion_watch: Duration::ZERO,
+            caller_left_after: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -196,6 +205,19 @@ impl StubConfig {
     fn hanging_up_on_completion(model: &str) -> Self {
         Self {
             hangs_up_on_completion: true,
+            ..Self::ready(model, 0)
+        }
+    }
+
+    /// A node working on a request for `hold`, watching for its caller to go.
+    ///
+    /// A real engine notices the same event by the same means — its handler
+    /// frame is dropped when the connection is — and stops its decode loop
+    /// within one step. `hold` stands in for the generation that would still
+    /// have been running.
+    fn working_on_a_completion(model: &str, hold: Duration) -> Self {
+        Self {
+            completion_watch: hold,
             ..Self::ready(model, 0)
         }
     }
@@ -307,6 +329,19 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
         return;
     }
 
+    if authorized
+        && !config.completion_watch.is_zero()
+        && PLACED_ROUTES.contains(&received.path.as_str())
+    {
+        // Recorded before the work starts, so a test can wait until the node
+        // really holds the request before taking its caller away.
+        requests.lock().expect("stub lock").push(received);
+        if caller_stayed(stream, config) {
+            write_json(stream, config.completion_status, &config.completion);
+        }
+        return;
+    }
+
     let (status, body) = match received.path.as_str() {
         _ if !authorized => (
             401_u16,
@@ -334,12 +369,53 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
     // Record only after deciding, so a malformed request never poisons the log.
     requests.lock().expect("stub lock").push(received);
 
+    write_json(stream, status, &body);
+}
+
+fn write_json(stream: &mut TcpStream, status: u16, body: &str) {
     let response = format!(
         "HTTP/1.1 {status} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
     let _ = stream.write_all(response.as_bytes());
     let _ = stream.flush();
+}
+
+/// Work on a placed request for `completion_watch`, watching the socket for the
+/// caller going away, and report whether it was still there at the end.
+///
+/// A node with one JSON answer to give writes nothing until it is finished, so
+/// unlike a stream there is no failing write to reveal a hang-up: it has to be
+/// looked for. A real engine notices the same event by the same means — its
+/// handler frame is dropped when the connection is.
+fn caller_stayed(stream: &mut TcpStream, config: &StubConfig) -> bool {
+    let started = Instant::now();
+    if stream
+        .set_read_timeout(Some(Duration::from_millis(20)))
+        .is_err()
+    {
+        return false;
+    }
+    let mut scratch = [0_u8; 64];
+    while started.elapsed() < config.completion_watch {
+        let gone = match stream.read(&mut scratch) {
+            // A graceful close reads as end-of-file and an abortive one as an
+            // error; both mean the caller has gone.
+            Ok(0) => true,
+            // Nothing here pipelines a second request, so anything readable is
+            // not the caller leaving.
+            Ok(_) => false,
+            Err(error) => !matches!(
+                error.kind(),
+                std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+            ),
+        };
+        if gone {
+            *config.caller_left_after.lock().expect("stub lock") = Some(started.elapsed());
+            return false;
+        }
+    }
+    true
 }
 
 /// What `/v1/health` answers: the configured body, carrying whatever load and
@@ -476,13 +552,27 @@ async fn start_proxy(fabric: Fabric, mode: RouteMode) -> SocketAddr {
 }
 
 async fn start_proxy_with_auth(fabric: Fabric, mode: RouteMode, auth: ClientAuth) -> SocketAddr {
+    start_proxy_waiting(fabric, mode, auth, FORWARD_TIMEOUT).await
+}
+
+/// The proxy with a forward budget of its own.
+///
+/// A cancellation test needs one far longer than the test itself, so that a
+/// request ending early can only be because it was given up on, never because
+/// it ran out of time.
+async fn start_proxy_waiting(
+    fabric: Fabric,
+    mode: RouteMode,
+    auth: ClientAuth,
+    forward_timeout: Duration,
+) -> SocketAddr {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind proxy");
     let addr = listener.local_addr().expect("proxy addr");
     let config = ServeConfig {
         mode,
-        forward_timeout: FORWARD_TIMEOUT,
+        forward_timeout,
         auth,
         tls: None,
         bound: addr,
@@ -1303,8 +1393,10 @@ async fn a_node_refusing_a_stream_is_relayed_as_a_readable_answer() {
 }
 
 /// A client that hangs up mid-stream must take the node's work with it.
-/// The buffered path cannot do this — blocking socket I/O is not cancellable —
-/// so this is a property the streaming path adds rather than inherits.
+///
+/// The relay notices because a send to a client that has gone fails. That only
+/// works once the node produces something to send, which is why the buffered
+/// path needs a mechanism of its own; see the test below it.
 #[tokio::test(flavor = "multi_thread")]
 async fn a_client_hanging_up_stops_the_node_generating() {
     let gap = Duration::from_millis(100);
@@ -1353,6 +1445,143 @@ async fn a_client_hanging_up_stops_the_node_generating() {
         later < events.len(),
         "the node wrote all {} events despite the client leaving",
         events.len()
+    );
+}
+
+/// Send a request over a real socket and leave without waiting for the answer.
+///
+/// Returns once the node holds the request, so the hang-up cannot land before
+/// there is anything to abandon. Polling the node beats sleeping a guess: the
+/// point of the measurement afterwards is that it is not a timing coincidence.
+async fn post_then_hang_up(addr: SocketAddr, node: &StubNode, path: &str, body: Value) {
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to proxy");
+    let payload = body.to_string();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while served_on(std::slice::from_ref(node), path)[0] == 0 {
+        assert!(
+            Instant::now() < deadline,
+            "the node never received the request, so there was nothing to abandon"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    drop(stream);
+}
+
+/// What the node observed, once it observes anything, or `None` if it never did.
+async fn caller_left_within(seen: &Mutex<Option<Duration>>, bound: Duration) -> Option<Duration> {
+    let deadline = Instant::now() + bound;
+    loop {
+        if let Some(elapsed) = *seen.lock().expect("stub lock") {
+            return Some(elapsed);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// The buffered path has no relay whose failure could reveal a client leaving,
+/// so it has to be told — and this is what being told is worth. A Camelid node
+/// runs one generation at a time, so a request nobody wants holds that node's
+/// only slot until it finishes or the proxy's forward budget expires.
+///
+/// The budget here is 60s and the node would work for 30s; noticing inside a
+/// couple of seconds cannot be either of those running out.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_client_hanging_up_gives_the_node_back_its_generation_slot() {
+    let config = StubConfig::working_on_a_completion("m", Duration::from_secs(30));
+    let left = Arc::clone(&config.caller_left_after);
+    let node = StubNode::start(config);
+    let fabric = fabric_of(vec![node.spec("only")]);
+    let addr = start_proxy_waiting(
+        fabric,
+        RouteMode::Throughput,
+        ClientAuth::none(),
+        Duration::from_secs(60),
+    )
+    .await;
+
+    post_then_hang_up(
+        addr,
+        &node,
+        "/v1/chat/completions",
+        serde_json::json!({ "model": "m" }),
+    )
+    .await;
+
+    let noticed = caller_left_within(&left, Duration::from_secs(10))
+        .await
+        .expect("the node was never told its caller had gone; it kept the request for 30s");
+    assert!(
+        noticed < Duration::from_secs(3),
+        "the node held the request for {noticed:?} after its client left"
+    );
+}
+
+/// The same for a streaming request that has not reached its first event: the
+/// relay's own mechanism cannot fire, because nothing has been relayed.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_client_leaving_before_the_first_event_still_stops_the_node() {
+    let config = StubConfig::working_on_a_completion("m", Duration::from_secs(30));
+    let left = Arc::clone(&config.caller_left_after);
+    let node = StubNode::start(config);
+    let fabric = fabric_of(vec![node.spec("only")]);
+    let addr = start_proxy_waiting(
+        fabric,
+        RouteMode::Throughput,
+        ClientAuth::none(),
+        Duration::from_secs(60),
+    )
+    .await;
+
+    post_then_hang_up(
+        addr,
+        &node,
+        "/v1/chat/completions",
+        serde_json::json!({ "model": "m", "stream": true }),
+    )
+    .await;
+
+    let noticed = caller_left_within(&left, Duration::from_secs(10))
+        .await
+        .expect("the node was never told its caller had gone before the first event");
+    assert!(
+        noticed < Duration::from_secs(3),
+        "the node held the request for {noticed:?} after its client left"
+    );
+}
+
+/// The control for both: a client that stays is served, and the node is never
+/// told to stop. Without this, a proxy that cancelled every request the moment
+/// it started one would pass the two tests above.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_client_that_waits_is_served_and_the_node_is_never_told_to_stop() {
+    let config = StubConfig::working_on_a_completion("m", Duration::from_millis(400));
+    let left = Arc::clone(&config.caller_left_after);
+    let node = StubNode::start(config);
+    let fabric = fabric_of(vec![node.spec("only")]);
+    let addr = start_proxy(fabric, RouteMode::Throughput).await;
+
+    let (status, body, _) = post_chat(addr, &serde_json::json!({ "model": "m" }), &[]).await;
+
+    assert_eq!(status, 200);
+    assert_eq!(body["choices"][0]["message"]["content"], "served by m");
+    assert_eq!(
+        *left.lock().expect("stub lock"),
+        None,
+        "a served request must not look like an abandoned one"
     );
 }
 


### PR DESCRIPTION
## The defect

`src/fabric/server.rs` documented it plainly on `main`:

> A non-streaming dispatch runs on a blocking thread and blocking socket I/O is not cancellable, so a
> client that hangs up leaves its dispatch running until the node answers or `forward_timeout`
> expires.

That is worse than a wasted thread. `src/api/engine.rs:1` describes the engine as *"one dedicated OS
thread ... executes at most one compute step at a time"*, so an abandoned request holds the **node's
only generation slot**, not this proxy's. On a two-machine fabric that is half the operator's
hardware, spent on an answer nobody will read, for up to `--forward-timeout-s` (300s by default).

A blocking thread cannot be aborted from outside — dropping its `JoinHandle` detaches it rather than
stopping it — so the only fix is to tell the work it is no longer wanted, and have it agree to look.

## What this does

Every handler frame holds a `Cancel`, fired when that frame is dropped, which is what a client
leaving looks like to axum. Every blocking loop that can wait on a node consults it beside its own
deadline, and the socket to the node is dropped on the way out. A node that sees its caller go is
already the case the engine handles: `src/api/engine.rs:14` says *"a dropped handler (client
disconnect) stops the running job within one step"*.

Both directions of the gap are covered:

| | before | after |
|---|---|---|
| buffered dispatch | nothing to relay, so nothing whose failure could reveal the client had gone | stops at the next socket-operation boundary |
| streaming, before the first event | the relay's own mechanism cannot fire — nothing has been sent yet, and a head is a whole prefill away | same |
| streaming, mid-relay | already stopped, via a failing send to the client | unchanged, plus the idle gap between two events is now covered |
| probe round | bounded by `--timeout-ms` | **unchanged, deliberately** — see Honest gaps |

## Design calls worth arguing with

**A cancellation is not a node failure, and that distinction is behavioural.**
`ForwardError::Cancelled` is its own variant rather than a `Transport`. `forget_observation_if_node_vanished`
drops the observation on `Transport`, which is what keeps #656's freshness bound honest — but folding
cancellation into it would mean *every client that hangs up makes the next request pay a whole probe
round*, on a fabric that is working perfectly. It also must not be `node_never_received_it()`: nobody
is left to hand a second node's answer to. Ablation A2 exists precisely to prove both.

**`Cancel` is an atomic flag, not a `tokio_util::CancellationToken`.** Nothing here ever awaits it —
the async side is the side that *fires* it — so importing an async notification primitive to answer a
synchronous question would be the wrong kind of reuse. `Cancel::never()` exists so the callers with
no client to lose (`fabric status|route|run`, and a health probe) say so at the call site rather than
pass an anonymous unfired one.

**The streaming guard is moved into the response body, not created inside it.** A body can be dropped
before it is ever polled — a client that leaves between the head and the first read — and a guard
declared inside the generator would never exist to fire. That distinction is invisible in the source,
so `a_response_body_dropped_before_it_is_read_still_gives_up_on_the_request` pins it.

**Cancellation is checked *before* the deadline in every loop**, so an abandoned request is reported
as abandoned rather than as a node that was too slow. The answer is 499, which nothing on the network
reads — the client it describes has gone — but which keeps a log or a test from being told a healthy
node failed.

## What I measured before building it

The whole design rests on axum dropping the handler future when a client half-closes while a response
is pending. I did not assume it. A throwaway probe (an axum handler holding a drop guard, a raw
socket that writes a complete request and then closes) reported the guard firing **15.9 ms** after the
close. The probe is not part of this PR; what is part of it is
`a_client_hanging_up_gives_the_node_back_its_generation_slot`, which proves the same thing end to end
over real sockets against a node that would otherwise have held the request for 30s, with the proxy's
forward budget set to 60s so that neither of those can be what ended it.

## Gates

Rebased onto `a825682d5` (main, after #672 and #674). Every leg re-run on the rebased commit
`17de63f5f`, with the tree verified clean at the end of the run, so the gates describe the commit
that is being merged rather than a working tree.

```
cargo fmt --all -- --check                     0
cargo clippy --all-targets -- -D warnings      0 findings
cargo test --lib fabric::                    206   (195 + 11)
cargo test --test fabric_serve                68   (65 + 3)
cargo test --test fabric_end_to_end           15   (14 + 1)
cargo test --bin camelid                      42   (unchanged)
scripts/check-public-scrub.sh                  0
git diff --check                               0
git ls-files --eol                             all i/lf w/lf
```

The four counts were predicted before the rebase was run, by adding this PR's contribution to the
counts main reached after #674, and each landed exactly: 206 / 68 / 15 / 42. The rebase resolved one
conflict, `src/fabric/mod.rs`'s module list, by keeping both neighbours' entries; this PR's own diff
is byte-identical across the rebase (10 files, +957/-43 before and after).

## Ablations

Each one breaks a single mechanism, predicts exactly which tests fail, and is restored
byte-identically (verified by SHA-256, not by `git status` — the new file is untracked during the
run).

| ablation | predicted | measured |
|---|---|---|
| **A1** nothing ever reads the cancellation | 9 unit, 1 e2e, 2 integration | **exactly that**, and the pre-existing streaming hang-up test still passed |
| **A2** a cancellation is reported as a `Transport` failure | exactly 1 unit + 1 e2e | **exactly that** — `fabric_serve` stayed 63/0, so the hang-up still reaches the node; what breaks is only the attribution and the observation |
| **A3** the buffered handler frame holds no guard | exactly 1 integration | **exactly that** — `a_client_hanging_up_gives_the_node_back_its_generation_slot`, while the streaming one kept passing |

Control on the restored tree: 181 / 15 / 63, all green.

The ablations above were measured on the pre-rebase base `d080367b4`; they exercise the cancellation
mechanism, which the rebase did not touch.

There is also a negative control in the suite itself,
`a_client_that_waits_is_served_and_the_node_is_never_told_to_stop`: a proxy that cancelled everything
the moment it started would pass the two hang-up tests and fail this one.

## A stale claim this PR had to fix

`a_client_hanging_up_stops_the_node_generating` carried the sentence *"The buffered path cannot do
this — blocking socket I/O is not cancellable — so this is a property the streaming path adds rather
than inherits."* That is now false, and the comment says what is actually true instead: the relay
notices because a send fails, which is why the buffered path needed a mechanism of its own.

## Honest gaps

* **Live receipt, on real binaries.** A real `camelid serve` node (Llama-3.2-1B-Instruct-Q8_0) behind
  `fabric serve --forward-timeout-s 120`, twice, with the node's own `/v1/health`
  `engine_queue_depth` as the instrument — that gauge is the generation slot this is about:

  | arm | took the job | slot free again | node busy | curl |
  | --- | --- | --- | --- | --- |
  | client waits | 200 ms | 4466 ms | **4266 ms** | 200 |
  | client hangs up at 2 s | 227 ms | 2273 ms | **2046 ms** | 000 |

  The slot came back **~46 ms after the client's socket closed**, not at 4.3 s when the answer would
  have been ready and nowhere near the 120 s budget, so neither of those is what ended it.
* **A probe round already in flight is not interrupted.** It is bounded by `--timeout-ms` (2s by
  default) and costs a node a health read rather than its generation slot, so threading cancellation
  through `probe.rs` would be noise for no gain. `probe.rs` passes `Cancel::never()` and says why.
* **A client that hangs up still produces no access-log line.** The middleware's own future is
  dropped with the handler's. That is pre-existing behaviour and unchanged here; it is worth knowing
  before reading `RUST_LOG=camelid=info` as a complete record.
* **The stop path is unchanged.** A graceful shutdown still drains in-flight work bounded by
  `forward_timeout`; this is about a client leaving, not about the proxy being asked to stop.
* Per the campaign's own standing rule, this is a third open fabric PR while #672 and #674 are still
  unmerged. Measured rather than guessed: #672 conflicts with #674 (`docs/CONFIGURATION.md`,
  `src/main.rs`) and with this one (`src/fabric/mod.rs`), while #674 and #675 are clean against each
  other — so #672 is the one to merge first or rebase last.

