### PR TITLE
fix(api): undo a schema envelope a model echoes around tool arguments

### DIFF
--- a/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
+++ b/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
@@ -27,7 +27,7 @@
   },
   "implementation": {
     "source_file": "src/api/mod.rs",
-    "source_git_blob_sha1": "ecfac8933fd4d550c8e45f2822e7560e5f0a69ff",
+    "source_git_blob_sha1": "44ae7d32d48294c2e33dbcb6d12ca9c792ea506a",
     "architecture": "smollm3",
     "renderer": "render_smollm3_production_chat_prompt",
     "public_chokepoints": [

--- a/scripts/hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/hf-qualification-smollm3-chat-parity.mjs
@@ -93,11 +93,11 @@ const GROUNDING_FILES = Object.freeze({
   }),
   runtime_envelope: Object.freeze({
     path: 'qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json',
-    sha256: 'c99b9752db771529ff447a05993a6f1119095c15b53fca3bf3491468c2c8590e',
+    sha256: 'ed1c78e040903f616032ce00cdec1b7b7d6453db8854f713774f289a4a2ee5d9',
   }),
 })
 
-const RENDERER_GIT_BLOB_SHA1 = 'ecfac8933fd4d550c8e45f2822e7560e5f0a69ff'
+const RENDERER_GIT_BLOB_SHA1 = '44ae7d32d48294c2e33dbcb6d12ca9c792ea506a'
 const SHAPE_CASE_ID = 'default_think_single_user_generation_prompt'
 const NORMALIZED_PROMPT_UTF8_BYTES = 1_392
 const NORMALIZED_PROMPT_SHA256 = '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1'

