### PR TITLE
Correct the fabric proxy authentication contract

### DIFF
--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -42,7 +42,9 @@
 //! * `--api-key` and `--api-key-file` configure one fixed key that cannot be
 //!   rotated without restarting. `--client-keys` instead names clients and
 //!   re-reads its file when it changes, so one client's key can be revoked or
-//!   rotated without disturbing the others.
+//!   rotated without disturbing the others — but a re-read that fails keeps
+//!   the previous set in force, so a revocation written into a file that no
+//!   longer parses has not taken effect until it does.
 //! * A [`ProxyTls`] pair encrypts what clients send. It is a separate refusal
 //!   from the one above and neither stands in for the other: a key sent over
 //!   cleartext is a key given away, and TLS says nothing about who may drive
@@ -512,7 +514,7 @@ fn refuse_unauthenticated_remote(
         format!(
             "refusing unauthenticated non-loopback listener {addr}; this would expose every \
              configured node to the network. Bind a loopback address, configure \
-             --api-key/--api-key-file, or explicitly acknowledge the risk with \
+             --api-key/--api-key-file/--client-keys, or explicitly acknowledge the risk with \
              --allow-unauthenticated-remote"
         ),
     ))
@@ -2266,8 +2268,9 @@ mod tests {
             error.to_string().contains("--allow-unauthenticated-remote"),
             "{error}"
         );
-        // ...including the way out that does not give up authentication.
+        // ...including both ways out that do not give up authentication.
         assert!(error.to_string().contains("--api-key"), "{error}");
+        assert!(error.to_string().contains("--client-keys"), "{error}");
     }
 
     #[test]

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -39,8 +39,10 @@
 //! * Without a [`ClientAuth`], anything that can reach this address can drive
 //!   every node in the fabric, so [`bind`] refuses a non-loopback address
 //!   unless a key is configured or the risk is acknowledged explicitly.
-//! * Authentication is all-or-nothing: there is one key, it is not per-client,
-//!   and nothing here revokes or rotates it while the proxy is running.
+//! * `--api-key` and `--api-key-file` configure one fixed key that cannot be
+//!   rotated without restarting. `--client-keys` instead names clients and
+//!   re-reads its file when it changes, so one client's key can be revoked or
+//!   rotated without disturbing the others.
 //! * A [`ProxyTls`] pair encrypts what clients send. It is a separate refusal
 //!   from the one above and neither stands in for the other: a key sent over
 //!   cleartext is a key given away, and TLS says nothing about who may drive

--- a/src/main.rs
+++ b/src/main.rs
@@ -1171,9 +1171,10 @@ enum FabricAction {
     /// asking for `stream: true` is relayed as server-sent events, so a stock
     /// OpenAI client works against this address unchanged.
     ///
-    /// The proxy has no authentication of its own, so it binds loopback by
-    /// default and refuses a routable address unless the exposure is
-    /// acknowledged explicitly.
+    /// Client authentication is separate from the bearer the proxy sends to
+    /// its nodes. The proxy binds loopback by default and refuses an
+    /// unauthenticated routable address unless the exposure is acknowledged
+    /// explicitly.
     Serve {
         #[arg(
             long = "node",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1172,9 +1172,9 @@ enum FabricAction {
     /// OpenAI client works against this address unchanged.
     ///
     /// Client authentication is separate from the bearer the proxy sends to
-    /// its nodes. The proxy binds loopback by default and refuses an
-    /// unauthenticated routable address unless the exposure is acknowledged
-    /// explicitly.
+    /// its nodes. The proxy binds loopback by default; a routable address is
+    /// refused unless it is both authenticated and encrypted, or whichever of
+    /// those it is missing is acknowledged explicitly.
     Serve {
         #[arg(
             long = "node",


### PR DESCRIPTION
## What changed

- replace the stale operator-limit claim that fabric client authentication is one non-reloadable key
- state the actual split: `--api-key` / `--api-key-file` are fixed, while `--client-keys` names clients and reloads for individual revocation or rotation
- correct `fabric serve --help` so it says client authentication is separate from the bearer sent to nodes

## Why

Named reloadable client keys shipped in #672, but two user-facing descriptions still documented the earlier single-key design. One was in the operator limits list and the other was rendered directly by `fabric serve --help`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --bin camelid fabric_command_tests -- --nocapture` (7 passed)
- real `target/debug/camelid.exe fabric serve --help` contract check: corrected text present, stale text absent, all three auth options present
- `bash scripts/check-public-scrub.sh`
- `git diff --check`

A local full all-target Clippy attempt was resource-blocked by unrelated compiler jobs from another checkout; no process outside this worktree was terminated. CI runs the repository-pinned Rust 1.89 gate on a clean runner.