### PR TITLE
Share one watched-file mechanism, and read the node file from every fabric subcommand

### DIFF
--- a/src/fabric/client_keys.rs
+++ b/src/fabric/client_keys.rs
@@ -20,12 +20,13 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, SystemTime};
+use std::sync::Arc;
+use std::time::Duration;
 
 use axum::http::HeaderMap;
 use serde::Deserialize;
 
+use super::watch::{Change, WatchedFile};
 use crate::api::ApiAuth;
 
 /// Longest client name this proxy will accept.
@@ -72,49 +73,12 @@ struct KeyFileEntry {
     key: String,
 }
 
-/// What the file looked like when it was last read.
-///
-/// Length as well as modification time, because a revocation usually shortens
-/// the file and mtime alone can be too coarse to notice a rewrite within one
-/// tick. It narrows that window rather than closing it: a key swapped for one
-/// of the same length inside a single tick still looks unchanged. Closing it
-/// would mean reading the file every interval, which is the cost this exists
-/// to avoid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct FileStamp {
-    modified: Option<SystemTime>,
-    len: u64,
-}
-
-impl FileStamp {
-    fn of(path: &Path) -> Result<Self> {
-        let metadata = fs::metadata(path)?;
-        Ok(Self {
-            modified: metadata.modified().ok(),
-            len: metadata.len(),
-        })
-    }
-}
-
-struct ReloadState {
-    clients: Arc<[ClientKey]>,
-    stamp: Option<FileStamp>,
-    last_checked: Option<Instant>,
-    /// Whether the last re-read failed, so the notice below is printed once
-    /// per transition rather than once per request.
-    stale: bool,
-}
-
 enum Source {
     /// A single key given on the command line or in a one-key file. It cannot
     /// change while the process runs, so there is nothing to re-read.
     Fixed(Arc<[ClientKey]>),
     /// A key set on disk, re-read when it changes.
-    File {
-        path: PathBuf,
-        interval: Duration,
-        state: Mutex<ReloadState>,
-    },
+    File(WatchedFile<Arc<[ClientKey]>>),
 }
 
 /// The credential a client must present to this proxy.
@@ -172,18 +136,10 @@ impl ClientAuth {
         // Loaded once here so an unusable file stops the proxy at startup
         // rather than at the first request.
         let clients = load_key_file(&path)?;
-        let stamp = FileStamp::of(&path).ok();
         Ok(Self {
-            source: Some(Arc::new(Source::File {
-                path,
-                interval,
-                state: Mutex::new(ReloadState {
-                    clients,
-                    stamp,
-                    last_checked: Some(Instant::now()),
-                    stale: false,
-                }),
-            })),
+            source: Some(Arc::new(Source::File(WatchedFile::new(
+                path, interval, clients,
+            )))),
         })
     }
 
@@ -193,7 +149,7 @@ impl ClientAuth {
 
     /// Whether revoking a client takes effect without a restart.
     pub fn is_reloadable(&self) -> bool {
-        matches!(self.source.as_deref(), Some(Source::File { .. }))
+        matches!(self.source.as_deref(), Some(Source::File(_)))
     }
 
     /// How many clients are currently served. Reported at startup, never per
@@ -202,7 +158,7 @@ impl ClientAuth {
         match self.source.as_deref() {
             None => 0,
             Some(Source::Fixed(clients)) => clients.len(),
-            Some(Source::File { state, .. }) => state.lock().expect("client keys").clients.len(),
+            Some(Source::File(watched)) => current_clients(watched).len(),
         }
     }
 
@@ -213,11 +169,7 @@ impl ClientAuth {
         };
         let clients = match source {
             Source::Fixed(clients) => Arc::clone(clients),
-            Source::File {
-                path,
-                interval,
-                state,
-            } => current_clients(path, *interval, state),
+            Source::File(watched) => current_clients(watched),
         };
         match_client(&clients, headers)
     }
@@ -247,69 +199,44 @@ fn match_client(clients: &[ClientKey], headers: &HeaderMap) -> Admission {
 }
 
 /// The key set as it stands, re-reading the file if it may have changed.