--- a/scripts/test-hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/test-hf-qualification-smollm3-chat-parity.mjs
@@ -114,7 +114,7 @@ assert.deepEqual(TEMPLATE_IDENTITY, {
 assert.equal(GROUNDING_FILES.shape_pack.sha256,
   'd46794448b7c2585d0aa83dfd7bb17d4904c2dcbc048ade1ef68cd3863166de6')
 assert.equal(GROUNDING_FILES.runtime_envelope.sha256,
-  'c99b9752db771529ff447a05993a6f1119095c15b53fca3bf3491468c2c8590e')
+  'ed1c78e040903f616032ce00cdec1b7b7d6453db8854f713774f289a4a2ee5d9')
 assert.equal(LLAMA_PIN.executable_sha256,
   '6c787bf07ac1d7e1bbaa1ee176c3ef0df58ea86494c8c1b1d2d9f4a9176b19ae')
 assert.equal(LLAMA_PIN.server_impl_sha256,
@@ -331,7 +331,7 @@ assert.equal(classifySmolLM3ChatParityError(sharedSmolError).error_code,
 
 const committedGrounding = await inspectGroundings(root)
 assert.equal(committedGrounding.renderer_git_blob_sha1,
-  'ecfac8933fd4d550c8e45f2822e7560e5f0a69ff')
+  '44ae7d32d48294c2e33dbcb6d12ca9c792ea506a')
 assert.equal(committedGrounding.shape_case.normalized_prompt_sha256,
   '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1')
 const shapePack = JSON.parse(await readFile(resolve(GROUNDING_FILES.shape_pack.path), 'utf8'))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -35,6 +35,7 @@ mod metrics;
 mod responses;
 mod responses_store;
 mod server;
+mod tool_envelope;
 mod web_research;
 pub(crate) mod workspace;
 
@@ -15672,7 +15673,7 @@ async fn completions(
     if stream {
         // Text-completion streaming does not implement stream_options yet
         // (scope: chat-completions only), so usage is never emitted here.
-        return stream_completion(&state, prepared, false, false, false);
+        return stream_completion(&state, prepared, false, false, None);
     }
 
     // The decode runs on the engine worker; CancelOnDrop stops it within one
@@ -15907,6 +15908,11 @@ async fn chat_completions(
     };
     let tools_active = req.tools.as_ref().is_some_and(|tools| !tools.is_empty())
         && tool_choice_allows_calls(req.tool_choice.as_ref());
+    // Captured before `req` is consumed downstream. This is the only thing that
+    // authorises undoing a schema envelope the model echoed around its arguments.
+    let declared_tool_parameters = tool_envelope::ToolParameterNames::from_request_tools(
+        req.tools.as_deref().unwrap_or_default(),
+    );
     let tools_unsupported_on_lane = |lane: &str| {
         api_error(
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -16158,7 +16164,11 @@ async fn chat_completions(
             prepared,
             true,
             include_usage,
-            tools_active && !constraint_active,
+            if tools_active && !constraint_active {
+                Some(declared_tool_parameters)
+            } else {
+                None
+            },
         );
     }
 
@@ -16205,7 +16215,7 @@ async fn chat_completions(
             // request supplied tools and tool_choice permits it. On a tool call,
             // content is emptied and finish_reason flips to "tool_calls".
             let tool_calls = if should_parse_tool_calls(tools_active, constraint_active) {
-                parse_tool_calls(&content)
+                parse_tool_calls(&content, &declared_tool_parameters)
             } else {
                 None
             };
@@ -20299,7 +20309,14 @@ fn should_parse_tool_calls(tools_active: bool, constraint_active: bool) -> bool 
 /// The parser tolerates trailing junk after a complete JSON value but remains
 /// strict about function names and JSON arguments, so ordinary prose is never
 /// reclassified as a call.
-fn parse_tool_calls(text: &str) -> Option<Vec<ToolCall>> {
+///
+/// `declared` carries the parameter names the request advertised, which is what
+/// authorises undoing a schema envelope the model echoed around its arguments;
+/// see [`tool_envelope`].
+fn parse_tool_calls(
+    text: &str,
+    declared: &tool_envelope::ToolParameterNames,
+) -> Option<Vec<ToolCall>> {
     let trimmed = text.trim();
     let trimmed = trimmed
         .strip_prefix("<|python_tag|>")
@@ -20335,7 +20352,7 @@ fn parse_tool_calls(text: &str) -> Option<Vec<ToolCall>> {
         .collect::<Vec<_>>();
     let calls = values
         .iter()
-        .filter_map(tool_call_from_value)
+        .filter_map(|value| tool_call_from_value(value, declared))
         .collect::<Vec<_>>();
     (!calls.is_empty()).then_some(calls)
 }
@@ -20347,7 +20364,10 @@ fn first_json_value(text: &str) -> Option<serde_json::Value> {
         .ok()
 }
 
-fn tool_call_from_value(value: &serde_json::Value) -> Option<ToolCall> {
+fn tool_call_from_value(
+    value: &serde_json::Value,
+    declared: &tool_envelope::ToolParameterNames,
+) -> Option<ToolCall> {
     let obj = value.as_object()?;
     let function = obj.get("function").and_then(serde_json::Value::as_object);
     let name = function
@@ -20370,6 +20390,7 @@ fn tool_call_from_value(value: &serde_json::Value) -> Option<ToolCall> {
         }
         args => args,
     };
+    let args = tool_envelope::unwrap_schema_envelope(name, args, declared);
     let arguments = serde_json::to_string(&args).ok()?;
     Some(ToolCall {
         id: format!("call_{}", uuid::Uuid::new_v4().simple()),
@@ -21433,7 +21454,7 @@ fn stream_completion(
     mut prepared: PreparedGeneration,
     chat: bool,
     include_usage: bool,
-    parse_stream_tool_calls: bool,
+    stream_tool_calls: Option<tool_envelope::ToolParameterNames>,
 ) -> Response {
     // Speculation only runs in the non-streaming loop; streaming requests on
     // a spec-enabled server keep the unchanged vanilla path (including the
@@ -21526,7 +21547,7 @@ fn stream_completion(
                             Some(stream_started.elapsed().as_millis());
                     }
                     if chat {
-                        if parse_stream_tool_calls {
+                        if stream_tool_calls.is_some() {
                             tool_candidate.push_str(&delta);
                             continue;
                         }
@@ -21589,8 +21610,8 @@ fn stream_completion(
                     });
                     if chat {
                         let mut resolved_finish_reason = finish_reason;
-                        if parse_stream_tool_calls {
-                            if let Some(tool_calls) = parse_tool_calls(&tool_candidate) {
+                        if let Some(declared) = stream_tool_calls.as_ref() {
+                            if let Some(tool_calls) = parse_tool_calls(&tool_candidate, declared) {
                                 resolved_finish_reason = "tool_calls";
                                 let tool_calls = tool_calls
                                     .into_iter()
@@ -24610,7 +24631,7 @@ mod tests {
             orphan_test_prepared("model-a.gguf"),
             true,
             false,
-            false,
+            None,
         );
 
         // Drive the SSE body the way a client does. The reader task polls the
@@ -25072,6 +25093,12 @@ mod tests {
         assert!(validate_choice_and_logprob_fields(&oob).is_err());
     }
 
+    /// No tools declared, so the schema-envelope repair can never fire: these
+    /// cases must behave exactly as they did before it existed.
+    fn no_declared_tools() -> tool_envelope::ToolParameterNames {
+        tool_envelope::ToolParameterNames::from_request_tools(&[])
+    }
+
     #[test]
     fn constrained_output_is_never_reclassified_as_tool_call() {
         // M3 regression: a schema that legitimately declares a `name` property
@@ -25081,7 +25108,7 @@ mod tests {
         // "tool_calls"). OpenAI allows tools + response_format together.
         let constrained_content = r#"{"name":"x","parameters":{}}"#;
         assert!(
-            parse_tool_calls(constrained_content).is_some(),
+            parse_tool_calls(constrained_content, &no_declared_tools()).is_some(),
             "the gate, not the parser, is what protects constrained output"
         );
         assert!(!should_parse_tool_calls(true, true));
@@ -25093,8 +25120,11 @@ mod tests {
     #[test]
     fn parse_tool_calls_extracts_llama_format() {
         // Llama 3.x: {"name", "parameters"}; arguments becomes a JSON string.
-        let tc = parse_tool_calls(r#"{"name": "get_weather", "parameters": {"city": "Paris"}}"#)
-            .unwrap();
+        let tc = parse_tool_calls(
+            r#"{"name": "get_weather", "parameters": {"city": "Paris"}}"#,
+            &no_declared_tools(),
+        )
+        .unwrap();
         assert_eq!(tc.len(), 1);
         assert_eq!(tc[0].function.name, "get_weather");
         assert_eq!(tc[0].kind, "function");
@@ -25104,16 +25134,51 @@ mod tests {
     }
 
     #[test]
+    fn a_schema_envelope_echoed_by_the_model_is_unwrapped_for_the_client() {
+        // Observed on Llama-3.2-1B-Instruct-Q8_0: the model replied with the
+        // schema shape it was shown, leaving `arguments.city` unreachable to an
+        // ordinary OpenAI client.
+        let echoed = r#"{"name": "get_weather", "parameters": {"properties": {"city": "Paris"}}}"#;
+        let declared =
+            tool_envelope::ToolParameterNames::from_request_tools(&[serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"]
+                    }
+                }
+            })]);
+
+        let repaired = parse_tool_calls(echoed, &declared).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&repaired[0].function.arguments).unwrap();
+        assert_eq!(args, serde_json::json!({"city": "Paris"}));
+
+        // The declared schema is the only thing that authorises the rewrite: with
+        // no tools declared the model's output is relayed exactly as produced.
+        let untouched = parse_tool_calls(echoed, &no_declared_tools()).unwrap();
+        let args: serde_json::Value =
+            serde_json::from_str(&untouched[0].function.arguments).unwrap();
+        assert_eq!(args, serde_json::json!({"properties": {"city": "Paris"}}));
+    }
+
+    #[test]
     fn parse_tool_calls_tolerates_python_tag_and_junk() {
         // python_tag prefix + trailing junk small models emit; "arguments" variant.
-        let tc = parse_tool_calls(r#"<|python_tag|>{"name": "f", "arguments": {"x": 1}} trailing"#)
-            .unwrap();
+        let tc = parse_tool_calls(
+            r#"<|python_tag|>{"name": "f", "arguments": {"x": 1}} trailing"#,
+            &no_declared_tools(),
+        )
+        .unwrap();
         assert_eq!(tc[0].function.name, "f");
         let args: serde_json::Value = serde_json::from_str(&tc[0].function.arguments).unwrap();
         assert_eq!(args["x"], 1);
         // prose is not a tool call; a JSON object without "name" is not either.
-        assert!(parse_tool_calls("The weather in Paris is sunny.").is_none());
-        assert!(parse_tool_calls(r#"{"parameters": {"x": 1}}"#).is_none());
+        assert!(parse_tool_calls("The weather in Paris is sunny.", &no_declared_tools()).is_none());
+        assert!(parse_tool_calls(r#"{"parameters": {"x": 1}}"#, &no_declared_tools()).is_none());
     }
 
     #[test]
@@ -25121,6 +25186,7 @@ mod tests {
         let qwen = parse_tool_calls(
             r#"<tool_call>{"name":"read_file","arguments":{"path":"a.txt"}}</tool_call>
 <tool_call>{"name":"list_dir","arguments":{"path":"."}}</tool_call>"#,
+            &no_declared_tools(),
         )
         .unwrap();
         assert_eq!(qwen.len(), 2);
@@ -25130,6 +25196,7 @@ mod tests {
 
         let mistral = parse_tool_calls(
             r#"[TOOL_CALLS] [{"name":"read_file","arguments":"{\"path\":\"b.txt\"}"}]"#,
+            &no_declared_tools(),
         )
         .unwrap();
         assert_eq!(mistral.len(), 1);
@@ -25170,9 +25237,12 @@ mod tests {
 
     #[test]
     fn chat_tool_call_delta_uses_openai_stream_shape() {
-        let call = parse_tool_calls(r#"{"name":"weather","parameters":{"city":"Paris"}}"#)
-            .unwrap()
-            .remove(0);
+        let call = parse_tool_calls(
+            r#"{"name":"weather","parameters":{"city":"Paris"}}"#,
+            &no_declared_tools(),
+        )
+        .unwrap()
+        .remove(0);
         let delta = ChatCompletionDelta {
             role: None,
             content: None,

--- a/src/api/tool_envelope.rs
+++ b/src/api/tool_envelope.rs
@@ -1,0 +1,385 @@
+//! Recognising (and undoing) a model that echoes the JSON-Schema envelope it was
+//! shown instead of the arguments that schema describes.
+//!
+//! A tool is advertised to the model as a JSON Schema:
+//!
+//! ```json
+//! {"name": "get_weather",
+//!  "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}
+//! ```
+//!
+//! Small models frequently reply with the *shape they were shown* rather than an
+//! instance of it, emitting `{"properties": {"city": "Paris"}}` where
+//! `{"city": "Paris"}` was meant. Relaying that verbatim is wire-correct but
+//! useless: an OpenAI client reads `arguments.city` and finds nothing.
+//!
+//! The repair here is deliberately narrow. It never guesses, never invents a
+//! value, and only unwraps when the *declared* schema proves the wrapper cannot
+//! itself be a real argument. Anything ambiguous is passed through untouched, so
+//! the worst case is the behaviour we already had.
+
+use std::collections::{BTreeSet, HashMap};
+
+use serde_json::Value;
+
+/// Keys that may appear beside `properties` in an echoed JSON-Schema envelope.
+///
+/// An arguments object made only of these (plus `properties`) cannot be a
+/// meaningful set of arguments, which is what makes the unwrap unambiguous.
+const SCHEMA_ENVELOPE_KEYS: &[&str] = &[
+    "$defs",
+    "$schema",
+    "additionalProperties",
+    "definitions",
+    "description",
+    "properties",
+    "required",
+    "title",
+    "type",
+];
+
+/// The literal key a schema-echoing model wraps its arguments in.
+const PROPERTIES_KEY: &str = "properties";
+
+/// The top-level parameter names each declared tool accepts, keyed by function name.
+///
+/// Absent function name means "this tool was never declared"; a present but empty
+/// set means "declared, and it takes no parameters". The two are treated
+/// differently on purpose: only a declared schema can authorise an unwrap.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ToolParameterNames(HashMap<String, BTreeSet<String>>);
+
+impl ToolParameterNames {
+    /// Read the declared parameter names out of an OpenAI `tools` array.
+    ///
+    /// Tolerates both the nested (`{"function": {"name", "parameters"}}`) and the
+    /// flat (`{"name", "parameters"}`) spellings; anything unrecognised is skipped
+    /// rather than rejected, because this type only ever *withholds* permission to
+    /// rewrite and so cannot make the response worse by knowing less.
+    pub(crate) fn from_request_tools(tools: &[Value]) -> Self {
+        let mut declared: HashMap<String, BTreeSet<String>> = HashMap::new();
+        for tool in tools {
+            let Some(obj) = tool.as_object() else {
+                continue;
+            };
+            let scope = obj
+                .get("function")
+                .and_then(Value::as_object)
+                .unwrap_or(obj);
+            let Some(name) = scope.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let name = name.trim();
+            if name.is_empty() {
+                continue;
+            }
+            let names = scope
+                .get("parameters")
+                .and_then(Value::as_object)
+                .and_then(|parameters| parameters.get(PROPERTIES_KEY))
+                .and_then(Value::as_object)
+                .map(|properties| properties.keys().cloned().collect())
+                .unwrap_or_default();
+            declared.insert(name.to_string(), names);
+        }
+        Self(declared)
+    }
+
+    fn declared_for(&self, function: &str) -> Option<&BTreeSet<String>> {
+        self.0.get(function.trim())
+    }
+}
+
+/// Undo a schema envelope the model echoed around its arguments.
+///
+/// Returns `args` unchanged unless every one of these holds:
+///
+/// 1. `args` is an object containing `properties`, and every other key it has is
+///    an envelope key that the tool does **not** declare as a parameter (a key
+///    the tool declares is a real argument, however envelope-like it looks);
+/// 2. the tool was actually declared, and does **not** declare a parameter named
+///    `properties` (otherwise the wrapper could legitimately be an argument);
+/// 3. `properties` holds a non-empty object whose every key is a parameter the
+///    tool declares.
+///
+/// Condition 3 is what keeps this from laundering a hallucination: if the model
+/// invented a field, nothing is unwrapped and the caller sees exactly what the
+/// model produced.
+pub(crate) fn unwrap_schema_envelope(
+    function: &str,
+    args: Value,
+    declared: &ToolParameterNames,
+) -> Value {
+    let Some(obj) = args.as_object() else {
+        return args;
+    };
+    if !obj.contains_key(PROPERTIES_KEY) {
+        return args;
+    }
+    let Some(names) = declared.declared_for(function) else {
+        return args;
+    };
+    if names.contains(PROPERTIES_KEY) {
+        return args;
+    }
+    // `type`, `title`, `description` and `required` are ordinary parameter names
+    // as well as schema keywords; when the tool declares one it is data, not noise.
+    if !obj.keys().all(|key| {
+        key == PROPERTIES_KEY
+            || (SCHEMA_ENVELOPE_KEYS.contains(&key.as_str()) && !names.contains(key))
+    }) {
+        return args;
+    }
+    let Some(inner) = obj.get(PROPERTIES_KEY).and_then(Value::as_object) else {
+        return args;
+    };
+    if inner.is_empty() || !inner.keys().all(|key| names.contains(key)) {
+        return args;
+    }
+    Value::Object(inner.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn weather_tool() -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"]
+                }
+            }
+        })
+    }
+
+    fn currency_tool() -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "convert_currency",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "amount": {"type": "number"},
+                        "from_currency": {"type": "string"},
+                        "to_currency": {"type": "string"}
+                    }
+                }
+            }
+        })
+    }
+
+    fn declared() -> ToolParameterNames {
+        ToolParameterNames::from_request_tools(&[weather_tool(), currency_tool()])
+    }
+
+    #[test]
+    fn the_observed_wrapper_is_unwrapped() {
+        // Exactly the shape Camelid returned for "What is the weather in Paris?".
+        let args = json!({"properties": {"city": "Paris"}});
+        let repaired = unwrap_schema_envelope("get_weather", args, &declared());
+        assert_eq!(repaired, json!({"city": "Paris"}));
+    }
+
+    #[test]
+    fn a_full_schema_echo_is_unwrapped() {
+        let args = json!({
+            "type": "object",
+            "required": ["city"],
+            "properties": {"city": "Tokyo"}
+        });
+        let repaired = unwrap_schema_envelope("get_weather", args, &declared());
+        assert_eq!(repaired, json!({"city": "Tokyo"}));
+    }
+
+    #[test]
+    fn every_declared_parameter_survives_the_unwrap() {
+        let args = json!({
+            "properties": {"amount": 100, "from_currency": "USD", "to_currency": "EUR"}
+        });
+        let repaired = unwrap_schema_envelope("convert_currency", args, &declared());
+        assert_eq!(
+            repaired,
+            json!({"amount": 100, "from_currency": "USD", "to_currency": "EUR"})
+        );
+    }
+
+    #[test]
+    fn arguments_that_are_already_correct_are_untouched() {
+        let args = json!({"city": "Paris"});
+        let repaired = unwrap_schema_envelope("get_weather", args.clone(), &declared());
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn unwrapping_is_idempotent() {
+        let once = unwrap_schema_envelope(
+            "get_weather",
+            json!({"properties": {"city": "Paris"}}),
+            &declared(),
+        );
+        let twice = unwrap_schema_envelope("get_weather", once.clone(), &declared());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn a_tool_that_really_takes_properties_is_never_unwrapped() {
+        // The wrapper is indistinguishable from a real argument here, so the
+        // model's output must be relayed exactly as produced.
+        let tool = json!({
+            "type": "function",
+            "function": {
+                "name": "configure",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"properties": {"type": "object"}}
+                }
+            }
+        });
+        let declared = ToolParameterNames::from_request_tools(&[tool]);
+        let args = json!({"properties": {"colour": "red"}});
+        let repaired = unwrap_schema_envelope("configure", args.clone(), &declared);
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn an_undeclared_field_blocks_the_unwrap() {
+        // "continent" is not part of the schema: unwrapping would launder an
+        // invention into something that looks authoritative.
+        let args = json!({"properties": {"city": "Paris", "continent": "Europe"}});
+        let repaired = unwrap_schema_envelope("get_weather", args.clone(), &declared());
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn an_undeclared_tool_blocks_the_unwrap() {
+        let args = json!({"properties": {"city": "Paris"}});
+        let repaired = unwrap_schema_envelope("send_email", args.clone(), &declared());
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn a_real_argument_beside_the_wrapper_blocks_the_unwrap() {
+        let args = json!({"properties": {"city": "Paris"}, "city": "Oslo"});
+        let repaired = unwrap_schema_envelope("get_weather", args.clone(), &declared());
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn a_declared_parameter_that_is_also_a_schema_keyword_blocks_the_unwrap() {
+        // "title" and "description" are schema keywords AND perfectly ordinary
+        // parameter names. Treating this as envelope noise would silently drop
+        // the title the model actually supplied.
+        let tool = json!({
+            "type": "function",
+            "function": {
+                "name": "create_issue",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "description": {"type": "string"}
+                    }
+                }
+            }
+        });
+        let declared = ToolParameterNames::from_request_tools(&[tool]);
+        let args = json!({"title": "Bug report", "properties": {"description": "it broke"}});
+        let repaired = unwrap_schema_envelope("create_issue", args.clone(), &declared);
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn a_schema_keyword_the_tool_does_not_declare_is_still_treated_as_envelope() {
+        // get_weather declares only "city", so "required" here really is noise.
+        let args = json!({"required": ["city"], "properties": {"city": "Lima"}});
+        let repaired = unwrap_schema_envelope("get_weather", args, &declared());
+        assert_eq!(repaired, json!({"city": "Lima"}));
+    }
+
+    #[test]
+    fn a_non_object_properties_value_blocks_the_unwrap() {
+        let args = json!({"properties": "city"});
+        let repaired = unwrap_schema_envelope("get_weather", args.clone(), &declared());
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn an_empty_wrapper_blocks_the_unwrap() {
+        let args = json!({"properties": {}});
+        let repaired = unwrap_schema_envelope("get_weather", args.clone(), &declared());
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn non_object_arguments_are_untouched() {
+        for args in [json!("Paris"), json!(7), json!(null), json!(["Paris"])] {
+            let repaired = unwrap_schema_envelope("get_weather", args.clone(), &declared());
+            assert_eq!(repaired, args);
+        }
+    }
+
+    #[test]
+    fn a_tool_with_no_declared_parameters_blocks_the_unwrap() {
+        let tool = json!({"type": "function", "function": {"name": "ping"}});
+        let declared = ToolParameterNames::from_request_tools(&[tool]);
+        let args = json!({"properties": {"city": "Paris"}});
+        let repaired = unwrap_schema_envelope("ping", args.clone(), &declared);
+        assert_eq!(repaired, args);
+    }
+
+    #[test]
+    fn declared_names_are_read_from_the_flat_tool_spelling() {
+        let tool = json!({
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}
+        });
+        let declared = ToolParameterNames::from_request_tools(&[tool]);
+        let repaired = unwrap_schema_envelope(
+            "get_weather",
+            json!({"properties": {"city": "Cairo"}}),
+            &declared,
+        );
+        assert_eq!(repaired, json!({"city": "Cairo"}));
+    }
+
+    #[test]
+    fn a_surrounding_name_is_matched_after_trimming() {
+        let repaired = unwrap_schema_envelope(
+            "  get_weather  ",
+            json!({"properties": {"city": "Oslo"}}),
+            &declared(),
+        );
+        assert_eq!(repaired, json!({"city": "Oslo"}));
+    }
+
+    #[test]
+    fn malformed_tool_entries_are_skipped_without_panicking() {
+        let declared = ToolParameterNames::from_request_tools(&[
+            json!("not an object"),
+            json!({"function": {"name": ""}}),
+            json!({"function": {}}),
+            json!(null),
+            weather_tool(),
+        ]);
+        assert!(declared.declared_for("get_weather").is_some());
+        assert!(declared.declared_for("").is_none());
+    }
+
+    #[test]
+    fn an_empty_tool_list_authorises_nothing() {
+        let declared = ToolParameterNames::from_request_tools(&[]);
+        assert!(declared.declared_for("get_weather").is_none());
+        let args = json!({"properties": {"city": "Paris"}});
+        assert_eq!(
+            unwrap_schema_envelope("get_weather", args.clone(), &declared),
+            args
+        );
+    }
+}


### PR DESCRIPTION
## The bug

A tool is advertised to the model as a JSON Schema:

```json
{"name": "get_weather",
 "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}
```

Small models frequently reply with the *shape they were shown* rather than an instance of it. Camelid relayed that verbatim, so this reached the client:

```json
{"name": "get_weather", "arguments": "{\"properties\":{\"city\":\"Paris\"}}"}
```

An OpenAI client reads `arguments.city`, finds `undefined`, and the tool call is unusable. The value was always there — just one level too deep.

Exact reproduction (a `tools` array declaring `get_weather(city)`, `tool_choice: "auto"`, `temperature: 0`, `seed: 0`):

> `What is the weather in Paris? Use the tool.`

## The fix

`src/api/tool_envelope.rs` recognises the envelope and undoes it, but **only where the declared schema proves the wrapper cannot itself be an argument**. The unwrap requires all of:

1. the arguments object contains `properties`, and every other key it has is a JSON-Schema keyword (`$defs`, `$schema`, `additionalProperties`, `definitions`, `description`, `required`, `title`, `type`) that **the tool does not itself declare as a parameter**;
2. the tool was actually declared, and does **not** itself declare a parameter named `properties`;
3. `properties` holds a non-empty object whose every key is a parameter that tool declares.

Anything ambiguous passes through untouched, so the worst case equals current behaviour. Rule 3 is what stops this laundering a hallucination: if the model invented a field, nothing is unwrapped and the caller sees exactly what the model produced.

The "does not itself declare" clause in rule 1 matters more than it looks. `title`, `description` and `type` are schema keywords *and* perfectly ordinary parameter names. For a `create_issue(title, description)` tool, `{"title": "Bug", "properties": {"description": "..."}}` would otherwise be read as envelope noise around one argument, and the title the model supplied would be silently dropped — strictly worse than the bug being fixed. When the tool declares the key, it is data, and the repair backs off entirely.

The declared parameter names are the only thing that authorises a rewrite, which is why `parse_tool_calls` now takes them. `stream_completion` previously took a `bool` meaning "parse tool calls from this stream" while the names would have had to be threaded separately; it now takes `Option<ToolParameterNames>` so the two cannot disagree.

## Measurement

60 tasks x 3 reps, `Llama-3.2-1B-Instruct-Q8_0.gguf` (1,321,082,528 bytes, sha256 `3f87a880...c7ffd1`), CPU lane (`--gpu off`). The pre-fix and fixed binaries were run **back to back on one host**, same model bytes, same task file (sha256 `b5f03f7c...`):

| arm | binary | strict | deep | suite C | args flat/nested/missing | non-200 |
|---|---|---|---|---|---|---|
| pre-fix | `c63dcaaa` | 80.00 | 88.33 | 53.33 | 8/**5**/2 | 0 |
| fixed | `6d25ea5a` | 88.33 | 88.33 | 86.67 | 13/**0**/2 | 0 |

15 of 180 rows changed — tasks C01, C02, C05, C06, C13, all three reps each, every one a pure unwrap:

```
C01  before {"properties":{"city":"Paris"}}      after {"city":"Paris"}
C05  before {"properties":{"ticker":"AAPL"}}     after {"ticker":"AAPL"}
C13  before {"properties":{"query":"notes.txt"}} after {"query":"notes.txt"}
```

**Zero** rows changed `content` or `finish_reason`.

`deep` is identical on both arms because the deep scorer already dug the value out of the wrapper. So this recovers exactly the strict/deep gap and invents no new correctness — worth stating plainly, because a headline "+8.33pp accuracy" would misrepresent what changed.

## Tests

`tool_envelope.rs` carries 19 unit tests, and `api::tests` carries one wiring-level regression test proving the repair reaches the client and that an empty declared set changes nothing. Two of the nineteen cover the keyword-collision case in both directions: a declared `title` blocks the unwrap, while a `required` key on a tool that does not declare it is still correctly stripped — so the guard is not just disabling the feature.

The suite was ablated: with `unwrap_schema_envelope` reduced to the identity function it replaced, `cargo test --lib` gives 6 failures, and the failing set is exactly the tests that assert an unwrap must happen. The fail-closed tests keep passing, because they assert ambiguous input is passed through untouched and a disabled repair passes everything through. The two directions are therefore tested independently rather than all keying off one flag.

Gates on the rebased branch: `cargo test --lib` 2208 passed / 0 failed; `cargo clippy --all-targets -- -D warnings` zero findings; `cargo fmt --check` clean; `check-public-scrub.sh` clean.

`src/api/mod.rs` changed, so the SmolLM3 provenance chain was re-pinned (fixture `source_git_blob_sha1`, plus the blob sha1 and fixture digest in both parity scripts). All four SmolLM3 parity scripts pass and no stale references remain.

## Honest limits

- One model, one host, one CPU lane. The mechanism is model-agnostic, but the measurement is not a broad claim.
- Scoped to the JSON tool-call parser. `parse_ornith_tool_calls_json` is untouched: it builds arguments key by key from `<parameter=name>` tags and is structurally immune to this.
- The repair cannot help a tool that genuinely declares a parameter named `properties`; that case is explicitly refused and tested.
- The measurement table above was taken before the rebase onto `243a1904`. The rebase changed no behaviour the table depends on, but the numbers were not re-measured against the new base.
- `scripts/test-metal-kv-dtype-harness.mjs` fails on my Windows host (the Store `python3.exe` stub returns 9009). It fails identically on unmodified `121898bb`, so it is environmental, not caused by this change.
