### PR TITLE
metal: run K-quant prefill on the simdgroup-matrix path (23.8x; 97s -> 4.1s to first token)

### DIFF
--- a/src/metal.rs
+++ b/src/metal.rs
@@ -73,7 +73,7 @@ fn attention_matmul_prefill_q8_stage_bytes(
 mod attention_matmul_prefill_shape_tests {
     use super::{
         attention_matmul_prefill_head_dim_supported, attention_matmul_prefill_q8_stage_bytes,
-        attention_matmul_prefill_rows_fit,
+        attention_matmul_prefill_rows_fit, kquant_mm_stage_bytes,
     };
 
     #[test]
@@ -118,6 +118,28 @@ mod attention_matmul_prefill_shape_tests {
             attention_matmul_prefill_q8_stage_bytes(0, 1_000, 64, usize::MAX),
             None
         );
+    }
+
+    /// The K-quant half panel is the one allocation this lane adds, and it is sized to the
+    /// largest projection in the model rather than to the prompt -- an 8B's ffn pair is
+    /// ~117 MB. It must decline the lane rather than allocate past the cap, and it must not
+    /// wrap: `rows * k * 2` overflows usize for a shape a corrupt header could claim.
+    #[test]
+    fn kquant_staging_fails_closed_before_an_oversized_or_overflowed_panel() {
+        // Llama-3.2-3B's ffn pair: 8192 rows contracting over 3072.
+        let needed = 8192 * 3072 * std::mem::size_of::<u16>();
+        assert_eq!(kquant_mm_stage_bytes(8192, 3072, needed), Some(needed));
+        assert_eq!(
+            kquant_mm_stage_bytes(8192, 3072, needed - 1),
+            None,
+            "a panel one byte over the scratch cap must decline the lane, not allocate"
+        );
+        assert_eq!(
+            kquant_mm_stage_bytes(usize::MAX, 2, usize::MAX),
+            None,
+            "checked shape arithmetic must reject overflow"
+        );
+        assert_eq!(kquant_mm_stage_bytes(0, 3072, usize::MAX), None);
     }
 }
 
@@ -14112,6 +14134,27 @@ fn kquant_mm_prefill_enabled() -> bool {
     })
 }
 
+/// Additionally admit the K-quant MM lane to the attention-as-matmul prefill.
+///
+/// Separate from `kquant_mm_prefill_enabled` because the two differ in kind, not just in
+/// degree. Staging the projections is TOKEN-IDENTICAL — verified at 871 and 1205 positions
+/// — and takes prefill 12 339 -> 899 ms. Admitting attention takes it further, to 595 ms,
+/// but attention-as-matmul stages K/Q scores as half, and on a K-quant model's flatter
+/// logits that moves greedy output (divergence at generated token 4 on Llama-3.2-1B-Q4_K_M,
+/// deterministic across processes). It is the same precision trade the Q8_0 lane already
+/// makes by default, but it should not be forced on anyone who armed the lane for the
+/// lossless part.
+///
+/// Requires `CAMELID_METAL_KQUANT_MM=1` as well; on its own it does nothing.
+#[cfg(target_os = "macos")]
+fn kquant_attn_mm_prefill_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("CAMELID_METAL_KQUANT_ATTN_MM")
+            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    })
+}
+
 /// Bytes for the K-quant half staging panel: the largest single projection in the model,
 /// reused by every projection of every layer. `None` when it would exceed the scratch cap,
 /// which declines the lane rather than allocating it.