-fn current_clients(
-    path: &Path,
-    interval: Duration,
-    state: &Mutex<ReloadState>,
-) -> Arc<[ClientKey]> {
-    let mut state = state.lock().expect("client keys");
-
-    let due = match state.last_checked {
-        Some(checked) if interval > Duration::ZERO => checked.elapsed() >= interval,
-        Some(_) => true,
-        None => true,
-    };
-    if !due {
-        return Arc::clone(&state.clients);
-    }
-    state.last_checked = Some(Instant::now());
-
-    let stamp = FileStamp::of(path).ok();
-    if stamp.is_some() && stamp == state.stamp {
-        return Arc::clone(&state.clients);
-    }
-
-    match load_key_file(path) {
-        Ok(clients) => {
+fn current_clients(watched: &WatchedFile<Arc<[ClientKey]>>) -> Arc<[ClientKey]> {
+    let (clients, change) = watched.look(load_key_file);
+    match change {
+        Change::None => {}
+        Change::Loaded { recovered, .. } => {
+            // Logged on every re-read, not only when the count changes: a key
+            // rotated for another would otherwise leave no trace at any level.
             tracing::info!(
                 clients = clients.len(),
-                path = %path.display(),
+                path = %watched.path().display(),
                 "client key set reloaded"
             );
-            if state.stale {
+            if recovered {
                 eprintln!(
                     "fabric: client keys reloaded from {}; now serving {}",
-                    path.display(),
+                    watched.path().display(),
                     clients_phrase(clients.len())
                 );
             }
-            state.clients = clients;
-            state.stamp = stamp;
-            state.stale = false;
         }
-        Err(error) => {
-            // The previous set is kept on purpose. A key file is often replaced
-            // by writing a new one and renaming it over the old, so a read that
-            // lands mid-swap sees a partial or missing file; refusing every
-            // client on that would turn an ordinary edit into an outage. The
+        Change::Failed { error, first } => {
+            // The previous set is kept on purpose; see [`super::watch`]. The
             // cost is that a revocation written into a broken or deleted file
             // has not taken effect, so the operator has to hear about it.
             tracing::warn!(
-                path = %path.display(),
+                path = %watched.path().display(),
                 %error,
                 "could not reload client keys; the previous set is still in force"
             );
             // Printed, not only traced: `RUST_LOG` is unset on a stock proxy,
             // so a revocation that has silently not happened would otherwise
-            // be invisible to the operator who just wrote it. Once per
-            // transition, so a file left broken does not fill the terminal.
-            if !state.stale {
-                eprintln!("{}", stale_key_set_notice(&error, state.clients.len()));
+            // be invisible to the operator who just wrote it.
+            if first {
+                eprintln!("{}", stale_key_set_notice(&error, clients.len()));
             }
-            state.stale = true;
         }
     }
-    Arc::clone(&state.clients)
+    clients
 }
 
 /// What an operator is told when a re-read fails. Pure, so it is tested rather

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -31,6 +31,7 @@ pub(crate) mod nodes;
 pub mod policy;
 pub mod probe;
 pub mod server;
+pub(crate) mod watch;
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};

--- a/src/fabric/nodes.rs
+++ b/src/fabric/nodes.rs
@@ -157,7 +157,11 @@ impl NodeSet {
 
 impl std::fmt::Debug for NodeSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (specs, generation) = self.current();
+        let specs = match &self.inner.source {
+            Source::Fixed(specs) => Arc::clone(specs),
+            Source::File(watched) => watched.cached(),
+        };
+        let generation = self.inner.generation.load(Ordering::SeqCst);
         f.debug_struct("NodeSet")
             .field("specs", &specs)
             .field("reloadable", &self.is_reloadable())
@@ -353,6 +357,28 @@ mod tests {
 
         assert_eq!(labels(&specs), vec!["a", "b"]);
         assert_eq!(before, after, "an identical rewrite is not a change");
+    }
+
+    #[test]
+    fn formatting_a_set_does_not_reload_its_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = write(&dir, "a=127.0.0.1:8181\n");
+        let set = NodeSet::from_file_every(path.clone(), Duration::ZERO).expect("load");
+        let (_, before) = set.current();
+
+        fs::write(&path, TWO).expect("rewrite");
+        let rendered = format!("{set:?}");
+
+        assert!(rendered.contains("a"), "{rendered}");
+        assert_eq!(
+            set.inner.generation.load(Ordering::SeqCst),
+            before,
+            "formatting must not perform I/O or change placement state"
+        );
+
+        let (specs, after) = set.current();
+        assert_eq!(labels(&specs), vec!["a", "b"]);
+        assert_ne!(before, after, "an explicit lookup still reloads the file");
     }
 
     /// Keeping the previous set is only safe if the operator is told, and

--- a/src/fabric/nodes.rs
+++ b/src/fabric/nodes.rs
@@ -14,10 +14,11 @@ use std::fs;
 use std::io::{Error, ErrorKind, Result};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, SystemTime};
+use std::sync::Arc;
+use std::time::Duration;
 
 use super::node::{parse_fabric, NodeSpec};
+use super::watch::{Change, WatchedFile};
 
 /// How long a loaded set is trusted before the file is looked at again.
 ///
@@ -26,52 +27,15 @@ use super::node::{parse_fabric, NodeSpec};
 /// proxy is not stat-ing a file on every placement.
 pub(crate) const DEFAULT_NODE_RELOAD_INTERVAL: Duration = Duration::from_secs(1);
 
-/// What the file looked like when it was last read.
-///
-/// Length as well as modification time, because adding or removing a machine
-/// changes the length and mtime alone can be too coarse to notice a rewrite
-/// within one tick. It narrows that window rather than closing it: an edit of
-/// the same length inside a single tick still looks unchanged. Closing it would
-/// mean reading the file every interval, which is the cost this exists to
-/// avoid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct FileStamp {
-    modified: Option<SystemTime>,
-    len: u64,
-}
-
-impl FileStamp {
-    fn of(path: &Path) -> Result<Self> {
-        let metadata = fs::metadata(path)?;
-        Ok(Self {
-            modified: metadata.modified().ok(),
-            len: metadata.len(),
-        })
-    }
-}
-
 enum Source {
     /// Specs given on the command line. They cannot change while the process
     /// runs, so there is nothing to re-read.
-    Fixed,
-    File {
-        path: PathBuf,
-        interval: Duration,
-    },
-}
-
-struct State {
-    specs: Arc<[NodeSpec]>,
-    stamp: Option<FileStamp>,
-    last_checked: Option<Instant>,
-    /// Whether the last re-read failed, so the notice below is printed once
-    /// per transition rather than once per interval for as long as it lasts.
-    stale: bool,
+    Fixed(Arc<[NodeSpec]>),
+    File(WatchedFile<Arc<[NodeSpec]>>),
 }
 
 struct Inner {
     source: Source,
-    state: Mutex<State>,
     /// Bumped only when the set actually changes, never merely because the
     /// file was re-read. An observation is valid for the generation it was
     /// taken in and no other; see [`NodeSet::current`].
@@ -94,13 +58,7 @@ impl NodeSet {
     pub(crate) fn fixed(specs: Vec<NodeSpec>) -> Self {
         Self {
             inner: Arc::new(Inner {
-                source: Source::Fixed,
-                state: Mutex::new(State {
-                    specs: Arc::from(specs),
-                    stamp: None,
-                    last_checked: None,
-                    stale: false,
-                }),
+                source: Source::Fixed(Arc::from(specs)),
                 generation: AtomicU64::new(0),
             }),
         }
@@ -118,17 +76,10 @@ impl NodeSet {
     pub(crate) fn from_file_every(path: PathBuf, interval: Duration) -> Result<Self> {
         // Loaded once here so an unusable file stops the proxy at startup
         // rather than at the first request.
-        let specs = load_node_file(&path)?;
-        let stamp = FileStamp::of(&path).ok();
+        let specs = load_specs(&path)?;
         Ok(Self {
             inner: Arc::new(Inner {
-                source: Source::File { path, interval },
-                state: Mutex::new(State {
-                    specs: Arc::from(specs),
-                    stamp,
-                    last_checked: Some(Instant::now()),
-                    stale: false,
-                }),
+                source: Source::File(WatchedFile::new(path, interval, specs)),
                 generation: AtomicU64::new(0),
             }),
         })
@@ -136,7 +87,7 @@ impl NodeSet {
 
     /// Whether the set changes without a restart.
     pub(crate) fn is_reloadable(&self) -> bool {
-        matches!(self.inner.source, Source::File { .. })
+        matches!(self.inner.source, Source::File(_))
     }
 
     /// The set as it stands, and the generation it belongs to.
@@ -150,103 +101,74 @@ impl NodeSet {
     /// change and leave the next caller reusing an observation of a set that
     /// no longer exists.
     pub(crate) fn current(&self) -> (Arc<[NodeSpec]>, u64) {
-        let Source::File { path, interval } = &self.inner.source else {
-            let state = lock(&self.inner.state);
-            return (Arc::clone(&state.specs), 0);
+        let Source::File(watched) = &self.inner.source else {
+            let Source::Fixed(specs) = &self.inner.source else {
+                unreachable!("a source is either fixed or a file")
+            };
+            return (Arc::clone(specs), 0);
         };
 
-        let mut state = lock(&self.inner.state);
-
-        let due = match state.last_checked {
-            Some(checked) if *interval > Duration::ZERO => checked.elapsed() >= *interval,
-            _ => true,
-        };
-        if !due {
-            return (
-                Arc::clone(&state.specs),
-                self.inner.generation.load(Ordering::SeqCst),
-            );
-        }
-        state.last_checked = Some(Instant::now());
-
-        let stamp = FileStamp::of(path).ok();
-        if stamp.is_some() && stamp == state.stamp {
-            return (
-                Arc::clone(&state.specs),
-                self.inner.generation.load(Ordering::SeqCst),
-            );
-        }
-
-        match load_node_file(path) {
-            Ok(specs) => {
-                state.stamp = stamp;
+        let (specs, change) = watched.look(load_specs);
+        match change {
+            Change::None => {}
+            Change::Loaded {
+                previous,
+                recovered,
+            } => {
                 // Compared, not assumed: touching a file without changing what
                 // it says must not throw away a usable observation.
-                if specs.as_slice() != &*state.specs {
+                if specs != previous {
                     tracing::info!(
                         nodes = specs.len(),
-                        path = %path.display(),
+                        path = %watched.path().display(),
                         "node set reloaded"
                     );
-                    state.specs = Arc::from(specs);
                     self.inner.generation.fetch_add(1, Ordering::SeqCst);
                 }
-                if state.stale {
+                if recovered {
                     eprintln!(
                         "fabric: node file {} is readable again; placing on {}",
-                        path.display(),
-                        nodes_phrase(state.specs.len())
+                        watched.path().display(),
+                        nodes_phrase(specs.len())
                     );
                 }
-                state.stale = false;
             }
-            Err(error) => {
-                // The previous set is kept on purpose. A file is often replaced
-                // by writing a new one and renaming it over the old, so a read
-                // that lands mid-swap sees a partial, empty or missing file;
-                // emptying the fabric on that would turn an ordinary edit into
-                // a total outage, because a fabric with no nodes refuses every
-                // request. The cost is that a change written into a broken or
-                // deleted file does not take effect, so the operator has to
-                // hear about it.
+            Change::Failed { error, first } => {
+                // The previous set is kept on purpose; see [`super::watch`].
+                // The cost is that a change written into a broken or deleted
+                // file does not take effect, so the operator has to hear about
+                // it.
                 tracing::warn!(
-                    path = %path.display(),
+                    path = %watched.path().display(),
                     %error,
                     "could not reload the node set; the previous one is still in force"
                 );
                 // Printed, not only traced: `RUST_LOG` is unset on a stock
                 // proxy, so a machine the operator meant to take out would go
-                // on being placed on with nothing said. Once per transition,
-                // because this is re-attempted every interval and a file left
-                // broken would otherwise emit a line a second indefinitely.
-                if !state.stale {
-                    eprintln!("{}", stale_node_set_notice(&error, state.specs.len()));
+                // on being placed on with nothing said.
+                if first {
+                    eprintln!("{}", stale_node_set_notice(&error, specs.len()));
                 }
-                state.stale = true;
             }
         }
-        (
-            Arc::clone(&state.specs),
-            self.inner.generation.load(Ordering::SeqCst),
-        )
+        (specs, self.inner.generation.load(Ordering::SeqCst))
     }
 }
 
 impl std::fmt::Debug for NodeSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let (specs, generation) = {
-            let state = lock(&self.inner.state);
-            (
-                Arc::clone(&state.specs),
-                self.inner.generation.load(Ordering::SeqCst),
-            )
-        };
+        let (specs, generation) = self.current();
         f.debug_struct("NodeSet")
             .field("specs", &specs)
             .field("reloadable", &self.is_reloadable())
             .field("generation", &generation)
             .finish()
     }
+}
+
+/// Read and validate a node file into the shape the set holds.
+fn load_specs(path: &Path) -> Result<Arc<[NodeSpec]>> {
+    load_node_file(path).map(Arc::from)
 }
 
 /// Read and validate a node file.
@@ -314,14 +236,6 @@ fn nodes_phrase(count: usize) -> String {
     } else {
         format!("{count} machines")
     }
-}
-
-/// A poisoned lock is not corrupted state: some other request panicked while
-/// holding it. Recover the value rather than spreading the panic.
-fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    mutex
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[cfg(test)]

--- a/src/fabric/watch.rs
+++ b/src/fabric/watch.rs
@@ -111,6 +111,11 @@ impl<T: Clone> WatchedFile<T> {
         &self.path
     }
 
+    /// The last value loaded, without looking at the file again.
+    pub(crate) fn cached(&self) -> T {
+        lock(&self.state).value.clone()
+    }
+
     /// The value as it stands, and what looking for a newer one did.
     ///
     /// `load` is called only when the interval has elapsed *and* the file's

--- a/src/fabric/watch.rs
+++ b/src/fabric/watch.rs
@@ -1,0 +1,389 @@
+//! A file the proxy re-reads while it runs, without re-reading it constantly.
+//!
+//! Two things the fabric loads are edited by an operator while the proxy is
+//! serving — the node set and the client key set — and both want the same
+//! behaviour: notice a change within a bound, do not stat the file on every
+//! request, and above all **keep the last good value when a read fails**. That
+//! last rule is what makes an ordinary edit safe: a file is usually replaced by
+//! writing a new one and renaming it over the old, so a read landing mid-swap
+//! sees a partial or missing file. Emptying the node set or refusing every
+//! client on that would turn an edit into an outage.
+//!
+//! The cost of keeping the old value is that a change written into a broken
+//! file has *not* taken effect, and nobody would know. So a failure is reported
+//! as an edge — the first look that fails, and the first that succeeds again —
+//! which is what lets a caller say so once rather than once per interval.
+//!
+//! This module owns the mechanism only. What the values mean, what is logged
+//! and what a change triggers stay with the caller, because those genuinely
+//! differ: a node set carries a generation that invalidates observations, and a
+//! key set does not.
+
+use std::fs;
+use std::io::{Error, Result};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant, SystemTime};
+
+/// What the file looked like when it was last read.
+///
+/// Length as well as modification time, because the edits that matter here
+/// usually change the length and mtime alone can be too coarse to notice a
+/// rewrite within one tick. It narrows that window rather than closing it: a
+/// same-length edit inside a single tick still looks unchanged. Closing it
+/// would mean reading the file every interval, which is the cost this exists
+/// to avoid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileStamp {
+    modified: Option<SystemTime>,
+    len: u64,
+}
+
+impl FileStamp {
+    fn of(path: &Path) -> Result<Self> {
+        let metadata = fs::metadata(path)?;
+        Ok(Self {
+            modified: metadata.modified().ok(),
+            len: metadata.len(),
+        })
+    }
+}
+
+/// What a look at the file did.
+///
+/// Reported rather than acted on, so each caller keeps its own wording and its
+/// own reaction to a change.
+pub(crate) enum Change<T> {
+    /// The interval had not elapsed, or the file's stamp had not moved.
+    None,
+    /// The file was re-read and parsed.
+    Loaded {
+        /// The value being replaced, so a caller can tell a real change from a
+        /// file that was merely touched.
+        previous: T,
+        /// True when the previous look had failed, so this is the recovery.
+        recovered: bool,
+    },
+    /// The read or parse failed and `previous` still stands.
+    Failed {
+        error: Error,
+        /// True only on the transition into failing, so a caller can report it
+        /// once instead of once per interval for as long as it lasts.
+        first: bool,
+    },
+}
+
+struct Watched<T> {
+    value: T,
+    stamp: Option<FileStamp>,
+    last_checked: Option<Instant>,
+    stale: bool,
+}
+
+/// A path, the value last read from it, and when it was last looked at.
+pub(crate) struct WatchedFile<T> {
+    path: PathBuf,
+    interval: Duration,
+    state: Mutex<Watched<T>>,
+}
+
+impl<T: Clone> WatchedFile<T> {
+    /// Hold `value`, already loaded from `path`.
+    ///
+    /// The first load is the caller's, deliberately: an unusable file has to
+    /// stop the proxy at startup rather than at the first request, and only the
+    /// caller can say what "unusable" means for its own format.
+    pub(crate) fn new(path: PathBuf, interval: Duration, value: T) -> Self {
+        let stamp = FileStamp::of(&path).ok();
+        Self {
+            path,
+            interval,
+            state: Mutex::new(Watched {
+                value,
+                stamp,
+                last_checked: Some(Instant::now()),
+                stale: false,
+            }),
+        }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The value as it stands, and what looking for a newer one did.
+    ///
+    /// `load` is called only when the interval has elapsed *and* the file's
+    /// stamp has moved, so a busy caller pays a `stat` at most once per
+    /// interval and a parse only when the file was actually written.
+    ///
+    /// A zero interval looks every time, which is what tests use so a change
+    /// does not have to be waited out.
+    pub(crate) fn look(&self, load: impl FnOnce(&Path) -> Result<T>) -> (T, Change<T>) {
+        let mut state = lock(&self.state);
+
+        let due = match state.last_checked {
+            Some(checked) if self.interval > Duration::ZERO => checked.elapsed() >= self.interval,
+            _ => true,
+        };
+        if !due {
+            return (state.value.clone(), Change::None);
+        }
+        state.last_checked = Some(Instant::now());
+
+        let stamp = FileStamp::of(&self.path).ok();
+        // A stamp that cannot be read at all is not "unchanged" — the file may
+        // have been deleted, which is a failure the caller must hear about.
+        if stamp.is_some() && stamp == state.stamp {
+            return (state.value.clone(), Change::None);
+        }
+
+        match load(&self.path) {
+            Ok(value) => {
+                let previous = std::mem::replace(&mut state.value, value);
+                state.stamp = stamp;
+                let recovered = state.stale;
+                state.stale = false;
+                (
+                    state.value.clone(),
+                    Change::Loaded {
+                        previous,
+                        recovered,
+                    },
+                )
+            }
+            Err(error) => {
+                let first = !state.stale;
+                state.stale = true;
+                // The stamp is deliberately not updated: a file that is broken
+                // now and repaired to the same length within one tick must
+                // still be re-read, because the value in hand came from neither.
+                (state.value.clone(), Change::Failed { error, first })
+            }
+        }
+    }
+}
+
+/// A poisoned lock is not corrupted state: some other caller panicked while
+/// holding it. Recover the value rather than spreading the panic — a proxy that
+/// stopped answering every later request because one panicked is a far worse
+/// failure than the one that started it.
+pub(crate) fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::ErrorKind;
+
+    fn load_text(path: &Path) -> Result<String> {
+        let text = fs::read_to_string(path)?;
+        if text.contains("bad") {
+            return Err(Error::new(ErrorKind::InvalidData, "refused"));
+        }
+        Ok(text)
+    }
+
+    /// Every fixture below differs in LENGTH from the one it replaces.
+    ///
+    /// `FileStamp` is length plus mtime, so a same-length rewrite inside one
+    /// mtime tick is invisible by design. A test that changed only the content
+    /// would pass or fail on how fast the machine happened to be, which is a
+    /// property of the clock rather than of this module.
+    const GOOD: &str = "one";
+    const CHANGED: &str = "two, and a different length";
+    const BROKEN: &str = "bad, and a different length";
+    const REPAIRED: &str = "repaired, and a different length again";
+
+    fn write(dir: &tempfile::TempDir, body: &str) -> PathBuf {
+        let path = dir.path().join("watched");
+        fs::write(&path, body).expect("write");
+        path
+    }
+
+    /// Every look re-reads at a zero interval, which the tests rely on.
+    fn watching(dir: &tempfile::TempDir, body: &str) -> WatchedFile<String> {
+        let path = write(dir, body);
+        let value = load_text(&path).expect("first load");
+        WatchedFile::new(path, Duration::ZERO, value)
+    }
+
+    #[test]
+    fn an_unchanged_file_is_not_parsed_again() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let watched = watching(&dir, GOOD);
+
+        let (value, change) = watched.look(|_| panic!("must not re-read an unchanged file"));
+
+        assert_eq!(value, GOOD);
+        assert!(matches!(change, Change::None));
+    }
+
+    #[test]
+    fn a_rewritten_file_is_loaded_and_hands_back_what_it_replaced() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let watched = watching(&dir, GOOD);
+        fs::write(watched.path(), CHANGED).expect("rewrite");
+
+        let (value, change) = watched.look(load_text);
+
+        assert_eq!(value, CHANGED);
+        match change {
+            Change::Loaded {
+                previous,
+                recovered,
+            } => {
+                assert_eq!(
+                    previous, GOOD,
+                    "the caller needs this to spot a real change"
+                );
+                assert!(!recovered, "nothing had failed, so nothing recovered");
+            }
+            _ => panic!("expected a load"),
+        }
+    }
+
+    #[test]
+    fn a_failed_read_keeps_the_last_good_value() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let watched = watching(&dir, GOOD);
+        fs::write(watched.path(), BROKEN).expect("rewrite");
+
+        let (value, change) = watched.look(load_text);
+
+        assert_eq!(value, GOOD, "an edit must not become an outage");
+        assert!(matches!(change, Change::Failed { first: true, .. }));
+    }
+
+    #[test]
+    fn a_deleted_file_fails_rather_than_reading_as_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let watched = watching(&dir, GOOD);
+        fs::remove_file(watched.path()).expect("remove");
+
+        let (value, change) = watched.look(load_text);
+
+        assert_eq!(value, GOOD);
+        assert!(
+            matches!(change, Change::Failed { first: true, .. }),
+            "a missing file has no stamp, and must not be mistaken for an unchanged one"
+        );
+    }
+
+    #[test]
+    fn a_failure_is_reported_once_however_long_it_lasts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let watched = watching(&dir, GOOD);
+        fs::write(watched.path(), BROKEN).expect("rewrite");
+
+        let (_, first) = watched.look(load_text);
+        assert!(matches!(first, Change::Failed { first: true, .. }));
+
+        for _ in 0..3 {
+            let (_, again) = watched.look(load_text);
+            assert!(
+                matches!(again, Change::Failed { first: false, .. }),
+                "a file left broken would otherwise emit a line per interval forever"
+            );
+        }
+    }
+
+    #[test]
+    fn a_repair_is_reported_as_a_recovery() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let watched = watching(&dir, GOOD);
+        fs::write(watched.path(), BROKEN).expect("break it");
+        watched.look(load_text);
+
+        fs::write(watched.path(), REPAIRED).expect("repair");
+        let (value, change) = watched.look(load_text);
+
+        assert_eq!(value, REPAIRED);
+        match change {
+            Change::Loaded { recovered, .. } => assert!(recovered, "the operator is owed the news"),
+            _ => panic!("expected a load"),
+        }
+    }
+
+    /// The stamp must not advance while the file is unreadable.
+    ///
+    /// Tested by counting loads rather than by rewriting the file to the same
+    /// length, which would only ever be a test of the clock: if a failure had
+    /// advanced the stamp, the second look would find it unchanged and never
+    /// call the loader at all.
+    #[test]
+    fn a_failed_read_does_not_advance_the_stamp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let watched = watching(&dir, GOOD);
+        fs::write(watched.path(), BROKEN).expect("break it");
+
+        let loads = std::cell::Cell::new(0_u32);
+        let counting = |path: &Path| {
+            loads.set(loads.get() + 1);
+            load_text(path)
+        };
+
+        watched.look(counting);
+        watched.look(counting);
+
+        assert_eq!(
+            loads.get(),
+            2,
+            "the broken file was accepted as the new stamp, so a repair of that \
+             same length would never be read again"
+        );
+    }
+
+    #[test]
+    fn an_interval_that_has_not_elapsed_is_not_looked_at() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write(&dir, GOOD);
+        let watched = WatchedFile::new(path, Duration::from_secs(60), GOOD.to_string());
+        fs::write(watched.path(), CHANGED).expect("rewrite");
+
+        let (value, change) = watched.look(|_| panic!("must not look before the interval"));
+
+        assert_eq!(value, GOOD);
+        assert!(matches!(change, Change::None));
+    }
+
+    #[test]
+    fn a_poisoned_lock_is_recovered_rather_than_spread() {
+        let mutex = Mutex::new(1_u32);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = lock(&mutex);
+            panic!("some other caller failed");
+        }));
+
+        assert!(mutex.is_poisoned(), "the panic really did poison it");
+        assert_eq!(*lock(&mutex), 1, "later callers must still be served");
+    }
+
+    /// The regression this module exists for.
+    ///
+    /// The state lock is held across `load`, so a panic in there poisons it.
+    /// One of the two watchers this replaced took that lock with `.expect(...)`,
+    /// which turned a single failed parse into a proxy that refused *every*
+    /// later request — while the other recovered. Sharing one helper is what
+    /// makes them agree.
+    #[test]
+    fn a_panic_while_loading_does_not_wedge_every_later_look() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let watched = watching(&dir, GOOD);
+        fs::write(watched.path(), CHANGED).expect("rewrite");
+
+        let blew_up = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            watched.look(|_| panic!("a loader panicked"));
+        }));
+        assert!(blew_up.is_err(), "the loader really did panic");
+
+        let (value, _) = watched.look(load_text);
+        assert_eq!(
+            value, CHANGED,
+            "one panicked load must not take every later caller with it"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1056,6 +1056,28 @@ fn route_mode(raw: &str) -> anyhow::Result<camelid::fabric::RouteMode> {
     }
 }
 
