### PR TITLE
fix(cuda): report a device whose GPU lane could not start

### DIFF
--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -462,6 +462,17 @@ extern "C" __global__ void q8_0_encoded_linear_rows(
 // per-block integer dot is exact; the cross-block f32 reduction is reassociated
 // vs the CPU's sequential sum, so this is token-identical (not bit-identical) —
 // the same standard as the Metal GPU path. Verified by the parity audit.
+// Spelled as the single PTX instruction `__dp4a` lowers to, so the kernel does
+// not depend on NVRTC preincluding the sm_61 intrinsics header that declares it.
+// `dp4a.s32.s32` needs PTX ISA 5.0 / sm_61, which `compile_options` already
+// targets. NVRTC 12.9 does resolve `__dp4a` on its own (measured on sm_89), so
+// this is portability insurance, not a fix for an observed failure.
+__device__ __forceinline__ int camelid_dp4a(int a, int b, int c) {
+    int d;
+    asm("dp4a.s32.s32 %0, %1, %2, %3;" : "=r"(d) : "r"(a), "r"(b), "r"(c));
+    return d;
+}
+
 extern "C" __global__ void q8_0_block_linear_row(
     const float* __restrict__ input_scales,   // [blocks_per_row]
     const signed char* __restrict__ input_quants, // [blocks_per_row * 32]
@@ -485,7 +496,7 @@ extern "C" __global__ void q8_0_block_linear_row(
         int int_sum = 0;
         #pragma unroll
         for (int k = 0; k < 8; k++) {
-            int_sum = __dp4a(wq[k], iq[k], int_sum);
+            int_sum = camelid_dp4a(wq[k], iq[k], int_sum);
         }
         partial += (float)int_sum * w_scale * input_scales[b];
     }
@@ -693,8 +704,8 @@ extern "C" __global__ void bitnet_f16_head_matvec(
             // compiler contract `a*b*c + sum` into a fused multiply-add, which
             // would round differently and could flip a near-tie token.
             fmad: Some(false),
-            // Target a virtual arch that supports the `__dp4a` 8-bit dot
-            // intrinsic (compute_61, Pascal+). The PTX is forward-compatible, so
+            // Target a virtual arch that supports the `dp4a` 8-bit dot
+            // instruction (compute_61, Pascal+). The PTX is forward-compatible, so
             // the driver JITs it for whatever newer GPU is present (e.g. sm_86).
             arch: Some("compute_61"),
             ..Default::default()

--- a/src/cuda.rs
+++ b/src/cuda.rs
@@ -747,36 +747,49 @@ extern "C" __global__ void bitnet_f16_head_matvec(
         // driver-only Linux host would abort the process at startup — including
         // under `--gpu off`, because capability detection reaches this path
         // regardless of the GPU switch. Degrade to the CPU path instead.
-        let ptx: Ptx = std::panic::catch_unwind(|| {
-            cudarc::nvrtc::compile_ptx_with_opts(Q8_KERNEL_SRC, compile_options())
-        })
-        .map_err(|_| "CUDA NVRTC library not available".to_string())?
-        .map_err(|e| format!("nvrtc compile failed: {e}"))?;
-        let module = ctx
-            .load_module(ptx)
-            .map_err(|e| format!("load_module failed: {e}"))?;
-        let kernel = module
-            .load_function("q8_0_encoded_linear_rows")
-            .map_err(|e| format!("load_function failed: {e}"))?;
-        let kernel_block = module
-            .load_function("q8_0_block_linear_row")
-            .map_err(|e| format!("load_function (block) failed: {e}"))?;
-        let kernel_bitnet = module
-            .load_function("bitnet_i2_s_linear_rows")
-            .map_err(|e| format!("load_function (BitNet I2_S) failed: {e}"))?;
-        let kernel_bitnet_f16_head = module
-            .load_function("bitnet_f16_head_matvec")
-            .map_err(|e| format!("load_function (BitNet F16 head) failed: {e}"))?;
-        Ok(CudaBackend {
-            ctx,
-            stream,
-            kernel,
-            kernel_block,
-            kernel_bitnet,
-            kernel_bitnet_f16_head,
-            device_name,
-            weight_cache: HashMap::new(),
-            bitnet_f16_head_weight_cache: HashMap::new(),
+        //
+        // Past the announcement above a usable device exists, so failing here
+        // leaves a working GPU idle while inference silently runs on the CPU.
+        // Say so once. Failures BEFORE the announcement mean "no CUDA device on
+        // this host", which is ordinary and stays quiet.
+        (|| -> Result<CudaBackend, String> {
+            let ptx: Ptx = std::panic::catch_unwind(|| {
+                cudarc::nvrtc::compile_ptx_with_opts(Q8_KERNEL_SRC, compile_options())
+            })
+            .map_err(|_| "CUDA NVRTC library not available".to_string())?
+            .map_err(|e| format!("nvrtc compile failed: {e}"))?;
+            let module = ctx
+                .load_module(ptx)
+                .map_err(|e| format!("load_module failed: {e}"))?;
+            let kernel = module
+                .load_function("q8_0_encoded_linear_rows")
+                .map_err(|e| format!("load_function failed: {e}"))?;
+            let kernel_block = module
+                .load_function("q8_0_block_linear_row")
+                .map_err(|e| format!("load_function (block) failed: {e}"))?;
+            let kernel_bitnet = module
+                .load_function("bitnet_i2_s_linear_rows")
+                .map_err(|e| format!("load_function (BitNet I2_S) failed: {e}"))?;
+            let kernel_bitnet_f16_head = module
+                .load_function("bitnet_f16_head_matvec")
+                .map_err(|e| format!("load_function (BitNet F16 head) failed: {e}"))?;
+            Ok(CudaBackend {
+                ctx,
+                stream,
+                kernel,
+                kernel_block,
+                kernel_bitnet,
+                kernel_bitnet_f16_head,
+                device_name,
+                weight_cache: HashMap::new(),
+                bitnet_f16_head_weight_cache: HashMap::new(),
+            })
+        })()
+        .inspect_err(|reason| {
+            eprintln!(
+                "[cuda] device found but the GPU lane could not start ({reason}); \
+                 running on the CPU path instead"
+            );
         })
     }
 


### PR DESCRIPTION
Split out of #708 at your request — the CUDA edits there had nothing to do with the agent harness. This is `src/cuda.rs` only, two commits, cut fresh from current `main` (`49ac4126`).

## 1. A present GPU that silently falls back to the CPU now says so

`init_backend` announces the selected device, then compiles the kernels. If that second half fails, the error is returned and `CudaBackend::get()` degrades to the CPU path — correctly, but **silently**. The user sees a working RTX card, a healthy driver, and unexplained slowness, with nothing in the log connecting the two.

I hit this myself: NVRTC ships with the CUDA toolkit, **not** the driver, so a driver-only host compiles nothing and there was no way to tell that from "the GPU just isn't being used".

The setup after the device announcement is now wrapped, and the reason is printed once per process:

```
[cuda] device found but the GPU lane could not start (CUDA NVRTC library not available); running on the CPU path instead
```

**The placement is the whole point.** A failure *before* the announcement means "no CUDA device on this host" — ordinary, and the repo deliberately stays quiet about it. Those paths are untouched, so driver-less machines print nothing, exactly as today. `init_backend` runs behind `get_or_init`, so this cannot repeat per request.

## 2. `__dp4a` spelled as the PTX instruction it lowers to

`__dp4a` is declared by the sm_61 intrinsics header. NVRTC compiles this kernel source with no CUDA headers on the include path, so resolving the name depends on NVRTC preincluding that declaration itself. The kernel now emits `dp4a.s32.s32` directly; `compile_options` already targets `compute_61`, which is where the instruction was introduced.

**I could not reproduce a failure this fixes, and the comment in the code says so.** NVRTC 12.9 resolves `__dp4a` on its own, measured below. This is portability insurance for an older NVRTC, nothing more. If you'd rather not carry it, **drop commit 2** — commit 1 stands alone and is the one with a real symptom behind it.

## Evidence — RTX 4060 Laptop (sm_89), NVRTC 12.9

`cargo test --lib cuda:: -- --ignored`, i.e. the four kernel tests CI can never run:

| test | result |
|---|---|
| `cuda_q8_kernel_is_bit_identical_to_cpu_reference` | ok |
| `cuda_block_kernel_matches_cpu_reference_within_tolerance` | ok |
| `cuda_bitnet_i2_s_cleanroom_modes_match_cpu_oracle` | ok |
| `cuda_bitnet_f16_head_matches_cpu_oracle_and_reuses_weights` | ok |

with the real device bound and real GPU matmuls executed:

```
[cuda] selected device 0 of 1: "NVIDIA GeForce RTX 4060 Laptop GPU" (compute capability 8.9)
[cuda] Q8_0 hybrid decode active on NVIDIA GeForce RTX 4060 Laptop GPU - first GPU matmul completed
```

`cuda_block_kernel_matches_cpu_reference_within_tolerance` is the one that exercises the changed kernel. I ran it **both ways** — with `camelid_dp4a` and with `main`'s `__dp4a` — and it passes identically. That is the measurement that demoted the PTX change from "fix" to "insurance".

## Gates

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --all-targets -- -D warnings` | 0 |
| `cargo test --lib cuda::` | 15 passed / 0 failed / 5 ignored |
| `cargo test --lib cuda:: -- --ignored` | 4 kernel tests passed (see above) |
| `git diff --check` | 0 |

## Honest gaps

- **CI proves nothing here.** All four kernel tests are `#[ignore = "requires a CUDA device"]` and no runner has a GPU. The local RTX 4060 run above is the only execution evidence, and it is one card, one architecture (sm_89), one NVRTC version.
- The `--ignored` run also picks up `gemma4_mtp_cuda::tests::official_device_upload_matches_resident_ledger`, which fails on any host without `CAMELID_GEMMA4_MTP_SAFETENSORS` set to the official BF16 checkpoint. Environmental, pre-existing, and outside this diff — this branch touches one file.
- I have not tested an NVRTC old enough to actually need commit 2. That is precisely why it is labelled insurance rather than a fix.
- The diagnostic writes to stderr, matching the existing `[cuda]` device line beside it; it is not routed through `tracing`.
