### PR TITLE
fix(qwen35/cuda): route the CUDA lane where the plan discloses it

### DIFF
--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -13730,6 +13730,21 @@ fn prism_cuda_bmma_enabled() -> bool {
     })
 }
 
+/// Opt-in for the parity-correct Q4_K/Q6_K batched-prefill tiles (see
+/// `prefers_batched_prefill`). Default OFF: the serial GEMVs stay the shipped
+/// policy for K-quant rows until a device carries a receipt.
+fn kquant_batched_prefill_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        matches!(
+            std::env::var("CAMELID_KQUANT_BATCHED_PREFILL")
+                .ok()
+                .as_deref(),
+            Some("1") | Some("true") | Some("on") | Some("yes")
+        )
+    })
+}
+
 fn prism_cuda_bmma_min_tokens() -> usize {
     static MIN_TOKENS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *MIN_TOKENS.get_or_init(|| {
@@ -14930,14 +14945,35 @@ impl CudaResidentDecode {
     /// Default policy after same-host Windows/WDDM benchmarking. Q8_0 batching
     /// remains a clear win; the parity-correct Q4_K/Q6_K tiles stay opt-in until
     /// a device shows a sustained gain over the mature serial GEMVs.
+    ///
+    /// `CAMELID_KQUANT_BATCHED_PREFILL=1` is that opt-in: it admits the Q4_K/Q6_K
+    /// tiles so a device can be measured against the serial GEMVs on a real row.
+    /// It only ever widens the set, and only where `supports_batched_prefill`
+    /// already holds — which requires full residency, so an offloaded model keeps
+    /// the serial path that streams its offloaded weights correctly.
+    ///
+    /// MEASURED NULL — qwen35 Ornith-1.0-9B Q4_K_M, RTX 3060 Laptop, fully resident
+    /// (`CAMELID_QWEN35_CUDA_HEADROOM_MB=0`), 2813-token prompt, paired A/B with
+    /// matched thermal start: serial 141.6s / 149.8s vs batched 148.5s / 151.7s =
+    /// 0.95x and 0.99x. Completions were token-for-token identical across all four
+    /// runs, so the tiles are parity-correct — they are simply not faster on this
+    /// row. MECHANISM: 24 of these 32 layers are SSM, and the gated-delta
+    /// recurrence is sequential ACROSS tokens, so a batched chunk can only amortize
+    /// weight reads for the 8 full-attention layers and the FFNs; the SSM majority
+    /// still walks token by token. Expect a null on any SSM-heavy qwen35 row and
+    /// spend the effort elsewhere. Dense K-quant rows are NOT covered by this
+    /// measurement and remain genuinely open.
     pub fn prefers_batched_prefill(&self) -> bool {
-        self.supports_batched_prefill()
-            && self.layers.iter().all(|layer| {
-                layer
-                    .quants
-                    .iter()
-                    .all(|q| matches!(q, ProjQuant::Q8_0 | ProjQuant::Q1_0))
-            })
+        if !self.supports_batched_prefill() {
+            return false;
+        }
+        let mature_quants_only = self.layers.iter().all(|layer| {
+            layer
+                .quants
+                .iter()
+                .all(|q| matches!(q, ProjQuant::Q8_0 | ProjQuant::Q1_0))
+        });
+        mature_quants_only || kquant_batched_prefill_enabled()
     }
 
     /// Whether linear speculative verification can use the batched stack,

--- a/src/execution_plan.rs
+++ b/src/execution_plan.rs
@@ -1025,6 +1025,45 @@ pub fn gemma4_cuda_lane_selectable() -> bool {
     cuda_resident_decode_will_run()
 }
 
+/// Whether the qwen35 serve lane should run on the CUDA-resident engine.
+///
+/// **Default ON** where a CUDA device is actually driving this process; opt out
+/// with `CAMELID_QWEN35_CUDA=0` (0/off/false/no/disabled). It used to be opt-IN
+/// for every row except Prism low-bit on Windows, which is the gemma4 Phase 0
+/// finding wearing different clothes: the certified Ornith K-quant rows decoded
+/// on the CPU out of the box on a CUDA host — `select_kquant_plan` advertised
+/// `cuda_resident_kquant_runtime` off `platform.cuda_resident_active` while
+/// `generate_qwen35_streaming` read `CAMELID_QWEN35_CUDA` itself and fell to the
+/// CPU runnable lane, because the two consulted different things.
+///
+/// This is the POLICY half only. It says nothing about whether a given file
+/// FITS: capacity is enforced per request by `qwen35_generation_budget` against
+/// `CAMELID_QWEN35_CUDA_MAXPOS`, and every CUDA error raised before a token is
+/// emitted falls back to the CPU oracle (`qwen35_cuda_with_cpu_fallback`).
+///
+/// `--gpu off` and the UI's live toggle stay authoritative: they clear
+/// `gpu_accel_enabled`, which `cuda_resident_decode_will_run` requires. An
+/// explicit `CAMELID_QWEN35_CUDA=1` is an opt-IN to this lane, never an override
+/// of that master switch.
+///
+/// The default flips only on Windows, which is where the qwen35 CUDA lane
+/// carries receipts (the Ornith Q4_K_M parity + agent-eval PASS receipts, and
+/// the Prism Windows CUDA branch this predicate replaces). Other CUDA hosts keep
+/// the historical opt-in until the same evidence exists for them, so this change
+/// cannot alter a platform it has not been measured on.
+pub fn qwen35_cuda_lane_selectable() -> bool {
+    if matches!(requested_profile().0, ExecutionProfile::Safe) {
+        return false;
+    }
+    if env_flag_disabled("CAMELID_QWEN35_CUDA") {
+        return false;
+    }
+    if !cfg!(windows) && !env_flag_enabled("CAMELID_QWEN35_CUDA") {
+        return false;
+    }
+    cuda_resident_decode_will_run()
+}
+
 /// Everything the gemma4 CUDA-resident lane puts in VRAM BESIDES the per-layer
 /// projections: the small per-layer norms, the f16 KV cache at the load site's
 /// 4096-position window, the GPU tied head, the GPU PLE context projection, and
@@ -2574,6 +2613,57 @@ mod tests {
         assert!(!lfm2_metal_plan_selectable());
         env::remove_var("CAMELID_PROFILE");
         env::remove_var("CAMELID_LFM2_METAL");
+    }
+
+    /// The qwen35 CUDA lane must ROUTE where the plan DISCLOSES it.
+    /// `select_kquant_plan` advertises `cuda_resident_kquant_runtime` off
+    /// `platform.cuda_resident_active` alone, but routing additionally required the
+    /// output tensor to be a Prism low-bit quant — so a certified Ornith Q4_K_M row
+    /// (qwen35) reported the CUDA lane in `/v1/health` and decoded on the CPU.
+    /// Measured on an RTX 3060 Laptop: 0.42 tok/s served, 6.14 tok/s once the lane
+    /// was reachable, same row, same host.
+    ///
+    /// Pins the two halves to one predicate: with no operator opt-out, Windows
+    /// routing tracks `cuda_resident_decode_will_run` exactly — the same signal the
+    /// plan reads — for every qwen35 row, Prism or K-quant.
+    #[test]
+    fn qwen35_cuda_routing_tracks_the_disclosed_resident_lane() {
+        let _guard = crate::test_support::env_lock();
+        env::remove_var("CAMELID_QWEN35_CUDA");
+        env::remove_var("CAMELID_PROFILE");
+        env::remove_var("CAMELID_DETERMINISTIC");
+
+        if cfg!(windows) {
+            assert_eq!(
+                qwen35_cuda_lane_selectable(),
+                cuda_resident_decode_will_run(),
+                "with no opt-out, routing must follow the same signal the plan discloses \
+                 — not a per-row quant test the plan never applied"
+            );
+        }
+
+        env::set_var("CAMELID_QWEN35_CUDA", "0");
+        assert!(
+            !qwen35_cuda_lane_selectable(),
+            "an explicit opt-out must still pin the CPU oracle"
+        );
+
+        env::set_var("CAMELID_QWEN35_CUDA", "1");
+        env::set_var("CAMELID_PROFILE", "safe");
+        assert!(
+            !qwen35_cuda_lane_selectable(),
+            "safe profile must beat an explicit opt-in"
+        );
+        env::remove_var("CAMELID_PROFILE");
+
+        env::set_var("CAMELID_DETERMINISTIC", "1");
+        assert!(
+            !qwen35_cuda_lane_selectable(),
+            "deterministic mode must pin the CPU oracle even with an explicit opt-in"
+        );
+
+        env::remove_var("CAMELID_DETERMINISTIC");
+        env::remove_var("CAMELID_QWEN35_CUDA");
     }
 
     use super::*;

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -273,17 +273,6 @@ impl Mat {
 }
 
 impl RawMat {
-    #[cfg(not(target_os = "macos"))]
-    fn is_prism_low_bit(&self) -> bool {
-        matches!(
-            self.tt,
-            GgufTensorType::Q1_0
-                | GgufTensorType::Q2_0G64
-                | GgufTensorType::Q2_0G128
-                | GgufTensorType::Pq2_0
-        )
-    }
-
     fn row_bytes(&self) -> usize {
         self.bytes.len() / self.out_features
     }
@@ -2973,26 +2962,16 @@ impl RunnableModel {
         }
         #[cfg(feature = "cuda")]
         {
-            let cuda_requested = match std::env::var("CAMELID_QWEN35_CUDA") {
-                Ok(value) => matches!(
-                    value.to_ascii_lowercase().as_str(),
-                    "1" | "true" | "on" | "yes"
-                ),
-                // Prism's Windows port is the packed resident CUDA graph. Keep
-                // Ornith's established opt-in policy, while selecting CUDA by
-                // default for Prism rows on Windows; CAMELID_QWEN35_CUDA=0 is
-                // still an explicit CPU fallback/debug override.
-                Err(_) => cfg!(windows) && self.output.is_prism_low_bit(),
-            };
-            // `--gpu off` (and the UI's live toggle) is the AUTHORITATIVE master switch:
-            // it is documented as "Force the CPU reference path; never use the GPU even
-            // if one is present". Nothing in this lane consulted it, so on Windows --
-            // where the default above is ON for every Prism row -- `--gpu off` could not
-            // select the CPU lane at all for the qwen35 Bonsai rows; they kept building
-            // the resident CUDA graph. `CAMELID_QWEN35_CUDA=1` is an opt-IN to this lane,
-            // not an override of the master switch. `gpu_accel_enabled()` lazily seeds
-            // from platform capability, so the default (auto) path is unchanged.
-            let cuda_enabled = cuda_requested && crate::cuda::gpu_accel_enabled();
+            // SINGLE SOURCE OF TRUTH with the disclosed execution plan. This lane used
+            // to read `CAMELID_QWEN35_CUDA` itself and default ON only for Prism low-bit
+            // rows on Windows, so a certified Ornith K-quant row (qwen35 Q4_K_M) served
+            // out of the box reported `cuda_resident_kquant_runtime` from
+            // `select_kquant_plan` while decoding here on the CPU — measured 0.42 tok/s
+            // against 6.1 tok/s on the very same row and host. That is the gemma4 Phase 0
+            // defect: the plan and the lane consulted different things. `--gpu off` and
+            // the UI toggle stay authoritative because the policy requires
+            // `gpu_accel_enabled()`; `CAMELID_QWEN35_CUDA=0` still forces the CPU oracle.
+            let cuda_enabled = crate::execution_plan::qwen35_cuda_lane_selectable();
             if cuda_enabled {
                 return qwen35_cuda_with_cpu_fallback(
                     on_token,


### PR DESCRIPTION
## The bug

`ornith-1.0-9b-Q4_K_M.gguf` served on Windows decoded on the **CPU** while `/v1/health` reported the CUDA lane.

`select_kquant_plan` advertises `cuda_resident_kquant_runtime` off `platform.cuda_resident_active` alone. `generate_qwen35_streaming` read `CAMELID_QWEN35_CUDA` itself and defaulted ON only for Prism low-bit rows:

```rust
Err(_) => cfg!(windows) && self.output.is_prism_low_bit(),
```

Ornith Q4_K_M's output tensor is **Q6_K**, so that was false. The lane worked — it was unreachable. `CAMELID_QWEN35_CUDA=1` was a bring-up flag from a8dacf5c that never got flipped after the row was certified.

This is the **gemma4 Phase 0 defect**, which `gemma4_cuda_lane_selectable` already fixed for gemma4 — its doc comment names it exactly: *"the plan advertised `cuda_resident_kquant_runtime` while serve ran the CPU runtime, because the two consulted different things."*

## The fix

New `execution_plan::qwen35_cuda_lane_selectable()` mirroring the gemma4 predicate; the lane delegates to it instead of reading the env, so disclosure and routing share one source of truth.

Scoped deliberately: the default flips **only on Windows**, where this lane carries receipts. Other CUDA hosts keep the historical opt-in rather than having a behaviour change land on a platform this was never measured on. That leaves a known, stated gap — Linux K-quant qwen35 still opts in although `select_kquant_plan` advertises CUDA there too.

## Measured — RTX 3060 Laptop, same row and host

| | decode | VRAM |
|---|---|---|
| before (default) | **0.42 tok/s** | 107 MiB (bare CUDA context) |
| after (default) | **6.56 tok/s** | 5389 MiB |

Guardrails re-verified live, not just reasoned about: `--gpu off` → 107 MiB/CPU, `CAMELID_QWEN35_CUDA=0` → 107 MiB/CPU, and under `--gpu off` the plan then also reports `cpu_kquant_block_dot` — the two agree in **both** directions.

Regression test `qwen35_cuda_routing_tracks_the_disclosed_resident_lane` pins routing to the same signal the plan reads, so a future per-row predicate can't silently diverge again.

## Second commit: a null, recorded

`prefers_batched_prefill` keeps Q4_K/Q6_K batching opt-in "until a device shows a sustained gain", but there was no way to measure that without editing code. `CAMELID_KQUANT_BATCHED_PREFILL=1` provides that hatch (default OFF — shipped behaviour byte-identical).

**This device shows no gain.** Paired A/B, matched thermal start, 2813-token prompt, fully resident:

| round | serial | batched | Δ |
|---|---|---|---|
| 1 | 141.6s | 148.5s | 0.95× |
| 2 | 149.8s | 151.7s | 0.99× |

Completions were token-for-token identical across all four runs — the tiles are parity-correct, just not faster. Mechanism, so the null generalises: **24 of these 32 layers are SSM**, and the gated-delta recurrence is sequential *across* tokens, so batching can only amortize the 8 attention layers and the FFNs. Recorded in the doc comment so nobody re-runs it. Dense K-quant rows remain genuinely open.

## Not in this PR

A **2.3–2.4× decode win** needs no code change: `CAMELID_QWEN35_CUDA_HEADROOM_MB=0`. The flat 768 MiB reserve forces 8/32 layers to stream from pinned host RAM (~803 MiB/token); at 0 the row is fully resident and decode goes **8.0 → 19.5 tok/s** (paired, two rounds, matched thermal start). Peak VRAM 5933 MiB with 211 MiB margin, and identical peak for a 2813-token prompt — scratch does not grow with prompt length.

I did not change that default here: headroom is a cross-model safety constant and I have one card and one row of evidence. Worth its own change with broader receipts.

## Gates

`cargo fmt --check` · `cargo clippy --all-targets --all-features -D warnings` · `cargo test --release --lib` (2189 passed, 0 failed) · `scripts/check-public-scrub.sh` — all green.