+/// Build a fabric from whichever way the operator named its nodes.
+///
+/// Every `fabric` subcommand takes both forms, so the file an operator already
+/// maintains for `fabric serve` is the same one they can inspect with
+/// `fabric status`. Clap makes the two mutually exclusive and requires one, so
+/// exactly one arrives populated here.
+///
+/// A file that cannot be read is an error rather than an empty fabric: on the
+/// CLI that is a message instead of a table of nothing, and on `serve` it stops
+/// the proxy before it announces an address.
+fn fabric_from(
+    nodes: Vec<String>,
+    nodes_file: Option<PathBuf>,
+) -> anyhow::Result<camelid::fabric::Fabric> {
+    match nodes_file {
+        Some(path) => Ok(camelid::fabric::Fabric::from_node_file(path)?),
+        None => Ok(camelid::fabric::Fabric::new(
+            camelid::fabric::parse_fabric(&nodes).map_err(|error| anyhow::anyhow!("{error}"))?,
+        )),
+    }
+}
+
 /// Resolve the token the fabric authenticates to its nodes with.
 ///
 /// Deliberately not `#[arg(env = "CAMELID_API_KEY")]`: clap prints an env var's
@@ -1089,8 +1111,17 @@ enum FabricAction {
     /// Probe every node once and report what the fabric can serve.
     Status {
         /// A node, as `LABEL=HOST[:PORT]`. Repeat for each node.
-        #[arg(long = "node", required = true, value_name = "LABEL=HOST[:PORT]")]
+        #[arg(
+            long = "node",
+            required_unless_present = "nodes_file",
+            conflicts_with = "nodes_file",
+            value_name = "LABEL=HOST[:PORT]"
+        )]
         nodes: Vec<String>,
