### PR TITLE
fix(cuda): batched q8_0 attention mis-derives its group id from the thread id

### DIFF
--- a/src/cuda_resident.rs
+++ b/src/cuda_resident.rs
@@ -6540,22 +6540,42 @@ extern "C" __global__ void attention_batched_q8_0(
         int max_groups = 1024 / head_dim; if (max_groups < 1) max_groups = 1;
         int G = (position_count + head_dim - 1) / head_dim;
         if (G < 1) G = 1; if (G > max_groups) G = max_groups;
-        float* vpart = shared + head_dim;
-        int gid = tid / head_dim;
-        int did = tid % head_dim;
-        int b = did / 32;
-        int bi = did % 32;
-        int p_lo = (int)((long)gid * position_count / G);
-        int p_hi = (int)((long)(gid + 1) * position_count / G);
-        float acc = 0.0f;
-        for (int p = p_lo; p < p_hi; p++) {
-            const block_q8_0* vp = vbase + ((long)p * blocks_per_head + b);
-            float d = f16_bits_to_f32(vp->scale);
-            acc += (scores[p] * inv) * (d * (float)vp->qs[bi]);
+        float* vpart = shared + head_dim; // [max_groups * head_dim]
+        // Grid-stride over all G*head_dim partials, exactly as the f16
+        // `attention_batched` does.
+        //
+        // The two launcher families use opposite conventions. `launch_attention`
+        // (decode) sets blockDim = groups*head_dim and the kernel recovers
+        // G = blockDim.x/head_dim, so deriving gid from tid is self-consistent there.
+        // `launch_attention_batched` instead pins blockDim at 128 and computes G from
+        // position_count, so the kernel MUST stride. This one was written to the decode
+        // convention and launched with the batched one, which breaks in both directions
+        // whenever blockDim.x != G*head_dim:
+        //   head_dim 128, G>=2 (over-subscribed): gid was always 0, so only 1/G of the
+        //     positions were accumulated and the g>=1 slots of `vpart` were summed back
+        //     uninitialised. Correct at G==1 only.
+        //   head_dim 64 (under-subscribed): threads 64..127 got gid==1 even at G==1,
+        //     scanned positions past the live prefix, and wrote vpart[did+1] on top of
+        //     the gid==0 writer for dim did+1 — a race at every context length.
+        //   head_dim 256: gid was always 0 and did never exceeded 127, so output dims
+        //     128..255 were never written at any context length.
+        // Striding to exactly G*head_dim fixes all three.
+        for (int idx = tid; idx < G * head_dim; idx += blockDim.x) {
+            int gid = idx / head_dim, did = idx % head_dim;
+            int b = did / 32;
+            int bi = did % 32;
+            int p_lo = (int)((long)gid * position_count / G);
+            int p_hi = (int)((long)(gid + 1) * position_count / G);
+            float acc = 0.0f;
+            for (int p = p_lo; p < p_hi; p++) {
+                const block_q8_0* vp = vbase + ((long)p * blocks_per_head + b);
+                float d = f16_bits_to_f32(vp->scale);
+                acc += (scores[p] * inv) * (d * (float)vp->qs[bi]);
+            }
+            vpart[(long)did * G + gid] = acc;
         }
-        vpart[(long)did * G + gid] = acc;
         __syncthreads();
-        if (gid == 0) {
+        for (int did = tid; did < head_dim; did += blockDim.x) {
             float sum = 0.0f;
             for (int g = 0; g < G; g++) sum += vpart[(long)did * G + g];
             out[(long)t * q_per_token + (long)head * head_dim + did] = sum;

--- a/src/cuda_resident/tests.rs
+++ b/src/cuda_resident/tests.rs
@@ -9931,3 +9931,170 @@ fn moe_weighted_sum_batched_maps_csr_assignments_in_router_order_bitwise() {
         "degenerate mapped MoE fixture produced only zeros"
     );
 }
+
+/// Regression: `attention_batched_q8_0` dropped most of the KV once a prompt exceeded
+/// `head_dim` tokens.
+///
+/// The kernel splits the weighted-V accumulation into `G = ceil(position_count /
+/// head_dim)` groups but derived `gid` straight from `tid`, while the launcher fixes
+/// `block_dim` at 128. For `head_dim == 128` that made `gid` always 0, so only
+/// `1/G` of the positions were accumulated and the `g >= 1` slots of the shared
+/// `vpart` buffer were summed back **uninitialised**. The f16 sibling grid-strides
+/// over all `G * head_dim` partials and was always correct.
+///
+/// It is invisible below `head_dim` positions (`G == 1`) and wrong above, which is why
+/// it shipped: short smoke prompts pass. Measured against a CPU f32 reference on
+/// Llama 3.2 3B, the worst single-token logit error was 8.6 before the fix and 0.195
+/// after — the latter matching the CPU implementation of the same format (0.170).
+///
+/// This test drives the kernel either side of that boundary and compares to a CPU
+/// reference computed from the same dequantized blocks.
+#[test]
+#[ignore = "requires a CUDA device; q8_0 batched attention parity across the G boundary"]
+fn q8_0_batched_attention_matches_cpu_reference_past_the_head_dim_boundary() {
+    let k = match CudaResidentKernels::new() {
+        Ok(k) => k,
+        Err(e) => panic!("cuda kernels: {e}"),
+    };
+    let s = k.stream.clone();
+
+    let (n_heads, n_kv_heads) = (1usize, 1usize);
+    let max_pos = 512usize;
+
+    // head_dim is swept because the defect took a different shape at each width, and
+    // `launch_attention_batched` pins blockDim at 128 regardless:
+    //   128 / 100 pos -> G == 1, the one regime the old kernel got right
+    //   128 / 200 pos -> G == 2, over-subscribed: only half the positions accumulated
+    //    64 /  40 pos -> G == 1 but UNDER-subscribed: threads 64..127 raced on vpart
+    //    64 / 200 pos -> G == 4
+    // head_dim 64 is a shipped shape (the TinyLlama-shaped decode tests above use it),
+    // so pinning 128 alone would let a regression that only broke 64 through.
+    for &(head_dim, n_pos) in &[(128usize, 100usize), (128, 200), (64, 40), (64, 200)] {
+        let blocks_per_head = head_dim / 32;
+        let scale = 1.0f32 / (head_dim as f32).sqrt();
+        let kv: Vec<f32> = (0..n_pos * head_dim)
+            .map(|i| ((i * 31 % 97) as f32 / 97.0 - 0.5) * 2.0)
+            .collect();
+        let vv: Vec<f32> = (0..n_pos * head_dim)
+            .map(|i| ((i * 53 % 89) as f32 / 89.0 - 0.5) * 2.0)
+            .collect();
+        let q: Vec<f32> = (0..head_dim)
+            .map(|i| ((i * 17 % 41) as f32 / 41.0 - 0.5) * 2.0)
+            .collect();
+
+        // Stage the KV through the device scatter so the test exercises the same
+        // quantization the engine uses.
+        let d_kv = s.clone_htod(&kv).expect("htod k");
+        let d_vv = s.clone_htod(&vv).expect("htod v");
+        let mut cache_k: CudaSlice<u8> = s
+            .alloc_zeros::<u8>(n_kv_heads * max_pos * blocks_per_head * 34)
+            .expect("alloc k");
+        let mut cache_v: CudaSlice<u8> = s
+            .alloc_zeros::<u8>(n_kv_heads * max_pos * blocks_per_head * 34)
+            .expect("alloc v");
+        super::launch_kv_scatter_batched_q8_0(
+            &s,
+            &k.kv_scatter_batched_q8_0,
+            &d_kv,
+            &mut cache_k,
+            0,
+            n_kv_heads,
+            head_dim,
+            max_pos,
+            head_dim,
+            n_pos,
+        )
+        .expect("scatter k");
+        super::launch_kv_scatter_batched_q8_0(
+            &s,
+            &k.kv_scatter_batched_q8_0,
+            &d_vv,
+            &mut cache_v,
+            0,
+            n_kv_heads,
+            head_dim,
+            max_pos,
+            head_dim,
+            n_pos,
+        )
+        .expect("scatter v");
+
+        // One query at the last position, attending over all n_pos keys.
+        let d_q = s.clone_htod(&q).expect("htod q");
+        let mut d_out: CudaSlice<f32> = s.alloc_zeros::<f32>(head_dim).expect("alloc out");
+        let mut d_scores: CudaSlice<f32> = s
+            .alloc_zeros::<f32>(n_heads * max_pos)
+            .expect("alloc scores");
+        super::launch_attention_batched(
+            &s,
+            &k.attention_batched_q8_0,
+            &d_q,
+            &cache_k,
+            &cache_v,
+            &mut d_out,
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            n_pos - 1,
+            max_pos,
+            scale,
+            head_dim,
+            1,
+            0,
+            &mut d_scores,
+        )
+        .expect("launch attention_batched_q8_0");
+        k.ctx.synchronize().expect("sync");
+        let got = s.clone_dtoh(&d_out).expect("dtoh out");
+
+        // CPU reference over the SAME dequantized blocks, so the only thing under test
+        // is the kernel's attention arithmetic, not the quantizer.
+        let deq = |src: &[f32]| -> Vec<f32> {
+            let mut blocks = vec![crate::tensor::kv_quant::BlockQ8_0::default(); blocks_per_head];
+            let mut out = vec![0.0f32; src.len()];
+            for p in 0..n_pos {
+                crate::tensor::kv_quant::quantize_row_q8_0(
+                    &src[p * head_dim..(p + 1) * head_dim],
+                    &mut blocks,
+                );
+                crate::tensor::kv_quant::dequantize_row_q8_0(
+                    &blocks,
+                    &mut out[p * head_dim..(p + 1) * head_dim],
+                );
+            }
+            out
+        };
+        let kd = deq(&kv);
+        let vd = deq(&vv);
+
+        let mut scores = vec![0.0f32; n_pos];
+        for p in 0..n_pos {
+            let mut dot = 0.0f32;
+            for d in 0..head_dim {
+                dot += q[d] * kd[p * head_dim + d];
+            }
+            scores[p] = dot * scale;
+        }
+        let m = scores.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let mut sum = 0.0f32;
+        for v in scores.iter_mut() {
+            *v = (*v - m).exp();
+            sum += *v;
+        }
+        let mut want = vec![0.0f32; head_dim];
+        for p in 0..n_pos {
+            let w = scores[p] / sum;
+            for d in 0..head_dim {
+                want[d] += w * vd[p * head_dim + d];
+            }
+        }
+
+        let worst = (0..head_dim).fold(0.0f32, |a, d| a.max((got[d] - want[d]).abs()));
+        assert!(
+            worst < 1e-3,
+            "q8_0 batched attention diverged from the CPU reference: head_dim {head_dim}, \
+             {n_pos} positions (G = {}), worst |delta| {worst}",
+            n_pos.div_ceil(head_dim)
+        );
+    }
+}


### PR DESCRIPTION
## The bug

`attention_batched_q8_0` drops most of the KV cache once a prompt exceeds `head_dim`
tokens. Anyone running `--kv-quant q8_0` on the resident CUDA lane with a prompt longer
than `head_dim` (128 for Llama 3.2 3B) is getting materially wrong attention today.

The kernel splits weighted-V accumulation into `G = ceil(position_count / head_dim)`
groups, but derives the group id straight from the thread id:

```c
int gid = tid / head_dim;
int did = tid % head_dim;
```

while `launch_attention_batched` hardcodes `block_dim: (128, 1, 1)`. For `head_dim == 128`
that makes `gid` **always 0**, so:

1. only `1/G` of the positions are ever accumulated, and
2. `vpart[did * G + g]` for `g >= 1` is summed back **uninitialised**.

It is correct only when `blockDim.x == G * head_dim`, and breaks in **both**
directions otherwise:

| shape | what went wrong |
|---|---|
| head_dim 128, `G >= 2` (over-subscribed) | `gid` always 0: only `1/G` of positions accumulated, `g >= 1` slots of `vpart` read uninitialised. Correct at `G == 1` only. |
| head_dim 64 (under-subscribed) | threads 64..127 get `gid == 1` even at `G == 1`, scan past the live prefix, and write `vpart[did+1]` over the `gid == 0` writer for dim `did+1` — a race at **every** context length. |
| head_dim 256 | `gid` always 0 and `did` never exceeds 127, so output dims 128..255 are **never written**, at any context length. |

It shipped because short smoke prompts at head_dim 128 pass.

### Why only this kernel

The two launcher families use opposite conventions, and this kernel was written to one
while being launched by the other:

| launcher | convention |
|---|---|
| `launch_attention` (decode) | sets `block_dim = groups * head_dim`; the kernel reads `G = blockDim.x / head_dim` |
| `launch_attention_batched` (prefill) | fixes `block_dim` at 128; the kernel must grid-stride over `G * head_dim` |

Auditing every sibling:

| kernel | `G` from | `gid` from | verdict |
|---|---|---|---|
| **`attention_batched_q8_0`** | `position_count` | `tid` | **mismatched — the bug** |
| `attention_batched` (f16) | `position_count` | grid-stride idx | correct |
| `attention_tree_batched_q8_0` | `count` | grid-stride idx | correct |
| `attention_decode_q8_0` | `blockDim.x` | `tid` | self-consistent |
| `attention_decode_sw_q8_0` | `blockDim.x` | `tid` | self-consistent |

So the f16 sibling was always right, and this is the only kernel that mixed the two. The
fix makes it grid-stride exactly as `attention_batched` does.

## Evidence

Llama 3.2 3B Instruct Q8_0, RTX 3060 Laptop, comparing the **first generated token's
logits** against the CPU f32 path across six context depths (72 → 6103 tokens). The same
prompt makes step-0 logits exactly comparable between lanes, which free-running text is
not:

| lane | top-1 | top-8 overlap | mean KL | worst \|Δlogit\| |
|---|---|---|---|---|
| cpu q8_0 (reference impl) | 6/6 | 8.0/8 | 8.7e-4 | 0.170 |
| gpu f16 | 6/6 | 7.8/8 | 2.6e-4 | 0.092 |
| **gpu q8_0 BEFORE** | 4/6 | 4.8/8 | 1.1e-1 | **8.648** |
| **gpu q8_0 AFTER** | **6/6** | **8.0/8** | **5.9e-4** | **0.195** |

After the fix the GPU lane matches the CPU implementation of the same format. Before it, a
prompt over 128 tokens could shift a logit by **8.6** and change the argmax.

A fine sweep of prompt length puts the cliff exactly at `head_dim`: errors stay at
0.04–0.25 logits up to ~114 tokens, then jump to 3–14 from ~133 onward and never recover.

## Why this was never caught

**Free-running greedy text cannot see it.** Token divergence is a near-tie coin flip that
cannot distinguish a 0.09 logit error from an 8.6 one — by that measure the broken lane
looked comparable to f16. `docs/perf-deep-dive/PERF_RECEIPTS/same-host/kv-cache-quantization-ab-20260728.md`
already warns exactly this: *"token identity on this benchmark is a regression check, not a
general model-quality certification."* This is what that warning looks like in practice.

That receipt's CUDA control (`## CUDA resident control`, 2048 positions) ran
`--kv-quant q8_0` past the boundary and reported token-identical output. Either its prompts
got lucky on near-ties, or the resident device cache was not q8_0 in that configuration —
worth re-running now that the kernel is fixed, but I have not re-measured it here, so I am
flagging rather than asserting it was wrong.

## The test

`q8_0_batched_attention_matches_cpu_reference_past_the_head_dim_boundary` sweeps
`(head_dim, positions)` over **(128, 100)**, **(128, 200)**, **(64, 40)** and **(64, 200)**,
comparing against a CPU reference computed over the same dequantized blocks — so the
quantizer is held constant and only the kernel's attention arithmetic is under test.

Verified in **both directions** against the `origin/main` kernel, not merely asserted once:

| case | vs origin/main |
|---|---|
| (128, 200) — `G == 2` | fails by **0.0354** |
| (64, 40) — `G == 1` | fails by **0.1356** |

That second row is the one worth noting: `G == 1` is the regime an over-subscription-only
analysis would call safe, and at head_dim 64 it is actually the *worse* of the two. head_dim
64 is a shipped shape — the existing `attention_decode_matches_cpu` /
`attention_decode_sw_matches_cpu` tests use it — so pinning 128 alone would let a regression
that only broke 64 straight through.

`#[ignore]`d for GPU-less CI, matching the file's convention.

## Gates

```
cargo fmt --all -- --check          clean
cargo clippy --all-targets -- -D warnings   clean
cargo test --lib                    2242 passed, 0 failed
bash scripts/check-public-scrub.sh  exit 0
```

Plus the GPU test above, run on the RTX 3060.

## Scope

One kernel, one grid-stride loop, plus the regression test. The f16 path is untouched, as
are both decode kernels and the tree-batched kernel — all three were already correct.

Note that "the previously-correct regime is unchanged" would be wrong to claim: at head_dim
128 `G == 1` was correct and stays correct, but at head_dim 64 the `G == 1` path was racy
before and is fixed here too. The new loop is a strict correction at every shape, not a
no-op below the boundary.

## Found while reviewing this, not fixed here

`d_verify_scores` is allocated once as `MAX_VERIFY_K * n_heads * max_pos` floats
(`cuda_resident.rs:14130`, `MAX_VERIFY_K = 8`), but the batched attention kernels index it
as `global_scores + blockIdx.x * max_pos` under a grid of `k * n_heads` blocks. Any launch
with `k > 8` writes past the allocation. Not reachable at defaults, but reachable two ways:
tree verify bounds `n` only by `TREE_MAX_NODES = 16`, and
`CAMELID_CUDA_PREFILL_BATCH_TOKENS` is clamped only by `prefill_token_cap_limit()`. It is
pre-existing and independent of this fix, so it belongs in its own PR — flagging it here so
it is not lost.
