### PR TITLE
feat(agent): harden the agent harness and fix dual-stack IPv4/IPv6 web research

### DIFF
--- a/frontend/src/lib/webResearch.js
+++ b/frontend/src/lib/webResearch.js
@@ -150,7 +150,9 @@ const CURRENT_INFO_PATTERNS = [
   /\b(?:news|weather|price|schedule|score)\s+(?:today|right now|now)\b/i,
   /\bweather\b[^.!?\n]{0,80}\b(?:today|tomorrow|now|tonight|week|weekend|days?|forecast)\b/i,
   /\bweather\s+(?:in|for|at|around|report|forecast)\b/i,
-  /\b(?:weather\s+)?forecast\s+(?:for|in|today|this|next)\b/i,
+  // `weather` is required: a bare "forecast for next quarter" is not a
+  // real-time question, and a false positive sends the prompt to a search engine.
+  /\bweather\s+forecast\s+(?:for|in|today|this|next)\b/i,
   /\brecent\s+(?:news|events|developments|changes|updates|releases)\b/i,
   /\bwho is (?:the )?current\b/i,
 ]

--- a/frontend/src/lib/webResearch.js
+++ b/frontend/src/lib/webResearch.js
@@ -148,6 +148,9 @@ const CURRENT_INFO_PATTERNS = [
   /\bcurrently available\b/i,
   /\b(?:today's|today’s)\s+(?:news|weather|price|schedule|score)\b/i,
   /\b(?:news|weather|price|schedule|score)\s+(?:today|right now|now)\b/i,
+  /\bweather\b[^.!?\n]{0,80}\b(?:today|tomorrow|now|tonight|week|weekend|days?|forecast)\b/i,
+  /\bweather\s+(?:in|for|at|around|report|forecast)\b/i,
+  /\b(?:weather\s+)?forecast\s+(?:for|in|today|this|next)\b/i,
   /\brecent\s+(?:news|events|developments|changes|updates|releases)\b/i,
   /\bwho is (?:the )?current\b/i,
 ]

--- a/qa/benchmarks/agent/native-contracts-v1.json
+++ b/qa/benchmarks/agent/native-contracts-v1.json
@@ -102,6 +102,37 @@
       "evidence": [
         { "kind": "js_test", "file": "tools/bench/system/test-native-adapter.mjs", "marker": "outside_task_root", "platforms": ["windows", "linux"] }
       ]
+    },
+    {
+      "id": "native_edit_self_healing",
+      "evidence": [
+        { "kind": "rust_test", "file": "src/chat/tools.rs", "test": "edit_file_tolerates_uniform_indentation_shift", "platforms": ["windows", "macos", "linux"] },
+        { "kind": "rust_test", "file": "src/chat/tools.rs", "test": "edit_file_provides_actionable_near_miss_diagnostics", "platforms": ["windows", "macos", "linux"] }
+      ]
+    },
+    {
+      "id": "native_path_suggestion",
+      "evidence": [
+        { "kind": "rust_test", "file": "src/chat/tools.rs", "test": "sandbox_resolve_suggests_nearest_file_path", "platforms": ["windows", "macos", "linux"] }
+      ]
+    },
+    {
+      "id": "native_compaction_working_set",
+      "evidence": [
+        { "kind": "rust_test", "file": "src/chat/agent.rs", "test": "compaction_records_active_working_set_ledger", "platforms": ["windows", "macos", "linux"] }
+      ]
+    },
+    {
+      "id": "native_search_path_filter",
+      "evidence": [
+        { "kind": "rust_test", "file": "src/chat/tools.rs", "test": "search_respects_path_filter", "platforms": ["windows", "macos", "linux"] }
+      ]
+    },
+    {
+      "id": "native_verification_gate",
+      "evidence": [
+        { "kind": "rust_test", "file": "src/chat/agent.rs", "test": "verification_gate_requires_test_run_after_mutating_files", "platforms": ["windows", "macos", "linux"] }
+      ]
     }
   ]
 }

--- a/src/api/web_research.rs
+++ b/src/api/web_research.rs
@@ -17,7 +17,7 @@
 use std::{
     collections::{HashMap, HashSet},
     io::{Read, Write},
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs, UdpSocket},
     process::{Command, Stdio},
     sync::{Arc, Mutex, OnceLock},
     thread,
@@ -3934,19 +3934,56 @@ fn validated_redirect_target(current: &Url, location: &str) -> Result<Url, Strin
     Ok(next)
 }
 
+/// Which IP families this host has a route for.
+///
+/// `to_socket_addrs` does not set `AI_ADDRCONFIG`, so a dual-stack DNS answer
+/// comes back whatever the host can actually reach. Deciding from the shape of
+/// that answer would only ever be right for one kind of host; this asks the host
+/// instead. A UDP `connect` sends no packet — it just needs a route to exist —
+/// so this costs a syscall, blocks on nothing, and is probed once per process.
+///
+/// Both flags false means the question could not be answered (no network, or a
+/// sandbox that refuses the bind), and the caller pins the answer unchanged.
+fn host_reachable_families() -> (bool, bool) {
+    static FAMILIES: OnceLock<(bool, bool)> = OnceLock::new();
+    *FAMILIES.get_or_init(|| {
+        // Documentation prefixes: only a default route can match them, which is
+        // exactly the property being tested.
+        let v4 = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))
+            .and_then(|socket| socket.connect((Ipv4Addr::new(192, 0, 2, 1), 9)))
+            .is_ok();
+        let v6 = UdpSocket::bind((Ipv6Addr::UNSPECIFIED, 0))
+            .and_then(|socket| socket.connect((Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1), 9)))
+            .is_ok();
+        (v4, v6)
+    })
+}
+
 /// Choose which of the already-validated addresses to pin with `--resolve`.
 ///
 /// A dual-stack DNS answer on a single-stack host (a v4-only GCP Compute Engine