+        /// Read the nodes from the same file `fabric serve` takes, one
+        /// `LABEL=HOST[:PORT]` per line.
+        #[arg(long, value_name = "PATH")]
+        nodes_file: Option<PathBuf>,
         /// Bearer token for nodes started with an API key. Falls back to
         /// CAMELID_API_KEY. Prefer the variable on a shared machine, so the
         /// secret is not in the process command line.
@@ -1108,8 +1139,16 @@ enum FabricAction {
     ///
     /// Placement is deterministic, so this dry run predicts the real decision.
     Route {
-        #[arg(long = "node", required = true, value_name = "LABEL=HOST[:PORT]")]
+        #[arg(
+            long = "node",
+            required_unless_present = "nodes_file",
+            conflicts_with = "nodes_file",
+            value_name = "LABEL=HOST[:PORT]"
+        )]
         nodes: Vec<String>,
+        /// Read the nodes from the same file `fabric serve` takes.
+        #[arg(long, value_name = "PATH")]
+        nodes_file: Option<PathBuf>,
         /// `throughput` spreads independent requests; `affinity` keeps a session
         /// on the node whose prefix and KV cache are already warm.
         #[arg(long, default_value = "throughput")]
@@ -1134,8 +1173,16 @@ enum FabricAction {
     /// Placement, then forward: the request crosses the network once, not once
     /// per token.
     Run {
-        #[arg(long = "node", required = true, value_name = "LABEL=HOST[:PORT]")]
+        #[arg(
+            long = "node",
+            required_unless_present = "nodes_file",
+            conflicts_with = "nodes_file",
+            value_name = "LABEL=HOST[:PORT]"
+        )]
         nodes: Vec<String>,
