### PR TITLE
Refuse a cleartext listener the network can reach

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,17 @@ Camelid opens `http://127.0.0.1:8181`. Use `camelid chat` for the terminal UI, o
 Run `camelid pull` without an argument to list the curated model catalog.
 
 > [!WARNING]
-> A non-loopback listener requires authentication. For browser Chat on a trusted private LAN, bind
+> A non-loopback listener requires authentication and either TLS or an explicit cleartext
+> acknowledgement. For browser Chat on a trusted private LAN, bind
 > the laptop's specific LAN address, start with a model, and use the restricted surface:
 >
 > ```bash
-> camelid serve --addr <LAPTOP-LAN-IP>:8181 --model models/Llama-3.2-3B-Instruct-Q8_0.gguf --api-key-file ./camelid-api.key --lan-chat-only
+> camelid serve --addr <LAPTOP-LAN-IP>:8181 --model models/Llama-3.2-3B-Instruct-Q8_0.gguf --api-key-file ./camelid-api.key --lan-chat-only --allow-cleartext-remote
 > ```
 >
 > The phone is only a web interface; inference stays on the laptop. Plain HTTP is not encrypted, and
-> Chat history is still stored separately in each browser. Run `camelid lan-key` on the laptop to
+> `--allow-cleartext-remote` acknowledges that risk rather than protecting the traffic. Chat history
+> is still stored separately in each browser. Run `camelid lan-key` on the laptop to
 > create or display the key shared with the phone. The mobile Chat model selector may switch only
 > among local GGUF files already in the configured models directory. See
 > [configuration](docs/CONFIGURATION.md) for the exact route boundary, key rotation, firewall

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -51,16 +51,39 @@ That startup path loads the model immediately and applies the default `auto` exe
 
 ## Production HTTP policy
 
-Anonymous loopback serving remains the default. A non-loopback address is refused unless you
-configure `--api-key` / `--api-key-file`, or deliberately acknowledge an externally protected
-deployment with `--allow-unauthenticated-remote`. Prefer a key file because a literal command-line
-key can be visible to other local users:
+Anonymous loopback serving remains the default. A non-loopback address has to answer two separate
+questions, because they are two separate risks and answering one does not answer the other:
+
+| | anonymous | authenticated |
+|---|---|---|
+| **cleartext** | refused: needs both acknowledgements | refused: needs `--tls-cert`/`--tls-key` or `--allow-cleartext-remote` |
+| **TLS** | refused: needs `--api-key`, `--api-key-file`, or `--allow-unauthenticated-remote` | serves |
+
+Loopback is unaffected and needs neither. This is the same policy `camelid fabric serve` applies,
+for the same reason: a key travels on every request, so over cleartext the credential that is meant
+to protect a routable bind is itself given away, along with every prompt and completion.
+
+The recommended production shape is therefore TLS plus a key. Prefer a key file because a literal
+command-line key can be visible to other local users:
+
+```bash
+target/release/camelid serve \
+  --addr 0.0.0.0:8443 \
+  --api-key-file ./camelid-api.key \
+  --tls-cert ./server-cert-chain \
+  --tls-key ./server-private-key \
+  --cors-origin https://chat.example
+```
+
+If TLS is terminated in front of Camelid — a reverse proxy, a service mesh, an SSH tunnel — then the
+hop Camelid itself serves is still cleartext, and it has no way to know what is in front of it. Say
+so explicitly:
 
 ```bash
 target/release/camelid serve \
   --addr 0.0.0.0:8181 \
   --api-key-file ./camelid-api.key \
-  --cors-origin https://chat.example
+  --allow-cleartext-remote
 ```
 
 API clients can send either `Authorization: Bearer <key>` or `X-API-Key: <key>`. Health and embedded
@@ -98,6 +121,7 @@ target/release/camelid serve \
   --model /path/to/model.gguf \
   --api-key-file ./camelid-api.key \
   --lan-chat-only \