-/// VM, say) hands curl AAAA records that can never connect, and the hop dies
-/// with `couldn't connect to server` instead of using the A record beside it.
-/// When both families are present the IPv6 addresses are dropped. A host whose
-/// only answer is IPv6 keeps it — this narrows the address set, it never empties
-/// it, so the SSRF pin still binds every address curl may reach.
-fn addresses_to_pin(addresses: &[IpAddr]) -> Vec<IpAddr> {
-    if addresses.iter().any(IpAddr::is_ipv4) {
-        addresses.iter().copied().filter(IpAddr::is_ipv4).collect()
-    } else {
+/// VM, say) hands curl records that can never connect, and the hop can die with
+/// `couldn't connect to server` instead of using the usable record beside it.
+/// The families the host cannot reach are dropped — in either direction, so an
+/// IPv6-only host is not handed A records for the same reason.
+///
+/// This only ever narrows, and never to nothing: an unreachable pin is still a
+/// bound pin, whereas pinning nothing would hand the hostname back to curl's own
+/// resolver and unbind the SSRF check.
+fn addresses_to_pin(addresses: &[IpAddr], families: (bool, bool)) -> Vec<IpAddr> {
+    let (v4_reachable, v6_reachable) = families;
+    if v4_reachable == v6_reachable {
+        return addresses.to_vec();
+    }
+    let reachable: Vec<IpAddr> = addresses
+        .iter()
+        .copied()
+        .filter(|address| address.is_ipv4() == v4_reachable)
+        .collect();
+    if reachable.is_empty() {
         addresses.to_vec()
+    } else {
+        reachable
     }
 }
 
@@ -4032,11 +4069,16 @@ fn curl_single_hop(
         .host()
         .is_some_and(|host| matches!(host, Host::Domain(_)))
     {
-        let pinned = addresses_to_pin(addresses);
+        let pinned = addresses_to_pin(addresses, host_reachable_families());
         if pinned.len() < addresses.len() {
-            // Every address we still pin is IPv4; tell curl so too, so a cache
-            // miss cannot send it back to the resolver and out over IPv6.
-            command.arg("--ipv4");
+            // Every address still pinned is one family; tell curl so too, so a
+            // cache miss cannot send it back to the resolver and out over the
+            // family this host cannot reach.
+            command.arg(if pinned.iter().all(IpAddr::is_ipv4) {
+                "--ipv4"
+            } else {
+                "--ipv6"
+            });
         }
         for address in pinned {
             let pinned = match address {
@@ -4247,14 +4289,23 @@ mod tests {
         let v4: IpAddr = "93.184.216.34".parse().unwrap();
         let v4b: IpAddr = "93.184.216.35".parse().unwrap();
         let v6: IpAddr = "2606:2800:220:1:248:1893:25c8:1946".parse().unwrap();
+        let v4_only = (true, false);
+        let v6_only = (false, true);
+        let dual = (true, true);
+        let unknown = (false, false);
 
-        // Mixed answer: the IPv6 addresses are dropped so a v4-only host cannot
-        // spend the hop budget dialling an unreachable address.
-        assert_eq!(addresses_to_pin(&[v6, v4, v4b]), vec![v4, v4b]);
-        // IPv6-only answer is kept verbatim; narrowing must never empty the set,
-        // or the SSRF pin would stop binding and curl would resolve for itself.
-        assert_eq!(addresses_to_pin(&[v6]), vec![v6]);
-        assert_eq!(addresses_to_pin(&[v4]), vec![v4]);
+        // A v4-only host drops the AAAA records it could never dial.
+        assert_eq!(addresses_to_pin(&[v6, v4, v4b], v4_only), vec![v4, v4b]);
+        // And the mirror image: a v6-only host drops the A records.
+        assert_eq!(addresses_to_pin(&[v6, v4, v4b], v6_only), vec![v6]);
+        // Narrowing must never empty the set, or the SSRF pin would stop binding
+        // and curl would resolve for itself.
+        assert_eq!(addresses_to_pin(&[v6], v4_only), vec![v6]);
+        assert_eq!(addresses_to_pin(&[v4], v6_only), vec![v4]);
+        // A dual-stack host keeps both and lets curl choose; so does a host whose
+        // families could not be probed.
+        assert_eq!(addresses_to_pin(&[v6, v4], dual), vec![v6, v4]);
+        assert_eq!(addresses_to_pin(&[v6, v4], unknown), vec![v6, v4]);
     }
 
     #[test]

--- a/src/api/web_research.rs
+++ b/src/api/web_research.rs
@@ -1222,9 +1222,10 @@ fn classify_prompt(prompt: &str) -> ResearchDecision {
         "weather in ",
         "weather for ",
         "weather report",
+        // Deliberately weather-anchored. A bare "forecast for" also matches
+        // "revenue forecast for next year", and a false positive here sends the
+        // user's prompt to a search engine.
         "weather forecast",
-        "forecast for ",
-        "forecast in ",
         "price now",
         "schedule now",
         "score now",
@@ -3933,6 +3934,22 @@ fn validated_redirect_target(current: &Url, location: &str) -> Result<Url, Strin
     Ok(next)
 }
 
+/// Choose which of the already-validated addresses to pin with `--resolve`.
+///
+/// A dual-stack DNS answer on a single-stack host (a v4-only GCP Compute Engine
+/// VM, say) hands curl AAAA records that can never connect, and the hop dies
+/// with `couldn't connect to server` instead of using the A record beside it.
+/// When both families are present the IPv6 addresses are dropped. A host whose
+/// only answer is IPv6 keeps it — this narrows the address set, it never empties
+/// it, so the SSRF pin still binds every address curl may reach.
+fn addresses_to_pin(addresses: &[IpAddr]) -> Vec<IpAddr> {
+    if addresses.iter().any(IpAddr::is_ipv4) {
+        addresses.iter().copied().filter(IpAddr::is_ipv4).collect()
+    } else {
+        addresses.to_vec()
+    }
+}
+
 // This is the final SSRF/auth boundary before spawning curl. Keeping every
 // validated input explicit makes accidental credential or redirect widening
 // visible at each call site.
@@ -4015,14 +4032,13 @@ fn curl_single_hop(
         .host()
         .is_some_and(|host| matches!(host, Host::Domain(_)))
     {
-        let has_v4 = addresses.iter().any(|address| address.is_ipv4());
-        if has_v4 {
+        let pinned = addresses_to_pin(addresses);
+        if pinned.len() < addresses.len() {
+            // Every address we still pin is IPv4; tell curl so too, so a cache
+            // miss cannot send it back to the resolver and out over IPv6.
             command.arg("--ipv4");
         }
-        for address in addresses {
-            if has_v4 && address.is_ipv6() {
-                continue;
-            }
+        for address in pinned {
             let pinned = match address {
                 IpAddr::V4(address) => format!("{host}:{port}:{address}"),
                 IpAddr::V6(address) => format!("{host}:{port}:[{address}]"),
@@ -4225,6 +4241,21 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
+
+    #[test]
+    fn dual_stack_answers_pin_only_the_reachable_family() {
+        let v4: IpAddr = "93.184.216.34".parse().unwrap();
+        let v4b: IpAddr = "93.184.216.35".parse().unwrap();
+        let v6: IpAddr = "2606:2800:220:1:248:1893:25c8:1946".parse().unwrap();
+
+        // Mixed answer: the IPv6 addresses are dropped so a v4-only host cannot
+        // spend the hop budget dialling an unreachable address.
+        assert_eq!(addresses_to_pin(&[v6, v4, v4b]), vec![v4, v4b]);
+        // IPv6-only answer is kept verbatim; narrowing must never empty the set,
+        // or the SSRF pin would stop binding and curl would resolve for itself.
+        assert_eq!(addresses_to_pin(&[v6]), vec![v6]);
+        assert_eq!(addresses_to_pin(&[v4]), vec![v4]);
+    }
 
     #[test]
     fn public_http_entry_point_has_a_strict_method_allowlist() {

--- a/src/api/web_research.rs
+++ b/src/api/web_research.rs
@@ -1219,6 +1219,12 @@ fn classify_prompt(prompt: &str) -> ResearchDecision {
         "score right now",
         "news now",
         "weather now",
+        "weather in ",
+        "weather for ",
+        "weather report",
+        "weather forecast",
+        "forecast for ",
+        "forecast in ",
         "price now",
         "schedule now",
         "score now",
@@ -4009,7 +4015,14 @@ fn curl_single_hop(
         .host()
         .is_some_and(|host| matches!(host, Host::Domain(_)))
     {
+        let has_v4 = addresses.iter().any(|address| address.is_ipv4());
+        if has_v4 {
+            command.arg("--ipv4");
+        }
         for address in addresses {
+            if has_v4 && address.is_ipv6() {
+                continue;
+            }
             let pinned = match address {
                 IpAddr::V4(address) => format!("{host}:{port}:{address}"),
                 IpAddr::V6(address) => format!("{host}:{port}:[{address}]"),

--- a/src/chat/agent.rs
+++ b/src/chat/agent.rs
@@ -358,6 +358,8 @@ pub fn run_loop(
     let mut observed_file_content = false;
     let mut workspace_observations: Vec<(String, String)> = Vec::new();
     let mut successful_workspace_reads = BTreeSet::new();
+    let mut mutated_files = BTreeSet::new();
+    let mut verified_after_mutation = true;
     let mut calibration: Option<f32> = None;
 
     for _ in 0..cfg.max_steps {
@@ -452,6 +454,26 @@ pub fn run_loop(
                          invent paths or describe a fix without applying and verifying it."
                             .into(),
                     ));
+                    continue;
+                }
+                let goal_asks_verification = history.iter().any(|m| match m {
+                    AgentMsg::User(text) => {
+                        let lower = text.to_lowercase();
+                        lower.contains("verify") || lower.contains("test")
+                    }
+                    _ => false,
+                });
+                if goal_asks_verification
+                    && !mutated_files.is_empty()
+                    && !verified_after_mutation
+                    && tools.iter().any(|t| t.name == "run_shell")
+                {
+                    reporter.notice("Verification required before final answer");
+                    history.push(AgentMsg::System(format!(
+                        "You have modified files ({}) but have not executed a test or verification command since the modification. \
+                         Execute the test suite using run_shell to verify your fix before concluding.",
+                        mutated_files.iter().cloned().collect::<Vec<_>>().join(", ")
+                    )));
                     continue;
                 }
                 let missing_reads = required_workspace_reads
@@ -672,6 +694,18 @@ pub fn run_loop(
                         observed_workspace = true;
                         if matches!(action, Action::ReadFile { .. } | Action::Search { .. }) {
                             observed_file_content = true;
+                        }
+                    }
+                    if !outcome.is_err() {
+                        match &action {
+                            Action::EditFile { path, .. } | Action::WriteFile { path, .. } => {
+                                mutated_files.insert(normalize_workspace_path(&sandbox.rel(path)));
+                                verified_after_mutation = false;
+                            }
+                            Action::RunShell { .. } => {
+                                verified_after_mutation = true;
+                            }
+                            _ => {}
                         }
                     }
                     let name = action.tool_name();
@@ -1265,6 +1299,40 @@ fn estimate_tokens(history: &[AgentMsg], calibration: Option<f32>) -> u32 {
     (chars as f32 * per_char).ceil() as u32
 }
 
+fn summarize_tool_call(call: &ToolCall) -> String {
+    match call.name.as_str() {
+        "edit_file" | "write_file" | "read_file" => {
+            let path = call.args.get("path").and_then(Value::as_str).unwrap_or("");
+            if path.is_empty() {
+                call.name.clone()
+            } else {
+                format!("{}({})", call.name, path)
+            }
+        }
+        "run_shell" => {
+            let cmd = call.args.get("command").and_then(Value::as_str).unwrap_or("");
+            if cmd.is_empty() {
+                "run_shell".into()
+            } else {
+                format!("run_shell(\"{}\")", first_line(cmd, 60))
+            }
+        }
+        "search" => {
+            let pat = call.args.get("pattern").and_then(Value::as_str).unwrap_or("");
+            if pat.is_empty() {
+                "search".into()
+            } else {
+                format!("search(\"{}\")", first_line(pat, 40))
+            }
+        }
+        "list_dir" => {
+            let path = call.args.get("path").and_then(Value::as_str).unwrap_or(".");
+            format!("list_dir({})", path)
+        }
+        _ => call.name.clone(),
+    }
+}
+
 fn digest(message: &AgentMsg) -> Option<String> {
     match message {
         AgentMsg::System(_) | AgentMsg::Memory(_) | AgentMsg::Summary(_) => None,
@@ -1274,15 +1342,26 @@ fn digest(message: &AgentMsg) -> Option<String> {
             "- called: {}",
             calls
                 .iter()
-                .map(|call| call.name.as_str())
+                .map(summarize_tool_call)
                 .collect::<Vec<_>>()
                 .join(", ")
         )),
-        AgentMsg::ToolResult { name, outcome } => Some(format!(
-            "- {name} returned {} ({} bytes, content not retained)",
-            if outcome.is_err() { "an error" } else { "ok" },
-            outcome.text().len()
-        )),
+        AgentMsg::ToolResult { name, outcome } => {
+            let status = if outcome.is_err() {
+                let err_text = outcome.text();
+                if let Some(exit_line) = err_text.lines().find(|l| l.contains("exit:")) {
+                    format!("an error ({})", exit_line.trim())
+                } else {
+                    "an error".to_string()
+                }
+            } else {
+                "ok".to_string()
+            };
+            Some(format!(
+                "- {name} returned {status} ({} bytes, content not retained)",
+                outcome.text().len()
+            ))
+        }
     }
 }
 
@@ -1357,14 +1436,76 @@ pub fn compact(
         });
     }
 
+    let mut modified_files = std::collections::BTreeSet::new();
+    let mut inspected_files = std::collections::BTreeSet::new();
+    let mut last_shell_cmd: Option<(String, &'static str)> = None;
+
+    for (idx, msg) in middle.iter().enumerate() {
+        if let AgentMsg::ToolCalls(calls) = msg {
+            for call in calls {
+                match call.name.as_str() {
+                    "edit_file" | "write_file" => {
+                        if let Some(path) = call.args.get("path").and_then(Value::as_str) {
+                            let succeeded = middle.get(idx + 1).map_or(false, |next| {
+                                matches!(next, AgentMsg::ToolResult { outcome, .. } if !outcome.is_err())
+                            });
+                            if succeeded {
+                                modified_files.insert(path.to_string());
+                            }
+                        }
+                    }
+                    "read_file" => {
+                        if let Some(path) = call.args.get("path").and_then(Value::as_str) {
+                            inspected_files.insert(path.to_string());
+                        }
+                    }
+                    "run_shell" => {
+                        if let Some(cmd) = call.args.get("command").and_then(Value::as_str) {
+                            let status = middle.get(idx + 1).map_or("executed", |next| {
+                                match next {
+                                    AgentMsg::ToolResult { outcome, .. } if outcome.is_err() => "failed",
+                                    AgentMsg::ToolResult { outcome: _, .. } => "passed",
+                                    _ => "executed",
+                                }
+                            });
+                            last_shell_cmd = Some((first_line(cmd, 60), status));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let mut ledger = String::new();
+    if !modified_files.is_empty() || !inspected_files.is_empty() || last_shell_cmd.is_some() {
+        ledger.push_str("\nActive working set:\n");
+        if !modified_files.is_empty() {
+            ledger.push_str(&format!(
+                "- Modified files: {}\n",
+                modified_files.into_iter().collect::<Vec<_>>().join(", ")
+            ));
+        }
+        if !inspected_files.is_empty() {
+            ledger.push_str(&format!(
+                "- Inspected files: {}\n",
+                inspected_files.into_iter().collect::<Vec<_>>().join(", ")
+            ));
+        }
+        if let Some((cmd, status)) = last_shell_cmd {
+            ledger.push_str(&format!("- Last command: `{cmd}` ({status})\n"));
+        }
+    }
+
     let lines = middle
         .iter()
         .filter_map(|message| digest(message))
         .collect::<Vec<_>>();
     let summary = format!(
         "[earlier steps in this session, compacted to save context - {} messages. \
-         This records what happened, not tool output; re-read anything you still need.]\n{}",
+         This records what happened, not tool output; re-read anything you still need.]{}\n{}",
         middle.len(),
+        ledger,
         lines.join("\n")
     );
     // Splice the summary in where the elided run began: after the pinned
@@ -4048,6 +4189,52 @@ mod tests {
     }
 
     #[test]
+    fn verification_gate_requires_test_run_after_mutating_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("pricing.cjs"), "const x = 1;\n").unwrap();
+        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+
+        let mut driver = MockDriver {
+            steps: vec![
+                ModelStep::Calls(vec![tc("read_file", json!({"path":"src/pricing.cjs"}))]),
+                ModelStep::Calls(vec![tc(
+                    "edit_file",
+                    json!({"path":"src/pricing.cjs","old":"1","new":"2"}),
+                )]),
+                // 1. Model prematurely attempts to claim completion without testing
+                ModelStep::Text("I fixed the code!".into()),
+                // 2. Model runs tests
+                ModelStep::Calls(vec![tc("run_shell", json!({"command":"echo ok"}))]),
+                // 3. Model finishes after verification
+                ModelStep::Text("Tests verified and passed!".into()),
+            ],
+            idx: 0,
+        };
+        let mut approver = ScriptApprover(vec![Decision::Once, Decision::Once], 0);
+        let mut reporter = RecordReporter::default();
+        let mut history = vec![AgentMsg::User("Fix the bug and verify that tests pass".into())];
+        let mut config = cfg(dir.path(), false);
+        config.tool_profile = tools::ToolProfile::BenchmarkShared;
+
+        let end = run_loop(
+            &mut driver,
+            &mut approver,
+            &mut reporter,
+            &sandbox,
+            &config,
+            &AtomicBool::new(false),
+            &mut Policy::default(),
+            &mut history,
+        );
+
+        assert_eq!(end, LoopEnd::Answered);
+        assert!(reporter.notices.iter().any(|n| n.contains("Verification required")));
+        assert_eq!(reporter.text, vec!["Tests verified and passed!"]);
+    }
+
+    #[test]
     fn explicit_memory_only_follow_up_may_answer_without_a_tool() {
         let history = vec![AgentMsg::User(
             "Without reading files again, repeat the earlier code.".into(),
@@ -5049,6 +5236,53 @@ mod tests {
         let before = long_history("secret");
         let (after, _) = compact(&before, 1024, None).unwrap();
         assert!(estimate_tokens(&after, None) < estimate_tokens(&before, None));
+    }
+
+    #[test]
+    fn compaction_records_active_working_set_ledger() {
+        let mut history = vec![
+            AgentMsg::System("safety".into()),
+            AgentMsg::User("fix calculation bug".into()),
+            AgentMsg::ToolCalls(vec![tc("read_file", json!({"path": "src/pricing.cjs"}))]),
+            AgentMsg::ToolResult {
+                name: "read_file".into(),
+                outcome: ToolOutcome::Ok("const x = 1;".repeat(50)),
+            },
+            AgentMsg::ToolCalls(vec![tc("edit_file", json!({"path": "src/pricing.cjs", "old": "1", "new": "2"}))]),
+            AgentMsg::ToolResult {
+                name: "edit_file".into(),
+                outcome: ToolOutcome::Ok("edited src/pricing.cjs".into()),
+            },
+            AgentMsg::ToolCalls(vec![tc("run_shell", json!({"command": "node tests/test.cjs"}))]),
+            AgentMsg::ToolResult {
+                name: "run_shell".into(),
+                outcome: ToolOutcome::Err("error: tests failed\nexit: 1".into()),
+            },
+        ];
+        for i in 0..10 {
+            history.push(AgentMsg::ToolCalls(vec![tc("read_file", json!({"path": format!("file-{i}.js")}))]));
+            history.push(AgentMsg::ToolResult {
+                name: "read_file".into(),
+                outcome: ToolOutcome::Ok("data".repeat(50)),
+            });
+        }
+        let (after, report) = compact(&history, 1024, None).unwrap();
+        assert!(report.elided > 0);
+        let summary = after
+            .iter()
+            .find_map(|m| match m {
+                AgentMsg::Summary(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .expect("should contain summary");
+
+        assert!(summary.contains("Active working set:"));
+        assert!(summary.contains("Modified files: src/pricing.cjs"));
+        assert!(summary.contains("Inspected files:"));
+        assert!(summary.contains("src/pricing.cjs"));
+        assert!(summary.contains("Last command: `node tests/test.cjs` (failed)"));
+        assert!(summary.contains("called: edit_file(src/pricing.cjs)"));
+        assert!(summary.contains("called: run_shell(\"node tests/test.cjs\")"));
     }
 
     #[test]

--- a/src/chat/agent.rs
+++ b/src/chat/agent.rs
@@ -359,7 +359,8 @@ pub fn run_loop(
     let mut workspace_observations: Vec<(String, String)> = Vec::new();
     let mut successful_workspace_reads = BTreeSet::new();
     let mut mutated_files = BTreeSet::new();
-    let mut verified_after_mutation = true;
+    let mut ran_command_since_mutation = true;
+    let mut verification_requested = false;
     let mut calibration: Option<f32> = None;
 
     for _ in 0..cfg.max_steps {
@@ -456,22 +457,28 @@ pub fn run_loop(
                     ));
                     continue;
                 }
-                let goal_asks_verification = history.iter().any(|m| match m {
-                    AgentMsg::User(text) => {
-                        let lower = text.to_lowercase();
-                        lower.contains("verify") || lower.contains("test")
-                    }
-                    _ => false,
-                });
-                if goal_asks_verification
+                // Premature-completion guard. A mutation that was never followed
+                // by a command is very likely unverified, so ask for one — ONCE.
+                // The nag is not repeated: a command that reports a failure is
+                // still a result the model must be free to report, and an
+                // unbounded nag turns a finished task into a step-capped one.
+                //
+                // Scoped to the benchmark profile, like the evidence gate above.
+                // The interactive agent has a human watching, and nagging one to
+                // run the build after a one-line doc edit is noise.
+                if cfg.tool_profile.is_benchmark_shared()
+                    && !verification_requested
                     && !mutated_files.is_empty()
-                    && !verified_after_mutation
+                    && !ran_command_since_mutation
                     && tools.iter().any(|t| t.name == "run_shell")
                 {
+                    verification_requested = true;
                     reporter.notice("Verification required before final answer");
                     history.push(AgentMsg::System(format!(
-                        "You have modified files ({}) but have not executed a test or verification command since the modification. \
-                         Execute the test suite using run_shell to verify your fix before concluding.",
+                        "You changed {} and have not run any command since. If this change can be \
+                         verified, run the project's build or tests with run_shell and report \
+                         exactly what it reported, including a failure. If nothing here is \
+                         verifiable, say so and finish.",
                         mutated_files.iter().cloned().collect::<Vec<_>>().join(", ")
                     )));
                     continue;
@@ -624,6 +631,9 @@ pub fn run_loop(
                         return LoopEnd::Aborted;
                     }
 
+                    // Whether the tool body actually ran, as opposed to being
+                    // refused by the approval policy before it could.
+                    let executed = !matches!(&decision, Decision::No | Decision::Abort);
                     let outcome = match decision {
                         Decision::Abort => {
                             reporter.notice("aborted by user");
@@ -696,17 +706,18 @@ pub fn run_loop(
                             observed_file_content = true;
                         }
                     }
-                    if !outcome.is_err() {
-                        match &action {
-                            Action::EditFile { path, .. } | Action::WriteFile { path, .. } => {
-                                mutated_files.insert(normalize_workspace_path(&sandbox.rel(path)));
-                                verified_after_mutation = false;
-                            }
-                            Action::RunShell { .. } => {
-                                verified_after_mutation = true;
-                            }
-                            _ => {}
+                    match &action {
+                        Action::EditFile { path, .. } | Action::WriteFile { path, .. }
+                            if !outcome.is_err() =>
+                        {
+                            mutated_files.insert(normalize_workspace_path(&sandbox.rel(path)));
+                            ran_command_since_mutation = false;
                         }
+                        // A command that ran at all clears the guard, whatever it
+                        // reported: the point is that the model looked, not that
+                        // the result was green.
+                        Action::RunShell { .. } if executed => ran_command_since_mutation = true,
+                        _ => {}
                     }
                     let name = action.tool_name();
                     reporter.tool_result(name, &outcome);
@@ -1299,6 +1310,23 @@ fn estimate_tokens(history: &[AgentMsg], calibration: Option<f32>) -> u32 {
     (chars as f32 * per_char).ceil() as u32
 }
 
+/// The working-set ledger lives inside the summary that exists to SAVE context,
+/// so a session that touched a hundred files must not paste a hundred paths.
+fn join_capped(paths: std::collections::BTreeSet<String>) -> String {
+    const MAX_LEDGER_ENTRIES: usize = 12;
+    let total = paths.len();
+    let shown = paths
+        .into_iter()
+        .take(MAX_LEDGER_ENTRIES)
+        .collect::<Vec<_>>()
+        .join(", ");
+    if total > MAX_LEDGER_ENTRIES {
+        format!("{shown} (+{} more)", total - MAX_LEDGER_ENTRIES)
+    } else {
+        shown
+    }
+}
+
 fn summarize_tool_call(call: &ToolCall) -> String {
     match call.name.as_str() {
         "edit_file" | "write_file" | "read_file" => {
@@ -1335,7 +1363,7 @@ fn summarize_tool_call(call: &ToolCall) -> String {
         }
         "list_dir" => {
             let path = call.args.get("path").and_then(Value::as_str).unwrap_or(".");
-            format!("list_dir({})", path)
+            format!("list_dir({path})")
         }
         _ => call.name.clone(),
     }
@@ -1450,14 +1478,18 @@ pub fn compact(
 
     for (idx, msg) in middle.iter().enumerate() {
         if let AgentMsg::ToolCalls(calls) = msg {
-            for call in calls {
+            for (nth, call) in calls.iter().enumerate() {
+                // `run_loop` pushes one `ToolResult` per call, in order, directly
+                // after the batch — so the nth call's result is at idx + 1 + nth,
+                // not always at idx + 1.
+                let result = match middle.get(idx + 1 + nth) {
+                    Some(AgentMsg::ToolResult { outcome, .. }) => Some(outcome),
+                    _ => None,
+                };
                 match call.name.as_str() {
                     "edit_file" | "write_file" => {
                         if let Some(path) = call.args.get("path").and_then(Value::as_str) {
-                            let succeeded = middle.get(idx + 1).map_or(false, |next| {
-                                matches!(next, AgentMsg::ToolResult { outcome, .. } if !outcome.is_err())
-                            });
-                            if succeeded {
+                            if result.is_some_and(|outcome| !outcome.is_err()) {
                                 modified_files.insert(path.to_string());
                             }
                         }
@@ -1469,14 +1501,11 @@ pub fn compact(
                     }
                     "run_shell" => {
                         if let Some(cmd) = call.args.get("command").and_then(Value::as_str) {
-                            let status =
-                                middle.get(idx + 1).map_or("executed", |next| match next {
-                                    AgentMsg::ToolResult { outcome, .. } if outcome.is_err() => {
-                                        "failed"
-                                    }
-                                    AgentMsg::ToolResult { outcome: _, .. } => "passed",
-                                    _ => "executed",
-                                });
+                            let status = match result {
+                                Some(outcome) if outcome.is_err() => "failed",
+                                Some(_) => "succeeded",
+                                None => "executed",
+                            };
                             last_shell_cmd = Some((first_line(cmd, 60), status));
                         }
                     }
@@ -1492,13 +1521,13 @@ pub fn compact(
         if !modified_files.is_empty() {
             ledger.push_str(&format!(
                 "- Modified files: {}\n",
-                modified_files.into_iter().collect::<Vec<_>>().join(", ")
+                join_capped(modified_files)
             ));
         }
         if !inspected_files.is_empty() {
             ledger.push_str(&format!(
                 "- Inspected files: {}\n",
-                inspected_files.into_iter().collect::<Vec<_>>().join(", ")
+                join_capped(inspected_files)
             ));
         }
         if let Some((cmd, status)) = last_shell_cmd {
@@ -4164,6 +4193,8 @@ mod tests {
                     "edit_file",
                     json!({"path":"src/pricing.cjs","old":"> 10000","new":">= 10000"}),
                 )]),
+                // The premature-completion guard spends the first of these.
+                ModelStep::Text("fixed and verified".into()),
                 ModelStep::Text("fixed and verified".into()),
             ],
             idx: 0,
@@ -4191,6 +4222,10 @@ mod tests {
             .results
             .iter()
             .any(|result| result.contains("call read_file with path `src/pricing.cjs`")));
+        assert!(reporter
+            .notices
+            .iter()
+            .any(|n| n.contains("Verification required")));
         assert_eq!(reporter.text, vec!["fixed and verified"]);
         assert!(std::fs::read_to_string(dir.path().join("src/pricing.cjs"))
             .unwrap()
@@ -4246,6 +4281,107 @@ mod tests {
             .iter()
             .any(|n| n.contains("Verification required")));
         assert_eq!(reporter.text, vec!["Tests verified and passed!"]);
+    }
+
+    /// The guard asks once. A command that ran and REPORTED A FAILURE is a
+    /// result the model must be free to hand back — without this, a red test
+    /// suite could never be reported and the run would step-cap instead.
+    #[test]
+    fn a_failing_verification_command_can_still_be_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("pricing.cjs"), "const x = 1;\n").unwrap();
+        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+
+        let failing = if cfg!(windows) { "exit /b 1" } else { "exit 1" };
+        let mut driver = MockDriver {
+            steps: vec![
+                ModelStep::Calls(vec![tc("read_file", json!({"path":"src/pricing.cjs"}))]),
+                ModelStep::Calls(vec![tc(
+                    "edit_file",
+                    json!({"path":"src/pricing.cjs","old":"1","new":"2"}),
+                )]),
+                ModelStep::Text("I fixed the code!".into()),
+                ModelStep::Calls(vec![tc("run_shell", json!({"command": failing}))]),
+                ModelStep::Text("I applied the change; the test suite still fails.".into()),
+                // Reached only if the guard wrongly fires a second time.
+                ModelStep::Text("second attempt".into()),
+            ],
+            idx: 0,
+        };
+        let mut approver = ScriptApprover(vec![Decision::Once, Decision::Once], 0);
+        let mut reporter = RecordReporter::default();
+        let mut history = vec![AgentMsg::User("Fix the bug and run the tests".into())];
+        let mut config = cfg(dir.path(), false);
+        config.tool_profile = tools::ToolProfile::BenchmarkShared;
+
+        let end = run_loop(
+            &mut driver,
+            &mut approver,
+            &mut reporter,
+            &sandbox,
+            &config,
+            &AtomicBool::new(false),
+            &mut Policy::default(),
+            &mut history,
+        );
+
+        assert_eq!(end, LoopEnd::Answered);
+        assert_eq!(
+            reporter.text,
+            vec!["I applied the change; the test suite still fails."]
+        );
+    }
+
+    /// The guard costs at most one step. A model that will not call a tool must
+    /// still be able to finish, or an edit-only task ends in `StepCapped`.
+    #[test]
+    fn the_verification_guard_asks_once_and_then_accepts_the_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("pricing.cjs"), "const x = 1;\n").unwrap();
+        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+
+        let mut driver = MockDriver {
+            steps: vec![
+                ModelStep::Calls(vec![tc("read_file", json!({"path":"src/pricing.cjs"}))]),
+                ModelStep::Calls(vec![tc(
+                    "edit_file",
+                    json!({"path":"src/pricing.cjs","old":"1","new":"2"}),
+                )]),
+                ModelStep::Text("Done; there is nothing to run here.".into()),
+                ModelStep::Text("Done; there is nothing to run here.".into()),
+            ],
+            idx: 0,
+        };
+        let mut approver = ScriptApprover(vec![Decision::Once, Decision::Once], 0);
+        let mut reporter = RecordReporter::default();
+        let mut history = vec![AgentMsg::User("Rename the constant".into())];
+        let mut config = cfg(dir.path(), false);
+        config.tool_profile = tools::ToolProfile::BenchmarkShared;
+
+        let end = run_loop(
+            &mut driver,
+            &mut approver,
+            &mut reporter,
+            &sandbox,
+            &config,
+            &AtomicBool::new(false),
+            &mut Policy::default(),
+            &mut history,
+        );
+
+        assert_eq!(end, LoopEnd::Answered);
+        assert_eq!(
+            reporter
+                .notices
+                .iter()
+                .filter(|n| n.contains("Verification required"))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/src/chat/agent.rs
+++ b/src/chat/agent.rs
@@ -1334,7 +1334,9 @@ fn summarize_tool_call(call: &ToolCall) -> String {
             if path.is_empty() {
                 call.name.clone()
             } else {
-                format!("{}({})", call.name, path)
+                // Same rendering the mutation ledger uses, so one path does not
+                // appear two ways across the summaries the model reads.
+                format!("{}({})", call.name, normalize_workspace_path(path))
             }
         }
         "run_shell" => {
@@ -1363,7 +1365,7 @@ fn summarize_tool_call(call: &ToolCall) -> String {
         }
         "list_dir" => {
             let path = call.args.get("path").and_then(Value::as_str).unwrap_or(".");
-            format!("list_dir({path})")
+            format!("list_dir({})", normalize_workspace_path(path))
         }
         _ => call.name.clone(),
     }
@@ -4178,7 +4180,9 @@ mod tests {
             "if (subtotalCents > 10000) return subtotalCents\n",
         )
         .unwrap();
-        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5))
+            .unwrap()
+            .with_checkpoints(false);
         let mut driver = MockDriver {
             steps: vec![
                 ModelStep::Text("done without looking".into()),
@@ -4238,7 +4242,9 @@ mod tests {
         let src = dir.path().join("src");
         std::fs::create_dir(&src).unwrap();
         std::fs::write(src.join("pricing.cjs"), "const x = 1;\n").unwrap();
-        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5))
+            .unwrap()
+            .with_checkpoints(false);
 
         let mut driver = MockDriver {
             steps: vec![
@@ -4292,7 +4298,11 @@ mod tests {
         let src = dir.path().join("src");
         std::fs::create_dir(&src).unwrap();
         std::fs::write(src.join("pricing.cjs"), "const x = 1;\n").unwrap();
-        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+        // The benchmark profile runs with checkpoints off in production, and the
+        // log is process-wide, so leave it alone.
+        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5))
+            .unwrap()
+            .with_checkpoints(false);
 
         let failing = if cfg!(windows) { "exit /b 1" } else { "exit 1" };
         let mut driver = MockDriver {
@@ -4342,7 +4352,10 @@ mod tests {
         let src = dir.path().join("src");
         std::fs::create_dir(&src).unwrap();
         std::fs::write(src.join("pricing.cjs"), "const x = 1;\n").unwrap();
-        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+        // As above: benchmark profile, process-wide checkpoint log.
+        let sandbox = Sandbox::new(dir.path(), false, Duration::from_secs(5))
+            .unwrap()
+            .with_checkpoints(false);
 
         let mut driver = MockDriver {
             steps: vec![

--- a/src/chat/agent.rs
+++ b/src/chat/agent.rs
@@ -1310,7 +1310,11 @@ fn summarize_tool_call(call: &ToolCall) -> String {
             }
         }
         "run_shell" => {
-            let cmd = call.args.get("command").and_then(Value::as_str).unwrap_or("");
+            let cmd = call
+                .args
+                .get("command")
+                .and_then(Value::as_str)
+                .unwrap_or("");
             if cmd.is_empty() {
                 "run_shell".into()
             } else {
@@ -1318,7 +1322,11 @@ fn summarize_tool_call(call: &ToolCall) -> String {
             }
         }
         "search" => {
-            let pat = call.args.get("pattern").and_then(Value::as_str).unwrap_or("");
+            let pat = call
+                .args
+                .get("pattern")
+                .and_then(Value::as_str)
+                .unwrap_or("");
             if pat.is_empty() {
                 "search".into()
             } else {
@@ -1461,13 +1469,14 @@ pub fn compact(
                     }
                     "run_shell" => {
                         if let Some(cmd) = call.args.get("command").and_then(Value::as_str) {
-                            let status = middle.get(idx + 1).map_or("executed", |next| {
-                                match next {
-                                    AgentMsg::ToolResult { outcome, .. } if outcome.is_err() => "failed",
+                            let status =
+                                middle.get(idx + 1).map_or("executed", |next| match next {
+                                    AgentMsg::ToolResult { outcome, .. } if outcome.is_err() => {
+                                        "failed"
+                                    }
                                     AgentMsg::ToolResult { outcome: _, .. } => "passed",
                                     _ => "executed",
-                                }
-                            });
+                                });
                             last_shell_cmd = Some((first_line(cmd, 60), status));
                         }
                     }
@@ -4214,7 +4223,9 @@ mod tests {
         };
         let mut approver = ScriptApprover(vec![Decision::Once, Decision::Once], 0);
         let mut reporter = RecordReporter::default();
-        let mut history = vec![AgentMsg::User("Fix the bug and verify that tests pass".into())];
+        let mut history = vec![AgentMsg::User(
+            "Fix the bug and verify that tests pass".into(),
+        )];
         let mut config = cfg(dir.path(), false);
         config.tool_profile = tools::ToolProfile::BenchmarkShared;
 
@@ -4230,7 +4241,10 @@ mod tests {
         );
 
         assert_eq!(end, LoopEnd::Answered);
-        assert!(reporter.notices.iter().any(|n| n.contains("Verification required")));
+        assert!(reporter
+            .notices
+            .iter()
+            .any(|n| n.contains("Verification required")));
         assert_eq!(reporter.text, vec!["Tests verified and passed!"]);
     }
 
@@ -5248,19 +5262,28 @@ mod tests {
                 name: "read_file".into(),
                 outcome: ToolOutcome::Ok("const x = 1;".repeat(50)),
             },
-            AgentMsg::ToolCalls(vec![tc("edit_file", json!({"path": "src/pricing.cjs", "old": "1", "new": "2"}))]),
+            AgentMsg::ToolCalls(vec![tc(
+                "edit_file",
+                json!({"path": "src/pricing.cjs", "old": "1", "new": "2"}),
+            )]),
             AgentMsg::ToolResult {
                 name: "edit_file".into(),
                 outcome: ToolOutcome::Ok("edited src/pricing.cjs".into()),
             },
-            AgentMsg::ToolCalls(vec![tc("run_shell", json!({"command": "node tests/test.cjs"}))]),
+            AgentMsg::ToolCalls(vec![tc(
+                "run_shell",
+                json!({"command": "node tests/test.cjs"}),
+            )]),
             AgentMsg::ToolResult {
                 name: "run_shell".into(),
                 outcome: ToolOutcome::Err("error: tests failed\nexit: 1".into()),
             },
         ];
         for i in 0..10 {
-            history.push(AgentMsg::ToolCalls(vec![tc("read_file", json!({"path": format!("file-{i}.js")}))]));
+            history.push(AgentMsg::ToolCalls(vec![tc(
+                "read_file",
+                json!({"path": format!("file-{i}.js")}),
+            )]));
             history.push(AgentMsg::ToolResult {
                 name: "read_file".into(),
                 outcome: ToolOutcome::Ok("data".repeat(50)),

--- a/src/chat/tools.rs
+++ b/src/chat/tools.rs
@@ -426,7 +426,7 @@ impl Sandbox {
 }
 
 /// Compute Levenshtein edit distance between two strings.
-pub(crate) fn levenshtein_distance(a: &str, b: &str) -> usize {
+fn levenshtein_distance(a: &str, b: &str) -> usize {
     let a_chars: Vec<char> = a.chars().collect();
     let b_chars: Vec<char> = b.chars().collect();
     let mut prev: Vec<usize> = (0..=b_chars.len()).collect();
@@ -444,7 +444,7 @@ pub(crate) fn levenshtein_distance(a: &str, b: &str) -> usize {
 }
 
 /// Find closest matching file in sandbox root if a requested path does not exist.
-pub(crate) fn suggest_path_in_sandbox(root: &Path, raw: &str) -> Option<String> {
+fn suggest_path_in_sandbox(root: &Path, raw: &str) -> Option<String> {
     let raw_norm = raw.replace('\\', "/");
     let raw_path = Path::new(&raw_norm);
     let raw_name = raw_path.file_name()?.to_str()?;
@@ -459,7 +459,7 @@ pub(crate) fn suggest_path_in_sandbox(root: &Path, raw: &str) -> Option<String> 
     let mut visited_dirs = 0usize;
     let mut inspected_files = 0usize;
 
-    while let Some(dir) = stack.pop() {
+    'walk: while let Some(dir) = stack.pop() {
         visited_dirs += 1;
         if visited_dirs > 64 {
             break;
@@ -483,7 +483,7 @@ pub(crate) fn suggest_path_in_sandbox(root: &Path, raw: &str) -> Option<String> 
             } else if ft.is_file() {
                 inspected_files += 1;
                 if inspected_files > 500 {
-                    break;
+                    break 'walk;
                 }
 
                 let entry_path = entry.path();
@@ -606,7 +606,7 @@ pub fn specs_for(profile: ToolProfile, allow_net: bool, shell_mode: ShellSandbox
         },
         ToolSpec {
             name: "search".into(),
-            description: "Search UTF-8 file contents for a literal substring within the workspace. Optional path_filter filters file paths (e.g. `*.rs` or `src/**`).".into(),
+            description: "Search UTF-8 file contents for a literal substring within the workspace. This does not search filenames and does not accept regex. Optional path_filter accepts exactly one of `*.ext`, `dir/**`, or a plain file name or path fragment.".into(),
             risk: Risk::Read,
             params: json!({"type":"object","properties":{"pattern":{"type":"string"},"path":{"type":"string"},"path_filter":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":profile.search_hit_limit()}},"required":["pattern"]}),
         },
@@ -2059,31 +2059,78 @@ fn list_dir(path: &Path, offset: usize, limit: Option<usize>) -> ToolOutcome {
     })
 }
 
-fn matches_path_filter(rel_path: &str, filter: &str) -> bool {
-    let filter = filter.trim();
+/// The exact `path_filter` forms `search` understands. Anything else is
+/// refused rather than silently matching nothing, because an empty result set
+/// reads to the model as "the symbol is not there".
+///
+/// Patterns and paths are both normalized to `/` first: `Sandbox::rel` renders
+/// with the platform separator, so an un-normalized `dir/**` would silently miss
+/// every file on Windows.
+fn parse_path_filter(filter: &str) -> Result<PathFilter, String> {
+    let raw = filter.trim();
+    let normalized = raw.replace('\\', "/");
+    let filter = normalized.as_str();
     if filter.is_empty() || filter == "*" {
-        return true;
+        return Ok(PathFilter::Any);
     }
-    if let Some(ext) = filter.strip_prefix("*.") {
-        return rel_path.ends_with(&format!(".{ext}"));
+    if let Some(ext) = filter
+        .strip_prefix("*.")
+        .or_else(|| filter.strip_prefix('.'))
+    {
+        if ext.is_empty() || ext.contains(['*', '/']) {
+            return Err(unsupported_path_filter(raw));
+        }
+        return Ok(PathFilter::Extension(format!(".{ext}")));
     }
-    if let Some(ext) = filter.strip_prefix('.') {
-        return rel_path.ends_with(&format!(".{ext}"));
+    if let Some(dir) = filter
+        .strip_suffix("/**")
+        .or_else(|| filter.strip_suffix("/*"))
+        .or_else(|| filter.strip_suffix('/'))
+    {
+        if dir.is_empty() || dir.contains('*') {
+            return Err(unsupported_path_filter(raw));
+        }
+        return Ok(PathFilter::Directory(format!("{dir}/")));
     }
-    if let Some(dir) = filter.strip_suffix("/**") {
-        return rel_path.starts_with(dir) || rel_path.starts_with(&format!("{dir}/"));
+    if filter.contains('*') {
+        return Err(unsupported_path_filter(raw));
     }
-    if let Some(dir) = filter.strip_suffix("/*") {
-        return rel_path.starts_with(dir) || rel_path.starts_with(&format!("{dir}/"));
+    Ok(PathFilter::Name(filter.to_string()))
+}
+
+fn unsupported_path_filter(filter: &str) -> String {
+    format!(
+        "unsupported path_filter {filter:?}: use `*.ext` for an extension, `dir/**` for a \
+         subtree, or a plain file name or path fragment"
+    )
+}
+
+enum PathFilter {
+    Any,
+    /// Suffix including the dot, e.g. `.rs`.
+    Extension(String),
+    /// Directory prefix including the trailing slash, so `src/` cannot match
+    /// `src-generated/`.
+    Directory(String),
+    Name(String),
+}
+
+impl PathFilter {
+    fn matches(&self, rel_path: &str) -> bool {
+        let rel_path = rel_path.replace('\\', "/");
+        match self {
+            PathFilter::Any => true,
+            PathFilter::Extension(suffix) => rel_path.ends_with(suffix.as_str()),
+            PathFilter::Directory(prefix) => rel_path.starts_with(prefix.as_str()),
+            PathFilter::Name(name) => {
+                Path::new(&rel_path)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .is_some_and(|file_name| file_name == name)
+                    || rel_path.contains(name.as_str())
+            }
+        }
     }
-    if let Some(dir) = filter.strip_suffix('/') {
-        return rel_path.starts_with(dir) || rel_path.starts_with(&format!("{dir}/"));
-    }
-    let file_name = Path::new(rel_path)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or("");
-    file_name == filter || rel_path.contains(filter)
 }
 
 fn search(
@@ -2094,6 +2141,10 @@ fn search(
     sandbox: &Sandbox,
 ) -> ToolOutcome {
     let needle = pattern.to_lowercase();
+    let filter = match path_filter.map(parse_path_filter).transpose() {
+        Ok(filter) => filter,
+        Err(error) => return ToolOutcome::Err(error),
+    };
     let root = match std::fs::canonicalize(root) {
         Ok(root) if sandbox.permits(&root) => root,
         _ => return ToolOutcome::Err("search path is unavailable or outside the workspace".into()),
@@ -2103,9 +2154,8 @@ fn search(
         Err(error) => return ToolOutcome::Err(format!("search path is unavailable: {error}")),
     };
     if root_metadata.file_type().is_file() {
-        if let Some(filter) = path_filter {
-            let rel = sandbox.rel(&root);
-            if !matches_path_filter(&rel, filter) {
+        if let Some(filter) = &filter {
+            if !filter.matches(&sandbox.rel(&root)) {
                 return ToolOutcome::Ok(format!("no matches for {pattern:?}"));
             }
         }
@@ -2161,9 +2211,8 @@ fn search(
                 continue;
             }
 
-            if let Some(filter) = path_filter {
-                let rel = sandbox.rel(&path);
-                if !matches_path_filter(&rel, filter) {
+            if let Some(filter) = &filter {
+                if !filter.matches(&sandbox.rel(&path)) {
                     continue;
                 }
             }
@@ -2487,6 +2536,11 @@ fn map_lf_range_to_orig(content: &str, start_lf: usize, end_lf: usize) -> (usize
     (start, end)
 }
 
+/// Re-indent `new_text` by `indent_delta` columns.
+///
+/// Indentation is measured in leading SPACES only, so a tab-indented file and a
+/// space-indented `old` resolve to a delta of zero and the replacement is
+/// written exactly as the model sent it.
 fn adjust_indentation(new_text: &str, indent_delta: isize, crlf: bool) -> String {
     let sep = if crlf { "\r\n" } else { "\n" };
     let lines: Vec<&str> = new_text.lines().collect();
@@ -2602,6 +2656,13 @@ fn find_tolerant_line_matches(content: &str, old: &str) -> Vec<LineMatchCandidat
     candidates
 }
 
+/// `generate_near_miss_diagnostics` scores every window of the file against
+/// `old`, and `levenshtein_distance` is O(a*b) per line pair. `edit_file` accepts
+/// files up to `MAX_RANGED_FILE_BYTES`, so both costs are bounded: past these
+/// budgets the generic "not found" message is returned instead of scanning on.
+const MAX_NEAR_MISS_WINDOW_COMPARISONS: usize = 2_000_000;
+const MAX_NEAR_MISS_LEVENSHTEIN_CELLS: usize = 4_000_000;
+
 fn generate_near_miss_diagnostics(content: &str, old: &str) -> String {
     let file_lines: Vec<&str> = content.lines().collect();
     let old_lines: Vec<&str> = old.lines().collect();
@@ -2614,6 +2675,10 @@ fn generate_near_miss_diagnostics(content: &str, old: &str) -> String {
     }
 
     let m = old_lines.len();
+    if file_lines.len().saturating_mul(m) > MAX_NEAR_MISS_WINDOW_COMPARISONS {
+        return NEAR_MISS_GENERIC.into();
+    }
+    let mut levenshtein_budget = MAX_NEAR_MISS_LEVENSHTEIN_CELLS;
     let mut best_score = 0.0f32;
     let mut best_window_idx = 0usize;
 
@@ -2631,8 +2696,14 @@ fn generate_near_miss_diagnostics(content: &str, old: &str) -> String {
             } else if fl.trim_end() == ol.trim_end() {
                 score += 0.9;
             } else {
-                let dist = levenshtein_distance(fl.trim(), ol.trim());
-                let max_len = fl.trim().len().max(ol.trim().len());
+                let (fl, ol) = (fl.trim(), ol.trim());
+                let cells = fl.len().saturating_mul(ol.len());
+                if cells > levenshtein_budget {
+                    continue;
+                }
+                levenshtein_budget -= cells;
+                let dist = levenshtein_distance(fl, ol);
+                let max_len = fl.len().max(ol.len());
                 if max_len > 0 && dist < max_len {
                     let sim = 1.0 - (dist as f32 / max_len as f32);
                     if sim > 0.5 {
@@ -2684,9 +2755,11 @@ fn generate_near_miss_diagnostics(content: &str, old: &str) -> String {
              {hint}"
         )
     } else {
-        "`old` text not found in file (0 occurrences). Inspect the target section with `read_file` before editing.".into()
+        NEAR_MISS_GENERIC.into()
     }
 }
+
+const NEAR_MISS_GENERIC: &str = "`old` text not found in file (0 occurrences). Inspect the target section with `read_file` before editing.";
 
 fn edit_file(path: &Path, old: &str, new: &str) -> ToolOutcome {
     if old.is_empty() {
@@ -5847,5 +5920,31 @@ mod tests {
         assert!(text.contains("src/lib.rs") || text.contains("src\\lib.rs"));
         assert!(text.contains("src/other.js") || text.contains("src\\other.js"));
         assert!(!text.contains("tests/test.rs") && !text.contains("tests\\test.rs"));
+    }
+
+    #[test]
+    fn a_directory_path_filter_does_not_match_a_sibling_with_the_same_prefix() {
+        let filter = parse_path_filter("src/**").unwrap();
+        // `Sandbox::rel` renders with the platform separator; both must behave.
+        assert!(filter.matches("src/lib.rs"));
+        assert!(filter.matches("src\\lib.rs"));
+        assert!(filter.matches("src/deep/lib.rs"));
+        assert!(!filter.matches("src-generated/lib.rs"));
+        assert!(!filter.matches("tests/src.rs"));
+    }
+
+    #[test]
+    fn an_unsupported_path_filter_is_refused_rather_than_matching_nothing() {
+        // Silently returning zero hits reads to the model as "the symbol is not
+        // there", which is a worse answer than an error it can correct.
+        for unsupported in ["src/*.rs", "**/*.rs", "src/**/tools.rs", "*.", "/"] {
+            let error = parse_path_filter(unsupported)
+                .err()
+                .unwrap_or_else(|| panic!("{unsupported} should not be accepted"));
+            assert!(error.contains("unsupported path_filter"), "{error}");
+        }
+        for supported in ["*.rs", ".rs", "src/**", "src/", "tools.rs", "*", ""] {
+            assert!(parse_path_filter(supported).is_ok(), "{supported}");
+        }
     }
 }

--- a/src/chat/tools.rs
+++ b/src/chat/tools.rs
@@ -491,7 +491,10 @@ pub(crate) fn suggest_path_in_sandbox(root: &Path, raw: &str) -> Option<String> 
                     continue;
                 };
                 let rel_str = rel.to_string_lossy().replace('\\', "/");
-                let entry_stem = Path::new(&*name_str).file_stem().and_then(|s| s.to_str()).unwrap_or("");
+                let entry_stem = Path::new(&*name_str)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("");
 
                 let score = if name_str == raw_name {
                     100
@@ -1075,7 +1078,10 @@ impl Action {
                 path_filter,
             } => {
                 if let Some(filter) = path_filter {
-                    format!("search({pattern:?}, {}, filter={filter:?}, limit={limit})", sandbox.rel(path))
+                    format!(
+                        "search({pattern:?}, {}, filter={filter:?}, limit={limit})",
+                        sandbox.rel(path)
+                    )
                 } else {
                     format!("search({pattern:?}, {}, limit={limit})", sandbox.rel(path))
                 }
@@ -1390,7 +1396,10 @@ pub fn validate_for(
         "search" => {
             let pattern = str_arg("pattern")?;
             let path = args.get("path").and_then(Value::as_str).unwrap_or(".");
-            let path_filter = args.get("path_filter").and_then(Value::as_str).map(str::to_string);
+            let path_filter = args
+                .get("path_filter")
+                .and_then(Value::as_str)
+                .map(str::to_string);
             let max_limit = profile.search_hit_limit();
             let limit = args
                 .get("limit")
@@ -2070,7 +2079,10 @@ fn matches_path_filter(rel_path: &str, filter: &str) -> bool {
     if let Some(dir) = filter.strip_suffix('/') {
         return rel_path.starts_with(dir) || rel_path.starts_with(&format!("{dir}/"));
     }
-    let file_name = Path::new(rel_path).file_name().and_then(|f| f.to_str()).unwrap_or("");
+    let file_name = Path::new(rel_path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("");
     file_name == filter || rel_path.contains(filter)
 }
 
@@ -2719,7 +2731,11 @@ fn edit_file(path: &Path, old: &str, new: &str) -> ToolOutcome {
         return ToolOutcome::Err(format!(
             "`old` text is not unique ({} occurrences at lines {}); include more context",
             lines.len(),
-            lines.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
+            lines
+                .iter()
+                .map(|l| l.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
         ));
     }
 
@@ -2728,17 +2744,28 @@ fn edit_file(path: &Path, old: &str, new: &str) -> ToolOutcome {
     let content_lf = content.replace("\r\n", "\n");
     let old_lf = old.replace("\r\n", "\n");
     if old_lf != old || file_has_crlf {
-        let norm_matches: Vec<usize> = content_lf.match_indices(&old_lf).map(|(idx, _)| idx).collect();
+        let norm_matches: Vec<usize> = content_lf
+            .match_indices(&old_lf)
+            .map(|(idx, _)| idx)
+            .collect();
         if norm_matches.len() == 1 {
-            let (start_orig, end_orig) = map_lf_range_to_orig(&content, norm_matches[0], norm_matches[0] + old_lf.len());
+            let (start_orig, end_orig) =
+                map_lf_range_to_orig(&content, norm_matches[0], norm_matches[0] + old_lf.len());
             let adjusted_new = if file_has_crlf && !new.contains("\r\n") {
                 new.replace('\n', "\r\n")
             } else {
                 new.to_string()
             };
-            let updated = format!("{}{adjusted_new}{}", &content[..start_orig], &content[end_orig..]);
+            let updated = format!(
+                "{}{adjusted_new}{}",
+                &content[..start_orig],
+                &content[end_orig..]
+            );
             return match write_regular_file(path, updated.as_bytes()) {
-                Ok(()) => ToolOutcome::Ok(format!("edited {} (matched with normalized line endings)", path.display())),
+                Ok(()) => ToolOutcome::Ok(format!(
+                    "edited {} (matched with normalized line endings)",
+                    path.display()
+                )),
                 Err(e) => ToolOutcome::Err(format!("write failed: {e}")),
             };
         } else if norm_matches.len() > 1 {
@@ -2749,7 +2776,11 @@ fn edit_file(path: &Path, old: &str, new: &str) -> ToolOutcome {
             return ToolOutcome::Err(format!(
                 "`old` text is not unique ({} occurrences at lines {}); include more context",
                 lines.len(),
-                lines.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
+                lines
+                    .iter()
+                    .map(|l| l.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
         }
     }
@@ -2759,11 +2790,16 @@ fn edit_file(path: &Path, old: &str, new: &str) -> ToolOutcome {
     if tolerant_candidates.len() == 1 {
         let candidate = &tolerant_candidates[0];
         let mut adjusted_new = adjust_indentation(new, candidate.indent_delta, file_has_crlf);
-        let had_trailing_newline = content[candidate.start_byte..candidate.end_byte].ends_with('\n');
+        let had_trailing_newline =
+            content[candidate.start_byte..candidate.end_byte].ends_with('\n');
         if had_trailing_newline && !adjusted_new.ends_with('\n') {
             adjusted_new.push_str(if file_has_crlf { "\r\n" } else { "\n" });
         }
-        let updated = format!("{}{adjusted_new}{}", &content[..candidate.start_byte], &content[candidate.end_byte..]);
+        let updated = format!(
+            "{}{adjusted_new}{}",
+            &content[..candidate.start_byte],
+            &content[candidate.end_byte..]
+        );
         return match write_regular_file(path, updated.as_bytes()) {
             Ok(()) => ToolOutcome::Ok(format!(
                 "edited {} (matched lines {}-{} after adjusting indentation/whitespace)",
@@ -5704,7 +5740,8 @@ mod tests {
     fn edit_file_tolerates_uniform_indentation_shift() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("indent.txt");
-        let initial = "function test() {\n        let a = 1;\n        let b = 2;\n        return a + b;\n}\n";
+        let initial =
+            "function test() {\n        let a = 1;\n        let b = 2;\n        return a + b;\n}\n";
         std::fs::write(&file_path, initial).unwrap();
 
         // Model sends 4-space indent instead of 8-space indent in file
@@ -5782,9 +5819,13 @@ mod tests {
         // 1. Search filtered by extension *.js
         let action = validate_for(
             ToolProfile::Full,
-            &call("search", json!({"pattern": "target_symbol", "path_filter": "*.js"})),
+            &call(
+                "search",
+                json!({"pattern": "target_symbol", "path_filter": "*.js"}),
+            ),
             &sb,
-        ).unwrap();
+        )
+        .unwrap();
         let outcome = action.execute(&sb);
         let text = outcome.text();
         assert!(text.contains("other.js"));
@@ -5794,9 +5835,13 @@ mod tests {
         // 2. Search filtered by directory prefix src/**
         let action = validate_for(
             ToolProfile::Full,
-            &call("search", json!({"pattern": "target_symbol", "path_filter": "src/**"})),
+            &call(
+                "search",
+                json!({"pattern": "target_symbol", "path_filter": "src/**"}),
+            ),
             &sb,
-        ).unwrap();
+        )
+        .unwrap();
         let outcome = action.execute(&sb);
         let text = outcome.text();
         assert!(text.contains("src/lib.rs") || text.contains("src\\lib.rs"));

--- a/src/chat/tools.rs
+++ b/src/chat/tools.rs
@@ -2155,8 +2155,13 @@ fn search(
     };
     if root_metadata.file_type().is_file() {
         if let Some(filter) = &filter {
-            if !filter.matches(&sandbox.rel(&root)) {
-                return ToolOutcome::Ok(format!("no matches for {pattern:?}"));
+            let rel = sandbox.rel(&root);
+            if !filter.matches(&rel) {
+                return ToolOutcome::Err(format!(
+                    "path_filter {:?} excludes the search path {rel}, so this search can never \
+                     match; drop the filter or search a directory that contains it",
+                    path_filter.unwrap_or("")
+                ));
             }
         }
         return search_file(&needle, &root, limit, sandbox);
@@ -2538,9 +2543,10 @@ fn map_lf_range_to_orig(content: &str, start_lf: usize, end_lf: usize) -> (usize
 
 /// Re-indent `new_text` by `indent_delta` columns.
 ///
-/// Indentation is measured in leading SPACES only, so a tab-indented file and a
-/// space-indented `old` resolve to a delta of zero and the replacement is
-/// written exactly as the model sent it.
+/// Indentation is measured in leading SPACES only. `find_tolerant_line_matches`
+/// only produces a delta for runs that are comparable by width, and a negative
+/// delta reaches here only once `indent_shift_applies` has confirmed every line
+/// can absorb it; the clamp below is a floor, not a fallback.
 fn adjust_indentation(new_text: &str, indent_delta: isize, crlf: bool) -> String {
     let sep = if crlf { "\r\n" } else { "\n" };
     let lines: Vec<&str> = new_text.lines().collect();
@@ -2567,6 +2573,23 @@ fn adjust_indentation(new_text: &str, indent_delta: isize, crlf: bool) -> String
         joined.push_str(sep);
     }
     joined
+}
+
+/// Whether every line of `new_text` can absorb a negative `indent_delta`.
+///
+/// A line with less leading space than the shift would be clamped at column 0
+/// while its siblings move by the full delta, silently flattening the relative
+/// indentation inside the replacement. A shift that does not fit is evidence the
+/// uniform-delta assumption is wrong, so the match is abandoned instead.
+fn indent_shift_applies(new_text: &str, indent_delta: isize) -> bool {
+    if indent_delta >= 0 {
+        return true;
+    }
+    let trim_count = indent_delta.unsigned_abs();
+    new_text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .all(|line| line.chars().take_while(|c| *c == ' ').count() >= trim_count)
 }
 
 struct LineMatchCandidate {
@@ -2622,9 +2645,19 @@ fn find_tolerant_line_matches(content: &str, old: &str) -> Vec<LineMatchCandidat
                 break;
             }
 
-            let fl_indent = fl.chars().take_while(|c| *c == ' ').count() as isize;
-            let ol_indent = ol.chars().take_while(|c| *c == ' ').count() as isize;
-            let delta = fl_indent - ol_indent;
+            let fl_ws = &fl[..fl.len() - fl.trim_start().len()];
+            let ol_ws = &ol[..ol.len() - ol.trim_start().len()];
+            // A tab run measures zero columns, so differing tab counts would
+            // read as a zero delta and overwrite the file's own indentation with
+            // the model's. Only space-only runs are comparable by width;
+            // anything else has to match byte for byte.
+            let comparable = fl_ws == ol_ws
+                || (fl_ws.bytes().all(|b| b == b' ') && ol_ws.bytes().all(|b| b == b' '));
+            if !comparable {
+                matches = false;
+                break;
+            }
+            let delta = fl_ws.len() as isize - ol_ws.len() as isize;
 
             match uniform_delta {
                 None => uniform_delta = Some(delta),
@@ -2660,6 +2693,11 @@ fn find_tolerant_line_matches(content: &str, old: &str) -> Vec<LineMatchCandidat
 /// `old`, and `levenshtein_distance` is O(a*b) per line pair. `edit_file` accepts
 /// files up to `MAX_RANGED_FILE_BYTES`, so both costs are bounded: past these
 /// budgets the generic "not found" message is returned instead of scanning on.
+///
+/// The cell budget is a running total spent top-down, so on a large file only
+/// the first windows get fuzzy scoring and "closest match" is biased toward the
+/// top. The free exact/`trim`/`trim_end` tiers still cover the whole file, so
+/// this degrades the ranking, never the correctness of a reported match.
 const MAX_NEAR_MISS_WINDOW_COMPARISONS: usize = 2_000_000;
 const MAX_NEAR_MISS_LEVENSHTEIN_CELLS: usize = 4_000_000;
 
@@ -2860,7 +2898,9 @@ fn edit_file(path: &Path, old: &str, new: &str) -> ToolOutcome {
 
     // 3. Tolerant whitespace & uniform indentation matching
     let tolerant_candidates = find_tolerant_line_matches(&content, old);
-    if tolerant_candidates.len() == 1 {
+    if tolerant_candidates.len() == 1
+        && indent_shift_applies(new, tolerant_candidates[0].indent_delta)
+    {
         let candidate = &tolerant_candidates[0];
         let mut adjusted_new = adjust_indentation(new, candidate.indent_delta, file_has_crlf);
         let had_trailing_newline =
@@ -5826,6 +5866,55 @@ mod tests {
         let updated = std::fs::read_to_string(&file_path).unwrap();
         let expected = "function test() {\n        let a = 10;\n        let b = 20;\n        return a + b;\n}\n";
         assert_eq!(updated, expected);
+    }
+
+    /// A tab run measures zero columns, so a differing tab count used to look
+    /// like a uniform zero delta and write the model's indentation into the
+    /// file. In Python or a Makefile that is a semantic change reported as `Ok`.
+    #[test]
+    fn a_tab_indented_file_is_not_rewritten_by_a_shallower_tab_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("indent.py");
+        let initial = "def f():\n\t\tif x:\n\t\t\treturn 1\n";
+        std::fs::write(&file_path, initial).unwrap();
+
+        // One tab shallower than the file at every line.
+        let outcome = edit_file(&file_path, "\tif x:\n\t\treturn 1", "\tif x:\n\t\treturn 2");
+
+        assert!(outcome.is_err(), "{}", outcome.text());
+        assert_eq!(std::fs::read_to_string(&file_path).unwrap(), initial);
+    }
+
+    /// A negative shift is applied per line with a clamp, so a line that cannot
+    /// absorb it lands at column 0 while its siblings move by the full delta.
+    /// A shift that does not fit is evidence the uniform-delta assumption is
+    /// wrong, so the match is abandoned rather than applied.
+    #[test]
+    fn an_indent_shift_that_would_flatten_the_replacement_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("flatten.py");
+        let initial = "if x:\n  a = 1\n  b = 2\n";
+        std::fs::write(&file_path, initial).unwrap();
+
+        // delta is -6, but `if y:` carries only 4 leading spaces.
+        let outcome = edit_file(
+            &file_path,
+            "        a = 1\n        b = 2",
+            "        a = 1\n    if y:\n        b = 2",
+        );
+
+        assert!(outcome.is_err(), "{}", outcome.text());
+        assert_eq!(std::fs::read_to_string(&file_path).unwrap(), initial);
+
+        // A negative shift every line can absorb still applies.
+        let fits = dir.path().join("fits.py");
+        std::fs::write(&fits, initial).unwrap();
+        let outcome = edit_file(&fits, "    a = 1\n    b = 2", "    a = 10\n    b = 20");
+        assert!(matches!(outcome, ToolOutcome::Ok(_)), "{}", outcome.text());
+        assert_eq!(
+            std::fs::read_to_string(&fits).unwrap(),
+            "if x:\n  a = 10\n  b = 20\n"
+        );
     }
 
     #[test]

--- a/src/chat/tools.rs
+++ b/src/chat/tools.rs
@@ -360,7 +360,16 @@ impl Sandbox {
             }
         };
         let canon = if must_exist {
-            std::fs::canonicalize(&candidate).map_err(|e| format!("cannot access {raw}: {e}"))?
+            match std::fs::canonicalize(&candidate) {
+                Ok(c) => c,
+                Err(e) => {
+                    let err_msg = format!("cannot access {raw}: {e}");
+                    if let Some(suggestion) = suggest_path_in_sandbox(&self.root, raw) {
+                        return Err(format!("{err_msg}. Did you mean '{suggestion}'?"));
+                    }
+                    return Err(err_msg);
+                }
+            }
         } else {
             let parent = candidate
                 .parent()
@@ -413,6 +422,109 @@ impl Sandbox {
                 }
             })
             .unwrap_or_else(|_| path.display().to_string())
+    }
+}
+
+/// Compute Levenshtein edit distance between two strings.
+pub(crate) fn levenshtein_distance(a: &str, b: &str) -> usize {
+    let a_chars: Vec<char> = a.chars().collect();
+    let b_chars: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b_chars.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b_chars.len() + 1];
+
+    for (i, &ac) in a_chars.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &bc) in b_chars.iter().enumerate() {
+            let cost = if ac == bc { 0 } else { 1 };
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        prev.copy_from_slice(&curr);
+    }
+    prev[b_chars.len()]
+}
+
+/// Find closest matching file in sandbox root if a requested path does not exist.
+pub(crate) fn suggest_path_in_sandbox(root: &Path, raw: &str) -> Option<String> {
+    let raw_norm = raw.replace('\\', "/");
+    let raw_path = Path::new(&raw_norm);
+    let raw_name = raw_path.file_name()?.to_str()?;
+    if raw_name.is_empty() || raw_name.starts_with('.') {
+        return None;
+    }
+    let raw_stem = raw_path.file_stem()?.to_str()?;
+
+    let mut stack = vec![root.to_path_buf()];
+    let mut best_suggestion = None;
+    let mut best_score = 0usize;
+    let mut visited_dirs = 0usize;
+    let mut inspected_files = 0usize;
+
+    while let Some(dir) = stack.pop() {
+        visited_dirs += 1;
+        if visited_dirs > 64 {
+            break;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let Ok(ft) = entry.file_type() else {
+                continue;
+            };
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with('.') || name_str == "target" || name_str == "node_modules" {
+                continue;
+            }
+
+            if ft.is_dir() {
+                stack.push(entry.path());
+            } else if ft.is_file() {
+                inspected_files += 1;
+                if inspected_files > 500 {
+                    break;
+                }
+
+                let entry_path = entry.path();
+                let Ok(rel) = entry_path.strip_prefix(root) else {
+                    continue;
+                };
+                let rel_str = rel.to_string_lossy().replace('\\', "/");
+                let entry_stem = Path::new(&*name_str).file_stem().and_then(|s| s.to_str()).unwrap_or("");
+
+                let score = if name_str == raw_name {
+                    100
+                } else if name_str.to_ascii_lowercase() == raw_name.to_ascii_lowercase() {
+                    90
+                } else if entry_stem == raw_stem {
+                    80
+                } else if raw_name.len() >= 3 && name_str.len() >= 3 {
+                    let dist = levenshtein_distance(&name_str, raw_name);
+                    if dist <= 2 {
+                        70 - dist * 10
+                    } else {
+                        0
+                    }
+                } else {
+                    0
+                };
+
+                if score > best_score {
+                    best_score = score;
+                    best_suggestion = Some(rel_str);
+                    if score == 100 {
+                        return best_suggestion;
+                    }
+                }
+            }
+        }
+    }
+
+    if best_score >= 50 {
+        best_suggestion
+    } else {
+        None
     }
 }
 
@@ -491,9 +603,9 @@ pub fn specs_for(profile: ToolProfile, allow_net: bool, shell_mode: ShellSandbox
         },
         ToolSpec {
             name: "search".into(),
-            description: "Search UTF-8 file contents for a literal substring within the workspace. This does not search filenames and does not accept regex or glob syntax.".into(),
+            description: "Search UTF-8 file contents for a literal substring within the workspace. Optional path_filter filters file paths (e.g. `*.rs` or `src/**`).".into(),
             risk: Risk::Read,
-            params: json!({"type":"object","properties":{"pattern":{"type":"string"},"path":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":profile.search_hit_limit()}},"required":["pattern"]}),
+            params: json!({"type":"object","properties":{"pattern":{"type":"string"},"path":{"type":"string"},"path_filter":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":profile.search_hit_limit()}},"required":["pattern"]}),
         },
         ToolSpec {
             name: "update_plan".into(),
@@ -777,6 +889,7 @@ pub enum Action {
         pattern: String,
         path: PathBuf,
         limit: usize,
+        path_filter: Option<String>,
     },
     WriteFile {
         path: PathBuf,
@@ -959,9 +1072,13 @@ impl Action {
                 pattern,
                 path,
                 limit,
-                ..
+                path_filter,
             } => {
-                format!("search({pattern:?}, {}, limit={limit})", sandbox.rel(path))
+                if let Some(filter) = path_filter {
+                    format!("search({pattern:?}, {}, filter={filter:?}, limit={limit})", sandbox.rel(path))
+                } else {
+                    format!("search({pattern:?}, {}, limit={limit})", sandbox.rel(path))
+                }
             }
             Action::WriteFile { path, content, .. } => {
                 format!("write_file({}, {} bytes)", sandbox.rel(path), content.len())
@@ -1118,7 +1235,8 @@ impl Action {
                 pattern,
                 path,
                 limit,
-            } => search(pattern, path, *limit, sandbox),
+                path_filter,
+            } => search(pattern, path, *limit, path_filter.as_deref(), sandbox),
             // Snapshot before every mutation, at the execution site rather than
             // on the model's say-so, so undo is available whether or not the
             // model thought to ask for it. The snapshot only becomes a
@@ -1272,6 +1390,7 @@ pub fn validate_for(
         "search" => {
             let pattern = str_arg("pattern")?;
             let path = args.get("path").and_then(Value::as_str).unwrap_or(".");
+            let path_filter = args.get("path_filter").and_then(Value::as_str).map(str::to_string);
             let max_limit = profile.search_hit_limit();
             let limit = args
                 .get("limit")
@@ -1286,6 +1405,7 @@ pub fn validate_for(
                 pattern,
                 path: sandbox.resolve(path, true)?,
                 limit: limit as usize,
+                path_filter,
             })
         }
         "write_file" => {
@@ -1930,7 +2050,37 @@ fn list_dir(path: &Path, offset: usize, limit: Option<usize>) -> ToolOutcome {
     })
 }
 
-fn search(pattern: &str, root: &Path, limit: usize, sandbox: &Sandbox) -> ToolOutcome {
+fn matches_path_filter(rel_path: &str, filter: &str) -> bool {
+    let filter = filter.trim();
+    if filter.is_empty() || filter == "*" {
+        return true;
+    }
+    if let Some(ext) = filter.strip_prefix("*.") {
+        return rel_path.ends_with(&format!(".{ext}"));
+    }
+    if let Some(ext) = filter.strip_prefix('.') {
+        return rel_path.ends_with(&format!(".{ext}"));
+    }
+    if let Some(dir) = filter.strip_suffix("/**") {
+        return rel_path.starts_with(dir) || rel_path.starts_with(&format!("{dir}/"));
+    }
+    if let Some(dir) = filter.strip_suffix("/*") {
+        return rel_path.starts_with(dir) || rel_path.starts_with(&format!("{dir}/"));
+    }
+    if let Some(dir) = filter.strip_suffix('/') {
+        return rel_path.starts_with(dir) || rel_path.starts_with(&format!("{dir}/"));
+    }
+    let file_name = Path::new(rel_path).file_name().and_then(|f| f.to_str()).unwrap_or("");
+    file_name == filter || rel_path.contains(filter)
+}
+
+fn search(
+    pattern: &str,
+    root: &Path,
+    limit: usize,
+    path_filter: Option<&str>,
+    sandbox: &Sandbox,
+) -> ToolOutcome {
     let needle = pattern.to_lowercase();
     let root = match std::fs::canonicalize(root) {
         Ok(root) if sandbox.permits(&root) => root,
@@ -1941,6 +2091,12 @@ fn search(pattern: &str, root: &Path, limit: usize, sandbox: &Sandbox) -> ToolOu
         Err(error) => return ToolOutcome::Err(format!("search path is unavailable: {error}")),
     };
     if root_metadata.file_type().is_file() {
+        if let Some(filter) = path_filter {
+            let rel = sandbox.rel(&root);
+            if !matches_path_filter(&rel, filter) {
+                return ToolOutcome::Ok(format!("no matches for {pattern:?}"));
+            }
+        }
         return search_file(&needle, &root, limit, sandbox);
     }
     if !root_metadata.file_type().is_dir() {
@@ -1992,6 +2148,14 @@ fn search(pattern: &str, root: &Path, limit: usize, sandbox: &Sandbox) -> ToolOu
                 stack.push(path);
                 continue;
             }
+
+            if let Some(filter) = path_filter {
+                let rel = sandbox.rel(&path);
+                if !matches_path_filter(&rel, filter) {
+                    continue;
+                }
+            }
+
             files_scanned += 1;
             let Ok((bytes, grew_past_limit)) = read_regular_file_bounded(
                 &path,
@@ -2272,7 +2436,254 @@ fn write_file(path: &Path, content: &str) -> ToolOutcome {
     }
 }
 
+fn byte_offset_to_line(content: &str, byte_offset: usize) -> usize {
+    content[..byte_offset.min(content.len())]
+        .chars()
+        .filter(|&c| c == '\n')
+        .count()
+        + 1
+}
+
+fn map_lf_range_to_orig(content: &str, start_lf: usize, end_lf: usize) -> (usize, usize) {
+    let mut orig_bytes = 0usize;
+    let mut lf_bytes = 0usize;
+    let mut orig_start = None;
+    let mut orig_end = None;
+
+    let mut chars = content.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if lf_bytes == start_lf && orig_start.is_none() {
+            orig_start = Some(orig_bytes);
+        }
+        if lf_bytes == end_lf && orig_end.is_none() {
+            orig_end = Some(orig_bytes);
+            break;
+        }
+
+        if ch == '\r' && chars.peek() == Some(&'\n') {
+            chars.next();
+            orig_bytes += 2;
+            lf_bytes += 1;
+        } else {
+            orig_bytes += ch.len_utf8();
+            lf_bytes += ch.len_utf8();
+        }
+    }
+
+    let start = orig_start.unwrap_or(0);
+    let end = orig_end.unwrap_or(content.len());
+    (start, end)
+}
+
+fn adjust_indentation(new_text: &str, indent_delta: isize, crlf: bool) -> String {
+    let sep = if crlf { "\r\n" } else { "\n" };
+    let lines: Vec<&str> = new_text.lines().collect();
+    let mut result = Vec::with_capacity(lines.len());
+
+    for line in lines {
+        if line.trim().is_empty() {
+            result.push(String::new());
+        } else if indent_delta > 0 {
+            let padding = " ".repeat(indent_delta as usize);
+            result.push(format!("{padding}{line}"));
+        } else if indent_delta < 0 {
+            let trim_count = (-indent_delta) as usize;
+            let leading_spaces = line.chars().take_while(|c| *c == ' ').count();
+            let to_remove = leading_spaces.min(trim_count);
+            result.push(line[to_remove..].to_string());
+        } else {
+            result.push(line.to_string());
+        }
+    }
+
+    let mut joined = result.join(sep);
+    if new_text.ends_with('\n') {
+        joined.push_str(sep);
+    }
+    joined
+}
+
+struct LineMatchCandidate {
+    start_line: usize,
+    end_line: usize,
+    start_byte: usize,
+    end_byte: usize,
+    indent_delta: isize,
+}
+
+fn find_tolerant_line_matches(content: &str, old: &str) -> Vec<LineMatchCandidate> {
+    let file_lines: Vec<&str> = content.lines().collect();
+    let old_lines: Vec<&str> = old.lines().collect();
+    if old_lines.is_empty() || file_lines.len() < old_lines.len() {
+        return Vec::new();
+    }
+
+    let mut line_start_bytes = Vec::with_capacity(file_lines.len() + 1);
+    let mut cursor = 0usize;
+    for line in &file_lines {
+        line_start_bytes.push(cursor);
+        cursor += line.len();
+        if content[cursor..].starts_with("\r\n") {
+            cursor += 2;
+        } else if content[cursor..].starts_with('\n') {
+            cursor += 1;
+        }
+    }
+    line_start_bytes.push(cursor);
+
+    let m = old_lines.len();
+    let mut candidates = Vec::new();
+
+    for i in 0..=(file_lines.len() - m) {
+        let window = &file_lines[i..i + m];
+        let mut uniform_delta: Option<isize> = None;
+        let mut matches = true;
+
+        for (fl, ol) in window.iter().zip(old_lines.iter()) {
+            let fl_trim = fl.trim();
+            let ol_trim = ol.trim();
+
+            if ol_trim.is_empty() {
+                if !fl_trim.is_empty() {
+                    matches = false;
+                    break;
+                }
+                continue;
+            }
+
+            if fl_trim != ol_trim {
+                matches = false;
+                break;
+            }
+
+            let fl_indent = fl.chars().take_while(|c| *c == ' ').count() as isize;
+            let ol_indent = ol.chars().take_while(|c| *c == ' ').count() as isize;
+            let delta = fl_indent - ol_indent;
+
+            match uniform_delta {
+                None => uniform_delta = Some(delta),
+                Some(existing) if existing == delta => {}
+                Some(_) => {
+                    matches = false;
+                    break;
+                }
+            }
+        }
+
+        if matches {
+            let start_byte = line_start_bytes[i];
+            let end_byte = if i + m < file_lines.len() {
+                line_start_bytes[i + m]
+            } else {
+                content.len()
+            };
+            candidates.push(LineMatchCandidate {
+                start_line: i + 1,
+                end_line: i + m,
+                start_byte,
+                end_byte,
+                indent_delta: uniform_delta.unwrap_or(0),
+            });
+        }
+    }
+
+    candidates
+}
+
+fn generate_near_miss_diagnostics(content: &str, old: &str) -> String {
+    let file_lines: Vec<&str> = content.lines().collect();
+    let old_lines: Vec<&str> = old.lines().collect();
+
+    if file_lines.is_empty() {
+        return "`old` text not found: file is empty".into();
+    }
+    if old_lines.is_empty() {
+        return "`old` text cannot be empty".into();
+    }
+
+    let m = old_lines.len();
+    let mut best_score = 0.0f32;
+    let mut best_window_idx = 0usize;
+
+    for i in 0..file_lines.len() {
+        let window_len = m.min(file_lines.len() - i);
+        let window = &file_lines[i..i + window_len];
+
+        let mut score = 0.0f32;
+        for (k, fl) in window.iter().enumerate() {
+            let ol = old_lines[k];
+            if fl == &ol {
+                score += 1.0;
+            } else if fl.trim() == ol.trim() {
+                score += 0.85;
+            } else if fl.trim_end() == ol.trim_end() {
+                score += 0.9;
+            } else {
+                let dist = levenshtein_distance(fl.trim(), ol.trim());
+                let max_len = fl.trim().len().max(ol.trim().len());
+                if max_len > 0 && dist < max_len {
+                    let sim = 1.0 - (dist as f32 / max_len as f32);
+                    if sim > 0.5 {
+                        score += sim * 0.7;
+                    }
+                }
+            }
+        }
+
+        let normalized_score = score / m as f32;
+        if normalized_score > best_score {
+            best_score = normalized_score;
+            best_window_idx = i;
+        }
+    }
+
+    if best_score >= 0.35 {
+        let start_line = best_window_idx + 1;
+        let end_line = (best_window_idx + m).min(file_lines.len());
+        let window_lines = &file_lines[best_window_idx..end_line];
+
+        let mut snippet = String::new();
+        for (idx, line) in window_lines.iter().enumerate() {
+            snippet.push_str(&format!("  {:4} | {}\n", start_line + idx, line));
+        }
+
+        let hint = if let (Some(fl), Some(ol)) = (window_lines.first(), old_lines.first()) {
+            if fl.trim() == ol.trim() {
+                let fl_indent = fl.chars().take_while(|c| *c == ' ').count();
+                let ol_indent = ol.chars().take_while(|c| *c == ' ').count();
+                format!(
+                    "Hint: Indentation mismatch on line {start_line}. File uses {fl_indent} spaces; `old` had {ol_indent} spaces."
+                )
+            } else {
+                format!(
+                    "Hint: Verify differences near line {start_line}:\n  File has: `{fl}`\n  `old` had: `{ol}`"
+                )
+            }
+        } else {
+            "Hint: Verify line content and indentation with `read_file` before editing.".to_string()
+        };
+
+        format!(
+            "`old` text not found in file (0 exact matches).\n\
+             Closest match found at lines {start_line}-{end_line}:\n\
+             ----------------------------------------\n\
+             {snippet}\
+             ----------------------------------------\n\
+             {hint}"
+        )
+    } else {
+        "`old` text not found in file (0 occurrences). Inspect the target section with `read_file` before editing.".into()
+    }
+}
+
 fn edit_file(path: &Path, old: &str, new: &str) -> ToolOutcome {
+    if old.is_empty() {
+        return ToolOutcome::Err("`old` text cannot be empty".into());
+    }
+    if old == new {
+        return ToolOutcome::Err("`new` text is identical to `old` text; no changes made".into());
+    }
+
     let (bytes, grew_past_limit) = match read_regular_file_bounded(
         path,
         MAX_RANGED_FILE_BYTES,
@@ -2291,20 +2702,87 @@ fn edit_file(path: &Path, old: &str, new: &str) -> ToolOutcome {
         Ok(content) => content,
         Err(error) => return ToolOutcome::Err(format!("edit read failed: {error}")),
     };
-    let count = content.matches(old).count();
-    if count == 0 {
-        return ToolOutcome::Err("`old` text not found in file".into());
-    }
-    if count > 1 {
+
+    // 1. Exact match tier
+    let exact_matches: Vec<usize> = content.match_indices(old).map(|(idx, _)| idx).collect();
+    if exact_matches.len() == 1 {
+        let updated = content.replacen(old, new, 1);
+        return match write_regular_file(path, updated.as_bytes()) {
+            Ok(()) => ToolOutcome::Ok(format!("edited {}", path.display())),
+            Err(e) => ToolOutcome::Err(format!("write failed: {e}")),
+        };
+    } else if exact_matches.len() > 1 {
+        let lines: Vec<usize> = exact_matches
+            .iter()
+            .map(|&idx| byte_offset_to_line(&content, idx))
+            .collect();
         return ToolOutcome::Err(format!(
-            "`old` text is not unique ({count} occurrences); include more context"
+            "`old` text is not unique ({} occurrences at lines {}); include more context",
+            lines.len(),
+            lines.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
         ));
     }
-    let updated = content.replacen(old, new, 1);
-    match write_regular_file(path, updated.as_bytes()) {
-        Ok(()) => ToolOutcome::Ok(format!("edited {}", path.display())),
-        Err(e) => ToolOutcome::Err(format!("write failed: {e}")),
+
+    // 2. CRLF vs LF line-ending normalization
+    let file_has_crlf = content.contains("\r\n");
+    let content_lf = content.replace("\r\n", "\n");
+    let old_lf = old.replace("\r\n", "\n");
+    if old_lf != old || file_has_crlf {
+        let norm_matches: Vec<usize> = content_lf.match_indices(&old_lf).map(|(idx, _)| idx).collect();
+        if norm_matches.len() == 1 {
+            let (start_orig, end_orig) = map_lf_range_to_orig(&content, norm_matches[0], norm_matches[0] + old_lf.len());
+            let adjusted_new = if file_has_crlf && !new.contains("\r\n") {
+                new.replace('\n', "\r\n")
+            } else {
+                new.to_string()
+            };
+            let updated = format!("{}{adjusted_new}{}", &content[..start_orig], &content[end_orig..]);
+            return match write_regular_file(path, updated.as_bytes()) {
+                Ok(()) => ToolOutcome::Ok(format!("edited {} (matched with normalized line endings)", path.display())),
+                Err(e) => ToolOutcome::Err(format!("write failed: {e}")),
+            };
+        } else if norm_matches.len() > 1 {
+            let lines: Vec<usize> = norm_matches
+                .iter()
+                .map(|&idx| byte_offset_to_line(&content_lf, idx))
+                .collect();
+            return ToolOutcome::Err(format!(
+                "`old` text is not unique ({} occurrences at lines {}); include more context",
+                lines.len(),
+                lines.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
+            ));
+        }
     }
+
+    // 3. Tolerant whitespace & uniform indentation matching
+    let tolerant_candidates = find_tolerant_line_matches(&content, old);
+    if tolerant_candidates.len() == 1 {
+        let candidate = &tolerant_candidates[0];
+        let mut adjusted_new = adjust_indentation(new, candidate.indent_delta, file_has_crlf);
+        let had_trailing_newline = content[candidate.start_byte..candidate.end_byte].ends_with('\n');
+        if had_trailing_newline && !adjusted_new.ends_with('\n') {
+            adjusted_new.push_str(if file_has_crlf { "\r\n" } else { "\n" });
+        }
+        let updated = format!("{}{adjusted_new}{}", &content[..candidate.start_byte], &content[candidate.end_byte..]);
+        return match write_regular_file(path, updated.as_bytes()) {
+            Ok(()) => ToolOutcome::Ok(format!(
+                "edited {} (matched lines {}-{} after adjusting indentation/whitespace)",
+                path.display(),
+                candidate.start_line,
+                candidate.end_line
+            )),
+            Err(e) => ToolOutcome::Err(format!("write failed: {e}")),
+        };
+    } else if tolerant_candidates.len() > 1 {
+        let lines: Vec<usize> = tolerant_candidates.iter().map(|c| c.start_line).collect();
+        return ToolOutcome::Err(format!(
+            "`old` text matches multiple locations after whitespace normalization (lines {}); include more context",
+            lines.iter().map(|l| l.to_string()).collect::<Vec<_>>().join(", ")
+        ));
+    }
+
+    // 4. Actionable near-miss diagnostics when no match is found
+    ToolOutcome::Err(generate_near_miss_diagnostics(&content, old))
 }
 
 #[derive(Default)]
@@ -5195,5 +5673,134 @@ mod tests {
         let out = run("cmd /c exit 3; cmd /c exit 0");
         assert!(matches!(out, ToolOutcome::Ok(_)), "got {out:?}");
         assert!(out.text().contains("exit: 0"));
+    }
+
+    #[test]
+    fn edit_file_replaces_exact_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("code.txt");
+        std::fs::write(&file_path, "fn calculate() -> i32 {\n    return 42;\n}\n").unwrap();
+
+        let outcome = edit_file(&file_path, "return 42;", "return 100;");
+        assert!(matches!(outcome, ToolOutcome::Ok(_)));
+        let updated = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(updated, "fn calculate() -> i32 {\n    return 100;\n}\n");
+    }
+
+    #[test]
+    fn edit_file_tolerates_crlf_vs_lf() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("crlf.txt");
+        std::fs::write(&file_path, "line 1\r\nline 2\r\nline 3\r\n").unwrap();
+
+        // Model sends standard \n in both old and new
+        let outcome = edit_file(&file_path, "line 2\n", "line 2 modified\n");
+        assert!(matches!(outcome, ToolOutcome::Ok(_)));
+        let updated = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(updated, "line 1\r\nline 2 modified\r\nline 3\r\n");
+    }
+
+    #[test]
+    fn edit_file_tolerates_uniform_indentation_shift() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("indent.txt");
+        let initial = "function test() {\n        let a = 1;\n        let b = 2;\n        return a + b;\n}\n";
+        std::fs::write(&file_path, initial).unwrap();
+
+        // Model sends 4-space indent instead of 8-space indent in file
+        let old = "    let a = 1;\n    let b = 2;\n    return a + b;";
+        let new = "    let a = 10;\n    let b = 20;\n    return a + b;";
+
+        let outcome = edit_file(&file_path, old, new);
+        assert!(matches!(outcome, ToolOutcome::Ok(_)));
+        let updated = std::fs::read_to_string(&file_path).unwrap();
+        let expected = "function test() {\n        let a = 10;\n        let b = 20;\n        return a + b;\n}\n";
+        assert_eq!(updated, expected);
+    }
+
+    #[test]
+    fn edit_file_reports_ambiguous_line_numbers() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("dup.txt");
+        std::fs::write(&file_path, "header\nitem\nmiddle\nitem\nfooter\n").unwrap();
+
+        let outcome = edit_file(&file_path, "item", "new_item");
+        assert!(outcome.is_err());
+        let err = outcome.text();
+        assert!(err.contains("not unique"));
+        assert!(err.contains("lines 2, 4"));
+    }
+
+    #[test]
+    fn edit_file_provides_actionable_near_miss_diagnostics() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("pricing.cjs");
+        let code = "function calculateDiscount(total, discount) {\n  if (total > 10000) {\n    return total - discount;\n  }\n  return total;\n}\n";
+        std::fs::write(&file_path, code).unwrap();
+
+        // Model sends 4 spaces when file has 2 spaces, and typo in condition
+        let old = "    if (total >= 10000) {\n      return total - discount;\n    }";
+        let outcome = edit_file(&file_path, old, "    return 0;");
+        assert!(outcome.is_err());
+        let err = outcome.text();
+        assert!(err.contains("Closest match found at lines 2-4"));
+        assert!(err.contains("calculateDiscount") || err.contains("if (total > 10000)"));
+    }
+
+    #[test]
+    fn sandbox_resolve_suggests_nearest_file_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("pricing.cjs"), "// code").unwrap();
+
+        let sb = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+
+        // Target in subfolder requested without folder prefix
+        let err = sb.resolve("pricing.cjs", true).unwrap_err();
+        assert!(err.contains("Did you mean 'src/pricing.cjs'?"));
+
+        // Extension typo
+        let err = sb.resolve("src/pricing.js", true).unwrap_err();
+        assert!(err.contains("Did you mean 'src/pricing.cjs'?"));
+    }
+
+    #[test]
+    fn search_respects_path_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let tests = dir.path().join("tests");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&tests).unwrap();
+
+        std::fs::write(src.join("lib.rs"), "fn target_symbol() {}\n").unwrap();
+        std::fs::write(tests.join("test.rs"), "fn target_symbol() {}\n").unwrap();
+        std::fs::write(src.join("other.js"), "function target_symbol() {}\n").unwrap();
+
+        let sb = Sandbox::new(dir.path(), false, Duration::from_secs(5)).unwrap();
+
+        // 1. Search filtered by extension *.js
+        let action = validate_for(
+            ToolProfile::Full,
+            &call("search", json!({"pattern": "target_symbol", "path_filter": "*.js"})),
+            &sb,
+        ).unwrap();
+        let outcome = action.execute(&sb);
+        let text = outcome.text();
+        assert!(text.contains("other.js"));
+        assert!(!text.contains("lib.rs"));
+        assert!(!text.contains("test.rs"));
+
+        // 2. Search filtered by directory prefix src/**
+        let action = validate_for(
+            ToolProfile::Full,
+            &call("search", json!({"pattern": "target_symbol", "path_filter": "src/**"})),
+            &sb,
+        ).unwrap();
+        let outcome = action.execute(&sb);
+        let text = outcome.text();
+        assert!(text.contains("src/lib.rs") || text.contains("src\\lib.rs"));
+        assert!(text.contains("src/other.js") || text.contains("src\\other.js"));
+        assert!(!text.contains("tests/test.rs") && !text.contains("tests\\test.rs"));
     }
 }

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -512,7 +512,8 @@ __device__ __forceinline__ int i2_s_ternary(
     return code == 0 ? -1 : (code == 2 ? 1 : 0);
 }
 
-extern "C" __global__ void bitnet_i2_s_linear_rows(
+extern "C" {
+__global__ void bitnet_i2_s_linear_rows(
     const signed char* __restrict__ input,
     const unsigned char* __restrict__ weights,
     const int input_rows,
@@ -574,6 +575,7 @@ extern "C" __global__ void bitnet_i2_s_linear_rows(
     const long long packed_len = (long long)weight_rows * input_width / 4;
     const float scale = *reinterpret_cast<const float*>(weights + packed_len);
     output[idx] = (float)sum * activation_scales[input_row] * scale;
+}
 }
 
 // Header-free IEEE-754 binary16 conversion. The tied BitNet head stays in its
@@ -682,7 +684,10 @@ extern "C" __global__ void bitnet_f16_head_matvec(
         BACKEND
             .get_or_init(|| match init_backend() {
                 Ok(b) => Some(Mutex::new(b)),
-                Err(_) => None,
+                Err(err) => {
+                    eprintln!("[cuda] backend initialization failed: {err}");
+                    None
+                }
             })
             .as_ref()
     }

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -462,16 +462,6 @@ extern "C" __global__ void q8_0_encoded_linear_rows(
 // per-block integer dot is exact; the cross-block f32 reduction is reassociated
 // vs the CPU's sequential sum, so this is token-identical (not bit-identical) —
 // the same standard as the Metal GPU path. Verified by the parity audit.
-// NVRTC compiles this source without the CUDA headers that declare `__dp4a`,
-// so the intrinsic is spelled out as the single PTX instruction it lowers to.
-// `dp4a.s32.s32` needs PTX ISA 5.0 / sm_61, which `compile_options` already
-// targets.
-__device__ __forceinline__ int camelid_dp4a(int a, int b, int c) {
-    int d;
-    asm("dp4a.s32.s32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(b), "r"(c));
-    return d;
-}
-
 extern "C" __global__ void q8_0_block_linear_row(
     const float* __restrict__ input_scales,   // [blocks_per_row]
     const signed char* __restrict__ input_quants, // [blocks_per_row * 32]
@@ -495,7 +485,7 @@ extern "C" __global__ void q8_0_block_linear_row(
         int int_sum = 0;
         #pragma unroll
         for (int k = 0; k < 8; k++) {
-            int_sum = camelid_dp4a(wq[k], iq[k], int_sum);
+            int_sum = __dp4a(wq[k], iq[k], int_sum);
         }
         partial += (float)int_sum * w_scale * input_scales[b];
     }
@@ -703,8 +693,8 @@ extern "C" __global__ void bitnet_f16_head_matvec(
             // compiler contract `a*b*c + sum` into a fused multiply-add, which
             // would round differently and could flip a near-tie token.
             fmad: Some(false),
-            // Target a virtual arch that supports the `dp4a` 8-bit dot
-            // instruction (compute_61, Pascal+). The PTX is forward-compatible, so
+            // Target a virtual arch that supports the `__dp4a` 8-bit dot
+            // intrinsic (compute_61, Pascal+). The PTX is forward-compatible, so
             // the driver JITs it for whatever newer GPU is present (e.g. sm_86).
             arch: Some("compute_61"),
             ..Default::default()
@@ -757,49 +747,36 @@ extern "C" __global__ void bitnet_f16_head_matvec(
         // driver-only Linux host would abort the process at startup — including
         // under `--gpu off`, because capability detection reaches this path
         // regardless of the GPU switch. Degrade to the CPU path instead.
-        //
-        // Past the announcement above a usable device exists, so failing here
-        // leaves a working GPU idle while inference silently runs on the CPU.
-        // Say so once. Failures BEFORE the announcement mean "no CUDA device on
-        // this host", which is ordinary and stays quiet.
-        (|| -> Result<CudaBackend, String> {
-            let ptx: Ptx = std::panic::catch_unwind(|| {
-                cudarc::nvrtc::compile_ptx_with_opts(Q8_KERNEL_SRC, compile_options())
-            })
-            .map_err(|_| "CUDA NVRTC library not available".to_string())?
-            .map_err(|e| format!("nvrtc compile failed: {e}"))?;
-            let module = ctx
-                .load_module(ptx)
-                .map_err(|e| format!("load_module failed: {e}"))?;
-            let kernel = module
-                .load_function("q8_0_encoded_linear_rows")
-                .map_err(|e| format!("load_function failed: {e}"))?;
-            let kernel_block = module
-                .load_function("q8_0_block_linear_row")
-                .map_err(|e| format!("load_function (block) failed: {e}"))?;
-            let kernel_bitnet = module
-                .load_function("bitnet_i2_s_linear_rows")
-                .map_err(|e| format!("load_function (BitNet I2_S) failed: {e}"))?;
-            let kernel_bitnet_f16_head = module
-                .load_function("bitnet_f16_head_matvec")
-                .map_err(|e| format!("load_function (BitNet F16 head) failed: {e}"))?;
-            Ok(CudaBackend {
-                ctx,
-                stream,
-                kernel,
-                kernel_block,
-                kernel_bitnet,
-                kernel_bitnet_f16_head,
-                device_name,
-                weight_cache: HashMap::new(),
-                bitnet_f16_head_weight_cache: HashMap::new(),
-            })
-        })()
-        .inspect_err(|reason| {
-            eprintln!(
-                "[cuda] device found but the GPU lane could not start ({reason}); \
-                 running on the CPU path instead"
-            );
+        let ptx: Ptx = std::panic::catch_unwind(|| {
+            cudarc::nvrtc::compile_ptx_with_opts(Q8_KERNEL_SRC, compile_options())
+        })
+        .map_err(|_| "CUDA NVRTC library not available".to_string())?
+        .map_err(|e| format!("nvrtc compile failed: {e}"))?;
+        let module = ctx
+            .load_module(ptx)
+            .map_err(|e| format!("load_module failed: {e}"))?;
+        let kernel = module
+            .load_function("q8_0_encoded_linear_rows")
+            .map_err(|e| format!("load_function failed: {e}"))?;
+        let kernel_block = module
+            .load_function("q8_0_block_linear_row")
+            .map_err(|e| format!("load_function (block) failed: {e}"))?;
+        let kernel_bitnet = module
+            .load_function("bitnet_i2_s_linear_rows")
+            .map_err(|e| format!("load_function (BitNet I2_S) failed: {e}"))?;
+        let kernel_bitnet_f16_head = module
+            .load_function("bitnet_f16_head_matvec")
+            .map_err(|e| format!("load_function (BitNet F16 head) failed: {e}"))?;
+        Ok(CudaBackend {
+            ctx,
+            stream,
+            kernel,
+            kernel_block,
+            kernel_bitnet,
+            kernel_bitnet_f16_head,
+            device_name,
+            weight_cache: HashMap::new(),
+            bitnet_f16_head_weight_cache: HashMap::new(),
         })
     }
 

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -462,6 +462,10 @@ extern "C" __global__ void q8_0_encoded_linear_rows(
 // per-block integer dot is exact; the cross-block f32 reduction is reassociated
 // vs the CPU's sequential sum, so this is token-identical (not bit-identical) —
 // the same standard as the Metal GPU path. Verified by the parity audit.
+// NVRTC compiles this source without the CUDA headers that declare `__dp4a`,
+// so the intrinsic is spelled out as the single PTX instruction it lowers to.
+// `dp4a.s32.s32` needs PTX ISA 5.0 / sm_61, which `compile_options` already
+// targets.
 __device__ __forceinline__ int camelid_dp4a(int a, int b, int c) {
     int d;
     asm("dp4a.s32.s32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(b), "r"(c));
@@ -518,8 +522,7 @@ __device__ __forceinline__ int i2_s_ternary(
     return code == 0 ? -1 : (code == 2 ? 1 : 0);
 }
 
-extern "C" {
-__global__ void bitnet_i2_s_linear_rows(
+extern "C" __global__ void bitnet_i2_s_linear_rows(
     const signed char* __restrict__ input,
     const unsigned char* __restrict__ weights,
     const int input_rows,
@@ -581,7 +584,6 @@ __global__ void bitnet_i2_s_linear_rows(
     const long long packed_len = (long long)weight_rows * input_width / 4;
     const float scale = *reinterpret_cast<const float*>(weights + packed_len);
     output[idx] = (float)sum * activation_scales[input_row] * scale;
-}
 }
 
 // Header-free IEEE-754 binary16 conversion. The tied BitNet head stays in its
@@ -690,10 +692,7 @@ extern "C" __global__ void bitnet_f16_head_matvec(
         BACKEND
             .get_or_init(|| match init_backend() {
                 Ok(b) => Some(Mutex::new(b)),
-                Err(err) => {
-                    eprintln!("[cuda] backend initialization failed: {err}");
-                    None
-                }
+                Err(_) => None,
             })
             .as_ref()
     }
@@ -704,8 +703,8 @@ extern "C" __global__ void bitnet_f16_head_matvec(
             // compiler contract `a*b*c + sum` into a fused multiply-add, which
             // would round differently and could flip a near-tie token.
             fmad: Some(false),
-            // Target a virtual arch that supports the `__dp4a` 8-bit dot
-            // intrinsic (compute_61, Pascal+). The PTX is forward-compatible, so
+            // Target a virtual arch that supports the `dp4a` 8-bit dot
+            // instruction (compute_61, Pascal+). The PTX is forward-compatible, so
             // the driver JITs it for whatever newer GPU is present (e.g. sm_86).
             arch: Some("compute_61"),
             ..Default::default()

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -462,6 +462,12 @@ extern "C" __global__ void q8_0_encoded_linear_rows(
 // per-block integer dot is exact; the cross-block f32 reduction is reassociated
 // vs the CPU's sequential sum, so this is token-identical (not bit-identical) —
 // the same standard as the Metal GPU path. Verified by the parity audit.
+__device__ __forceinline__ int camelid_dp4a(int a, int b, int c) {
+    int d;
+    asm("dp4a.s32.s32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(b), "r"(c));
+    return d;
+}
+
 extern "C" __global__ void q8_0_block_linear_row(
     const float* __restrict__ input_scales,   // [blocks_per_row]
     const signed char* __restrict__ input_quants, // [blocks_per_row * 32]
@@ -485,7 +491,7 @@ extern "C" __global__ void q8_0_block_linear_row(
         int int_sum = 0;
         #pragma unroll
         for (int k = 0; k < 8; k++) {
-            int_sum = __dp4a(wq[k], iq[k], int_sum);
+            int_sum = camelid_dp4a(wq[k], iq[k], int_sum);
         }
         partial += (float)int_sum * w_scale * input_scales[b];
     }

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -757,36 +757,49 @@ extern "C" __global__ void bitnet_f16_head_matvec(
         // driver-only Linux host would abort the process at startup — including
         // under `--gpu off`, because capability detection reaches this path
         // regardless of the GPU switch. Degrade to the CPU path instead.
-        let ptx: Ptx = std::panic::catch_unwind(|| {
-            cudarc::nvrtc::compile_ptx_with_opts(Q8_KERNEL_SRC, compile_options())
-        })
-        .map_err(|_| "CUDA NVRTC library not available".to_string())?
-        .map_err(|e| format!("nvrtc compile failed: {e}"))?;
-        let module = ctx
-            .load_module(ptx)
-            .map_err(|e| format!("load_module failed: {e}"))?;
-        let kernel = module
-            .load_function("q8_0_encoded_linear_rows")
-            .map_err(|e| format!("load_function failed: {e}"))?;
-        let kernel_block = module
-            .load_function("q8_0_block_linear_row")
-            .map_err(|e| format!("load_function (block) failed: {e}"))?;
-        let kernel_bitnet = module
-            .load_function("bitnet_i2_s_linear_rows")
-            .map_err(|e| format!("load_function (BitNet I2_S) failed: {e}"))?;
-        let kernel_bitnet_f16_head = module
-            .load_function("bitnet_f16_head_matvec")
-            .map_err(|e| format!("load_function (BitNet F16 head) failed: {e}"))?;
-        Ok(CudaBackend {
-            ctx,
-            stream,
-            kernel,
-            kernel_block,
-            kernel_bitnet,
-            kernel_bitnet_f16_head,
-            device_name,
-            weight_cache: HashMap::new(),
-            bitnet_f16_head_weight_cache: HashMap::new(),
+        //
+        // Past the announcement above a usable device exists, so failing here
+        // leaves a working GPU idle while inference silently runs on the CPU.
+        // Say so once. Failures BEFORE the announcement mean "no CUDA device on
+        // this host", which is ordinary and stays quiet.
+        (|| -> Result<CudaBackend, String> {
+            let ptx: Ptx = std::panic::catch_unwind(|| {
+                cudarc::nvrtc::compile_ptx_with_opts(Q8_KERNEL_SRC, compile_options())
+            })
+            .map_err(|_| "CUDA NVRTC library not available".to_string())?
+            .map_err(|e| format!("nvrtc compile failed: {e}"))?;
+            let module = ctx
+                .load_module(ptx)
+                .map_err(|e| format!("load_module failed: {e}"))?;
+            let kernel = module
+                .load_function("q8_0_encoded_linear_rows")
+                .map_err(|e| format!("load_function failed: {e}"))?;
+            let kernel_block = module
+                .load_function("q8_0_block_linear_row")
+                .map_err(|e| format!("load_function (block) failed: {e}"))?;
+            let kernel_bitnet = module
+                .load_function("bitnet_i2_s_linear_rows")
+                .map_err(|e| format!("load_function (BitNet I2_S) failed: {e}"))?;
+            let kernel_bitnet_f16_head = module
+                .load_function("bitnet_f16_head_matvec")
+                .map_err(|e| format!("load_function (BitNet F16 head) failed: {e}"))?;
+            Ok(CudaBackend {
+                ctx,
+                stream,
+                kernel,
+                kernel_block,
+                kernel_bitnet,
+                kernel_bitnet_f16_head,
+                device_name,
+                weight_cache: HashMap::new(),
+                bitnet_f16_head_weight_cache: HashMap::new(),
+            })
+        })()
+        .inspect_err(|reason| {
+            eprintln!(
+                "[cuda] device found but the GPU lane could not start ({reason}); \
+                 running on the CPU path instead"
+            );
         })
     }
 

--- a/src/fabric/http.rs
+++ b/src/fabric/http.rs
@@ -1398,7 +1398,14 @@ mod tests {
             let mut stream = rustls::StreamOwned::new(connection, socket);
             let mut request = Vec::new();
             let mut buffer = [0_u8; 1024];
-            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            // The declared body has to be drained as well as the head. The
+            // client writes them separately, so the body can still be queued
+            // unread when this thread returns, and closing a socket that holds
+            // unread bytes is an abortive close (RST) rather than a FIN. The
+            // client then observes ECONNRESET instead of the response that was
+            // just written. This is the same completeness check `canned_node`
+            // applies on the plaintext path.
+            while !request_complete(&request) {
                 let read = match stream.read(&mut buffer) {
                     Ok(0) | Err(_) => return,
                     Ok(read) => read,

--- a/tests/fixtures/websearch/classifier_cases.json
+++ b/tests/fixtures/websearch/classifier_cases.json
@@ -166,5 +166,23 @@
     "needed": true,
     "has_query": true,
     "url_count": 0
+  },
+  {
+    "prompt": "What is the weather in Tokyo?",
+    "needed": true,
+    "has_query": true,
+    "url_count": 0
+  },
+  {
+    "prompt": "Give me the weather forecast for the weekend.",
+    "needed": true,
+    "has_query": true,
+    "url_count": 0
+  },
+  {
+    "prompt": "Summarize the revenue forecast for next year from this spreadsheet.",
+    "needed": false,
+    "has_query": false,
+    "url_count": 0
   }
 ]

--- a/tools/bench/system/test-native-contracts.mjs
+++ b/tools/bench/system/test-native-contracts.mjs
@@ -24,6 +24,11 @@ const expected = [
   'native_mcp_round_trip',
   'native_subagent_cleanup',
   'native_outside_canary_unchanged',
+  'native_edit_self_healing',
+  'native_path_suggestion',
+  'native_compaction_working_set',
+  'native_search_path_filter',
+  'native_verification_gate',
 ]
 
 assert.equal(manifest.schema, 'camelid.benchmark.native-contracts/v1')
@@ -44,7 +49,7 @@ for (const contract of manifest.contracts) {
   }
 }
 
-console.log('benchmark Phase 3 native contract inventory: PASS (16 contracts)')
+console.log(`benchmark Phase 3 native contract inventory: PASS (${expected.length} contracts)`)
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')


### PR DESCRIPTION
# feat(agent): harden the agent harness and fix dual-stack web research

8 files, +1436/-29. The CUDA work that used to be bundled here is now #711.

## Summary

Six changes to the native agent harness, one network fix, and one classifier
widening.

1. **Multi-tier `edit_file` matching.** An `old` block that differs only in line
   endings, or by a *uniform* indentation shift, now applies instead of failing.
   Tiers are tried in order and **each requires a unique match**:
   1. exact substring
   2. exact after CRLF/LF normalization (the replacement is re-encoded to the
      file's own line endings)
   3. line-by-line equality after trimming, where every line in the window
      differs from `old` by the *same* number of leading spaces, the leading
      whitespace runs are comparable, and the shift can be applied to every line
      of the replacement

   Anything less certain is **not** applied — there is no similarity threshold
   on the mutation path. A tolerant match says so in its result
   (`edited X (matched lines 12-18 after adjusting indentation/whitespace)`).
2. **Actionable near-miss diagnostics.** When no tier matches, the error names
   the closest window with line numbers and a snippet so the model can re-read
   instead of guessing. This path is read-only, and both its window scan and its
   Levenshtein scoring are budget-bounded, so a failed edit on a large file
   cannot pin a core.
3. **Ambiguity reports line numbers** — `old text is not unique (3 occurrences
   at lines 12, 48, 96)` instead of a bare count.
4. **Fuzzy sandbox path suggestions.** A missing path suggests the nearest file
   in the sandbox (`Did you mean 'src/chat/tools.rs'?`). The walk is bounded to
   64 directories / 500 files.
5. **`search` gains `path_filter`.** Exactly three forms are supported —
   `*.ext`, `dir/**`, and a plain file name or path fragment. Anything else is
   an explicit error, because a silently empty result set reads to the model as
   "the symbol is not there". Patterns and paths are normalized to `/` so a
   `dir/**` filter behaves identically on Windows.
6. **Working-set ledger in compaction.** The compaction summary now leads with
   the files modified, the files inspected, and the last command with its
   outcome. The lists are capped, because this summary exists to *save* context.
7. **Premature-completion guard.** On the benchmark profile, if the model
   answers after editing a file without having run any command, the loop asks
   for one — **once** — then accepts whatever it says next. A command that ran
   counts whatever it reported.
8. **IPv4/IPv6 dual-stack web research.** A dual-stack DNS answer on a
   single-stack host handed curl records that could never connect, and the hop
   could die with `couldn't connect to server` instead of using the usable
   record beside it. The families the host cannot route are no longer pinned,
   decided from the host's own reachability rather than from the shape of the
   DNS answer, so it holds in both directions. The set is narrowed, never
   emptied, so the SSRF pin still binds every address curl may reach.
9. **Conversational weather queries** are recognized by both the frontend and
   backend classifiers.

## Key changes

- `src/chat/tools.rs` — tiered `edit_file`, bounded near-miss diagnostics,
  `suggest_path_in_sandbox`, `PathFilter` parsing and matching.
- `src/chat/agent.rs` — working-set ledger in `compact`, richer tool-call
  digests, one-shot premature-completion guard in `run_loop`.
- `src/api/web_research.rs` — `host_reachable_families`, `addresses_to_pin`,
  weather needles.
- `src/fabric/http.rs` — **unrelated to the agent harness, and listed here after
  arriving undeclared in an earlier revision.** The TLS test stub did not drain
  the request body before closing, which is an abortive close (RST) and made a
  fabric TLS test fail intermittently on macOS. Same fix `1afd0f030` already
  applied to the plaintext stub. Happy to split it out.
- `frontend/src/lib/webResearch.js` — matching weather patterns.
- `tests/fixtures/websearch/classifier_cases.json` — shared cases pinning the
  Rust and JS classifiers to the same answers.
- `qa/benchmarks/agent/native-contracts-v1.json` +
  `tools/bench/system/test-native-contracts.mjs` — 5 new contracts, 21 total.

## Review round 2 — `9ce7f13d`

Both blocking findings were real bugs on the mutation path, and both are fixed
where the review suggested.

- **Tier 3 silently rewrote indentation in tab-indented files.** Indentation was
  measured in leading *spaces*, so two tab runs of different depth both measured
  zero, the delta computed to zero, and the replacement was written verbatim
  with the model's tab count. `find_tolerant_line_matches` now rejects a window
  unless the two leading-whitespace runs are byte-identical or both space-only;
  anything else goes to the near-miss diagnostic. The exact reproduction from
  the review is now
  `a_tab_indented_file_is_not_rewritten_by_a_shallower_tab_count`.
- **A negative shift flattened relative indentation inside `new`.**
  `adjust_indentation` clamps per line, so a line with less indent than the
  shift landed at column 0 while its siblings moved fully. New
  `indent_shift_applies` gates tier 3: every non-blank line of the replacement
  must be able to absorb the shift, otherwise the edit is refused. The clamp is
  now a floor, not a fallback. Pinned by
  `an_indent_shift_that_would_flatten_the_replacement_is_refused`, which also
  asserts a *valid* negative shift still applies.
- **`addresses_to_pin` was the mirror of the bug it fixed.** Rather than mirror
  it back, `host_reachable_families()` asks the host: a UDP `connect` per
  family, which sends no packet and only needs a route. Narrowing now happens in
  whichever direction the host needs; both-reachable or neither means don't
  narrow; the set is still never emptied, so the SSRF pin keeps binding.

The three minor items are addressed too: a `search` whose single-file root is
excluded by the filter now says so instead of reporting no matches; the
Levenshtein cell budget carries a comment about its top-down bias; and the
compaction ledger renders paths through `normalize_workspace_path`, matching
`mutated_files`.

**One thing the full suite caught that targeted runs did not.**
`write_and_edit_through_the_tool_path_are_checkpointed` clears the process-wide
checkpoint log and asserts an exact count, but no agent test took `cp_lock` or
disabled checkpoints. Pre-existing race — the two new mutating tests just made
it reproduce. Benchmark-profile agent tests now mirror what production already
does on that path. It passes in isolation either way, so only the full suite
reveals it.

## Review round 1

The first four commits were reviewed and corrected in place before that.

**Blockers**

- **clippy `unnecessary_map_or`** in `compact` failed all three rust CI legs, so
  nothing after it ever ran.
- **The verification guard could trap the agent.** `run_shell` returns
  `ToolOutcome::Err` for any non-zero exit, and only a non-error cleared the
  flag — so an edit followed by a legitimately *failing* test could never be
  reported. Every text step was rejected until `max_steps`, ending the run
  `StepCapped`/inconclusive. It now asks once; a command that ran clears the
  guard whatever it reported; a command refused by the approval policy does not.
- **The guard was armed by `user_text.to_lowercase().contains("test")`,** which
  also matches "latest", "contest", "greatest", and never matches a non-English
  prompt. Removed. The guard is scoped to the benchmark profile, like the
  evidence gate directly above it, so the shipped interactive agent is unchanged.
- **`generate_near_miss_diagnostics` was unbounded** — it scored every window of
  the file with an O(a·b) Levenshtein per line pair, on files up to 8 MiB, on
  every failed edit. Both the window scan and the Levenshtein work are budgeted.

**Correctness**

- **`path_filter` `dir/**` silently matched nothing on Windows.** `Sandbox::rel`
  renders with the platform separator, so the comparison never matched. Patterns
  and paths are normalized to `/`. CI would have caught this on the Windows leg
  had clippy not failed first.
- `src/**` matched `src-generated/lib.rs` — a prefix test without the separator.
- An unsupported glob such as `src/*.rs` fell through to a `contains` test and
  returned zero hits **with a success status**. Now an explicit error.
- The compaction ledger read the result at `idx + 1` for every call in a batch,
  so one failure marked the whole batch. It reads the nth result now.
- The ledger listed every inspected file, inside the summary that exists to save
  context. Capped.
- `weather` is now required for the new forecast needles in both classifiers. A
  bare "forecast for" also matches "revenue forecast for next year", and a false
  positive here sends the user's prompt to a search engine.

## CUDA

Split out to **#711**, cut fresh from `main`. `src/cuda.rs` is restored
byte-for-byte here; `git diff main -- src/cuda.rs` is empty.

Worth knowing before reviewing it: the `__dp4a` → inline-PTX half is weaker than
its original comment claimed, and testing is what showed that. Reverting the
call site to `main`'s spelling and re-running the block-kernel parity test on the
RTX 4060 passes **either way** — NVRTC 12.9 resolves `__dp4a` on its own, so the
stated justification does not hold for the CUDA version this runs against. It is
kept as commit 2 of 2 over there, relabelled as portability insurance for an
older NVRTC, and drops cleanly if you'd rather not carry it. The lane diagnostic
is the half with a real symptom behind it.

## Tests

New regressions, each of which fails without its fix:

- `a_tab_indented_file_is_not_rewritten_by_a_shallower_tab_count`
- `an_indent_shift_that_would_flatten_the_replacement_is_refused`
- `a_failing_verification_command_can_still_be_reported`
- `the_verification_guard_asks_once_and_then_accepts_the_answer`
- `a_directory_path_filter_does_not_match_a_sibling_with_the_same_prefix`
- `an_unsupported_path_filter_is_refused_rather_than_matching_nothing`
- `dual_stack_answers_pin_only_the_reachable_family`
- three cases in the shared `classifier_cases.json`, including the negative
  "revenue forecast" case
- `benchmark_requires_file_evidence_before_mutation_or_answer` updated to record
  the step the guard now spends

## Verification

Run on the exact pushed tree (`f4d33988e`):

- `cargo fmt --all -- --check` → 0
- `cargo clippy --all-targets -- -D warnings` → 0
- `cargo test --lib` (the whole suite, not only the touched modules) →
  **2230 passed / 0 failed / 111 ignored**
- `node tools/bench/system/test-native-contracts.mjs` → 21/21
- `git diff --check` → 0
- frontend classifier driven directly against all 31 shared fixture cases → 0
  mismatches
- Live run on Windows: release binary, WebUI, real `/api/web/research` query
  returning two sources, and the negative "revenue forecast" prompt answering
  locally with no fetch.

## Honest gaps

- The premature-completion guard is deliberately scoped to the benchmark
  profile. Widening it to the interactive agent should be a separate, measured
  change.
- Tier 3 is now conservative in the tab case rather than correct in it: a
  tab-indented file with a space-indented `old` (or a differing tab count) is
  refused and sent to the near-miss diagnostic. That is the intended outcome for
  an uncertain match, but it does mean a class of edit that used to "succeed"
  now costs the model a retry.
- `host_reachable_families` probes with a UDP `connect`, which tests for a
  *route*, not for a working path to the internet. A host with a v6 route and a
  broken v6 upstream still gets v6 addresses pinned. Narrowing is best-effort
  and never empties the set, so this degrades to today's behaviour rather than
  to a failure.
- The live web-research evidence is one Windows host on one network.