+        /// Read the nodes from the same file `fabric serve` takes.
+        #[arg(long, value_name = "PATH")]
+        nodes_file: Option<PathBuf>,
         /// The user message to send.
         #[arg(long)]
         prompt: String,
@@ -1346,6 +1393,73 @@ mod fabric_command_tests {
                     other => panic!("expected a fabric command, got {other:?}"),
                 };
                 assert_eq!(bearer.as_deref(), Some("s3cret"), "{argv:?}");
+            }
+        });
+    }
+
+    /// The node file is the set an operator maintains for `fabric serve`.
+    /// Every subcommand has to read it, or inspecting the fabric means retyping
+    /// by hand the machines the proxy already knows about — and the two answers
+    /// can then disagree.
+    #[test]
+    fn every_fabric_subcommand_accepts_a_node_file() {
+        on_cli_test_stack(|| {
+            for argv in [
+                vec!["camelid", "fabric", "status"],
+                vec!["camelid", "fabric", "route"],
+                vec!["camelid", "fabric", "run", "--prompt", "hi"],
+                vec!["camelid", "fabric", "serve"],
+            ] {
+                let mut argv = argv;
+                argv.extend(["--nodes-file", "fabric.nodes"]);
+                let cli = Cli::try_parse_from(&argv).expect("parses");
+                let nodes_file = match cli.command {
+                    Some(Command::Fabric { action }) => match action {
+                        FabricAction::Status { nodes_file, .. }
+                        | FabricAction::Route { nodes_file, .. }
+                        | FabricAction::Run { nodes_file, .. }
+                        | FabricAction::Serve { nodes_file, .. } => nodes_file,
+                    },
+                    other => panic!("expected a fabric command, got {other:?}"),
+                };
+                assert_eq!(
+                    nodes_file.as_deref(),
+                    Some(std::path::Path::new("fabric.nodes")),
+                    "{argv:?}"
+                );
+            }
+        });
+    }
+
+    /// Two answers to "which machines" must not be configurable at once: the
+    /// file is the one that can change while the proxy runs, so a stray
+    /// `--node` silently winning would leave an operator editing a file that
+    /// nothing reads.
+    #[test]
+    fn naming_nodes_twice_is_refused_and_naming_them_not_at_all_is_too() {
+        on_cli_test_stack(|| {
+            for subcommand in [
+                vec!["status"],
+                vec!["route"],
+                vec!["run", "--prompt", "hi"],
+                vec!["serve"],
+            ] {
+                let both: Vec<&str> = ["camelid", "fabric"]
+                    .into_iter()
+                    .chain(subcommand.iter().copied())
+                    .chain(["--node", "a=127.0.0.1", "--nodes-file", "fabric.nodes"])
+                    .collect();
+                Cli::try_parse_from(&both)
+                    .err()
+                    .unwrap_or_else(|| panic!("{both:?} named its nodes twice and was accepted"));
+
+                let neither: Vec<&str> = ["camelid", "fabric"]
+                    .into_iter()
+                    .chain(subcommand.iter().copied())
+                    .collect();
+                Cli::try_parse_from(&neither).err().unwrap_or_else(|| {
+                    panic!("{neither:?} named no nodes at all and was accepted")
+                });
             }
         });
     }