@@ -24782,6 +24825,29 @@ impl ResidentDecodeState {
             .iter()
             .flatten()
             .all(|w| w.format == ResidentWeightFormat::Q8_0);
+        // Every resident weight is Q4_K or Q6_K -- the shape a Q4_K_M download has, which
+        // mixes the two. Q5_K is excluded: it has no dequant kernel here, and one mixed-in
+        // Q5_K tensor would silently fall back per projection rather than per model.
+        let all_kquant_mm = resident.iter().flatten().all(|w| {
+            matches!(
+                w.format,
+                ResidentWeightFormat::Q4K | ResidentWeightFormat::Q6K
+            )
+        });
+        // The panel is reused by every projection of every layer, so it only has to hold
+        // the largest one. `down` contracts over ffn_dim into hidden rows; `gate`/`up`
+        // expand hidden into ffn_dim rows -- both are hidden * ffn_dim elements, and that
+        // dominates the attention projections whenever ffn_dim >= q_dim.
+        let kq_stage_bytes = (all_kquant_mm && kquant_mm_prefill_enabled())
+            .then(|| {
+                kquant_mm_stage_bytes(
+                    self.ffn_dim.max(q_dim).max(kv_dim),
+                    self.ffn_dim.max(self.hidden),
+                    attn_mm_scratch_cap_bytes(),
+                )
+            })
+            .flatten();
+        let use_kq_mm = kq_stage_bytes.is_some();
         let resident_moe: Vec<Option<ResidentMoeResolved>> = if has_moe {
             let mut cache = metal_linear_cache().lock().ok()?;
             layers
@@ -24851,10 +24917,23 @@ impl ResidentDecodeState {
         // MoE layers ride the f16 stream only when the routed path is the id-GEMM + panel
         // add (those have half variants); the grouped-GEMV fallback reads/writes f32.
         let use_attn_mm = (!has_moe || (moe_prefill_mm_enabled() && moe_prefill_grouped_enabled()))
-            && !self.kv16
+            // An F16 primary IS the half cache this path reads, exactly as it is for the
+            // split-K decode attention: `attn_k16`/`attn_v16` below bind the primary
+            // instead of the (empty) mirrors. Scoped to the K-quant MM lane rather than
+            // opened for every kv16 primary, so the blast radius is the lane being
+            // measured -- a Q8_0 model forced to `CAMELID_METAL_KV_DTYPE=f16` keeps its
+            // current behaviour.
+            && (!self.kv16 || (use_kq_mm && kquant_attn_mm_prefill_enabled()))
             && (!self.kvq8 || stage_q8_kv)
             && (!stage_q8_kv || q8_stage_bytes.is_some())
-            && all_q8
+            // A K-quant model staged onto the MM lane has the same half activation stream
+            // this path needs; the attention matmuls never touch a weight, so `all_q8` was
+            // only ever standing in for "the f16 stream is available". Note the surviving
+            // `!self.kv16` conjunct above still excludes the K-quant DEFAULT, whose primary
+            // is F16 — this admits a K-quant model only when it is running an F32 primary.
+            // Admitting the F16 primary needs the same "the primary IS the half cache"
+            // binding the split-K path uses, at the `cache_k16`/`cache_v16` sites below.
+            && (all_q8 || (use_kq_mm && kquant_attn_mm_prefill_enabled()))
             && mm_prefill_enabled()
             && !has_qk_norm
             && attention_matmul_prefill_rows_fit(n_tokens, self.max_positions)
@@ -24889,7 +24968,17 @@ impl ResidentDecodeState {
         // fused rope+scatter kernel -- which would have been the wrong shape anyway, since
         // Q8 needs a per-32-element-block amax and the fused kernel runs one thread per
         // RoPE pair. The convert is now guarded on `!use_h16` to match.
-        let use_h16 = use_attn_mm && half_rope * 2 == self.head_dim;
+        // Excludes the F16-primary lane. The es=2 stream has exactly two producers for the
+        // half query panel -- the fused rope+scatter, and `rope_rotate_batch_h` on the Q8
+        // lane -- and an F16 primary can use neither: the fused kernel writes K into both
+        // cache_k and cache_k16 (the second of which does not exist here), and
+        // `rope_rotate_batch_h` belongs to the Q8 scatter. With both declined, nothing
+        // would write `q_h` and attention would read an uninitialized panel. Keeping es=4
+        // routes Q through the guarded `!use_fused_rope && !use_h16` f32->half convert
+        // instead, which costs one dispatch per layer; the receipt for the Q8 lane records
+        // es=2 as a fidelity and dispatch-count improvement, not a throughput one, so this
+        // gives up nothing measurable.
+        let use_h16 = use_attn_mm && !self.kv16 && half_rope * 2 == self.head_dim;
         let es = if use_h16 { 2 } else { 4 }; // element size of the activation stream
         let seq = nb(n_tokens * self.hidden * es);
         let seq_out = nb(n_tokens * self.hidden * es);
@@ -25037,29 +25126,6 @@ impl ResidentDecodeState {
         // ~85% of the prefill and the batched-column GEMV is issue-bound); only the
         // attention-as-matmul/f16-stream path is declined so the residual stream stays f32
         // for the routed-expert kernels.
-        // Every resident weight is Q4_K or Q6_K -- the shape a Q4_K_M download has, which
-        // mixes the two. Q5_K is excluded: it has no dequant kernel here, and one mixed-in
-        // Q5_K tensor would silently fall back per projection rather than per model.
-        let all_kquant_mm = resident.iter().flatten().all(|w| {
-            matches!(
-                w.format,
-                ResidentWeightFormat::Q4K | ResidentWeightFormat::Q6K
-            )
-        });
-        // The panel is reused by every projection of every layer, so it only has to hold
-        // the largest one. `down` contracts over ffn_dim into hidden rows; `gate`/`up`
-        // expand hidden into ffn_dim rows -- both are hidden * ffn_dim elements, and that
-        // dominates the attention projections whenever ffn_dim >= q_dim.
-        let kq_stage_bytes = (all_kquant_mm && kquant_mm_prefill_enabled())
-            .then(|| {
-                kquant_mm_stage_bytes(
-                    self.ffn_dim.max(q_dim).max(kv_dim),
-                    self.ffn_dim.max(self.hidden),
-                    attn_mm_scratch_cap_bytes(),
-                )
-            })
-            .flatten();
-        let use_kq_mm = kq_stage_bytes.is_some();
         let use_mm = (all_q8 || use_kq_mm)
             && mm_prefill_enabled()
             && q_dim.is_multiple_of(128)
@@ -25588,7 +25654,13 @@ impl ResidentDecodeState {
             // twin of that kernel. Decoupling it from use_attn_mm keeps this change to the
             // attention path; the unfused RoPE costs three dispatches instead of one per
             // layer, which is small next to the O(n^2) attention win being unblocked.
-            let use_fused_rope = use_attn_mm && !stage_q8_kv && half_rope * 2 == self.head_dim;
+            // Also excludes an F16 primary, for the same reason it excludes the Q8 lane:
+            // this kernel writes rotated K into cache_k AND cache_k16, and under a half
+            // primary the first is already half while the second is an empty Vec. The
+            // unfused RoPE costs three dispatches instead of one per layer, which is small
+            // next to the O(n^2) attention win it unblocks.
+            let use_fused_rope =
+                use_attn_mm && !stage_q8_kv && !self.kv16 && half_rope * 2 == self.head_dim;
             if use_fused_rope {
                 // Fused rope(Q)->half panel + rope(K)->caches + V scatter, one dispatch.
                 e.set_compute_pipeline_state(if use_h16 {
@@ -25910,13 +25982,21 @@ impl ResidentDecodeState {
                         );
                     }
                 }
+                // Three sources of half K/V, in the order their primaries compress:
+                // a Q8 primary stages into a transient panel, an F16 primary IS the half
+                // cache, and an F32 primary keeps persistent mirrors. Same layout and the
+                // same max_positions stride in all three.
                 let attn_k16: &Buffer = if stage_q8_kv {
                     &q8_k_stage
+                } else if self.kv16 {
+                    &self.cache_k[i]
                 } else {
                     &self.cache_k16[i]
                 };
                 let attn_v16: &Buffer = if stage_q8_kv {
                     &q8_v_stage
+                } else if self.kv16 {
+                    &self.cache_v[i]
                 } else {
                     &self.cache_v16[i]
                 };

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -201,6 +201,10 @@ struct MetalLinearKernel {
     q5k_linear_simd_pipeline: ComputePipelineState,
     q6k_linear_simd_pipeline: ComputePipelineState,
     q4k_linear_tiled_pipeline: ComputePipelineState,
+    /// K-quant -> half weight staging that admits a K-quant model to the
+    /// simdgroup-matrix prefill. See `q4k_dequant_to_half`.
+    q4k_dequant_to_half_pipeline: ComputePipelineState,
+    q6k_dequant_to_half_pipeline: ComputePipelineState,
     q5k_linear_tiled_pipeline: ComputePipelineState,
     q6k_linear_tiled_pipeline: ComputePipelineState,
     q1_0_linear_pipeline: ComputePipelineState,
@@ -2190,6 +2194,75 @@ kernel void q6k_linear_tiled(
         float acc = 0.0f;
         for (uint l = 0; l < 8; ++l) acc += sums[t][l];
         output[(t0 + t) * rows + row] = acc;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// K-quant -> half weight staging for the simdgroup-matrix prefill.
+//
+// The MM prefill path (`q8_0_block_wire_mm_f16o`) reads the Q8_0 wire format
+// directly, so a K-quant model has nothing to bind to and falls back to
+// `*_linear_tiled` above: a 4-token tiled GEMV that re-unpacks every super-block
+// once per token. `CAMELID_PREFILL_TRACE=1` on an M4 at 871 tokens puts the four
+// projection GEMMs at 98.9% of that model's prefill and the whole prefill at
+// 22.6x the same model in Q8_0.
+//
+// Raising the token tile does NOT fix it -- TILE_T 4 -> 8 measured +1.6%, so the
+// kernel is not weight-bandwidth-bound; it is ALU-bound on the per-token unpack.
+// Unpacking ONCE into a half panel removes exactly that redundancy, after which
+// the existing general `half_mm_batched_f16o` runs the projection with no new
+// matmul kernel. The dequant is O(weight) per layer against a GEMM that is
+// O(weight x tokens), so it amortizes away at any useful prompt length.
+//
+// Output layout is [row][col] half, row-major with row stride n_sb * 256 -- the
+// `a` operand `half_mm_batched_f16o` wants, with a_row_stride = k and
+// a_elem_stride = 1.
+//
+// One thread owns one (row, super-block) pair and writes its 256 values.
+kernel void q4k_dequant_to_half(
+    device const uchar* weight_blocks [[buffer(0)]],
+    device half* out [[buffer(1)]],
+    constant uint& n_sb [[buffer(2)]],
+    constant uint& rows [[buffer(3)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    const uint row = gid / n_sb;
+    if (row >= rows) return;
+    const uint b = gid - row * n_sb;
+    device const uchar* block = weight_blocks + (row * n_sb + b) * 144;
+    // Reconstruction mirrors q4k_linear_tiled exactly: value =
+    // dw * sc[idx/32] * code - dm * mn[idx/32].
+    const float dw = float(*reinterpret_cast<device const half*>(block));
+    const float dm = float(*reinterpret_cast<device const half*>(block + 2));
+    uchar sc[8], mn[8];
+    q4k_scale_min(block, sc, mn);
+    device half* dst = out + (ulong)row * n_sb * 256 + (ulong)b * 256;
+    for (uint idx = 0; idx < 256; ++idx) {
+        const uint j = idx >> 5;
+        dst[idx] = half(dw * float(sc[j]) * float(q4k_code(block, idx))
+                        - dm * float(mn[j]));
+    }
+}
+
+// Q6_K twin. Reconstruction mirrors q6k_linear_tiled: the 16 signed sub-scales
+// live at byte 192 and each covers 16 values; the super-block scale is the half
+// at byte 208; there is no min term.
+kernel void q6k_dequant_to_half(
+    device const uchar* weight_blocks [[buffer(0)]],
+    device half* out [[buffer(1)]],
+    constant uint& n_sb [[buffer(2)]],
+    constant uint& rows [[buffer(3)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    const uint row = gid / n_sb;
+    if (row >= rows) return;
+    const uint b = gid - row * n_sb;
+    device const uchar* block = weight_blocks + (row * n_sb + b) * 210;
+    const float dw = float(*reinterpret_cast<device const half*>(block + 208));
+    device const char* sc = reinterpret_cast<device const char*>(block + 192);
+    device half* dst = out + (ulong)row * n_sb * 256 + (ulong)b * 256;
+    for (uint idx = 0; idx < 256; ++idx) {
+        dst[idx] = half(dw * float(int(sc[idx >> 4])) * float(q6k_code(block, idx)));
     }
 }
 
@@ -9450,6 +9523,16 @@ fn metal_linear_kernel() -> Option<&'static MetalLinearKernel> {
             let q4k_linear_tiled_pipeline = device
                 .new_compute_pipeline_state_with_function(&q4k_linear_tiled_function)
                 .ok()?;
+            let q4k_dequant_to_half_function =
+                library.get_function("q4k_dequant_to_half", None).ok()?;
+            let q4k_dequant_to_half_pipeline = device
+                .new_compute_pipeline_state_with_function(&q4k_dequant_to_half_function)
+                .ok()?;
+            let q6k_dequant_to_half_function =
+                library.get_function("q6k_dequant_to_half", None).ok()?;
+            let q6k_dequant_to_half_pipeline = device
+                .new_compute_pipeline_state_with_function(&q6k_dequant_to_half_function)
+                .ok()?;
             let q5k_linear_tiled_function = library.get_function("q5k_linear_tiled", None).ok()?;
             let q5k_linear_tiled_pipeline = device
                 .new_compute_pipeline_state_with_function(&q5k_linear_tiled_function)
@@ -9564,6 +9647,8 @@ fn metal_linear_kernel() -> Option<&'static MetalLinearKernel> {
                 q5k_linear_simd_pipeline,
                 q6k_linear_simd_pipeline,
                 q4k_linear_tiled_pipeline,
+                q4k_dequant_to_half_pipeline,
+                q6k_dequant_to_half_pipeline,
                 q5k_linear_tiled_pipeline,
                 q6k_linear_tiled_pipeline,
                 q1_0_linear_pipeline,
@@ -13988,6 +14073,52 @@ fn mm_prefill_enabled() -> bool {
     *ENABLED.get_or_init(|| {
         std::env::var("CAMELID_METAL_MM").is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
     })
+}
+
+/// Admit a K-QUANT model to the simdgroup-matrix prefill by staging each projection's
+/// weight into a transient half panel (`q4k_dequant_to_half` / `q6k_dequant_to_half`),
+/// then running the existing general `half_mm_batched_f16o` against it.
+///
+/// `use_mm` requires `all_q8` because `q8_0_block_wire_mm_f16o` reads the Q8_0 wire format
+/// directly, so a Q4_K/Q6_K model has nothing to bind to and keeps `*_linear_tiled` — a
+/// 4-token tiled GEMV that re-unpacks every super-block once per token. Measured on an M4,
+/// 871 tokens, Llama-3.2-1B, the same model in the two formats:
+///
+/// | stage | Q4_K_M | Q8_0 |
+/// |---|---|---|
+/// | gemm_qkv | 1268 ms | 56 ms |
+/// | gemm_o | 791 ms | 37 ms |
+/// | gemm_gateup | 6312 ms | 272 ms |
+/// | gemm_down | 3652 ms | 144 ms |
+/// | attention | 346 ms | 28 ms |
+/// | **total** | **12 387 ms** | **549 ms** |
+///
+/// The four projection GEMMs are 98.9% of it, which is why this gate is about `use_mm` and
+/// not `use_attn_mm` — attention is 2.8%. Raising the GEMV's token tile is not the fix
+/// either: TILE_T 4 -> 8 measured +1.6%, so that kernel is ALU-bound on the per-token
+/// unpack rather than weight-bandwidth-bound, and unpacking once is exactly what removes it.
+///
+/// The staged weight is rounded to f16. That is lossy against the exact K-quant GEMV, by
+/// roughly 2^-11 relative — around a fiftieth of the quantization error already present in
+/// a Q4_K weight — and the accumulate stays f32 in `simdgroup_float8x8`.
+///
+/// Off by default: `CAMELID_METAL_KQUANT_MM=1` to arm.
+#[cfg(target_os = "macos")]
+fn kquant_mm_prefill_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("CAMELID_METAL_KQUANT_MM")
+            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    })
+}
+
+/// Bytes for the K-quant half staging panel: the largest single projection in the model,
+/// reused by every projection of every layer. `None` when it would exceed the scratch cap,
+/// which declines the lane rather than allocating it.
+#[cfg(target_os = "macos")]
+fn kquant_mm_stage_bytes(max_rows: usize, max_k: usize, cap: usize) -> Option<usize> {
+    let bytes = max_rows.checked_mul(max_k)?.checked_mul(2)?;
+    (bytes > 0 && bytes <= cap).then_some(bytes)
 }
 
 /// Admit a Q8_0 primary to the attention-as-matmul prefill by staging its blocks into a
@@ -24906,12 +25037,38 @@ impl ResidentDecodeState {
         // ~85% of the prefill and the batched-column GEMV is issue-bound); only the
         // attention-as-matmul/f16-stream path is declined so the residual stream stays f32
         // for the routed-expert kernels.
-        let use_mm = all_q8
+        // Every resident weight is Q4_K or Q6_K -- the shape a Q4_K_M download has, which
+        // mixes the two. Q5_K is excluded: it has no dequant kernel here, and one mixed-in
+        // Q5_K tensor would silently fall back per projection rather than per model.
+        let all_kquant_mm = resident.iter().flatten().all(|w| {
+            matches!(
+                w.format,
+                ResidentWeightFormat::Q4K | ResidentWeightFormat::Q6K
+            )
+        });
+        // The panel is reused by every projection of every layer, so it only has to hold
+        // the largest one. `down` contracts over ffn_dim into hidden rows; `gate`/`up`
+        // expand hidden into ffn_dim rows -- both are hidden * ffn_dim elements, and that
+        // dominates the attention projections whenever ffn_dim >= q_dim.
+        let kq_stage_bytes = (all_kquant_mm && kquant_mm_prefill_enabled())
+            .then(|| {
+                kquant_mm_stage_bytes(
+                    self.ffn_dim.max(q_dim).max(kv_dim),
+                    self.ffn_dim.max(self.hidden),
+                    attn_mm_scratch_cap_bytes(),
+                )
+            })
+            .flatten();
+        let use_kq_mm = kq_stage_bytes.is_some();
+        let use_mm = (all_q8 || use_kq_mm)
             && mm_prefill_enabled()
             && q_dim.is_multiple_of(128)
             && kv_dim.is_multiple_of(128)
             && self.hidden.is_multiple_of(128)
             && self.ffn_dim.is_multiple_of(128);
+        // Only reachable with `use_mm`, so a declined MM leaves the K-quant GEMV path
+        // exactly as it was.
+        let use_kq_mm = use_kq_mm && use_mm;
         // Half-precision GEMM inputs, padded to a 64-token multiple so the MM kernel's
         // direct device B loads never run off the end (padding rows are garbage; they
         // only feed output columns past n_tokens, which are never stored).
@@ -25032,6 +25189,10 @@ impl ResidentDecodeState {
             e.set_buffer(2, Some(count_buf), count_off);
             dispatch_1d(e, &k.f32_to_f16_pipeline, count);
         };
+        // One half panel, reused by every projection of every layer. Serial dispatch in
+        // this encoder orders each dequant before the GEMM that reads it and before the
+        // next dequant overwrites it.
+        let kq_stage = nb(kq_stage_bytes.unwrap_or(2));
         let mut projection_keep = Vec::new();
         // One activation-quant scratch pair per contraction width, shared by
         // every K-quant projection of every layer. See
@@ -25050,6 +25211,98 @@ impl ResidentDecodeState {
                         n_off: u64,
                         input_width: usize,
                         rows: usize| {
+            // K-quant weight on the MM lane: unpack this projection into the shared half
+            // panel, then run the general half GEMM against it. `half_mm_batched_f16o`
+            // computes C[token][row] = sum_k A[row][k] * B[token][k] with c_row_stride =
+            // rows -- byte-identical in layout to what `q8_0_block_wire_mm_f16o` writes,
+            // so everything downstream is unchanged.
+            if use_kq_mm
+                && matches!(
+                    w.format,
+                    ResidentWeightFormat::Q4K | ResidentWeightFormat::Q6K
+                )
+            {
+                let n_sb = input_width / 256;
+                let dq_scalar = pool_get(k, 8);
+                unsafe {
+                    let p = dq_scalar.contents() as *mut u32;
+                    *p = n_sb as u32;
+                    *p.add(1) = rows as u32;
+                }
+                e.set_compute_pipeline_state(if w.format == ResidentWeightFormat::Q4K {
+                    &k.q4k_dequant_to_half_pipeline
+                } else {
+                    &k.q6k_dequant_to_half_pipeline
+                });
+                e.set_buffer(0, Some(&w.buffer), 0);
+                e.set_buffer(1, Some(&kq_stage), 0);
+                e.set_buffer(2, Some(&dq_scalar), 0);
+                e.set_buffer(3, Some(&dq_scalar), 4);
+                dispatch_1d(e, &k.q4k_dequant_to_half_pipeline, rows * n_sb);
+
+                let mm_scalar = pool_get(k, 48);
+                unsafe {
+                    let p = mm_scalar.contents() as *mut u32;
+                    *p = 0; // a_batch_stride
+                    *p.add(1) = 0; // b_batch_stride
+                    *p.add(2) = 0; // c_batch_stride
+                    *p.add(3) = input_width as u32; // a_row_stride: staged [row][k]
+                    *p.add(4) = input_width as u32; // b_row_stride: activations [token][k]
+                    *p.add(5) = rows as u32; // c_row_stride: out [token][row]
+                    *p.add(6) = 1; // a_elem_stride
+                    *p.add(7) = 1; // group_a
+                    *p.add(8) = 0; // causal_mode: a plain GEMM
+                    *p.add(9) = n_tokens as u32; // cols
+                    *p.add(10) = 0; // q_offset
+                    *p.add(11) = 0; // window
+                }
+                let dims = pool_get(k, 8);
+                unsafe {
+                    let p = dims.contents() as *mut u32;
+                    *p = input_width as u32; // kdim
+                    *p.add(1) = rows as u32; // rows
+                }
+                // Output element type must match what the Q8 lane would have written for
+                // this same `use_h16`, because everything downstream reads `out` on that
+                // assumption: `_f16o` writes half, the plain kernel writes f32. A K-quant
+                // model has `use_attn_mm` false (it requires `all_q8`) and therefore
+                // `use_h16` false, so this takes the f32 arm today -- but selecting on the
+                // flag rather than hardcoding it keeps the two lanes in step if that
+                // changes.
+                e.set_compute_pipeline_state(if use_h16 {
+                    &k.half_mm_batched_f16o_pipeline
+                } else {
+                    &k.half_mm_batched_pipeline
+                });
+                e.set_buffer(0, Some(&kq_stage), 0);
+                e.set_buffer(1, Some(y), 0);
+                e.set_buffer(2, Some(out), 0);
+                e.set_buffer(3, Some(&dims), 0);
+                e.set_buffer(4, Some(&dims), 4);
+                e.set_buffer(5, Some(&mm_scalar), 36);
+                for j in 0..9u64 {
+                    e.set_buffer(6 + j, Some(&mm_scalar), j * 4);
+                }
+                e.set_buffer(15, Some(&mm_scalar), 40);
+                e.set_buffer(16, Some(&mm_scalar), 44);
+                e.set_threadgroup_memory_length(0, 8192);
+                e.dispatch_thread_groups(
+                    metal::MTLSize {
+                        width: (rows as u64).div_ceil(64),
+                        height: (n_tokens as u64).div_ceil(64),
+                        depth: 1,
+                    },
+                    metal::MTLSize {
+                        width: 128,
+                        height: 1,
+                        depth: 1,
+                    },
+                );
+                projection_keep.push(dq_scalar);
+                projection_keep.push(mm_scalar);
+                projection_keep.push(dims);
+                return;
+            }
             if use_mm {
                 // Simdgroup-matrix tiles: 64-row x 64-token output per threadgroup, so
                 // weights stream once per 64 tokens instead of once per 8.

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -73,7 +73,7 @@ fn attention_matmul_prefill_q8_stage_bytes(
 mod attention_matmul_prefill_shape_tests {
     use super::{
         attention_matmul_prefill_head_dim_supported, attention_matmul_prefill_q8_stage_bytes,
-        attention_matmul_prefill_rows_fit, kquant_mm_stage_bytes,
+        attention_matmul_prefill_rows_fit,
     };
 
     #[test]
@@ -124,8 +124,15 @@ mod attention_matmul_prefill_shape_tests {
     /// largest projection in the model rather than to the prompt -- an 8B's ffn pair is
     /// ~117 MB. It must decline the lane rather than allocate past the cap, and it must not
     /// wrap: `rows * k * 2` overflows usize for a shape a corrupt header could claim.
+    ///
+    /// Gated with its import: `kquant_mm_stage_bytes` is macOS-only, and this module is not,
+    /// so a module-level `use` of it breaks the ubuntu and windows legs — which is the one
+    /// failure mode a macOS-only build can never reproduce locally.
+    #[cfg(target_os = "macos")]
     #[test]
     fn kquant_staging_fails_closed_before_an_oversized_or_overflowed_panel() {
+        use super::kquant_mm_stage_bytes;
+
         // Llama-3.2-3B's ffn pair: 8192 rows contracting over 3072.
         let needed = 8192 * 3072 * std::mem::size_of::<u16>();
         assert_eq!(kquant_mm_stage_bytes(8192, 3072, needed), Some(needed));


### PR DESCRIPTION
## What

A Q4_K_M model prefills a 2066-token prompt on an M4 in **97 seconds**. The same prompt on a Q8_0 model of the same family takes 3.9. The smaller model is 25x slower to first token, and it is the quantization most people actually download.

`use_mm` requires `all_q8`, because `q8_0_block_wire_mm_f16o` reads the Q8_0 wire format directly — so a Q4_K/Q6_K model has nothing to bind to and keeps `*_linear_tiled`, a 4-token tiled GEMV that re-unpacks every super-block once per token.

This adds `q4k_dequant_to_half` / `q6k_dequant_to_half`, which unpack a weight **once** into a transient half panel; the existing general `half_mm_batched` / `half_mm_batched_f16o` then runs the projection. **No new matmul kernel.** A second commit admits the same lane to the attention-as-matmul prefill.

## Where the time was

`CAMELID_PREFILL_TRACE=1`, M4, 871 tokens, Llama-3.2-1B in both formats — this is what set the design:

| stage | Q4_K_M | Q8_0 | ratio |
|---|---:|---:|---|
| gemm_qkv | 1268 ms | 56 | 22.6x |
| gemm_o | 791 ms | 37 | 21.4x |
| gemm_gateup | 6312 ms | 272 | 23.2x |
| gemm_down | 3652 ms | 144 | 25.4x |
| attention | 346 ms | 28 | 12.4x |
| **total** | **12 387 ms** | **549 ms** | **22.6x** |

The four projection GEMMs are **98.9%** of it, so this is a `use_mm` problem and not a `use_attn_mm` one. Raising the GEMV's token tile is not the fix either — TILE_T 4 -> 8 measured **+1.6%**, so that kernel is ALU-bound on the per-token unpack rather than weight-bandwidth-bound, and unpacking once is exactly what removes it.

## Measured — Llama-3.2-3B-Instruct-Q4_K_M, Apple M4 / 16 GiB

| Prompt | baseline | +GEMM staging | +GEMM +attention |
|---|---:|---:|---:|
| 2066 tok (filler) | 97 105 ms | 8 228 ms (**11.8x**) | **4 085 ms (23.8x)** |
| 1460 tok (real text) | 67 587 ms | 4 945 ms | **2 871 ms (23.5x)** |

Per-stage after, 871 tokens on the 1B, against the Q8_0 reference in parentheses: qkv 58 (55), o 36 (35), gateup 276 (268), down 167 (141), attention 29 (28) — total 581 vs 537. **The K-quant prefill now runs at the Q8_0 prefill's rate.** Decode is unchanged (15.29 / 15.31 / 15.16 tok/s), as a prefill change should be.

## Parity

**Token-identical on coherent English**: 3B Q4_K_M, 1460-token real-text prompt, all 32 generated tokens, all three configurations. That is the probe that counts — this repo's own analysis is that filler parity is uninformative in both directions.

Also token-identical on the 1B at 871 and 1205 positions for the GEMM step, and at 1205 for the attention step. At 871 the attention step diverges at generated token 4, deterministically (3/3 identical across independent processes, which rules out an uninitialized read) — a prompt-specific argmax flip on flatter logits, not a systematic defect.

Non-interference, both gates armed: a **Q8_0** model is unchanged (prefill 524 -> 523 ms, identical tokens) and a **Q5_K_M** model declines the lane whole and is token-identical. The attention gate without the MM gate is a no-op.

## Two gates, deliberately

- `CAMELID_METAL_KQUANT_MM=1` — stages the projections. Token-identical everywhere it was checked.
- `CAMELID_METAL_KQUANT_ATTN_MM=1` — additionally admits attention. Needs the first; attention-as-matmul stages K/Q scores as half, which can move greedy output.

They differ in kind, not degree, so nobody who armed the lane for the lossless part gets the lossy part by surprise.

## Correctness notes

The dequant kernels reuse `q4k_scale_min`, `q4k_code` and `q6k_code` **verbatim** from the GEMV kernels they mirror, so the reconstruction cannot drift from the path they must agree with. The staged weight is rounded to f16 — lossy by roughly 2^-11 relative, about a fiftieth of the quantization error already present in a Q4_K weight — while the accumulate stays f32 in `simdgroup_float8x8`.

Output element type is selected on `use_h16` exactly as the Q8 lane does: the plain kernel writes f32, `_f16o` writes half, and everything downstream reads `out` on that assumption. Getting this wrong is not a crash — an earlier revision wrote half into a buffer read as f32 and produced fluent garbage.

Two paths must decline under an F16 primary, and both are load-bearing:

- **`use_fused_rope`** writes rotated K into *both* `cache_k` and `cache_k16`. Under a half primary the first is already half and the second is an empty `Vec`. Excluded exactly as it already excludes the Q8 lane.
- **`use_h16`** follows, because the es=2 stream has exactly two producers for the half query panel — the fused rope, and `rope_rotate_batch_h` on the Q8 lane — and this lane can use neither. With both declined nothing would write `q_h`; that is what an earlier revision did, and it produced fluent garbage rather than failing. Staying at es=4 routes Q through the guarded `!use_fused_rope && !use_h16` convert. The Q8 receipt records es=2 as a fidelity and dispatch-count improvement, not a throughput one.

The staging panel is sized to the largest single projection, reused by every projection of every layer, and **declined rather than allocated** when it exceeds `attn_mm_scratch_cap_bytes()` — with a test pinning the cap and the overflow arithmetic. Serial dispatch in the encoder orders each dequant before the GEMM that reads it and before the next dequant overwrites it.

Q5_K is deliberately excluded from admission: it has no dequant kernel here, and admitting per projection would let one mixed-in Q5_K tensor fall back silently mid-model. The model declines the lane whole instead.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, the new test, and `scripts/check-public-scrub.sh` all green.

## Default

**Off.** One host. Stacks with #712 — that PR gives this same model class 1.47x decode, this one gives it 23.8x prefill, and they touch different stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
