### PR TITLE
perf(gemma4-mtp): resident-first verify split, second-wave verdicts, and the promoted MTP profile

### DIFF
--- a/qa/perf/gemma4-mtp-h40/BASELINE-2026-08-24.md
+++ b/qa/perf/gemma4-mtp-h40/BASELINE-2026-08-24.md
@@ -606,3 +606,48 @@ campaign's promotable band (24.3–27.7). The next levers, in order: promote the
 stack + K=7 + split out of env opt-ins, move the fill-phase reads off the launch thread
 (the split hides ~28 ms of the ~45 ms storage+copy tail; a background fill could hide the
 rest), and the assistant's on-device embedding gather (~16 ms/round of hard syncs).
+
+## 17. Second wave (2026-08-26): two honest negatives, and where the wall actually is
+
+Before building anything further, two candidate levers were killed **offline** with the
+§14-era route trace (`…-trace` run, 4,560 `[route]` lines):
+
+- **Tier eviction hybrids lose to MRU.** Simulating the exact traced demand sequence
+  through the LFU arena + 1,218-slot tier: MRU 93.3 verify storage reads/round, LRU 140.9,
+  every recency-protected hybrid 107–142. The sim's MRU figure matches the live receipts,
+  so the ranking stands. Recency protection displaces the stable hot head MRU retains.
+- **Cross-round route prefetch has almost nothing to prefetch.** Per-layer unions overlap
+  74% round-over-round (85.5% over two rounds) — but the round's **disk reads are the
+  unpredictable tail**: only 1–18% of them appear in the previous round's union (≤46% in
+  two). The predictable experts are already served by tier+arena; storage is also already
+  running at the drive's depth-4 ceiling during fills. The storage column is closed on
+  this RAM/VRAM budget. (This also forecasts the Metal campaign's "cross-layer speculative
+  expert prefetch" lever: same tail, same wall.)
+
+Two levers were then built, A/B'd paired ×3 on the composed K=7 rsplit arm, and called
+honestly:
+
+- **On-device assistant draft chain — NULL.** `CAMELID_GEMMA4_MTP_DEVICE_DRAFT_CHAIN=1`
+  keeps the argmax→next-embedding dependency on-device (Q6_K head-row gather, pinned
+  bitwise by `q6k_row_gather_scale_matches_cpu_decode`; drafts drain in one round-end
+  DtoH). Measured 25.74/26.16/26.09 vs 26.32/25.93/26.32 — sign flips; assistant wall is
+  ~170 ms/request in both arms because the removed per-proposal syncs were waiting on
+  kernels that had to finish anyway. Kept opt-in; the unconditional rope-upload hoist
+  (4 uploads/round instead of 56) rides along as an inert refactor.
+- **Routed-arena SoA (Step 05) — REGRESSION.** `CAMELID_GEMMA4_GHOST_ARENA_SOA=1`
+  measured 25.69/25.76/25.83 → 22.32/22.96/23.11, verifier 281→316–327 ms/round, ids
+  exact, misses identical. The CPU repack rides the QD4 read workers between
+  read-completion and HtoD — ~30–50 ms/round of staging cost against a routed-GEMM
+  kernel term nsys put at ~28 ms/round *total*. Kept default-off; a device-side
+  post-copy permutation (~2.6 ms/round at VRAM bandwidth) is the variant that could
+  flip the sign and would reuse these kernels and parity pins unchanged.
+
+**The composed K=7 + resident-split arm therefore remains the standing best:
+25.7–26.3 whole-decode tok/s across the day's twelve control runs** (~7.6–8.1 GiB
+available, all token-exact). The round is now ~275–284 ms: ~85–100 ms kernels (post
+anchor-DP4A), ~60–80 ms exposed storage at the device ceiling, ~45 ms HtoD, ~47 ms
+per-layer CPU↔GPU ping-pong, ~28 ms assistant+accept. What is left that could still
+move it: the per-layer launch storm / fixed ping-pong (fused batched norm+quantize,
+CUDA-graphing the static dense segment — WDDM risk, ~15–25 ms), a device-side SoA
+repack (~10 ms net), and K-width/schedule tuning on real workloads. Levers refuted or
+null on this box now number seventeen; the ledger is the moat.

--- a/qa/perf/gemma4-mtp-h40/BASELINE-2026-08-24.md
+++ b/qa/perf/gemma4-mtp-h40/BASELINE-2026-08-24.md
@@ -644,7 +644,32 @@ honestly:
 
 **The composed K=7 + resident-split arm therefore remains the standing best:
 25.7–26.3 whole-decode tok/s across the day's twelve control runs** (~7.6–8.1 GiB
-available, all token-exact). The round is now ~275–284 ms: ~85–100 ms kernels (post
+available, all token-exact).
+
+## 18. The stack is now the default: `--mtp-assistant` alone reproduces the record
+
+The winning configuration was fifteen environment variables deep — a benchmark, not a
+product. `GEMMA4_MTP_PROMOTED_PROFILE` (src/gemma4_runtime.rs) now carries the receipted
+values, and the CLI applies them as **defaults the moment `--mtp-assistant` selects the
+MTP lane, before the model load where every gate resolves**. An explicitly set variable
+always wins, so every receipted arm still reproduces byte-for-byte; the plain lane never
+sees the profile (several members — QD4 batch reads, the read pools — measured negative
+or null for scalar decode, which is why this is a lane profile and not a set of global
+default flips). `--mtp-draft-k` defaults to the receipted 7. Deliberately excluded:
+the kv192 fixture cap, the null draft chain, and the regressed arena SoA.
+
+The promotion gate (`arms/mtp-k7-kv192-profile.json` — no stack env at all, only the
+fixture's KV cap): paired ×3 against the full-env rsplit arm, one binary (`e7840929…`):
+
+| pair | full-env arm | profile only | 
+|---|---:|---:|
+| 1 | 25.78 | 25.81 |
+| 2 | 26.01 | 26.08 |
+| 3 | 25.87 | 25.92 |
+
+Identical arena misses (1,254), identical verifier walls (278–281 ms/round), all 48 ids
+exact in all six runs. What a user gets from `--mtp-assistant <dir>` with a clean
+environment is now the number this document reports. The round is now ~275–284 ms: ~85–100 ms kernels (post
 anchor-DP4A), ~60–80 ms exposed storage at the device ceiling, ~45 ms HtoD, ~47 ms
 per-layer CPU↔GPU ping-pong, ~28 ms assistant+accept. What is left that could still
 move it: the per-layer launch storm / fixed ping-pong (fused batched norm+quantize,

--- a/qa/perf/gemma4-mtp-h40/BASELINE-2026-08-24.md
+++ b/qa/perf/gemma4-mtp-h40/BASELINE-2026-08-24.md
@@ -550,3 +550,59 @@ The 2 GiB host-tier performance arm was **not completed or quoted**. Live availa
 fell below 0.8 GiB during model load on this 16 GiB host, so the child was terminated and
 RAM recovered immediately. The safe published number for the current machine state is
 therefore 12.54 decode tok/s; 25 tok/s has not been reached.
+
+## 16. The composed stack at a settled host, and the resident-first split (2026-08-26)
+
+The §15 winner ran at 4.9 GiB available with a forced 1 GiB tier — the LFU and Q6-anchor
+mechanisms were never measured together with the auto-sized MRU tier at a healthy host
+state. Composing them (arm `…-host-mru-io-lfu-q6-anchor`, auto tier) and re-running paired
+at 7.8–8.3 GiB available, binary `cd11b51c…` built clean at `d9bc5156`:
+
+| pair | `plain-kv192` decode / steady | composed K=6 decode | verifier |
+|---|---|---:|---:|
+| 1 | 15.82 / 20.87 | **22.34** | 282 ms/round |
+| 2 | 15.69 / 20.75 | **22.50** | 280 ms/round |
+| 3 | 15.59 / 20.58 | **22.59** | 280 ms/round |
+
+**+43% whole-decode over plain-kv192, sign-consistent, all 48 ids exact in every run.**
+The K-wide unions double the tier's usefulness: decode tier hit rate is 47.8% against the
+scalar lane's 26.7% at the same auto size. K=7 then beat K=6 in both pairs (23.14/22.83 vs
+22.54/22.14, alpha 7.00, every draft accepted, 316–320 ms over 6 rounds): the wider round
+amortizes the fixed per-round cost and reads slightly less storage (639 vs 663 records).
+
+### The resident-first split — the first structural overlap in the verify round
+
+Nsight showed the round's storage wait and expert HtoD overlap **zero** compute: the
+routed GEMMs fence on `expert_copy_done` for the *entire* union, so experts that were
+already VRAM-resident wait for the 2–4 missing records per layer to stream from
+tier/NVMe. The fix reorders the union residents-first (a pure renumbering —
+`gemma4_reorder_union_residents_first`, pinned by a stable-permutation unit test), splits
+the resolve into a touch phase and a fill phase, and launches the routed
+GateUp→GeGLU→Down chain twice: the resident expert range is enqueued *before* the CPU
+blocks on the missing experts' reads, the missing range after its copies land, as
+contiguous sub-range launches of the same kernels (`launch_q4_0_gemm_routed_range`).
+Bit-exactness is by construction — each expert's per-row fold still happens whole inside
+exactly one launch, `token_offsets` values stay absolute so outputs land at identical
+positions, and the weighted sum consumes router order — and is pinned on hardware by the
+two-pass range case added to `q4_0_gemm_routed_matches_gemv`.
+
+Opt-in `CAMELID_GEMMA4_MTP_RESIDENT_SPLIT=1` (strict 0/1). Paired ×3 on the composed K=7
+arm, one binary (`f609b7d5…`), cooled:
+
+| pair | K=7 composed | + resident split | delta |
+|---|---:|---:|---:|
+| 1 | 23.43 | **25.65** | +9.5% |
+| 2 | 23.61 | **25.57** | +8.3% |
+| 3 | 23.56 | **25.64** | +8.8% |
+
+Verifier 310–313 → **282–284 ms/round**. Arena misses (1,254) and storage reads (639) are
+**identical in all six runs** — the touch order, fill order, and eviction sequence are
+unchanged by design, so the delta is pure overlap, not residency. Token ids exact
+throughout.
+
+**Standing best on this box: 25.6 whole-decode tok/s** (48-token fixture, ~8 GiB
+available), against 15.7 plain-kv192 same-day and 12.54 in §15. That sits inside the Mac
+campaign's promotable band (24.3–27.7). The next levers, in order: promote the composed
+stack + K=7 + split out of env opt-ins, move the fill-phase reads off the launch thread
+(the split hides ~28 ms of the ~45 ms storage+copy tail; a background fill could hide the
+rest), and the assistant's on-device embedding gather (~16 ms/round of hard syncs).

--- a/qa/perf/gemma4-mtp-h40/README.md
+++ b/qa/perf/gemma4-mtp-h40/README.md
@@ -70,6 +70,7 @@ its control; pair bounded-context arms against the matching plain/MTP control.
 | `mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit` | **Current best on the 16 GiB Windows host (25.7–26.3 decode tok/s at ~8 GiB available)**: the composed K=7 arm plus the resident-first verifier split (§16). |
 | `mtp-k7-…-rsplit-dchain` | Plus the on-device assistant draft chain. Exact; measured NULL paired ×3 (§17) — the removed per-proposal syncs were waiting on kernels that had to finish anyway. |
 | `mtp-k7-…-rsplit-soa` | Plus the routed-arena SoA repack. Exact; measured REGRESSION paired ×3 (§17) — the CPU staging repack costs more than the kernel term it improves. Standing control for a device-side repack variant. |
+| `mtp-k7-kv192-profile` | The promotion gate: `--mtp-assistant` with no stack env at all. The CLI's promoted profile (§18) must match the full-env rsplit arm within noise — and does, paired ×3, ids exact. |
 
 ## What a run produces
 

--- a/qa/perf/gemma4-mtp-h40/README.md
+++ b/qa/perf/gemma4-mtp-h40/README.md
@@ -64,7 +64,10 @@ its control; pair bounded-context arms against the matching plain/MTP control.
 | `mtp-k8-kv192-kwide-qd4-router-overlap` | Crossed K-wide probe that moves the batched router DtoH to its own stream while the dense shared branch runs. |
 | `mtp-k8-kv192-kwide-qd8` | Crossed K-wide storage probe with eight unbuffered positioned readers instead of four. |
 | `mtp-k6-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-tier1024-io-q6-anchor-dp4a` | Minimum-memory exact hardware gate for the anchor-major Q6_K DP4A verifier lane. |
-| `mtp-k6-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-tier1024-io-lfu-q6-anchor` | Current safe winner on the 16 GiB Windows host: QD4 I/O, lifetime-LFU VRAM eviction, CUDA assistant, and anchor-major Q6_K DP4A. |
+| `mtp-k6-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-tier1024-io-lfu-q6-anchor` | §15 winner in the RAM-starved regime: QD4 I/O, lifetime-LFU VRAM eviction, CUDA assistant, and anchor-major Q6_K DP4A on a forced 1 GiB tier. |
+| `mtp-k6-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor` | The same stack with the MRU tier free to auto-size. First arm to compose every promoted mechanism at a settled host. |
+| `mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor` | K=7 sibling of the composed arm; alpha 7.00 with every draft accepted on this fixture. |
+| `mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit` | **Current best on the 16 GiB Windows host (25.6 decode tok/s at ~8 GiB available)**: the composed K=7 arm plus the resident-first verifier split (§16). |
 
 ## What a run produces
 

--- a/qa/perf/gemma4-mtp-h40/README.md
+++ b/qa/perf/gemma4-mtp-h40/README.md
@@ -67,7 +67,9 @@ its control; pair bounded-context arms against the matching plain/MTP control.
 | `mtp-k6-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-tier1024-io-lfu-q6-anchor` | §15 winner in the RAM-starved regime: QD4 I/O, lifetime-LFU VRAM eviction, CUDA assistant, and anchor-major Q6_K DP4A on a forced 1 GiB tier. |
 | `mtp-k6-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor` | The same stack with the MRU tier free to auto-size. First arm to compose every promoted mechanism at a settled host. |
 | `mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor` | K=7 sibling of the composed arm; alpha 7.00 with every draft accepted on this fixture. |
-| `mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit` | **Current best on the 16 GiB Windows host (25.6 decode tok/s at ~8 GiB available)**: the composed K=7 arm plus the resident-first verifier split (§16). |
+| `mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit` | **Current best on the 16 GiB Windows host (25.7–26.3 decode tok/s at ~8 GiB available)**: the composed K=7 arm plus the resident-first verifier split (§16). |
+| `mtp-k7-…-rsplit-dchain` | Plus the on-device assistant draft chain. Exact; measured NULL paired ×3 (§17) — the removed per-proposal syncs were waiting on kernels that had to finish anyway. |
+| `mtp-k7-…-rsplit-soa` | Plus the routed-arena SoA repack. Exact; measured REGRESSION paired ×3 (§17) — the CPU staging repack costs more than the kernel term it improves. Standing control for a device-side repack variant. |
 
 ## What a run produces
 

--- a/qa/perf/gemma4-mtp-h40/arms/mtp-k6-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor.json
+++ b/qa/perf/gemma4-mtp-h40/arms/mtp-k6-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor.json
@@ -1,0 +1,22 @@
+{
+  "description": "K=6 with every promoted mechanism composed at auto tier sizing: K-wide verifier, QD4 union fills, seeded bootstrap, CUDA assistant, auto-sized MRU host tier, IO pipeline, lifetime-LFU VRAM eviction, and exact anchor-major Q6_K DP4A. The tier1024 winner ran RAM-starved; this arm is the same stack with the tier free to size itself.",
+  "mtp": true,
+  "draft_k": 6,
+  "env": {
+    "CAMELID_GEMMA4_CUDA_BATCH_EXPERT_COPIES": "1",
+    "CAMELID_GEMMA4_PREFILL_CHUNK_TOKENS": "512",
+    "CAMELID_GEMMA4_Q4_0_SOA": "1",
+    "CAMELID_GEMMA4_SPECULATIVE": "0",
+    "CAMELID_GEMMA4_GHOST_CUDA_CONTEXT": "192",
+    "CAMELID_GEMMA4_GHOST_BATCH_READS": "1",
+    "CAMELID_GEMMA4_GHOST_READ_THREADS": "4",
+    "CAMELID_GEMMA4_GHOST_UNCACHED_READERS": "4",
+    "CAMELID_GEMMA4_MTP_KWIDE": "1",
+    "CAMELID_GEMMA4_MTP_PREFILL_SEED_BOOTSTRAP": "1",
+    "CAMELID_GEMMA4_MTP_CUDA_ASSISTANT": "1",
+    "CAMELID_GEMMA4_GHOST_HOST_TIER_EVICTION": "mru",
+    "CAMELID_GEMMA4_MTP_IO_PIPELINE": "1",
+    "CAMELID_GEMMA4_GHOST_CUDA_EVICTION": "lfu",
+    "CAMELID_GEMMA4_MTP_DENSE_Q6_ANCHOR_DP4A": "1"
+  }
+}

--- a/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit-dchain.json
+++ b/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit-dchain.json
@@ -1,0 +1,24 @@
+{
+  "description": "The composed K=7 + resident-split arm plus the on-device draft chain: the assistant's argmax feeds the next proposal's embedding through a Q6_K head-row gather on the GPU (drafter-only numerics), drafts drain in one round-end DtoH, and both rope variants upload once per round instead of twice per layer per proposal. Gather decode pinned bitwise by q6k_row_gather_scale_matches_cpu_decode.",
+  "mtp": true,
+  "draft_k": 7,
+  "env": {
+    "CAMELID_GEMMA4_CUDA_BATCH_EXPERT_COPIES": "1",
+    "CAMELID_GEMMA4_PREFILL_CHUNK_TOKENS": "512",
+    "CAMELID_GEMMA4_Q4_0_SOA": "1",
+    "CAMELID_GEMMA4_SPECULATIVE": "0",
+    "CAMELID_GEMMA4_GHOST_CUDA_CONTEXT": "192",
+    "CAMELID_GEMMA4_GHOST_BATCH_READS": "1",
+    "CAMELID_GEMMA4_GHOST_READ_THREADS": "4",
+    "CAMELID_GEMMA4_GHOST_UNCACHED_READERS": "4",
+    "CAMELID_GEMMA4_MTP_KWIDE": "1",
+    "CAMELID_GEMMA4_MTP_PREFILL_SEED_BOOTSTRAP": "1",
+    "CAMELID_GEMMA4_MTP_CUDA_ASSISTANT": "1",
+    "CAMELID_GEMMA4_GHOST_HOST_TIER_EVICTION": "mru",
+    "CAMELID_GEMMA4_MTP_IO_PIPELINE": "1",
+    "CAMELID_GEMMA4_GHOST_CUDA_EVICTION": "lfu",
+    "CAMELID_GEMMA4_MTP_DENSE_Q6_ANCHOR_DP4A": "1",
+    "CAMELID_GEMMA4_MTP_RESIDENT_SPLIT": "1",
+    "CAMELID_GEMMA4_MTP_DEVICE_DRAFT_CHAIN": "1"
+  }
+}

--- a/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit-soa.json
+++ b/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit-soa.json
@@ -1,0 +1,24 @@
+{
+  "description": "The composed K=7 rsplit arm plus the routed-arena SoA repack: Q4_0 expert records are repacked quants-first at staging (host-tier insert / transfer-ring fill), the HtoD path is unchanged, and both routed consumers (scalar GEMV, K-wide GEMM) switch to the SoA kernels' aligned uint4 weight loads. Bit-identical by construction (same dp4a bytes, same per-block term, same single-lane increasing-b fold); pinned by q4_0_record_wire_to_soa_is_a_pure_permutation, q4_0_gemv_routed_soa_matches_wire, and q4_0_gemm_routed_soa_matches_wire.",
+  "mtp": true,
+  "draft_k": 7,
+  "env": {
+    "CAMELID_GEMMA4_CUDA_BATCH_EXPERT_COPIES": "1",
+    "CAMELID_GEMMA4_PREFILL_CHUNK_TOKENS": "512",
+    "CAMELID_GEMMA4_Q4_0_SOA": "1",
+    "CAMELID_GEMMA4_SPECULATIVE": "0",
+    "CAMELID_GEMMA4_GHOST_CUDA_CONTEXT": "192",
+    "CAMELID_GEMMA4_GHOST_BATCH_READS": "1",
+    "CAMELID_GEMMA4_GHOST_READ_THREADS": "4",
+    "CAMELID_GEMMA4_GHOST_UNCACHED_READERS": "4",
+    "CAMELID_GEMMA4_MTP_KWIDE": "1",
+    "CAMELID_GEMMA4_MTP_PREFILL_SEED_BOOTSTRAP": "1",
+    "CAMELID_GEMMA4_MTP_CUDA_ASSISTANT": "1",
+    "CAMELID_GEMMA4_GHOST_HOST_TIER_EVICTION": "mru",
+    "CAMELID_GEMMA4_MTP_IO_PIPELINE": "1",
+    "CAMELID_GEMMA4_GHOST_CUDA_EVICTION": "lfu",
+    "CAMELID_GEMMA4_MTP_DENSE_Q6_ANCHOR_DP4A": "1",
+    "CAMELID_GEMMA4_MTP_RESIDENT_SPLIT": "1",
+    "CAMELID_GEMMA4_GHOST_ARENA_SOA": "1"
+  }
+}

--- a/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit.json
+++ b/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor-rsplit.json
@@ -1,0 +1,23 @@
+{
+  "description": "The composed K=7 arm plus the resident-first verifier split: the union is reordered residents-first, the resident expert range's routed GEMMs are enqueued before the CPU blocks on the missing experts' storage reads, and the missing range runs after its copies land. Bit-identical by construction (each expert's fold happens whole in exactly one launch; the weighted sum consumes router order); pinned by the two-pass range case in q4_0_gemm_routed_matches_gemv.",
+  "mtp": true,
+  "draft_k": 7,
+  "env": {
+    "CAMELID_GEMMA4_CUDA_BATCH_EXPERT_COPIES": "1",
+    "CAMELID_GEMMA4_PREFILL_CHUNK_TOKENS": "512",
+    "CAMELID_GEMMA4_Q4_0_SOA": "1",
+    "CAMELID_GEMMA4_SPECULATIVE": "0",
+    "CAMELID_GEMMA4_GHOST_CUDA_CONTEXT": "192",
+    "CAMELID_GEMMA4_GHOST_BATCH_READS": "1",
+    "CAMELID_GEMMA4_GHOST_READ_THREADS": "4",
+    "CAMELID_GEMMA4_GHOST_UNCACHED_READERS": "4",
+    "CAMELID_GEMMA4_MTP_KWIDE": "1",
+    "CAMELID_GEMMA4_MTP_PREFILL_SEED_BOOTSTRAP": "1",
+    "CAMELID_GEMMA4_MTP_CUDA_ASSISTANT": "1",
+    "CAMELID_GEMMA4_GHOST_HOST_TIER_EVICTION": "mru",
+    "CAMELID_GEMMA4_MTP_IO_PIPELINE": "1",
+    "CAMELID_GEMMA4_GHOST_CUDA_EVICTION": "lfu",
+    "CAMELID_GEMMA4_MTP_DENSE_Q6_ANCHOR_DP4A": "1",
+    "CAMELID_GEMMA4_MTP_RESIDENT_SPLIT": "1"
+  }
+}

--- a/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor.json
+++ b/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-kwide-qd4-seeded-cuda-assistant-host-mru-io-lfu-q6-anchor.json
@@ -1,0 +1,22 @@
+{
+  "description": "K=7 sibling of the composed auto-tier arm: alpha reached 7.00 at K=7 in the morning sweep (every draft accepted), so if the composed stack cuts the per-round wall the wider round should amortize it better. Same env as the K=6 composed arm.",
+  "mtp": true,
+  "draft_k": 7,
+  "env": {
+    "CAMELID_GEMMA4_CUDA_BATCH_EXPERT_COPIES": "1",
+    "CAMELID_GEMMA4_PREFILL_CHUNK_TOKENS": "512",
+    "CAMELID_GEMMA4_Q4_0_SOA": "1",
+    "CAMELID_GEMMA4_SPECULATIVE": "0",
+    "CAMELID_GEMMA4_GHOST_CUDA_CONTEXT": "192",
+    "CAMELID_GEMMA4_GHOST_BATCH_READS": "1",
+    "CAMELID_GEMMA4_GHOST_READ_THREADS": "4",
+    "CAMELID_GEMMA4_GHOST_UNCACHED_READERS": "4",
+    "CAMELID_GEMMA4_MTP_KWIDE": "1",
+    "CAMELID_GEMMA4_MTP_PREFILL_SEED_BOOTSTRAP": "1",
+    "CAMELID_GEMMA4_MTP_CUDA_ASSISTANT": "1",
+    "CAMELID_GEMMA4_GHOST_HOST_TIER_EVICTION": "mru",
+    "CAMELID_GEMMA4_MTP_IO_PIPELINE": "1",
+    "CAMELID_GEMMA4_GHOST_CUDA_EVICTION": "lfu",
+    "CAMELID_GEMMA4_MTP_DENSE_Q6_ANCHOR_DP4A": "1"
+  }
+}

--- a/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-profile.json
+++ b/qa/perf/gemma4-mtp-h40/arms/mtp-k7-kv192-profile.json
@@ -1,0 +1,8 @@
+{
+  "description": "The promotion gate: --mtp-assistant with NO stack environment at all. The CLI's promoted profile must reconstruct the receipted composed K=7 + resident-split configuration on its own; this arm must match `...-io-lfu-q6-anchor-rsplit` within noise and reproduce the Windows ids exactly. Only the benchmark fixture's KV cap is set, because it is deliberately NOT part of the profile.",
+  "mtp": true,
+  "draft_k": 7,
+  "env": {
+    "CAMELID_GEMMA4_GHOST_CUDA_CONTEXT": "192"
+  }
+}

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -2798,6 +2798,150 @@ extern "C" __global__ void q4_0_gemm_routed_chunked(
     }
 }
 
