### PR TITLE
Add Code context profiles and writes-auto mode

### DIFF
--- a/frontend/scripts/code-workbench-visual-smoke.mjs
+++ b/frontend/scripts/code-workbench-visual-smoke.mjs
@@ -29,17 +29,19 @@ const health = {
   engine: 'camelid',
   loaded_now: true,
   generation_ready: true,
-  active_model_id: 'Qwen3-4B-Q8_0.gguf',
+  // Deliberately use the catalog id rather than the filename. Context-profile
+  // eligibility must follow the resolved exact row, not this display/runtime id.
+  active_model_id: 'qwen3_4b_instruct_q8_0',
   backend: 'llama',
   model_family: 'qwen3',
   execution_plan: { selected_backend: 'cuda_resident_q8', cuda_resident_active: true },
 }
 const models = {
   object: 'list',
-  data: [{ id: 'Qwen3-4B-Q8_0.gguf', object: 'model', created: 0, owned_by: 'camelid', meta: { size: 4_280_404_704 } }],
+  data: [{ id: 'qwen3_4b_instruct_q8_0', object: 'model', created: 0, owned_by: 'camelid', meta: { size: 4_280_404_704 } }],
 }
 const currentModel = {
-  id: 'Qwen3-4B-Q8_0.gguf',
+  id: 'qwen3_4b_instruct_q8_0',
   path: 'models/Qwen3-4B-Q8_0.gguf',
   gguf: { metadata: { 'general.file_type': 7 } },
   tokenizer: { status: 'available' },
@@ -60,7 +62,7 @@ const localModels = {
 }
 const capabilities = {
   model_compatibility: [{
-    id: 'Qwen3-4B-Q8_0.gguf',
+    id: 'qwen3_4b_instruct_q8_0',
     family: 'qwen3',
     quantization: 'Q8_0',
     status: 'supported_exact_row_smoke',
@@ -241,9 +243,11 @@ try {
     if (url.endsWith('/api/agent/workspace/sessions') && request.method() === 'POST') {
       const body = JSON.parse(request.postData() || '{}')
       sessionBodies.push(body)
-      // The third start answers slowly on purpose: the composer offers Stop from
-      // the moment it is submitted, which is before any session id exists.
-      if (sessionBodies.length === 3) await new Promise((resolve) => setTimeout(resolve, 500))
+      // The third request is an in-thread replacement and the fifth a brand-new
+      // session. Both answer slowly so Stop lands before a session id exists.
+      if (sessionBodies.length === 3) await new Promise((resolve) => setTimeout(resolve, 1_250))
+      if (sessionBodies.length === 5) await new Promise((resolve) => setTimeout(resolve, 500))
+      const standardContext = body.context_profile === 'standard'
       return respondJson(request, {
         id: 'code-workbench-smoke',
         workspace: 'C:/projects/camelid-demo',
@@ -251,17 +255,18 @@ try {
         state: 'waiting_for_events',
         max_steps: 0,
         max_tokens: 768,
+        context_profile: body.context_profile || 'auto',
         context_window: {
           mode: 'auto',
-          effective_tokens: 16_384,
+          effective_tokens: standardContext ? 8_192 : 16_384,
           recommended_max_tokens: 8_192,
           memory_safe_max_tokens: 2_048,
           model_max_tokens: 40_960,
           validated_max_tokens: 8_192,
           kv_owner_slots: 1,
-          paged_target_tokens: 16_384,
-          paged_working_set_tokens: 8_000,
-          limiting_factor: 'paged_model_target',
+          paged_target_tokens: standardContext ? null : 16_384,
+          paged_working_set_tokens: standardContext ? null : 8_000,
+          limiting_factor: standardContext ? 'validated_agent_maximum' : 'paged_model_target',
         },
         allow_writes: true,
         approval_mode: body.approval_mode,
@@ -274,7 +279,9 @@ try {
       return request.respond({ status: 204, body: '' })
     }
     if (url.endsWith('/api/agent/workspace/sessions/code-workbench-smoke/changes')) {
-      const completed = decisions.length > 0
+      // A replacement session on the same saved thread owns a fresh checkpoint
+      // journal. Its Changes view must not retain files from the prior session.
+      const completed = decisions.length > 0 && sessionBodies.length < 2
       return respondJson(request, completed ? {
         summary: '1 file changed',
         diff: '+++ frontend/src/components/InteractiveAgent.jsx\\n+export function InteractiveAgent() {\\n+  return <section>Interactive agent</section>\\n+}',
@@ -360,6 +367,7 @@ try {
     || sessionBodies[0].mode !== 'code'
     || Object.hasOwn(sessionBodies[0], 'max_steps')
     || sessionBodies[0].approval_mode !== 'approval_gated'
+    || sessionBodies[0].context_profile !== 'auto'
     || sessionBodies[0].allow_network !== false) {
     throw new Error(`Code session contract mismatch: ${JSON.stringify(sessionBodies)}`)
   }
@@ -406,7 +414,7 @@ try {
   }
 
   await page.click('.code-inline-approval__actions .cx-btn--primary')
-  await page.waitForFunction(() => document.body.textContent.includes('Decision sent'), { timeout: 5000 })
+  await page.waitForFunction(() => document.body.textContent.includes('Reviewed'), { timeout: 5000 })
   await page.evaluate(() => globalThis.__finishCodeTurn())
   await page.waitForFunction(() => document.body.textContent.includes('Implemented the interactive agent component'), { timeout: 5000 })
   await page.waitForFunction(() => document.body.textContent.includes('InteractiveAgent.jsx'), { timeout: 5000 })
@@ -533,6 +541,98 @@ try {
   await page.keyboard.press('Escape')
   await page.waitForSelector('.code-access-menu', { hidden: true })
 
+  // Access and context are fixed per session. Changing either after a turn must
+  // resume the same saved thread through a replacement session, not silently
+  // send a follow-up under the old configuration. The replacement owns fresh
+  // diagnostics and a fresh checkpoint journal.
+  await page.click('.code-access-chip')
+  await page.waitForSelector('.code-access-menu')
+  await page.click('.code-access-menu > button.is-writes-auto')
+  await page.click('.code-context-chip')
+  await page.waitForSelector('.code-context-menu', { timeout: 5000 })
+  await page.click('.code-context-menu > button:last-child')
+  await page.click('.code-composer textarea')
+  await page.type('.code-composer textarea', 'Continue with automatic writes in the standard context.')
+  await page.click('.code-composer__send')
+  await page.waitForFunction(
+    () => globalThis.__codeStreamsOpened === 3
+      && document.querySelector('.code-context-chip')?.textContent.includes('Q4 8K'),
+    { timeout: 5000 },
+  )
+  await new Promise((resolve) => setTimeout(resolve, 650))
+  const replacementState = await page.evaluate(() => ({
+    primary: document.querySelector('.code-agent-list li')?.textContent.replace(/\s+/g, ' ').trim(),
+    contextChip: document.querySelector('.code-context-chip')?.textContent.replace(/\s+/g, ' ').trim(),
+    changedFiles: document.querySelectorAll('.code-file-list li').length,
+    hasContextComposition: [...document.querySelectorAll('.ci-fold > summary')]
+      .some((summary) => summary.textContent.includes('Composition')),
+  }))
+  if (sessionBodies.length !== 2
+    || sessionBodies[1].thread_id !== 'code-workbench-smoke'
+    || sessionBodies[1].approval_mode !== 'writes_auto'
+    || sessionBodies[1].context_profile !== 'standard'
+    || sessionBodies[1].allow_network !== false
+    || !replacementState.primary?.includes('0 model steps this session')
+    || replacementState.contextChip !== 'Q4 8K · 8K'
+    || replacementState.changedFiles !== 0
+    || replacementState.hasContextComposition) {
+    throw new Error(`replacement session kept stale configuration or diagnostics: ${JSON.stringify({ sessionBodies, replacementState })}`)
+  }
+  await page.click('.code-composer__send.is-stop')
+  await page.evaluate(() => globalThis.__abortCodeTurn())
+  await page.waitForFunction(() => !document.querySelector('.code-composer__send.is-stop'), { timeout: 8000 })
+
+  // Cancelling a replacement while its POST is still pending must put the old
+  // completed session back exactly as it was. `session.starting` clears
+  // diagnostics optimistically, so treating the abandoned replacement as a
+  // terminal event would leave the old session mislabeled and half-empty.
+  const beforeAbandonedReplacement = await page.evaluate(() => ({
+    status: document.querySelector('.code-stage__status')?.textContent.trim(),
+    elapsed: document.querySelector('.code-elapsed')?.textContent.trim(),
+    transcript: document.querySelector('.code-thread')?.textContent.replace(/\s+/g, ' ').trim(),
+    environment: document.querySelector('.ci-environment__rows')?.textContent.replace(/\s+/g, ' ').trim(),
+    runSummary: [...(document.querySelector('.code-agent-list li')?.querySelectorAll('.ci-task__meta') || [])]
+      .at(-1)?.textContent.replace(/\s+/g, ' ').trim(),
+    process: document.querySelector('.code-process-row')?.textContent.replace(/\s+/g, ' ').trim(),
+    changedFiles: document.querySelectorAll('.code-file-list li').length,
+  }))
+  await page.click('.code-context-chip')
+  await page.waitForSelector('.code-context-menu')
+  await page.click('.code-context-menu > button:first-of-type')
+  await page.click('.code-composer textarea')
+  await page.type('.code-composer textarea', 'Try a replacement, then stop before it starts.')
+  await page.click('.code-composer__send')
+  await page.waitForSelector('.code-composer__send.is-stop', { timeout: 3000 })
+  await page.click('.code-composer__send.is-stop')
+  await page.waitForFunction(() => !document.querySelector('.code-composer__send.is-stop'), { timeout: 8000 })
+  const abandonedReplacement = await page.evaluate(() => ({
+    status: document.querySelector('.code-stage__status')?.textContent.trim(),
+    elapsed: document.querySelector('.code-elapsed')?.textContent.trim(),
+    transcript: document.querySelector('.code-thread')?.textContent.replace(/\s+/g, ' ').trim(),
+    environment: document.querySelector('.ci-environment__rows')?.textContent.replace(/\s+/g, ' ').trim(),
+    runSummary: [...(document.querySelector('.code-agent-list li')?.querySelectorAll('.ci-task__meta') || [])]
+      .at(-1)?.textContent.replace(/\s+/g, ' ').trim(),
+    process: document.querySelector('.code-process-row')?.textContent.replace(/\s+/g, ' ').trim(),
+    changedFiles: document.querySelectorAll('.code-file-list li').length,
+    streamsOpened: globalThis.__codeStreamsOpened,
+    contextChip: document.querySelector('.code-context-chip')?.textContent.replace(/\s+/g, ' ').trim(),
+  }))
+  if (sessionBodies.length !== 3
+    || sessionBodies[2].thread_id !== 'code-workbench-smoke'
+    || sessionBodies[2].context_profile !== 'auto'
+    || cancels.length !== 3
+    || abandonedReplacement.streamsOpened !== 3
+    || abandonedReplacement.status !== beforeAbandonedReplacement.status
+    || abandonedReplacement.elapsed !== beforeAbandonedReplacement.elapsed
+    || abandonedReplacement.transcript !== beforeAbandonedReplacement.transcript
+    || abandonedReplacement.environment !== beforeAbandonedReplacement.environment
+    || abandonedReplacement.runSummary !== beforeAbandonedReplacement.runSummary
+    || abandonedReplacement.process !== beforeAbandonedReplacement.process
+    || abandonedReplacement.changedFiles !== beforeAbandonedReplacement.changedFiles
+    || abandonedReplacement.contextChip !== 'Auto') {
+    throw new Error(`abandoned replacement did not restore the prior session: ${JSON.stringify({ beforeAbandonedReplacement, abandonedReplacement, sessionBodies, cancels: cancels.length })}`)
+  }
+
   await page.click('button[aria-label="New coding session"]')
   await page.click('.code-access-chip')
   await page.waitForSelector('.code-access-menu')
@@ -541,14 +641,81 @@ try {
     checked: [...document.querySelectorAll('.code-access-menu > button')].map((node) => node.getAttribute('aria-checked')),
     bodyWidth: [document.documentElement.clientWidth, document.documentElement.scrollWidth],
   }))
-  if (!menuState.text?.includes('Today is a good day to die')
+  if (!menuState.text?.includes('Writes auto')
+    || !menuState.text?.includes('Full auto')
     || !menuState.text?.includes('Network and web search')
     || menuState.checked.at(-1) !== 'false'
     || menuState.bodyWidth[0] !== menuState.bodyWidth[1]) {
     throw new Error(`access menu mismatch: ${JSON.stringify(menuState)}`)
   }
   await page.screenshot({ path: join(outputDir, 'code-workbench-access-menu.png'), fullPage: true })
-  await page.click('.code-access-menu > button.is-danger')
+  await page.waitForFunction(() => document.activeElement?.getAttribute('role') === 'menuitemradio')
+  await page.keyboard.press('ArrowDown')
+  const accessArrowFocus = await page.evaluate(() => document.activeElement?.textContent.replace(/\s+/g, ' ').trim())
+  if (!accessArrowFocus?.startsWith('Writes auto')) {
+    throw new Error(`access menu did not move focus with ArrowDown: ${accessArrowFocus}`)
+  }
+  await page.keyboard.press('Escape')
+  await page.waitForSelector('.code-access-menu', { hidden: true })
+  const accessReturnedFocus = await page.evaluate(() => document.activeElement?.classList.contains('code-access-chip'))
+  if (!accessReturnedFocus) throw new Error('access menu Escape did not restore trigger focus')
+
+  // A wrapped context chip sits near the left edge on phones. The popup must
+  // clamp to the viewport instead of anchoring its right edge there and opening
+  // mostly offscreen. Exercise the same ARIA focus contract while narrow.
+  await page.setViewport({ width: 320, height: 820, deviceScaleFactor: 1 })
+  await page.click('.code-inspector__header button')
+  await page.waitForSelector('.code-inspector', { hidden: true })
+  await page.$eval('.code-context-chip', (node) => node.click())
+  await page.waitForSelector('.code-context-menu', { timeout: 5000 })
+  await page.waitForFunction(() => document.activeElement?.getAttribute('role') === 'menuitemradio')
+  const narrowContextMenu = await page.evaluate(() => {
+    const rect = document.querySelector('.code-context-menu')?.getBoundingClientRect()
+    const trigger = document.querySelector('.code-context-chip')?.getBoundingClientRect()
+    const firstChip = document.querySelector('.code-access-chip')?.getBoundingClientRect()
+    const footer = document.querySelector('.code-composer__footer')?.getBoundingClientRect()
+    return rect && trigger && firstChip && footer ? {
+      left: rect.left,
+      right: rect.right,
+      width: rect.width,
+      viewport: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      wrapped: trigger.top > firstChip.top + 2,
+      footerLeft: footer.left,
+      footerRight: footer.right,
+    } : null
+  })
+  if (!narrowContextMenu
+    || !narrowContextMenu.wrapped
+    || narrowContextMenu.width < 240
+    || narrowContextMenu.left < -0.5
+    || narrowContextMenu.right > narrowContextMenu.viewport + 0.5
+    || narrowContextMenu.left < narrowContextMenu.footerLeft - 0.5
+    || narrowContextMenu.right > narrowContextMenu.footerRight + 0.5
+    || narrowContextMenu.scrollWidth !== narrowContextMenu.viewport) {
+    throw new Error(`context menu escaped the narrow viewport: ${JSON.stringify(narrowContextMenu)}`)
+  }
+  await page.keyboard.press('ArrowDown')
+  const contextArrowFocus = await page.evaluate(() => document.activeElement?.textContent.replace(/\s+/g, ' ').trim())
+  if (!contextArrowFocus?.startsWith('Q8 16K')) {
+    throw new Error(`context menu did not move focus with ArrowDown: ${contextArrowFocus}`)
+  }
+  await page.keyboard.press('Escape')
+  await page.waitForSelector('.code-context-menu', { hidden: true })
+  const contextReturnedFocus = await page.evaluate(() => document.activeElement?.classList.contains('code-context-chip'))
+  if (!contextReturnedFocus) throw new Error('context menu Escape did not restore trigger focus')
+  await page.setViewport({ width: 1180, height: 820, deviceScaleFactor: 1 })
+
+  await page.click('.code-access-chip')
+  await page.waitForSelector('.code-access-menu')
+  await page.waitForFunction(() => document.activeElement?.getAttribute('role') === 'menuitemradio')
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('ArrowDown')
+  const fullAutoKeyboardFocus = await page.evaluate(() => document.activeElement?.textContent.replace(/\s+/g, ' ').trim())
+  if (!fullAutoKeyboardFocus?.startsWith('Full auto')) {
+    throw new Error(`access menu did not reach Full auto by keyboard: ${fullAutoKeyboardFocus}`)
+  }
+  await page.keyboard.press('Enter')
   await page.waitForSelector('.cx-modal')
   const confirmation = await page.$eval('.cx-modal', (node) => node.textContent)
   // The warning must state what full auto grants AND how far confinement
@@ -573,9 +740,10 @@ try {
   await page.type('.code-composer textarea', 'Run the complete test suite and research any failing dependency.')
   await page.click('.code-composer__send')
   await new Promise((resolve) => setTimeout(resolve, 120))
-  if (sessionBodies.length !== 2
-    || sessionBodies[1].approval_mode !== 'full_auto'
-    || sessionBodies[1].allow_network !== true) {
+  if (sessionBodies.length !== 4
+    || sessionBodies[3].approval_mode !== 'full_auto'
+    || sessionBodies[3].context_profile !== 'auto'
+    || sessionBodies[3].allow_network !== true) {
     throw new Error(`full-auto session contract mismatch: ${JSON.stringify(sessionBodies)}`)
   }
 
@@ -597,14 +765,14 @@ try {
     streamsOpened: globalThis.__codeStreamsOpened,
     composerPlaceholder: document.querySelector('.code-composer textarea')?.placeholder,
   }))
-  if (sessionBodies.length !== 3
-    || cancels.length !== 4
-    || abandonedStart.streamsOpened !== 3
+  if (sessionBodies.length !== 5
+    || cancels.length !== 6
+    || abandonedStart.streamsOpened !== 4
     || !abandonedStart.composerPlaceholder?.includes('Describe the change')) {
     throw new Error(`Stop during session creation did not take: ${JSON.stringify({ ...abandonedStart, sessions: sessionBodies.length, cancels: cancels.length })}`)
   }
 
-  console.log(`code-workbench: PASS ${JSON.stringify({ pendingState, railGuard, backgroundSwitchState, pairedState, completedState, followUpState, evictedState, stoppedState, menuState, fullAutoBody: sessionBodies[1], abandonedStart })}`)
+  console.log(`code-workbench: PASS ${JSON.stringify({ pendingState, railGuard, backgroundSwitchState, pairedState, completedState, followUpState, evictedState, stoppedState, abandonedReplacement: { status: abandonedReplacement.status, streamsOpened: abandonedReplacement.streamsOpened, contextChip: abandonedReplacement.contextChip }, menuState, fullAutoBody: sessionBodies[3], abandonedStart })}`)
 } finally {
   await browser.close()
 }

--- a/frontend/src/components/ui/icons.jsx
+++ b/frontend/src/components/ui/icons.jsx
@@ -85,3 +85,8 @@ export const IconGrid = (p) => <Svg {...p}><path d="M3 3h7v7H3V3zm11 0h7v7h-7V3z
 export const IconCpu = (p) => <Svg {...p} strokeIcon><rect x="7" y="7" width="10" height="10" rx="1.5" /><path d="M9.5 3v2M14.5 3v2M9.5 19v2M14.5 19v2M3 9.5h2M3 14.5h2M19 9.5h2M19 14.5h2" /></Svg>
 export const IconWifi = (p) => <Svg {...p} strokeIcon><path d="M5 12.5a10 10 0 0 1 14 0M8 15.5a6 6 0 0 1 8 0" /><circle cx="12" cy="18.5" r="1" fill="currentColor" stroke="none" /></Svg>
 export const IconLink = (p) => <Svg {...p} strokeIcon><path d="M9 12h6M8.5 8H7a4 4 0 0 0 0 8h1.5M15.5 8H17a4 4 0 0 1 0 8h-1.5" /></Svg>
+export const IconLaptop = (p) => <Svg {...p} strokeIcon><rect x="4" y="5" width="16" height="11" rx="1.5" /><path d="M2.5 19h19M8.5 19l.8-3h5.4l.8 3" /></Svg>
+export const IconBranch = (p) => <Svg {...p} strokeIcon><circle cx="7" cy="5" r="2" /><circle cx="17" cy="7" r="2" /><circle cx="7" cy="19" r="2" /><path d="M7 7v10M9 13h2a6 6 0 0 0 6-4" /></Svg>
+export const IconTerminal = (p) => <Svg {...p} strokeIcon><rect x="3" y="4" width="18" height="16" rx="2" /><path d="m7 9 3 3-3 3M12.5 15H17" /></Svg>
+export const IconFile = (p) => <Svg {...p} strokeIcon><path d="M6 3h8l4 4v14H6zM14 3v5h4" /></Svg>
+export const IconCommit = (p) => <Svg {...p} strokeIcon><path d="M3 12h6M15 12h6" /><circle cx="12" cy="12" r="3" /></Svg>

--- a/frontend/src/lib/contextProfiles.js
+++ b/frontend/src/lib/contextProfiles.js
@@ -1,0 +1,29 @@
+/**
+ * Session-scoped context policies offered by Code mode.
+ *
+ * The values are part of the workspace-session wire contract. Keep the labels
+ * here as the single source of truth for both the composer and inspector.
+ */
+export const CONTEXT_PROFILES = Object.freeze([
+  Object.freeze({
+    value: 'auto',
+    label: 'Auto',
+    detail: 'Use the best validated context window for the loaded model.',
+  }),
+  Object.freeze({
+    value: 'q8_16k',
+    label: 'Q8 16K',
+    detail: 'Use the 16K paged window available only to Qwen3 4B Q8_0.',
+  }),
+  Object.freeze({
+    value: 'standard',
+    label: 'Q4 8K',
+    detail: 'Use the standard 8K window for Q4 and other supported models.',
+  }),
+])
+
+export const DEFAULT_CONTEXT_PROFILE = CONTEXT_PROFILES[0].value
+
+export function contextProfileMeta(value) {
+  return CONTEXT_PROFILES.find((profile) => profile.value === value) || CONTEXT_PROFILES[0]
+}

--- a/frontend/src/lib/workspaceAgent.js
+++ b/frontend/src/lib/workspaceAgent.js
@@ -98,6 +98,11 @@ function reduceAgentEvent(state, envelope, allowApprovals) {
   const event = envelope?.event
   if (!event) return state
   if (event === 'session.reset') return { ...WORKSPACE_IDLE_STATE, events: [], turns: [], totalTurns: 0 }
+  if (event === 'session.client_restore') {
+    const snapshot = envelope.snapshot
+    if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) return state
+    return { ...snapshot, error: String(envelope.message || '') }
+  }
   if (event === 'thread.restored') {
     const turns = (Array.isArray(envelope.turns) ? envelope.turns : []).map((turn) => ({
       user: String(turn.user_text || ''),
@@ -355,15 +360,17 @@ function withDerived(previous, next, envelope) {
     derived.latestTool = null
     derived.latestResult = envelope
   }
-  else if (event === 'thread.restored') {
+  else if (event === 'session.starting' || event === 'thread.restored') {
     derived.latestTool = null
     derived.latestResult = null
   }
 
   // ---- Monotonic totals (see `runTotals` in WORKSPACE_IDLE_STATE) ----
-  // A restore replaces the event list wholesale, so its totals restart too;
-  // anything else only ever adds.
-  if (event === 'thread.restored') {
+  // A new session owns a new context window and run ledger even when it resumes
+  // the same saved thread under a different access/context configuration. A
+  // restore also replaces the event list wholesale. Follow-up turns within one
+  // session keep accumulating; these two session boundaries restart instead.
+  if (event === 'session.starting' || event === 'thread.restored') {
     derived.runTotals = WORKSPACE_IDLE_STATE.runTotals
     derived.context = null
     derived.modelSteps = []

--- a/frontend/src/styles/workspace.css
+++ b/frontend/src/styles/workspace.css
@@ -654,10 +654,56 @@
      signal lives in the border and the header glyph, which are full strength. */
   background: color-mix(in srgb, var(--color-warning) 6%, var(--color-bg-elevated));
 }
-.code-inline-approval header { display: flex; align-items: baseline; gap: var(--space-2); color: var(--color-warning); }
-.code-inline-approval header > svg { flex: none; align-self: center; }
-.code-inline-approval header strong { flex: none; color: var(--color-text); font-size: var(--text-sm); }
-.code-inline-approval header small { color: var(--color-text-muted); font-size: var(--text-2xs); text-transform: capitalize; }
+.code-inline-approval header {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: var(--space-2);
+}
+.code-inline-approval__icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-warning) 13%, transparent);
+  color: var(--color-warning);
+}
+.code-inline-approval__title { display: grid; min-width: 0; gap: 2px; }
+.code-inline-approval__title strong {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.code-inline-approval__title small {
+  color: var(--color-text-muted);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-snug);
+}
+.code-inline-approval__risk {
+  padding: 3px 7px;
+  border: 1px solid color-mix(in srgb, var(--color-warning) 35%, var(--color-border-soft));
+  border-radius: var(--radius-pill);
+  color: var(--color-warning);
+  font-size: var(--text-micro);
+  font-weight: 650;
+  white-space: nowrap;
+}
+.code-inline-approval.is-pending.is-exec {
+  border-color: color-mix(in srgb, var(--color-error) 45%, var(--color-border-soft));
+}
+.code-inline-approval.is-exec .code-inline-approval__icon {
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  color: var(--color-error);
+}
+.code-inline-approval.is-exec .code-inline-approval__risk {
+  border-color: color-mix(in srgb, var(--color-error) 38%, var(--color-border-soft));
+  color: var(--color-error);
+}
+.code-inline-approval.is-network .code-inline-approval__icon,
+.code-inline-approval.is-network .code-inline-approval__risk { color: var(--color-accent-text); }
 .code-inline-approval pre {
   max-height: 260px;
   margin: var(--space-3) 0;
@@ -839,10 +885,11 @@
 }
 .code-composer textarea::placeholder { color: var(--color-text-faint); }
 .code-composer textarea:disabled { cursor: not-allowed; }
-.code-composer__footer { display: flex; align-items: flex-end; justify-content: space-between; gap: var(--space-3); margin-top: var(--space-2); }
+.code-composer__footer { position: relative; display: flex; align-items: flex-end; justify-content: space-between; gap: var(--space-3); margin-top: var(--space-2); }
 .code-composer__chips { display: flex; min-width: 0; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
 .code-composer__chips > span,
-.code-access-chip {
+.code-access-chip,
+.code-context-chip {
   display: inline-flex;
   max-width: 220px;
   align-items: center;
@@ -856,14 +903,22 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.code-composer__chips > .code-context-chip {
+.code-context-chip {
   flex: none;
   max-width: none;
+  background: transparent;
   color: var(--color-text-muted);
+  font: inherit;
   font-family: var(--font-mono);
+  font-size: 10px;
   font-variant-numeric: tabular-nums;
+  cursor: pointer;
 }
+.code-context-chip:hover:not(:disabled),
+.code-context-chip[aria-expanded="true"] { border-color: var(--color-border); background: var(--color-surface-hover); color: var(--color-text); }
+.code-context-chip:disabled { cursor: default; opacity: 0.72; }
 .code-access-control { position: relative; }
+.code-context-control { position: static; }
 .code-access-chip {
   border-color: color-mix(in srgb, var(--color-warning) 28%, var(--color-border-soft));
   background: transparent;
@@ -873,6 +928,12 @@
 }
 .code-access-chip:hover:not(:disabled),
 .code-access-chip[aria-expanded="true"] { background: color-mix(in srgb, var(--color-warning) 9%, transparent); }
+.code-access-chip.is-writes-auto {
+  border-color: color-mix(in srgb, var(--color-accent) 42%, var(--color-border-soft));
+  color: var(--color-accent-text);
+}
+.code-access-chip.is-writes-auto:hover:not(:disabled),
+.code-access-chip.is-writes-auto[aria-expanded="true"] { background: color-mix(in srgb, var(--color-accent) 10%, transparent); }
 .code-access-chip.is-full-auto {
   border-color: color-mix(in srgb, var(--color-error) 42%, var(--color-border-soft));
   color: var(--color-error);
@@ -918,6 +979,8 @@
 .code-access-menu > button.is-selected { background: var(--color-surface-hover); }
 .code-access-menu > button.is-danger .code-access-menu__icon,
 .code-access-menu > button.is-danger > span:nth-child(2) > strong { color: var(--color-error); }
+.code-access-menu > button.is-writes-auto .code-access-menu__icon,
+.code-access-menu > button.is-writes-auto > span:nth-child(2) > strong { color: var(--color-accent-text); }
 .code-access-menu > button > span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
 .code-access-menu > button strong { font-size: var(--text-xs); }
 .code-access-menu > button small { color: var(--color-text-faint); font-size: 10px; line-height: 1.35; }
@@ -953,6 +1016,47 @@
 }
 .code-access-switch.is-on { background: var(--color-accent); }
 .code-access-switch.is-on > span { background: white; transform: translateX(11px); }
+.code-context-menu {
+  position: absolute;
+  z-index: 30;
+  right: 0;
+  bottom: calc(100% + 9px);
+  width: min(340px, 100%);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  box-shadow: 0 18px 46px color-mix(in srgb, #000 36%, transparent);
+}
+.code-context-menu__heading {
+  display: grid;
+  gap: 2px;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-soft);
+}
+.code-context-menu__heading strong { color: var(--color-text); font-size: var(--text-sm); }
+.code-context-menu__heading small { color: var(--color-text-faint); font-size: 10px; line-height: 1.35; }
+.code-context-menu > button {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr) 28px;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 11px var(--space-3) 11px var(--space-4);
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.code-context-menu > button:hover,
+.code-context-menu > button.is-selected { background: var(--color-surface-hover); }
+.code-context-menu > button:disabled { opacity: 0.5; cursor: not-allowed; }
+.code-context-menu > button > span:first-child { display: grid; min-width: 0; gap: 2px; }
+.code-context-menu > button strong { font-size: var(--text-xs); }
+.code-context-menu > button small { color: var(--color-text-faint); font-size: 10px; line-height: 1.35; }
+.code-context-menu__check { color: var(--color-accent-text); font-weight: 800; text-align: center; }
 .code-composer__send {
   display: grid;
   width: 34px;
@@ -1026,10 +1130,86 @@
 }
 .code-inspector__header button:hover { background: var(--color-surface-hover); color: var(--color-text); }
 
+.code-inspector .ci-environment {
+  margin: var(--space-3);
+  overflow: hidden;
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--color-surface) 72%, transparent);
+}
+.code-inspector .ci-environment__lead {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border-soft);
+}
+.code-inspector .ci-environment__mark {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  color: var(--color-accent-text);
+}
+.code-inspector .ci-environment__lead > div { display: grid; min-width: 0; gap: 1px; }
+.code-inspector .ci-environment h3 {
+  margin: 0 0 3px;
+  color: var(--color-text-faint);
+  font-size: var(--text-micro);
+  font-weight: 750;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+.code-inspector .ci-environment__lead strong {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.code-inspector .ci-environment__lead small {
+  overflow: hidden;
+  color: var(--color-text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.code-inspector .ci-environment__rows { margin: 0; padding: var(--space-1) var(--space-3); }
+.code-inspector .ci-environment__rows > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 28px;
+}
+.code-inspector .ci-environment__rows dt {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-faint);
+  font-size: var(--text-2xs);
+}
+.code-inspector .ci-environment__rows dt svg { flex: none; }
+.code-inspector .ci-environment__rows dd {
+  max-width: 148px;
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .code-inspector .ci-group { min-width: 0; padding: var(--space-2) var(--space-4); border-bottom: 1px solid var(--color-border-soft); }
 /* The running agent and the plan it is working through are one block. */
 .code-inspector .ci-group--joined { padding-bottom: 0; border-bottom: 0; }
-.code-inspector .ci-group:first-of-type { padding-top: var(--space-4); }
+.code-inspector .ci-environment + .ci-group { padding-top: var(--space-3); }
 .code-inspector .ci-group__head { display: flex; min-height: 22px; align-items: center; justify-content: space-between; gap: var(--space-2); }
 .code-inspector .ci-group__label {
   display: flex;
@@ -1043,6 +1223,7 @@
   letter-spacing: var(--tracking-label);
   text-transform: uppercase;
 }
+.code-inspector .ci-group__label > svg { flex: none; align-self: center; }
 .code-inspector .ci-empty { margin: var(--space-2) 0 0; color: var(--color-text-faint); font-size: var(--text-2xs); line-height: var(--leading-snug); }
 .code-inspector .ci-icon-btn {
   display: grid;
@@ -1091,8 +1272,27 @@
 .code-inspector .code-agent-list { display: grid; gap: 0; margin: var(--space-2) 0 0; padding: 0; list-style: none; }
 .code-inspector .code-agent-list li { min-width: 0; padding: var(--space-2) 0; border-top: 1px solid var(--color-border-soft); }
 .code-inspector .code-agent-list li:first-child { padding-top: 0; border-top: 0; }
-.code-inspector .ci-task__head { display: grid; grid-template-columns: 12px minmax(0, 1fr) 24px; align-items: center; gap: var(--space-2); }
+.code-inspector .ci-task__head { display: grid; grid-template-columns: 28px minmax(0, 1fr) 12px 24px; align-items: center; gap: var(--space-2); }
 .code-inspector .ci-task__title { overflow: hidden; color: var(--color-text); font-size: var(--text-xs); font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
+.code-inspector .ci-agent-mark {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  border-radius: 9px;
+  background: color-mix(in srgb, currentColor 9%, transparent);
+  color: var(--color-accent-text);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  font-weight: 800;
+}
+.code-inspector .ci-agent-mark.is-primary { color: var(--color-accent-text); }
+.code-inspector .ci-agent-mark.is-blue { color: var(--color-accent-text); }
+.code-inspector .ci-agent-mark.is-teal { color: var(--color-ready); }
+.code-inspector .ci-agent-mark.is-amber { color: var(--color-warning); }
+.code-inspector .ci-agent-mark.is-rose { color: var(--color-error); }
+.code-inspector .ci-agent-mark.is-indigo { color: color-mix(in srgb, var(--color-accent-text) 65%, var(--color-error)); }
 .code-inspector .ci-task__glyph { display: grid; width: 12px; height: 12px; place-items: center; color: var(--color-text-faint); }
 /* cxPulse animates box-shadow from currentColor, so the colour has to sit on
    the element itself rather than on a background. */
@@ -1118,7 +1318,7 @@
   align-items: baseline;
   gap: var(--space-2);
   margin: 3px 0 0;
-  padding-left: 20px;
+  padding-left: 36px;
   color: var(--color-text-faint);
   font-size: var(--text-2xs);
 }
@@ -1134,7 +1334,7 @@
   -webkit-line-clamp: 3;
   line-clamp: 3;
   margin: var(--space-1) 0 0;
-  padding-left: 20px;
+  padding-left: 36px;
   overflow: hidden;
   color: var(--color-text-muted);
   font-size: var(--text-2xs);
@@ -1154,14 +1354,35 @@
   line-height: var(--leading-snug);
   overflow-wrap: anywhere;
 }
-.code-inspector .code-agent-list .ci-task__note { padding-left: 20px; }
+.code-inspector .code-agent-list .ci-task__note { padding-left: 36px; }
 .code-inspector .code-process-row {
   display: grid;
-  grid-template-columns: max-content minmax(0, 1fr);
-  align-items: baseline;
+  grid-template-columns: 26px minmax(0, 1fr) max-content;
+  align-items: center;
   gap: var(--space-2);
-  margin-top: var(--space-1);
-  padding-left: 20px;
+  margin-top: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-surface) 58%, transparent);
+}
+.code-inspector .code-process-row__icon {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-hover);
+  color: var(--color-accent-text);
+}
+.code-inspector .code-process-row__body { display: grid; min-width: 0; gap: 2px; }
+.code-inspector .code-process-row__body strong {
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: var(--text-2xs);
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .code-inspector .ci-task__stage {
   color: var(--color-accent-text);
@@ -1178,6 +1399,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.code-inspector .code-process-row__state {
+  color: var(--color-text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+}
+.code-inspector .code-process-row.is-running .code-process-row__state,
+.code-inspector .code-process-row.is-starting .code-process-row__state { color: var(--color-accent-text); }
 
 /* Plan. Pending squares are OUTLINED, not filled: a --color-border-strong fill
    composites to ~1.6:1 in both themes, i.e. absent, and this is the only

--- a/frontend/src/views/CodeWorkspace.jsx
+++ b/frontend/src/views/CodeWorkspace.jsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import { findCompatibilityHint } from '../lib/capabilities'
+import { CONTEXT_PROFILES, DEFAULT_CONTEXT_PROFILE, contextProfileMeta } from '../lib/contextProfiles'
 import {
   cancelWorkspaceSession,
   createWorkspaceSession,
@@ -25,9 +26,9 @@ import { ConfirmDialog } from '../components/ui/ConfirmDialog'
 import { AssistantMarkdown } from '../lib/markdown'
 import { FolderPicker } from './WorkspaceView'
 import {
-  IconBolt, IconCheck, IconCheckCircle, IconChevronDown, IconChevronRight, IconClose, IconEdit,
-  IconError, IconHistory, IconNetwork, IconRefresh, IconSearch, IconSend, IconSidebar,
-  IconStop, IconWarning,
+  IconBolt, IconBranch, IconCheck, IconCheckCircle, IconChevronDown, IconChevronRight, IconClose,
+  IconCommit, IconEdit, IconError, IconFile, IconHistory, IconLaptop, IconNetwork, IconRefresh,
+  IconSearch, IconSend, IconSidebar, IconStop, IconTerminal, IconWarning,
 } from '../components/ui/icons'
 
 // `cancel_error` is deliberately NOT here. It means a Stop could not be
@@ -74,6 +75,52 @@ const EMPTY_CHANGES = Object.freeze({
   diff: 'No changes this session',
   files: [],
 })
+
+const APPROVAL_MODE_LABELS = Object.freeze({
+  approval_gated: 'Approval gated',
+  writes_auto: 'Writes auto',
+  full_auto: 'Full auto',
+})
+
+function approvalModeLabel(mode) {
+  return APPROVAL_MODE_LABELS[mode] || APPROVAL_MODE_LABELS.approval_gated
+}
+
+const APPROVAL_RISKS = Object.freeze({
+  read: Object.freeze({ label: 'Read', detail: 'Reads workspace data without changing it.', tone: 'is-read' }),
+  plan: Object.freeze({ label: 'Plan', detail: 'Updates the agent plan without changing files.', tone: 'is-plan' }),
+  write: Object.freeze({ label: 'Workspace write', detail: 'Creates, edits, or removes files in this workspace.', tone: 'is-write' }),
+  exec: Object.freeze({ label: 'Shell command', detail: 'Starts a local process. Review the command and its arguments.', tone: 'is-exec' }),
+  network: Object.freeze({ label: 'Network', detail: 'Sends a request outside this workspace.', tone: 'is-network' }),
+})
+
+function approvalRiskMeta(risk) {
+  const key = String(risk || '').trim().toLowerCase()
+  return APPROVAL_RISKS[key] || {
+    label: key ? formatToolName(key) : 'Agent action',
+    detail: 'Review this action before Camelid continues.',
+    tone: 'is-unknown',
+  }
+}
+
+function handleMenuNavigation(event, onEscape) {
+  const items = [...event.currentTarget.querySelectorAll('button[role^="menuitem"]:not(:disabled)')]
+  if (!items.length) return
+  const current = items.indexOf(document.activeElement)
+  let next = null
+  if (event.key === 'ArrowDown') next = current === -1 ? items[0] : items[(current + 1) % items.length]
+  else if (event.key === 'ArrowUp') next = current === -1 ? items.at(-1) : items[(current - 1 + items.length) % items.length]
+  else if (event.key === 'Home') next = items[0]
+  else if (event.key === 'End') next = items.at(-1)
+  else if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    onEscape()
+    return
+  } else return
+  event.preventDefault()
+  next?.focus()
+}
 
 function initialCodeState() {
   return { ...WORKSPACE_IDLE_STATE, events: [], turns: [], approval: null }
@@ -305,6 +352,37 @@ function visibleLiveText(raw) {
   return text.trim()
 }
 
+// A stable mark lets the eye follow a delegated agent between Running and
+// Finished without depending on its model-authored label. The palette is CSS
+// driven so it remains legible in both themes; only the deterministic slot is
+// chosen here.
+const AGENT_MARKS = Object.freeze([
+  Object.freeze({ glyph: 'A', tone: 'violet' }),
+  Object.freeze({ glyph: 'B', tone: 'blue' }),
+  Object.freeze({ glyph: 'C', tone: 'teal' }),
+  Object.freeze({ glyph: 'D', tone: 'amber' }),
+  Object.freeze({ glyph: 'E', tone: 'rose' }),
+  Object.freeze({ glyph: 'F', tone: 'indigo' }),
+])
+
+function agentMarkIndex(agent) {
+  const value = String(agent?.id || agent?.label || 'agent')
+  let hash = 0
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0
+  }
+  return Math.abs(hash) % AGENT_MARKS.length
+}
+
+function AgentMark({ agent, isMain = false }) {
+  const mark = AGENT_MARKS[agentMarkIndex(agent)]
+  return (
+    <span className={`ci-agent-mark is-${isMain ? 'primary' : mark.tone}`} aria-hidden="true">
+      {isMain ? <IconBolt size={13} /> : mark.glyph}
+    </span>
+  )
+}
+
 function HistoricalTurn({ turn }) {
   return (
     <div className="code-turn-pair">
@@ -481,6 +559,7 @@ const ActivityEvent = memo(function ActivityEvent({ event, pairedResult, timing,
 
   if (event.event === 'approval.required') {
     const pending = activeApproval?.approval_id === event.approval_id
+    const risk = approvalRiskMeta(event.risk)
     if (!pending) {
       // A decided approval is history, but it is also the audit record of what
       // was allowed — so it collapses to a line that still carries the payload
@@ -498,13 +577,18 @@ const ActivityEvent = memo(function ActivityEvent({ event, pairedResult, timing,
       )
     }
     // The one element that keeps its box. It blocks the run and carries four
-    // consequential actions; containment is the point.
+    // consequential actions; containment is the point. Risk copy is explicit:
+    // in Writes auto an approval here is normally an exec boundary, not a file
+    // write or enabled network action that the selected posture already grants.
     return (
-      <article className="code-inline-approval is-pending" role="group" aria-label={`Review ${formatToolName(event.tool)}`}>
+      <article className={`code-inline-approval is-pending ${risk.tone}`} role="group" aria-label={`Review ${formatToolName(event.tool)}`}>
         <header>
-          <IconWarning size={15} />
-          <strong>Review {formatToolName(event.tool)}</strong>
-          <small>{event.risk} action</small>
+          <span className="code-inline-approval__icon"><IconWarning size={15} /></span>
+          <span className="code-inline-approval__title">
+            <strong>Review {formatToolName(event.tool)}</strong>
+            <small>{risk.detail}</small>
+          </span>
+          <span className="code-inline-approval__risk">{risk.label}</span>
         </header>
         <pre>{event.detail}</pre>
         <div className="code-inline-approval__actions">
@@ -619,13 +703,14 @@ function AgentCard({ agent, isMain, anchor, anchorTitle, action, children }) {
   return (
     <li className={`ci-task is-${status}`}>
       <div className="ci-task__head">
-        <span className="ci-task__glyph" aria-hidden="true"><span /></span>
+        <AgentMark agent={agent} isMain={isMain} />
         <strong className="ci-task__title">{isMain ? 'Primary agent' : agent.label}</strong>
+        <span className="ci-task__glyph" aria-hidden="true"><span /></span>
         {action ? (
           <button type="button" className="ci-icon-btn" aria-label={action.label} title={action.label} onClick={action.onClick}>
             {action.icon}
           </button>
-        ) : <span aria-hidden="true" />}
+        ) : null}
       </div>
       <p className="ci-task__meta">
         <span>{isMain ? 'Agent' : 'Subagent'} · {AGENT_STATUS_LABEL[status] || formatToolName(status)}</span>
@@ -689,6 +774,7 @@ const CodeInspector = memo(function CodeInspector({
   allowNetwork,
   changes,
   context,
+  contextProfile,
   contextWindow,
   modelName,
   modelSteps,
@@ -717,6 +803,8 @@ const CodeInspector = memo(function CodeInspector({
   const visibleFinished = finishedChildren.filter((agent) => !hiddenIds.has(agent.id))
   const steps = modelSteps || []
   const runTotals = totals || { steps: 0, outputTokens: 0, elapsedMs: 0, tools: 0, toolFailures: 0 }
+  const profile = contextProfileMeta(contextProfile)
+  const workspaceName = String(workspacePath || '').replace(/[\\/]+$/, '').split(/[\\/]/).at(-1) || 'No workspace selected'
 
   const liveStage = activity.stage ? formatToolName(activity.stage) : (running ? 'Working' : 'Idle')
   const liveDetail = activity.detail
@@ -741,15 +829,40 @@ const CodeInspector = memo(function CodeInspector({
     <aside className="code-inspector" aria-label="Coding session details">
       <header className="code-inspector__header">
         <div>
-          <strong>Work details</strong>
-          {workspacePath ? <small title={workspacePath}>{compactPath(workspacePath)}</small> : null}
+          <strong>Code inspector</strong>
+          <small>{running ? `${(main ? 1 : 0) + runningChildren.length} active ${runningChildren.length ? 'agents' : 'agent'}` : 'Environment and session activity'}</small>
         </div>
-        <button type="button" aria-label="Close work details" onClick={onClose}><IconClose size={18} /></button>
+        <button type="button" aria-label="Close code inspector" onClick={onClose}><IconClose size={18} /></button>
       </header>
+
+      <section className="ci-environment" aria-labelledby="ci-environment-title">
+        <div className="ci-environment__lead">
+          <span className="ci-environment__mark" aria-hidden="true"><IconLaptop size={17} /></span>
+          <div>
+            <h3 id="ci-environment-title">Environment</h3>
+            <strong title={workspacePath || undefined}>{workspaceName}</strong>
+            <small title={workspacePath || undefined}>{workspacePath ? compactPath(workspacePath) : 'Choose a workspace to begin'}</small>
+          </div>
+        </div>
+        <dl className="ci-environment__rows">
+          <div>
+            <dt><IconBranch size={13} /><span>Session</span></dt>
+            <dd>{session ? 'Connected' : 'Not started'}</dd>
+          </div>
+          <div>
+            <dt><IconTerminal size={13} /><span>Access</span></dt>
+            <dd>{approvalModeLabel(approvalMode)}{allowNetwork ? ' + web' : ''}</dd>
+          </div>
+          <div>
+            <dt><IconCommit size={13} /><span>Context</span></dt>
+            <dd>{profile.label}{contextWindow ? ` · ${formatContextTokens(contextWindow.effectiveTokens)}` : ''}</dd>
+          </div>
+        </dl>
+      </section>
 
       <section className={`ci-group ${planSteps.length ? 'ci-group--joined' : ''}`}>
         <div className="ci-group__head">
-          <h3 className="ci-group__label">Running <span className="ci-num">{(main ? 1 : 0) + runningChildren.length}</span></h3>
+          <h3 className="ci-group__label">Agents <span className="ci-num">{(main ? 1 : 0) + children.length}</span></h3>
         </div>
         {main || runningChildren.length ? (
           <ul className="code-agent-list">
@@ -766,17 +879,6 @@ const CodeInspector = memo(function CodeInspector({
                   <span>{runTotals.steps} model {runTotals.steps === 1 ? 'step' : 'steps'} this session</span>
                   <span className="ci-num">{formatTokens(runTotals.outputTokens)} tokens</span>
                 </p>
-                {liveDetail ? (
-                  <div className="code-process-row">
-                    <span className="ci-task__stage">{liveStage}</span>
-                    <small>{liveDetail}</small>
-                  </div>
-                ) : null}
-                {steps.length || running ? (
-                  <Fold className="ci-fold--nested" label="Model steps" count={runTotals.steps}>
-                    <StepTable steps={steps} running={running} />
-                  </Fold>
-                ) : null}
               </AgentCard>
             ) : null}
             {runningChildren.map((agent) => (
@@ -793,6 +895,29 @@ const CodeInspector = memo(function CodeInspector({
             ))}
           </ul>
         ) : <p className="ci-empty">Agents appear here when a coding task starts.</p>}
+      </section>
+
+      <section className="ci-group ci-processes">
+        <div className="ci-group__head">
+          <h3 className="ci-group__label">Processes <span className="ci-num">{main ? 1 : 0}</span></h3>
+        </div>
+        {main ? (
+          <>
+            <div className={`code-process-row is-${main.status || 'running'}`}>
+              <span className="code-process-row__icon" aria-hidden="true"><IconTerminal size={14} /></span>
+              <span className="code-process-row__body">
+                <strong>{liveStage}</strong>
+                <small title={liveDetail || undefined}>{liveDetail || (running ? 'Waiting for the next agent action' : 'No process is running')}</small>
+              </span>
+              <span className="code-process-row__state">{running ? 'Live' : AGENT_STATUS_LABEL[main.status] || 'Idle'}</span>
+            </div>
+            {steps.length || running ? (
+              <Fold className="ci-fold--nested" label="Model steps" count={runTotals.steps}>
+                <StepTable steps={steps} running={running} />
+              </Fold>
+            ) : null}
+          </>
+        ) : <p className="ci-empty">Processes appear here when an agent starts working.</p>}
       </section>
 
       {planSteps.length ? (
@@ -821,7 +946,7 @@ const CodeInspector = memo(function CodeInspector({
 
       <section className="ci-group">
         <div className="ci-group__head">
-          <h3 className="ci-group__label">Changes <span className="ci-num">{changes.files?.length || 0}</span></h3>
+          <h3 className="ci-group__label"><IconCommit size={13} /> Changes <span className="ci-num">{changes.files?.length || 0}</span></h3>
           <button type="button" className="ci-icon-btn" aria-label="Refresh changes" onClick={onRefreshChanges} disabled={!session}>
             <IconRefresh size={14} />
           </button>
@@ -829,7 +954,7 @@ const CodeInspector = memo(function CodeInspector({
         {changes.files?.length ? (
           <>
             <ul className="code-file-list">
-              {changes.files.map((file) => <li key={file}><IconEdit size={13} /><span>{file}</span></li>)}
+              {changes.files.map((file) => <li key={file}><IconFile size={13} /><span>{file}</span></li>)}
             </ul>
             {changes.summary ? <p className="ci-task__note">{changes.summary}</p> : null}
             <Fold className="code-patch" label="View patch" count="">
@@ -863,9 +988,10 @@ const CodeInspector = memo(function CodeInspector({
       ) : null}
 
       <section className="ci-group">
-        <Fold label="Session" count={approvalMode === 'full_auto' ? 'Full auto' : 'Gated'}>
+        <Fold label="Session" count={approvalModeLabel(approvalMode)}>
           <dl className="ci-kv ci-kv--wide">
             <div><dt>Model</dt><dd>{modelName || 'No model loaded'}</dd></div>
+            <div><dt>Context profile</dt><dd>{profile.label}</dd></div>
             {contextWindow ? (
               <div><dt>Context</dt><dd className="ci-num">{contextWindowModeLabel(contextWindow)} · {formatContextTokens(contextWindow.effectiveTokens)}</dd></div>
             ) : null}
@@ -885,7 +1011,7 @@ const CodeInspector = memo(function CodeInspector({
             {contextWindow?.limitingFactor ? (
               <div><dt>Limited by</dt><dd>{contextLimitingFactorLabel(contextWindow.limitingFactor)}</dd></div>
             ) : null}
-            <div><dt>Access</dt><dd>{approvalMode === 'full_auto' ? 'Full auto' : 'Approval gated'}</dd></div>
+            <div><dt>Access</dt><dd>{approvalModeLabel(approvalMode)}</dd></div>
             <div><dt>Web tools</dt><dd>{allowNetwork ? 'On · search and fetch' : 'Off'}</dd></div>
             <div><dt>Tools run</dt><dd>{runTotals.tools} · {runTotals.toolFailures} failed</dd></div>
           </dl>
@@ -962,6 +1088,8 @@ export default function CodeWorkspace({
   const [approvalMode, setApprovalMode] = useState('approval_gated')
   const [allowNetwork, setAllowNetwork] = useState(false)
   const [accessMenuOpen, setAccessMenuOpen] = useState(false)
+  const [contextProfile, setContextProfile] = useState(DEFAULT_CONTEXT_PROFILE)
+  const [contextMenuOpen, setContextMenuOpen] = useState(false)
   const [fullAutoConfirmOpen, setFullAutoConfirmOpen] = useState(false)
   const [inspectorOpen, setInspectorOpen] = useState(() => window.localStorage.getItem('camelid.codeInspectorOpen') !== 'false')
   const [startedAt, setStartedAt] = useState(null)
@@ -983,6 +1111,9 @@ export default function CodeWorkspace({
   const activityRecoverySuppressedRef = useRef(false)
   const threadRef = useRef(null)
   const accessMenuRef = useRef(null)
+  const accessTriggerRef = useRef(null)
+  const contextMenuRef = useRef(null)
+  const contextTriggerRef = useRef(null)
   const stickToBottomRef = useRef(true)
   const changesTimerRef = useRef(null)
   // Highest session-scoped sequence this page has applied. Sequences are
@@ -1010,15 +1141,35 @@ export default function CodeWorkspace({
   // A Stop that could not be CONFIRMED: the composer is usable again, but the
   // run may still be executing server-side, so Stop stays offered as a retry.
   const stopUnconfirmed = state.phase === 'cancel_error' && !running
-  const canStart = Boolean(workspacePath.trim() && goal.trim() && toolCapable && runtimeReady && !running && !session)
   const modelName = hasLoadedModel ? runtime?.active_model_id || selectedModel?.name || 'Loaded model' : ''
+  // The runtime id is an operator-supplied alias, not artifact identity. The
+  // compatibility resolver has already joined the selected model to the
+  // backend's exact, capability-gated row, so use that fact for the one profile
+  // whose larger window is row-specific.
+  const q8ProfileAvailable = Boolean(
+    compatibility?.exact && target?.id === 'qwen3_4b_instruct_q8_0',
+  )
+  const selectedProfileAvailable = contextProfile !== 'q8_16k' || q8ProfileAvailable
+  const canStart = Boolean(workspacePath.trim() && goal.trim() && toolCapable && runtimeReady
+    && selectedProfileAvailable && !running && !session)
   const contextWindow = useMemo(
     () => normalizeContextWindow(session?.context_window, state.context?.budgetTotal),
     [session?.context_window, state.context?.budgetTotal],
   )
+  const selectedContextProfile = contextProfileMeta(contextProfile)
+  const profileMatchesSession = !session
+    || (session.context_profile || DEFAULT_CONTEXT_PROFILE) === contextProfile
+  const configurationMatchesSession = !session
+    || ((session.approval_mode || 'approval_gated') === approvalMode
+      && Boolean(session.allow_network) === allowNetwork
+      && profileMatchesSession)
+  const contextChipText = contextWindow && profileMatchesSession
+    ? `${selectedContextProfile.label} · ${formatContextTokens(contextWindow.effectiveTokens)}`
+    : selectedContextProfile.label
   const composerValue = session ? followUp : goal
   const canSubmit = session
-    ? Boolean(followUp.trim() && !running)
+    ? Boolean(followUp.trim() && !running
+      && (configurationMatchesSession || (toolCapable && runtimeReady && selectedProfileAvailable)))
     : canStart
   // Everything derived from the event list is computed ONCE per event, not per
   // render. Streamed deltas re-render this component on every token, and the
@@ -1113,6 +1264,7 @@ export default function CodeWorkspace({
           setSelectedThreadId(next.id)
           setApprovalMode(next.approval_mode || 'approval_gated')
           setAllowNetwork(Boolean(next.allow_network))
+          setContextProfile(next.context_profile || DEFAULT_CONTEXT_PROFILE)
           setStartedAt(Number(next.started_at_ms) || Date.now())
           setClock(Date.now())
           getWorkspaceChanges(apiBase, next.id).then(setChanges).catch(() => {})
@@ -1163,19 +1315,52 @@ export default function CodeWorkspace({
 
   useEffect(() => {
     if (!accessMenuOpen) return undefined
+    const focusFrame = window.requestAnimationFrame(() => {
+      const menu = accessMenuRef.current?.querySelector('.code-access-menu')
+      ;(menu?.querySelector('[aria-checked="true"]') || menu?.querySelector('button'))?.focus()
+    })
     const close = (event) => {
       if (!accessMenuRef.current?.contains(event.target)) setAccessMenuOpen(false)
     }
     const closeOnEscape = (event) => {
-      if (event.key === 'Escape') setAccessMenuOpen(false)
+      if (event.key === 'Escape') {
+        setAccessMenuOpen(false)
+        accessTriggerRef.current?.focus()
+      }
     }
     window.addEventListener('pointerdown', close)
     window.addEventListener('keydown', closeOnEscape)
     return () => {
+      window.cancelAnimationFrame(focusFrame)
       window.removeEventListener('pointerdown', close)
       window.removeEventListener('keydown', closeOnEscape)
     }
   }, [accessMenuOpen])
+
+  useEffect(() => {
+    if (!contextMenuOpen) return undefined
+    const focusFrame = window.requestAnimationFrame(() => {
+      const menu = contextMenuRef.current?.querySelector('.code-context-menu')
+      ;(menu?.querySelector('[aria-checked="true"]:not(:disabled)')
+        || menu?.querySelector('button:not(:disabled)'))?.focus()
+    })
+    const close = (event) => {
+      if (!contextMenuRef.current?.contains(event.target)) setContextMenuOpen(false)
+    }
+    const closeOnEscape = (event) => {
+      if (event.key === 'Escape') {
+        setContextMenuOpen(false)
+        contextTriggerRef.current?.focus()
+      }
+    }
+    window.addEventListener('pointerdown', close)
+    window.addEventListener('keydown', closeOnEscape)
+    return () => {
+      window.cancelAnimationFrame(focusFrame)
+      window.removeEventListener('pointerdown', close)
+      window.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [contextMenuOpen])
 
   useEffect(() => {
     if (!running || !startedAt) return undefined
@@ -1440,18 +1625,24 @@ export default function CodeWorkspace({
   }
 
   const start = async () => {
-    if (!canStart) return
+    const task = (session ? followUp : goal).trim()
+    if (!workspacePath.trim() || !task || !toolCapable || !runtimeReady
+      || !selectedProfileAvailable || running) return
+    const replacementSnapshot = session ? { state, changes, startedAt, clock, session } : null
     activityRecoverySuppressedRef.current = false
     const pending = { abandoned: false }
     pendingStartRef.current = pending
-    dispatch({ event: 'session.starting', task: goal.trim() })
+    dispatch({ event: 'session.starting', task })
     setStartedAt(Date.now())
     setClock(Date.now())
     try {
       const created = await createWorkspaceSession(apiBase, {
         workspace: workspacePath.trim(),
-        goal: goal.trim(),
-        thread_id: selectedThreadId || undefined,
+        goal: task,
+        // A changed access posture or context preset starts a new session but
+        // keeps the conversation. A newly-created Code thread is its session
+        // id, so fall back to the current id when no rail selection exists.
+        thread_id: selectedThreadId || session?.id || undefined,
         // A single write_file argument routinely carries a whole source file.
         // At the old 768 the call was cut off mid-JSON, parsed as no call, and
         // surfaced as a mangled "answer" while the write was silently dropped.
@@ -1462,24 +1653,55 @@ export default function CodeWorkspace({
         allow_writes: true,
         approval_mode: approvalMode,
         allow_network: allowNetwork,
+        context_profile: contextProfile,
       })
       if (pending.abandoned) {
         // Stop was pressed while this request was in flight. The session exists
         // now, so cancel it rather than adopting a run the user has already
         // walked away from — and never open a stream for it.
         try { await cancelWorkspaceSession(apiBase, created.id) } catch {}
-        dispatch({ event: 'session.finished', outcome: 'cancelled' })
+        if (replacementSnapshot) {
+          // The create was replacing a completed session on the same thread.
+          // `session.starting` temporarily cleared that session's diagnostics;
+          // put its complete client view back when the replacement is abandoned.
+          dispatch({
+            event: 'session.client_restore',
+            snapshot: replacementSnapshot.state,
+            message: '',
+          })
+          setChanges(replacementSnapshot.changes)
+          setStartedAt(replacementSnapshot.startedAt)
+          setClock(replacementSnapshot.clock)
+          setSession(replacementSnapshot.session)
+        } else {
+          dispatch({ event: 'session.finished', outcome: 'cancelled' })
+        }
         signalHistoryChanged()
         return
       }
       setAccessMenuOpen(false)
+      setContextMenuOpen(false)
+      setChanges({ ...EMPTY_CHANGES })
       setSession(created)
-      dispatch({ event: 'turn.user', content: goal.trim() })
-      setGoal('')
+      dispatch({ event: 'turn.user', content: task })
+      if (session) setFollowUp('')
+      else setGoal('')
       openEventStream(created)
       signalHistoryChanged()
     } catch (error) {
-      dispatch({ event: 'session.error', message: error.message })
+      if (replacementSnapshot) {
+        dispatch({
+          event: 'session.client_restore',
+          snapshot: replacementSnapshot.state,
+          message: error.message,
+        })
+        setChanges(replacementSnapshot.changes)
+        setStartedAt(replacementSnapshot.startedAt)
+        setClock(replacementSnapshot.clock)
+        setSession(replacementSnapshot.session)
+      } else {
+        dispatch({ event: 'session.error', message: error.message })
+      }
     } finally {
       if (pendingStartRef.current === pending) pendingStartRef.current = null
       if (pending.abandoned) setStopPending(false)
@@ -1508,13 +1730,13 @@ export default function CodeWorkspace({
     // it as soon as `session.starting` is dispatched, but the session id it
     // needs only exists once the create request comes back. Mark the pending
     // start abandoned and let `start` cancel the session the server hands over.
-    if (!session) {
-      if (!pendingStartRef.current || pendingStartRef.current.abandoned) return
+    if (pendingStartRef.current && !pendingStartRef.current.abandoned) {
       pendingStartRef.current.abandoned = true
       setStopPending(true)
       dispatch({ event: 'turn.stopping' })
       return
     }
+    if (!session) return
     setStopPending(true)
     dispatch({ event: 'turn.stopping' })
     try {
@@ -1589,26 +1811,23 @@ export default function CodeWorkspace({
     setChanges({ ...EMPTY_CHANGES })
     setApprovalMode('approval_gated')
     setAllowNetwork(false)
+    setContextProfile(DEFAULT_CONTEXT_PROFILE)
     setAccessMenuOpen(false)
+    setContextMenuOpen(false)
     setFullAutoConfirmOpen(false)
     dispatch({ event: 'session.reset' })
     signalHistoryChanged()
   }
 
-  // Whether the live session already runs under the access the user has
-  // selected. Approval mode and the network grant are fixed when the server
-  // creates a session, so a follow-up cannot carry a change — it would silently
-  // run under the old posture, which is worse than refusing.
-  const accessMatchesSession = !session
-    || ((session.approval_mode || 'approval_gated') === approvalMode
-      && Boolean(session.allow_network) === allowNetwork)
-
+  // Access and context are session-bound. If the composer selection differs,
+  // the next task must create a fresh session on the same thread; sending a
+  // follow-up would silently keep the old grants or context window.
   const submitComposer = (event) => {
     event?.preventDefault()
     if (running) return
     // A changed posture starts a new session on the same thread, so the
     // transcript continues while the new access actually takes effect.
-    if (session && accessMatchesSession) sendFollowUp()
+    if (session && configurationMatchesSession) sendFollowUp()
     else start()
   }
 
@@ -1714,10 +1933,20 @@ export default function CodeWorkspace({
                 <div className="code-access-control" ref={accessMenuRef}>
                   <button
                     type="button"
-                    className={`code-access-chip ${approvalMode === 'full_auto' ? 'is-full-auto' : ''}`}
+                    ref={accessTriggerRef}
+                    className={`code-access-chip is-${approvalMode.replace('_', '-')}`}
                     aria-haspopup="menu"
                     aria-expanded={accessMenuOpen}
-                    onClick={() => setAccessMenuOpen((open) => !open)}
+                    onClick={() => {
+                      setContextMenuOpen(false)
+                      setAccessMenuOpen((open) => !open)
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+                      event.preventDefault()
+                      setContextMenuOpen(false)
+                      setAccessMenuOpen(true)
+                    }}
                     // Gated on a RUNNING turn, not on having a session at all.
                     // The server binds approval mode when a session is created,
                     // so a change cannot alter the turn in flight — but once one
@@ -1731,13 +1960,22 @@ export default function CodeWorkspace({
                       ? 'Access cannot change while a turn is running'
                       : 'Choose approval and network access'}
                   >
-                    <IconWarning size={14} />
-                    {approvalMode === 'full_auto' ? 'Full auto' : 'Approval gated'}
+                    {approvalMode === 'full_auto' ? <IconBolt size={14} />
+                      : approvalMode === 'writes_auto' ? <IconEdit size={14} /> : <IconWarning size={14} />}
+                    {approvalModeLabel(approvalMode)}
                     {allowNetwork ? <IconNetwork size={13} /> : null}
                     <IconChevronDown size={12} />
                   </button>
                   {accessMenuOpen && !running ? (
-                    <div className="code-access-menu" role="menu" aria-label="Agent access">
+                    <div
+                      className="code-access-menu"
+                      role="menu"
+                      aria-label="Agent access"
+                      onKeyDown={(event) => handleMenuNavigation(event, () => {
+                        setAccessMenuOpen(false)
+                        accessTriggerRef.current?.focus()
+                      })}
+                    >
                       <div className="code-access-menu__heading">
                         <strong>Agent access</strong>
                         <small>
@@ -1751,11 +1989,30 @@ export default function CodeWorkspace({
                         role="menuitemradio"
                         aria-checked={approvalMode === 'approval_gated'}
                         className={approvalMode === 'approval_gated' ? 'is-selected' : ''}
-                        onClick={() => { setApprovalMode('approval_gated'); setAccessMenuOpen(false) }}
+                        onClick={() => {
+                          setApprovalMode('approval_gated')
+                          setAccessMenuOpen(false)
+                          accessTriggerRef.current?.focus()
+                        }}
                       >
                         <span className="code-access-menu__icon"><IconWarning size={16} /></span>
                         <span><strong>Approval gated</strong><small>Ask before writes, commands, and network actions.</small></span>
                         <span className="code-access-menu__check">{approvalMode === 'approval_gated' ? '✓' : ''}</span>
+                      </button>
+                      <button
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={approvalMode === 'writes_auto'}
+                        className={`is-writes-auto ${approvalMode === 'writes_auto' ? 'is-selected' : ''}`}
+                        onClick={() => {
+                          setApprovalMode('writes_auto')
+                          setAccessMenuOpen(false)
+                          accessTriggerRef.current?.focus()
+                        }}
+                      >
+                        <span className="code-access-menu__icon"><IconEdit size={16} /></span>
+                        <span><strong>Writes auto</strong><small>Edit files and run enabled network actions without asking. Shell commands still require approval.</small></span>
+                        <span className="code-access-menu__check">{approvalMode === 'writes_auto' ? '✓' : ''}</span>
                       </button>
                       <button
                         type="button"
@@ -1765,7 +2022,7 @@ export default function CodeWorkspace({
                         onClick={() => { setAccessMenuOpen(false); setFullAutoConfirmOpen(true) }}
                       >
                         <span className="code-access-menu__icon"><IconBolt size={16} /></span>
-                        <span><strong>Today is a good day to die</strong><small>Full auto: run writes and shell commands without asking.</small></span>
+                        <span><strong>Full auto</strong><small>Edit files and run shell commands without asking. This is the YOLO posture.</small></span>
                         <span className="code-access-menu__check">{approvalMode === 'full_auto' ? '✓' : ''}</span>
                       </button>
                       <div className="code-access-menu__divider" />
@@ -1777,21 +2034,87 @@ export default function CodeWorkspace({
                         onClick={() => setAllowNetwork((enabled) => !enabled)}
                       >
                         <span className="code-access-menu__icon"><IconNetwork size={16} /></span>
-                        <span><strong>Network and web search</strong><small>Give the agent built-in web_search and http_fetch tools.</small></span>
+                        <span><strong>Network and web search</strong><small>Enable web_search and http_fetch. Writes auto runs these actions without asking.</small></span>
                         <span className={`code-access-switch ${allowNetwork ? 'is-on' : ''}`}><span /></span>
                       </button>
                     </div>
                   ) : null}
                 </div>
                 <span title={modelName}><IconBolt size={14} /> {modelName || 'No model'}</span>
-                {contextWindow ? (
-                  <span
+                <div className="code-context-control" ref={contextMenuRef}>
+                  <button
+                    type="button"
+                    ref={contextTriggerRef}
                     className="code-context-chip"
-                    title={`${contextWindowModeLabel(contextWindow)} context: ${contextWindow.effectiveTokens.toLocaleString()} tokens${contextWindow.pagedWorkingSetTokens ? ` · active paged working set ${contextWindow.pagedWorkingSetTokens.toLocaleString()}` : ''}${contextWindow.validatedMaxTokens ? ` · agent ceiling ${contextWindow.validatedMaxTokens.toLocaleString()}` : ''}${contextWindow.modelMaxTokens ? ` · model max ${contextWindow.modelMaxTokens.toLocaleString()}` : ''}${contextWindow.limitingFactor ? ` · limited by ${contextLimitingFactorLabel(contextWindow.limitingFactor)}` : ''}`}
+                    aria-haspopup="menu"
+                    aria-expanded={contextMenuOpen}
+                    disabled={running}
+                    title={running
+                      ? 'Context cannot change while a turn is running'
+                      : !selectedProfileAvailable
+                        ? 'Q8 16K requires the exact Qwen3 4B Q8_0 model.'
+                        : `${selectedContextProfile.detail}${contextWindow && profileMatchesSession ? ` Effective window: ${contextWindow.effectiveTokens.toLocaleString()} tokens.` : ''}`}
+                    onClick={() => {
+                      setAccessMenuOpen(false)
+                      setContextMenuOpen((open) => !open)
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+                      event.preventDefault()
+                      setAccessMenuOpen(false)
+                      setContextMenuOpen(true)
+                    }}
                   >
-                    {contextWindowModeLabel(contextWindow)} · {formatContextTokens(contextWindow.effectiveTokens)}
-                  </span>
-                ) : null}
+                    <IconCommit size={13} />
+                    {contextChipText}
+                    <IconChevronDown size={12} />
+                  </button>
+                  {contextMenuOpen && !running ? (
+                    <div
+                      className="code-context-menu"
+                      role="menu"
+                      aria-label="Context profile"
+                      onKeyDown={(event) => handleMenuNavigation(event, () => {
+                        setContextMenuOpen(false)
+                        contextTriggerRef.current?.focus()
+                      })}
+                    >
+                      <div className="code-context-menu__heading">
+                        <strong>Context profile</strong>
+                        <small>
+                          {session
+                            ? 'Applies to your next task, which starts a fresh session on this thread'
+                            : 'Choose the context policy for this coding session'}
+                        </small>
+                      </div>
+                      {CONTEXT_PROFILES.map((profile) => {
+                        const unavailable = profile.value === 'q8_16k' && !q8ProfileAvailable
+                        return (
+                          <button
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={contextProfile === profile.value}
+                            aria-disabled={unavailable}
+                            className={contextProfile === profile.value ? 'is-selected' : ''}
+                            disabled={unavailable}
+                            onClick={() => {
+                              setContextProfile(profile.value)
+                              setContextMenuOpen(false)
+                              contextTriggerRef.current?.focus()
+                            }}
+                            key={profile.value}
+                          >
+                            <span>
+                              <strong>{profile.label}</strong>
+                              <small>{unavailable ? 'Requires the exact Qwen3 4B Q8_0 model.' : profile.detail}</small>
+                            </span>
+                            <span className="code-context-menu__check">{contextProfile === profile.value ? '✓' : ''}</span>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  ) : null}
+                </div>
               </div>
               {running ? (
                 <button type="button" className="code-composer__send is-stop" aria-label="Stop coding task" onClick={stop} disabled={stopPending}><IconStop size={17} /></button>
@@ -1810,8 +2133,10 @@ export default function CodeWorkspace({
           </form>
           <small className="code-composer-hint">
             Enter to send · Shift+Enter for a new line · {approvalMode === 'full_auto'
-              ? `full auto can write and run commands without stopping${allowNetwork ? ' · web search on' : ''}`
-              : `writes and commands require approval${allowNetwork ? ' · web search on' : ''}`}
+              ? 'full auto writes and runs commands without approval'
+              : approvalMode === 'writes_auto'
+                ? `writes${allowNetwork ? ' and network actions' : ''} run automatically · shell commands require approval`
+                : 'writes and shell commands require approval'}{allowNetwork ? ' · web search on' : ''}
           </small>
         </footer>
       </section>
@@ -1825,6 +2150,7 @@ export default function CodeWorkspace({
           allowNetwork={session?.allow_network ?? allowNetwork}
           changes={changes}
           context={state.context}
+          contextProfile={session?.context_profile || contextProfile}
           contextWindow={contextWindow}
           modelName={modelName}
           modelSteps={state.modelSteps}
@@ -1857,9 +2183,9 @@ export default function CodeWorkspace({
       <ConfirmDialog
         open={fullAutoConfirmOpen}
         title="Enable full auto?"
-        detail="Today is a good day to die mode lets Camelid edit files and run shell commands without asking. File tools stay confined to the selected workspace. How far shell commands are confined depends on your OS: on Linux and macOS they run under a kernel sandbox with no network and writes limited to the workspace and the temp directory, while on Windows they are working-directory pinned and hard-timed but are not filesystem- or network-isolated. Stop remains available; the network switch separately controls Camelid's built-in web tools."
+        detail="Full auto lets Camelid edit files and run shell commands without asking. File tools stay confined to the selected workspace. How far shell commands are confined depends on your OS: on Linux and macOS they run under a kernel sandbox with no network and writes limited to the workspace and the temp directory, while on Windows they are working-directory pinned and hard-timed but are not filesystem- or network-isolated. Stop remains available; the network switch separately controls Camelid's built-in web tools."
         confirmLabel="Enable full auto"
-        cancelLabel="Keep approval gated"
+        cancelLabel={`Keep ${approvalModeLabel(approvalMode)}`}
         onCancel={() => setFullAutoConfirmOpen(false)}
         onConfirm={() => {
           setApprovalMode('full_auto')

--- a/src/api/workspace.rs
+++ b/src/api/workspace.rs
@@ -29,6 +29,15 @@ use crate::chat::workspace_memory::{
     default_store_path, EvidenceInput, StoredThread, WorkspaceMemoryStore,
 };
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WorkspaceContextProfile {
+    #[default]
+    Auto,
+    Q8_16k,
+    Standard,
+}
+
 // Every generated token is one `model.delta` through this bounded channel, and
 // the send BLOCKS. It used to be the browser's render loop that could throttle
 // decode through it; the forwarder on the other end now drains into a retained
@@ -151,6 +160,14 @@ fn workspace_max_steps(mode: WorkspaceRunMode, requested: Option<usize>) -> Resu
         .then_some(max_steps)
         .ok_or(())
 }
+
+fn approval_mode_available_in(
+    mode: WorkspaceRunMode,
+    approval_mode: WorkspaceApprovalMode,
+) -> bool {
+    mode.is_code() || !approval_mode.auto_approve_writes()
+}
+
 const AUTO_COMPACT_MIN_TURNS: u32 = 4;
 
 async fn run_workspace_blocking<T, F>(operation: F) -> Result<T, Response>
@@ -201,6 +218,7 @@ struct ActiveWorkspaceSession {
     /// created. It stays fixed for the session so follow-up turns and spawned
     /// children share one predictable prompt/cache contract.
     context_window: ContextWindowSelection,
+    context_profile: WorkspaceContextProfile,
     max_steps: usize,
     max_tokens: u32,
     temperature: f32,
@@ -1315,6 +1333,8 @@ pub(super) struct CreateWorkspaceSessionRequest {
     #[serde(default)]
     approval_mode: WorkspaceApprovalMode,
     #[serde(default)]
+    context_profile: WorkspaceContextProfile,
+    #[serde(default)]
     allow_network: bool,
 }
 
@@ -1333,6 +1353,7 @@ struct WorkspaceSessionResponse {
     max_steps: usize,
     max_tokens: u32,
     context_window: ContextWindowSelection,
+    context_profile: WorkspaceContextProfile,
     allow_writes: bool,
     approval_mode: WorkspaceApprovalMode,
     allow_network: bool,
@@ -1350,6 +1371,7 @@ struct WorkspaceSessionStatusResponse {
     state: &'static str,
     context_budget_tokens: u32,
     context_window: ContextWindowSelection,
+    context_profile: WorkspaceContextProfile,
     resident_cuda: Option<crate::inference::ResidentCudaStatus>,
     allow_writes: bool,
     approval_mode: WorkspaceApprovalMode,
@@ -1367,6 +1389,7 @@ struct WorkspaceActivityResponse {
     model_id: String,
     state: &'static str,
     context_window: ContextWindowSelection,
+    context_profile: WorkspaceContextProfile,
     approval_mode: WorkspaceApprovalMode,
     allow_network: bool,
     mode: WorkspaceRunMode,
@@ -2118,6 +2141,7 @@ pub(super) async fn create_session(
         );
     }
     let approval_mode = request.approval_mode;
+    let context_profile = request.context_profile;
     let allow_network = request.allow_network;
     if request.allow_writes.unwrap_or(false) && !mode.is_code() {
         return api_error(
@@ -2127,11 +2151,16 @@ pub(super) async fn create_session(
             Some("allow_writes"),
         );
     }
-    if approval_mode.is_full_auto() && !mode.is_code() {
+    if !approval_mode_available_in(mode, approval_mode) {
+        let message = if approval_mode.is_yolo() {
+            "Full-auto approval mode is available only in Code mode"
+        } else {
+            "Writes-auto approval mode is available only in Code mode"
+        };
         return api_error(
             StatusCode::BAD_REQUEST,
             "workspace_read_only",
-            "Full-auto approval mode is available only in Code mode".to_string(),
+            message.to_string(),
             Some("approval_mode"),
         );
     }
@@ -2143,11 +2172,22 @@ pub(super) async fn create_session(
             Some("allow_network"),
         );
     }
-    if approval_mode.is_full_auto() && crate::chat::agent::is_production() {
+    if approval_mode.auto_approve_writes() && crate::chat::agent::is_production() {
+        let (code, message) = if approval_mode.is_yolo() {
+            (
+                "workspace_full_auto_refused",
+                "Full auto is disabled while CAMELID_PRODUCTION is set",
+            )
+        } else {
+            (
+                "workspace_writes_auto_refused",
+                "Writes auto is disabled while CAMELID_PRODUCTION is set",
+            )
+        };
         return api_error(
             StatusCode::FORBIDDEN,
-            "workspace_full_auto_refused",
-            "Full auto is disabled while CAMELID_PRODUCTION is set".to_string(),
+            code,
+            message.to_string(),
             Some("approval_mode"),
         );
     }
@@ -2196,8 +2236,13 @@ pub(super) async fn create_session(
         .is_code()
         .then(crate::chat::context_paging::ContextPagingConfig::from_env);
     let enabled_paging_config = paging_config.as_ref().filter(|config| config.enabled);
-    let (context_window, enable_single_kv_owner_mode) =
-        select_workspace_context_window(&state, &model, max_tokens, enabled_paging_config);
+    let (context_window, enable_single_kv_owner_mode) = select_workspace_context_window(
+        &state,
+        &model,
+        max_tokens,
+        enabled_paging_config,
+        context_profile,
+    );
     if let Some((memory_safe, required)) = workspace_context_memory_shortfall(&context_window) {
         return api_error(
             StatusCode::SERVICE_UNAVAILABLE,
@@ -2370,6 +2415,7 @@ pub(super) async fn create_session(
         model_id: model.id.clone(),
         model_sha256: model.lane.gguf_sha256.to_string(),
         context_window,
+        context_profile,
         max_steps,
         max_tokens,
         temperature,
@@ -2421,6 +2467,7 @@ pub(super) async fn create_session(
             max_steps,
             max_tokens,
             context_window,
+            context_profile,
             allow_writes,
             approval_mode,
             allow_network,
@@ -2781,6 +2828,7 @@ pub(super) async fn session_status(
         state: status,
         context_budget_tokens: session.context_window.effective_tokens,
         context_window: session.context_window,
+        context_profile: session.context_profile,
         resident_cuda: crate::inference::resident_cuda_status(super::model_resident_cache_key(
             &session.model_id,
         )),
@@ -2835,6 +2883,7 @@ pub(super) async fn current_activity(
             model_id: session.model_id.clone(),
             state,
             context_window: session.context_window,
+            context_profile: session.context_profile,
             approval_mode: session.approval_mode,
             allow_network: session.allow_network,
             mode: session.mode,
@@ -3230,9 +3279,14 @@ const QWEN3_4B_PAGED_CONTEXT_TARGET_TOKENS: u32 = 16_384;
 fn paged_context_policy_for_row(
     row_id: Option<&str>,
     paging_config: Option<&crate::chat::context_paging::ContextPagingConfig>,
+    profile: WorkspaceContextProfile,
 ) -> (Option<u32>, Option<u32>) {
     let qwen3_4b_q8 = matches!(row_id, Some("qwen3_4b_instruct_q8_0"));
-    match paging_config.filter(|config| config.enabled && qwen3_4b_q8) {
+    let permits_q8_16k = matches!(
+        profile,
+        WorkspaceContextProfile::Auto | WorkspaceContextProfile::Q8_16k
+    );
+    match paging_config.filter(|config| config.enabled && qwen3_4b_q8 && permits_q8_16k) {
         Some(config) => (
             Some(QWEN3_4B_PAGED_CONTEXT_TARGET_TOKENS),
             Some(config.working_set_tokens()),
@@ -3246,6 +3300,7 @@ fn select_workspace_context_window(
     model: &LoadedModel,
     generation_allowance_tokens: u32,
     paging_config: Option<&crate::chat::context_paging::ContextPagingConfig>,
+    profile: WorkspaceContextProfile,
 ) -> (ContextWindowSelection, bool) {
     let native_context_tokens = model
         .llama_config
@@ -3267,7 +3322,7 @@ fn select_workspace_context_window(
     let row_id = tool_capable_row_for_loaded_artifact(filename, &model.lane.gguf_sha256)
         .map(|(row_id, _)| row_id);
     let (paged_target_tokens, paged_working_set_tokens) =
-        paged_context_policy_for_row(row_id, paging_config);
+        paged_context_policy_for_row(row_id, paging_config, profile);
 
     let kv_owner_slots = if state.engine.single_kv_owner_mode() {
         1
@@ -3807,7 +3862,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_session_request_defaults_to_gated_and_offline() {
+    fn workspace_session_request_defaults_preserve_conservative_access_and_auto_context() {
         let request: CreateWorkspaceSessionRequest = serde_json::from_value(serde_json::json!({
             "workspace": ".",
             "goal": "inspect the project",
@@ -3815,7 +3870,43 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(request.approval_mode, WorkspaceApprovalMode::ApprovalGated);
+        assert_eq!(request.context_profile, WorkspaceContextProfile::Auto);
         assert!(!request.allow_network);
+
+        let configured: CreateWorkspaceSessionRequest = serde_json::from_value(serde_json::json!({
+            "workspace": ".",
+            "goal": "edit the project",
+            "mode": "code",
+            "approval_mode": "writes_auto",
+            "context_profile": "q8_16k"
+        }))
+        .unwrap();
+        assert_eq!(configured.approval_mode, WorkspaceApprovalMode::WritesAuto);
+        assert_eq!(configured.context_profile, WorkspaceContextProfile::Q8_16k);
+        assert_eq!(
+            serde_json::to_value(configured.context_profile).unwrap(),
+            serde_json::json!("q8_16k")
+        );
+    }
+
+    #[test]
+    fn automatic_approval_modes_are_code_only() {
+        assert!(approval_mode_available_in(
+            WorkspaceRunMode::ReadOnly,
+            WorkspaceApprovalMode::ApprovalGated,
+        ));
+        assert!(!approval_mode_available_in(
+            WorkspaceRunMode::ReadOnly,
+            WorkspaceApprovalMode::WritesAuto,
+        ));
+        assert!(!approval_mode_available_in(
+            WorkspaceRunMode::ReadOnly,
+            WorkspaceApprovalMode::FullAuto,
+        ));
+        assert!(approval_mode_available_in(
+            WorkspaceRunMode::Code,
+            WorkspaceApprovalMode::WritesAuto,
+        ));
     }
 
     #[test]
@@ -3909,6 +4000,7 @@ mod tests {
                 model_id: "model-test".to_string(),
                 model_sha256: "sha-test".to_string(),
                 context_window: test_context_window(),
+                context_profile: WorkspaceContextProfile::Auto,
                 max_steps: 1,
                 max_tokens: 1,
                 temperature: 0.0,
@@ -3965,6 +4057,7 @@ mod tests {
             model_id: "model".into(),
             model_sha256: "sha-test".to_string(),
             context_window: test_context_window(),
+            context_profile: WorkspaceContextProfile::Auto,
             max_steps: 1,
             max_tokens: 1,
             temperature: 0.0,
@@ -4042,6 +4135,7 @@ mod tests {
             model_id: "model".into(),
             model_sha256: "sha-test".to_string(),
             context_window: test_context_window(),
+            context_profile: WorkspaceContextProfile::Auto,
             max_steps: 1,
             max_tokens: 1,
             temperature: 0.0,
@@ -4079,6 +4173,7 @@ mod tests {
             model_id: "model".into(),
             model_sha256: "sha-test".to_string(),
             context_window: test_context_window(),
+            context_profile: WorkspaceContextProfile::Auto,
             max_steps: 1,
             max_tokens: 1,
             temperature: 0.0,
@@ -4150,6 +4245,7 @@ mod tests {
             model_id: "model".into(),
             model_sha256: "sha-test".to_string(),
             context_window: test_context_window(),
+            context_profile: WorkspaceContextProfile::Auto,
             max_steps: 1,
             max_tokens: 1,
             temperature: 0.0,
@@ -4250,6 +4346,7 @@ mod tests {
                 model_id: "model".into(),
                 model_sha256: "sha-test".to_string(),
                 context_window: test_context_window(),
+                context_profile: WorkspaceContextProfile::Auto,
                 max_steps: 1,
                 max_tokens: 1,
                 temperature: 0.0,
@@ -4314,6 +4411,7 @@ mod tests {
             model_id: "model".into(),
             model_sha256: "sha-test".to_string(),
             context_window: test_context_window(),
+            context_profile: WorkspaceContextProfile::Auto,
             max_steps: 1,
             max_tokens: 1,
             temperature: 0.0,
@@ -4534,30 +4632,72 @@ mod tests {
     }
 
     #[test]
-    fn exact_qwen3_4b_paging_policy_gives_only_q8_the_16k_target() {
+    fn context_profiles_keep_the_16k_target_on_the_exact_q8_row() {
         let config = crate::chat::context_paging::ContextPagingConfig::default();
         assert_eq!(
-            paged_context_policy_for_row(Some("qwen3_4b_instruct_q8_0"), Some(&config)),
+            paged_context_policy_for_row(
+                Some("qwen3_4b_instruct_q8_0"),
+                Some(&config),
+                WorkspaceContextProfile::Auto,
+            ),
             (Some(16_384), Some(8_000))
         );
         assert_eq!(
-            paged_context_policy_for_row(Some("qwen3_4b_q4_k_m"), Some(&config)),
+            paged_context_policy_for_row(
+                Some("qwen3_4b_instruct_q8_0"),
+                Some(&config),
+                WorkspaceContextProfile::Q8_16k,
+            ),
+            (Some(16_384), Some(8_000))
+        );
+        assert_eq!(
+            paged_context_policy_for_row(
+                Some("qwen3_4b_q4_k_m"),
+                Some(&config),
+                WorkspaceContextProfile::Q8_16k,
+            ),
+            (None, None),
+            "the Q8 16K preset must not promote a neighboring quantization"
+        );
+        assert_eq!(
+            paged_context_policy_for_row(
+                Some("qwen3_4b_q4_k_m"),
+                Some(&config),
+                WorkspaceContextProfile::Auto,
+            ),
             (None, None),
             "Q4_K_M's legacy 8K operational envelope is not a promoted context bucket"
         );
         assert_eq!(
-            paged_context_policy_for_row(Some("llama32_3b_instruct_q8_0"), Some(&config)),
+            paged_context_policy_for_row(
+                Some("llama32_3b_instruct_q8_0"),
+                Some(&config),
+                WorkspaceContextProfile::Auto,
+            ),
             (None, None)
+        );
+        assert_eq!(
+            paged_context_policy_for_row(
+                Some("qwen3_4b_instruct_q8_0"),
+                Some(&config),
+                WorkspaceContextProfile::Standard,
+            ),
+            (None, None),
+            "the standard profile must force the operational 8K envelope"
         );
 
         let mut disabled = config.clone();
         disabled.enabled = false;
         assert_eq!(
-            paged_context_policy_for_row(Some("qwen3_4b_instruct_q8_0"), Some(&disabled)),
+            paged_context_policy_for_row(
+                Some("qwen3_4b_instruct_q8_0"),
+                Some(&disabled),
+                WorkspaceContextProfile::Auto,
+            ),
             (None, None)
         );
 
-        let q4_operational = select_context_window(ContextWindowInputs {
+        let standard_operational = select_context_window(ContextWindowInputs {
             native_context_tokens: 40_960,
             validated_context_tokens: crate::chat::agent::AGENT_VALIDATED_CTX,
             server_context_tokens: 131_072,
@@ -4567,17 +4707,19 @@ mod tests {
             resident_capacity_tokens: None,
             configured_max_tokens: None,
             paged_target_tokens: paged_context_policy_for_row(
-                Some("qwen3_4b_q4_k_m"),
+                Some("qwen3_4b_instruct_q8_0"),
                 Some(&config),
+                WorkspaceContextProfile::Standard,
             )
             .0,
             paged_working_set_tokens: paged_context_policy_for_row(
-                Some("qwen3_4b_q4_k_m"),
+                Some("qwen3_4b_instruct_q8_0"),
                 Some(&config),
+                WorkspaceContextProfile::Standard,
             )
             .1,
         });
-        assert_eq!(q4_operational.effective_tokens, 8_192);
-        assert_eq!(q4_operational.paged_target_tokens, None);
+        assert_eq!(standard_operational.effective_tokens, 8_192);
+        assert_eq!(standard_operational.paged_target_tokens, None);
     }
 }

--- a/src/chat/subagent.rs
+++ b/src/chat/subagent.rs
@@ -269,7 +269,8 @@ impl SubagentConfig {
 
     /// Browser/Desktop Code child configuration. Unlike the legacy terminal
     /// constructor, this preserves the complete parent capability boundary:
-    /// narrow WebCode tools, the explicit network switch, and full-auto Exec.
+    /// narrow WebCode tools, the explicit network switch, and independent
+    /// write-auto and full-auto Exec grants.
     #[allow(clippy::too_many_arguments)]
     pub fn for_web_code_session(
         addr: SocketAddr,
@@ -277,15 +278,16 @@ impl SubagentConfig {
         family: String,
         max_tokens: u32,
         context_budget_tokens: u32,
-        full_auto: bool,
+        auto_approve: bool,
+        yolo: bool,
         allow_net: bool,
         shell_mode: super::shell_sandbox::ShellSandbox,
     ) -> Self {
         let mut config =
-            Self::for_session(addr, model_id, family, max_tokens, full_auto, shell_mode);
+            Self::for_session(addr, model_id, family, max_tokens, auto_approve, shell_mode);
         config.context_budget_tokens = context_budget_tokens.max(1);
         config.allow_net = allow_net;
-        config.yolo = full_auto;
+        config.yolo = yolo;
         config.web_code = true;
         config
     }
@@ -1184,8 +1186,11 @@ mod tests {
             32_768,
             true,
             false,
+            false,
             super::super::shell_sandbox::ShellSandbox::Sandboxed,
         );
+        assert!(config.auto_approve);
+        assert!(!config.yolo);
         let _configured = configure_for_test(config);
         assert!(is_enabled());
         assert!(std::thread::spawn(|| !is_enabled()).join().unwrap());
@@ -1235,6 +1240,7 @@ mod tests {
             "qwen3".into(),
             2048,
             32_768,
+            true,
             true,
             true,
             super::super::shell_sandbox::ShellSandbox::Sandboxed,

--- a/src/chat/workspace_bridge.rs
+++ b/src/chat/workspace_bridge.rs
@@ -64,12 +64,17 @@ pub(crate) enum WorkspaceRunMode {
 pub(crate) enum WorkspaceApprovalMode {
     #[default]
     ApprovalGated,
+    WritesAuto,
     FullAuto,
 }
 
 impl WorkspaceApprovalMode {
-    pub(crate) fn is_full_auto(self) -> bool {
-        self == Self::FullAuto
+    pub(crate) fn auto_approve_writes(self) -> bool {
+        matches!(self, Self::WritesAuto | Self::FullAuto)
+    }
+
+    pub(crate) fn is_yolo(self) -> bool {
+        matches!(self, Self::FullAuto)
     }
 }
 
@@ -783,8 +788,8 @@ pub(crate) fn run_live(
         }
     };
     let mut policy = match super::agent::resolve_policy(
-        false,
-        config.approval_mode.is_full_auto(),
+        config.approval_mode.auto_approve_writes(),
+        config.approval_mode.is_yolo(),
         super::agent::is_production(),
     ) {
         Ok(policy) => policy,
@@ -834,7 +839,8 @@ pub(crate) fn run_live(
             config.family.clone(),
             config.max_tokens,
             config.context_budget_tokens,
-            config.approval_mode.is_full_auto(),
+            config.approval_mode.auto_approve_writes(),
+            config.approval_mode.is_yolo(),
             config.allow_network,
             shell_sandbox,
         ));
@@ -910,8 +916,8 @@ pub(crate) fn run_live(
     let agent_config = AgentConfig {
         workdir: config.workspace,
         max_steps: config.max_steps,
-        auto_approve: config.approval_mode.is_full_auto(),
-        yolo: config.approval_mode.is_full_auto(),
+        auto_approve: config.approval_mode.auto_approve_writes(),
+        yolo: config.approval_mode.is_yolo(),
         allow_net: config.allow_network,
         allow_fs: false,
         shell_timeout: Duration::from_secs(30),
@@ -1022,6 +1028,7 @@ mod tests {
             "llama".into(),
             2048,
             32_768,
+            true,
             true,
             true,
             WorkspaceRunMode::Code.shell_sandbox(),
@@ -1178,12 +1185,40 @@ mod tests {
     }
 
     #[test]
+    fn writes_auto_promotes_writes_without_promoting_exec() {
+        let mode = WorkspaceApprovalMode::WritesAuto;
+        assert!(mode.auto_approve_writes());
+        assert!(!mode.is_yolo());
+
+        let policy =
+            crate::chat::agent::resolve_policy(mode.auto_approve_writes(), mode.is_yolo(), false)
+                .unwrap();
+        assert_eq!(
+            policy.tier_for(&Action::WriteFile {
+                path: PathBuf::from("result.txt"),
+                content: "done".to_string(),
+                summary: "write result".to_string(),
+            }),
+            ApprovalTier::Auto
+        );
+        assert_eq!(
+            policy.tier_for(&Action::RunShell {
+                command: "cargo test".to_string(),
+            }),
+            ApprovalTier::Confirm
+        );
+    }
+
+    #[test]
     fn workspace_access_defaults_fail_closed() {
         assert_eq!(
             WorkspaceApprovalMode::default(),
             WorkspaceApprovalMode::ApprovalGated
         );
-        assert!(!WorkspaceApprovalMode::default().is_full_auto());
+        assert!(!WorkspaceApprovalMode::default().auto_approve_writes());
+        assert!(!WorkspaceApprovalMode::default().is_yolo());
+        assert!(WorkspaceApprovalMode::FullAuto.auto_approve_writes());
+        assert!(WorkspaceApprovalMode::FullAuto.is_yolo());
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #655 at its requested head commit 4548af6c.

## Summary

- add session-scoped Auto, Q8 16K, and Q4 8K context profiles with the Code composer selector and inspector details
- add Writes auto as a Code-only policy that auto-approves writes without granting Full auto shell execution, including subagents
- refresh approval, agent, process, and environment UI and strengthen the visual smoke coverage for replacement sessions, accessibility, and narrow layouts
- keep context_profile on ActiveWorkspaceSession only; WorkspaceRunConfig is unchanged
- leave frontend/package-lock.json untouched

## Validation

- npm run build
- CAMELID_CAPTURE_URL=http://127.0.0.1:4176 npm run smoke:code-workbench
- cargo fmt --all -- --check
- cargo check --lib
- cargo clippy --lib --tests -- -D warnings
- cargo test --lib api::workspace::tests
- cargo test --lib chat::workspace_bridge::tests
- cargo test --lib chat::subagent::tests