### PR TITLE
feat(fabric): learn completion-time placement

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -208,9 +208,10 @@ successful requests completed during this proxy process, then minimizes:
 The estimate is scoped to the node's label, address, backend and version; the model; the API route;
 streaming versus buffered delivery; and coarse power-of-two buckets for request bytes and requested
 output tokens. That prevents a node which happened to receive a longer prompt or generation from
-being labelled intrinsically slow. A measurement is wall time, so it also carries whatever the node
-was already working through; it is divided by the work the node reported in flight when the request
-was placed, because the formula above puts the queue back. No prompt or response content is retained.
+being labelled intrinsically slow. Only a completion placed while the node's observed-or-reserved
+load was zero is sampled. A busy completion includes unknown queueing from other workload classes,
+so dividing its wall time by total in-flight work would invent a service time the proxy did not
+observe. No prompt or response content is retained.
 
 Every eligible node needs five successful completions in the same workload class before an estimate
 may decide placement. Until then the proxy uses least-load, rotating equal-load cold candidates by
@@ -218,12 +219,13 @@ least-recent selection so sequential traffic samples all of them. The response h
 `x-camelid-fabric-reason: LeastLoaded` while cold and `EstimatedCompletion` once learned timing made
 the decision.
 
-Only clean success is a speed sample. A node-attributable 5xx, unreadable answer, transport failure,
-or truncated stream invalidates that node's estimate for the workload immediately. A queue-full
-refusal does not: it says the load bound worked, not that service became slow. Client cancellation
-does not either, because it says nothing about the node. A stream is sampled only at clean EOF, and
-not if the bounded relay channel filled behind a slow client. A request carrying a sticky header is
-not sampled either: affinity, rather than this policy, chose its node.
+Only a clean, queue-free success is a speed sample. A node-attributable 5xx, unreadable answer,
+transport failure, or truncated stream invalidates that node's estimate for the workload
+immediately. A queue-full refusal does not: it says the load bound worked, not that service became
+slow. Client cancellation does not either, because it says nothing about the node. A stream is
+sampled only at clean EOF, and not if the bounded relay channel filled behind a slow client. A
+request carrying a sticky header is not sampled either: affinity, rather than this policy, chose its
+node.
 
 Estimates older than five minutes become cold and have to be sampled again. They are memory-only,
 bounded to 1,024 node/workload entries, and disappear when the proxy restarts. `fabric route` and

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -208,7 +208,9 @@ successful requests completed during this proxy process, then minimizes:
 The estimate is scoped to the node's label, address, backend and version; the model; the API route;
 streaming versus buffered delivery; and coarse power-of-two buckets for request bytes and requested
 output tokens. That prevents a node which happened to receive a longer prompt or generation from
-being labelled intrinsically slow. No prompt or response content is retained.
+being labelled intrinsically slow. A measurement is wall time, so it also carries whatever the node
+was already working through; it is divided by the work the node reported in flight when the request
+was placed, because the formula above puts the queue back. No prompt or response content is retained.
 
 Every eligible node needs five successful completions in the same workload class before an estimate
 may decide placement. Until then the proxy uses least-load, rotating equal-load cold candidates by

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -190,6 +190,48 @@ Three limits are deliberate and worth knowing before you deploy it:
   loopback, the bearer above and every prompt and completion still cross that network unencrypted,
   whatever the proxy presents to its own clients. Keep those hops on a trusted link.
 
+### Placement modes
+
+`--mode throughput` is the default and preserves the established policy: choose the smallest
+`max(node-reported in-flight jobs, requests this proxy has reserved)`, breaking ties by node label.
+`--mode affinity` prefers the node named by `x-camelid-fabric-sticky` and falls back to that same
+least-load rule if the node is unavailable or no longer serves the requested model. A sticky header
+requests affinity whatever default mode the proxy was started with.
+
+`--mode completion-time` is opt-in. It learns an exponentially weighted service time from clean,
+successful requests completed during this proxy process, then minimizes:
+
+```text
+(observed-or-reserved load + 1) * learned service time
+```
+
+The estimate is scoped to the node's label, address, backend and version; the model; the API route;
+streaming versus buffered delivery; and coarse power-of-two buckets for request bytes and requested
+output tokens. That prevents a node which happened to receive a longer prompt or generation from
+being labelled intrinsically slow. No prompt or response content is retained.
+
+Every eligible node needs five successful completions in the same workload class before an estimate
+may decide placement. Until then the proxy uses least-load, rotating equal-load cold candidates by
+least-recent selection so sequential traffic samples all of them. The response header says
+`x-camelid-fabric-reason: LeastLoaded` while cold and `EstimatedCompletion` once learned timing made
+the decision.
+
+Only clean success is a speed sample. A node-attributable 5xx, unreadable answer, transport failure,
+or truncated stream invalidates that node's estimate for the workload immediately. A queue-full
+refusal does not: it says the load bound worked, not that service became slow. Client cancellation
+does not either, because it says nothing about the node. A stream is sampled only at clean EOF, and
+not if the bounded relay channel filled behind a slow client. A request carrying a sticky header is
+not sampled either: affinity, rather than this policy, chose its node.
+
+Estimates older than five minutes become cold and have to be sampled again. They are memory-only,
+bounded to 1,024 node/workload entries, and disappear when the proxy restarts. `fabric route` and
+`fabric run` reject `completion-time`: as one-shot commands they have no resident history and could
+only pretend to make a learned decision.
+
+This mode changes placement, not node capacity or admission. A sole eligible node still receives the
+request, and a genuinely full node still owns its typed 503. Treat performance improvement as a
+measurement question: use a paired, interleaved fabric campaign before making a deployment claim.
+
 ### Naming clients, and cutting one off
 
 `--api-key` gives every client the same secret, so the access log can only say that *someone*

--- a/src/fabric/forward.rs
+++ b/src/fabric/forward.rs
@@ -294,6 +294,7 @@ pub struct Streaming {
     /// The node's `Content-Type`, so the client is told what it is reading.
     pub content_type: Option<String>,
     stream: http::ResponseStream,
+    started: Instant,
 }
 
 impl std::fmt::Debug for Streaming {
@@ -317,6 +318,11 @@ impl Streaming {
         self.stream
             .next_chunk()
             .map_err(|error| after_the_head(&self.label, error))
+    }
+
+    /// Time from starting the request through the latest body read.
+    pub(crate) fn elapsed(&self) -> Duration {
+        self.started.elapsed()
     }
 }
 
@@ -408,6 +414,7 @@ pub fn forward_streaming(
         status: head.status,
         content_type: head.content_type,
         stream,
+        started,
     }))
 }
 

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -48,11 +48,11 @@ pub use node::{
     NodeStatus, DEFAULT_NODE_PORT,
 };
 use nodes::NodeSet;
+use policy::{load_of, route_reserved_with_estimates, ServiceTimeEstimates};
 pub use policy::{
     route, route_reserved, Reservations, RouteDecision, RouteError, RouteMode, RouteReason,
     RouteRequest,
 };
-use policy::{route_reserved_with_estimates, ServiceTimeEstimates};
 pub use probe::{probe_fabric, probe_node, Observation, ProbeError, DEFAULT_PROBE_TIMEOUT};
 
 /// How many nodes one request may be sent to before it fails.