+  --allow-cleartext-remote \
   --no-open
 ```
 
@@ -107,19 +131,14 @@ switch to another local GGUF from that host's configured model directory. No COR
 the embedded same-origin UI. Permit the port only on the operating system's private-network firewall
 profile.
 
-This mode authenticates but does not encrypt plain HTTP. Use it only on a trusted private LAN, or put
-the listener behind an encrypted private transport. Ordinary Chat conversations still live in each
-browser's storage, so laptop and phone history do not synchronize in this phase.
+This mode authenticates but does not encrypt plain HTTP. `--allow-cleartext-remote` is the explicit
+acknowledgement required for that direct-LAN shape; it does not protect the credential, prompts, or
+responses from anyone on the path. Use it only on a trusted private LAN, or put the listener behind
+an encrypted private transport. Ordinary Chat conversations still live in each browser's storage,
+so laptop and phone history do not synchronize in this phase.
 
-Direct TLS is optional and requires a PEM certificate chain and private key together:
-
-```bash
-target/release/camelid serve \
-  --addr 0.0.0.0:8443 \
-  --api-key-file ./camelid-api.key \
-  --tls-cert ./server-cert-chain \
-  --tls-key ./server-private-key
-```
+Both acknowledgements also read from the environment, as `CAMELID_ALLOW_UNAUTHENTICATED_REMOTE` and
+`CAMELID_ALLOW_CLEARTEXT_REMOTE`.
 
 Resource ceilings are resolved once at startup. Their CLI names and environment aliases are:
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -554,8 +554,10 @@ mod tests {
         .expect("an operator who says so explicitly is still allowed to");
 
         let dir = tempfile::tempdir().unwrap();
-        let cert = dir.path().join("cert.pem");
-        let key = dir.path().join("key.pem");
+        // Extensionless on purpose: the public-scrub guard bars a PEM suffix
+        // anywhere in tracked source. Same names as the neighbouring TLS test.
+        let cert = dir.path().join("certificate-chain");
+        let key = dir.path().join("private-key");
         std::fs::write(&cert, "certificate-chain").unwrap();
         std::fs::write(&key, "private-key").unwrap();
         let tls = ServerPolicy::resolve(

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -285,18 +285,18 @@ impl ServerPolicy {
 
         let tls = resolve_tls(options.tls_cert, options.tls_key)?;
 
-        // The key configured above is sent on every request, so without TLS the
-        // very thing protecting a routable bind is what the bind gives away,
-        // along with every prompt and completion. `crate::fabric::server`
-        // refuses this same shape on the same three conditions.
+        // Without TLS the whole request path is readable, including any
+        // configured credential and every prompt and completion.
+        // `crate::fabric::server` refuses this same shape on the same three
+        // conditions.
         if !addr.ip().is_loopback() && tls.is_none() && !options.allow_cleartext_remote {
             return Err(Error::new(
                 ErrorKind::PermissionDenied,
                 format!(
-                    "refusing cleartext non-loopback listener {addr}; the API key and every \
-                     prompt would cross the network unencrypted. Bind a loopback address, \
-                     configure --tls-cert/--tls-key, or explicitly acknowledge the risk with \
-                     --allow-cleartext-remote"
+                    "refusing cleartext non-loopback listener {addr}; any credentials, prompts, \
+                     and completions would cross the network unencrypted. Bind a loopback \
+                     address, configure --tls-cert/--tls-key, or explicitly acknowledge the \
+                     risk with --allow-cleartext-remote"
                 ),
             ));
         }
@@ -534,6 +534,23 @@ mod tests {
             message.contains("--tls-cert"),
             "and the way to do it properly: {message}"
         );
+    }
+
+    #[test]
+    fn an_anonymous_override_is_not_told_it_has_a_key() {
+        let error = ServerPolicy::resolve(
+            SocketAddr::from(([0, 0, 0, 0], 8181)),
+            ServeOptions {
+                allow_unauthenticated_remote: true,
+                ..ServeOptions::default()
+            },
+        )
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("any credentials"), "{message}");
+        assert!(!message.contains("the API key"), "{message}");
+        assert!(message.contains("--allow-cleartext-remote"), "{message}");
     }
 
     #[test]

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -88,6 +88,7 @@ pub struct ServeOptions {
     pub api_key_file: Option<PathBuf>,
     pub cors_origins: Vec<String>,
     pub allow_unauthenticated_remote: bool,
+    pub allow_cleartext_remote: bool,
     pub tls_cert: Option<PathBuf>,
     pub tls_key: Option<PathBuf>,
     pub max_request_body_bytes: usize,
@@ -104,6 +105,7 @@ impl Default for ServeOptions {
             api_key_file: None,
             cors_origins: Vec::new(),
             allow_unauthenticated_remote: false,
+            allow_cleartext_remote: false,
             tls_cert: None,
             tls_key: None,
             max_request_body_bytes: DEFAULT_MAX_REQUEST_BODY_BYTES,
@@ -125,6 +127,7 @@ impl fmt::Debug for ServeOptions {
                 "allow_unauthenticated_remote",
                 &self.allow_unauthenticated_remote,
             )
+            .field("allow_cleartext_remote", &self.allow_cleartext_remote)
             .field("tls_cert", &self.tls_cert)
             .field("tls_key", &self.tls_key.as_ref().map(|_| "[REDACTED PATH]"))
             .field("max_request_body_bytes", &self.max_request_body_bytes)
@@ -281,6 +284,23 @@ impl ServerPolicy {
         }
 
         let tls = resolve_tls(options.tls_cert, options.tls_key)?;
+
+        // The key configured above is sent on every request, so without TLS the
+        // very thing protecting a routable bind is what the bind gives away,
+        // along with every prompt and completion. `crate::fabric::server`
+        // refuses this same shape on the same three conditions.
+        if !addr.ip().is_loopback() && tls.is_none() && !options.allow_cleartext_remote {
+            return Err(Error::new(
+                ErrorKind::PermissionDenied,
+                format!(
+                    "refusing cleartext non-loopback listener {addr}; the API key and every \
+                     prompt would cross the network unencrypted. Bind a loopback address, \
+                     configure --tls-cert/--tls-key, or explicitly acknowledge the risk with \
+                     --allow-cleartext-remote"
+                ),
+            ));
+        }
+
         let cors_origins = options
             .cors_origins
             .iter()
@@ -464,10 +484,13 @@ mod tests {
         let error = ServerPolicy::resolve(addr, ServeOptions::default()).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::PermissionDenied);
 
+        // Cleartext is acknowledged throughout so this stays a test of the
+        // authentication question alone; the encryption one is tested below.
         let authenticated = ServerPolicy::resolve(
             addr,
             ServeOptions {
                 api_key: Some("secret".to_string()),
+                allow_cleartext_remote: true,
                 ..ServeOptions::default()
             },
         )
@@ -478,11 +501,83 @@ mod tests {
             addr,
             ServeOptions {
                 allow_unauthenticated_remote: true,
+                allow_cleartext_remote: true,
                 ..ServeOptions::default()
             },
         )
         .unwrap();
         assert!(overridden.remote_unauthenticated_override);
+    }
+
+    /// A key sent over cleartext protects nothing: it is on every request, so
+    /// the bind gives away the credential that was supposed to guard it.
+    #[test]
+    fn a_routable_cleartext_listener_is_refused_even_with_a_key() {
+        let addr = SocketAddr::from(([0, 0, 0, 0], 8181));
+
+        let error = ServerPolicy::resolve(
+            addr,
+            ServeOptions {
+                api_key: Some("secret".to_string()),
+                ..ServeOptions::default()
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        let message = error.to_string();
+        assert!(
+            message.contains("--allow-cleartext-remote"),
+            "the refusal has to name the way out: {message}"
+        );
+        assert!(
+            message.contains("--tls-cert"),
+            "and the way to do it properly: {message}"
+        );
+    }
+
+    #[test]
+    fn loopback_is_unaffected_and_an_acknowledgement_or_tls_lets_a_routable_bind_through() {
+        let loopback = SocketAddr::from(([127, 0, 0, 1], 8181));
+        ServerPolicy::resolve(loopback, ServeOptions::default())
+            .expect("loopback never leaves the machine, so neither question applies");
+
+        let addr = SocketAddr::from(([0, 0, 0, 0], 8181));
+        ServerPolicy::resolve(
+            addr,
+            ServeOptions {
+                api_key: Some("secret".to_string()),
+                allow_cleartext_remote: true,
+                ..ServeOptions::default()
+            },
+        )
+        .expect("an operator who says so explicitly is still allowed to");
+
+        let dir = tempfile::tempdir().unwrap();
+        let cert = dir.path().join("cert.pem");
+        let key = dir.path().join("key.pem");
+        std::fs::write(&cert, "certificate-chain").unwrap();
+        std::fs::write(&key, "private-key").unwrap();
+        let tls = ServerPolicy::resolve(
+            addr,
+            ServeOptions {
+                api_key: Some("secret".to_string()),
+                tls_cert: Some(cert),
+                tls_key: Some(key),
+                ..ServeOptions::default()
+            },
+        )
+        .expect("TLS answers the question the acknowledgement only waives");
+        assert!(tls.tls.is_some());
+    }
+
+    #[test]
+    fn the_cleartext_acknowledgement_is_not_a_secret_but_is_still_reported() {
+        let options = ServeOptions {
+            allow_cleartext_remote: true,
+            ..ServeOptions::default()
+        };
+        assert!(format!("{options:?}").contains("allow_cleartext_remote: true"));
     }
 
     #[test]
@@ -650,6 +745,29 @@ mod tests {
         .unwrap_err();
         assert_eq!(error.kind(), ErrorKind::PermissionDenied);
         assert!(error.to_string().contains("--api-key"));
+    }
+
+    #[test]
+    fn lan_chat_surface_obeys_the_remote_cleartext_guard() {
+        let addr = SocketAddr::from(([0, 0, 0, 0], 8181));
+        let options = ServeOptions {
+            api_key: Some("test-key".to_string()),
+            api_surface: ApiSurface::LanChatOnly,
+            ..ServeOptions::default()
+        };
+
+        let error = ServerPolicy::resolve(addr, options.clone()).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert!(error.to_string().contains("--allow-cleartext-remote"));
+
+        ServerPolicy::resolve(
+            addr,
+            ServeOptions {
+                allow_cleartext_remote: true,
+                ..options
+            },
+        )
+        .expect("LAN Chat has the same explicit cleartext escape hatch as the full API");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -395,6 +395,15 @@ mod ghost_moe_cli_tests {
             }
         });
     }
+
+    #[test]
+    fn lan_key_prints_a_server_command_that_passes_both_remote_guards() {
+        assert_eq!(
+            lan_chat_serve_command(std::path::Path::new("camelid.key")),
+            "camelid serve --lan-chat-only --api-key-file \"camelid.key\" \
+             --allow-cleartext-remote --addr <LAPTOP-LAN-IP>:8181 --model <MODEL.gguf>"
+        );
+    }
 }
 
 use camelid::{
@@ -418,6 +427,14 @@ use camelid::{
     tensor::{CpuTensor, Q8_0TensorBlocks, TensorStore},
     tokenizer::Tokenizer,
 };
+
+fn lan_chat_serve_command(key_path: &std::path::Path) -> String {
+    format!(
+        "camelid serve --lan-chat-only --api-key-file \"{}\" \
+         --allow-cleartext-remote --addr <LAPTOP-LAN-IP>:8181 --model <MODEL.gguf>",
+        key_path.display()
+    )
+}
 use clap::{Args, Parser, Subcommand};
 use rayon::ThreadPoolBuilder;
 use serde::Serialize;
@@ -2820,8 +2837,8 @@ async fn main() -> anyhow::Result<()> {
             println!("Treat this key like a password. Share it directly with the phone user.");
             println!("Never put it in a URL, screenshot, issue, or chat message.");
             println!(
-                "\nStart the server with:\n  camelid serve --lan-chat-only --api-key-file \"{}\" --addr <LAPTOP-LAN-IP>:8181 --model <MODEL.gguf>",
-                credential.path().display()
+                "\nStart the server with:\n  {}",
+                lan_chat_serve_command(credential.path())
             );
         }
         Command::Serve {

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,6 +354,7 @@ mod ghost_moe_cli_tests {
                 "--lan-chat-only",
                 "--api-key-file",
                 "camelid.key",
+                "--allow-cleartext-remote",
                 "--no-open",
             ])
             .expect("parse authenticated LAN Chat flags");
@@ -362,6 +363,7 @@ mod ghost_moe_cli_tests {
                     server, no_open, ..
                 }) => {
                     assert!(server.lan_chat_only);
+                    assert!(server.allow_cleartext_remote);
                     assert_eq!(server.api_key_file, Some(PathBuf::from("camelid.key")));
                     assert!(no_open);
                 }
@@ -524,6 +526,11 @@ struct ServerPolicyArgs {
         conflicts_with = "allow_unauthenticated_remote"
     )]
     lan_chat_only: bool,
+    /// Explicitly permit a cleartext non-loopback listener. Without this
+    /// acknowledgement or TLS, Camelid refuses the bind, because the API key
+    /// and every prompt would otherwise cross the network unencrypted.
+    #[arg(long, env = "CAMELID_ALLOW_CLEARTEXT_REMOTE", default_value_t = false)]
+    allow_cleartext_remote: bool,
     /// PEM certificate chain for HTTPS. Requires --tls-key.
     #[arg(long, env = "CAMELID_TLS_CERT", requires = "tls_key")]
     tls_cert: Option<PathBuf>,
@@ -586,6 +593,7 @@ impl ServerPolicyArgs {
                 .unwrap_or_default(),
             allow_unauthenticated_remote: enabled("CAMELID_ALLOW_UNAUTHENTICATED_REMOTE"),
             lan_chat_only: enabled("CAMELID_LAN_CHAT_ONLY"),
+            allow_cleartext_remote: enabled("CAMELID_ALLOW_CLEARTEXT_REMOTE"),
             tls_cert: std::env::var_os("CAMELID_TLS_CERT").map(PathBuf::from),
             tls_key: std::env::var_os("CAMELID_TLS_KEY").map(PathBuf::from),
             max_request_body_bytes: parsed("CAMELID_MAX_REQUEST_BODY_BYTES", 16 * 1024 * 1024),
@@ -601,6 +609,7 @@ impl ServerPolicyArgs {
             api_key_file: self.api_key_file,
             cors_origins: self.cors_origins,
             allow_unauthenticated_remote: self.allow_unauthenticated_remote,
+            allow_cleartext_remote: self.allow_cleartext_remote,
             tls_cert: self.tls_cert,
             tls_key: self.tls_key,
             max_request_body_bytes: self.max_request_body_bytes,


### PR DESCRIPTION
`camelid fabric serve` already refuses a routable bind with no TLS. `camelid serve` did not ask the
question at all, and the documented production command was the insecure shape.

## The asymmetry

At `2d1c68192`, grepping `src/api/server.rs` and `src/api/mod.rs` for `cleartext` returns **zero
hits**. The engine's only routable guard is "is there a key?" ??? so a key was sufficient. Meanwhile
`docs/CONFIGURATION.md` recommended exactly:

```
camelid serve --addr 0.0.0.0:8181 --api-key-file ./camelid-api.key
```

with TLS described as "optional". A key is sent on **every request**, so over cleartext the
credential that is supposed to protect the bind is the very thing the bind gives away ??? along with
every prompt and completion. The proxy refuses that shape; the engine, in the same binary, invited
it.

## The change

The engine now asks both questions, in the same shape and with the same escape hatch as the proxy:

| | anonymous | authenticated |
| --- | --- | --- |
| **cleartext** | refused: needs both acknowledgements | refused: needs `--tls-cert`/`--tls-key` or `--allow-cleartext-remote` |
| **TLS** | refused: needs a key or `--allow-unauthenticated-remote` | serves |

Loopback is unaffected. The refusal names both ways out, and a test asserts that it does.

`--allow-cleartext-remote` / `CAMELID_ALLOW_CLEARTEXT_REMOTE` exists for the real case where TLS is
terminated in front ??? a reverse proxy, a mesh, a tunnel ??? which Camelid cannot detect for itself.

## This is a breaking change, deliberately

A deployment running the previously documented command refuses to start until it adds TLS or the
acknowledgement. That is the point: the insecure case should be chosen, not inherited. Both docs that
showed the old command are updated, and `docs/CONFIGURATION.md` now carries the same two-question
table the fabric section has.

It also applies to `serve-distributed`, which shares `ServerPolicyArgs`. `gemma4-worker` does not
touch `ServeOptions` and is unaffected ??? checked, not assumed.

## One existing test changed, and why

`remote_listener_requires_auth_or_explicit_override` resolved a routable bind with a key and no TLS,
which this now refuses. It keeps its subject: it acknowledges cleartext so it still tests the
authentication question **alone**. The encryption question gets its own tests rather than being
folded into that one.

## Final rebase and validation

Rebased onto final upstream `main` after #681, #680, #676, #683, and #678 landed. The four commits remained patch-identical across the final rebase. LAN Chat has no exemption from the cleartext rule: the direct-LAN examples and the command printed by `camelid lan-key` now include `--allow-cleartext-remote`, while TLS remains the preferred answer.

Final local gates on `7659ff16b3f937f832b5756b7dd59c2cef0a0b7c`:

| gate | result |
| --- | --- |
| API server policy module | 16 passed, 0 failed |
| binary CLI suite | 48 passed, 0 failed |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| public scrub | clean |
| `git diff --check` | clean |

Additional regression coverage pins that:

- authenticated LAN Chat is refused on routable cleartext unless TLS or `--allow-cleartext-remote` answers the transport question;
- `--lan-chat-only` and `--allow-cleartext-remote` parse together, while anonymous LAN Chat remains forbidden;
- `camelid lan-key` prints a server command that passes both remote guards;
- an anonymous override is not falsely told that it has an API key;
- loopback remains unaffected, and neither remote guard satisfies the other.

Fresh cross-platform CI is running on that exact head.

## What this does not fix

The proxy-to-node hop is still cleartext, always ??? `tls`/`https`/`rustls` appear **zero** times in
`fabric/http.rs`, `fabric/forward.rs`, `fabric/probe.rs` and `fabric/node.rs`. This PR secures the
front door; that back door is a separate, larger piece of work.