+// ---- Routed Q4_0 GEMM, quants-first SoA expert slots ------------------------
+// Identical arithmetic to `q4_0_gemm_routed`; the ONLY change is how each weight
+// block's 18 bytes reach the registers. Under CAMELID_GEMMA4_GHOST_ARENA_SOA=1
+// every Q4_0 expert projection is stored in its arena slot pre-split by
+// `q4_0_record_wire_to_soa` into the same quants-first planes the dense lane uses:
+//   [rows*blocks_per_row*16 nibble bytes][rows*blocks_per_row*2 f16 scale bits]
+// so block (row, b) is ONE aligned uint4 load plus a coalesced u16 scale read,
+// instead of sixteen scalar byte loads assembled off an 18-byte stride (the same
+// defect the dense q4_0_gemv_soa repack removed for +12% on this GPU).
+//
+// BIT-IDENTICAL BY CONSTRUCTION: `q4_0_dot32_dp4a_packed` consumes exactly the
+// bytes the wire kernel packed with `q4_pack4_le`, the per-block float term is
+// the same product in the same order, each row is still folded by ONE lane over
+// increasing b, and output stays per-ASSIGNMENT. Only the load instructions
+// change. Pinned by `q4_0_gemm_routed_soa_matches_wire`.
+extern "C" __global__ void q4_0_gemm_routed_soa(
+    const float* __restrict__ input_scales,
+    const signed char* __restrict__ input_quants,
+    const unsigned char* __restrict__ weight_arena,
+    const int* __restrict__ slot_ids,
+    const int* __restrict__ token_offsets,
+    const int* __restrict__ token_ids,
+    unsigned long long weight_stride, int rows, int blocks_per_row,
+    float* __restrict__ output, int expert_count, int tile
+) {
+    int expert = blockIdx.y;
+    if (expert >= expert_count) return;
+    int first = token_offsets[expert];
+    int count = token_offsets[expert + 1] - first;
+    int tile_base = blockIdx.z * tile;
+    if (tile_base >= count) return;
+    int n_tok = count - tile_base;
+    if (n_tok > tile) n_tok = tile;
+
+    const unsigned char* expert_weights = weight_arena + (long)slot_ids[expert] * weight_stride;
+    // Plane bases within THIS expert's slot. The scale plane begins after every
+    // row's nibbles; the slot stride is validated to a 16-byte multiple at load
+    // so the uint4 quant-plane loads stay aligned for every slot id.
+    const uint4* quant_plane = (const uint4*)expert_weights;
+    const unsigned short* scale_plane =
+        (const unsigned short*)(expert_weights + (long)rows * blocks_per_row * 16);
+
+    extern __shared__ float smem40grs[];
+    int warp = threadIdx.x >> 5;
+    int lane = threadIdx.x & 31;
+    int warps_per_block = blockDim.x >> 5;
+    int row = blockIdx.x * warps_per_block + warp;
+    float* myterms = smem40grs + (long)warp * tile * blocks_per_row;
+
+    if (row < rows) {
+        long row_block0 = (long)row * blocks_per_row;
+        for (int b = lane; b < blocks_per_row; b += 32) {
+            long idx = row_block0 + b;
+            float w_scale = f16_bits_to_f32(scale_plane[idx]);
+            uint4 packed = quant_plane[idx];       // one aligned 16-byte load
+            for (int j = 0; j < n_tok; j++) {
+                int t = token_ids[first + tile_base + j];
+                const signed char* y = input_quants
+                    + ((long)t * blocks_per_row + b) * 32;
+                int isum = q4_0_dot32_dp4a_packed(packed, y);
+                myterms[(long)j * blocks_per_row + b] =
+                    (float)isum * w_scale * input_scales[(long)t * blocks_per_row + b];
+            }
+        }
+    }
+    __syncwarp();
+    if (row < rows && lane == 0) {
+        for (int j = 0; j < n_tok; j++) {
+            float acc = 0.0f;
+            for (int b = 0; b < blocks_per_row; b++)
+                acc += myterms[(long)j * blocks_per_row + b];
+            output[(long)(first + tile_base + j) * rows + row] = acc;
+        }
+    }
+}
+
+// SoA twin of q4_0_gemm_routed_chunked: same bounded scratch lifetime and the
+// same per-token strictly-increasing-block fold; only the weight addressing
+// moves to the quants-first planes described on q4_0_gemm_routed_soa.
+extern "C" __global__ void q4_0_gemm_routed_chunked_soa(
+    const float* __restrict__ input_scales,
+    const signed char* __restrict__ input_quants,
+    const unsigned char* __restrict__ weight_arena,
+    const int* __restrict__ slot_ids,
+    const int* __restrict__ token_offsets,
+    const int* __restrict__ token_ids,
+    unsigned long long weight_stride, int rows, int blocks_per_row,
+    float* __restrict__ output, int expert_count, int tile
+) {
+    int expert = blockIdx.y;
+    if (expert >= expert_count) return;
+    int first = token_offsets[expert];
+    int count = token_offsets[expert + 1] - first;
+    int tile_base = blockIdx.z * tile;
+    if (tile_base >= count) return;
+    int n_tok = count - tile_base;
+    if (n_tok > tile) n_tok = tile;
+
+    const unsigned char* expert_weights = weight_arena + (long)slot_ids[expert] * weight_stride;
+    const uint4* quant_plane = (const uint4*)expert_weights;
+    const unsigned short* scale_plane =
+        (const unsigned short*)(expert_weights + (long)rows * blocks_per_row * 16);
+    extern __shared__ float smem40gcs[];
+    int warp = threadIdx.x >> 5;
+    int lane = threadIdx.x & 31;
+    int warps_per_block = blockDim.x >> 5;
+    int row = blockIdx.x * warps_per_block + warp;
+    int chunk_stride = blocks_per_row < G4_ROUTED_GEMM_CHUNK
+        ? blocks_per_row : G4_ROUTED_GEMM_CHUNK;
+    float* myterms = smem40gcs + (long)warp * tile * chunk_stride;
+    float token_acc = 0.0f;
+
+    for (int block0 = 0; block0 < blocks_per_row; block0 += G4_ROUTED_GEMM_CHUNK) {
+        int chunk_blocks = blocks_per_row - block0;
+        if (chunk_blocks > G4_ROUTED_GEMM_CHUNK) chunk_blocks = G4_ROUTED_GEMM_CHUNK;
+        int b = block0 + lane;
+        if (row < rows && lane < chunk_blocks) {
+            long idx = (long)row * blocks_per_row + b;
+            float w_scale = f16_bits_to_f32(scale_plane[idx]);
+            uint4 packed = quant_plane[idx];
+            for (int j = 0; j < n_tok; j++) {
+                int t = token_ids[first + tile_base + j];
+                const signed char* y = input_quants
+                    + ((long)t * blocks_per_row + b) * 32;
+                int isum = q4_0_dot32_dp4a_packed(packed, y);
+                myterms[(long)j * chunk_stride + lane] =
+                    (float)isum * w_scale * input_scales[(long)t * blocks_per_row + b];
+            }
+        }
+        __syncwarp();
+        if (row < rows && lane < n_tok) {
+            const float* token_terms = myterms + (long)lane * chunk_stride;
+            for (int owner = 0; owner < chunk_blocks; owner++)
+                token_acc += token_terms[owner];
+        }
+        // Token owners must finish reading this chunk before block owners reuse
+        // the same bounded scratch for the next 32 weight blocks.
+        __syncwarp();
+    }
+    if (row < rows && lane < n_tok) {
+        output[(long)(first + tile_base + lane) * rows + row] = token_acc;
+    }
+}
+
 // ---- Routed Q4_1 GEMM: the mixed-format half of the same lever -------------
 // The 26B-A4B `.cghost` is MIXED — `down_exps` is Q4_1 in layers 0..=6 and Q4_0 in
 // 7..=29 — so batching only the Q4_0 form would leave a seventh of the stack on the
@@ -5143,6 +5287,77 @@ extern "C" __global__ void q4_0_gemv_routed(
                 (unsigned short)(blk[0] | (blk[1] << 8)));
             const signed char* y = s_iq + (long)b * 32;
             int isum = q4_0_dot32_dp4a(blk + 2, y);