@@ -331,7 +331,8 @@ impl Fabric {
             .filter(|snapshot| !excluded.iter().any(|label| label == snapshot.label()))
             .collect();
 
-        let (decision, service_model) = if request.mode == RouteMode::CompletionTime {
+        let (decision, service_model, service_ahead) = if request.mode == RouteMode::CompletionTime
+        {
             // Deciding, reserving and recording cold-selection recency are one
             // step. Split them and concurrent placements can all decide from
             // the same policy state. These are the only nested fabric locks,
@@ -342,11 +343,14 @@ impl Fabric {
             let mut reserved = lock(&self.reserved);
             let decision =
                 route_reserved_with_estimates(&snapshots, request, &reserved, &service_times)?;
-            reserved.take(&decision.label);
             let selected = snapshots
                 .iter()
                 .find(|snapshot| snapshot.label() == decision.label)
                 .expect("placement returns a label it was given");
+            let service_ahead = selected.status.ready().map_or(0, |ready| {
+                load_of(ready.in_flight, reserved.get(&decision.label))
+            });
+            reserved.take(&decision.label);
             let service_model = request
                 .model
                 .or_else(|| selected.active_model_id())
@@ -356,7 +360,7 @@ impl Fabric {
             }
             drop(reserved);
             drop(service_times);
-            (decision, service_model)
+            (decision, service_model, service_ahead)
         } else {
             // Exactly the pre-existing throughput/affinity path: those modes
             // neither allocate nor lock service-time state during placement.
@@ -372,7 +376,7 @@ impl Fabric {
                 .model
                 .or_else(|| selected.active_model_id())
                 .map(str::to_string);
-            (decision, service_model)
+            (decision, service_model, 0)
         };
 
         let node = snapshots
@@ -387,6 +391,7 @@ impl Fabric {
             service_model,
             service_class: request.service_class.map(str::to_string),
             service_mode: request.mode,
+            service_ahead,
             service_recorded: false,
         })
     }
@@ -669,16 +674,6 @@ fn service_class(path: &str, body: &Value) -> String {
     )
 }
 
-/// One request's own service cost, with the queueing it waited through removed.
-///
-/// A sample is wall time from sending to completion, so it already contains the
-/// work the node was carrying when the request arrived. Selection multiplies an
-/// estimate by the load it can see, so leaving that in counts the same queue
-/// twice and ranks a fast node that is busy behind a slow node that is idle.
-fn service_time(elapsed: Duration, ahead: usize) -> Duration {
-    elapsed / u32::try_from(ahead.saturating_add(1)).unwrap_or(u32::MAX)
-}
-
 /// A request that a node took, and what it cost to get there.
 struct Sent<T> {
     value: T,
@@ -730,6 +725,7 @@ pub struct Placement {
     service_model: Option<String>,
     service_class: Option<String>,
     service_mode: RouteMode,
+    service_ahead: usize,
     service_recorded: bool,
 }
 
@@ -754,16 +750,17 @@ impl Placement {
             return;
         }
         self.service_recorded = true;
+        // A busy completion's wall time includes queueing from work whose
+        // workload class is not exposed by node health. Dividing by the total
+        // in-flight count would fabricate this class's service time, so only a
+        // request placed with nobody ahead becomes a sample.
+        if self.service_ahead != 0 {
+            return;
+        }
         let (Some(model), Some(service_class)) = (&self.service_model, &self.service_class) else {
             return;
         };
-        let ahead = self.node.status.ready().map_or(0, |ready| ready.in_flight);
-        lock(&self.service_times).observe(
-            &self.node,
-            model,
-            service_class,
-            service_time(elapsed, ahead),
-        );
+        lock(&self.service_times).observe(&self.node, model, service_class, elapsed);
     }
 
     /// Forget a learned speed after the node itself fails this workload.
@@ -1060,19 +1057,74 @@ mod tests {
     }
 
     #[test]
-    fn a_sample_is_this_requests_own_cost_not_the_queue_it_waited_in() {
-        // 160ms spent behind three other requests on a node that runs one at a
-        // time is 40ms of work, and 40ms is what selection multiplies by the
-        // load it can see.
-        assert_eq!(
-            service_time(Duration::from_millis(160), 3),
-            Duration::from_millis(40)
+    fn a_busy_completion_is_not_a_service_sample() {
+        let node = snapshot(
+            "a",
+            NodeStatus::Ready(NodeReady {
+                active_model_id: Some("m".to_string()),
+                backend: "llama".to_string(),
+                version: "0.5.4".to_string(),
+                in_flight: 0,
+                waiting: 0,
+            }),
         );
-        // Nothing was ahead of it, so the measurement already is the cost.
+        let measured = node.clone();
+        let fabric = Fabric::new(Vec::new());
+        {
+            let mut reserved = lock(&fabric.reserved);
+            reserved.take("a");
+            reserved.take("a");
+        }
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("class"));
+
+        let mut placement = fabric
+            .place_observed(vec![node], &request, &[])
+            .expect("routes");
+
         assert_eq!(
-            service_time(Duration::from_millis(400), 0),
-            Duration::from_millis(400)
+            placement.service_ahead, 2,
+            "sampling must use the same max(observed, reserved) load as selection"
         );
+        assert_eq!(fabric.reserved().get("a"), 3);
+        placement.record_success(Duration::from_millis(300));
+        let (_, samples) = lock(&fabric.service_times)
+            .sample_for(&measured, "m", "class")
+            .expect("selection recency keeps the class present");
+        assert_eq!(samples, 0, "busy queueing became a speed sample");
+        drop(placement);
+        assert_eq!(fabric.reserved().get("a"), 2);
+    }
+
+    #[test]
+    fn a_queue_free_completion_records_its_observed_wall_time() {
+        let node = snapshot(
+            "a",
+            NodeStatus::Ready(NodeReady {
+                active_model_id: Some("m".to_string()),
+                backend: "llama".to_string(),
+                version: "0.5.4".to_string(),
+                in_flight: 0,
+                waiting: 0,
+            }),
+        );
+        let measured = node.clone();
+        let fabric = Fabric::new(Vec::new());
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("class"));
+        let mut placement = fabric
+            .place_observed(vec![node], &request, &[])
+            .expect("routes");
+
+        placement.record_success(Duration::from_millis(400));
+
+        let (mean_nanos, samples) = lock(&fabric.service_times)
+            .sample_for(&measured, "m", "class")
+            .expect("the queue-free completion was sampled");
+        assert_eq!(samples, 1);
+        assert_eq!(mean_nanos, Duration::from_millis(400).as_nanos());
     }
 
     #[test]

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -52,6 +52,7 @@ pub use policy::{
     route, route_reserved, Reservations, RouteDecision, RouteError, RouteMode, RouteReason,
     RouteRequest,
 };
+use policy::{route_reserved_with_estimates, ServiceTimeEstimates};
 pub use probe::{probe_fabric, probe_node, Observation, ProbeError, DEFAULT_PROBE_TIMEOUT};
 
 /// How many nodes one request may be sent to before it fails.
@@ -79,6 +80,12 @@ pub struct Fabric {
     /// every request, and they have to be counting into the same place or they
     /// cannot see each other.
     reserved: Arc<Mutex<Reservations>>,
+    /// Successful service times learned by this resident fabric.
+    ///
+    /// Shared across clones because each proxy request receives a clone and
+    /// all of them must learn one policy. The estimates are consulted only by
+    /// the opt-in completion-time mode.
+    service_times: Arc<Mutex<ServiceTimeEstimates>>,
     /// The most recent observation, with the node-set generation it was taken
     /// over, reused while it is fresh enough *and* still describes the set.
     ///
@@ -132,6 +139,7 @@ impl Fabric {
             timeout: DEFAULT_PROBE_TIMEOUT,
             bearer: None,
             reserved: Arc::new(Mutex::new(Reservations::none())),
+            service_times: Arc::new(Mutex::new(ServiceTimeEstimates::default())),
             observed: Arc::new(Mutex::new(None)),
             max_observation_age: Duration::ZERO,
             max_forward_attempts: DEFAULT_MAX_FORWARD_ATTEMPTS,
@@ -323,13 +331,49 @@ impl Fabric {
             .filter(|snapshot| !excluded.iter().any(|label| label == snapshot.label()))
             .collect();
 
-        // Deciding and recording are one step. Split them and two concurrent
-        // placements both decide before either records, which is the pile-up
-        // this reservation exists to prevent.
-        let mut reserved = lock(&self.reserved);
-        let decision = route_reserved(&snapshots, request, &reserved)?;
-        reserved.take(&decision.label);
-        drop(reserved);
+        let (decision, service_model) = if request.mode == RouteMode::CompletionTime {
+            // Deciding, reserving and recording cold-selection recency are one
+            // step. Split them and concurrent placements can all decide from
+            // the same policy state. These are the only nested fabric locks,
+            // always in service-times -> reservations order; completion
+            // recording takes only service-times and Placement::drop takes
+            // only reservations.
+            let mut service_times = lock(&self.service_times);
+            let mut reserved = lock(&self.reserved);
+            let decision =
+                route_reserved_with_estimates(&snapshots, request, &reserved, &service_times)?;
+            reserved.take(&decision.label);
+            let selected = snapshots
+                .iter()
+                .find(|snapshot| snapshot.label() == decision.label)
+                .expect("placement returns a label it was given");
+            let service_model = request
+                .model
+                .or_else(|| selected.active_model_id())
+                .map(str::to_string);
+            if let (Some(model), Some(route)) = (&service_model, request.service_class) {
+                service_times.selected(selected, model, route);
+            }
+            drop(reserved);
+            drop(service_times);
+            (decision, service_model)
+        } else {
+            // Exactly the pre-existing throughput/affinity path: those modes
+            // neither allocate nor lock service-time state during placement.
+            let mut reserved = lock(&self.reserved);
+            let decision = route_reserved(&snapshots, request, &reserved)?;
+            reserved.take(&decision.label);
+            drop(reserved);
+            let selected = snapshots
+                .iter()
+                .find(|snapshot| snapshot.label() == decision.label)
+                .expect("placement returns a label it was given");
+            let service_model = request
+                .model
+                .or_else(|| selected.active_model_id())
+                .map(str::to_string);
+            (decision, service_model)
+        };
 
         let node = snapshots
             .into_iter()
@@ -339,6 +383,11 @@ impl Fabric {
             decision,
             node,
             reserved: Arc::clone(&self.reserved),
+            service_times: Arc::clone(&self.service_times),
+            service_model,
+            service_class: request.service_class.map(str::to_string),
+            service_mode: request.mode,
+            service_recorded: false,
         })
     }
 
@@ -365,7 +414,10 @@ impl Fabric {
         // Refuse an unsupported request before spending any probes on it.
         forward::reject_streaming(body)?;
 
-        let sent = self.send_until_a_node_takes_it(request, |spec| {
+        let service_class =
+            (request.mode != RouteMode::Throughput).then(|| service_class(path, body));
+        let request = request.with_service_class(service_class.as_deref());
+        let mut sent = self.send_until_a_node_takes_it(&request, |spec| {
             forward::forward(
                 spec,
                 path,
@@ -375,6 +427,11 @@ impl Fabric {
                 cancel,
             )
         })?;
+        if sent.value.is_success() {
+            sent.placement.record_success(sent.value.elapsed);
+        } else if sent.value.status >= 500 && !sent.value.refused_for_backpressure() {
+            sent.placement.invalidate_service_time();
+        }
         Ok(Dispatched {
             decision: sent.placement.decision.clone(),
             answer: sent.value,
@@ -401,7 +458,10 @@ impl Fabric {
         idle_timeout: Duration,
         cancel: &Cancel,
     ) -> Result<DispatchedStream, DispatchError> {
-        let sent = self.send_until_a_node_takes_it(request, |spec| {
+        let service_class =
+            (request.mode != RouteMode::Throughput).then(|| service_class(path, body));
+        let request = request.with_service_class(service_class.as_deref());
+        let mut sent = self.send_until_a_node_takes_it(&request, |spec| {
             forward::forward_streaming(
                 spec,
                 path,
@@ -412,6 +472,13 @@ impl Fabric {
                 cancel,
             )
         })?;
+        if let StreamOutcome::Buffered(answer) = &sent.value {
+            if answer.is_success() {
+                sent.placement.record_success(answer.elapsed);
+            } else if answer.status >= 500 && !answer.refused_for_backpressure() {
+                sent.placement.invalidate_service_time();
+            }
+        }
         Ok(DispatchedStream {
             outcome: sent.value,
             placement: sent.placement,
@@ -461,7 +528,7 @@ impl Fabric {
 
         for attempt in 1..=self.max_forward_attempts.max(1) {
             let excluded: Vec<String> = gone.iter().chain(saturated.iter()).cloned().collect();
-            let placement = match self.place_excluding(request, &excluded) {
+            let mut placement = match self.place_excluding(request, &excluded) {
                 Ok(placement) => placement,
                 Err(refusal) => {
                     if let Some((value, placement)) = refused {
@@ -495,6 +562,7 @@ impl Fabric {
                     });
                 }
                 Err(error) if error.node_never_received_it() => {
+                    placement.invalidate_service_time();
                     gone.push(placement.decision.label.clone());
                     first_failure.get_or_insert(error);
                 }
@@ -504,6 +572,9 @@ impl Fabric {
                 // fabric successfully routed around, and say nothing about the
                 // one actually failing requests.
                 Err(error) => {
+                    if !matches!(error, ForwardError::Cancelled { .. }) {
+                        placement.invalidate_service_time();
+                    }
                     if gone.is_empty() {
                         self.forget_observation_if_node_vanished(&error);
                     } else {
@@ -571,6 +642,33 @@ impl Fabric {
     }
 }
 
+/// Group requests whose service cost is comparable enough to learn together.
+///
+/// Raw wall time without a workload class would teach the policy that the node
+/// receiving longer prompts or generations is intrinsically slower. Powers of
+/// two keep the number of classes bounded while separating order-of-magnitude
+/// differences. Streaming is distinct because its measured lifetime ends at
+/// body EOF rather than at one buffered response.
+fn service_class(path: &str, body: &Value) -> String {
+    fn bucket(value: usize) -> usize {
+        value.checked_next_power_of_two().unwrap_or(usize::MAX)
+    }
+
+    let request_bytes = serde_json::to_vec(body).map_or(0, |encoded| encoded.len());
+    let output_tokens = body
+        .get("max_completion_tokens")
+        .or_else(|| body.get("max_tokens"))
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(0);
+    format!(
+        "{path}|stream={}|bytes={}|output={}",
+        wants_streaming(body),
+        bucket(request_bytes),
+        bucket(output_tokens),
+    )
+}
+
 /// A request that a node took, and what it cost to get there.
 struct Sent<T> {
     value: T,
@@ -618,6 +716,11 @@ pub struct Placement {
     decision: RouteDecision,
     node: NodeSnapshot,
     reserved: Arc<Mutex<Reservations>>,
+    service_times: Arc<Mutex<ServiceTimeEstimates>>,
+    service_model: Option<String>,
+    service_class: Option<String>,
+    service_mode: RouteMode,
+    service_recorded: bool,
 }
 
 impl Placement {
@@ -629,6 +732,31 @@ impl Placement {
     /// already serving before building a request body for it.
     pub fn node(&self) -> &NodeSnapshot {
         &self.node
+    }
+
+    /// Record one successful, fully completed request.
+    ///
+    /// Failures and cancellations never call this. Idempotence is defensive:
+    /// one request must never outweigh another because two completion paths
+    /// happened to report it.
+    pub(crate) fn record_success(&mut self, elapsed: Duration) {
+        if self.service_recorded || self.service_mode != RouteMode::CompletionTime {
+            return;
+        }
+        self.service_recorded = true;
+        let (Some(model), Some(service_class)) = (&self.service_model, &self.service_class) else {
+            return;
+        };
+        lock(&self.service_times).observe(&self.node, model, service_class, elapsed);
+    }
+
+    /// Forget a learned speed after the node itself fails this workload.
+    /// Selection recency is retained so cold fallback explores a sibling next.
+    pub(crate) fn invalidate_service_time(&mut self) {
+        let (Some(model), Some(service_class)) = (&self.service_model, &self.service_class) else {
+            return;
+        };
+        lock(&self.service_times).invalidate(&self.node, model, service_class);
     }
 }
 
@@ -880,6 +1008,51 @@ mod tests {
             in_flight: 1,
             waiting: 0,
         })
+    }
+
+    #[test]
+    fn service_classes_separate_workloads_with_different_cost_shapes() {
+        let base = serde_json::json!({
+            "model": "m",
+            "messages": [{ "role": "user", "content": "short" }],
+            "max_tokens": 64,
+            "stream": false,
+        });
+        let base_class = service_class("/v1/chat/completions", &base);
+
+        let mut streaming = base.clone();
+        streaming["stream"] = true.into();
+        assert_ne!(
+            base_class,
+            service_class("/v1/chat/completions", &streaming)
+        );
+
+        let mut larger_output = base.clone();
+        larger_output["max_tokens"] = 65.into();
+        assert_ne!(
+            base_class,
+            service_class("/v1/chat/completions", &larger_output)
+        );
+
+        let mut larger_input = base.clone();
+        larger_input["messages"][0]["content"] = "x".repeat(1_024).into();
+        assert_ne!(
+            base_class,
+            service_class("/v1/chat/completions", &larger_input)
+        );
+        assert_ne!(base_class, service_class("/v1/embeddings", &base));
+    }
+
+    #[test]
+    fn service_classes_do_not_record_request_content() {
+        let body = serde_json::json!({
+            "model": "m",
+            "messages": [{ "role": "user", "content": "private prompt" }],
+            "max_tokens": 64,
+        });
+        let class = service_class("/v1/chat/completions", &body);
+        assert!(!class.contains("private"), "{class}");
+        assert!(!class.contains("prompt"), "{class}");
     }
 
     #[test]

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -669,6 +669,16 @@ fn service_class(path: &str, body: &Value) -> String {
     )
 }
 
+/// One request's own service cost, with the queueing it waited through removed.
+///
+/// A sample is wall time from sending to completion, so it already contains the
+/// work the node was carrying when the request arrived. Selection multiplies an
+/// estimate by the load it can see, so leaving that in counts the same queue
+/// twice and ranks a fast node that is busy behind a slow node that is idle.
+fn service_time(elapsed: Duration, ahead: usize) -> Duration {
+    elapsed / u32::try_from(ahead.saturating_add(1)).unwrap_or(u32::MAX)
+}
+
 /// A request that a node took, and what it cost to get there.
 struct Sent<T> {
     value: T,
@@ -747,7 +757,13 @@ impl Placement {
         let (Some(model), Some(service_class)) = (&self.service_model, &self.service_class) else {
             return;
         };
-        lock(&self.service_times).observe(&self.node, model, service_class, elapsed);
+        let ahead = self.node.status.ready().map_or(0, |ready| ready.in_flight);
+        lock(&self.service_times).observe(
+            &self.node,
+            model,
+            service_class,
+            service_time(elapsed, ahead),
+        );
     }
 
     /// Forget a learned speed after the node itself fails this workload.
@@ -1041,6 +1057,22 @@ mod tests {
             service_class("/v1/chat/completions", &larger_input)
         );
         assert_ne!(base_class, service_class("/v1/embeddings", &base));
+    }
+
+    #[test]
+    fn a_sample_is_this_requests_own_cost_not_the_queue_it_waited_in() {
+        // 160ms spent behind three other requests on a node that runs one at a
+        // time is 40ms of work, and 40ms is what selection multiplies by the
+        // load it can see.
+        assert_eq!(
+            service_time(Duration::from_millis(160), 3),
+            Duration::from_millis(40)
+        );
+        // Nothing was ahead of it, so the measurement already is the cost.
+        assert_eq!(
+            service_time(Duration::from_millis(400), 0),
+            Duration::from_millis(400)
+        );
     }
 
     #[test]

--- a/src/fabric/policy.rs
+++ b/src/fabric/policy.rs
@@ -1,9 +1,9 @@
 //! Routing policy: which node receives a whole request.
 //!
-//! Every function here is pure. The fabric's correctness lives in this file, so
-//! it is deliberately separated from the socket work in [`super::probe`] and can
-//! be tested exhaustively against hand-built snapshots with no network, no
-//! server and no model.
+//! Selection has no I/O or external side effects: the fabric supplies snapshots
+//! of observed load, reservations and learned service time, and this module
+//! returns a decision. The service-time book performs no socket work either, so
+//! both halves are tested against hand-built facts with no server or model.
 //!
 //! Two properties are load-bearing and each has a test that fails without it:
 //!
@@ -15,11 +15,34 @@
 
 use super::node::{NodeSnapshot, NodeStatus};
 
+/// Successful completions required from every candidate before learned
+/// service times may decide placement.
+///
+/// Until then the existing least-load rule explores the fabric without making
+/// a routing claim from one unusually fast or slow request.
+const MIN_SERVICE_TIME_SAMPLES: u32 = 5;
+
+/// Weight of history in the steady-state EWMA. The new sample owns the fifth
+/// part; integer arithmetic keeps the policy deterministic on every platform.
+const EWMA_HISTORY_WEIGHT: u128 = 4;
+
+/// A node not sampled inside this window is explored again before its old
+/// speed may decide placement. This catches thermal, power and topology
+/// changes without continuously diverting traffic from the estimated winner.
+const MAX_SERVICE_TIME_AGE: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+/// Dynamic node files and model switches must not grow resident policy state
+/// without bound. This is far above a practical fabric's active class count.
+const MAX_SERVICE_CLASSES: usize = 1_024;
+
 /// How to choose among eligible nodes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RouteMode {
     /// Spread independent requests over the least-loaded nodes.
     Throughput,
+    /// Minimise estimated time to finish from measured service time and load,
+    /// falling back to [`RouteMode::Throughput`] while the estimate is cold.
+    CompletionTime,
     /// Prefer the node that last served this session so its prompt prefix and KV
     /// cache stay warm, falling back to [`RouteMode::Throughput`] when it cannot.
     Affinity,
@@ -31,6 +54,9 @@ pub struct RouteRequest<'a> {
     pub mode: RouteMode,
     /// Required model id. `None` means any ready node will do.
     pub model: Option<&'a str>,
+    /// Comparable workload class supplied by dispatch. Service times from
+    /// unlike request sizes, routes or response shapes must not be mixed.
+    pub service_class: Option<&'a str>,
     /// Label of the node that served this session previously, if any.
     pub sticky: Option<&'a str>,
 }
@@ -40,12 +66,18 @@ impl<'a> RouteRequest<'a> {
         Self {
             mode,
             model: None,
+            service_class: None,
             sticky: None,
         }
     }
 
     pub fn with_model(mut self, model: Option<&'a str>) -> Self {
         self.model = model;
+        self
+    }
+
+    pub fn with_service_class(mut self, service_class: Option<&'a str>) -> Self {
+        self.service_class = service_class;
         self
     }
 
@@ -64,6 +96,8 @@ pub enum RouteReason {
     OnlyCandidate,
     /// Fewest queued jobs among the eligible nodes.
     LeastLoaded,
+    /// Lowest predicted time until this request finishes.
+    EstimatedCompletion,
 }
 
 impl RouteReason {
@@ -78,6 +112,7 @@ impl RouteReason {
             Self::Affinity => "Affinity",
             Self::OnlyCandidate => "OnlyCandidate",
             Self::LeastLoaded => "LeastLoaded",
+            Self::EstimatedCompletion => "EstimatedCompletion",
         }
     }
 }
@@ -193,10 +228,185 @@ impl Reservations {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ServiceClass {
+    label: String,
+    authority: String,
+    backend: String,
+    version: String,
+    model: String,
+    workload: String,
+}
+
+impl ServiceClass {
+    fn of(node: &NodeSnapshot, model: &str, workload: &str) -> Option<Self> {
+        let ready = node.status.ready()?;
+        Some(Self {
+            label: node.label().to_string(),
+            authority: node.spec.authority(),
+            backend: ready.backend.clone(),
+            version: ready.version.clone(),
+            model: model.to_string(),
+            workload: workload.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ServiceTimeEstimate {
+    mean_nanos: u128,
+    samples: u32,
+    last_observed: Option<std::time::Instant>,
+    last_selected: Option<std::time::Instant>,
+}
+
+/// Service time learned by this resident fabric, scoped to one node identity,
+/// model and comparable workload class.
+///
+/// Only successful completed requests belong here. The dispatch layer owns
+/// that distinction; this type only maintains deterministic estimates.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ServiceTimeEstimates(
+    std::collections::BTreeMap<ServiceClass, ServiceTimeEstimate>,
+);
+
+impl ServiceTimeEstimates {
+    pub(crate) fn selected(&mut self, node: &NodeSnapshot, model: &str, workload: &str) {
+        self.selected_at(node, model, workload, std::time::Instant::now());
+    }
+
+    fn selected_at(
+        &mut self,
+        node: &NodeSnapshot,
+        model: &str,
+        workload: &str,
+        now: std::time::Instant,
+    ) {
+        let Some(class) = ServiceClass::of(node, model, workload) else {
+            return;
+        };
+        self.0
+            .entry(class)
+            .and_modify(|estimate| estimate.last_selected = Some(now))
+            .or_insert(ServiceTimeEstimate {
+                mean_nanos: 0,
+                samples: 0,
+                last_observed: None,
+                last_selected: Some(now),
+            });
+        self.prune();
+    }
+
+    pub(crate) fn observe(
+        &mut self,
+        node: &NodeSnapshot,
+        model: &str,
+        workload: &str,
+        elapsed: std::time::Duration,
+    ) {
+        self.observe_at(node, model, workload, elapsed, std::time::Instant::now());
+    }
+
+    pub(crate) fn invalidate(&mut self, node: &NodeSnapshot, model: &str, workload: &str) {
+        let Some(class) = ServiceClass::of(node, model, workload) else {
+            return;
+        };
+        let now = std::time::Instant::now();
+        self.0
+            .entry(class)
+            .and_modify(|estimate| {
+                estimate.mean_nanos = 0;
+                estimate.samples = 0;
+                estimate.last_observed = None;
+                estimate.last_selected = Some(now);
+            })
+            .or_insert(ServiceTimeEstimate {
+                mean_nanos: 0,
+                samples: 0,
+                last_observed: None,
+                last_selected: Some(now),
+            });
+        self.prune();
+    }
+
+    fn observe_at(
+        &mut self,
+        node: &NodeSnapshot,
+        model: &str,
+        workload: &str,
+        elapsed: std::time::Duration,
+        now: std::time::Instant,
+    ) {
+        let Some(class) = ServiceClass::of(node, model, workload) else {
+            return;
+        };
+        let sample = elapsed.as_nanos().max(1);
+        self.0
+            .entry(class)
+            .and_modify(|estimate| {
+                let stale = estimate.last_observed.is_some_and(|observed| {
+                    now.saturating_duration_since(observed) > MAX_SERVICE_TIME_AGE
+                });
+                if stale {
+                    estimate.mean_nanos = sample;
+                    estimate.samples = 0;
+                } else if estimate.samples < MIN_SERVICE_TIME_SAMPLES {
+                    let samples = u128::from(estimate.samples);
+                    estimate.mean_nanos = estimate
+                        .mean_nanos
+                        .saturating_mul(samples)
+                        .saturating_add(sample)
+                        / (samples + 1);
+                } else {
+                    estimate.mean_nanos = estimate
+                        .mean_nanos
+                        .saturating_mul(EWMA_HISTORY_WEIGHT)
+                        .saturating_add(sample)
+                        / (EWMA_HISTORY_WEIGHT + 1);
+                }
+                estimate.samples = estimate.samples.saturating_add(1);
+                estimate.last_observed = Some(now);
+            })
+            .or_insert(ServiceTimeEstimate {
+                mean_nanos: sample,
+                samples: 1,
+                last_observed: Some(now),
+                last_selected: None,
+            });
+
+        self.prune();
+    }
+
+    fn prune(&mut self) {
+        if self.0.len() > MAX_SERVICE_CLASSES {
+            let oldest = self
+                .0
+                .iter()
+                .min_by_key(|(_, estimate)| estimate.last_observed.max(estimate.last_selected))
+                .map(|(class, _)| class.clone())
+                .expect("an oversized estimate map is non-empty");
+            self.0.remove(&oldest);
+        }
+    }
+
+    fn get(
+        &self,
+        node: &NodeSnapshot,
+        model: Option<&str>,
+        workload: Option<&str>,
+    ) -> Option<ServiceTimeEstimate> {
+        let model = model.or_else(|| node.active_model_id())?;
+        let class = ServiceClass::of(node, model, workload?)?;
+        self.0.get(&class).copied()
+    }
+}
+
 /// One eligible node reduced to the fields selection actually uses.
 struct Candidate<'a> {
     label: &'a str,
     load: usize,
+    service_nanos: Option<u128>,
+    last_selected: Option<std::time::Instant>,
 }
 
 /// What a node is carrying, as far as this fabric can tell. Pure.
@@ -233,6 +443,36 @@ pub fn route_reserved(
     snapshots: &[NodeSnapshot],
     request: &RouteRequest<'_>,
     reserved: &Reservations,
+) -> Result<RouteDecision, RouteError> {
+    route_reserved_with_estimates(
+        snapshots,
+        request,
+        reserved,
+        &ServiceTimeEstimates::default(),
+    )
+}
+
+pub(crate) fn route_reserved_with_estimates(
+    snapshots: &[NodeSnapshot],
+    request: &RouteRequest<'_>,
+    reserved: &Reservations,
+    estimates: &ServiceTimeEstimates,
+) -> Result<RouteDecision, RouteError> {
+    route_reserved_with_estimates_at(
+        snapshots,
+        request,
+        reserved,
+        estimates,
+        std::time::Instant::now(),
+    )
+}
+
+fn route_reserved_with_estimates_at(
+    snapshots: &[NodeSnapshot],
+    request: &RouteRequest<'_>,
+    reserved: &Reservations,
+    estimates: &ServiceTimeEstimates,
+    now: std::time::Instant,
 ) -> Result<RouteDecision, RouteError> {
     if snapshots.is_empty() {
         return Err(RouteError::NoNodesConfigured);
@@ -285,9 +525,21 @@ pub fn route_reserved(
     let candidates: Vec<Candidate<'_>> = serving_model
         .iter()
         .filter_map(|snapshot| {
-            snapshot.status.ready().map(|ready| Candidate {
-                label: snapshot.label(),
-                load: load_of(ready.in_flight, reserved.get(snapshot.label())),
+            snapshot.status.ready().map(|ready| {
+                let estimate = estimates.get(snapshot, request.model, request.service_class);
+                let current = estimate.filter(|estimate| {
+                    estimate.last_observed.is_some_and(|observed| {
+                        now.saturating_duration_since(observed) <= MAX_SERVICE_TIME_AGE
+                    })
+                });
+                Candidate {
+                    label: snapshot.label(),
+                    load: load_of(ready.in_flight, reserved.get(snapshot.label())),
+                    service_nanos: current
+                        .filter(|estimate| estimate.samples >= MIN_SERVICE_TIME_SAMPLES)
+                        .map(|estimate| estimate.mean_nanos),
+                    last_selected: estimate.and_then(|estimate| estimate.last_selected),
+                }
             })
         })
         .collect();
@@ -311,14 +563,52 @@ pub fn route_reserved(
         }
     }
 
-    // Ties break on label so a dry run predicts the real decision.
-    let chosen = candidates
-        .iter()
-        .min_by(|a, b| a.load.cmp(&b.load).then_with(|| a.label.cmp(b.label)))
-        .expect("candidates is non-empty");
+    let has_complete_estimates = request.mode == RouteMode::CompletionTime
+        && candidates
+            .iter()
+            .all(|candidate| candidate.service_nanos.is_some());
+
+    // Ties break on label so a dry run predicts the real decision. Completion
+    // scores use u128 and saturating multiplication: neither a pathological
+    // duration nor load may wrap around and make a node look fast.
+    let chosen = if has_complete_estimates {
+        candidates
+            .iter()
+            .min_by(|a, b| {
+                let score = |candidate: &Candidate<'_>| {
+                    candidate
+                        .service_nanos
+                        .expect("all estimates are complete")
+                        .saturating_mul((candidate.load as u128).saturating_add(1))
+                };
+                score(a)
+                    .cmp(&score(b))
+                    .then_with(|| a.load.cmp(&b.load))
+                    .then_with(|| a.label.cmp(b.label))
+            })
+            .expect("candidates is non-empty")
+    } else {
+        candidates
+            .iter()
+            .min_by(|a, b| {
+                a.load
+                    .cmp(&b.load)
+                    .then_with(|| {
+                        if request.mode == RouteMode::CompletionTime {
+                            a.last_selected.cmp(&b.last_selected)
+                        } else {
+                            std::cmp::Ordering::Equal
+                        }
+                    })
+                    .then_with(|| a.label.cmp(b.label))
+            })
+            .expect("candidates is non-empty")
+    };
 
     let reason = if candidates.len() == 1 {
         RouteReason::OnlyCandidate
+    } else if has_complete_estimates {
+        RouteReason::EstimatedCompletion
     } else {
         RouteReason::LeastLoaded
     };
@@ -505,6 +795,322 @@ mod tests {
         assert_eq!(RouteReason::Affinity.as_str(), "Affinity");
         assert_eq!(RouteReason::OnlyCandidate.as_str(), "OnlyCandidate");
         assert_eq!(RouteReason::LeastLoaded.as_str(), "LeastLoaded");
+        assert_eq!(
+            RouteReason::EstimatedCompletion.as_str(),
+            "EstimatedCompletion"
+        );
+    }
+
+    fn observe_n(estimates: &mut ServiceTimeEstimates, node: &NodeSnapshot, elapsed_ms: u64) {
+        for _ in 0..MIN_SERVICE_TIME_SAMPLES {
+            estimates.observe(
+                node,
+                "m",
+                "/v1/chat/completions",
+                std::time::Duration::from_millis(elapsed_ms),
+            );
+        }
+    }
+
+    #[test]
+    fn completion_time_waits_for_every_candidate_before_using_estimates() {
+        let fast = ready("fast", Some("m"), 4);
+        let slow = ready("slow", Some("m"), 0);
+        let nodes = vec![fast.clone(), slow];
+        let mut estimates = ServiceTimeEstimates::default();
+        observe_n(&mut estimates, &fast, 100);
+
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/chat/completions"));
+        let decision =
+            route_reserved_with_estimates(&nodes, &request, &Reservations::none(), &estimates)
+                .expect("routes");
+
+        assert_eq!(decision.label, "slow", "cold estimates must fall back");
+        assert_eq!(decision.reason, RouteReason::LeastLoaded);
+    }
+
+    #[test]
+    fn completion_time_explores_cold_nodes_without_overriding_load() {
+        let nodes = vec![ready("a", Some("m"), 0), ready("b", Some("m"), 0)];
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/chat/completions"));
+        let mut estimates = ServiceTimeEstimates::default();
+        let mut chosen = Vec::new();
+
+        for _ in 0..(MIN_SERVICE_TIME_SAMPLES * 2) {
+            let decision =
+                route_reserved_with_estimates(&nodes, &request, &Reservations::none(), &estimates)
+                    .expect("routes");
+            chosen.push(decision.label.clone());
+            let node = nodes
+                .iter()
+                .find(|node| node.label() == decision.label)
+                .expect("chosen node exists");
+            estimates.selected(node, "m", "/v1/chat/completions");
+            estimates.observe(
+                node,
+                "m",
+                "/v1/chat/completions",
+                std::time::Duration::from_millis(100),
+            );
+        }
+
+        assert_eq!(
+            chosen,
+            vec!["a", "b", "a", "b", "a", "b", "a", "b", "a", "b"]
+        );
+
+        let busy_cold = ready("c", Some("m"), 1);
+        let decision = route_reserved_with_estimates(
+            &[nodes[0].clone(), busy_cold],
+            &request,
+            &Reservations::none(),
+            &estimates,
+        )
+        .expect("routes");
+        assert_eq!(
+            decision.label, "a",
+            "exploration may break an equal-load tie but must not override queue depth"
+        );
+    }
+
+    #[test]
+    fn a_failed_cold_selection_rotates_without_becoming_a_speed_sample() {
+        let nodes = vec![ready("a", Some("m"), 0), ready("b", Some("m"), 0)];
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/chat/completions"));
+        let mut estimates = ServiceTimeEstimates::default();
+
+        let first =
+            route_reserved_with_estimates(&nodes, &request, &Reservations::none(), &estimates)
+                .expect("routes");
+        assert_eq!(first.label, "a");
+        estimates.selected(&nodes[0], "m", "/v1/chat/completions");
+
+        let second =
+            route_reserved_with_estimates(&nodes, &request, &Reservations::none(), &estimates)
+                .expect("routes");
+        assert_eq!(
+            second.label, "b",
+            "a failed selection must not monopolise cold traffic"
+        );
+        assert_eq!(
+            estimates
+                .get(&nodes[0], Some("m"), Some("/v1/chat/completions"))
+                .expect("selection is tracked")
+                .samples,
+            0,
+            "selection recency must not masquerade as a successful service sample"
+        );
+    }
+
+    #[test]
+    fn invalidating_a_degraded_node_returns_the_class_to_cold_fallback() {
+        let fast = ready("fast", Some("m"), 4);
+        let slow = ready("slow", Some("m"), 0);
+        let nodes = vec![fast.clone(), slow.clone()];
+        let mut estimates = ServiceTimeEstimates::default();
+        observe_n(&mut estimates, &fast, 100);
+        observe_n(&mut estimates, &slow, 1_000);
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/chat/completions"));
+
+        let learned =
+            route_reserved_with_estimates(&nodes, &request, &Reservations::none(), &estimates)
+                .expect("routes");
+        assert_eq!(learned.label, "fast");
+
+        estimates.invalidate(&fast, "m", "/v1/chat/completions");
+        let after_failure =
+            route_reserved_with_estimates(&nodes, &request, &Reservations::none(), &estimates)
+                .expect("routes");
+        assert_eq!(after_failure.label, "slow");
+        assert_eq!(after_failure.reason, RouteReason::LeastLoaded);
+    }
+
+    #[test]
+    fn a_stale_estimate_is_explored_before_it_decides_placement_again() {
+        let now = std::time::Instant::now();
+        let fast = ready("fast", Some("m"), 4);
+        let slow = ready("slow", Some("m"), 0);
+        let nodes = vec![fast.clone(), slow.clone()];
+        let mut estimates = ServiceTimeEstimates::default();
+        for _ in 0..MIN_SERVICE_TIME_SAMPLES {
+            estimates.observe_at(
+                &fast,
+                "m",
+                "/v1/chat/completions",
+                std::time::Duration::from_millis(100),
+                now,
+            );
+            estimates.observe_at(
+                &slow,
+                "m",
+                "/v1/chat/completions",
+                std::time::Duration::from_millis(1_000),
+                now,
+            );
+        }
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/chat/completions"));
+
+        let learned = route_reserved_with_estimates_at(
+            &nodes,
+            &request,
+            &Reservations::none(),
+            &estimates,
+            now,
+        )
+        .expect("routes");
+        assert_eq!(learned.label, "fast");
+
+        let stale = route_reserved_with_estimates_at(
+            &nodes,
+            &request,
+            &Reservations::none(),
+            &estimates,
+            now + MAX_SERVICE_TIME_AGE + std::time::Duration::from_nanos(1),
+        )
+        .expect("routes");
+        assert_eq!(
+            stale.label, "slow",
+            "stale estimates must fall back to load"
+        );
+        assert_eq!(stale.reason, RouteReason::LeastLoaded);
+
+        estimates.observe_at(
+            &fast,
+            "m",
+            "/v1/chat/completions",
+            std::time::Duration::from_millis(100),
+            now + MAX_SERVICE_TIME_AGE + std::time::Duration::from_nanos(1),
+        );
+        assert_eq!(
+            estimates
+                .get(&fast, Some("m"), Some("/v1/chat/completions"))
+                .expect("the class remains present")
+                .samples,
+            1,
+            "one fresh sample must not revive a stale mature estimate"
+        );
+    }
+
+    #[test]
+    fn completion_time_accounts_for_both_speed_and_outstanding_work() {
+        let fast = ready("fast", Some("m"), 4);
+        let slow = ready("slow", Some("m"), 0);
+        let nodes = vec![fast.clone(), slow.clone()];
+        let mut estimates = ServiceTimeEstimates::default();
+        observe_n(&mut estimates, &fast, 100);
+        observe_n(&mut estimates, &slow, 1_000);
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/chat/completions"));
+
+        let decision =
+            route_reserved_with_estimates(&nodes, &request, &Reservations::none(), &estimates)
+                .expect("routes");
+        assert_eq!(decision.label, "fast");
+        assert_eq!(decision.reason, RouteReason::EstimatedCompletion);
+
+        let fast = ready("fast", Some("m"), 9);
+        let decision = route_reserved_with_estimates(
+            &[fast, slow],
+            &request,
+            &Reservations::none(),
+            &estimates,
+        )
+        .expect("routes");
+        assert_eq!(
+            decision.label, "slow",
+            "the slow node must receive work once the fast node's queue erases its advantage"
+        );
+    }
+
+    #[test]
+    fn service_time_is_scoped_to_node_identity_model_and_workload() {
+        let measured = ready("fast", Some("m"), 4);
+        let other = ready("slow", Some("m"), 0);
+        let mut estimates = ServiceTimeEstimates::default();
+        observe_n(&mut estimates, &measured, 100);
+        observe_n(&mut estimates, &other, 1_000);
+
+        let another_fast = ready("fast", Some("another-model"), 4);
+        let another_slow = ready("slow", Some("another-model"), 0);
+        let another_model = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("another-model"))
+            .with_service_class(Some("/v1/chat/completions"));
+        let decision = route_reserved_with_estimates(
+            &[another_fast, another_slow],
+            &another_model,
+            &Reservations::none(),
+            &estimates,
+        )
+        .expect("routes");
+        assert_eq!(decision.label, "slow");
+        assert_eq!(decision.reason, RouteReason::LeastLoaded);
+
+        let another_route = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/embeddings"));
+        let decision = route_reserved_with_estimates(
+            &[measured.clone(), other.clone()],
+            &another_route,
+            &Reservations::none(),
+            &estimates,
+        )
+        .expect("routes");
+        assert_eq!(decision.label, "slow");
+        assert_eq!(decision.reason, RouteReason::LeastLoaded);
+
+        let mut moved = measured.clone();
+        moved.spec.port += 1;
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/chat/completions"));
+        let decision = route_reserved_with_estimates(
+            &[moved, other],
+            &request,
+            &Reservations::none(),
+            &estimates,
+        )
+        .expect("routes");
+        assert_eq!(decision.reason, RouteReason::LeastLoaded);
+    }
+
+    #[test]
+    fn service_time_state_is_bounded() {
+        let node = ready("node", Some("m"), 0);
+        let now = std::time::Instant::now();
+        let mut estimates = ServiceTimeEstimates::default();
+        for index in 0..=MAX_SERVICE_CLASSES {
+            estimates.selected_at(
+                &node,
+                "m",
+                &format!("workload-{index}"),
+                now + std::time::Duration::from_nanos(index as u64),
+            );
+        }
+
+        assert_eq!(estimates.0.len(), MAX_SERVICE_CLASSES);
+        assert!(
+            estimates
+                .get(&node, Some("m"), Some("workload-0"))
+                .is_none(),
+            "the least-recent entry was not pruned"
+        );
+        assert!(
+            estimates
+                .get(&node, Some("m"), Some("workload-1024"))
+                .is_some(),
+            "the newest entry was pruned"
+        );
     }
 
     #[test]

--- a/src/fabric/policy.rs
+++ b/src/fabric/policy.rs
@@ -399,6 +399,17 @@ impl ServiceTimeEstimates {
         let class = ServiceClass::of(node, model, workload?)?;
         self.0.get(&class).copied()
     }
+
+    #[cfg(test)]
+    pub(crate) fn sample_for(
+        &self,
+        node: &NodeSnapshot,
+        model: &str,
+        workload: &str,
+    ) -> Option<(u128, u32)> {
+        self.get(node, Some(model), Some(workload))
+            .map(|estimate| (estimate.mean_nanos, estimate.samples))
+    }
 }
 
 /// One eligible node reduced to the fields selection actually uses.
@@ -419,7 +430,7 @@ struct Candidate<'a> {
 /// Adding them instead would double-count for most of a request's life, and
 /// would do so asymmetrically: a node busy with this fabric's work would be
 /// ranked worse than a node equally busy with somebody else's.
-fn load_of(observed: usize, reserved: usize) -> usize {
+pub(crate) fn load_of(observed: usize, reserved: usize) -> usize {
     observed.max(reserved)
 }
 

--- a/src/fabric/policy.rs
+++ b/src/fabric/policy.rs
@@ -831,6 +831,29 @@ mod tests {
         assert_eq!(decision.reason, RouteReason::LeastLoaded);
     }
 
+    /// The point of this mode is that idle is not the same as fast. Given real
+    /// service costs, a node three requests deep still wins if it is ten times
+    /// quicker than the idle one.
+    #[test]
+    fn a_fast_busy_node_beats_a_slow_idle_one() {
+        let fast = ready("fast", Some("m"), 3);
+        let slow = ready("slow", Some("m"), 0);
+        let nodes = vec![fast.clone(), slow.clone()];
+        let mut estimates = ServiceTimeEstimates::default();
+        observe_n(&mut estimates, &fast, 40);
+        observe_n(&mut estimates, &slow, 400);
+
+        let request = RouteRequest::new(RouteMode::CompletionTime)
+            .with_model(Some("m"))
+            .with_service_class(Some("/v1/chat/completions"));
+        let decision =
+            route_reserved_with_estimates(&nodes, &request, &Reservations::none(), &estimates)
+                .expect("routes");
+
+        assert_eq!(decision.label, "fast");
+        assert_eq!(decision.reason, RouteReason::EstimatedCompletion);
+    }
+
     #[test]
     fn completion_time_explores_cold_nodes_without_overriding_load() {
         let nodes = vec![ready("a", Some("m"), 0), ready("b", Some("m"), 0)];

--- a/src/fabric/server.rs
+++ b/src/fabric/server.rs
@@ -108,8 +108,8 @@ use serde_json::Value;
 
 use super::client_keys::Admission;
 use super::policy::{route, RouteDecision, RouteError, RouteMode, RouteRequest};
-use super::{self as fabric, Cancel, DispatchError, Fabric, ForwardError, StreamOutcome};
 use crate::api::{ApiAuth, DEFAULT_MAX_REQUEST_BODY_BYTES};
+use crate::fabric::{self as fabric, Cancel, DispatchError, Fabric, ForwardError, StreamOutcome};
 use crate::tls_pair::resolve_tls;
 
 /// Optional header a client sends to request affinity to a specific node.
@@ -1122,7 +1122,7 @@ async fn stream_completion(
             &dispatch_cancel,
         );
 
-        let (mut streaming, _placement) = match outcome {
+        let (mut streaming, mut placement) = match outcome {
             Err(error) => {
                 let _ = start_tx.send(StreamStart::Failed(error));
                 return;
@@ -1156,19 +1156,38 @@ async fn stream_completion(
                 }
             }
         };
+        let mut client_backpressured = false;
 
         loop {
             match streaming.next_chunk() {
-                Ok(None) => return,
+                Ok(None) => {
+                    if !client_backpressured {
+                        placement.record_success(streaming.elapsed());
+                    }
+                    return;
+                }
                 Ok(Some(chunk)) => {
                     // A closed channel means the client hung up. Returning drops
                     // the node's socket with it, so the generation is not left
                     // running for nobody.
-                    if chunk_tx.blocking_send(Ok(chunk)).is_err() {
-                        return;
+                    match chunk_tx.try_send(Ok(chunk)) {
+                        Ok(()) => {}
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(chunk)) => {
+                            // Once the channel fills, elapsed wall time includes
+                            // client backpressure rather than only node service.
+                            // Finish relaying, but never train placement on it.
+                            client_backpressured = true;
+                            if chunk_tx.blocking_send(chunk).is_err() {
+                                return;
+                            }
+                        }
+                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => return,
                     }
                 }
                 Err(error) => {
+                    if !matches!(error, ForwardError::Cancelled { .. }) {
+                        placement.invalidate_service_time();
+                    }
                     let _ = chunk_tx.blocking_send(Err(error.to_string()));
                     return;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1112,12 +1112,26 @@ fn read_tokenizer_gguf(
     Ok(gguf)
 }
 
-/// Parse the `--mode` flag shared by `fabric route` and `fabric run`.
+/// Parse the placement mode used by a resident or request-sending fabric.
 fn route_mode(raw: &str) -> anyhow::Result<camelid::fabric::RouteMode> {
     match raw {
         "throughput" => Ok(camelid::fabric::RouteMode::Throughput),
+        "completion-time" => Ok(camelid::fabric::RouteMode::CompletionTime),
         "affinity" => Ok(camelid::fabric::RouteMode::Affinity),
-        other => anyhow::bail!("unknown mode `{other}`; expected `throughput` or `affinity`"),
+        other => anyhow::bail!(
+            "unknown mode `{other}`; expected `throughput`, `completion-time` or `affinity`"
+        ),
+    }
+}
+
+/// A one-shot command owns no reusable service history, so it cannot honestly
+/// offer the resident completion-time policy.
+fn stateless_route_mode(raw: &str) -> anyhow::Result<camelid::fabric::RouteMode> {
+    match route_mode(raw)? {
+        camelid::fabric::RouteMode::CompletionTime => anyhow::bail!(
+            "mode `completion-time` learns across completed requests and is available only to the resident `fabric serve` command"
+        ),
+        mode => Ok(mode),
     }
 }
 
@@ -1215,7 +1229,8 @@ enum FabricAction {
         #[arg(long, value_name = "PATH")]
         nodes_file: Option<PathBuf>,
         /// `throughput` spreads independent requests; `affinity` keeps a session
-        /// on the node whose prefix and KV cache are already warm.
+        /// on the node whose prefix and KV cache are already warm. The learned
+        /// `completion-time` mode is unavailable to this stateless dry run.
         #[arg(long, default_value = "throughput")]
         mode: String,
         /// Only consider nodes serving this exact model id.
@@ -1251,6 +1266,8 @@ enum FabricAction {
         /// The user message to send.
         #[arg(long)]
         prompt: String,
+        /// `throughput` ranks queue depth; `affinity` prefers the requested
+        /// sticky node. Use resident `fabric serve` for learned placement.
         #[arg(long, default_value = "throughput")]
         mode: String,
         /// Require a node serving this exact model id. When omitted, the fabric
@@ -1305,8 +1322,9 @@ enum FabricAction {
         nodes_file: Option<PathBuf>,
         #[arg(long, default_value = "127.0.0.1:8282")]
         addr: SocketAddr,
-        /// Default placement mode; a client can still request affinity to a
-        /// specific node via the `x-camelid-fabric-sticky` request header.
+        /// Default placement mode. `completion-time` learns successful service
+        /// time per node, model and route; it falls back to queue depth until
+        /// every candidate is warm. A sticky header still requests affinity.
         #[arg(long, default_value = "throughput")]
         mode: String,
         /// Bearer token for nodes started with an API key. Falls back to
@@ -1432,6 +1450,28 @@ mod fabric_command_tests {
         assert_eq!(resolve_bearer(None, Some(String::new())), None);
         assert_eq!(resolve_bearer(None, Some("   ".into())), None);
         assert_eq!(resolve_bearer(Some("  ".into()), None), None);
+    }
+
+    #[test]
+    fn completion_time_is_available_only_to_the_resident_command() {
+        assert_eq!(
+            route_mode("completion-time").expect("resident mode parses"),
+            camelid::fabric::RouteMode::CompletionTime
+        );
+        assert!(stateless_route_mode("completion-time").is_err());
+
+        on_cli_test_stack(|| {
+            let argv = [
+                "camelid",
+                "fabric",
+                "serve",
+                "--node",
+                "a=127.0.0.1",
+                "--mode",
+                "completion-time",
+            ];
+            Cli::try_parse_from(argv).expect("resident mode must parse");
+        });
     }
 
     #[test]
@@ -3184,7 +3224,7 @@ async fn main() -> anyhow::Result<()> {
                 json,
             } => {
                 let bearer = fabric_bearer(bearer);
-                let mode = route_mode(&mode)?;
+                let mode = stateless_route_mode(&mode)?;
                 let fabric = fabric_from(nodes, nodes_file)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref());
@@ -3231,7 +3271,7 @@ async fn main() -> anyhow::Result<()> {
                 json,
             } => {
                 let bearer = fabric_bearer(bearer);
-                let mode = route_mode(&mode)?;
+                let mode = stateless_route_mode(&mode)?;
                 let fabric = fabric_from(nodes, nodes_file)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref());

--- a/tests/fabric_serve.rs
+++ b/tests/fabric_serve.rs
@@ -51,6 +51,8 @@ struct StubConfig {
     health: String,
     completion: String,
     completion_status: u16,
+    /// Mutable status for a node that degrades after the policy has learned it.
+    live_completion_status: Option<Arc<AtomicUsize>>,
     /// Held before answering `/v1/chat/completions`, to stand in for a real
     /// generation that takes a while. Health is never delayed.
     completion_delay: Duration,
@@ -70,6 +72,8 @@ struct StubConfig {
     /// Hang up after the events instead of writing the terminal chunk, which is
     /// what a node that dies mid-generation leaves on the wire.
     stream_truncated: bool,
+    /// Mutable truncation for a stream that degrades after warm-up.
+    live_stream_truncated: Option<Arc<AtomicBool>>,
     /// Events actually written to the socket. It stops advancing once the peer
     /// has gone, which is how a cancellation test observes the hang-up.
     events_written: Arc<AtomicUsize>,
@@ -86,6 +90,9 @@ struct StubConfig {
     /// write until it is finished, so unlike `events_written` there is no
     /// failing write to reveal a hang-up — it has to be looked for.
     completion_watch: Duration,
+    /// Mutable work duration for a node that is made long-running only for a
+    /// cancellation probe after quick policy warm-up.
+    live_completion_watch: Option<Arc<Mutex<Duration>>>,
     /// How far into `completion_watch` the caller went away, if it did.
     caller_left_after: Arc<Mutex<Option<Duration>>>,
 }
@@ -102,16 +109,19 @@ impl StubConfig {
                 r#"{{"choices":[{{"message":{{"role":"assistant","content":"served by {model}"}}}}]}}"#
             ),
             completion_status: 200,
+            live_completion_status: None,
             completion_delay: Duration::ZERO,
             required_key: None,
             hangs_up_on_completion: false,
             stream_events: Vec::new(),
             stream_gap: Duration::ZERO,
             stream_truncated: false,
+            live_stream_truncated: None,
             events_written: Arc::new(AtomicUsize::new(0)),
             live_in_flight: None,
             live_model: None,
             completion_watch: Duration::ZERO,
+            live_completion_watch: None,
             caller_left_after: Arc::new(Mutex::new(None)),
         }
     }
@@ -330,14 +340,14 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
     }
 
     if authorized
-        && !config.completion_watch.is_zero()
+        && !completion_watch(config).is_zero()
         && PLACED_ROUTES.contains(&received.path.as_str())
     {
         // Recorded before the work starts, so a test can wait until the node
         // really holds the request before taking its caller away.
         requests.lock().expect("stub lock").push(received);
         if caller_stayed(stream, config) {
-            write_json(stream, config.completion_status, &config.completion);
+            write_json(stream, completion_status(config), &config.completion);
         }
         return;
     }
@@ -361,7 +371,7 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
             if let Some(count) = busy {
                 count.fetch_sub(1, Ordering::SeqCst);
             }
-            (config.completion_status, config.completion.clone())
+            (completion_status(config), config.completion.clone())
         }
         _ => (404, "{}".to_string()),
     };
@@ -381,6 +391,15 @@ fn write_json(stream: &mut TcpStream, status: u16, body: &str) {
     let _ = stream.flush();
 }
 
+fn completion_status(config: &StubConfig) -> u16 {
+    config
+        .live_completion_status
+        .as_ref()
+        .map_or(config.completion_status, |status| {
+            status.load(Ordering::SeqCst) as u16
+        })
+}
+
 /// Work on a placed request for `completion_watch`, watching the socket for the
 /// caller going away, and report whether it was still there at the end.
 ///
@@ -390,6 +409,7 @@ fn write_json(stream: &mut TcpStream, status: u16, body: &str) {
 /// handler frame is dropped when the connection is.
 fn caller_stayed(stream: &mut TcpStream, config: &StubConfig) -> bool {
     let started = Instant::now();
+    let hold = completion_watch(config);
     if stream
         .set_read_timeout(Some(Duration::from_millis(20)))
         .is_err()
@@ -397,7 +417,7 @@ fn caller_stayed(stream: &mut TcpStream, config: &StubConfig) -> bool {
         return false;
     }
     let mut scratch = [0_u8; 64];
-    while started.elapsed() < config.completion_watch {
+    while started.elapsed() < hold {
         let gone = match stream.read(&mut scratch) {
             // A graceful close reads as end-of-file and an abortive one as an
             // error; both mean the caller has gone.
@@ -416,6 +436,15 @@ fn caller_stayed(stream: &mut TcpStream, config: &StubConfig) -> bool {
         }
     }
     true
+}
+
+fn completion_watch(config: &StubConfig) -> Duration {
+    config
+        .live_completion_watch
+        .as_ref()
+        .map_or(config.completion_watch, |watch| {
+            *watch.lock().expect("stub watch lock")
+        })
 }
 
 /// What `/v1/health` answers: the configured body, carrying whatever load and
@@ -454,7 +483,12 @@ fn serve_event_stream(stream: &mut TcpStream, config: &StubConfig) {
         }
         config.events_written.fetch_add(1, Ordering::SeqCst);
     }
-    if config.stream_truncated {
+    if config.stream_truncated
+        || config
+            .live_stream_truncated
+            .as_ref()
+            .is_some_and(|truncated| truncated.load(Ordering::SeqCst))
+    {
         return;
     }
     let _ = stream.write_all(b"0\r\n\r\n");
@@ -1454,6 +1488,7 @@ async fn a_client_hanging_up_stops_the_node_generating() {
 /// there is anything to abandon. Polling the node beats sleeping a guess: the
 /// point of the measurement afterwards is that it is not a timing coincidence.
 async fn post_then_hang_up(addr: SocketAddr, node: &StubNode, path: &str, body: Value) {
+    let already_received = served_on(std::slice::from_ref(node), path)[0];
     let mut stream = tokio::net::TcpStream::connect(addr)
         .await
         .expect("connect to proxy");
@@ -1468,7 +1503,7 @@ async fn post_then_hang_up(addr: SocketAddr, node: &StubNode, path: &str, body: 
         .expect("write request");
 
     let deadline = Instant::now() + Duration::from_secs(10);
-    while served_on(std::slice::from_ref(node), path)[0] == 0 {
+    while served_on(std::slice::from_ref(node), path)[0] <= already_received {
         assert!(
             Instant::now() < deadline,
             "the node never received the request, so there was nothing to abandon"
@@ -1476,6 +1511,46 @@ async fn post_then_hang_up(addr: SocketAddr, node: &StubNode, path: &str, body: 
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
     drop(stream);
+}
+
+/// Send one request and return which candidate held it before hanging up.
+async fn post_then_hang_up_on_one(
+    addr: SocketAddr,
+    nodes: &[&StubNode],
+    path: &str,
+    body: Value,
+) -> usize {
+    let before: Vec<usize> = nodes
+        .iter()
+        .map(|node| served_on(std::slice::from_ref(*node), path)[0])
+        .collect();
+    let mut stream = tokio::net::TcpStream::connect(addr)
+        .await
+        .expect("connect to proxy");
+    let payload = body.to_string();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(index) = nodes.iter().enumerate().find_map(|(index, node)| {
+            (served_on(std::slice::from_ref(*node), path)[0] > before[index]).then_some(index)
+        }) {
+            drop(stream);
+            return index;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no node received the request, so there was nothing to abandon"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
 }
 
 /// What the node observed, once it observes anything, or `None` if it never did.
@@ -1645,6 +1720,290 @@ async fn a_burst_of_requests_spreads_across_the_nodes_serving_the_model() {
     assert!(
         served.iter().all(|count| *count > 0),
         "a node serving the model was never used: {served:?}"
+    );
+}
+
+/// Completion-time placement learns only from completed requests, then uses
+/// the measured service difference instead of treating equal queue depths as
+/// equal machines.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn completion_time_learns_buffered_service_speed_over_real_sockets() {
+    const WARMUP_REQUESTS: usize = 10;
+    const MEASURED_REQUESTS: usize = 6;
+    let nodes = vec![
+        StubNode::start(StubConfig::slow("shared-model", Duration::from_millis(20))),
+        StubNode::start(StubConfig::slow("shared-model", Duration::from_millis(200))),
+    ];
+    let fabric = fabric_reusing_observations(
+        vec![nodes[0].spec("fast"), nodes[1].spec("slow")],
+        Duration::from_secs(30),
+    );
+    let addr = start_proxy(fabric, RouteMode::CompletionTime).await;
+    let body = serde_json::json!({ "model": "shared-model" });
+
+    for _ in 0..WARMUP_REQUESTS {
+        let (status, _, headers) = post_chat(addr, &body, &[]).await;
+        assert_eq!(status, 200);
+        assert_eq!(
+            header(&headers, "x-camelid-fabric-reason"),
+            Some("LeastLoaded"),
+            "the policy must say when it is still using the cold fallback"
+        );
+    }
+    assert_eq!(
+        completions_served(&nodes),
+        [5, 5],
+        "cold exploration must collect the same number of samples from both nodes"
+    );
+
+    for _ in 0..MEASURED_REQUESTS {
+        let (status, _, headers) = post_chat(addr, &body, &[]).await;
+        assert_eq!(status, 200);
+        assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("fast"));
+        assert_eq!(
+            header(&headers, "x-camelid-fabric-reason"),
+            Some("EstimatedCompletion")
+        );
+    }
+    assert_eq!(completions_served(&nodes), [5 + MEASURED_REQUESTS, 5]);
+}
+
+/// A quick failure is not quick service. Counting it would teach the policy to
+/// prefer the node that fails fastest, which is worse than speed-blind routing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn completion_time_never_learns_from_http_failures() {
+    let failing = StubNode::start(StubConfig {
+        completion_status: 500,
+        completion: r#"{"error":{"message":"generation failed"}}"#.to_string(),
+        ..StubConfig::ready("shared-model", 0)
+    });
+    let serving = StubNode::start(StubConfig::slow("shared-model", Duration::from_millis(60)));
+    let fabric = fabric_reusing_observations(
+        vec![failing.spec("a-failing"), serving.spec("b-serving")],
+        Duration::from_secs(30),
+    );
+    let addr = start_proxy(fabric, RouteMode::CompletionTime).await;
+    let body = serde_json::json!({ "model": "shared-model" });
+
+    let mut statuses = Vec::new();
+    for _ in 0..12 {
+        let (status, _, headers) = post_chat(addr, &body, &[]).await;
+        statuses.push(status);
+        assert_eq!(
+            header(&headers, "x-camelid-fabric-reason"),
+            Some("LeastLoaded"),
+            "a failed request must never mature the completion-time policy"
+        );
+    }
+    assert_eq!(statuses.iter().filter(|status| **status == 500).count(), 6);
+    assert_eq!(statuses.iter().filter(|status| **status == 200).count(), 6);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn completion_time_invalidates_a_learned_node_on_5xx() {
+    let fast_status = Arc::new(AtomicUsize::new(200));
+    let fast = StubNode::start(StubConfig {
+        completion_delay: Duration::from_millis(20),
+        live_completion_status: Some(Arc::clone(&fast_status)),
+        ..StubConfig::ready("shared-model", 0)
+    });
+    let slow = StubNode::start(StubConfig::slow("shared-model", Duration::from_millis(200)));
+    let fabric = fabric_reusing_observations(
+        vec![fast.spec("fast"), slow.spec("slow")],
+        Duration::from_secs(30),
+    );
+    let addr = start_proxy(fabric, RouteMode::CompletionTime).await;
+    let body = serde_json::json!({ "model": "shared-model" });
+
+    for _ in 0..10 {
+        assert_eq!(post_chat(addr, &body, &[]).await.0, 200);
+    }
+    fast_status.store(500, Ordering::SeqCst);
+
+    // Force the failure through affinity: invalidation describes the node's
+    // health, not the policy that happened to select it.
+    let (failed, _, failed_headers) =
+        post_chat(addr, &body, &[("x-camelid-fabric-sticky", "fast")]).await;
+    assert_eq!(failed, 500);
+    assert_eq!(
+        header(&failed_headers, "x-camelid-fabric-node"),
+        Some("fast")
+    );
+    assert_eq!(
+        header(&failed_headers, "x-camelid-fabric-reason"),
+        Some("Affinity")
+    );
+
+    let (recovered, _, recovered_headers) = post_chat(addr, &body, &[]).await;
+    assert_eq!(recovered, 200);
+    assert_eq!(
+        header(&recovered_headers, "x-camelid-fabric-node"),
+        Some("slow")
+    );
+    assert_eq!(
+        header(&recovered_headers, "x-camelid-fabric-reason"),
+        Some("LeastLoaded"),
+        "the 5xx must return the class to cold fallback"
+    );
+}
+
+/// Streaming service time ends at clean EOF, not when the response head
+/// arrives. Otherwise a slow decoder that flushes an early role frame would
+/// look identical to a fast one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn completion_time_learns_streaming_service_through_clean_eof() {
+    const EVENTS: [&str; 2] = ["data: token\n\n", "data: [DONE]\n\n"];
+    let fast = StubNode::start(StubConfig::streaming(
+        "shared-model",
+        &EVENTS,
+        Duration::from_millis(5),
+    ));
+    let slow = StubNode::start(StubConfig::streaming(
+        "shared-model",
+        &EVENTS,
+        Duration::from_millis(50),
+    ));
+    let fabric = fabric_reusing_observations(
+        vec![fast.spec("fast"), slow.spec("slow")],
+        Duration::from_secs(30),
+    );
+    let addr = start_proxy(fabric, RouteMode::CompletionTime).await;
+    let body = serde_json::json!({ "model": "shared-model", "stream": true });
+
+    for _ in 0..10 {
+        let (status, headers, pieces) = post_chat_streaming(addr, &body).await;
+        assert_eq!(status, 200);
+        assert_eq!(
+            header(&headers, "x-camelid-fabric-reason"),
+            Some("LeastLoaded")
+        );
+        let framed: String = pieces.iter().map(|piece| piece.text.as_str()).collect();
+        assert_eq!(dechunk(&framed), EVENTS.concat());
+    }
+
+    for _ in 0..4 {
+        let (status, headers, pieces) = post_chat_streaming(addr, &body).await;
+        assert_eq!(status, 200);
+        assert_eq!(header(&headers, "x-camelid-fabric-node"), Some("fast"));
+        assert_eq!(
+            header(&headers, "x-camelid-fabric-reason"),
+            Some("EstimatedCompletion")
+        );
+        let framed: String = pieces.iter().map(|piece| piece.text.as_str()).collect();
+        assert_eq!(dechunk(&framed), EVENTS.concat());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn completion_time_invalidates_a_stream_that_stops_before_clean_eof() {
+    const EVENTS: [&str; 2] = ["data: token\n\n", "data: [DONE]\n\n"];
+    let fast_truncated = Arc::new(AtomicBool::new(false));
+    let fast = StubNode::start(StubConfig {
+        live_stream_truncated: Some(Arc::clone(&fast_truncated)),
+        ..StubConfig::streaming("shared-model", &EVENTS, Duration::from_millis(5))
+    });
+    let slow = StubNode::start(StubConfig::streaming(
+        "shared-model",
+        &EVENTS,
+        Duration::from_millis(50),
+    ));
+    let fabric = fabric_reusing_observations(
+        vec![fast.spec("fast"), slow.spec("slow")],
+        Duration::from_secs(30),
+    );
+    let addr = start_proxy(fabric, RouteMode::CompletionTime).await;
+    let body = serde_json::json!({ "model": "shared-model", "stream": true });
+
+    for _ in 0..10 {
+        assert_eq!(post_chat_streaming(addr, &body).await.0, 200);
+    }
+    fast_truncated.store(true, Ordering::SeqCst);
+
+    let (status, failed_headers, failed_pieces) = post_chat_streaming(addr, &body).await;
+    assert_eq!(status, 200, "the response head arrived before truncation");
+    assert_eq!(
+        header(&failed_headers, "x-camelid-fabric-node"),
+        Some("fast")
+    );
+    let failed: String = failed_pieces
+        .iter()
+        .map(|piece| piece.text.as_str())
+        .collect();
+    assert!(
+        !failed.ends_with("0\r\n\r\n"),
+        "the failed stream looked complete"
+    );
+
+    let (recovered, recovered_headers, _) = post_chat_streaming(addr, &body).await;
+    assert_eq!(recovered, 200);
+    assert_eq!(
+        header(&recovered_headers, "x-camelid-fabric-node"),
+        Some("slow")
+    );
+    assert_eq!(
+        header(&recovered_headers, "x-camelid-fabric-reason"),
+        Some("LeastLoaded")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn completion_time_keeps_a_learned_estimate_when_only_the_client_leaves() {
+    let fast_watch = Arc::new(Mutex::new(Duration::from_millis(50)));
+    let fast_config = StubConfig {
+        live_completion_watch: Some(Arc::clone(&fast_watch)),
+        ..StubConfig::ready("shared-model", 0)
+    };
+    let fast_left = Arc::clone(&fast_config.caller_left_after);
+    let fast = StubNode::start(fast_config);
+    let slow_watch = Arc::new(Mutex::new(Duration::from_millis(300)));
+    let slow_config = StubConfig {
+        live_completion_watch: Some(Arc::clone(&slow_watch)),
+        ..StubConfig::ready("shared-model", 0)
+    };
+    let slow_left = Arc::clone(&slow_config.caller_left_after);
+    let slow = StubNode::start(slow_config);
+    let fabric = fabric_reusing_observations(
+        vec![fast.spec("fast"), slow.spec("slow")],
+        Duration::from_secs(30),
+    );
+    let addr = start_proxy_waiting(
+        fabric,
+        RouteMode::CompletionTime,
+        ClientAuth::none(),
+        Duration::from_secs(5),
+    )
+    .await;
+    let body = serde_json::json!({ "model": "shared-model" });
+
+    for _ in 0..10 {
+        assert_eq!(post_chat(addr, &body, &[]).await.0, 200);
+    }
+
+    *fast_watch.lock().expect("fast watch lock") = Duration::from_secs(30);
+    *slow_watch.lock().expect("slow watch lock") = Duration::from_secs(30);
+
+    let candidates = [&fast, &slow];
+    let left = [&fast_left, &slow_left];
+    let labels = ["fast", "slow"];
+    let winner =
+        post_then_hang_up_on_one(addr, &candidates, "/v1/chat/completions", body.clone()).await;
+    caller_left_within(left[winner], Duration::from_secs(3))
+        .await
+        .expect("the learned node never observed the client cancellation");
+
+    *fast_watch.lock().expect("fast watch lock") = Duration::from_millis(50);
+    *slow_watch.lock().expect("slow watch lock") = Duration::from_millis(300);
+
+    let (status, _, headers) = post_chat(addr, &body, &[]).await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-node"),
+        Some(labels[winner])
+    );
+    assert_eq!(
+        header(&headers, "x-camelid-fabric-reason"),
+        Some("EstimatedCompletion"),
+        "client cancellation must not invalidate a healthy node's estimate"
     );
 }
 


### PR DESCRIPTION
## Summary

- add an opt-in resident `completion-time` placement mode while leaving `throughput` as the default
- learn workload-scoped service durations only from clean, queue-free buffered completions and clean, queue-free streaming EOF, then rank mature candidates by `(load + 1) * estimated service time`
- preserve least-load cold fallback until every eligible candidate has five fresh samples, invalidate node-attributable failures, expire estimates after five minutes, and bound in-memory state to 1,024 entries
- keep busy placements, queue-full refusals, client cancellation, affinity-selected successes, and client-backpressured streams out of timing samples
- reject the stateful mode from one-shot `fabric route` and `fabric run`, and document the complete operational contract

## Design

The estimate key includes node label and authority, backend/version, model, API path, streaming shape, request-byte bucket, and requested-output-token bucket. Prompt and response content are never retained.

Only a successful completion placed at observed-or-reserved load zero is a duration sample. Busy completions are skipped because total in-flight work can belong to other workload classes; dividing sojourn time by that count would fabricate a per-class service duration. Non-backpressure 5xx, unreachable/transport, malformed-body, and truncated-stream failures invalidate the relevant estimate and force a fresh five-sample warmup. Queue saturation and cancellation are not node-speed evidence. Streaming is sampled only at clean EOF and never after the relay has observed client backpressure.

The mature score uses integer nanoseconds with saturating `u128` multiplication. Mature ties break by load and then label. Estimate state is process-local and intentionally resets on restart.

## Validation

- `rustup run 1.89.0 cargo test --all-targets` with `CARGO_BUILD_JOBS=1`: passed
- focused fabric coverage: 304 passed, 0 failed
  - policy: 33 passed
  - fabric library: 215 passed
  - fabric end-to-end: 15 passed
  - resident proxy: 74 passed
- CLI tests: 8 passed, 0 failed
- pinned Rust 1.89 all-target Clippy with `-D warnings`: passed with only scoped allowances for verified pre-existing `duplicated_attributes` and `needless_range_loop` warnings in untouched code
- rustdoc broken-link gate: passed
- available `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- public scrub: passed
- VS Code diagnostics: no errors in touched Rust files

A parallel Windows all-target compile first hit `rustc` `STATUS_STACK_BUFFER_OVERRUN`; the one-job pinned retry compiled the same targets and completed the full suite successfully. Windows Defender later blocked a newly downloaded pinned `rustfmt.exe` with OS error 225, so CI remains authoritative for the exact Rust 1.89 formatting binary.

## Performance evidence

This PR makes no throughput or latency improvement claim. The paired F3 Macs and their tunnels are currently unavailable, so the required interleaved physical `throughput` versus `completion-time` campaign could not be run. The policy is opt-in and the existing default is unchanged pending that measurement.