### PR TITLE
feat(fabric): authenticate and encrypt node transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ serde_json = "1"
 sha2 = "0.10"
 minijinja = { version = "2", features = ["json"] }
 rust-embed = { version = "8", features = ["mime-guess"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
+rustls-pki-types = "1"
 libc = "0.2"
 rayon = "1"
 ratatui = "0.29"
@@ -161,8 +163,6 @@ tempfile = "3"
 # HTTPS to the proxy, rather than committing a private key or trusting that an
 # untested branch serves what it claims.
 rcgen = { version = "0.13", default-features = false, features = ["aws_lc_rs", "pem"] }
-rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
-rustls-pki-types = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 
 [lints.rust]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -225,6 +225,11 @@ only to another machine. Direct cleartext requires the explicit
 `CAMELID_ALLOW_CLEARTEXT_NODE_TRANSPORT=1`). This is separate from
 `--allow-cleartext-remote`, which controls the client-facing proxy listener.
 
+Named nodes use the host operating system's resolver, preserving its hosts-file, split-DNS, VPN, and
+multicast-discovery behavior. Resolution runs in a fixed-size process-wide pool and shares the
+command's deadline, so a stuck resolver cannot hold the calling request indefinitely or grow one
+thread per request. IP literals bypass resolution and remain usable even while DNS is unavailable.
+
 For direct connections between machines, issue each node a certificate from one private CA. The
 certificate SAN must match the exact host or IP literal in `LABEL=HOST[:PORT]`; a DNS name is not
 accepted merely because it resolves to the certificate's IP. Start each node with the normal engine

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -204,10 +204,63 @@ Three limits are deliberate and worth knowing before you deploy it:
   `fabric status|route|run`. A node started with `--api-key` needs it: `/v1/health` is exempt from
   that node's auth, so without a token the node observes as ready and then answers every forwarded
   request with 401.
-- **TLS covers the client's hop only.** What the proxy speaks to a node is whatever that node's
-  listener speaks, and the proxy has no way to speak TLS to one. On a fabric whose nodes are not
-  loopback, the bearer above and every prompt and completion still cross that network unencrypted,
-  whatever the proxy presents to its own clients. Keep those hops on a trusted link.
+- Client-facing TLS (`--tls-cert`/`--tls-key`) and node-facing TLS (`--node-tls-ca`) are independent.
+  Configuring one does not protect the other hop.
+
+### Encrypting the node hop
+
+Every Fabric command applies the same node transport policy to health probes, buffered requests,
+streaming requests, failover attempts, and nodes added later through `--nodes-file`.
+
+| Node transport | Required option | Reachable nodes |
+|---|---|---|
+| CA-pinned TLS | `--node-tls-ca <PATH>` | any address whose certificate SAN matches the configured host/IP |
+| tunnel/local cleartext | none | loopback resolutions only |
+| direct cleartext | `--allow-cleartext-node-transport` | any resolution, explicitly unencrypted |
+
+Without extra flags, cleartext node transport is restricted after DNS resolution to loopback
+addresses. That preserves local nodes and encrypted tunnels while refusing a hostname that resolves
+only to another machine. Direct cleartext requires the explicit
+`--allow-cleartext-node-transport` acknowledgement (or
+`CAMELID_ALLOW_CLEARTEXT_NODE_TRANSPORT=1`). This is separate from
+`--allow-cleartext-remote`, which controls the client-facing proxy listener.
+
+For direct connections between machines, issue each node a certificate from one private CA. The
+certificate SAN must match the exact host or IP literal in `LABEL=HOST[:PORT]`; a DNS name is not
+accepted merely because it resolves to the certificate's IP. Start each node with the normal engine
+TLS and API-key options, then pin that CA at the Fabric:
+
+```bash
+# On each node (use that node's own certificate and key):
+camelid serve \
+  --addr <NODE-HOST>:8181 \
+  --model /path/to/model.gguf \
+  --api-key-file ./node-api.key \
+  --tls-cert ./node-cert-chain \
+  --tls-key ./node-private-key \
+  --no-open
+
+# On the proxy host:
+export CAMELID_API_KEY="$(cat ./node-api.key)"
+camelid fabric serve \
+  --node a=node-a.example:8181 --node b=node-b.example:8181 \
+  --node-tls-ca ./fabric-node-ca \
+  --addr 127.0.0.1:8282
+```
+
+The CA bundle is loaded before the first probe. Missing, empty, malformed, or unusable bundles stop
+the command. TLS verifies the node certificate and host/IP SAN before the HTTP request head is sent,
+so a failed handshake sends neither the bearer nor prompt bytes. The existing bearer authenticates
+the Fabric to the node; mutual TLS is not a second required client-identity system.
+
+A tunnel remains a supported alternative. Bind each node to loopback, forward a distinct local port
+to it with SSH, Tailscale, or another authenticated encrypted transport, and name the local tunnel
+endpoints (for example `a=127.0.0.1:18181`). No cleartext acknowledgement is needed because the
+Fabric sees only loopback; the tunnel owns encryption and remote identity.
+
+One Fabric uses one transport posture for all nodes: either one pinned CA or guarded cleartext. This
+prevents a node from silently downgrading while a node file reloads. CA rotation or changing posture
+requires restarting the Fabric; adding or removing nodes does not.
 
 ### Placement modes
 
@@ -363,8 +416,9 @@ way is not interrupted, but it is bounded by `--timeout-ms` and costs a node a h
 than its generation slot.
 
 Request bodies are bounded at the same 16 MiB default the node itself uses. A streaming request is
-relayed as it arrives; `fabric run`, which returns one complete answer, refuses `stream: true` with
-400 instead.
+relayed as it arrives. `--forward-timeout-s` bounds the wait for the first response head and each
+later silent gap; every event resets the latter, so it is not a cap on total stream duration.
+`fabric run`, which returns one complete answer, refuses `stream: true` with 400 instead.
 
 ### What the proxy serves
 

--- a/src/fabric/forward.rs
+++ b/src/fabric/forward.rs
@@ -17,6 +17,7 @@ use serde_json::{json, Value};
 
 use super::http::{self, HttpError};
 use super::node::NodeSpec;
+use super::transport::NodeTransport;
 use super::Cancel;
 
 /// Generation can legitimately take minutes, so this is far longer than a probe
@@ -238,6 +239,27 @@ pub fn forward(
     timeout: Duration,
     cancel: &Cancel,
 ) -> Result<Forwarded, ForwardError> {
+    forward_with_transport(
+        spec,
+        path,
+        body,
+        bearer,
+        timeout,
+        cancel,
+        &NodeTransport::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn forward_with_transport(
+    spec: &NodeSpec,
+    path: &str,
+    body: &Value,
+    bearer: Option<&str>,
+    timeout: Duration,
+    cancel: &Cancel,
+    transport: &NodeTransport,
+) -> Result<Forwarded, ForwardError> {
     reject_streaming(body)?;
 
     let encoded = serde_json::to_vec(body).map_err(|error| ForwardError::Json {
@@ -246,7 +268,7 @@ pub fn forward(
     })?;
 
     let started = Instant::now();
-    let response = http::request(
+    let response = http::request_with_transport(
         &spec.host,
         spec.port,
         "POST",
@@ -256,6 +278,7 @@ pub fn forward(
         timeout,
         MAX_RESPONSE_BYTES,
         cancel,
+        transport,
     )
     .map_err(|error| attribute(&spec.label, error))?;
     let elapsed = started.elapsed();
@@ -366,13 +389,36 @@ pub fn forward_streaming(
     idle_timeout: Duration,
     cancel: &Cancel,
 ) -> Result<StreamOutcome, ForwardError> {
+    forward_streaming_with_transport(
+        spec,
+        path,
+        body,
+        bearer,
+        head_timeout,
+        idle_timeout,
+        cancel,
+        &NodeTransport::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn forward_streaming_with_transport(
+    spec: &NodeSpec,
+    path: &str,
+    body: &Value,
+    bearer: Option<&str>,
+    head_timeout: Duration,
+    idle_timeout: Duration,
+    cancel: &Cancel,
+    transport: &NodeTransport,
+) -> Result<StreamOutcome, ForwardError> {
     let encoded = serde_json::to_vec(body).map_err(|error| ForwardError::Json {
         label: spec.label.clone(),
         detail: format!("request body could not be encoded: {error}"),
     })?;
 
     let started = Instant::now();
-    let stream = http::open_stream(
+    let stream = http::open_stream_with_transport(
         &spec.host,
         spec.port,
         "POST",
@@ -383,6 +429,7 @@ pub fn forward_streaming(
         idle_timeout,
         MAX_RESPONSE_BYTES,
         cancel,
+        transport,
     )
     .map_err(|error| attribute(&spec.label, error))?;
 

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -18,8 +18,9 @@
 //! node to stop generating.
 
 use std::io::{Read, Write};
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
-use std::sync::Arc;
+use std::net::{IpAddr, SocketAddr, TcpStream, ToSocketAddrs};
+use std::panic::AssertUnwindSafe;
+use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use rustls::{ClientConfig, ClientConnection, StreamOwned};
@@ -32,6 +33,15 @@ use super::transport::NodeTransport;
 /// forward budget is minutes long and a node that has not completed transport
 /// setup in five seconds is not about to.
 const CONNECT_ATTEMPT_CAP: Duration = Duration::from_secs(5);
+
+/// The host resolver has no portable cancellation API. Keep it off request and
+/// probe threads, and cap both workers and queued work so a broken resolver
+/// cannot grow one abandoned thread per incoming request. Callers still stop at
+/// their own deadline; IP literals remain usable even if every worker is stuck.
+const RESOLVER_WORKERS: usize = 4;
+const RESOLVER_QUEUE_CAPACITY: usize = 64;
+const RESOLVER_WAIT_SLICE: Duration = Duration::from_millis(100);
+const RESOLVER_QUEUE_WAIT_SLICE: Duration = Duration::from_millis(10);
 
 /// Bounds the header block and a chunked body's size line, so a peer that never
 /// terminates either cannot grow a buffer without bound.
@@ -58,11 +68,12 @@ pub(crate) enum HttpError {
 impl HttpError {
     /// Whether the peer provably never received any part of the request.
     ///
-    /// Only resolution and dialling qualify. Every other variant is raised at or
-    /// after the first write, and `write_all` does not say how many bytes left
-    /// the socket, so the request may already be running on the peer. Answering
-    /// "it may have arrived" whenever that is possible is what lets a caller
-    /// re-send elsewhere without risking a second execution.
+    /// Resolution, dialling, local transport policy, and TLS setup/authentication
+    /// qualify. Every other transport variant is raised at or after the first
+    /// write, and `write_all` does not say how many bytes left the socket, so the
+    /// request may already be running on the peer. Answering "it may have arrived"
+    /// whenever that is possible is what lets a caller re-send elsewhere without
+    /// risking a second execution.
     ///
     /// [`HttpError::InvalidRequest`] is deliberately excluded: nothing was sent,
     /// but the request is malformed, so another peer would refuse it identically.
@@ -100,6 +111,167 @@ impl std::fmt::Display for HttpError {
 enum NodeConnection {
     Plain(TcpStream),
     Tls(Box<StreamOwned<ClientConnection, TcpStream>>),
+}
+
+type ResolveResult = Result<Vec<SocketAddr>, String>;
+type Lookup = Box<dyn FnOnce() -> ResolveResult + Send + 'static>;
+
+struct ResolveJob {
+    lookup: Lookup,
+    reply: mpsc::Sender<ResolveResult>,
+    deadline: Instant,
+    cancel: Cancel,
+}
+
+struct ResolverPool {
+    jobs: mpsc::SyncSender<ResolveJob>,
+}
+
+impl ResolverPool {
+    fn new(worker_count: usize, queue_capacity: usize) -> Result<Self, String> {
+        let (jobs, receiver) = mpsc::sync_channel::<ResolveJob>(queue_capacity);
+        let receiver = Arc::new(Mutex::new(receiver));
+        for index in 0..worker_count {
+            let receiver = Arc::clone(&receiver);
+            std::thread::Builder::new()
+                .name(format!("camelid-node-resolver-{index}"))
+                .spawn(move || loop {
+                    let job = {
+                        let receiver = receiver
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        match receiver.recv() {
+                            Ok(job) => job,
+                            Err(_) => return,
+                        }
+                    };
+                    if job.cancel.is_cancelled() || Instant::now() >= job.deadline {
+                        let _ = job.reply.send(Err(
+                            "resolution was no longer wanted before it started".to_string(),
+                        ));
+                        continue;
+                    }
+                    let answer = std::panic::catch_unwind(AssertUnwindSafe(job.lookup))
+                        .unwrap_or_else(|_| Err("resolver worker caught a panic".to_string()));
+                    let _ = job.reply.send(answer);
+                })
+                .map_err(|error| format!("could not start resolver worker: {error}"))?;
+        }
+        Ok(Self { jobs })
+    }
+}
+
+fn resolver_sender() -> Result<mpsc::SyncSender<ResolveJob>, HttpError> {
+    static RESOLVER: OnceLock<Mutex<Option<ResolverPool>>> = OnceLock::new();
+    let resolver = RESOLVER.get_or_init(|| Mutex::new(None));
+    let mut resolver = resolver
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if resolver.is_none() {
+        *resolver = Some(
+            ResolverPool::new(RESOLVER_WORKERS, RESOLVER_QUEUE_CAPACITY)
+                .map_err(HttpError::Resolve)?,
+        );
+    }
+    Ok(resolver
+        .as_ref()
+        .expect("resolver initialized above")
+        .jobs
+        .clone())
+}
+
+fn resolve_with_sender(
+    jobs: &mpsc::SyncSender<ResolveJob>,
+    deadline: Instant,
+    cancel: &Cancel,
+    lookup: Lookup,
+) -> Result<Vec<SocketAddr>, HttpError> {
+    if cancel.is_cancelled() {
+        return Err(HttpError::Cancelled);
+    }
+    if Instant::now() >= deadline {
+        return Err(HttpError::Resolve(
+            "resolution exceeded the request deadline".to_string(),
+        ));
+    }
+    let (reply, result) = mpsc::channel();
+    let mut job = ResolveJob {
+        lookup,
+        reply,
+        deadline,
+        cancel: cancel.clone(),
+    };
+    loop {
+        if cancel.is_cancelled() {
+            return Err(HttpError::Cancelled);
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(HttpError::Resolve(
+                "resolution exceeded the request deadline while queued".to_string(),
+            ));
+        }
+        match jobs.try_send(job) {
+            Ok(()) => break,
+            Err(mpsc::TrySendError::Full(returned)) => {
+                job = returned;
+                std::thread::sleep(remaining.min(RESOLVER_QUEUE_WAIT_SLICE));
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                return Err(HttpError::Resolve("resolver workers stopped".to_string()))
+            }
+        }
+    }
+
+    loop {
+        if cancel.is_cancelled() {
+            return Err(HttpError::Cancelled);
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(HttpError::Resolve(
+                "resolution exceeded the request deadline".to_string(),
+            ));
+        }
+        match result.recv_timeout(remaining.min(RESOLVER_WAIT_SLICE)) {
+            Ok(Ok(addrs)) => return Ok(addrs),
+            Ok(Err(detail)) => return Err(HttpError::Resolve(detail)),
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(HttpError::Resolve(
+                    "resolver worker stopped without an answer".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+fn resolve_host(
+    host: &str,
+    port: u16,
+    deadline: Instant,
+    cancel: &Cancel,
+) -> Result<Vec<SocketAddr>, HttpError> {
+    let bare_host = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
+    if let Ok(ip) = bare_host.parse::<IpAddr>() {
+        return Ok(vec![SocketAddr::new(ip, port)]);
+    }
+    let host = bare_host.to_string();
+    let lookup_host = host.clone();
+    resolve_with_sender(
+        &resolver_sender()?,
+        deadline,
+        cancel,
+        Box::new(move || {
+            (lookup_host.as_str(), port)
+                .to_socket_addrs()
+                .map(|addrs| addrs.collect())
+                .map_err(|error| format!("{host}: {error}"))
+        }),
+    )
 }
 
 impl Read for NodeConnection {
@@ -614,10 +786,7 @@ fn connect_and_send(
     // refused without touching the network.
     let head = request_head(method, path, &authority, accept, body, bearer)?;
 
-    let addrs: Vec<SocketAddr> = authority
-        .to_socket_addrs()
-        .map_err(|error| HttpError::Resolve(error.to_string()))?
-        .collect();
+    let addrs = resolve_host(host, port, deadline, cancel)?;
     if addrs.is_empty() {
         return Err(HttpError::Resolve(
             "host resolved to no addresses".to_string(),
@@ -1029,6 +1198,172 @@ mod tests {
     use std::sync::mpsc;
 
     const LIMIT: usize = 1024 * 1024;
+
+    #[test]
+    fn a_stalled_resolution_cannot_outlive_the_request_deadline() {
+        let pool = ResolverPool::new(1, 1).expect("resolver pool starts");
+        let (release, blocked) = mpsc::channel();
+        let started = Instant::now();
+        let error = resolve_with_sender(
+            &pool.jobs,
+            started + Duration::from_millis(150),
+            &Cancel::never(),
+            Box::new(move || {
+                blocked.recv().expect("test releases resolver");
+                Ok(vec![SocketAddr::from(([127, 0, 0, 1], 8181))])
+            }),
+        )
+        .expect_err("a stalled resolver must not escape the request deadline");
+        assert!(matches!(error, HttpError::Resolve(_)), "{error:?}");
+        assert!(started.elapsed() < Duration::from_secs(1));
+        release.send(()).expect("release resolver worker");
+    }
+
+    #[test]
+    fn cancellation_stops_waiting_for_a_blocked_resolution() {
+        let pool = Arc::new(ResolverPool::new(1, 1).expect("resolver pool starts"));
+        let cancel = Cancel::new();
+        let handed_to_waiter = cancel.clone();
+        let (release, blocked) = mpsc::channel();
+        let started = Instant::now();
+        let waiter = {
+            let pool = Arc::clone(&pool);
+            std::thread::spawn(move || {
+                resolve_with_sender(
+                    &pool.jobs,
+                    Instant::now() + Duration::from_secs(5),
+                    &handed_to_waiter,
+                    Box::new(move || {
+                        blocked.recv().expect("test releases resolver");
+                        Ok(vec![SocketAddr::from(([127, 0, 0, 1], 8181))])
+                    }),
+                )
+            })
+        };
+        std::thread::sleep(Duration::from_millis(50));
+        cancel.cancel();
+        let error = waiter
+            .join()
+            .expect("waiter exits")
+            .expect_err("cancelled resolution is abandoned");
+        assert_eq!(error, HttpError::Cancelled);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        release.send(()).expect("release resolver worker");
+    }
+
+    #[test]
+    fn a_saturated_resolver_queue_backpressures_until_the_deadline() {
+        let pool = ResolverPool::new(1, 1).expect("resolver pool starts");
+        let first_jobs = pool.jobs.clone();
+        let (first_started, wait_for_first) = mpsc::channel();
+        let (release_first, first_blocked) = mpsc::channel();
+        let first = std::thread::spawn(move || {
+            resolve_with_sender(
+                &first_jobs,
+                Instant::now() + Duration::from_secs(5),
+                &Cancel::never(),
+                Box::new(move || {
+                    first_started.send(()).expect("announce first lookup");
+                    first_blocked.recv().expect("release first lookup");
+                    Ok(vec![SocketAddr::from(([127, 0, 0, 1], 8181))])
+                }),
+            )
+        });
+        wait_for_first.recv().expect("first lookup started");
+
+        let second_jobs = pool.jobs.clone();
+        let (release_second, second_blocked) = mpsc::channel();
+        let second = std::thread::spawn(move || {
+            resolve_with_sender(
+                &second_jobs,
+                Instant::now() + Duration::from_secs(5),
+                &Cancel::never(),
+                Box::new(move || {
+                    second_blocked.recv().expect("release second lookup");
+                    Ok(vec![SocketAddr::from(([127, 0, 0, 1], 8182))])
+                }),
+            )
+        });
+        std::thread::sleep(Duration::from_millis(50));
+
+        let started = Instant::now();
+        let error = resolve_with_sender(
+            &pool.jobs,
+            started + Duration::from_millis(150),
+            &Cancel::never(),
+            Box::new(|| Ok(vec![SocketAddr::from(([127, 0, 0, 1], 8183))])),
+        )
+        .expect_err("a full queue must remain bounded by the caller deadline");
+        assert!(matches!(error, HttpError::Resolve(_)), "{error:?}");
+        assert!(started.elapsed() >= Duration::from_millis(100));
+        assert!(started.elapsed() < Duration::from_secs(1));
+
+        release_first.send(()).expect("release first lookup");
+        release_second.send(()).expect("release second lookup");
+        first
+            .join()
+            .expect("first waiter exits")
+            .expect("first resolves");
+        second
+            .join()
+            .expect("second waiter exits")
+            .expect("second resolves");
+    }
+
+    #[test]
+    fn a_panicking_lookup_does_not_retire_its_resolver_worker() {
+        let pool = ResolverPool::new(1, 1).expect("resolver pool starts");
+        let error = resolve_with_sender(
+            &pool.jobs,
+            Instant::now() + Duration::from_secs(1),
+            &Cancel::never(),
+            Box::new(|| panic!("synthetic resolver panic")),
+        )
+        .expect_err("resolver panic becomes an error");
+        assert!(matches!(error, HttpError::Resolve(_)), "{error:?}");
+
+        assert_eq!(
+            resolve_with_sender(
+                &pool.jobs,
+                Instant::now() + Duration::from_secs(1),
+                &Cancel::never(),
+                Box::new(|| Ok(vec![SocketAddr::from(([127, 0, 0, 1], 8181))])),
+            )
+            .expect("worker still resolves"),
+            vec![SocketAddr::from(([127, 0, 0, 1], 8181))]
+        );
+    }
+
+    #[test]
+    fn a_burst_of_resolutions_is_backpressured_not_rejected() {
+        const CALLERS: usize = 128;
+        let pool = Arc::new(ResolverPool::new(4, 64).expect("resolver pool starts"));
+        let start = Arc::new(std::sync::Barrier::new(CALLERS + 1));
+        let handles: Vec<_> = (0..CALLERS)
+            .map(|_| {
+                let jobs = pool.jobs.clone();
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    resolve_with_sender(
+                        &jobs,
+                        Instant::now() + Duration::from_secs(5),
+                        &Cancel::never(),
+                        Box::new(|| Ok(vec![SocketAddr::from(([127, 0, 0, 1], 8181))])),
+                    )
+                })
+            })
+            .collect();
+        start.wait();
+
+        for handle in handles {
+            let addrs = handle
+                .join()
+                .expect("resolver caller exits")
+                .expect("resolution is not rejected under a burst");
+            assert!(!addrs.is_empty());
+        }
+    }
 
     fn tls_material(names: Vec<String>) -> (Arc<rustls::ServerConfig>, NodeTransport) {
         let issued = rcgen::generate_simple_self_signed(names).expect("generate certificate");

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -3,7 +3,7 @@
 //!
 //! Response parsing is pure over byte slices, so the awkward parts — chunked
 //! bodies, truncated frames, a node that answers 500 — are tested without a
-//! server. Only [`request`] touches a socket.
+//! server. Only [`connect_and_send`] touches a socket.
 //!
 //! This deliberately does not reuse `chat::client`: that module is private to
 //! `chat`, is keyed on a resolved `SocketAddr` where fabric members are named
@@ -19,9 +19,14 @@
 
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use rustls::{ClientConfig, ClientConnection, StreamOwned};
+use rustls_pki_types::ServerName;
+
 use super::cancel::Cancel;
+use super::transport::NodeTransport;
 
 /// Never spend the whole budget dialling; a forward budget is minutes long and
 /// a node that has not accepted in five seconds is not about to.
@@ -41,6 +46,10 @@ pub(crate) enum HttpError {
     TooLarge(usize),
     /// The request could not be written safely; refused before any socket work.
     InvalidRequest(String),
+    /// Local policy refused the transport before any request bytes were sent.
+    Policy(String),
+    /// TLS setup or the handshake failed before any request bytes were sent.
+    Tls(String),
     /// The caller stopped wanting the answer before it arrived.
     Cancelled,
 }
@@ -61,7 +70,7 @@ impl HttpError {
     /// answer for a caller that has already stopped waiting for one.
     pub(crate) fn peer_never_received_it(&self) -> bool {
         match self {
-            Self::Resolve(_) | Self::Connect(_) => true,
+            Self::Resolve(_) | Self::Connect(_) | Self::Policy(_) | Self::Tls(_) => true,
             Self::Io(_)
             | Self::Malformed(_)
             | Self::TooLarge(_)
@@ -80,7 +89,39 @@ impl std::fmt::Display for HttpError {
             Self::Malformed(detail) => write!(f, "malformed HTTP response: {detail}"),
             Self::TooLarge(limit) => write!(f, "response exceeded {limit} bytes"),
             Self::InvalidRequest(detail) => write!(f, "cannot build request: {detail}"),
+            Self::Policy(detail) => write!(f, "node transport refused: {detail}"),
+            Self::Tls(detail) => write!(f, "node TLS failed: {detail}"),
             Self::Cancelled => write!(f, "the answer was no longer wanted"),
+        }
+    }
+}
+
+enum NodeConnection {
+    Plain(TcpStream),
+    Tls(Box<StreamOwned<ClientConnection, TcpStream>>),
+}
+
+impl Read for NodeConnection {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Plain(stream) => stream.read(buffer),
+            Self::Tls(stream) => stream.read(buffer),
+        }
+    }
+}
+
+impl Write for NodeConnection {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Plain(stream) => stream.write(buffer),
+            Self::Tls(stream) => stream.write(buffer),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Plain(stream) => stream.flush(),
+            Self::Tls(stream) => stream.flush(),
         }
     }
 }
@@ -386,6 +427,52 @@ fn connect_any(
     })))
 }
 
+fn tls_server_name(host: &str) -> Result<ServerName<'static>, HttpError> {
+    let host = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
+    ServerName::try_from(host.to_string())
+        .map_err(|error| HttpError::Tls(format!("`{host}` is not a valid server name: {error}")))
+}
+
+fn negotiate_tls(
+    mut stream: TcpStream,
+    host: &str,
+    config: Arc<ClientConfig>,
+    deadline: Instant,
+    cancel: &Cancel,
+) -> Result<NodeConnection, HttpError> {
+    let server_name = tls_server_name(host)?;
+    let mut connection = ClientConnection::new(config, server_name)
+        .map_err(|error| HttpError::Tls(error.to_string()))?;
+
+    // Keep the handshake responsive to cancellation and the shared request
+    // deadline. The larger body-write timeout is restored once authentication
+    // has completed.
+    stream
+        .set_write_timeout(Some(Duration::from_millis(100)))
+        .map_err(|error| HttpError::Io(error.to_string()))?;
+    while connection.is_handshaking() {
+        if cancel.is_cancelled() {
+            return Err(HttpError::Cancelled);
+        }
+        if Instant::now() >= deadline {
+            return Err(HttpError::Tls(
+                "handshake exceeded the request deadline".to_string(),
+            ));
+        }
+        match connection.complete_io(&mut stream) {
+            Ok(_) => {}
+            Err(error) if is_retryable(&error) => continue,
+            Err(error) => return Err(HttpError::Tls(error.to_string())),
+        }
+    }
+    Ok(NodeConnection::Tls(Box::new(StreamOwned::new(
+        connection, stream,
+    ))))
+}
+
 /// Build the request head. Pure, so the header set — including whether an
 /// `Authorization` line is present at all — is tested without a server.
 ///
@@ -431,8 +518,8 @@ pub(crate) const ACCEPT_EVENT_STREAM: &str = "text/event-stream";
 
 /// Resolve, connect, and write one request, leaving the socket ready to read.
 ///
-/// Shared by [`request`] and [`open_stream`] so both dial, authenticate and
-/// frame a request exactly the same way.
+/// Shared by [`request_with_transport`] and [`open_stream_with_transport`] so
+/// both dial, authenticate and frame a request exactly the same way.
 #[allow(clippy::too_many_arguments)]
 fn connect_and_send(
     host: &str,
@@ -445,7 +532,8 @@ fn connect_and_send(
     deadline: Instant,
     write_timeout: Duration,
     cancel: &Cancel,
-) -> Result<TcpStream, HttpError> {
+    transport: &NodeTransport,
+) -> Result<NodeConnection, HttpError> {
     // Before resolving, which is itself a blocking call: a caller that has
     // already given up costs its node nothing at all, not even a connection.
     if cancel.is_cancelled() {
@@ -467,7 +555,10 @@ fn connect_and_send(
         ));
     }
 
-    let mut stream = connect_any(&addrs, deadline, cancel)?;
+    let addrs = transport
+        .permitted_addresses(&addrs)
+        .map_err(|error| HttpError::Policy(error.to_string()))?;
+    let stream = connect_any(&addrs, deadline, cancel)?;
     // Short socket reads keep the caller's loop responsive to its own deadline;
     // one long read timeout would overshoot it on a stalled peer.
     stream
@@ -476,6 +567,22 @@ fn connect_and_send(
     stream
         .set_write_timeout(Some(write_timeout))
         .map_err(|error| HttpError::Io(error.to_string()))?;
+
+    let mut stream = match transport.tls_config() {
+        Some(config) => {
+            let connection = negotiate_tls(stream, host, config, deadline, cancel)?;
+            // `negotiate_tls` temporarily narrows this for cancellation.
+            match &connection {
+                NodeConnection::Tls(stream) => stream
+                    .sock
+                    .set_write_timeout(Some(write_timeout))
+                    .map_err(|error| HttpError::Io(error.to_string()))?,
+                NodeConnection::Plain(_) => unreachable!("TLS negotiation returns TLS"),
+            }
+            connection
+        }
+        None => NodeConnection::Plain(stream),
+    };
 
     stream
         .write_all(head.as_bytes())
@@ -501,6 +608,7 @@ fn connect_and_send(
 // One more parameter than clippy's threshold; every one of them is a distinct
 // property of a single round trip, so bundling them would only move the list.
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub(crate) fn request(
     host: &str,
     port: u16,
@@ -511,6 +619,33 @@ pub(crate) fn request(
     timeout: Duration,
     max_body: usize,
     cancel: &Cancel,
+) -> Result<HttpResponse, HttpError> {
+    request_with_transport(
+        host,
+        port,
+        method,
+        path,
+        body,
+        bearer,
+        timeout,
+        max_body,
+        cancel,
+        &NodeTransport::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn request_with_transport(
+    host: &str,
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&[u8]>,
+    bearer: Option<&str>,
+    timeout: Duration,
+    max_body: usize,
+    cancel: &Cancel,
+    transport: &NodeTransport,
 ) -> Result<HttpResponse, HttpError> {
     let deadline = Instant::now() + timeout;
     let mut stream = connect_and_send(
@@ -524,6 +659,7 @@ pub(crate) fn request(
         deadline,
         timeout,
         cancel,
+        transport,
     )?;
 
     let mut raw = Vec::new();
@@ -546,6 +682,17 @@ pub(crate) fn request(
                 }
             }
             Err(error) if is_retryable(&error) => continue,
+            // rustls reports an EOF without close_notify as UnexpectedEof.
+            // HTTP framing can still prove the authenticated response whole:
+            // Content-Length and the terminal chunk both make truncation
+            // detectable. Never apply this to a close-delimited or incomplete
+            // body, where the TLS close is the only end marker.
+            Err(error)
+                if error.kind() == std::io::ErrorKind::UnexpectedEof
+                    && parse_response(&raw, max_body).is_ok() =>
+            {
+                break;
+            }
             Err(error) => return Err(HttpError::Io(error.to_string())),
         }
     }
@@ -569,7 +716,7 @@ fn is_retryable(error: &std::io::Error) -> bool {
 /// payload — a caller relaying server-sent events forwards the bytes verbatim,
 /// so an event field this client has never heard of cannot be mangled.
 pub(crate) struct ResponseStream {
-    stream: TcpStream,
+    stream: NodeConnection,
     head: ResponseHead,
     decoder: ChunkDecoder,
     /// Body bytes that arrived alongside the head, not yet framed.
@@ -595,6 +742,7 @@ fn truncated_body() -> HttpError {
 /// `cancel` bounds the wait for that head and is kept by the returned stream,
 /// so it bounds every later read too.
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub(crate) fn open_stream(
     host: &str,
     port: u16,
@@ -606,6 +754,35 @@ pub(crate) fn open_stream(
     idle_timeout: Duration,
     max_chunk: usize,
     cancel: &Cancel,
+) -> Result<ResponseStream, HttpError> {
+    open_stream_with_transport(
+        host,
+        port,
+        method,
+        path,
+        body,
+        bearer,
+        head_timeout,
+        idle_timeout,
+        max_chunk,
+        cancel,
+        &NodeTransport::default(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn open_stream_with_transport(
+    host: &str,
+    port: u16,
+    method: &str,
+    path: &str,
+    body: Option<&[u8]>,
+    bearer: Option<&str>,
+    head_timeout: Duration,
+    idle_timeout: Duration,
+    max_chunk: usize,
+    cancel: &Cancel,
+    transport: &NodeTransport,
 ) -> Result<ResponseStream, HttpError> {
     let deadline = Instant::now() + head_timeout;
     let mut stream = connect_and_send(
@@ -619,6 +796,7 @@ pub(crate) fn open_stream(
         deadline,
         head_timeout,
         cancel,
+        transport,
     )?;
 
     let mut raw = Vec::new();
@@ -789,8 +967,261 @@ impl ResponseStream {
 mod tests {
     use super::*;
     use std::net::TcpListener;
+    use std::sync::mpsc;
 
     const LIMIT: usize = 1024 * 1024;
+
+    fn tls_material(names: Vec<String>) -> (Arc<rustls::ServerConfig>, NodeTransport) {
+        let issued = rcgen::generate_simple_self_signed(names).expect("generate certificate");
+        let key = rustls_pki_types::PrivatePkcs8KeyDer::from(issued.key_pair.serialize_der());
+        let server = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![issued.cert.der().clone()], key.into())
+            .expect("server certificate and key agree");
+
+        let directory = tempfile::tempdir().expect("temp dir");
+        let ca_path = directory.path().join("node-ca");
+        std::fs::write(&ca_path, rcgen::Certificate::pem(&issued.cert)).expect("write CA");
+        let transport = NodeTransport::resolve(Some(&ca_path), false).expect("load CA");
+        (Arc::new(server), transport)
+    }
+
+    fn serve_tls_once(
+        server: Arc<rustls::ServerConfig>,
+        response: &'static [u8],
+    ) -> (u16, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind TLS node");
+        let port = listener.local_addr().expect("local address").port();
+        let handle = std::thread::spawn(move || {
+            let (socket, _) = listener.accept().expect("accept TLS client");
+            socket
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("bound reads");
+            socket
+                .set_write_timeout(Some(Duration::from_secs(2)))
+                .expect("bound writes");
+            let connection = rustls::ServerConnection::new(server).expect("server connection");
+            let mut stream = rustls::StreamOwned::new(connection, socket);
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = match stream.read(&mut buffer) {
+                    Ok(0) | Err(_) => return,
+                    Ok(read) => read,
+                };
+                request.extend_from_slice(&buffer[..read]);
+            }
+            stream.write_all(response).expect("write TLS response");
+            stream.flush().expect("flush TLS response");
+        });
+        (port, handle)
+    }
+
+    #[test]
+    fn a_ca_authenticated_node_serves_a_real_https_request() {
+        let (server, transport) = tls_material(vec!["localhost".to_string()]);
+        let (port, handle) = serve_tls_once(
+            server,
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"ok\":true}",
+        );
+
+        let response = request_with_transport(
+            "localhost",
+            port,
+            "GET",
+            "/v1/health",
+            None,
+            None,
+            Duration::from_secs(2),
+            LIMIT,
+            &Cancel::never(),
+            &transport,
+        )
+        .expect("trusted TLS node answers");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, br#"{"ok":true}"#);
+        handle.join().expect("TLS node exits");
+    }
+
+    #[test]
+    fn an_ip_literal_is_verified_against_an_ip_subject_alt_name() {
+        let (server, transport) = tls_material(vec!["127.0.0.1".to_string()]);
+        let (port, handle) = serve_tls_once(
+            server,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}",
+        );
+        let response = request_with_transport(
+            "127.0.0.1",
+            port,
+            "GET",
+            "/v1/health",
+            None,
+            None,
+            Duration::from_secs(2),
+            LIMIT,
+            &Cancel::never(),
+            &transport,
+        )
+        .expect("IP SAN matches the node IP literal");
+        assert_eq!(response.status, 200);
+        handle.join().expect("IP SAN TLS node exits");
+    }
+
+    #[test]
+    fn a_streaming_response_crosses_the_same_authenticated_tls_transport() {
+        let (server, transport) = tls_material(vec!["localhost".to_string()]);
+        let body = b"data: {\"token\":\"hi\"}\n\n";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        let response = Box::leak([response.as_bytes(), body].concat().into_boxed_slice());
+        let (port, handle) = serve_tls_once(server, response);
+
+        let mut stream = open_stream_with_transport(
+            "localhost",
+            port,
+            "POST",
+            "/v1/chat/completions",
+            Some(b"{}"),
+            None,
+            Duration::from_secs(2),
+            Duration::from_secs(2),
+            LIMIT,
+            &Cancel::never(),
+            &transport,
+        )
+        .expect("trusted TLS stream opens");
+        assert!(stream.head().is_event_stream());
+        assert_eq!(
+            stream.next_chunk().expect("reads event"),
+            Some(body.to_vec())
+        );
+        assert_eq!(stream.next_chunk().expect("stream ends"), None);
+        handle.join().expect("TLS node exits");
+    }
+
+    #[test]
+    fn a_tls_stream_cut_off_before_its_declared_end_is_not_a_clean_eof() {
+        let (server, transport) = tls_material(vec!["localhost".to_string()]);
+        let body = b"data: partial\n\n";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len() + 20
+        );
+        let response = Box::leak([response.as_bytes(), body].concat().into_boxed_slice());
+        let (port, handle) = serve_tls_once(server, response);
+        let mut stream = open_stream_with_transport(
+            "localhost",
+            port,
+            "POST",
+            "/v1/chat/completions",
+            Some(b"{}"),
+            None,
+            Duration::from_secs(2),
+            Duration::from_secs(2),
+            LIMIT,
+            &Cancel::never(),
+            &transport,
+        )
+        .expect("TLS stream opens before the truncation");
+        assert_eq!(
+            stream.next_chunk().expect("partial event arrives"),
+            Some(body.to_vec())
+        );
+        let error = stream
+            .next_chunk()
+            .expect_err("missing authenticated bytes are not a clean EOF");
+        assert!(
+            matches!(error, HttpError::Io(_) | HttpError::Malformed(_)),
+            "{error:?}"
+        );
+        handle.join().expect("truncated TLS node exits");
+    }
+
+    #[test]
+    fn an_untrusted_ca_and_a_wrong_server_name_are_refused_before_http() {
+        let (server, _) = tls_material(vec!["localhost".to_string()]);
+        let (_, wrong_ca) = tls_material(vec!["localhost".to_string()]);
+        let (port, handle) = serve_tls_once(server, b"");
+        let error = request_with_transport(
+            "localhost",
+            port,
+            "GET",
+            "/v1/health",
+            None,
+            None,
+            Duration::from_secs(2),
+            LIMIT,
+            &Cancel::never(),
+            &wrong_ca,
+        )
+        .expect_err("untrusted certificate is refused");
+        assert!(matches!(error, HttpError::Tls(_)), "{error:?}");
+        assert!(error.peer_never_received_it());
+        handle.join().expect("untrusted TLS node exits");
+
+        let (server, transport) = tls_material(vec!["node.example".to_string()]);
+        let (port, handle) = serve_tls_once(server, b"");
+        let error = request_with_transport(
+            "localhost",
+            port,
+            "GET",
+            "/v1/health",
+            None,
+            None,
+            Duration::from_secs(2),
+            LIMIT,
+            &Cancel::never(),
+            &transport,
+        )
+        .expect_err("name mismatch is refused");
+        assert!(matches!(error, HttpError::Tls(_)), "{error:?}");
+        handle.join().expect("wrong-name TLS node exits");
+    }
+
+    #[test]
+    fn bearer_bytes_are_not_sent_before_the_tls_peer_is_authenticated() {
+        let (_, transport) = tls_material(vec!["localhost".to_string()]);
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind impostor");
+        let port = listener.local_addr().expect("local address").port();
+        let (sent, received) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let (mut socket, _) = listener.accept().expect("accept client");
+            socket
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("bound reads");
+            let mut bytes = vec![0_u8; 8192];
+            let read = socket.read(&mut bytes).expect("read ClientHello");
+            bytes.truncate(read);
+            sent.send(bytes).expect("send captured bytes");
+            // Closing here makes the handshake fail immediately.
+        });
+
+        let secret = "bearer-must-not-cross-before-auth-9f72";
+        let error = request_with_transport(
+            "localhost",
+            port,
+            "GET",
+            "/v1/health",
+            None,
+            Some(secret),
+            Duration::from_secs(2),
+            LIMIT,
+            &Cancel::never(),
+            &transport,
+        )
+        .expect_err("a non-TLS peer is refused");
+        assert!(matches!(error, HttpError::Tls(_)), "{error:?}");
+        let captured = received.recv().expect("captured ClientHello");
+        assert!(
+            !captured
+                .windows(secret.len())
+                .any(|window| window == secret.as_bytes()),
+            "bearer appeared before server authentication"
+        );
+        handle.join().expect("impostor exits");
+    }
 
     #[test]
     fn a_dead_leading_address_does_not_hide_a_live_one() {
@@ -841,6 +1272,12 @@ mod tests {
             HttpError::Cancelled,
         ] {
             assert!(!error.peer_never_received_it(), "{error:?}");
+        }
+        for error in [
+            HttpError::Policy("cleartext refused".to_string()),
+            HttpError::Tls("certificate rejected".to_string()),
+        ] {
+            assert!(error.peer_never_received_it(), "{error:?}");
         }
     }
 

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -28,8 +28,9 @@ use rustls_pki_types::ServerName;
 use super::cancel::Cancel;
 use super::transport::NodeTransport;
 
-/// Never spend the whole budget dialling; a forward budget is minutes long and
-/// a node that has not accepted in five seconds is not about to.
+/// Never spend the whole budget dialling or authenticating one address; a
+/// forward budget is minutes long and a node that has not completed transport
+/// setup in five seconds is not about to.
 const CONNECT_ATTEMPT_CAP: Duration = Duration::from_secs(5);
 
 /// Bounds the header block and a chunked body's size line, so a peer that never
@@ -438,12 +439,11 @@ fn tls_server_name(host: &str) -> Result<ServerName<'static>, HttpError> {
 
 fn negotiate_tls(
     mut stream: TcpStream,
-    host: &str,
+    server_name: ServerName<'static>,
     config: Arc<ClientConfig>,
     deadline: Instant,
     cancel: &Cancel,
 ) -> Result<NodeConnection, HttpError> {
-    let server_name = tls_server_name(host)?;
     let mut connection = ClientConnection::new(config, server_name)
         .map_err(|error| HttpError::Tls(error.to_string()))?;
 
@@ -452,7 +452,7 @@ fn negotiate_tls(
     // has completed.
     stream
         .set_write_timeout(Some(Duration::from_millis(100)))
-        .map_err(|error| HttpError::Io(error.to_string()))?;
+        .map_err(|error| HttpError::Tls(error.to_string()))?;
     while connection.is_handshaking() {
         if cancel.is_cancelled() {
             return Err(HttpError::Cancelled);
@@ -471,6 +471,75 @@ fn negotiate_tls(
     Ok(NodeConnection::Tls(Box::new(StreamOwned::new(
         connection, stream,
     ))))
+}
+
+fn connect_tls_any(
+    addrs: &[SocketAddr],
+    host: &str,
+    config: Arc<ClientConfig>,
+    deadline: Instant,
+    write_timeout: Duration,
+    cancel: &Cancel,
+) -> Result<NodeConnection, HttpError> {
+    let server_name = tls_server_name(host)?;
+    let mut last: Option<HttpError> = None;
+    for (index, addr) in addrs.iter().enumerate() {
+        if cancel.is_cancelled() {
+            return Err(HttpError::Cancelled);
+        }
+        let now = Instant::now();
+        let remaining = deadline.saturating_duration_since(now);
+        if remaining.is_zero() {
+            break;
+        }
+        // The address is not usable until its certificate authenticates. Give
+        // each untried address a bounded share of the remaining budget so a
+        // TCP endpoint that stalls or rejects TLS cannot hide a valid sibling.
+        let untried = (addrs.len() - index) as u32;
+        let attempt = (remaining / untried)
+            .min(CONNECT_ATTEMPT_CAP)
+            .max(Duration::from_millis(1));
+        let attempt_deadline = now + attempt;
+        let stream = match TcpStream::connect_timeout(addr, attempt) {
+            Ok(stream) => stream,
+            Err(error) => {
+                last = Some(HttpError::Connect(format!("{addr}: {error}")));
+                continue;
+            }
+        };
+        if let Err(error) = stream.set_read_timeout(Some(Duration::from_millis(100))) {
+            last = Some(HttpError::Tls(format!(
+                "could not configure {addr} for TLS: {error}"
+            )));
+            continue;
+        }
+        match negotiate_tls(
+            stream,
+            server_name.clone(),
+            Arc::clone(&config),
+            attempt_deadline,
+            cancel,
+        ) {
+            Ok(connection) => {
+                let configured = match &connection {
+                    NodeConnection::Tls(stream) => {
+                        stream.sock.set_write_timeout(Some(write_timeout))
+                    }
+                    NodeConnection::Plain(_) => unreachable!("TLS negotiation returns TLS"),
+                };
+                if let Err(error) = configured {
+                    last = Some(HttpError::Tls(error.to_string()));
+                    continue;
+                }
+                return Ok(connection);
+            }
+            Err(HttpError::Cancelled) => return Err(HttpError::Cancelled),
+            Err(error) => last = Some(error),
+        }
+    }
+    Err(last.unwrap_or_else(|| {
+        HttpError::Tls("no address authenticated within the connection budget".to_string())
+    }))
 }
 
 /// Build the request head. Pure, so the header set — including whether an
@@ -558,30 +627,20 @@ fn connect_and_send(
     let addrs = transport
         .permitted_addresses(&addrs)
         .map_err(|error| HttpError::Policy(error.to_string()))?;
-    let stream = connect_any(&addrs, deadline, cancel)?;
-    // Short socket reads keep the caller's loop responsive to its own deadline;
-    // one long read timeout would overshoot it on a stalled peer.
-    stream
-        .set_read_timeout(Some(Duration::from_millis(100)))
-        .map_err(|error| HttpError::Io(error.to_string()))?;
-    stream
-        .set_write_timeout(Some(write_timeout))
-        .map_err(|error| HttpError::Io(error.to_string()))?;
-
     let mut stream = match transport.tls_config() {
-        Some(config) => {
-            let connection = negotiate_tls(stream, host, config, deadline, cancel)?;
-            // `negotiate_tls` temporarily narrows this for cancellation.
-            match &connection {
-                NodeConnection::Tls(stream) => stream
-                    .sock
-                    .set_write_timeout(Some(write_timeout))
-                    .map_err(|error| HttpError::Io(error.to_string()))?,
-                NodeConnection::Plain(_) => unreachable!("TLS negotiation returns TLS"),
-            }
-            connection
+        Some(config) => connect_tls_any(&addrs, host, config, deadline, write_timeout, cancel)?,
+        None => {
+            let stream = connect_any(&addrs, deadline, cancel)?;
+            // Short socket reads keep the caller's loop responsive to its own
+            // deadline; one long timeout would overshoot on a stalled peer.
+            stream
+                .set_read_timeout(Some(Duration::from_millis(100)))
+                .map_err(|error| HttpError::Io(error.to_string()))?;
+            stream
+                .set_write_timeout(Some(write_timeout))
+                .map_err(|error| HttpError::Io(error.to_string()))?;
+            NodeConnection::Plain(stream)
         }
-        None => NodeConnection::Plain(stream),
     };
 
     stream
@@ -1178,6 +1237,61 @@ mod tests {
         .expect_err("name mismatch is refused");
         assert!(matches!(error, HttpError::Tls(_)), "{error:?}");
         handle.join().expect("wrong-name TLS node exits");
+    }
+
+    #[test]
+    fn a_stalled_tls_address_does_not_hide_an_authenticated_sibling() {
+        let (server, transport) = tls_material(vec!["localhost".to_string()]);
+        let (release_impostor, wait_for_sibling) = mpsc::channel();
+
+        let impostor = TcpListener::bind("127.0.0.1:0").expect("bind impostor");
+        let impostor_addr = impostor.local_addr().expect("impostor address");
+        let impostor_thread = std::thread::spawn(move || {
+            let (mut socket, _) = impostor.accept().expect("accept first attempt");
+            let mut client_hello = [0_u8; 1024];
+            let _ = socket.read(&mut client_hello);
+            // Keep the unauthenticated connection open. Only the trusted
+            // sibling releases it, so reaching that sibling proves this
+            // handshake was bounded rather than waited out indefinitely.
+            wait_for_sibling
+                .recv_timeout(Duration::from_secs(5))
+                .expect("trusted sibling was attempted");
+        });
+
+        let trusted = TcpListener::bind("127.0.0.1:0").expect("bind trusted node");
+        let trusted_addr = trusted.local_addr().expect("trusted address");
+        let trusted_thread = std::thread::spawn(move || {
+            let (mut socket, _) = trusted.accept().expect("accept second attempt");
+            socket
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("bound reads");
+            socket
+                .set_write_timeout(Some(Duration::from_secs(2)))
+                .expect("bound writes");
+            let mut connection = rustls::ServerConnection::new(server).expect("create TLS server");
+            while connection.is_handshaking() {
+                connection
+                    .complete_io(&mut socket)
+                    .expect("complete TLS handshake");
+            }
+            release_impostor
+                .send(())
+                .expect("release stalled first address");
+        });
+
+        let connection = connect_tls_any(
+            &[impostor_addr, trusted_addr],
+            "localhost",
+            transport.tls_config().expect("TLS config"),
+            Instant::now() + Duration::from_secs(3),
+            Duration::from_secs(2),
+            &Cancel::never(),
+        )
+        .expect("the authenticated second address remains usable");
+        assert!(matches!(connection, NodeConnection::Tls(_)));
+
+        impostor_thread.join().expect("impostor exits");
+        trusted_thread.join().expect("trusted node exits");
     }
 
     #[test]

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -1080,6 +1080,124 @@ mod tests {
         })
     }
 
+    fn ready_snapshot(spec: NodeSpec, model: &str) -> NodeSnapshot {
+        NodeSnapshot {
+            spec,
+            status: ready_status(model),
+            latency: Some(Duration::from_millis(4)),
+        }
+    }
+
+    #[test]
+    fn a_tls_authentication_failure_fails_over_without_leaking_the_bearer() {
+        use std::io::{Read, Write};
+
+        let issued = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("generate trusted node certificate");
+        let key = rustls_pki_types::PrivatePkcs8KeyDer::from(issued.key_pair.serialize_der());
+        let server = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![issued.cert.der().clone()], key.into())
+            .expect("trusted certificate and key agree");
+        let directory = tempfile::tempdir().expect("temp dir");
+        let ca_path = directory.path().join("node-ca");
+        std::fs::write(&ca_path, rcgen::Certificate::pem(&issued.cert)).expect("write CA");
+
+        let impostor = std::net::TcpListener::bind("127.0.0.1:0").expect("bind impostor");
+        let impostor_port = impostor.local_addr().expect("impostor address").port();
+        let (captured_tx, captured_rx) = std::sync::mpsc::channel();
+        let impostor_thread = std::thread::spawn(move || {
+            let (mut socket, _) = impostor.accept().expect("accept first attempt");
+            socket
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("bound impostor read");
+            let mut bytes = vec![0_u8; 8192];
+            let read = socket.read(&mut bytes).expect("read ClientHello");
+            bytes.truncate(read);
+            captured_tx.send(bytes).expect("send captured bytes");
+        });
+
+        let trusted = std::net::TcpListener::bind("127.0.0.1:0").expect("bind trusted node");
+        let trusted_port = trusted.local_addr().expect("trusted address").port();
+        let trusted_thread = std::thread::spawn(move || {
+            let (socket, _) = trusted.accept().expect("accept failover attempt");
+            socket
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("bound trusted read");
+            socket
+                .set_write_timeout(Some(Duration::from_secs(2)))
+                .expect("bound trusted write");
+            let connection =
+                rustls::ServerConnection::new(Arc::new(server)).expect("create TLS server");
+            let mut stream = rustls::StreamOwned::new(connection, socket);
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream
+                    .read(&mut buffer)
+                    .expect("read authenticated request");
+                assert_ne!(read, 0, "request ended before its headers");
+                request.extend_from_slice(&buffer[..read]);
+            }
+            let body = r#"{"choices":[{"message":{"role":"assistant","content":"served"}}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write authenticated answer");
+            stream.flush().expect("flush authenticated answer");
+        });
+
+        let bad = NodeSpec {
+            label: "a-impostor".to_string(),
+            host: "localhost".to_string(),
+            port: impostor_port,
+        };
+        let good = NodeSpec {
+            label: "b-trusted".to_string(),
+            host: "localhost".to_string(),
+            port: trusted_port,
+        };
+        let bearer = "must-not-cross-before-authentication-74d1";
+        let fabric = Fabric::new(vec![bad.clone(), good.clone()])
+            .with_bearer(Some(bearer))
+            .with_node_transport(Some(&ca_path), false)
+            .expect("TLS transport resolves")
+            .with_max_observation_age(Duration::from_secs(30))
+            .with_max_forward_attempts(2);
+        *lock(&fabric.observed) = Some((
+            0,
+            Observation::taken_at(
+                vec![ready_snapshot(bad, "m"), ready_snapshot(good, "m")],
+                Instant::now(),
+            ),
+        ));
+
+        let dispatched = fabric
+            .dispatch(
+                "/v1/chat/completions",
+                &forward::chat_request("m", "ping", 8),
+                &RouteRequest::new(RouteMode::Throughput).with_model(Some("m")),
+                Duration::from_secs(3),
+                &Cancel::never(),
+            )
+            .expect("the authenticated sibling serves after TLS refusal");
+        assert_eq!(dispatched.answer.label, "b-trusted");
+        assert_eq!(dispatched.attempts, 2);
+
+        let captured = captured_rx.recv().expect("captured ClientHello");
+        assert!(
+            !captured
+                .windows(bearer.len())
+                .any(|window| window == bearer.as_bytes()),
+            "bearer crossed before server authentication"
+        );
+        impostor_thread.join().expect("impostor exits");
+        trusted_thread.join().expect("trusted node exits");
+    }
+
     #[test]
     fn service_classes_separate_workloads_with_different_cost_shapes() {
         let base = serde_json::json!({

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -1139,6 +1139,31 @@ mod tests {
                 assert_ne!(read, 0, "request ended before its headers");
                 request.extend_from_slice(&buffer[..read]);
             }
+            let header_end = request
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+                .expect("request headers end")
+                + 4;
+            let content_length = std::str::from_utf8(&request[..header_end])
+                .expect("ASCII request headers")
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length").then(|| {
+                        value
+                            .trim()
+                            .parse::<usize>()
+                            .expect("numeric content length")
+                    })
+                })
+                .unwrap_or(0);
+            while request.len() - header_end < content_length {
+                let read = stream
+                    .read(&mut buffer)
+                    .expect("read authenticated request body");
+                assert_ne!(read, 0, "request ended before its body");
+                request.extend_from_slice(&buffer[..read]);
+            }
             let body = r#"{"choices":[{"message":{"role":"assistant","content":"served"}}]}"#;
             let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",

--- a/src/fabric/mod.rs
+++ b/src/fabric/mod.rs
@@ -21,6 +21,7 @@
 //! * [`policy`] — pure placement decisions; the correctness of the fabric.
 //! * [`forward`] — sending a placed request to the node that will serve it.
 //! * [`cancel`] — telling that send it is no longer wanted.
+//! * `transport` — authenticating or explicitly constraining the node hop.
 
 pub mod cancel;
 pub(crate) mod client_keys;
@@ -31,6 +32,7 @@ pub(crate) mod nodes;
 pub mod policy;
 pub mod probe;
 pub mod server;
+mod transport;
 pub(crate) mod watch;
 
 use std::sync::{Arc, Mutex};
@@ -54,6 +56,7 @@ pub use policy::{
     RouteRequest,
 };
 pub use probe::{probe_fabric, probe_node, Observation, ProbeError, DEFAULT_PROBE_TIMEOUT};
+use transport::NodeTransport;
 
 /// How many nodes one request may be sent to before it fails.
 ///
@@ -74,6 +77,7 @@ pub struct Fabric {
     nodes: NodeSet,
     timeout: Duration,
     bearer: Option<String>,
+    transport: NodeTransport,
     /// Requests this fabric has placed and not yet finished.
     ///
     /// Shared across clones on purpose: the resident proxy hands a `Fabric` to
@@ -106,6 +110,7 @@ impl std::fmt::Debug for Fabric {
             .field("nodes", &self.nodes)
             .field("timeout", &self.timeout)
             .field("bearer", &self.bearer.as_ref().map(|_| "[REDACTED]"))
+            .field("transport", &self.transport)
             .field("max_observation_age", &self.max_observation_age)
             .field("max_forward_attempts", &self.max_forward_attempts)
             .finish()
@@ -138,6 +143,7 @@ impl Fabric {
             nodes,
             timeout: DEFAULT_PROBE_TIMEOUT,
             bearer: None,
+            transport: NodeTransport::default(),
             reserved: Arc::new(Mutex::new(Reservations::none())),
             service_times: Arc::new(Mutex::new(ServiceTimeEstimates::default())),
             observed: Arc::new(Mutex::new(None)),
@@ -182,6 +188,21 @@ impl Fabric {
         self
     }
 
+    /// Configure how every probe and forwarded request reaches a node.
+    ///
+    /// A CA bundle enables server-authenticated TLS for every node. Without
+    /// one, cleartext is restricted to loopback unless the operator explicitly
+    /// acknowledges direct cleartext node transport. The two modes cannot be
+    /// combined.
+    pub fn with_node_transport(
+        mut self,
+        ca_file: Option<&std::path::Path>,
+        allow_cleartext_remote: bool,
+    ) -> std::io::Result<Self> {
+        self.transport = NodeTransport::resolve(ca_file, allow_cleartext_remote)?;
+        Ok(self)
+    }
+
     /// The machines this fabric places on, as they stand right now.
     pub fn specs(&self) -> Vec<NodeSpec> {
         self.nodes.current().0.to_vec()
@@ -194,6 +215,11 @@ impl Fabric {
 
     pub fn is_empty(&self) -> bool {
         self.nodes.current().0.is_empty()
+    }
+
+    /// A secret-free description suitable for startup logs.
+    pub fn node_transport_description(&self) -> &'static str {
+        self.transport.description()
     }
 
     /// Observe every node.
@@ -247,7 +273,12 @@ impl Fabric {
 
     /// Probe every node in `specs`, whatever was observed before.
     fn probe(&self, specs: &[NodeSpec]) -> Vec<NodeSnapshot> {
-        probe_fabric(specs, self.bearer.as_deref(), self.timeout)
+        probe::probe_fabric_with_transport(
+            specs,
+            self.bearer.as_deref(),
+            self.timeout,
+            &self.transport,
+        )
     }
 
     /// Drop the current observation, so the next one is taken fresh.
@@ -402,6 +433,30 @@ impl Fabric {
         lock(&self.reserved).clone()
     }
 
+    /// Send a request to a node already chosen by this fabric.
+    ///
+    /// This exists for the one-shot `fabric run` path, whose request body uses
+    /// the chosen node's active model. Keeping the send here ensures it cannot
+    /// bypass the fabric's bearer or transport policy.
+    pub fn forward_to(
+        &self,
+        spec: &NodeSpec,
+        path: &str,
+        body: &Value,
+        timeout: Duration,
+        cancel: &Cancel,
+    ) -> Result<Forwarded, ForwardError> {
+        forward::forward_with_transport(
+            spec,
+            path,
+            body,
+            self.bearer.as_deref(),
+            timeout,
+            cancel,
+            &self.transport,
+        )
+    }
+
     /// Observe, place, and send — the whole path a caller actually wants.
     ///
     /// Returns the placement alongside the answer so a caller can record which
@@ -423,13 +478,14 @@ impl Fabric {
             (request.mode != RouteMode::Throughput).then(|| service_class(path, body));
         let request = request.with_service_class(service_class.as_deref());
         let mut sent = self.send_until_a_node_takes_it(&request, |spec| {
-            forward::forward(
+            forward::forward_with_transport(
                 spec,
                 path,
                 body,
                 self.bearer.as_deref(),
                 forward_timeout,
                 cancel,
+                &self.transport,
             )
         })?;
         if sent.value.is_success() {
@@ -467,7 +523,7 @@ impl Fabric {
             (request.mode != RouteMode::Throughput).then(|| service_class(path, body));
         let request = request.with_service_class(service_class.as_deref());
         let mut sent = self.send_until_a_node_takes_it(&request, |spec| {
-            forward::forward_streaming(
+            forward::forward_streaming_with_transport(
                 spec,
                 path,
                 body,
@@ -475,6 +531,7 @@ impl Fabric {
                 head_timeout,
                 idle_timeout,
                 cancel,
+                &self.transport,
             )
         })?;
         if let StreamOutcome::Buffered(answer) = &sent.value {

--- a/src/fabric/probe.rs
+++ b/src/fabric/probe.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use super::cancel::Cancel;
 use super::http::{self, HttpError};
 use super::node::{NodeReady, NodeSnapshot, NodeSpec, NodeStatus};
+use super::transport::NodeTransport;
 
 /// Refuse a health body larger than this. A health response is a few KiB;
 /// anything at this size means we are not talking to a Camelid engine.
@@ -95,8 +96,9 @@ fn read_health(
     spec: &NodeSpec,
     bearer: Option<&str>,
     timeout: Duration,
+    transport: &NodeTransport,
 ) -> Result<HealthPayload, ProbeError> {
-    let response = http::request(
+    let response = http::request_with_transport(
         &spec.host,
         spec.port,
         "GET",
@@ -109,6 +111,7 @@ fn read_health(
         // health read, not a generation slot, so there is nothing here worth
         // the noise of making cancellable.
         &Cancel::never(),
+        transport,
     )?;
     if response.status != 200 {
         return Err(ProbeError::Status(response.status));
@@ -136,8 +139,17 @@ fn unreachable_reason(error: &ProbeError) -> String {
 /// Probe one node. Never fails: an unreachable node is a routing fact, not an
 /// error the caller has to handle separately.
 pub fn probe_node(spec: &NodeSpec, bearer: Option<&str>, timeout: Duration) -> NodeSnapshot {
+    probe_node_with_transport(spec, bearer, timeout, &NodeTransport::default())
+}
+
+pub(crate) fn probe_node_with_transport(
+    spec: &NodeSpec,
+    bearer: Option<&str>,
+    timeout: Duration,
+    transport: &NodeTransport,
+) -> NodeSnapshot {
     let started = Instant::now();
-    match read_health(spec, bearer, timeout) {
+    match read_health(spec, bearer, timeout, transport) {
         Ok(payload) => NodeSnapshot {
             spec: spec.clone(),
             status: classify(&payload),
@@ -162,13 +174,24 @@ pub fn probe_fabric(
     bearer: Option<&str>,
     timeout: Duration,
 ) -> Vec<NodeSnapshot> {
+    probe_fabric_with_transport(specs, bearer, timeout, &NodeTransport::default())
+}
+
+pub(crate) fn probe_fabric_with_transport(
+    specs: &[NodeSpec],
+    bearer: Option<&str>,
+    timeout: Duration,
+    transport: &NodeTransport,
+) -> Vec<NodeSnapshot> {
     if specs.is_empty() {
         return Vec::new();
     }
     std::thread::scope(|scope| {
         let handles: Vec<_> = specs
             .iter()
-            .map(|spec| scope.spawn(move || probe_node(spec, bearer, timeout)))
+            .map(|spec| {
+                scope.spawn(move || probe_node_with_transport(spec, bearer, timeout, transport))
+            })
             .collect();
         handles
             .into_iter()

--- a/src/fabric/transport.rs
+++ b/src/fabric/transport.rs
@@ -1,0 +1,230 @@
+//! Authentication and confidentiality policy for the proxy-to-node hop.
+//!
+//! A node already authenticates the fabric with its API bearer. This module
+//! binds that application credential to an authenticated transport: either a
+//! CA-pinned TLS connection, or cleartext that resolves only to loopback (the
+//! supported shape for a local node or an operator-owned tunnel). Direct
+//! cleartext to another machine requires an explicit acknowledgement.
+
+use std::fmt;
+use std::io::{Error, ErrorKind, Result};
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::{ClientConfig, RootCertStore};
+use rustls_pki_types::pem::PemObject;
+use rustls_pki_types::CertificateDer;
+
+#[derive(Clone)]
+pub(crate) enum NodeTransport {
+    Plaintext { allow_remote: bool },
+    Tls { config: Arc<ClientConfig> },
+}
+
+impl NodeTransport {
+    pub(crate) fn resolve(ca_file: Option<&Path>, allow_cleartext_remote: bool) -> Result<Self> {
+        match (ca_file, allow_cleartext_remote) {
+            (Some(_), true) => Err(Error::new(
+                ErrorKind::InvalidInput,
+                "--node-tls-ca and --allow-cleartext-node-transport cannot be combined",
+            )),
+            (Some(path), false) => Self::from_ca_file(path),
+            (None, allow_remote) => Ok(Self::Plaintext { allow_remote }),
+        }
+    }
+
+    fn from_ca_file(path: &Path) -> Result<Self> {
+        let bytes = std::fs::read(path).map_err(|error| {
+            Error::new(
+                error.kind(),
+                format!(
+                    "could not read node TLS CA bundle `{}`: {error}",
+                    path.display()
+                ),
+            )
+        })?;
+        let certificates = CertificateDer::pem_slice_iter(&bytes)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|error| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "node TLS CA bundle `{}` is not valid PEM: {error}",
+                        path.display()
+                    ),
+                )
+            })?;
+        if certificates.is_empty() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "node TLS CA bundle `{}` contains no certificates",
+                    path.display()
+                ),
+            ));
+        }
+
+        let mut roots = RootCertStore::empty();
+        for certificate in certificates {
+            roots.add(certificate).map_err(|error| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!(
+                        "node TLS CA bundle `{}` contains an unusable certificate: {error}",
+                        path.display()
+                    ),
+                )
+            })?;
+        }
+        let config = ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        Ok(Self::Tls {
+            config: Arc::new(config),
+        })
+    }
+
+    pub(crate) fn permitted_addresses(&self, addresses: &[SocketAddr]) -> Result<Vec<SocketAddr>> {
+        match self {
+            Self::Tls { .. } | Self::Plaintext { allow_remote: true } => Ok(addresses.to_vec()),
+            Self::Plaintext {
+                allow_remote: false,
+            } => {
+                let loopback: Vec<_> = addresses
+                    .iter()
+                    .copied()
+                    .filter(|address| address.ip().is_loopback())
+                    .collect();
+                if loopback.is_empty() {
+                    return Err(Error::new(
+                        ErrorKind::PermissionDenied,
+                        "refusing cleartext transport to a non-loopback node; configure --node-tls-ca or acknowledge --allow-cleartext-node-transport",
+                    ));
+                }
+                Ok(loopback)
+            }
+        }
+    }
+
+    pub(crate) fn tls_config(&self) -> Option<Arc<ClientConfig>> {
+        match self {
+            Self::Plaintext { .. } => None,
+            Self::Tls { config } => Some(Arc::clone(config)),
+        }
+    }
+
+    pub(crate) fn description(&self) -> &'static str {
+        match self {
+            Self::Tls { .. } => "server-authenticated TLS (pinned CA)",
+            Self::Plaintext { allow_remote: true } => {
+                "cleartext (direct remote transport explicitly acknowledged)"
+            }
+            Self::Plaintext {
+                allow_remote: false,
+            } => "cleartext restricted to loopback/tunnels",
+        }
+    }
+}
+
+impl Default for NodeTransport {
+    fn default() -> Self {
+        Self::Plaintext {
+            allow_remote: false,
+        }
+    }
+}
+
+impl fmt::Debug for NodeTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Plaintext { allow_remote } => formatter
+                .debug_struct("Plaintext")
+                .field("allow_remote", allow_remote)
+                .finish(),
+            Self::Tls { .. } => formatter.write_str("Tls { server_auth: pinned_ca }"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn guarded_cleartext_keeps_loopback_and_refuses_only_remote_answers() {
+        let transport = NodeTransport::default();
+        let v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8181);
+        let v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8181);
+        let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)), 8181);
+
+        assert_eq!(
+            transport
+                .permitted_addresses(&[remote, v6, v4])
+                .expect("loopback answers remain usable"),
+            vec![v6, v4]
+        );
+        let error = transport
+            .permitted_addresses(&[remote])
+            .expect_err("remote cleartext is refused");
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert!(error.to_string().contains("--node-tls-ca"), "{error}");
+    }
+
+    #[test]
+    fn cleartext_acknowledgement_allows_remote_addresses() {
+        let transport = NodeTransport::resolve(None, true).expect("acknowledgement resolves");
+        let remote = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)), 8181);
+        assert_eq!(
+            transport
+                .permitted_addresses(&[remote])
+                .expect("remote address is acknowledged"),
+            vec![remote]
+        );
+        assert!(transport.description().contains("acknowledged"));
+    }
+
+    #[test]
+    fn tls_and_a_cleartext_acknowledgement_are_not_two_simultaneous_modes() {
+        let error = NodeTransport::resolve(Some(Path::new("node-ca")), true)
+            .expect_err("contradictory transport flags are refused");
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("--node-tls-ca"), "{error}");
+        assert!(
+            error
+                .to_string()
+                .contains("--allow-cleartext-node-transport"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn a_ca_bundle_must_exist_and_contain_at_least_one_certificate() {
+        let missing = NodeTransport::resolve(Some(Path::new("missing-node-ca")), false)
+            .expect_err("missing CA is refused");
+        assert_eq!(missing.kind(), ErrorKind::NotFound);
+
+        let directory = tempfile::tempdir().expect("temp dir");
+        let empty = directory.path().join("empty-node-ca");
+        std::fs::write(&empty, b"").expect("writes empty bundle");
+        let error =
+            NodeTransport::resolve(Some(&empty), false).expect_err("an empty CA bundle is refused");
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        assert!(error.to_string().contains("no certificates"), "{error}");
+    }
+
+    #[test]
+    fn a_certificate_bundle_builds_a_server_authentication_config() {
+        let certified = rcgen::generate_simple_self_signed(vec!["node.example".to_string()])
+            .expect("creates a certificate");
+        let bundle = rcgen::Certificate::pem(&certified.cert);
+        let directory = tempfile::tempdir().expect("temp dir");
+        let path = directory.path().join("node-ca");
+        std::fs::write(&path, bundle).expect("writes bundle");
+
+        let transport =
+            NodeTransport::resolve(Some(&path), false).expect("valid certificate bundle resolves");
+        assert!(transport.tls_config().is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1183,6 +1183,16 @@ fn fabric_from(
     }
 }
 
+fn configure_node_transport(
+    fabric: camelid::fabric::Fabric,
+    transport: &NodeTransportArgs,
+) -> anyhow::Result<camelid::fabric::Fabric> {
+    Ok(fabric.with_node_transport(
+        transport.node_tls_ca.as_deref(),
+        transport.allow_cleartext_node_transport,
+    )?)
+}
+
 /// Resolve the token the fabric authenticates to its nodes with.
 ///
 /// Deliberately not `#[arg(env = "CAMELID_API_KEY")]`: clap prints an env var's
@@ -1211,6 +1221,28 @@ fn resolve_bearer(flag: Option<String>, from_env: Option<String>) -> Option<Stri
 /// session, so nothing crosses the network inside the token loop. This is the
 /// throughput complement to `serve-distributed`, which shards one model's layers
 /// across machines and is slower than a single node by construction.
+#[derive(Debug, Clone, Args)]
+struct NodeTransportArgs {
+    /// PEM CA bundle that authenticates every node. Node hostnames and IP
+    /// literals are verified against the certificate SAN before any bearer or
+    /// request bytes are sent.
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "allow_cleartext_node_transport"
+    )]
+    node_tls_ca: Option<PathBuf>,
+    /// Permit direct cleartext transport to a node that resolves outside
+    /// loopback. Without this acknowledgement, plaintext is limited to local
+    /// nodes and operator-owned tunnels.
+    #[arg(
+        long,
+        env = "CAMELID_ALLOW_CLEARTEXT_NODE_TRANSPORT",
+        default_value_t = false
+    )]
+    allow_cleartext_node_transport: bool,
+}
+
 #[derive(Debug, Subcommand)]
 enum FabricAction {
     /// Probe every node once and report what the fabric can serve.
@@ -1232,6 +1264,8 @@ enum FabricAction {
         /// secret is not in the process command line.
         #[arg(long, value_name = "TOKEN")]
         bearer: Option<String>,
+        #[command(flatten)]
+        transport: NodeTransportArgs,
         /// Per-node probe budget. Nodes are probed concurrently, so this bounds
         /// the whole command, not each node in turn.
         #[arg(long, default_value_t = 2000)]
@@ -1269,6 +1303,8 @@ enum FabricAction {
         /// CAMELID_API_KEY.
         #[arg(long, value_name = "TOKEN")]
         bearer: Option<String>,
+        #[command(flatten)]
+        transport: NodeTransportArgs,
         #[arg(long, default_value_t = 2000)]
         timeout_ms: u64,
         #[arg(long)]
@@ -1307,6 +1343,8 @@ enum FabricAction {
         /// ready and then answers this request with 401.
         #[arg(long, value_name = "TOKEN")]
         bearer: Option<String>,
+        #[command(flatten)]
+        transport: NodeTransportArgs,
         #[arg(long, default_value_t = 64)]
         max_tokens: u32,
         /// Per-node health probe budget.
@@ -1358,6 +1396,8 @@ enum FabricAction {
         /// answers every forwarded request with 401.
         #[arg(long, value_name = "TOKEN")]
         bearer: Option<String>,
+        #[command(flatten)]
+        transport: NodeTransportArgs,
         /// Require this key from clients of the proxy. This is the opposite
         /// direction to --bearer, and deliberately does NOT read CAMELID_API_KEY:
         /// on this command that variable already names the token sent to nodes,
@@ -1525,6 +1565,48 @@ mod fabric_command_tests {
                     other => panic!("expected a fabric command, got {other:?}"),
                 };
                 assert_eq!(bearer.as_deref(), Some("s3cret"), "{argv:?}");
+            }
+        });
+    }
+
+    #[test]
+    fn every_fabric_subcommand_has_the_same_node_transport_contract() {
+        on_cli_test_stack(|| {
+            for argv in [
+                vec!["camelid", "fabric", "status"],
+                vec!["camelid", "fabric", "route"],
+                vec!["camelid", "fabric", "run", "--prompt", "hi"],
+                vec!["camelid", "fabric", "serve"],
+            ] {
+                let mut tls = argv.clone();
+                tls.extend(["--node", "a=node.example", "--node-tls-ca", "node-ca"]);
+                let cli = Cli::try_parse_from(&tls).expect("TLS mode parses");
+                let transport = match cli.command {
+                    Some(Command::Fabric { action }) => match action {
+                        FabricAction::Status { transport, .. }
+                        | FabricAction::Route { transport, .. }
+                        | FabricAction::Run { transport, .. }
+                        | FabricAction::Serve { transport, .. } => transport,
+                    },
+                    other => panic!("expected a fabric command, got {other:?}"),
+                };
+                assert_eq!(
+                    transport.node_tls_ca.as_deref(),
+                    Some(std::path::Path::new("node-ca")),
+                    "{tls:?}"
+                );
+                assert!(!transport.allow_cleartext_node_transport, "{tls:?}");
+
+                let mut contradictory = argv;
+                contradictory.extend([
+                    "--node",
+                    "a=node.example",
+                    "--node-tls-ca",
+                    "node-ca",
+                    "--allow-cleartext-node-transport",
+                ]);
+                Cli::try_parse_from(&contradictory)
+                    .expect_err("TLS and cleartext acknowledgement conflict");
             }
         });
     }
@@ -3225,11 +3307,12 @@ async fn main() -> anyhow::Result<()> {
                 nodes,
                 nodes_file,
                 bearer,
+                transport,
                 timeout_ms,
                 json,
             } => {
                 let bearer = fabric_bearer(bearer);
-                let fabric = fabric_from(nodes, nodes_file)?
+                let fabric = configure_node_transport(fabric_from(nodes, nodes_file)?, &transport)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref());
                 let snapshots = fabric.observe();
@@ -3246,12 +3329,13 @@ async fn main() -> anyhow::Result<()> {
                 model,
                 sticky,
                 bearer,
+                transport,
                 timeout_ms,
                 json,
             } => {
                 let bearer = fabric_bearer(bearer);
                 let mode = stateless_route_mode(&mode)?;
-                let fabric = fabric_from(nodes, nodes_file)?
+                let fabric = configure_node_transport(fabric_from(nodes, nodes_file)?, &transport)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref());
                 let snapshots = fabric.observe();
@@ -3291,6 +3375,7 @@ async fn main() -> anyhow::Result<()> {
                 model,
                 sticky,
                 bearer,
+                transport,
                 max_tokens,
                 timeout_ms,
                 forward_timeout_s,
@@ -3298,7 +3383,7 @@ async fn main() -> anyhow::Result<()> {
             } => {
                 let bearer = fabric_bearer(bearer);
                 let mode = stateless_route_mode(&mode)?;
-                let fabric = fabric_from(nodes, nodes_file)?
+                let fabric = configure_node_transport(fabric_from(nodes, nodes_file)?, &transport)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref());
 
@@ -3329,17 +3414,17 @@ async fn main() -> anyhow::Result<()> {
                 };
 
                 let body = camelid::fabric::forward::chat_request(&model_id, &prompt, max_tokens);
-                let answer = camelid::fabric::forward::forward(
-                    &chosen.spec,
-                    "/v1/chat/completions",
-                    &body,
-                    bearer.as_deref(),
-                    std::time::Duration::from_secs(forward_timeout_s),
-                    // One request per process: this ends when the process does,
-                    // so there is no client that can leave while it runs.
-                    &camelid::fabric::Cancel::never(),
-                )
-                .map_err(|error| anyhow::anyhow!("{error}"))?;
+                let answer = fabric
+                    .forward_to(
+                        &chosen.spec,
+                        "/v1/chat/completions",
+                        &body,
+                        std::time::Duration::from_secs(forward_timeout_s),
+                        // One request per process: this ends when the process does,
+                        // so there is no client that can leave while it runs.
+                        &camelid::fabric::Cancel::never(),
+                    )
+                    .map_err(|error| anyhow::anyhow!("{error}"))?;
 
                 if json {
                     println!(
@@ -3384,6 +3469,7 @@ async fn main() -> anyhow::Result<()> {
                 addr,
                 mode,
                 bearer,
+                transport,
                 api_key,
                 api_key_file,
                 timeout_ms,
@@ -3409,7 +3495,7 @@ async fn main() -> anyhow::Result<()> {
                 let tls = camelid::fabric::server::ProxyTls::resolve(tls_cert, tls_key).await?;
                 // Same reason: a node file that cannot be read is a refusal,
                 // and it has to arrive before the listening line.
-                let fabric = fabric_from(nodes, nodes_file)?
+                let fabric = configure_node_transport(fabric_from(nodes, nodes_file)?, &transport)?
                     .with_timeout(std::time::Duration::from_millis(timeout_ms))
                     .with_bearer(bearer.as_deref())
                     .with_max_observation_age(std::time::Duration::from_millis(
@@ -3432,6 +3518,7 @@ async fn main() -> anyhow::Result<()> {
                 let bound = listener.local_addr()?;
                 let scheme = if tls.is_some() { "https" } else { "http" };
                 println!("fabric serve listening on {scheme}://{bound}");
+                println!("node transport: {}", fabric.node_transport_description());
                 // A key set is the only thing here an operator can get subtly
                 // wrong without being told: a file that parsed but named one
                 // client when they meant three looks exactly like success.

--- a/tests/fabric_end_to_end.rs
+++ b/tests/fabric_end_to_end.rs
@@ -123,6 +123,7 @@ impl StubNode {
                     break;
                 }
                 let Ok(mut stream) = stream else { continue };
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
                 serve_once(&mut stream, &config, &thread_requests);
             }
         });
@@ -159,7 +160,89 @@ impl Drop for StubNode {
     }
 }
 
-fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<Received>>) {
+/// The same stub node over server-authenticated TLS.
+struct TlsStubNode {
+    port: u16,
+    shutdown: Arc<AtomicBool>,
+    requests: Arc<Mutex<Vec<Received>>>,
+    thread: Option<JoinHandle<()>>,
+    _directory: tempfile::TempDir,
+    ca_path: std::path::PathBuf,
+}
+
+impl TlsStubNode {
+    fn start(config: StubConfig) -> Self {
+        let issued = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("generate a node certificate");
+        let key = rustls_pki_types::PrivatePkcs8KeyDer::from(issued.key_pair.serialize_der());
+        let server = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![issued.cert.der().clone()], key.into())
+            .expect("node certificate and key agree");
+        let directory = tempfile::tempdir().expect("temp dir");
+        let ca_path = directory.path().join("node-ca");
+        std::fs::write(&ca_path, rcgen::Certificate::pem(&issued.cert)).expect("write node CA");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind TLS node");
+        let port = listener.local_addr().expect("local addr").port();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_requests = Arc::clone(&requests);
+        let server = Arc::new(server);
+        let thread = std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                if thread_shutdown.load(Ordering::SeqCst) {
+                    break;
+                }
+                let Ok(stream) = stream else { continue };
+                let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+                let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+                let connection = rustls::ServerConnection::new(Arc::clone(&server))
+                    .expect("create TLS server connection");
+                let mut stream = rustls::StreamOwned::new(connection, stream);
+                serve_once(&mut stream, &config, &thread_requests);
+            }
+        });
+
+        Self {
+            port,
+            shutdown,
+            requests,
+            thread: Some(thread),
+            _directory: directory,
+            ca_path,
+        }
+    }
+
+    fn spec(&self, label: &str) -> NodeSpec {
+        NodeSpec {
+            label: label.to_string(),
+            host: "localhost".to_string(),
+            port: self.port,
+        }
+    }
+
+    fn received(&self) -> Vec<Received> {
+        self.requests.lock().expect("TLS stub lock").clone()
+    }
+}
+
+impl Drop for TlsStubNode {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = TcpStream::connect(("127.0.0.1", self.port));
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn serve_once(
+    stream: &mut (impl Read + Write),
+    config: &StubConfig,
+    requests: &Mutex<Vec<Received>>,
+) {
     let Some(received) = read_request(stream) else {
         return;
     };
@@ -196,9 +279,7 @@ fn serve_once(stream: &mut TcpStream, config: &StubConfig, requests: &Mutex<Vec<
     let _ = stream.flush();
 }
 
-fn read_request(stream: &mut TcpStream) -> Option<Received> {
-    stream.set_read_timeout(Some(Duration::from_secs(2))).ok()?;
-
+fn read_request(stream: &mut impl Read) -> Option<Received> {
     let mut raw = Vec::new();
     let mut chunk = [0_u8; 1024];
     // Read until the headers are complete, then until Content-Length is met.
@@ -534,6 +615,43 @@ fn a_fabric_carrying_the_key_is_served_by_an_authenticated_node() {
             request.path
         );
     }
+}
+
+#[test]
+fn a_fabric_observes_and_dispatches_through_one_ca_pinned_tls_policy() {
+    let alpha = TlsStubNode::start(StubConfig::requiring_key("model-alpha", "s3cret"));
+    let fabric = fabric_of(vec![alpha.spec("alpha")])
+        .with_bearer(Some("s3cret"))
+        .with_node_transport(Some(&alpha.ca_path), false)
+        .expect("node TLS policy resolves");
+
+    let snapshots = fabric.observe();
+    assert_eq!(snapshots[0].active_model_id(), Some("model-alpha"));
+
+    let dispatched = fabric
+        .dispatch(
+            "/v1/chat/completions",
+            &forward::chat_request("model-alpha", "ping", 8),
+            &RouteRequest::new(RouteMode::Throughput),
+            FORWARD_TIMEOUT,
+            &Cancel::never(),
+        )
+        .expect("the TLS node serves the request");
+    assert_eq!(dispatched.decision.label, "alpha");
+    assert_eq!(dispatched.answer.status, 200);
+    assert_eq!(
+        forward::completion_text(&dispatched.answer.body),
+        Some("served by model-alpha")
+    );
+
+    let seen = alpha.received();
+    assert!(seen.iter().any(|request| request.path == "/v1/health"));
+    assert!(seen
+        .iter()
+        .any(|request| request.path == "/v1/chat/completions"));
+    assert!(seen
+        .iter()
+        .all(|request| { request.header("authorization") == Some("Bearer s3cret") }));
 }
 
 #[test]

--- a/tests/fabric_end_to_end.rs
+++ b/tests/fabric_end_to_end.rs
@@ -655,6 +655,62 @@ fn a_fabric_observes_and_dispatches_through_one_ca_pinned_tls_policy() {
 }
 
 #[test]
+fn a_node_loaded_later_from_the_file_inherits_the_tls_policy() {
+    let original = TlsStubNode::start(StubConfig::ready("model-alpha", 0));
+    let joined = TlsStubNode::start(StubConfig::ready("model-alpha", 0));
+    let directory = tempfile::tempdir().expect("temp dir");
+    let path = directory.path().join("nodes");
+    std::fs::write(&path, format!("original=localhost:{}\n", original.port))
+        .expect("write initial node file");
+    let ca_path = directory.path().join("node-ca-bundle");
+    let ca_bundle = format!(
+        "{}\n{}",
+        std::fs::read_to_string(&original.ca_path).expect("read original CA"),
+        std::fs::read_to_string(&joined.ca_path).expect("read joined CA")
+    );
+    std::fs::write(&ca_path, ca_bundle).expect("write shared CA bundle");
+
+    let fabric = Fabric::from_node_file(path.clone())
+        .expect("load node file")
+        .with_timeout(PROBE_TIMEOUT)
+        .with_node_transport(Some(&ca_path), false)
+        .expect("node TLS policy resolves");
+    let initial = fabric.observe();
+    assert_eq!(initial.len(), 1);
+    assert_eq!(initial[0].label(), "original");
+    assert!(initial[0].status.is_ready());
+
+    // The shipped watcher checks once per second. Rewrite after that bound so
+    // this test exercises a newly loaded spec rather than the startup value.
+    std::thread::sleep(Duration::from_millis(1_100));
+    std::fs::write(&path, format!("joined-later=localhost:{}\n", joined.port))
+        .expect("replace node file with a distinct endpoint");
+
+    let reloaded = fabric.observe();
+    assert_eq!(reloaded.len(), 1);
+    assert_eq!(reloaded[0].label(), "joined-later");
+    assert!(reloaded[0].status.is_ready());
+    assert_eq!(
+        original
+            .received()
+            .iter()
+            .filter(|request| request.path == "/v1/health")
+            .count(),
+        1,
+        "the original endpoint must not be reused after reload"
+    );
+    assert_eq!(
+        joined
+            .received()
+            .iter()
+            .filter(|request| request.path == "/v1/health")
+            .count(),
+        1,
+        "the newly loaded endpoint must cross the existing TLS policy"
+    );
+}
+
+#[test]
 fn a_missing_or_wrong_key_arrives_as_a_401_answer_not_a_transport_failure() {
     // The defect this flag exists for. `/v1/health` is auth-exempt, so an
     // authenticated node observes as ready and places fine; only the forward is


### PR DESCRIPTION
## Summary

- Add server-authenticated TLS for every Fabric proxy-to-node path through a pinned private CA.
- Keep the existing node bearer as application authentication; TLS authenticates the server before any bearer, header, or body byte is sent.
- Restrict plaintext node transport to loopback/tunnel endpoints by default. Direct remote plaintext requires `--allow-cleartext-node-transport`.
- Apply one transport policy to probes, buffered forwarding, streaming, failover, dynamic `--nodes-file` reloads, and all Fabric CLI actions.
- Bound named-node resolution by the same request deadline and cancellation contract without bypassing native OS resolver semantics.

## Security and retry boundary

`--node-tls-ca <PATH>` loads a PEM CA bundle once and verifies the exact DNS name or IP literal from `LABEL=HOST[:PORT]` against the node certificate SAN. TLS and the cleartext acknowledgement conflict in both Clap and runtime policy resolution.

TLS authentication is part of address selection rather than a step after the first TCP success. Each resolved address receives a fair share of the remaining deadline, capped at five seconds. A TCP-accepting peer that stalls or rejects TLS cannot hide a later authenticated address.

Resolution, connection, cleartext policy, and TLS setup failures are pre-request failures, so failover may safely try another node. Errors after the first HTTP write remain non-retryable. TLS EOF without `close_notify` is accepted only when HTTP framing independently proves the authenticated response complete.

## Native resolver bound

Named nodes retain the platform resolver, including hosts-file, VPN split-DNS, enterprise resolver, and multicast behavior. Native `ToSocketAddrs` calls run behind one process-wide pool:

- 4 fixed workers
- bounded queue capacity of 64
- deadline-aware queue backpressure
- caller deadline and cancellation while waiting
- worker panic containment and retryable pool initialization
- IP literals bypass the resolver pool

A permanently wedged OS resolver call can consume at most four resolver workers. Caller latency, queue memory, and thread count remain bounded, and IP-SAN nodes remain usable. The implementation does not create unbounded helper threads or replace platform DNS with an independent resolver.

## Validation

Final head: `e99661961ced852aa2d18dda90ef27d83d6c7104`

Local final-head gates:

- Fabric library: 248 passed, 0 failed
- exact TLS-authentication failover regression on Windows: passed
- exact regression on a physical M5 Pro: passed, then passed 100 consecutive runs
- pinned Rust 1.89 all-target Clippy with `-D warnings`: passed; allowances are limited to verified pre-existing `duplicated_attributes` and `needless_range_loop` findings in untouched code
- rustfmt check: passed
- `git diff --check`: passed
- touched-file diagnostics: no errors

The first final-head CI attempt found a macOS-only defect in the new regression harness: its trusted TLS stub replied after reading only HTTP headers and then closed with an unread request body. macOS surfaced that abortive close as `Connection reset by peer`, which could discard the valid reply. Commit `e9966196` makes the stub consume its declared `Content-Length` before replying. This is test-only; it does not change production transport code. The corrected test passed on the physical M5 and 100 repeated M5 runs.

Fresh GitHub CI on `e9966196`: 9 successful, 0 failing, 0 pending, including the aggregate `ci-gate`.

TLS-specific coverage includes:

- real rustls request and SSE streaming over generated CA/certificate material
- DNS and IPv4 SAN verification
- wrong-CA and wrong-server-name refusal before HTTP
- captured ClientHello proving bearer non-disclosure before server authentication
- stalled first-address TLS handshake advancing to an authenticated sibling
- Fabric-level TLS-authentication failover without bearer leakage
- dynamic node-file endpoints inheriting the original CA policy
- TLS mid-stream truncation remaining an error
- plaintext loopback/tunnel compatibility and direct remote plaintext refusal
- DNS deadline, cancellation, queue saturation, panic survival, and 128-caller backpressure regressions

## Exact-head physical receipt

The final merge candidate was rebuilt on both physical machines:

- Windows client: `camelid v0.6.1-195-ge9966196`
- M5 Pro node health build: `0.6.1+e99661961ced`
- M5 debug binary SHA-256: `bfa6a4e015d0f6a3e701e6567220b6e4194a0875d05aa792fc2a34c95e0d2f60`
- model/backend: Llama 3.2 1B Instruct, `metal_resident_q8_runtime`

A two-day private CA and an IP-SAN leaf for `192.168.29.158` were used across the real LAN from the Windows client at `192.168.29.49`:

- TCP port 8181 reachable through the physical network/firewall
- OpenSSL chain and IP SAN verification passed
- cleartext without acknowledgement refused before dial
- correct CA reported the expected model ready
- wrong CA refused with `UnknownIssuer`
- no bearer returned HTTP 401 `authentication_error`
- correct bearer returned HTTP 200 with generated token IDs
- asserted receipt marker: `PR685_PHYSICAL_RECEIPT=PASS`

Windows native resolution did not resolve the available Mac host aliases, so the receipt used the documented IP-SAN posture rather than pretending DNS-SAN coverage existed on this LAN.

The node was stopped after the receipt. The Mac test clone, CA, leaf private key, API key, scripts, and all Windows temporary credentials were deleted. No key or certificate is tracked.