+            myterms[b] = (float)isum * w_scale * s_is[b];
+        }
+    }
+    __syncwarp();
+    if (row < rows && lane == 0) {
+        float acc = 0.0f;
+        for (int b = 0; b < blocks_per_row; b++) acc += myterms[b];
+        output[(long)route * rows + row] = acc;
+    }
+}
+
+// ---- Routed Q4_0 GEMV, quants-first SoA expert slots ------------------------
+// Identical arithmetic to `q4_0_gemv_routed`; the ONLY change is how each weight
+// block's 18 bytes reach the registers. Under CAMELID_GEMMA4_GHOST_ARENA_SOA=1
+// each Q4_0 projection inside an expert's arena slot is stored pre-split by
+// `q4_0_record_wire_to_soa` as
+//   [rows*blocks_per_row*16 nibble bytes][rows*blocks_per_row*2 f16 scale bits]
+// so a block is ONE aligned uint4 load plus a coalesced u16 scale read.
+// `q4_0_dot32_dp4a_packed` consumes exactly the bytes `q4_0_dot32_dp4a` did with
+// the same nibble split and activation pairing, the per-block float term is
+// unchanged, and lane 0 still folds terms in increasing block order — so the
+// result is bit-identical (the four-step argument on `q4_0_gemv_soa`). Pinned by
+// `q4_0_gemv_routed_soa_matches_wire`.
+extern "C" __global__ void q4_0_gemv_routed_soa(
+    const float* __restrict__ input_scales,
+    const signed char* __restrict__ input_quants,
+    const unsigned char* __restrict__ weight_arena,
+    const int* __restrict__ slot_ids,
+    const int* __restrict__ route_ids,
+    unsigned long long weight_stride, int rows, int blocks_per_row,
+    float* __restrict__ output, int expert_count, int batched_input
+) {
+    int expert = blockIdx.y;
+    if (expert >= expert_count) return;
+    int route = route_ids[expert];
+    int slot = slot_ids[expert];
+    const float* expert_scales = input_scales
+        + (batched_input ? (long)route * blocks_per_row : 0);
+    const signed char* expert_quants = input_quants
+        + (batched_input ? (long)route * blocks_per_row * 32 : 0);
+    const unsigned char* expert_weights = weight_arena + (long)slot * weight_stride;
+    // Plane bases within THIS expert's slot. The slot stride is validated to a
+    // 16-byte multiple at load so the uint4 loads stay aligned for every slot.
+    const uint4* quant_plane = (const uint4*)expert_weights;
+    const unsigned short* scale_plane =
+        (const unsigned short*)(expert_weights + (long)rows * blocks_per_row * 16);
+
+    extern __shared__ unsigned char smem40rs[];
+    signed char* s_iq = (signed char*)smem40rs;
+    float* s_is = (float*)(smem40rs + (long)blocks_per_row * 32);
+    float* terms = (float*)(smem40rs + (long)blocks_per_row * 36);
+    int tid = threadIdx.x;
+    for (int i = tid; i < blocks_per_row * 8; i += blockDim.x)
+        ((int*)s_iq)[i] = ((const int*)expert_quants)[i];
+    for (int i = tid; i < blocks_per_row; i += blockDim.x)
+        s_is[i] = expert_scales[i];
+    __syncthreads();
+
+    int warp = tid >> 5;
+    int lane = tid & 31;
+    int warps_per_block = blockDim.x >> 5;
+    int row = blockIdx.x * warps_per_block + warp;
+    float* myterms = terms + (long)warp * blocks_per_row;
+    if (row < rows) {
+        long row_block0 = (long)row * blocks_per_row;
+        for (int b = lane; b < blocks_per_row; b += 32) {
+            long idx = row_block0 + b;
+            float w_scale = f16_bits_to_f32(scale_plane[idx]);
+            uint4 packed = quant_plane[idx];       // one aligned 16-byte load
+            const signed char* y = s_iq + (long)b * 32;
+            int isum = q4_0_dot32_dp4a_packed(packed, y);
             myterms[b] = (float)isum * w_scale * s_is[b];
         }
     }
@@ -8029,10 +8244,17 @@ pub struct CudaResidentKernels {
     pub(crate) q4_0_gemv_routed: CudaFunction,
     /// R-rows-per-warp variant of `q4_0_gemv_routed`; bitwise-identical, opt-in.
     pub(crate) q4_0_gemv_routed_rows: CudaFunction,
+    /// Quants-first SoA twin of `q4_0_gemv_routed` for repacked expert arenas
+    /// (`CAMELID_GEMMA4_GHOST_ARENA_SOA=1`); bitwise-identical.
+    pub(crate) q4_0_gemv_routed_soa: CudaFunction,
     /// Prefill counterpart of `q4_0_gemv_routed`: one expert against its CSR token list.
     pub(crate) q4_0_gemm_routed: CudaFunction,
     /// 32-block low-shared A/B twin; never selected unless the strict opt-in is `1`.
     pub(crate) q4_0_gemm_routed_chunked: CudaFunction,
+    /// Quants-first SoA twin of `q4_0_gemm_routed`; bitwise-identical.
+    pub(crate) q4_0_gemm_routed_soa: CudaFunction,
+    /// Quants-first SoA twin of `q4_0_gemm_routed_chunked`; bitwise-identical.
+    pub(crate) q4_0_gemm_routed_chunked_soa: CudaFunction,
     pub(crate) q4_1_gemm_routed: CudaFunction,
     pub(crate) q4_1_gemm_routed_chunked: CudaFunction,
     pub(crate) q4_1_gemv_routed: CudaFunction,
@@ -8317,8 +8539,11 @@ impl CudaResidentKernels {
             scaled_axpy: f("scaled_axpy")?,
             q4_0_gemv_routed: f("q4_0_gemv_routed")?,
             q4_0_gemv_routed_rows: f("q4_0_gemv_routed_rows")?,
+            q4_0_gemv_routed_soa: f("q4_0_gemv_routed_soa")?,
             q4_0_gemm_routed: f("q4_0_gemm_routed")?,
             q4_0_gemm_routed_chunked: f("q4_0_gemm_routed_chunked")?,
+            q4_0_gemm_routed_soa: f("q4_0_gemm_routed_soa")?,
+            q4_0_gemm_routed_chunked_soa: f("q4_0_gemm_routed_chunked_soa")?,
             q4_1_gemm_routed: f("q4_1_gemm_routed")?,
             q4_1_gemm_routed_chunked: f("q4_1_gemm_routed_chunked")?,
             q4_1_gemv_routed: f("q4_1_gemv_routed")?,
@@ -8391,11 +8616,14 @@ impl CudaResidentKernels {
         })
     }
 
-    pub(crate) fn gemma4_mtp_q4_0_gemm_routed_kernel(&self) -> (&CudaFunction, bool) {
-        if self.gemma4_mtp_routed_q4_chunked {
-            (&self.q4_0_gemm_routed_chunked, true)
-        } else {
-            (&self.q4_0_gemm_routed, false)
+    /// `soa` selects the quants-first-arena twin of whichever routed Q4_0 GEMM
+    /// the chunked policy picked; every pairing is pinned bitwise-identical.
+    pub(crate) fn gemma4_mtp_q4_0_gemm_routed_kernel(&self, soa: bool) -> (&CudaFunction, bool) {
+        match (self.gemma4_mtp_routed_q4_chunked, soa) {
+            (true, true) => (&self.q4_0_gemm_routed_chunked_soa, true),
+            (true, false) => (&self.q4_0_gemm_routed_chunked, true),
+            (false, true) => (&self.q4_0_gemm_routed_soa, false),
+            (false, false) => (&self.q4_0_gemm_routed, false),
         }
     }
 
@@ -8475,16 +8703,63 @@ pub(crate) fn widen_q8(bytes: &[u8]) -> Vec<u8> {
 /// `q4_0_gemv_soa_matches_wire` for the test that pins it. Mirrors the same
 /// contract as `repack_q8_soa`, `swz_q4k_blocks` and `repack_q1_t128`.
 pub(crate) fn q4_0_wire_to_soa(bytes: &[u8]) -> Vec<u8> {
+    let mut out = vec![0u8; bytes.len()];
+    q4_0_wire_to_soa_into(bytes, &mut out);
+    out
+}
+
+/// Non-allocating core of [`q4_0_wire_to_soa`]: split one contiguous Q4_0 wire
+/// region into the quants-first SoA planes, writing into `out` (same length,
+/// disjoint from `wire`). Same pure byte permutation, same bit-exactness
+/// argument; this form exists so per-record staging paths (page-locked tier
+/// slots, the pinned transfer ring) can repack without a per-record `Vec`.
+pub(crate) fn q4_0_wire_to_soa_into(wire: &[u8], out: &mut [u8]) {
     const WIRE: usize = 18;
-    let n = bytes.len() / WIRE;
-    let mut out = vec![0u8; n * WIRE];
+    let n = wire.len() / WIRE;
+    debug_assert_eq!(
+        wire.len(),
+        n * WIRE,
+        "Q4_0 wire region must be whole blocks"
+    );
+    debug_assert_eq!(out.len(), wire.len(), "SoA repack must not change size");
     let (quants, scales) = out.split_at_mut(n * 16);
     for b in 0..n {
-        let blk = &bytes[b * WIRE..b * WIRE + WIRE];
+        let blk = &wire[b * WIRE..b * WIRE + WIRE];
         scales[b * 2..b * 2 + 2].copy_from_slice(&blk[0..2]);
         quants[b * 16..b * 16 + 16].copy_from_slice(&blk[2..WIRE]);
     }
-    out
+}
+
+/// Repack every Q4_0 projection region of one routed expert record IN PLACE
+/// into the quants-first SoA layout of [`q4_0_wire_to_soa`], region by region
+/// (`gate_up` first, then `down`, using the record layout's role-aware byte
+/// ranges). A region whose dtype is not Q4_0 (the Q4_1 down variant of some
+/// layers) is left byte-for-byte untouched, so its wire kernels keep reading
+/// exactly what they always read.
+///
+/// Pure byte permutation of each repacked region — every byte lands exactly
+/// once, nothing is synthesized — so the SoA consumers are bit-identical by the
+/// same four-step argument as the dense lane. `scratch` is caller-owned reusable
+/// space (grown to the largest region, ~2.2 MiB on the tracked geometry) so the
+/// staging threads do not allocate per record. Pinned by
+/// `q4_0_record_wire_to_soa_is_a_pure_permutation`.
+pub(crate) fn q4_0_record_wire_to_soa(
+    record: &mut [u8],
+    gate_up: std::ops::Range<usize>,
+    gate_up_is_q4_0: bool,
+    down: std::ops::Range<usize>,
+    down_is_q4_0: bool,
+    scratch: &mut Vec<u8>,
+) {
+    for (range, is_q4_0) in [(gate_up, gate_up_is_q4_0), (down, down_is_q4_0)] {
+        if !is_q4_0 {
+            continue;
+        }
+        let region = &mut record[range];
+        scratch.clear();
+        scratch.extend_from_slice(region);
+        q4_0_wire_to_soa_into(scratch, region);
+    }
 }
 
 pub(crate) fn repack_q8_soa(bytes: &[u8]) -> Vec<u8> {

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -10739,8 +10739,8 @@ fn launch_q4_wire_gemm_routed(
     in_scales: &CudaSlice<f32>,
     in_quants: &CudaSlice<i8>,
     weight_arena: &CudaSlice<u8>,
-    slot_ids: &CudaSlice<i32>,
-    token_offsets: &CudaSlice<i32>,
+    slot_ids: &CudaView<i32>,
+    token_offsets: &CudaView<i32>,
     token_ids: &CudaSlice<i32>,
     weight_stride: usize,
     rows: usize,
@@ -10856,8 +10856,92 @@ pub(crate) fn launch_q4_0_gemm_routed(
         in_scales,
         in_quants,
         weight_arena,
-        slot_ids,
-        token_offsets,
+        &slot_ids.slice(..),
+        &token_offsets.slice(..),
+        token_ids,
+        weight_stride,
+        rows,
+        blocks_per_row,
+        expert_count,
+        max_assignments_per_expert,
+        chunked,
+        out,
+    )
+}
+
+/// Sub-range twin of [`launch_q4_0_gemm_routed`] for a residents-first-ordered
+/// CSR: launches the identical kernel over the contiguous expert range
+/// `[expert_offset, expert_offset + expert_count)`. `token_offsets` values are
+/// absolute assignment indices, so every per-assignment output row lands at
+/// exactly the position the single full-union launch writes; each expert's
+/// per-row fold still happens whole inside one launch, which is what keeps a
+/// two-pass split bit-identical to the one-pass launch.
+#[allow(dead_code, clippy::too_many_arguments)]
+pub(crate) fn launch_q4_0_gemm_routed_range(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    in_scales: &CudaSlice<f32>,
+    in_quants: &CudaSlice<i8>,
+    weight_arena: &CudaSlice<u8>,
+    slot_ids: &CudaSlice<i32>,
+    token_offsets: &CudaSlice<i32>,
+    token_ids: &CudaSlice<i32>,
+    weight_stride: usize,
+    rows: usize,
+    blocks_per_row: usize,
+    expert_offset: usize,
+    expert_count: usize,
+    max_assignments_per_expert: usize,
+    chunked: bool,
+    out: &mut CudaSlice<f32>,
+) -> Result<(), cudarc::driver::DriverError> {
+    launch_q4_wire_gemm_routed(
+        s,
+        f,
+        in_scales,
+        in_quants,
+        weight_arena,
+        &slot_ids.slice(expert_offset..),
+        &token_offsets.slice(expert_offset..),
+        token_ids,
+        weight_stride,
+        rows,
+        blocks_per_row,
+        expert_count,
+        max_assignments_per_expert,
+        chunked,
+        out,
+    )
+}
+
+/// Q4_1 twin of [`launch_q4_0_gemm_routed_range`].
+#[allow(dead_code, clippy::too_many_arguments)]
+pub(crate) fn launch_q4_1_gemm_routed_range(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    in_scales: &CudaSlice<f32>,
+    in_quants: &CudaSlice<i8>,
+    weight_arena: &CudaSlice<u8>,
+    slot_ids: &CudaSlice<i32>,
+    token_offsets: &CudaSlice<i32>,
+    token_ids: &CudaSlice<i32>,
+    weight_stride: usize,
+    rows: usize,
+    blocks_per_row: usize,
+    expert_offset: usize,
+    expert_count: usize,
+    max_assignments_per_expert: usize,
+    chunked: bool,
+    out: &mut CudaSlice<f32>,
+) -> Result<(), cudarc::driver::DriverError> {
+    launch_q4_wire_gemm_routed(
+        s,
+        f,
+        in_scales,
+        in_quants,
+        weight_arena,
+        &slot_ids.slice(expert_offset..),
+        &token_offsets.slice(expert_offset..),
         token_ids,
         weight_stride,
         rows,
@@ -10893,8 +10977,8 @@ pub(crate) fn launch_q4_1_gemm_routed(
         in_scales,
         in_quants,
         weight_arena,
-        slot_ids,
-        token_offsets,
+        &slot_ids.slice(..),
+        &token_offsets.slice(..),
         token_ids,
         weight_stride,
         rows,

--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -3485,6 +3485,43 @@ extern "C" __global__ void q5k_gemv(
 // where a[256] are the rebuilt signed-6-bit weights (recombination order from
 // q6_k_wire_block_dequant). Lane l (0..8) owns its own aux32 lane; lane 0 then
 // replays sums[l] += (d_w * d_act) * aux32[l] per superblock, in order.
+// Draft-chain helper: dequantize ONE row of the 224-byte PADDED Q6_K tied head
+// (the exact layout q6k_gemv reads below — its unit (h, s, l) element map is
+// mirrored here per element) for the token id sitting in a device buffer, and
+// write it scaled by `scale` (the embedding's sqrt(hidden)). This keeps the
+// assistant's argmax -> next-embedding dependency on-device, so a draft round
+// pays one host synchronization instead of one per proposal. Drafter-only
+// numerics: accuracy moves acceptance, never emitted tokens.
+extern "C" __global__ void q6k_row_gather_scale(
+    const unsigned char* __restrict__ head_bytes, // 224-byte PADDED Q6_K blocks
+    const unsigned int* __restrict__ token,       // device token id buffer
+    int slot,                                     // index into `token`
+    float* __restrict__ out, int hidden, float scale
+) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= hidden) return;
+    long row = (long)token[slot];
+    int n_sb = hidden >> 8;
+    int sb = i >> 8;
+    int r = i & 255;
+    const unsigned char* block = head_bytes + (row * n_sb + sb) * 224L;
+    int h = r >> 7;         // 128-element half
+    int rem = r & 127;
+    int q = rem >> 5;       // quadrant: weight offset {+0,+32,+64,+96}
+    int s = (rem >> 4) & 1; // 16-element scale sub-group
+    int l = rem & 15;
+    unsigned char albyte = block[h * 64 + ((q & 1) ? 32 : 0) + s * 16 + l];
+    unsigned char hbyte = block[128 + h * 32 + s * 16 + l];
+    int a;
+    if (q == 0)      a = ((albyte & 0xF) | ((hbyte & 3) << 4)) - 32;
+    else if (q == 1) a = ((albyte & 0xF) | (((hbyte >> 2) & 3) << 4)) - 32;
+    else if (q == 2) a = ((albyte >> 4) | (((hbyte >> 4) & 3) << 4)) - 32;
+    else             a = ((albyte >> 4) | (((hbyte >> 6) & 3) << 4)) - 32;
+    int sc = (int)((signed char)block[192 + 8 * h + s + 2 * q]);
+    float d = f16_bits_to_f32((unsigned short)(block[208] | (block[209] << 8)));
+    out[i] = d * (float)(sc * a) * scale;
+}
+
 extern "C" __global__ void q6k_gemv(
     const float* __restrict__ input_scales,         // n_sb f32 (Q8_K d per superblock)
     const signed char* __restrict__ input_quants,   // n_sb*256 i8 (Q8_K quants)
@@ -7966,6 +8003,7 @@ pub struct CudaResidentKernels {
     pub(crate) q4k_gemv: CudaFunction,
     pub(crate) q5k_gemv: CudaFunction,
     pub(crate) q6k_gemv: CudaFunction,
+    pub(crate) q6k_row_gather_scale: CudaFunction,
     pub(crate) q2k_gemv: CudaFunction,
     pub(crate) q3k_gemv: CudaFunction,
     pub(crate) iq4xs_gemv: CudaFunction,
@@ -8254,6 +8292,7 @@ impl CudaResidentKernels {
             q4k_gemv: f("q4k_gemv")?,
             q5k_gemv: f("q5k_gemv")?,
             q6k_gemv: f("q6k_gemv")?,
+            q6k_row_gather_scale: f("q6k_row_gather_scale")?,
             q2k_gemv: f("q2k_gemv")?,
             iq4xs_gemv: f("iq4xs_gemv")?,
             q3k_gemv: f("q3k_gemv")?,
@@ -10912,6 +10951,39 @@ pub(crate) fn launch_q4_0_gemm_routed_range(
         chunked,
         out,
     )
+}
+
+/// Launch the draft-chain embedding gather: dequantize one PADDED-Q6_K head row
+/// (selected by the device-resident token id at `token[slot]`) into
+/// `out[0..hidden]`, scaled by the embedding's sqrt(hidden). The row id never
+/// crosses PCIe, which is the point: the assistant's argmax feeds its next
+/// proposal without a host round-trip.
+#[allow(dead_code, clippy::too_many_arguments)]
+pub(crate) fn launch_q6k_row_gather_scale(
+    s: &Arc<CudaStream>,
+    f: &CudaFunction,
+    head_bytes: &CudaSlice<u8>,
+    token: &CudaSlice<u32>,
+    slot: usize,
+    out: &mut CudaSlice<f32>,
+    hidden: usize,
+    scale: f32,
+) -> Result<(), cudarc::driver::DriverError> {
+    use cudarc::driver::{LaunchConfig, PushKernelArg};
+    let cfg = LaunchConfig {
+        grid_dim: ((hidden as u32).div_ceil(256), 1, 1),
+        block_dim: (256, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let (slot_i, hidden_i) = (slot as i32, hidden as i32);
+    let mut b = s.launch_builder(f);
+    b.arg(head_bytes)
+        .arg(token)
+        .arg(&slot_i)
+        .arg(out)
+        .arg(&hidden_i)
+        .arg(&scale);
+    unsafe { b.launch(cfg) }.map(|_| ())
 }
 
 /// Q4_1 twin of [`launch_q4_0_gemm_routed_range`].

--- a/src/cuda_resident/tests.rs
+++ b/src/cuda_resident/tests.rs
@@ -6375,6 +6375,90 @@ fn q4_0_gemm_routed_matches_gemv() {
     }
 }
 
+/// The draft-chain gather must decode exactly the padded-Q6_K element map that
+/// `q6k_gemv` reads, from a device-resident token id. Pinned BITWISE against a
+/// CPU mirror of the kernel's own expression (`d * (sc*a) * scale`) over
+/// synthesized blocks that exercise every quadrant, both halves, and all scale
+/// groups, at the real head geometry (2816 = 11 super-blocks per row).
+#[test]
+#[ignore = "requires a CUDA device"]
+fn q6k_row_gather_scale_matches_cpu_decode() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    let hidden = 2816usize;
+    let rows = 5usize;
+    let n_sb = hidden / 256;
+    let mut rng = Lcg(0x6e_77);
+    // Q6_K wire super-block: ql[128] qh[64] scales[16] d(f16) = 210 bytes.
+    let mut wire = vec![0u8; rows * n_sb * 210];
+    for chunk in wire.chunks_mut(210) {
+        for byte in chunk[..208].iter_mut() {
+            *byte = rng.next_u8();
+        }
+        // A modest positive normal f16 keeps every product finite and nonzero.
+        let d_bits = 0x2C00u16 | (u16::from(rng.next_u8()) & 0x03FF);
+        chunk[208] = (d_bits & 0xFF) as u8;
+        chunk[209] = (d_bits >> 8) as u8;
+    }
+    let padded = super::pad_q6k_blocks(&wire);
+    let d_head = k.stream.clone_htod(&padded).unwrap();
+    let scale = (hidden as f32).sqrt();
+    for token in [0u32, 2, 4] {
+        let d_token = k.stream.clone_htod(&[token]).unwrap();
+        let mut d_out = k.stream.alloc_zeros::<f32>(hidden).unwrap();
+        super::launch_q6k_row_gather_scale(
+            &k.stream,
+            &k.q6k_row_gather_scale,
+            &d_head,
+            &d_token,
+            0,
+            &mut d_out,
+            hidden,
+            scale,
+        )
+        .unwrap();
+        let mut got = vec![0f32; hidden];
+        k.stream.memcpy_dtoh(&d_out, &mut got).unwrap();
+        k.ctx.synchronize().unwrap();
+
+        let mut nonzero = 0usize;
+        for (i, &got_bits) in got.iter().enumerate() {
+            let sb = i >> 8;
+            let r = i & 255;
+            let block = &padded[(token as usize * n_sb + sb) * 224..][..224];
+            let h = r >> 7;
+            let rem = r & 127;
+            let q = rem >> 5;
+            let s = (rem >> 4) & 1;
+            let l = rem & 15;
+            let albyte = i32::from(block[h * 64 + if q & 1 == 1 { 32 } else { 0 } + s * 16 + l]);
+            let hbyte = i32::from(block[128 + h * 32 + s * 16 + l]);
+            let a = match q {
+                0 => ((albyte & 0xF) | ((hbyte & 3) << 4)) - 32,
+                1 => ((albyte & 0xF) | (((hbyte >> 2) & 3) << 4)) - 32,
+                2 => ((albyte >> 4) | (((hbyte >> 4) & 3) << 4)) - 32,
+                _ => ((albyte >> 4) | (((hbyte >> 6) & 3) << 4)) - 32,
+            };
+            let sc = i32::from(block[192 + 8 * h + s + 2 * q] as i8);
+            let d = crate::inference::f16_bits_to_f32(u16::from_le_bytes([block[208], block[209]]));
+            let expect = d * ((sc * a) as f32) * scale;
+            assert_eq!(
+                got_bits.to_bits(),
+                expect.to_bits(),
+                "element {i} of row {token}: got {got_bits} expected {expect}"
+            );
+            if expect != 0.0 {
+                nonzero += 1;
+            }
+        }
+        assert!(
+            nonzero > hidden / 2,
+            "degenerate fixture: row {token} decoded mostly to zeros"
+        );
+    }
+}
+
 /// `q4_0_gemv_routed_rows` must be BITWISE identical to `q4_0_gemv_routed`.
 ///
 /// Step 08 moves the tail fold from one lane to R lanes, but each row is still

--- a/src/cuda_resident/tests.rs
+++ b/src/cuda_resident/tests.rs
@@ -6308,6 +6308,54 @@ fn q4_0_gemm_routed_matches_gemv() {
         k.ctx.synchronize().unwrap();
         assert_same_bits("Q4_0 routed launch helper", &helper, &reference);
 
+        // Two-pass range launch — the resident-first split's mechanism: experts
+        // [0,2) in one launch, [2,4) in a second, same CSR arrays, same output
+        // buffer. Each expert's per-row fold still happens whole inside exactly
+        // one launch, so the split must be BITWISE identical to the full launch.
+        let mut d_split = k.stream.alloc_zeros::<f32>(assignments * rows).unwrap();
+        super::launch_q4_0_gemm_routed_range(
+            &k.stream,
+            &k.q4_0_gemm_routed,
+            &d_s,
+            &d_q,
+            &d_w,
+            &d_slots,
+            &d_off,
+            &d_tok,
+            per_slot,
+            rows,
+            bpr,
+            0,
+            2,
+            max_count,
+            false,
+            &mut d_split,
+        )
+        .unwrap();
+        super::launch_q4_0_gemm_routed_range(
+            &k.stream,
+            &k.q4_0_gemm_routed,
+            &d_s,
+            &d_q,
+            &d_w,
+            &d_slots,
+            &d_off,
+            &d_tok,
+            per_slot,
+            rows,
+            bpr,
+            2,
+            experts - 2,
+            max_count,
+            false,
+            &mut d_split,
+        )
+        .unwrap();
+        let mut split = vec![0f32; assignments * rows];
+        k.stream.memcpy_dtoh(&d_split, &mut split).unwrap();
+        k.ctx.synchronize().unwrap();
+        assert_same_bits("Q4_0 routed two-pass range launch", &split, &reference);
+
         let mismatches = got
             .iter()
             .zip(&reference)

--- a/src/cuda_resident/tests.rs
+++ b/src/cuda_resident/tests.rs
@@ -6459,6 +6459,392 @@ fn q6k_row_gather_scale_matches_cpu_decode() {
     }
 }
 
+/// The routed-record SoA repack is a pure byte permutation, region by region.
+///
+/// Asserted with explicit index arithmetic rather than by calling the helper
+/// back, so this still fails if `q4_0_record_wire_to_soa` is ever changed to
+/// agree with a broken kernel — the same convention as
+/// `q4_0_wire_to_soa_is_a_pure_permutation`. Also pins the mixed-record
+/// contract (a non-Q4_0 down region stays byte-identical wire) and exercises
+/// the real 3,345,408-byte record geometry. No GPU required.
+#[test]
+fn q4_0_record_wire_to_soa_is_a_pure_permutation() {
+    const WIRE: usize = 18;
+    let assert_region_soa = |wire: &[u8], soa: &[u8]| {
+        assert_eq!(soa.len(), wire.len(), "SoA must not change the region size");
+        let n = wire.len() / WIRE;
+        let (quants, scales) = soa.split_at(n * 16);
+        for b in 0..n {
+            assert_eq!(
+                &scales[b * 2..b * 2 + 2],
+                &wire[b * WIRE..b * WIRE + 2],
+                "block {b}: f16 scale bits must survive verbatim into the scale plane"
+            );
+            assert_eq!(
+                &quants[b * 16..b * 16 + 16],
+                &wire[b * WIRE + 2..b * WIRE + WIRE],
+                "block {b}: the 16 nibble bytes must survive verbatim into the quant plane"
+            );
+        }
+    };
+    let invert_region = |soa: &[u8]| -> Vec<u8> {
+        let n = soa.len() / WIRE;
+        let (quants, scales) = soa.split_at(n * 16);
+        let mut wire = vec![0u8; soa.len()];
+        for b in 0..n {
+            wire[b * WIRE..b * WIRE + 2].copy_from_slice(&scales[b * 2..b * 2 + 2]);
+            wire[b * WIRE + 2..b * WIRE + WIRE].copy_from_slice(&quants[b * 16..b * 16 + 16]);
+        }
+        wire
+    };
+
+    // Small geometry with explicit arithmetic, then the real routed record
+    // (gate_up 1408x88 + down 2816x22 = 3,345,408 bytes). One reused scratch
+    // pins that a dirty scratch from a previous record cannot leak through.
+    let mut scratch = Vec::new();
+    for (gu_rows, gu_bpr, down_rows, down_bpr) in
+        [(64usize, 2usize, 64usize, 1usize), (1408, 88, 2816, 22)]
+    {
+        let mut rng = Lcg(0x50_a2_01 ^ ((gu_rows as u64) << 16));
+        let gu_wire = synth_q4_0_wire(gu_rows, gu_bpr, &mut rng);
+        let down_wire = synth_q4_0_wire(down_rows, down_bpr, &mut rng);
+        let gate_up = 0..gu_wire.len();
+        let down = gu_wire.len()..gu_wire.len() + down_wire.len();
+        let mut record = [gu_wire.as_slice(), down_wire.as_slice()].concat();
+        if (gu_rows, gu_bpr) == (1408, 88) {
+            assert_eq!(record.len(), 3_345_408, "real routed record byte length");
+        }
+
+        super::q4_0_record_wire_to_soa(
+            &mut record,
+            gate_up.clone(),
+            true,
+            down.clone(),
+            true,
+            &mut scratch,
+        );
+        assert_ne!(
+            record[gate_up.clone()],
+            gu_wire[..],
+            "raw passthrough is the defect this repack exists to remove"
+        );
+        assert_region_soa(&gu_wire, &record[gate_up.clone()]);
+        assert_region_soa(&down_wire, &record[down.clone()]);
+        // Every input byte is accounted for exactly once: inverting both
+        // regions reproduces the wire record byte for byte.
+        assert_eq!(
+            invert_region(&record[gate_up.clone()]),
+            gu_wire,
+            "gate_up permutation must be exactly invertible"
+        );
+        assert_eq!(
+            invert_region(&record[down.clone()]),
+            down_wire,
+            "down permutation must be exactly invertible"
+        );
+
+        // The mixed layout (Q4_1 down, layers 0..=6 of the tracked artifact):
+        // only the Q4_0 gate_up region moves; down stays byte-identical wire.
+        let mut mixed = [gu_wire.as_slice(), down_wire.as_slice()].concat();
+        super::q4_0_record_wire_to_soa(
+            &mut mixed,
+            gate_up.clone(),
+            true,
+            down.clone(),
+            false,
+            &mut scratch,
+        );
+        assert_eq!(mixed[gate_up.clone()], record[gate_up.clone()]);
+        assert_eq!(
+            mixed[down.clone()],
+            down_wire[..],
+            "a non-Q4_0 region must never be touched"
+        );
+    }
+}
+
+/// `q4_0_gemv_routed_soa` on per-slot repacked arenas must be BITWISE identical
+/// to `q4_0_gemv_routed` on the raw-wire arenas.
+///
+/// Same four-step argument as the dense `q4_0_gemv_soa`: identical dp4a bytes,
+/// identical per-block term, identical lane-0 increasing-b fold — only the load
+/// instructions change. Exercised on both real routed geometries plus a small
+/// synthetic one, with a permuted slot map and both `batched_input` forms
+/// (shared gate/up activation and per-route down activation), because per-slot
+/// plane bases and the `route * rows + row` output index are exactly what an
+/// arena repack gets wrong.
+#[test]
+#[ignore = "requires a CUDA device"]
+fn q4_0_gemv_routed_soa_matches_wire() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    for (rows, bpr, seed) in [
+        (1408usize, 88usize, 0x50_a3_01u64),
+        (2816, 22, 0x50_a3_02),
+        (96, 8, 0x50_a3_03),
+    ] {
+        let experts = 4usize;
+        let kdim = bpr * 32;
+        let mut rng = Lcg(seed);
+
+        let per_slot = rows * bpr * 18;
+        assert_eq!(
+            per_slot % 16,
+            0,
+            "slot stride must keep uint4 loads aligned"
+        );
+        let mut arena = Vec::with_capacity(experts * per_slot);
+        for _ in 0..experts {
+            arena.extend_from_slice(&synth_q4_0_wire(rows, bpr, &mut rng));
+        }
+        let mut arena_soa = vec![0u8; arena.len()];
+        for slot in 0..experts {
+            super::q4_0_wire_to_soa_into(
+                &arena[slot * per_slot..(slot + 1) * per_slot],
+                &mut arena_soa[slot * per_slot..(slot + 1) * per_slot],
+            );
+        }
+
+        // Per-route activations; batched_input=0 reads only route 0's view.
+        let mut in_s = vec![0f32; experts * bpr];
+        let mut in_q = vec![0i8; experts * kdim];
+        for t in 0..experts {
+            let act: Vec<f32> = (0..kdim).map(|_| rng.next_f32()).collect();
+            let q8 = crate::inference::quantize_q8_0_blocks(&act);
+            for (b, blk) in q8.iter().enumerate() {
+                in_s[t * bpr + b] = blk.scale;
+                in_q[t * kdim + b * 32..t * kdim + (b + 1) * 32].copy_from_slice(&blk.quants);
+            }
+        }
+        let slots: Vec<i32> = vec![2, 0, 3, 1];
+        let routes: Vec<i32> = vec![1, 3, 0, 2];
+
+        let d_s = k.stream.clone_htod(&in_s).unwrap();
+        let d_q = k.stream.clone_htod(&in_q).unwrap();
+        let d_slots = k.stream.clone_htod(&slots).unwrap();
+        let d_routes = k.stream.clone_htod(&routes).unwrap();
+
+        for batched_input in [0i32, 1] {
+            let run = |weights: &[u8], func: &cudarc::driver::CudaFunction| -> Vec<f32> {
+                use cudarc::driver::{LaunchConfig, PushKernelArg};
+                let d_w = k.stream.clone_htod(weights).unwrap();
+                let mut d_out = k.stream.alloc_zeros::<f32>(experts * rows).unwrap();
+                let block = 256u32;
+                let warps = block / 32;
+                let cfg = LaunchConfig {
+                    grid_dim: ((rows as u32).div_ceil(warps), experts as u32, 1),
+                    block_dim: (block, 1, 1),
+                    shared_mem_bytes: bpr as u32 * 32 + bpr as u32 * 4 + warps * bpr as u32 * 4,
+                };
+                let (stride, rows_i, bpr_i, experts_i) =
+                    (per_slot as u64, rows as i32, bpr as i32, experts as i32);
+                let mut b = k.stream.launch_builder(func);
+                b.arg(&d_s)
+                    .arg(&d_q)
+                    .arg(&d_w)
+                    .arg(&d_slots)
+                    .arg(&d_routes)
+                    .arg(&stride)
+                    .arg(&rows_i)
+                    .arg(&bpr_i)
+                    .arg(&mut d_out)
+                    .arg(&experts_i)
+                    .arg(&batched_input);
+                unsafe { b.launch(cfg) }.unwrap();
+                let mut host = vec![0f32; experts * rows];
+                k.stream.memcpy_dtoh(&d_out, &mut host).unwrap();
+                k.ctx.synchronize().unwrap();
+                host
+            };
+
+            let from_wire = run(&arena, &k.q4_0_gemv_routed);
+            let from_soa = run(&arena_soa, &k.q4_0_gemv_routed_soa);
+            assert_same_bits(
+                &format!("q4_0_gemv_routed_soa {rows}x{bpr} batched_input={batched_input}"),
+                &from_soa,
+                &from_wire,
+            );
+            assert!(
+                from_wire.iter().any(|v| *v != 0.0),
+                "degenerate fixture: the wire reference produced all zeros"
+            );
+        }
+    }
+}
+
+/// The SoA routed GEMMs (plain and chunked32) on per-slot repacked arenas must
+/// be BITWISE identical to `q4_0_gemm_routed` on the raw-wire arena.
+///
+/// Modeled on `q4_0_gemm_routed_matches_gemv`: RAGGED CSR (experts with 0, 1,
+/// and many tokens), a permuted slot map, both real routed shapes (1408x88 and
+/// 2816x22) plus a synthetic one, an explicit tile-2 launch so the `blockIdx.z`
+/// tiling path runs, and the production launch helper for both SoA kernels.
+#[test]
+#[ignore = "requires a CUDA device"]
+fn q4_0_gemm_routed_soa_matches_wire() {
+    let Some(k) = kernels() else {
+        return;
+    };
+    for (rows, bpr, seed) in [
+        (1408usize, 88usize, 0x50_a4_01u64),
+        (2816, 22, 0x50_a4_02),
+        (96, 8, 0x50_a4_03),
+    ] {
+        let experts = 4usize;
+        let n_tokens = 7usize;
+        let kdim = bpr * 32;
+        let mut rng = Lcg(seed);
+
+        let per_slot = rows * bpr * 18;
+        assert_eq!(
+            per_slot % 16,
+            0,
+            "slot stride must keep uint4 loads aligned"
+        );
+        let mut arena = Vec::with_capacity(experts * per_slot);
+        for _ in 0..experts {
+            arena.extend_from_slice(&synth_q4_0_wire(rows, bpr, &mut rng));
+        }
+        let mut arena_soa = vec![0u8; arena.len()];
+        for slot in 0..experts {
+            super::q4_0_wire_to_soa_into(
+                &arena[slot * per_slot..(slot + 1) * per_slot],
+                &mut arena_soa[slot * per_slot..(slot + 1) * per_slot],
+            );
+        }
+        let mut in_s = vec![0f32; n_tokens * bpr];
+        let mut in_q = vec![0i8; n_tokens * kdim];
+        for t in 0..n_tokens {
+            let act: Vec<f32> = (0..kdim).map(|_| rng.next_f32()).collect();
+            let q8 = crate::inference::quantize_q8_0_blocks(&act);
+            for (b, blk) in q8.iter().enumerate() {
+                in_s[t * bpr + b] = blk.scale;
+                in_q[t * kdim + b * 32..t * kdim + (b + 1) * 32].copy_from_slice(&blk.quants);
+            }
+        }
+        // Ragged CSR: expert 0 -> 3 tokens, 1 -> 0, 2 -> 1, 3 -> 4. Total 8.
+        let token_offsets: Vec<i32> = vec![0, 3, 3, 4, 8];
+        let token_ids: Vec<i32> = vec![5, 0, 3, 6, 2, 4, 1, 5];
+        let slots: Vec<i32> = vec![2, 0, 3, 1];
+        let assignments = *token_offsets.last().unwrap() as usize;
+        let max_count = (0..experts)
+            .map(|e| token_offsets[e + 1] - token_offsets[e])
+            .max()
+            .unwrap() as usize;
+
+        let d_s = k.stream.clone_htod(&in_s).unwrap();
+        let d_q = k.stream.clone_htod(&in_q).unwrap();
+        let d_w = k.stream.clone_htod(&arena).unwrap();
+        let d_w_soa = k.stream.clone_htod(&arena_soa).unwrap();
+        let d_slots = k.stream.clone_htod(&slots).unwrap();
+        let d_off = k.stream.clone_htod(&token_offsets).unwrap();
+        let d_tok = k.stream.clone_htod(&token_ids).unwrap();
+
+        // Reference: the shipped wire GEMM (itself pinned bitwise against
+        // per-token q4_0_gemv_routed by q4_0_gemm_routed_matches_gemv).
+        let mut d_ref = k.stream.alloc_zeros::<f32>(assignments * rows).unwrap();
+        super::launch_q4_0_gemm_routed(
+            &k.stream,
+            &k.q4_0_gemm_routed,
+            &d_s,
+            &d_q,
+            &d_w,
+            &d_slots,
+            &d_off,
+            &d_tok,
+            per_slot,
+            rows,
+            bpr,
+            experts,
+            max_count,
+            false,
+            &mut d_ref,
+        )
+        .unwrap();
+        let mut reference = vec![0f32; assignments * rows];
+        k.stream.memcpy_dtoh(&d_ref, &mut reference).unwrap();
+        k.ctx.synchronize().unwrap();
+        assert!(
+            reference.iter().any(|v| *v != 0.0),
+            "degenerate fixture: the wire reference produced all zeros"
+        );
+
+        // Explicit tile-2 launch of the SoA kernel so blockIdx.z tiling runs.
+        let tile = 2usize;
+        let mut d_tiled = k.stream.alloc_zeros::<f32>(assignments * rows).unwrap();
+        {
+            use cudarc::driver::{LaunchConfig, PushKernelArg};
+            let block = 256u32;
+            let warps = block / 32;
+            let cfg = LaunchConfig {
+                grid_dim: (
+                    (rows as u32).div_ceil(warps),
+                    experts as u32,
+                    max_count.div_ceil(tile) as u32,
+                ),
+                block_dim: (block, 1, 1),
+                shared_mem_bytes: warps * tile as u32 * bpr as u32 * 4,
+            };
+            let (stride, rows_i, bpr_i, experts_i, tile_i) = (
+                per_slot as u64,
+                rows as i32,
+                bpr as i32,
+                experts as i32,
+                tile as i32,
+            );
+            let mut b = k.stream.launch_builder(&k.q4_0_gemm_routed_soa);
+            b.arg(&d_s)
+                .arg(&d_q)
+                .arg(&d_w_soa)
+                .arg(&d_slots)
+                .arg(&d_off)
+                .arg(&d_tok)
+                .arg(&stride)
+                .arg(&rows_i)
+                .arg(&bpr_i)
+                .arg(&mut d_tiled)
+                .arg(&experts_i)
+                .arg(&tile_i);
+            unsafe { b.launch(cfg) }.unwrap();
+        }
+        let mut tiled = vec![0f32; assignments * rows];
+        k.stream.memcpy_dtoh(&d_tiled, &mut tiled).unwrap();
+        k.ctx.synchronize().unwrap();
+        assert_same_bits(
+            &format!("q4_0_gemm_routed_soa tile-2 {rows}x{bpr}"),
+            &tiled,
+            &reference,
+        );
+
+        // Production launch helper, both SoA kernels: the pairing the runtime's
+        // (chunked policy x arena-SoA gate) dispatch actually selects.
+        for (label, func, chunked) in [
+            (
+                "q4_0_gemm_routed_soa helper",
+                &k.q4_0_gemm_routed_soa,
+                false,
+            ),
+            (
+                "q4_0_gemm_routed_chunked_soa helper",
+                &k.q4_0_gemm_routed_chunked_soa,
+                true,
+            ),
+        ] {
+            let mut d_out = k.stream.alloc_zeros::<f32>(assignments * rows).unwrap();
+            super::launch_q4_0_gemm_routed(
+                &k.stream, func, &d_s, &d_q, &d_w_soa, &d_slots, &d_off, &d_tok, per_slot, rows,
+                bpr, experts, max_count, chunked, &mut d_out,
+            )
+            .unwrap();
+            let mut got = vec![0f32; assignments * rows];
+            k.stream.memcpy_dtoh(&d_out, &mut got).unwrap();
+            k.ctx.synchronize().unwrap();
+            assert_same_bits(&format!("{label} {rows}x{bpr}"), &got, &reference);
+        }
+    }
+}
+
 /// `q4_0_gemv_routed_rows` must be BITWISE identical to `q4_0_gemv_routed`.
 ///
 /// Step 08 moves the tail fold from one lane to R lanes, but each row is still

--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -234,8 +234,9 @@ mod gemma4_mtp_kwide_planner_tests {
 #[cfg(test)]
 mod gemma4_mtp_resident_split_tests {
     use super::{
-        gemma4_mtp_resident_split_policy, gemma4_plan_route_union,
-        gemma4_reorder_union_residents_first, Gemma4RouteUnionPlan, GEMMA4_MTP_ROUTE_COUNT,
+        gemma4_mtp_device_draft_chain_policy, gemma4_mtp_resident_split_policy,
+        gemma4_plan_route_union, gemma4_reorder_union_residents_first, Gemma4RouteUnionPlan,
+        GEMMA4_MTP_ROUTE_COUNT,
     };
 
     #[test]
@@ -246,6 +247,18 @@ mod gemma4_mtp_resident_split_tests {
         for invalid in ["", "true", "on", "2", "01", "disabled"] {
             let error = gemma4_mtp_resident_split_policy(Some(invalid))
                 .expect_err("non-0/1 split values must fail closed");
+            assert!(error.contains("must be exactly 0 or 1"), "{error}");
+        }
+    }
+
+    #[test]
+    fn device_draft_chain_gate_is_default_off_and_strictly_zero_or_one() {
+        assert_eq!(gemma4_mtp_device_draft_chain_policy(None), Ok(false));
+        assert_eq!(gemma4_mtp_device_draft_chain_policy(Some("0")), Ok(false));
+        assert_eq!(gemma4_mtp_device_draft_chain_policy(Some(" 1 ")), Ok(true));
+        for invalid in ["", "true", "on", "2", "01", "disabled"] {
+            let error = gemma4_mtp_device_draft_chain_policy(Some(invalid))
+                .expect_err("non-0/1 draft-chain values must fail closed");
             assert!(error.contains("must be exactly 0 or 1"), "{error}");
         }
     }
@@ -8237,8 +8250,16 @@ struct Gemma4MtpCudaScratchDev {
     logits: cudarc::driver::CudaSlice<f32>,
     cos: cudarc::driver::CudaSlice<f32>,
     sin: cudarc::driver::CudaSlice<f32>,
+    /// Full-attention rope tables get their own buffers so BOTH variants can be
+    /// uploaded once per draft round (position is fixed across a round) instead
+    /// of re-uploaded per layer per proposal; `cos`/`sin` hold the sliding pair.
+    cos_full: cudarc::driver::CudaSlice<f32>,
+    sin_full: cudarc::driver::CudaSlice<f32>,
     position: cudarc::driver::CudaSlice<i32>,
     argmax: cudarc::driver::CudaSlice<u32>,
+    /// One argmax per proposal, drained in a single round-end DtoH by the
+    /// device draft chain.
+    draft_ring: cudarc::driver::CudaSlice<u32>,
     scores: cudarc::driver::CudaSlice<f32>,
 }
 
@@ -8501,6 +8522,23 @@ const GEMMA4_MTP_RESIDENT_SPLIT_ENV: &str = "CAMELID_GEMMA4_MTP_RESIDENT_SPLIT";
 /// slots (`-1` = not resident) and the missing entries as `(union_index, expert)`.
 #[cfg(feature = "cuda")]
 type Gemma4KwideTouchedUnion = (Vec<i32>, Vec<(usize, usize)>);
+
+#[cfg(any(feature = "cuda", test))]
+const GEMMA4_MTP_DEVICE_DRAFT_CHAIN_ENV: &str = "CAMELID_GEMMA4_MTP_DEVICE_DRAFT_CHAIN";
+
+/// Strict parser for the on-device draft chain (argmax feeds the next proposal's
+/// embedding through a device gather, drafts drain in one round-end DtoH).
+/// Mirrors the other K-wide gates: a typo fails model load.
+#[cfg(any(feature = "cuda", test))]
+fn gemma4_mtp_device_draft_chain_policy(value: Option<&str>) -> std::result::Result<bool, String> {
+    match value.map(str::trim) {
+        None | Some("0") => Ok(false),
+        Some("1") => Ok(true),
+        Some(other) => Err(format!(
+            "{GEMMA4_MTP_DEVICE_DRAFT_CHAIN_ENV} must be exactly 0 or 1; got {other:?}"
+        )),
+    }
+}
 
 /// Strict parser for the resident-first verifier split, mirroring
 /// [`gemma4_mtp_io_pipeline_policy`]: a typo fails model load instead of
@@ -10608,6 +10646,12 @@ pub struct Gemma4CudaResident {
     /// copies land. Bit-identical by construction (each expert's fold happens
     /// whole in exactly one launch; the weighted sum consumes router order).
     mtp_resident_split: bool,
+    /// Opt-in on-device assistant draft chain: the argmax feeds the next
+    /// proposal's embedding through a Q6_K head-row gather on the GPU, and the
+    /// drafts drain in ONE round-end DtoH+sync instead of one per proposal.
+    /// Drafter-only numerics (moves acceptance, never emitted tokens); engages
+    /// only when the tied head is device-resident in the padded Q6_K lane.
+    mtp_device_draft_chain: bool,
     /// Default-off 236 MiB full-Q4 assistant plus its persistent activation
     /// scratch. Loaded only after the exact tracked geometry is admitted.
     mtp_cuda_assistant: Option<Gemma4MtpCudaResident>,
@@ -10717,6 +10761,17 @@ impl Gemma4CudaResident {
         if mtp_resident_split {
             eprintln!(
                 "[gemma4-mtp-cuda] K-wide resident-first split ON: resident expert GEMMs overlap missing-union storage reads"
+            );
+        }
+        let mtp_device_draft_chain = gemma4_mtp_device_draft_chain_policy(
+            std::env::var(GEMMA4_MTP_DEVICE_DRAFT_CHAIN_ENV)
+                .ok()
+                .as_deref(),
+        )
+        .map_err(BackendError::InvalidModelMetadata)?;
+        if mtp_device_draft_chain {
+            eprintln!(
+                "[gemma4-mtp-cuda] device draft chain ON: assistant argmax feeds the next embedding via a Q6_K head-row gather"
             );
         }
         let ghost_moe = cpu.ghost_moe_cache.is_some();
@@ -11308,6 +11363,7 @@ impl Gemma4CudaResident {
             mtp_kwide_last_completed: std::cell::Cell::new(false),
             mtp_io_pipeline,
             mtp_resident_split,
+            mtp_device_draft_chain,
             mtp_cuda_assistant: None,
             norms,
             lweights,
@@ -11667,8 +11723,11 @@ impl Gemma4CudaResident {
             logits: alloc_f(self.vocab)?,
             cos: alloc_f(mtp::FULL_HEAD_DIM / 2)?,
             sin: alloc_f(mtp::FULL_HEAD_DIM / 2)?,
+            cos_full: alloc_f(mtp::FULL_HEAD_DIM / 2)?,
+            sin_full: alloc_f(mtp::FULL_HEAD_DIM / 2)?,
             position: stream.alloc_zeros::<i32>(1).map_err(cu)?,
             argmax: stream.alloc_zeros::<u32>(1).map_err(cu)?,
+            draft_ring: stream.alloc_zeros::<u32>(MAX_MTP_VERIFY_ROWS).map_err(cu)?,
             scores: alloc_f(mtp::NUM_ATTENTION_HEADS * self.max_positions)?,
         };
         let bytes = weights.accounting().total_bytes;
@@ -16556,16 +16615,59 @@ impl Gemma4CudaResident {
             mtp::FULL_ROPE_THETA,
             Some(mtp::FULL_PARTIAL_ROTARY_FACTOR),
         );
+        // Position is fixed for the whole round (the assistant is KV-shared and
+        // appends nothing), so both rope variants upload exactly once per round.
+        stream
+            .memcpy_htod(
+                &sliding_rope.0,
+                &mut scratch.cos.slice_mut(0..mtp::SLIDING_HEAD_DIM / 2),
+            )
+            .map_err(cu)?;
+        stream
+            .memcpy_htod(
+                &sliding_rope.1,
+                &mut scratch.sin.slice_mut(0..mtp::SLIDING_HEAD_DIM / 2),
+            )
+            .map_err(cu)?;
+        stream
+            .memcpy_htod(
+                &full_rope.0,
+                &mut scratch.cos_full.slice_mut(0..mtp::FULL_HEAD_DIM / 2),
+            )
+            .map_err(cu)?;
+        stream
+            .memcpy_htod(
+                &full_rope.1,
+                &mut scratch.sin_full.slice_mut(0..mtp::FULL_HEAD_DIM / 2),
+            )
+            .map_err(cu)?;
+
+        // The device draft chain needs the target's tied head resident in the
+        // padded Q6_K lane the gather kernel decodes; any other lane falls back
+        // to the per-proposal host round-trip.
+        let device_head = if self.mtp_device_draft_chain {
+            self.gpu_head
+                .as_ref()
+                .filter(|head| matches!(head.lane, HeadLane::Q6K))
+        } else {
+            None
+        };
+        let embed_scale = (self.hidden as f32).sqrt();
 
         let mut drafts = Vec::with_capacity(k);
         for proposal in 0..k {
             if proposal != 0 {
-                stream
-                    .memcpy_htod(
-                        &embedding,
-                        &mut scratch.joined.slice_mut(0..mtp::BACKBONE_HIDDEN),
-                    )
-                    .map_err(cu)?;
+                // Under the device chain the gather at the end of the previous
+                // iteration already wrote joined[0..hidden] on-stream; only the
+                // recurrent half moves here.
+                if device_head.is_none() {
+                    stream
+                        .memcpy_htod(
+                            &embedding,
+                            &mut scratch.joined.slice_mut(0..mtp::BACKBONE_HIDDEN),
+                        )
+                        .map_err(cu)?;
+                }
                 let recurrent = scratch.recurrent.slice(0..mtp::BACKBONE_HIDDEN);
                 let mut hidden_slot = scratch
                     .joined
@@ -16598,18 +16700,10 @@ impl Gemma4CudaResident {
                     post_feedforward_norm,
                 ) = gemma4_mtp_cuda_layer_ids(layer);
                 let sliding = layer < mtp::SLIDING_LAYERS;
-                let (head_dim, host_layer, rope) = if sliding {
-                    (
-                        mtp::SLIDING_HEAD_DIM,
-                        mtp::SHARED_KV_SLIDING_HOST_LAYER,
-                        &sliding_rope,
-                    )
+                let (head_dim, host_layer) = if sliding {
+                    (mtp::SLIDING_HEAD_DIM, mtp::SHARED_KV_SLIDING_HOST_LAYER)
                 } else {
-                    (
-                        mtp::FULL_HEAD_DIM,
-                        mtp::SHARED_KV_FULL_HOST_LAYER,
-                        &full_rope,
-                    )
+                    (mtp::FULL_HEAD_DIM, mtp::SHARED_KV_FULL_HOST_LAYER)
                 };
                 gemma4_mtp_cuda_launch_rmsnorm(
                     &stream,
@@ -16639,18 +16733,20 @@ impl Gemma4CudaResident {
                     mtp::RMS_NORM_EPS,
                 )
                 .map_err(cu)?;
-                stream
-                    .memcpy_htod(&rope.0, &mut scratch.cos.slice_mut(0..head_dim / 2))
-                    .map_err(cu)?;
-                stream
-                    .memcpy_htod(&rope.1, &mut scratch.sin.slice_mut(0..head_dim / 2))
-                    .map_err(cu)?;
                 crate::cuda_resident::launch_rope(
                     &stream,
                     &kernels.rope,
                     &mut scratch.q,
-                    &scratch.cos,
-                    &scratch.sin,
+                    if sliding {
+                        &scratch.cos
+                    } else {
+                        &scratch.cos_full
+                    },
+                    if sliding {
+                        &scratch.sin
+                    } else {
+                        &scratch.sin_full
+                    },
                     mtp::NUM_ATTENTION_HEADS,
                     head_dim,
                     head_dim,
@@ -16823,19 +16919,60 @@ impl Gemma4CudaResident {
                 &mut scratch.argmax,
             )
             .map_err(cu)?;
-            let mut token = [0u32; 1];
+            if let Some(head) = device_head {
+                let argmax_src = scratch.argmax.slice(0..1);
+                let mut ring_slot = scratch.draft_ring.slice_mut(proposal..proposal + 1);
+                stream
+                    .memcpy_dtod(&argmax_src, &mut ring_slot)
+                    .map_err(cu)?;
+                if proposal + 1 < k {
+                    // Write the next proposal's scaled embedding into
+                    // joined[0..hidden] entirely on-device: no DtoH, no host
+                    // synchronization, no CPU dequantize on the chain.
+                    crate::cuda_resident::launch_q6k_row_gather_scale(
+                        &stream,
+                        &kernels.q6k_row_gather_scale,
+                        &head.weight,
+                        &scratch.argmax,
+                        0,
+                        &mut scratch.joined,
+                        self.hidden,
+                        embed_scale,
+                    )
+                    .map_err(cu)?;
+                }
+            } else {
+                let mut token = [0u32; 1];
+                stream
+                    .memcpy_dtoh(&scratch.argmax, &mut token)
+                    .map_err(cu)?;
+                stream.synchronize().map_err(cu)?;
+                if token[0] as usize >= self.vocab {
+                    return Err(BackendError::RuntimeShapeMismatch(format!(
+                        "CUDA assistant argmax {} exceeds target vocab {}",
+                        token[0], self.vocab
+                    )));
+                }
+                drafts.push(token[0]);
+                embedding = self.mtp_scaled_embedding(token[0])?;
+            }
+        }
+        if device_head.is_some() {
+            // One round-end drain replaces the k per-proposal syncs.
+            let mut tokens = vec![0u32; MAX_MTP_VERIFY_ROWS];
             stream
-                .memcpy_dtoh(&scratch.argmax, &mut token)
+                .memcpy_dtoh(&scratch.draft_ring, &mut tokens)
                 .map_err(cu)?;
             stream.synchronize().map_err(cu)?;
-            if token[0] as usize >= self.vocab {
-                return Err(BackendError::RuntimeShapeMismatch(format!(
-                    "CUDA assistant argmax {} exceeds target vocab {}",
-                    token[0], self.vocab
-                )));
+            for &token in &tokens[..k] {
+                if token as usize >= self.vocab {
+                    return Err(BackendError::RuntimeShapeMismatch(format!(
+                        "CUDA assistant argmax {} exceeds target vocab {}",
+                        token, self.vocab
+                    )));
+                }
+                drafts.push(token);
             }
-            drafts.push(token[0]);
-            embedding = self.mtp_scaled_embedding(token[0])?;
         }
         Ok(drafts)
     }

--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -232,6 +232,148 @@ mod gemma4_mtp_kwide_planner_tests {
 }
 
 #[cfg(test)]
+mod gemma4_mtp_resident_split_tests {
+    use super::{
+        gemma4_mtp_resident_split_policy, gemma4_plan_route_union,
+        gemma4_reorder_union_residents_first, Gemma4RouteUnionPlan, GEMMA4_MTP_ROUTE_COUNT,
+    };
+
+    #[test]
+    fn gate_is_default_off_and_strictly_zero_or_one() {
+        assert_eq!(gemma4_mtp_resident_split_policy(None), Ok(false));
+        assert_eq!(gemma4_mtp_resident_split_policy(Some("0")), Ok(false));
+        assert_eq!(gemma4_mtp_resident_split_policy(Some(" 1 ")), Ok(true));
+        for invalid in ["", "true", "on", "2", "01", "disabled"] {
+            let error = gemma4_mtp_resident_split_policy(Some(invalid))
+                .expect_err("non-0/1 split values must fail closed");
+            assert!(error.contains("must be exactly 0 or 1"), "{error}");
+        }
+    }
+
+    /// The whole bit-exactness argument of the resident-first split rests on the
+    /// permutation being a pure renumbering: same experts, same per-expert
+    /// assignment spans (moved whole), and a `route_to_assignment` rebuilt through
+    /// the same renumbering. This pins each of those properties on the CSR shape
+    /// the union test upstream already exercises (shared experts spanning rows).
+    #[test]
+    fn residents_first_reorder_is_a_pure_stable_renumbering() {
+        let routes = vec![
+            vec![7, 2, 5, 11, 13, 17, 19, 23],
+            vec![2, 7, 29, 31, 13, 37, 41, 43],
+            vec![7, 47, 2, 53, 59, 61, 67, 71],
+        ];
+        let plan = gemma4_plan_route_union(&routes, 128).expect("valid top-8 routes");
+        // Mark an interleaved subset resident; slot value = expert id so slot
+        // identity can be checked after the permutation.
+        let union_slots = plan
+            .union_experts
+            .iter()
+            .enumerate()
+            .map(|(index, &expert)| if index % 3 == 1 { -1 } else { expert as i32 })
+            .collect::<Vec<_>>();
+        let (permuted, slots, n_resident, resident_assignments) =
+            gemma4_reorder_union_residents_first(&plan, &union_slots);
+
+        // Stable partition: residents keep their relative order in the prefix,
+        // missing keep theirs in the tail, and every slot follows its expert.
+        let residents = plan
+            .union_experts
+            .iter()
+            .zip(&union_slots)
+            .filter(|&(_, &slot)| slot >= 0)
+            .map(|(&expert, _)| expert)
+            .collect::<Vec<_>>();
+        let missing = plan
+            .union_experts
+            .iter()
+            .zip(&union_slots)
+            .filter(|&(_, &slot)| slot < 0)
+            .map(|(&expert, _)| expert)
+            .collect::<Vec<_>>();
+        assert_eq!(n_resident, residents.len());
+        assert_eq!(&permuted.union_experts[..n_resident], residents.as_slice());
+        assert_eq!(&permuted.union_experts[n_resident..], missing.as_slice());
+        for (index, &expert) in permuted.union_experts.iter().enumerate() {
+            if index < n_resident {
+                assert_eq!(slots[index], expert as i32);
+            } else {
+                assert_eq!(slots[index], -1);
+            }
+        }
+
+        // Every expert's assignment span moved whole: same tokens, same
+        // within-expert order.
+        let spans = |p: &Gemma4RouteUnionPlan| {
+            let mut spans = p
+                .union_experts
+                .iter()
+                .enumerate()
+                .map(|(e, &expert)| {
+                    (
+                        expert,
+                        p.token_ids[p.token_offsets[e] as usize..p.token_offsets[e + 1] as usize]
+                            .to_vec(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            spans.sort();
+            spans
+        };
+        assert_eq!(spans(&plan), spans(&permuted));
+
+        // route_to_assignment still names, for every token and router rank, an
+        // assignment holding that token inside that expert's span.
+        for (token, route) in routes.iter().enumerate() {
+            for (rank, &expert) in route.iter().enumerate() {
+                let assignment =
+                    permuted.route_to_assignment[token * GEMMA4_MTP_ROUTE_COUNT + rank] as usize;
+                assert_eq!(permuted.token_ids[assignment] as usize, token);
+                let owner = permuted
+                    .token_offsets
+                    .windows(2)
+                    .position(|w| (w[0] as usize) <= assignment && assignment < w[1] as usize)
+                    .expect("assignment lies in exactly one expert span");
+                assert_eq!(permuted.union_experts[owner], expert);
+            }
+        }
+
+        // The resident prefix covers exactly the leading assignment range the
+        // two-pass launches split at.
+        assert_eq!(
+            resident_assignments,
+            permuted.token_offsets[n_resident] as usize
+        );
+        assert_eq!(
+            permuted.max_assignments_per_expert,
+            plan.max_assignments_per_expert
+        );
+        assert_eq!(permuted.token_ids.len(), plan.token_ids.len());
+    }
+
+    #[test]
+    fn all_resident_and_all_missing_unions_reorder_to_identity() {
+        let routes = vec![vec![3, 1, 4, 15, 9, 2, 6, 5]];
+        let plan = gemma4_plan_route_union(&routes, 128).expect("valid top-8 route");
+
+        let all_resident = vec![7i32; plan.union_experts.len()];
+        let (permuted, slots, n_resident, resident_assignments) =
+            gemma4_reorder_union_residents_first(&plan, &all_resident);
+        assert_eq!(permuted, plan);
+        assert_eq!(slots, all_resident);
+        assert_eq!(n_resident, plan.union_experts.len());
+        assert_eq!(resident_assignments, plan.token_ids.len());
+
+        let all_missing = vec![-1i32; plan.union_experts.len()];
+        let (permuted, slots, n_resident, resident_assignments) =
+            gemma4_reorder_union_residents_first(&plan, &all_missing);
+        assert_eq!(permuted, plan);
+        assert_eq!(slots, all_missing);
+        assert_eq!(n_resident, 0);
+        assert_eq!(resident_assignments, 0);
+    }
+}
+
+#[cfg(test)]
 mod gemma4_mtp_io_pipeline_tests {
     use super::{gemma4_mtp_io_pipeline_batches, gemma4_mtp_io_pipeline_policy};
 
@@ -7238,9 +7380,15 @@ fn gemma4_launch_geglu(
     unsafe { builder.launch(config) }.map(|_| ())
 }
 
+/// Launch the per-assignment GeGLU+quantize for the contiguous assignment range
+/// `[assignment_offset, assignment_offset + assignments)` (offset 0 with the
+/// full count is the whole batch). `assignment_ids` is the identity map, so the
+/// offset sub-view's *values* are the absolute assignment indices of the range,
+/// and the kernel reads and writes at absolute positions — a two-pass split
+/// touches exactly the rows a full pass would.
 #[cfg(feature = "cuda")]
 #[allow(clippy::too_many_arguments)]
-fn gemma4_launch_geglu_quantize_assignments(
+fn gemma4_launch_geglu_quantize_assignments_range(
     s: &std::sync::Arc<cudarc::driver::CudaStream>,
     kernel: &cudarc::driver::CudaFunction,
     gate_up: &cudarc::driver::CudaSlice<f32>,
@@ -7248,9 +7396,13 @@ fn gemma4_launch_geglu_quantize_assignments(
     quants: &mut cudarc::driver::CudaSlice<i8>,
     scales: &mut cudarc::driver::CudaSlice<f32>,
     nff: usize,
+    assignment_offset: usize,
     assignments: usize,
 ) -> std::result::Result<(), cudarc::driver::DriverError> {
     use cudarc::driver::{LaunchConfig, PushKernelArg};
+    if assignments == 0 {
+        return Ok(());
+    }
     let blocks = nff / 32;
     let warps = 8u32;
     let config = LaunchConfig {
@@ -7262,11 +7414,12 @@ fn gemma4_launch_geglu_quantize_assignments(
         block_dim: (warps * 32, 1, 1),
         shared_mem_bytes: 0,
     };
+    let ids = assignment_ids.slice(assignment_offset..);
     let (nff, blocks, assignments) = (nff as i32, blocks as i32, assignments as i32);
     let mut builder = s.launch_builder(kernel);
     builder
         .arg(gate_up)
-        .arg(assignment_ids)
+        .arg(&ids)
         .arg(quants)
         .arg(scales)
         .arg(&nff)
@@ -8341,6 +8494,28 @@ fn gemma4_mtp_io_pipeline_policy(value: Option<&str>) -> std::result::Result<boo
     }
 }
 
+#[cfg(any(feature = "cuda", test))]
+const GEMMA4_MTP_RESIDENT_SPLIT_ENV: &str = "CAMELID_GEMMA4_MTP_RESIDENT_SPLIT";
+
+/// Touch-phase result of the K-wide union resolve: the per-union-index arena
+/// slots (`-1` = not resident) and the missing entries as `(union_index, expert)`.
+#[cfg(feature = "cuda")]
+type Gemma4KwideTouchedUnion = (Vec<i32>, Vec<(usize, usize)>);
+
+/// Strict parser for the resident-first verifier split, mirroring
+/// [`gemma4_mtp_io_pipeline_policy`]: a typo fails model load instead of
+/// silently selecting a lane the receipt did not request.
+#[cfg(any(feature = "cuda", test))]
+fn gemma4_mtp_resident_split_policy(value: Option<&str>) -> std::result::Result<bool, String> {
+    match value.map(str::trim) {
+        None | Some("0") => Ok(false),
+        Some("1") => Ok(true),
+        Some(other) => Err(format!(
+            "{GEMMA4_MTP_RESIDENT_SPLIT_ENV} must be exactly 0 or 1; got {other:?}"
+        )),
+    }
+}
+
 /// Plan ordered read groups and the host-tier prefix made ready by each group.
 /// `pending_ordinals` is strictly increasing and names the storage misses among
 /// all VRAM misses; host-tier hits between them ride the next completed prefix.
@@ -8582,6 +8757,78 @@ fn gemma4_plan_route_union(
         route_to_assignment,
         max_assignments_per_expert: counts.into_iter().max().unwrap_or(0),
     })
+}
+
+/// Stable-partition a route-union plan so SSER-resident experts precede missing
+/// ones, renumbering assignments to match. With this ordering the resident half
+/// of the union is one contiguous expert range `[0, n_resident)` covering the
+/// contiguous assignment range `[0, resident_assignments)`, so the routed GEMMs
+/// and the per-assignment GeGLU can each run as two sub-range launches: the
+/// resident pass enqueued *before* the CPU blocks on the missing experts'
+/// storage reads, the missing pass after their copies land.
+///
+/// Bit-exactness: relative order inside each class is preserved, every expert's
+/// per-assignment span is moved whole (so within-expert assignment order — and
+/// with it each output row's fold — is untouched), and `route_to_assignment` is
+/// rebuilt through the same renumbering, so the strict token-major router-order
+/// weighted sum consumes identical values in an identical order.
+///
+/// `union_slots` uses `-1` for missing experts, matching the touch phase's
+/// output; the returned slots are the same values in the permuted order.
+#[cfg(any(feature = "cuda", test))]
+fn gemma4_reorder_union_residents_first(
+    plan: &Gemma4RouteUnionPlan,
+    union_slots: &[i32],
+) -> (Gemma4RouteUnionPlan, Vec<i32>, usize, usize) {
+    debug_assert_eq!(plan.union_experts.len(), union_slots.len());
+    let expert_count = plan.union_experts.len();
+    let mut order = Vec::with_capacity(expert_count);
+    order.extend((0..expert_count).filter(|&e| union_slots[e] >= 0));
+    let n_resident = order.len();
+    order.extend((0..expert_count).filter(|&e| union_slots[e] < 0));
+
+    let old_first = |e: usize| plan.token_offsets[e] as usize;
+    let old_count = |e: usize| (plan.token_offsets[e + 1] - plan.token_offsets[e]) as usize;
+
+    let mut union_experts = Vec::with_capacity(expert_count);
+    let mut slots = Vec::with_capacity(expert_count);
+    let mut token_offsets = Vec::with_capacity(expert_count + 1);
+    token_offsets.push(0i32);
+    let assignment_count = plan.token_ids.len();
+    let mut token_ids = Vec::with_capacity(assignment_count);
+    // old assignment index -> new assignment index, for route_to_assignment.
+    let mut assignment_map = vec![0i32; assignment_count];
+    for &old_e in &order {
+        union_experts.push(plan.union_experts[old_e]);
+        slots.push(union_slots[old_e]);
+        let first = old_first(old_e);
+        let count = old_count(old_e);
+        let new_first = token_ids.len();
+        for offset in 0..count {
+            assignment_map[first + offset] = (new_first + offset) as i32;
+            token_ids.push(plan.token_ids[first + offset]);
+        }
+        token_offsets.push((new_first + count) as i32);
+    }
+    let route_to_assignment = plan
+        .route_to_assignment
+        .iter()
+        .map(|&assignment| assignment_map[assignment as usize])
+        .collect::<Vec<_>>();
+    let resident_assignments = token_offsets[n_resident] as usize;
+
+    (
+        Gemma4RouteUnionPlan {
+            union_experts,
+            token_offsets,
+            token_ids,
+            route_to_assignment,
+            max_assignments_per_expert: plan.max_assignments_per_expert,
+        },
+        slots,
+        n_resident,
+        resident_assignments,
+    )
 }
 
 /// Run the exact scalar Gemma router for K post-attention rows and prepare the
@@ -10355,6 +10602,12 @@ pub struct Gemma4CudaResident {
     /// Opt-in QD4 read/HtoD pipeline for K-wide expert unions. Parsed strictly
     /// once at load so a typo cannot vary behavior between verifier layers.
     mtp_io_pipeline: bool,
+    /// Opt-in resident-first split of the K-wide routed GEMMs: enqueue the
+    /// already-resident expert range's compute before the CPU blocks on the
+    /// missing experts' storage reads, then run the missing range after its
+    /// copies land. Bit-identical by construction (each expert's fold happens
+    /// whole in exactly one launch; the weighted sum consumes router order).
+    mtp_resident_split: bool,
     /// Default-off 236 MiB full-Q4 assistant plus its persistent activation
     /// scratch. Loaded only after the exact tracked geometry is admitted.
     mtp_cuda_assistant: Option<Gemma4MtpCudaResident>,
@@ -10455,6 +10708,15 @@ impl Gemma4CudaResident {
         if mtp_io_pipeline {
             eprintln!(
                 "[gemma4-mtp-cuda] K-wide expert I/O pipeline ON: QD{GEMMA4_MTP_IO_PIPELINE_READ_DEPTH} storage reads overlap expert HtoD"
+            );
+        }
+        let mtp_resident_split = gemma4_mtp_resident_split_policy(
+            std::env::var(GEMMA4_MTP_RESIDENT_SPLIT_ENV).ok().as_deref(),
+        )
+        .map_err(BackendError::InvalidModelMetadata)?;
+        if mtp_resident_split {
+            eprintln!(
+                "[gemma4-mtp-cuda] K-wide resident-first split ON: resident expert GEMMs overlap missing-union storage reads"
             );
         }
         let ghost_moe = cpu.ghost_moe_cache.is_some();
@@ -11045,6 +11307,7 @@ impl Gemma4CudaResident {
             verify_scratch: None,
             mtp_kwide_last_completed: std::cell::Cell::new(false),
             mtp_io_pipeline,
+            mtp_resident_split,
             mtp_cuda_assistant: None,
             norms,
             lweights,
@@ -11732,30 +11995,35 @@ impl Gemma4CudaResident {
     /// the same host slots in the same order, then lets each completed QD4 prefix
     /// begin HtoD while the next storage group runs. Both paths protect the full
     /// union and publish only after every read and HtoD enqueue succeeds.
-    fn mtp_kwide_resolve_union(
+    /// Phase A of the K-wide union resolve: touch the SSER arena for every
+    /// union expert, in union (route) order — identical bookkeeping to the
+    /// former combined resolve — and report which experts still need a fill.
+    /// Resident experts' slots are final on return, which is what lets the
+    /// caller enqueue their routed GEMMs before any storage read blocks the
+    /// launch thread. Returns `(union_slots with -1 for missing, missing as
+    /// (union_index, expert))`.
+    fn mtp_kwide_touch_union(
         &self,
         li: usize,
         moe: &MoeWeights,
         union_experts: &[usize],
-    ) -> Result<Vec<i32>> {
+    ) -> Result<Gemma4KwideTouchedUnion> {
         let global_layer = self.cpu.first_layer + li;
         let sser = self.sser.as_ref().ok_or_else(|| {
             BackendError::InvalidModelMetadata(
                 "Gemma 4 K-wide verifier requires the SSER expert arena".into(),
             )
         })?;
-        let tier = self.host_tier.as_ref().ok_or_else(|| {
+        self.host_tier.as_ref().ok_or_else(|| {
             BackendError::InvalidModelMetadata(
                 "Gemma 4 K-wide verifier requires the page-locked expert tier".into(),
             )
         })?;
-        let ghost = moe.ghost.as_ref().ok_or_else(|| {
+        moe.ghost.as_ref().ok_or_else(|| {
             BackendError::InvalidModelMetadata(
                 "Gemma 4 K-wide verifier requires paired .cghost expert records".into(),
             )
         })?;
-        let ghost_file = ghost.cache.file.as_ref();
-        let ghost_layer = ghost.layer_idx;
 
         let mut union_slots = vec![-1i32; union_experts.len()];
         let mut missing = Vec::<(usize, usize)>::new();
@@ -11780,16 +12048,48 @@ impl Gemma4CudaResident {
                 }
             }
         }
+        Ok((union_slots, missing))
+    }
+
+    /// Phase B of the K-wide union resolve: fill the missing experts through
+    /// the host tier (QD4-pipelined when enabled), publish their arena slots,
+    /// and make `cap_stream` wait on the copies. `missing` must come from
+    /// [`Self::mtp_kwide_touch_union`] over the same `union_experts` — its order
+    /// is the reservation/eviction order and is part of the byte-identical cache
+    /// trajectory the resident-first split preserves.
+    fn mtp_kwide_fill_missing(
+        &self,
+        li: usize,
+        moe: &MoeWeights,
+        union_experts: &[usize],
+        mut union_slots: Vec<i32>,
+        missing: &[(usize, usize)],
+    ) -> Result<Vec<i32>> {
         if missing.is_empty() {
             return Ok(union_slots);
         }
+        let global_layer = self.cpu.first_layer + li;
+        let sser = self
+            .sser
+            .as_ref()
+            .expect("touch phase validated the SSER arena");
+        let tier = self
+            .host_tier
+            .as_ref()
+            .expect("touch phase validated the host tier");
+        let ghost = moe
+            .ghost
+            .as_ref()
+            .expect("touch phase validated the ghost pairing");
+        let ghost_file = ghost.cache.file.as_ref();
+        let ghost_layer = ghost.layer_idx;
         if self.mtp_io_pipeline {
             return self.mtp_kwide_resolve_union_pipelined(
                 li,
                 moe,
                 union_experts,
                 union_slots,
-                &missing,
+                missing,
             );
         }
 
@@ -11920,7 +12220,7 @@ impl Gemma4CudaResident {
         Ok(union_slots)
     }
 
-    /// Stage-1 variant of [`Self::mtp_kwide_resolve_union`]. Host-tier slot
+    /// Pipelined arm of [`Self::mtp_kwide_fill_missing`]. Host-tier slot
     /// reservation and publication still happen in router order. Only the join
     /// boundary moves: after four independent storage reads complete, that
     /// contiguous prefix is enqueued on `expert_copy_stream`, then the CPU joins
@@ -12110,6 +12410,121 @@ impl Gemma4CudaResident {
     }
 
     #[allow(clippy::too_many_lines)]
+    /// Enqueue the routed GateUp -> GeGLU-quantize -> Down chain for one
+    /// contiguous expert range of a K-wide union whose CSR arrays are already
+    /// uploaded. `token_offsets` values are absolute assignment indices, so a
+    /// range launch writes exactly the rows the full-union launch writes; each
+    /// expert's per-row fold happens whole inside one launch either way, which
+    /// is the bit-exactness contract of the resident-first split.
+    #[allow(clippy::too_many_arguments)]
+    fn mtp_kwide_launch_expert_range(
+        &self,
+        scratch: &mut Gemma4VerifyScratchDev,
+        moe: &MoeWeights,
+        expert_offset: usize,
+        expert_len: usize,
+        assignment_offset: usize,
+        assignment_len: usize,
+        max_assignments_per_expert: usize,
+    ) -> Result<()> {
+        if expert_len == 0 {
+            return Ok(());
+        }
+        let s = &self.cap_stream;
+        let kernels = &self.kernels;
+        let hidden = self.hidden;
+        {
+            let cache = self.sser.as_ref().unwrap().borrow();
+            let (routed_kernel, chunked) = kernels.gemma4_mtp_q4_0_gemm_routed_kernel();
+            crate::cuda_resident::launch_q4_0_gemm_routed_range(
+                s,
+                routed_kernel,
+                &scratch.in_s,
+                &scratch.in_q,
+                &cache.gate_up_arena,
+                &scratch.union_slots,
+                &scratch.token_offsets,
+                &scratch.token_ids,
+                cache.gate_up_stride,
+                2 * moe.n_ff_exp,
+                hidden / 32,
+                expert_offset,
+                expert_len,
+                max_assignments_per_expert,
+                chunked,
+                &mut scratch.expert_gate_up,
+            )
+            .map_err(cu)?;
+        }
+        gemma4_launch_geglu_quantize_assignments_range(
+            s,
+            &kernels.geglu_quantize_routed,
+            &scratch.expert_gate_up,
+            &scratch.assignment_ids,
+            &mut scratch.expert_geglu_q,
+            &mut scratch.expert_geglu_s,
+            moe.n_ff_exp,
+            assignment_offset,
+            assignment_len,
+        )
+        .map_err(cu)?;
+        {
+            let cache = self.sser.as_ref().unwrap().borrow();
+            match moe.down_exps.format {
+                WireFormat::Q4_0 => {
+                    let (routed_kernel, chunked) = kernels.gemma4_mtp_q4_0_gemm_routed_kernel();
+                    crate::cuda_resident::launch_q4_0_gemm_routed_range(
+                        s,
+                        routed_kernel,
+                        &scratch.expert_geglu_s,
+                        &scratch.expert_geglu_q,
+                        &cache.down_arena,
+                        &scratch.union_slots,
+                        &scratch.token_offsets,
+                        &scratch.assignment_ids,
+                        cache.down_stride,
+                        hidden,
+                        moe.n_ff_exp / 32,
+                        expert_offset,
+                        expert_len,
+                        max_assignments_per_expert,
+                        chunked,
+                        &mut scratch.expert_y,
+                    )
+                    .map_err(cu)?
+                }
+                WireFormat::Q4_1 => {
+                    let (routed_kernel, chunked) = kernels.gemma4_mtp_q4_1_gemm_routed_kernel();
+                    crate::cuda_resident::launch_q4_1_gemm_routed_range(
+                        s,
+                        routed_kernel,
+                        &scratch.expert_geglu_s,
+                        &scratch.expert_geglu_q,
+                        &cache.down_arena,
+                        &scratch.union_slots,
+                        &scratch.token_offsets,
+                        &scratch.assignment_ids,
+                        cache.down_stride,
+                        hidden,
+                        moe.n_ff_exp / 32,
+                        expert_offset,
+                        expert_len,
+                        max_assignments_per_expert,
+                        chunked,
+                        &mut scratch.expert_y,
+                    )
+                    .map_err(cu)?
+                }
+                unsupported => {
+                    return Err(BackendError::UnsupportedGguf(format!(
+                        "Gemma 4 K-wide routed down projection does not support {unsupported:?}"
+                    )))
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn verify_batch_moe_inner(
         &mut self,
         tokens: &[u32],
@@ -12623,29 +13038,53 @@ impl Gemma4CudaResident {
                     &mut scratch.in_s.slice_mut(0..k_tokens * (hidden / 32)),
                 )
                 .map_err(cu)?;
-                let union_slots =
-                    self.mtp_kwide_resolve_union(li, moe, &router.csr.union_experts)?;
-                let expert_count = router.csr.union_experts.len();
+                let (touched_slots, touched_missing) =
+                    self.mtp_kwide_touch_union(li, moe, &router.csr.union_experts)?;
+                // Resident-first split: reorder the union so the resident range is
+                // contiguous, enqueue its GEMMs, and only then let the CPU block on
+                // the missing experts' storage reads. An all-resident union has
+                // nothing to wait for and an all-missing one nothing to overlap, so
+                // both fall back to the single-pass shape.
+                let mut plan_storage: Option<Gemma4RouteUnionPlan> = None;
+                let mut slots = touched_slots;
+                let mut missing = touched_missing;
+                let mut split_bounds: Option<(usize, usize)> = None;
+                if self.mtp_resident_split
+                    && !missing.is_empty()
+                    && missing.len() < router.csr.union_experts.len()
+                {
+                    let (permuted, permuted_slots, n_resident, resident_assignments) =
+                        gemma4_reorder_union_residents_first(&router.csr, &slots);
+                    // Residents-first ordering places the missing entries at the
+                    // tail in their original relative order, so the fill phase's
+                    // reservation and eviction sequence stays byte-identical to
+                    // the unsplit resolve.
+                    missing = missing
+                        .iter()
+                        .enumerate()
+                        .map(|(index, &(_, expert))| (n_resident + index, expert))
+                        .collect();
+                    slots = permuted_slots;
+                    split_bounds = Some((n_resident, resident_assignments));
+                    plan_storage = Some(permuted);
+                }
+                let plan = plan_storage.as_ref().unwrap_or(&router.csr);
+                let expert_count = plan.union_experts.len();
                 let assignment_count = k_tokens * GEMMA4_MTP_ROUTE_COUNT;
                 s.memcpy_htod(
-                    &union_slots,
-                    &mut scratch.union_slots.slice_mut(0..expert_count),
-                )
-                .map_err(cu)?;
-                s.memcpy_htod(
-                    &router.csr.token_offsets,
+                    &plan.token_offsets,
                     &mut scratch
                         .token_offsets
                         .slice_mut(0..expert_count.saturating_add(1)),
                 )
                 .map_err(cu)?;
                 s.memcpy_htod(
-                    &router.csr.token_ids,
+                    &plan.token_ids,
                     &mut scratch.token_ids.slice_mut(0..assignment_count),
                 )
                 .map_err(cu)?;
                 s.memcpy_htod(
-                    &router.csr.route_to_assignment,
+                    &plan.route_to_assignment,
                     &mut scratch.route_to_assignment.slice_mut(0..assignment_count),
                 )
                 .map_err(cu)?;
@@ -12655,92 +13094,58 @@ impl Gemma4CudaResident {
                 )
                 .map_err(cu)?;
 
-                {
-                    let cache = self.sser.as_ref().unwrap().borrow();
-                    let (routed_kernel, chunked) = kernels.gemma4_mtp_q4_0_gemm_routed_kernel();
-                    crate::cuda_resident::launch_q4_0_gemm_routed(
-                        &s,
-                        routed_kernel,
-                        &scratch.in_s,
-                        &scratch.in_q,
-                        &cache.gate_up_arena,
-                        &scratch.union_slots,
-                        &scratch.token_offsets,
-                        &scratch.token_ids,
-                        cache.gate_up_stride,
-                        2 * moe.n_ff_exp,
-                        hidden / 32,
-                        expert_count,
-                        router.csr.max_assignments_per_expert,
-                        chunked,
-                        &mut scratch.expert_gate_up,
+                if let Some((n_resident, resident_assignments)) = split_bounds {
+                    // Partial slot map: missing entries are -1, and the resident
+                    // pass's expert range never indexes them.
+                    s.memcpy_htod(&slots, &mut scratch.union_slots.slice_mut(0..expert_count))
+                        .map_err(cu)?;
+                    self.mtp_kwide_launch_expert_range(
+                        scratch,
+                        moe,
+                        0,
+                        n_resident,
+                        0,
+                        resident_assignments,
+                        plan.max_assignments_per_expert,
+                    )?;
+                    // The GPU chews the resident range while this blocks on the
+                    // missing experts' tier/storage reads.
+                    let union_slots =
+                        self.mtp_kwide_fill_missing(li, moe, &plan.union_experts, slots, &missing)?;
+                    // In-order stream: this overwrite executes after the resident
+                    // launches read the partial map, and the missing launches sit
+                    // behind fill's expert_copy_done wait.
+                    s.memcpy_htod(
+                        &union_slots,
+                        &mut scratch.union_slots.slice_mut(0..expert_count),
                     )
                     .map_err(cu)?;
-                }
-                gemma4_launch_geglu_quantize_assignments(
-                    &s,
-                    &kernels.geglu_quantize_routed,
-                    &scratch.expert_gate_up,
-                    &scratch.assignment_ids,
-                    &mut scratch.expert_geglu_q,
-                    &mut scratch.expert_geglu_s,
-                    moe.n_ff_exp,
-                    assignment_count,
-                )
-                .map_err(cu)?;
-                {
-                    let cache = self.sser.as_ref().unwrap().borrow();
-                    match moe.down_exps.format {
-                        WireFormat::Q4_0 => {
-                            let (routed_kernel, chunked) =
-                                kernels.gemma4_mtp_q4_0_gemm_routed_kernel();
-                            crate::cuda_resident::launch_q4_0_gemm_routed(
-                                &s,
-                                routed_kernel,
-                                &scratch.expert_geglu_s,
-                                &scratch.expert_geglu_q,
-                                &cache.down_arena,
-                                &scratch.union_slots,
-                                &scratch.token_offsets,
-                                &scratch.assignment_ids,
-                                cache.down_stride,
-                                hidden,
-                                moe.n_ff_exp / 32,
-                                expert_count,
-                                router.csr.max_assignments_per_expert,
-                                chunked,
-                                &mut scratch.expert_y,
-                            )
-                            .map_err(cu)?
-                        }
-                        WireFormat::Q4_1 => {
-                            let (routed_kernel, chunked) =
-                                kernels.gemma4_mtp_q4_1_gemm_routed_kernel();
-                            crate::cuda_resident::launch_q4_1_gemm_routed(
-                                &s,
-                                routed_kernel,
-                                &scratch.expert_geglu_s,
-                                &scratch.expert_geglu_q,
-                                &cache.down_arena,
-                                &scratch.union_slots,
-                                &scratch.token_offsets,
-                                &scratch.assignment_ids,
-                                cache.down_stride,
-                                hidden,
-                                moe.n_ff_exp / 32,
-                                expert_count,
-                                router.csr.max_assignments_per_expert,
-                                chunked,
-                                &mut scratch.expert_y,
-                            )
-                            .map_err(cu)?
-                        }
-                        unsupported => {
-                            return Err(BackendError::UnsupportedGguf(format!(
-                                "Gemma 4 K-wide routed down projection does not support {unsupported:?}"
-                            )))
-                        }
-                    }
+                    self.mtp_kwide_launch_expert_range(
+                        scratch,
+                        moe,
+                        n_resident,
+                        expert_count - n_resident,
+                        resident_assignments,
+                        assignment_count - resident_assignments,
+                        plan.max_assignments_per_expert,
+                    )?;
+                } else {
+                    let union_slots =
+                        self.mtp_kwide_fill_missing(li, moe, &plan.union_experts, slots, &missing)?;
+                    s.memcpy_htod(
+                        &union_slots,
+                        &mut scratch.union_slots.slice_mut(0..expert_count),
+                    )
+                    .map_err(cu)?;
+                    self.mtp_kwide_launch_expert_range(
+                        scratch,
+                        moe,
+                        0,
+                        expert_count,
+                        0,
+                        assignment_count,
+                        plan.max_assignments_per_expert,
+                    )?;
                 }
                 crate::cuda_resident::launch_moe_weighted_sum_batched(
                     &s,

--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -426,6 +426,23 @@ mod gemma4_mtp_io_pipeline_tests {
 }
 
 #[cfg(test)]
+mod gemma4_ghost_arena_soa_tests {
+    use super::gemma4_ghost_arena_soa_policy;
+
+    #[test]
+    fn arena_soa_gate_is_default_off_and_strictly_zero_or_one() {
+        assert_eq!(gemma4_ghost_arena_soa_policy(None), Ok(false));
+        assert_eq!(gemma4_ghost_arena_soa_policy(Some("0")), Ok(false));
+        assert_eq!(gemma4_ghost_arena_soa_policy(Some(" 1 ")), Ok(true));
+        for invalid in ["", "true", "on", "2", "01", "disabled"] {
+            let error = gemma4_ghost_arena_soa_policy(Some(invalid))
+                .expect_err("non-0/1 arena-SoA values must fail closed");
+            assert!(error.contains("must be exactly 0 or 1"), "{error}");
+        }
+    }
+}
+
+#[cfg(test)]
 mod gemma4_mtp_prefill_seed_tests {
     use super::{gemma4_mtp_prefill_seed_policy, ChunkLogits};
 
@@ -8126,6 +8143,11 @@ struct SserHostTier {
     hits: u64,
     misses: u64,
     bytes_read: u64,
+    /// `CAMELID_GEMMA4_GHOST_ARENA_SOA=1`: every record is repacked to the
+    /// quants-first SoA layout AT INSERT (storage read -> tier slot), so the
+    /// HtoD path DMAs the already-repacked bytes unchanged and the arenas hold
+    /// exactly what the SoA kernels read. Every tier fill site must honor this.
+    soa_repack: bool,
 }
 
 #[cfg(feature = "cuda")]
@@ -8552,6 +8574,50 @@ fn gemma4_mtp_resident_split_policy(value: Option<&str>) -> std::result::Result<
             "{GEMMA4_MTP_RESIDENT_SPLIT_ENV} must be exactly 0 or 1; got {other:?}"
         )),
     }
+}
+
+#[cfg(any(feature = "cuda", test))]
+const GEMMA4_GHOST_ARENA_SOA_ENV: &str = "CAMELID_GEMMA4_GHOST_ARENA_SOA";
+
+/// Strict parser for the routed-arena SoA repack gate, mirroring
+/// [`gemma4_mtp_io_pipeline_policy`]: a typo fails model load instead of
+/// silently selecting a lane the receipt did not request.
+#[cfg(any(feature = "cuda", test))]
+fn gemma4_ghost_arena_soa_policy(value: Option<&str>) -> std::result::Result<bool, String> {
+    match value.map(str::trim) {
+        None | Some("0") => Ok(false),
+        Some("1") => Ok(true),
+        Some(other) => Err(format!(
+            "{GEMMA4_GHOST_ARENA_SOA_ENV} must be exactly 0 or 1; got {other:?}"
+        )),
+    }
+}
+
+/// Repack the Q4_0 projection regions of one staged expert record in place,
+/// wherever record bytes are STAGED for the arenas (page-locked tier slot or
+/// pinned transfer-ring slot), off the GPU critical path. Non-Q4_0 regions
+/// (the Q4_1 down variant) stay byte-identical wire. The scratch is
+/// thread-local because `ensure_resident_many` runs its reads on a rayon pool.
+#[cfg(feature = "cuda")]
+fn gemma4_arena_soa_repack_record(
+    record: &mut [u8],
+    layout: &crate::ghost::GhostMoeExpertRecordLayout,
+) {
+    thread_local! {
+        static SOA_SCRATCH: std::cell::RefCell<Vec<u8>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+    SOA_SCRATCH.with(|scratch| {
+        let mut scratch = scratch.borrow_mut();
+        crate::cuda_resident::q4_0_record_wire_to_soa(
+            record,
+            layout.gate_up.clone(),
+            layout.gate_up_dtype == GgufTensorType::Q4_0,
+            layout.down.clone(),
+            layout.down_dtype == GgufTensorType::Q4_0,
+            &mut scratch,
+        );
+    });
 }
 
 /// Plan ordered read groups and the host-tier prefix made ready by each group.
@@ -9119,6 +9185,7 @@ impl SserHostTier {
         ghost: &GhostFile,
         budget_bytes: usize,
         eviction_policy: SserHostTierEvictionPolicy,
+        soa_repack: bool,
     ) -> Result<Option<Self>> {
         if budget_bytes == 0 {
             return Ok(None);
@@ -9158,6 +9225,7 @@ impl SserHostTier {
                 hits: 0,
                 misses: 0,
                 bytes_read: 0,
+                soa_repack,
             }));
         }
         // Otherwise take what the host will give, in chunks, and keep it. Stopping
@@ -9211,6 +9279,7 @@ impl SserHostTier {
             hits: 0,
             misses: 0,
             bytes_read: 0,
+            soa_repack,
         }))
     }
 
@@ -9275,7 +9344,8 @@ impl SserHostTier {
         // Reads land in the page-locked tier slot without a caller-owned Vec. Windows'
         // NO_BUFFERING reader still copies once from its sector-aligned private scratch.
         let (chunk_idx, chunk_off) = self.slot_location(slot);
-        let expert_len = ghost.moe_expert_record_layout(layer, expert)?.byte_len;
+        let layout = ghost.moe_expert_record_layout(layer, expert)?;
+        let expert_len = layout.byte_len;
         let t_read = sser_profile_enabled().then(std::time::Instant::now);
         let read_result = ghost.read_moe_expert_into(
             layer,
@@ -9293,6 +9363,12 @@ impl SserHostTier {
         if let Err(error) = read_result {
             self.free_slots.push(slot);
             return Err(error);
+        }
+        if self.soa_repack {
+            gemma4_arena_soa_repack_record(
+                &mut self.chunks[chunk_idx].slice_mut(chunk_off, stride)[..expert_len],
+                &layout,
+            );
         }
         self.misses += 1;
         self.bytes_read = self.bytes_read.saturating_add(expert_len as u64);
@@ -9432,12 +9508,21 @@ impl SserHostTier {
             return Ok(resolved);
         }
 
+        let soa_repack = self.soa_repack;
         let read_one = |read: &PendingRead| {
             // SAFETY: see the reservation invariant above. `destination..destination+len`
             // is unique for this job and lies inside one live page-locked tier slot.
             let destination =
                 unsafe { std::slice::from_raw_parts_mut(read.destination as *mut u8, read.len) };
-            ghost.read_moe_expert_into(layer, read.expert, destination)
+            ghost.read_moe_expert_into(layer, read.expert, &mut destination[..])?;
+            if soa_repack {
+                // Repack on the read worker, before the record becomes visible
+                // to the DMA callback: each job owns its slot exclusively, and
+                // the repack scratch is thread-local.
+                let layout = ghost.moe_expert_record_layout(layer, read.expert)?;
+                gemma4_arena_soa_repack_record(destination, &layout);
+            }
+            Ok(())
         };
         let pending_ordinals = pending.iter().map(|read| read.ordinal).collect::<Vec<_>>();
         let batches = if on_ready.is_some() {
@@ -9565,8 +9650,8 @@ impl SserHostTier {
                 };
                 let stride = self.stride;
                 let (chunk_idx, chunk_off) = self.slot_location(slot);
-                let expert_len = match ghost.moe_expert_byte_len(layer, expert) {
-                    Ok(len) => len,
+                let layout = match ghost.moe_expert_record_layout(layer, expert) {
+                    Ok(layout) => layout,
                     Err(e) => {
                         self.free_slots.push(slot);
                         eprintln!(
@@ -9575,12 +9660,20 @@ impl SserHostTier {
                         break 'fill;
                     }
                 };
+                let expert_len = layout.byte_len;
                 match ghost.read_moe_expert_into(
                     layer,
                     expert,
                     &mut self.chunks[chunk_idx].slice_mut(chunk_off, stride)[..expert_len],
                 ) {
                     Ok(()) => {
+                        if self.soa_repack {
+                            gemma4_arena_soa_repack_record(
+                                &mut self.chunks[chunk_idx].slice_mut(chunk_off, stride)
+                                    [..expert_len],
+                                &layout,
+                            );
+                        }
                         self.entries.insert(
                             (layer as u16, expert as u16),
                             SserHostEntry { slot, last_used: 0 },
@@ -10640,6 +10733,12 @@ pub struct Gemma4CudaResident {
     /// Opt-in QD4 read/HtoD pipeline for K-wide expert unions. Parsed strictly
     /// once at load so a typo cannot vary behavior between verifier layers.
     mtp_io_pipeline: bool,
+    /// Opt-in quants-first SoA layout for the routed Q4_0 expert arenas
+    /// (`CAMELID_GEMMA4_GHOST_ARENA_SOA`). Records are repacked where they are
+    /// STAGED (host-tier insert / transfer-ring fill), the HtoD path is
+    /// unchanged, and both routed consumers (scalar GEMV, K-wide GEMM) switch
+    /// to the bitwise-identical SoA kernels. Parsed strictly once at load.
+    ghost_arena_soa: bool,
     /// Opt-in resident-first split of the K-wide routed GEMMs: enqueue the
     /// already-resident expert range's compute before the CPU blocks on the
     /// missing experts' storage reads, then run the missing range after its
@@ -10772,6 +10871,15 @@ impl Gemma4CudaResident {
         if mtp_device_draft_chain {
             eprintln!(
                 "[gemma4-mtp-cuda] device draft chain ON: assistant argmax feeds the next embedding via a Q6_K head-row gather"
+            );
+        }
+        let ghost_arena_soa = gemma4_ghost_arena_soa_policy(
+            std::env::var(GEMMA4_GHOST_ARENA_SOA_ENV).ok().as_deref(),
+        )
+        .map_err(BackendError::InvalidModelMetadata)?;
+        if ghost_arena_soa {
+            eprintln!(
+                "[gemma4-mtp-cuda] routed expert arena SoA ON: Q4_0 expert records repacked quants-first at staging; routed consumers use the SoA kernels"
             );
         }
         let ghost_moe = cpu.ghost_moe_cache.is_some();
@@ -11226,6 +11334,58 @@ impl Gemma4CudaResident {
                 )
             })
             .unwrap_or(true);
+        // Fail-closed eligibility for the routed-arena SoA repack. The invariant
+        // the gate promises is "every Q4_0 expert region in every arena is SoA,
+        // and every consumer of a Q4_0 region uses an SoA kernel"; any
+        // configuration with a consumer or fill path outside that invariant is a
+        // typed LOAD error, never a silent wire/SoA mix.
+        if ghost_arena_soa {
+            if !routed_batch_enabled {
+                return Err(BackendError::InvalidModelMetadata(format!(
+                    "{GEMMA4_GHOST_ARENA_SOA_ENV}=1 requires the batched routed expert path; the serial diagnostic lane (CAMELID_GEMMA4_CUDA_BATCHED_EXPERTS=0) reads the arenas as raw wire"
+                )));
+            }
+            if gemma4_cuda_routed_rows_per_warp() > 1 {
+                return Err(BackendError::InvalidModelMetadata(format!(
+                    "{GEMMA4_GHOST_ARENA_SOA_ENV}=1 has no SoA twin of q4_0_gemv_routed_rows; unset CAMELID_GEMMA4_CUDA_ROUTED_ROWS"
+                )));
+            }
+            let mut q4_0_regions = 0usize;
+            for (l, layer) in cpu.layers.iter().enumerate() {
+                let Some(moe) = layer.moe.as_ref() else {
+                    continue;
+                };
+                let gu_fmt = moe.gate_up_exps.format;
+                let down_fmt = moe.down_exps.format;
+                if gu_fmt != WireFormat::Q4_0
+                    || !matches!(down_fmt, WireFormat::Q4_0 | WireFormat::Q4_1)
+                {
+                    return Err(BackendError::InvalidModelMetadata(format!(
+                        "{GEMMA4_GHOST_ARENA_SOA_ENV}=1 supports Q4_0 gate/up with a Q4_0 or Q4_1 down projection; layer {l} has gate_up={gu_fmt:?} down={down_fmt:?}"
+                    )));
+                }
+                // The SoA kernels read the quant plane as aligned uint4, so every
+                // Q4_0 region's byte length (== its slot stride) must be a
+                // 16-byte multiple for every slot id.
+                let gu_bytes = 2 * moe.n_ff_exp * (hidden / 32 * 18);
+                let down_bytes = if down_fmt == WireFormat::Q4_0 {
+                    hidden * (moe.n_ff_exp / 32 * 18)
+                } else {
+                    hidden * (moe.n_ff_exp / 32 * 20)
+                };
+                if !gu_bytes.is_multiple_of(16) || !down_bytes.is_multiple_of(16) {
+                    return Err(BackendError::InvalidModelMetadata(format!(
+                        "{GEMMA4_GHOST_ARENA_SOA_ENV}=1 requires 16-byte-aligned expert slot strides; layer {l} has gate_up={gu_bytes} down={down_bytes} bytes"
+                    )));
+                }
+                q4_0_regions += 1 + usize::from(down_fmt == WireFormat::Q4_0);
+            }
+            if q4_0_regions == 0 {
+                return Err(BackendError::InvalidModelMetadata(format!(
+                    "{GEMMA4_GHOST_ARENA_SOA_ENV}=1 requires routed Q4_0 MoE expert records; this model has none"
+                )));
+            }
+        }
         let host_tier_eviction_policy =
             match std::env::var_os("CAMELID_GEMMA4_GHOST_HOST_TIER_EVICTION") {
                 None => parse_sser_host_tier_eviction_policy(None)?,
@@ -11250,6 +11410,7 @@ impl Gemma4CudaResident {
                     &ghost_cache.file,
                     host_tier_budget_bytes,
                     host_tier_eviction_policy,
+                    ghost_arena_soa,
                 ) {
                     Ok(tier) => tier,
                     Err(e) => {
@@ -11362,6 +11523,7 @@ impl Gemma4CudaResident {
             verify_scratch: None,
             mtp_kwide_last_completed: std::cell::Cell::new(false),
             mtp_io_pipeline,
+            ghost_arena_soa,
             mtp_resident_split,
             mtp_device_draft_chain,
             mtp_cuda_assistant: None,
@@ -12494,7 +12656,8 @@ impl Gemma4CudaResident {
         let hidden = self.hidden;
         {
             let cache = self.sser.as_ref().unwrap().borrow();
-            let (routed_kernel, chunked) = kernels.gemma4_mtp_q4_0_gemm_routed_kernel();
+            let (routed_kernel, chunked) =
+                kernels.gemma4_mtp_q4_0_gemm_routed_kernel(self.ghost_arena_soa);
             crate::cuda_resident::launch_q4_0_gemm_routed_range(
                 s,
                 routed_kernel,
@@ -12531,7 +12694,8 @@ impl Gemma4CudaResident {
             let cache = self.sser.as_ref().unwrap().borrow();
             match moe.down_exps.format {
                 WireFormat::Q4_0 => {
-                    let (routed_kernel, chunked) = kernels.gemma4_mtp_q4_0_gemm_routed_kernel();
+                    let (routed_kernel, chunked) =
+                        kernels.gemma4_mtp_q4_0_gemm_routed_kernel(self.ghost_arena_soa);
                     crate::cuda_resident::launch_q4_0_gemm_routed_range(
                         s,
                         routed_kernel,
@@ -13755,6 +13919,16 @@ impl Gemma4CudaResident {
                             );
                         }
                         read_result?;
+                        if self.ghost_arena_soa {
+                            // Same staging contract as the host tier: the ring
+                            // slot holds the repacked record BEFORE its ranges
+                            // become DMA sources, so the arenas always receive
+                            // the layout the SoA kernels read.
+                            gemma4_arena_soa_repack_record(
+                                transfer.record.slice_mut(0, layout.byte_len),
+                                &layout,
+                            );
+                        }
                         let record = transfer.record.slice(0, layout.byte_len);
                         pending[pending_index] = SserPinnedBatchCopy {
                             key: (l as u16, expert as u16),
@@ -13976,8 +14150,19 @@ impl Gemma4CudaResident {
                             })?;
                         let record = transfer.record.slice_mut(0, record_len);
                         let (gu_buf, down_buf) = record.split_at_mut(expected_gu);
-                        gu_buf.copy_from_slice(gu_host);
-                        down_buf.copy_from_slice(down_host);
+                        // Under the arena-SoA gate the ring stages the repacked
+                        // form directly (source and destination are disjoint, so
+                        // no scratch); non-Q4_0 regions stay byte-identical wire.
+                        if self.ghost_arena_soa && gu_fmt == WireFormat::Q4_0 {
+                            crate::cuda_resident::q4_0_wire_to_soa_into(gu_host, gu_buf);
+                        } else {
+                            gu_buf.copy_from_slice(gu_host);
+                        }
+                        if self.ghost_arena_soa && down_fmt == WireFormat::Q4_0 {
+                            crate::cuda_resident::q4_0_wire_to_soa_into(down_host, down_buf);
+                        } else {
+                            down_buf.copy_from_slice(down_host);
+                        }
                         self.expert_copy_stream
                             .memcpy_htod(
                                 gu_buf,
@@ -13991,9 +14176,28 @@ impl Gemma4CudaResident {
                             )
                             .map_err(cu)?;
                     } else {
+                        // Pageable direct path: every arena fill must produce the
+                        // gate's layout, so repack Q4_0 regions into a temporary
+                        // before the copy (this opt-out lane already pays a
+                        // pageable staging copy inside the driver).
+                        let gu_soa;
+                        let gu_src: &[u8] = if self.ghost_arena_soa && gu_fmt == WireFormat::Q4_0 {
+                            gu_soa = crate::cuda_resident::q4_0_wire_to_soa(gu_host);
+                            &gu_soa
+                        } else {
+                            gu_host
+                        };
+                        let down_soa;
+                        let down_src: &[u8] =
+                            if self.ghost_arena_soa && down_fmt == WireFormat::Q4_0 {
+                                down_soa = crate::cuda_resident::q4_0_wire_to_soa(down_host);
+                                &down_soa
+                            } else {
+                                down_host
+                            };
                         self.expert_copy_stream
                             .memcpy_htod(
-                                gu_host,
+                                gu_src,
                                 &mut cache
                                     .gate_up_arena
                                     .slice_mut(gu_start..gu_start + expected_gu),
@@ -14001,7 +14205,7 @@ impl Gemma4CudaResident {
                             .map_err(cu)?;
                         self.expert_copy_stream
                             .memcpy_htod(
-                                down_host,
+                                down_src,
                                 &mut cache
                                     .down_arena
                                     .slice_mut(down_start..down_start + expected_down),
@@ -14087,7 +14291,11 @@ impl Gemma4CudaResident {
                 let rows_i = rows as i32;
                 let blocks_i = blocks as i32;
                 let rows_per_warp_i = rows_per_warp as i32;
-                let mut builder = s.launch_builder(if rows_per_warp > 1 {
+                // The arena-SoA gate refused CAMELID_GEMMA4_CUDA_ROUTED_ROWS>1 at
+                // load, so the SoA arm here is always the scalar one-row shape.
+                let mut builder = s.launch_builder(if self.ghost_arena_soa {
+                    &k.q4_0_gemv_routed_soa
+                } else if rows_per_warp > 1 {
                     &k.q4_0_gemv_routed_rows
                 } else {
                     &k.q4_0_gemv_routed

--- a/src/gemma4_runtime.rs
+++ b/src/gemma4_runtime.rs
@@ -252,6 +252,49 @@ mod gemma4_mtp_resident_split_tests {
     }
 
     #[test]
+    fn promoted_profile_respects_user_overrides_and_excludes_refuted_gates() {
+        use super::{gemma4_mtp_profile_defaults_to_apply, GEMMA4_MTP_PROMOTED_PROFILE};
+        // Nothing set: the whole profile applies.
+        let all = gemma4_mtp_profile_defaults_to_apply(|_| false);
+        assert_eq!(all.len(), GEMMA4_MTP_PROMOTED_PROFILE.len());
+        // A user-set variable is never overridden.
+        let filtered =
+            gemma4_mtp_profile_defaults_to_apply(|key| key == "CAMELID_GEMMA4_MTP_KWIDE");
+        assert!(filtered
+            .iter()
+            .all(|(key, _)| *key != "CAMELID_GEMMA4_MTP_KWIDE"));
+        assert_eq!(filtered.len(), GEMMA4_MTP_PROMOTED_PROFILE.len() - 1);
+        // Fixture caps and measured-null/regression gates must never ride in.
+        for refuted in [
+            "CAMELID_GEMMA4_GHOST_CUDA_CONTEXT",
+            "CAMELID_GEMMA4_MTP_DEVICE_DRAFT_CHAIN",
+            "CAMELID_GEMMA4_GHOST_ARENA_SOA",
+        ] {
+            assert!(
+                GEMMA4_MTP_PROMOTED_PROFILE
+                    .iter()
+                    .all(|(key, _)| *key != refuted),
+                "{refuted} must not be in the promoted profile"
+            );
+        }
+        // Every strict-parsed member must parse under its own gate.
+        let value_of = |key: &str| {
+            GEMMA4_MTP_PROMOTED_PROFILE
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| *v)
+        };
+        assert_eq!(
+            super::gemma4_mtp_io_pipeline_policy(value_of("CAMELID_GEMMA4_MTP_IO_PIPELINE")),
+            Ok(true)
+        );
+        assert_eq!(
+            super::gemma4_mtp_resident_split_policy(value_of("CAMELID_GEMMA4_MTP_RESIDENT_SPLIT")),
+            Ok(true)
+        );
+    }
+
+    #[test]
     fn device_draft_chain_gate_is_default_off_and_strictly_zero_or_one() {
         assert_eq!(gemma4_mtp_device_draft_chain_policy(None), Ok(false));
         assert_eq!(gemma4_mtp_device_draft_chain_policy(Some("0")), Ok(false));
@@ -8544,6 +8587,52 @@ const GEMMA4_MTP_RESIDENT_SPLIT_ENV: &str = "CAMELID_GEMMA4_MTP_RESIDENT_SPLIT";
 /// slots (`-1` = not resident) and the missing entries as `(union_index, expert)`.
 #[cfg(feature = "cuda")]
 type Gemma4KwideTouchedUnion = (Vec<i32>, Vec<(usize, usize)>);
+
+/// The receipted Windows MTP profile: the environment the composed K-wide arm
+/// measured 25.7–26.3 whole-decode tok/s with on the 16 GiB reference box
+/// (BASELINE-2026-08-24 §16–17, arm `…-io-lfu-q6-anchor-rsplit`). The CLI
+/// applies these as DEFAULTS when `--mtp-assistant` selects the MTP lane, for
+/// every variable the user has not set — an explicit value always wins, so any
+/// receipted arm reproduces byte-for-byte. The plain lane never sees this:
+/// several members (QD4 batch reads, the read pools) measured NEGATIVE or null
+/// for scalar decode, which is exactly why these are a lane profile and not
+/// global default flips.
+///
+/// Deliberately absent: `CAMELID_GEMMA4_GHOST_CUDA_CONTEXT` (a benchmark
+/// fixture cap, not a serving default), `CAMELID_GEMMA4_MTP_DEVICE_DRAFT_CHAIN`
+/// (measured null), and `CAMELID_GEMMA4_GHOST_ARENA_SOA` (measured regression).
+#[cfg(any(feature = "cuda", test))]
+pub const GEMMA4_MTP_PROMOTED_PROFILE: &[(&str, &str)] = &[
+    ("CAMELID_GEMMA4_CUDA_BATCH_EXPERT_COPIES", "1"),
+    ("CAMELID_GEMMA4_PREFILL_CHUNK_TOKENS", "512"),
+    ("CAMELID_GEMMA4_Q4_0_SOA", "1"),
+    ("CAMELID_GEMMA4_SPECULATIVE", "0"),
+    ("CAMELID_GEMMA4_GHOST_BATCH_READS", "1"),
+    ("CAMELID_GEMMA4_GHOST_READ_THREADS", "4"),
+    ("CAMELID_GEMMA4_GHOST_UNCACHED_READERS", "4"),
+    ("CAMELID_GEMMA4_MTP_KWIDE", "1"),
+    ("CAMELID_GEMMA4_MTP_PREFILL_SEED_BOOTSTRAP", "1"),
+    ("CAMELID_GEMMA4_MTP_CUDA_ASSISTANT", "1"),
+    ("CAMELID_GEMMA4_GHOST_HOST_TIER_EVICTION", "mru"),
+    ("CAMELID_GEMMA4_MTP_IO_PIPELINE", "1"),
+    ("CAMELID_GEMMA4_GHOST_CUDA_EVICTION", "lfu"),
+    ("CAMELID_GEMMA4_MTP_DENSE_Q6_ANCHOR_DP4A", "1"),
+    ("CAMELID_GEMMA4_MTP_RESIDENT_SPLIT", "1"),
+];
+
+/// The subset of [`GEMMA4_MTP_PROMOTED_PROFILE`] to actually apply, given which
+/// variables are already set. Pure so the override contract is unit-testable
+/// without touching the process environment.
+#[cfg(any(feature = "cuda", test))]
+pub fn gemma4_mtp_profile_defaults_to_apply(
+    is_set: impl Fn(&str) -> bool,
+) -> Vec<(&'static str, &'static str)> {
+    GEMMA4_MTP_PROMOTED_PROFILE
+        .iter()
+        .copied()
+        .filter(|(key, _)| !is_set(key))
+        .collect()
+}
 
 #[cfg(any(feature = "cuda", test))]
 const GEMMA4_MTP_DEVICE_DRAFT_CHAIN_ENV: &str = "CAMELID_GEMMA4_MTP_DEVICE_DRAFT_CHAIN";

--- a/src/main.rs
+++ b/src/main.rs
@@ -2348,7 +2348,11 @@ enum Command {
         /// Maximum draft tokens proposed per verify round. The default-off
         /// `CAMELID_GEMMA4_MTP_WIDTH_SCHEDULE` instead names verifier widths
         /// (current target row plus drafts), each bounded by this value plus one.
-        #[arg(long, default_value_t = 8)]
+        /// Default 7: on the frozen H40 fixture K=7 accepted every draft
+        /// (alpha 7.00) and beat both K=6 and K=8 paired
+        /// (BASELINE-2026-08-24 §16); K=8's extra row hit the known
+        /// content-boundary miss and paid union bytes for nothing.
+        #[arg(long, default_value_t = 7)]
         mtp_draft_k: usize,
         /// OpenAI-shaped chat request to run instead of `--prompt`, templated through the
         /// SAME renderer `/v1/chat/completions` uses. This is how an offline throughput
@@ -4595,6 +4599,30 @@ async fn main() -> anyhow::Result<()> {
                 .as_deref()
                 .map(gemma4_harness_expected)
                 .transpose()?;
+            // The MTP lane's receipted profile becomes the default the moment the
+            // lane is selected — BEFORE the model load, where every gate resolves.
+            // An explicitly set variable always wins, so receipted arms reproduce
+            // byte-for-byte, and the plain lane (no --mtp-assistant) is untouched.
+            if mtp_assistant.is_some() {
+                let applied =
+                    camelid::gemma4_runtime::gemma4_mtp_profile_defaults_to_apply(|key| {
+                        std::env::var_os(key).is_some()
+                    });
+                if !applied.is_empty() {
+                    for (key, value) in &applied {
+                        std::env::set_var(key, value);
+                    }
+                    eprintln!(
+                        "[gemma4-mtp] promoted profile: {} default(s) applied ({})",
+                        applied.len(),
+                        applied
+                            .iter()
+                            .map(|(key, value)| format!("{key}={value}"))
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    );
+                }
+            }
             eprintln!("[gemma4-cuda] loading resident {}...", path.display());
             let t0 = std::time::Instant::now();
             let mut runtime = match cghost.as_deref() {


### PR DESCRIPTION
Takes the Windows 26B-A4B MTP lane from 17.3 to a receipted **25.7–26.3 whole-decode tok/s, token-exact**, and makes that number the default: \`--mtp-assistant <dir>\` with a clean environment now reproduces it on its own. Five commits, every claim paired ×3 with cooling on the frozen H40 fixture, all runs gated on the 48 Windows token ids.

## What's in here

**1. Resident-first verifier split (\`87c22ba9\`) — the win.**
The K-wide routed GEMMs fenced on \`expert_copy_done\` for the *entire* per-layer union, so already-resident experts idled while 2–4 missing records streamed from tier/NVMe (Nsight: zero copy/compute overlap). The union resolve is now touch/fill phases; the union is reordered residents-first (pure renumbering, unit-pinned); the routed GateUp→GeGLU→Down chain runs as two contiguous sub-range launches, the resident range enqueued before the CPU blocks on reads. Bit-identical by construction — each expert's fold happens whole in one launch, offsets stay absolute, the weighted sum consumes router order — and pinned on hardware by a two-pass range case in \`q4_0_gemm_routed_matches_gemv\`.
Paired ×3, one binary: **23.43/23.61/23.56 → 25.65/25.57/25.64** decode tok/s, verifier 310–313 → 282–284 ms/round, arena misses and storage reads byte-identical across arms (the cache trajectory is untouched; the delta is pure overlap). Opt-in \`CAMELID_GEMMA4_MTP_RESIDENT_SPLIT\`, promoted by commit 5.

**2. Device draft chain (\`3e34d701\`) — measured null, kept opt-in.**
Argmax→next-embedding on-device via a padded-Q6_K head-row gather (bitwise-pinned), one round-end DtoH instead of per-proposal syncs. Paired ×3: sign flips ±1% — the removed syncs were waiting on kernels that had to finish anyway. The unconditional rope-upload hoist (56 → 4 uploads/round, identical values) rides along.

**3. Routed-arena SoA / Step 05 (\`e64aa714\`) — measured regression, kept default-off.**
Parity-perfect (bitwise GPU pins for both consumers, every pre-existing routed pin green), but the CPU staging repack rides the QD4 read workers between read-completion and HtoD: **25.69/25.76/25.83 → 22.32/22.96/23.11**. ~30–50 ms/round of staging cost against a routed-GEMM kernel term of ~28 ms/round total. Standing control for a device-side post-copy repack variant, which would reuse these kernels and tests unchanged.

**4. Docs (\`fad4acbb\`) — BASELINE §17.**
Includes two levers killed *offline* via route-trace simulation before any code: tier-eviction hybrids (MRU 93 verify disk reads/round beats LRU 141 and every recency-protected variant) and cross-round expert prefetch (per-layer unions overlap 74–85% round-over-round, but the round's **disk reads are the unpredictable tail** — only 1–18% appear in the previous round's union; the storage column is closed on this RAM/VRAM budget).

**5. Promoted MTP profile (\`390d11ba\`) — the product step.**
\`GEMMA4_MTP_PROMOTED_PROFILE\` carries the fifteen receipted values; the CLI applies them as defaults when \`--mtp-assistant\` selects the lane, before the load where the gates resolve. Explicit env always wins (receipted arms reproduce byte-for-byte); the plain lane never sees the profile (QD4 batch reads measured −2.5% for scalar decode — this is a lane profile, not global flips). \`--mtp-draft-k\` defaults to the receipted 7. Promotion gate: bare-env arm vs full-env arm, paired ×3, within 0.3% every pair, identical misses and round walls, ids exact ×6.

## Verification

- \`cargo fmt\` / \`clippy --features cuda --all-targets\` zero warnings / full lib suite 2,057 passed
- GPU parity pins (all bitwise, \`-- --ignored\` on the RTX 3060): two-pass range split, Q6_K row gather, both SoA consumers, plus every pre-existing routed pin
- \`scripts/check-public-scrub.sh\` clean on every commit
- Receipts and verdicts in \`qa/perf/gemma4-mtp-h40/\` (BASELINE §16–§18, README arm table)