@@ -2951,14 +3065,13 @@ async fn main() -> anyhow::Result<()> {
         Command::Fabric { action } => match action {
             FabricAction::Status {
                 nodes,
+                nodes_file,
                 bearer,
                 timeout_ms,
                 json,
             } => {
                 let bearer = fabric_bearer(bearer);
-                let specs = camelid::fabric::parse_fabric(&nodes)
-                    .map_err(|error| anyhow::anyhow!("{error}"))?;
-                let fabric = camelid::fabric::Fabric::new(specs)
+                let fabric = fabric_from(nodes, nodes_file)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref());
                 let snapshots = fabric.observe();
@@ -2970,6 +3083,7 @@ async fn main() -> anyhow::Result<()> {
             }
             FabricAction::Route {
                 nodes,
+                nodes_file,
                 mode,
                 model,
                 sticky,
@@ -2979,9 +3093,7 @@ async fn main() -> anyhow::Result<()> {
             } => {
                 let bearer = fabric_bearer(bearer);
                 let mode = route_mode(&mode)?;
-                let specs = camelid::fabric::parse_fabric(&nodes)
-                    .map_err(|error| anyhow::anyhow!("{error}"))?;
-                let fabric = camelid::fabric::Fabric::new(specs)
+                let fabric = fabric_from(nodes, nodes_file)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref());
                 let snapshots = fabric.observe();
@@ -3015,6 +3127,7 @@ async fn main() -> anyhow::Result<()> {
             }
             FabricAction::Run {
                 nodes,
+                nodes_file,
                 prompt,
                 mode,
                 model,
@@ -3027,9 +3140,7 @@ async fn main() -> anyhow::Result<()> {
             } => {
                 let bearer = fabric_bearer(bearer);
                 let mode = route_mode(&mode)?;
-                let specs = camelid::fabric::parse_fabric(&nodes)
-                    .map_err(|error| anyhow::anyhow!("{error}"))?;
-                let fabric = camelid::fabric::Fabric::new(specs)
+                let fabric = fabric_from(nodes, nodes_file)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref());
 
@@ -3140,17 +3251,13 @@ async fn main() -> anyhow::Result<()> {
                 let tls = camelid::fabric::server::ProxyTls::resolve(tls_cert, tls_key).await?;
                 // Same reason: a node file that cannot be read is a refusal,
                 // and it has to arrive before the listening line.
-                let fabric = match nodes_file {
-                    Some(path) => camelid::fabric::Fabric::from_node_file(path)?,
-                    None => camelid::fabric::Fabric::new(
-                        camelid::fabric::parse_fabric(&nodes)
-                            .map_err(|error| anyhow::anyhow!("{error}"))?,
-                    ),
-                }
-                .with_timeout(std::time::Duration::from_millis(timeout_ms))
-                .with_bearer(bearer.as_deref())
-                .with_max_observation_age(std::time::Duration::from_millis(observation_max_age_ms))
-                .with_max_forward_attempts(max_forward_attempts);
+                let fabric = fabric_from(nodes, nodes_file)?
+                    .with_timeout(std::time::Duration::from_millis(timeout_ms))
+                    .with_bearer(bearer.as_deref())
+                    .with_max_observation_age(std::time::Duration::from_millis(
+                        observation_max_age_ms,
+                    ))
+                    .with_max_forward_attempts(max_forward_attempts);
 
                 // Bind before announcing, so a refused or already-taken address
                 // never prints a listening line it did not earn.


### PR DESCRIPTION
Two changes to how the fabric reads the files an operator maintains. They are in
one PR because they are the same subject from two sides: the node file should be
readable by every subcommand, and the two files the proxy re-reads while it runs
should not hold two different ideas of what re-reading means.

## 1. A poisoned lock meant opposite things in the two files

`nodes.rs` and `client_keys.rs` had each grown their own copy of the same
mechanism: stamp the file, re-read it on an interval, keep the last good value
when a read fails, and report that failure once rather than once per interval.

They had already drifted, and the drift was not cosmetic. At `a89e6b823`:

```
src/fabric/nodes.rs        .lock().unwrap_or_else(std::sync::PoisonError::into_inner)
src/fabric/client_keys.rs  .lock().expect("client keys")     <- both lock sites
```

A panic under that lock therefore left the two halves of the same proxy in
opposite states. Node lookups carried on with the recovered value, while every
later authenticated request panicked again, permanently, because a poisoned lock
never un-poisons. One transient panic becomes a proxy that refuses every client
until it is restarted.

Both now share `src/fabric/watch.rs`. The mechanism moves; the policy stays with
the callers, because that part genuinely differs - a node set carries a
generation that invalidates observations, and a key set does not.

I am not going to argue that the panic is likely. It is the disagreement that is
the defect: one mechanism, two copies, opposite behaviour under the same fault.

## 2. Only `fabric serve` could read the node file

`status`, `route` and `run` took repeated `--node` flags only. Inspecting the
fabric therefore meant retyping by hand the machines the proxy already knew
about, and the moment the file changed the two answers could disagree - which is
exactly the situation in which someone reaches for `fabric status`.

All four subcommands now take `--nodes-file`. The file and the flags are mutually
exclusive rather than silently merged, so there is one answer to "which
machines", not two. Naming neither is still refused, so that failure stays at the
command line instead of becoming an empty fabric at runtime.

## Measured

Base `a89e6b823`, gates run one at a time on a clean tree at `25c1d0f0e`:

| gate | base | this branch |
| --- | --- | --- |
| `cargo fmt --check` | clean | clean |
| `cargo clippy --all-targets -- -D warnings` | clean | clean |
| `cargo test --lib fabric::` | 206 | 216 |
| `cargo test --test fabric_serve` | 68 | 68 |
| `cargo test --test fabric_end_to_end` | 15 | 15 |
| `cargo test --bin camelid` | 42 | 44 |

5 files, +589 / -251, of which `watch.rs` is +389 new.

## Ablations

Each new behaviour removed on its own, with the named test required to fail and
the file restored byte-for-byte afterwards (SHA-256 compared). All six behaved:

| behaviour removed | test that then failed |
| --- | --- |
| advance the stamp when a read fails | `a_failed_read_does_not_advance_the_stamp` |
| `PoisonError::into_inner` -> `.expect()` | `a_panic_while_loading_does_not_wedge_every_later_look` |
| the stamp short-circuit | `an_unchanged_file_is_not_parsed_again` |
| report every failure as the first | `a_failure_is_reported_once_however_long_it_lasts` |
| `conflicts_with = "nodes_file"` (4 sites) | `naming_nodes_twice_is_refused_and_naming_them_not_at_all_is_too` |
| `--nodes-file` on `route` | `every_fabric_subcommand_accepts_a_node_file` |

## Two things this does not fix

- `FileStamp` is modification time and length, so a same-length edit inside one
  mtime tick still reads as unchanged. Closing that would mean reading the file
  every interval, which is the cost the stamp exists to avoid, so it is narrowed
  rather than closed and the module docs say so. The tests are deliberately
  written not to depend on it: every fixture differs in length, and "the stamp
  must not advance while the file is unreadable" is asserted by counting loader
  calls rather than by rewriting the file to the same length, which would only
  ever have tested how fast the machine is.
- `admit()` still does blocking file work on the tokio worker. Untouched here and
  out of scope for this PR, but worth recording.
