### PR TITLE
Render the Llama 4 header chat template for MobileMoE

### DIFF
--- a/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
+++ b/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
@@ -27,7 +27,7 @@
   },
   "implementation": {
     "source_file": "src/api/mod.rs",
-    "source_git_blob_sha1": "1950c39305ee897e8b059fb05f1d01a29cbbf232",
+    "source_git_blob_sha1": "b24a67f63f1cf0afcea656485218fce4270ca2f0",
     "architecture": "smollm3",
     "renderer": "render_smollm3_production_chat_prompt",
     "public_chokepoints": [

--- a/scripts/hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/hf-qualification-smollm3-chat-parity.mjs
@@ -93,11 +93,11 @@ const GROUNDING_FILES = Object.freeze({
   }),
   runtime_envelope: Object.freeze({
     path: 'qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json',
-    sha256: 'a475d731c262ab412d7c0e1e88e1cf50ce9cf518d5b42dd9629363e11d9939a2',
+    sha256: 'b0c96b19295937e4407f231df3ea2d9e4f2b70bd16cb3c5a2708eb27d8b3485d',
   }),
 })
 
-const RENDERER_GIT_BLOB_SHA1 = '1950c39305ee897e8b059fb05f1d01a29cbbf232'
+const RENDERER_GIT_BLOB_SHA1 = 'b24a67f63f1cf0afcea656485218fce4270ca2f0'
 const SHAPE_CASE_ID = 'default_think_single_user_generation_prompt'
 const NORMALIZED_PROMPT_UTF8_BYTES = 1_392
 const NORMALIZED_PROMPT_SHA256 = '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1'

--- a/scripts/test-hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/test-hf-qualification-smollm3-chat-parity.mjs
@@ -114,7 +114,7 @@ assert.deepEqual(TEMPLATE_IDENTITY, {
 assert.equal(GROUNDING_FILES.shape_pack.sha256,
   'd46794448b7c2585d0aa83dfd7bb17d4904c2dcbc048ade1ef68cd3863166de6')
 assert.equal(GROUNDING_FILES.runtime_envelope.sha256,
-  'a475d731c262ab412d7c0e1e88e1cf50ce9cf518d5b42dd9629363e11d9939a2')
+  'b0c96b19295937e4407f231df3ea2d9e4f2b70bd16cb3c5a2708eb27d8b3485d')
 assert.equal(LLAMA_PIN.executable_sha256,
   '6c787bf07ac1d7e1bbaa1ee176c3ef0df58ea86494c8c1b1d2d9f4a9176b19ae')
 assert.equal(LLAMA_PIN.server_impl_sha256,
@@ -331,7 +331,7 @@ assert.equal(classifySmolLM3ChatParityError(sharedSmolError).error_code,
 
 const committedGrounding = await inspectGroundings(root)
 assert.equal(committedGrounding.renderer_git_blob_sha1,
-  '1950c39305ee897e8b059fb05f1d01a29cbbf232')
+  'b24a67f63f1cf0afcea656485218fce4270ca2f0')
 assert.equal(committedGrounding.shape_case.normalized_prompt_sha256,
   '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1')
 const shapePack = JSON.parse(await readFile(resolve(GROUNDING_FILES.shape_pack.path), 'utf8'))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22452,6 +22452,22 @@ fn render_chat_prompt_for_tokenization_fallback(
                 parse_special: tokenizer.chat_prompt_parse_special(),
             };
         }
+        // Llama 4's header-marker family (Meta MobileMoE and siblings). Kept
+        // ahead of the Llama 3 branch because the two are one lineage with two
+        // marker spellings; neither recognizer can fire on the other's
+        // template, so the order documents the kinship rather than guarding it.
+        if is_llama4_header_template(template) {
+            return RenderedPrompt {
+                text: render_llama4_header_prompt(messages),
+                // No BOS text in the rendered string; add_bos_token=true puts
+                // <|begin_of_text|> in exactly once at token level.
+                add_special: true,
+                // <|header_start|>/<|header_end|>/<|eot|> are control tokens in
+                // this vocabulary; special parsing is what turns them into their
+                // ids instead of spelling them out as ordinary text.
+                parse_special: tokenizer.chat_prompt_parse_special(),
+            };
+        }
         if is_llama3_instruct_template(template) {
             return RenderedPrompt {
                 text: render_llama3_instruct_prompt(messages),
@@ -23050,6 +23066,22 @@ fn is_llama3_instruct_template(template: &str) -> bool {
         && template.contains("<|eot_id|>")
 }
 
+/// Llama 4's header-marker chat template — the family Meta's MobileMoE ships
+/// (`general.architecture = mobilemoe`): every turn is
+/// `<|header_start|>{role}<|header_end|>\n\n{content}<|eot|>`, closed by a bare
+/// assistant header. Same shape as Llama 3 instruct with different marker
+/// spellings, and the two cannot cross-match: `<|header_start|>` never appears
+/// in a Llama 3 template, and `<|eot|>` is not a substring of `<|eot_id|>`
+/// (after `<|eot` comes `_`, not `|`). Without this branch the template fell
+/// through the whole chain to `render_role_colon_prompt` and served a
+/// `"User: …"` transcript these weights were never trained on, so the model
+/// continued the transcript instead of ending its turn.
+fn is_llama4_header_template(template: &str) -> bool {
+    template.contains("<|header_start|>")
+        && template.contains("<|header_end|>")
+        && template.contains("<|eot|>")
+}
+
 fn is_exact_llama31_instruct_template(template: &str) -> bool {
     template.len() == 4613
         && format!("{:x}", Sha256::digest(template.as_bytes()))
@@ -23391,6 +23423,39 @@ fn render_llama3_instruct_prompt_with_options(
     if append_generation_prompt {
         prompt.push_str("<|start_header_id|>assistant<|end_header_id|>\n\n");
     }
+    prompt
+}
+
+/// Render Llama 4's header-marker template byte-faithfully for the
+/// `add_generation_prompt = true` case.
+///
+/// The source template opens with `{{ bos_token }}`, but the rendered string
+/// carries NO BOS text. The GGUF declares `add_bos_token = true` and this
+/// branch encodes with `add_special = true`, so `<|begin_of_text|>` lands
+/// exactly once at token level — the resolution `render_llama3_instruct_prompt`
+/// and `render_gemma3_prompt` took for the same conflict. Spelling BOS into the
+/// text as well is the Mistral shape, which works only because that branch
+/// pairs it with `add_special: false`; doing both here would double the BOS.
+///
+/// Every message is closed with `<|eot|>`, the trailing user turn included: the
+/// template's `{{ content + '<|eot|>' }}` runs unconditionally inside the loop.
+/// The generation prompt is the assistant header with its two literal newlines
+/// and deliberately no `<|eot|>` — that is the token the model must produce to
+/// end its turn, and it is what the GGUF declares as EOS.
+///
+/// Content is emitted untrimmed because the template has no `| trim`. The role
+/// is trimmed: it arrives from the HTTP wire, and stray whitespace inside
+/// `<|header_start|>…<|header_end|>` would break the header into ordinary text.
+fn render_llama4_header_prompt(messages: &[ChatMessage]) -> String {
+    let mut prompt = String::new();
+    for message in messages {
+        prompt.push_str("<|header_start|>");
+        prompt.push_str(message.role.trim());
+        prompt.push_str("<|header_end|>\n\n");
+        prompt.push_str(&message.content);
+        prompt.push_str("<|eot|>");
+    }
+    prompt.push_str("<|header_start|>assistant<|header_end|>\n\n");
     prompt
 }
 
@@ -24101,6 +24166,8 @@ fn detect_chat_template_format(template: &str) -> &'static str {
         "gemma2_it_exact"
     } else if is_gemma3_chat_template(template) {
         "gemma3_turn_markers"
+    } else if is_llama4_header_template(template) {
+        "llama4_header_markers"
     } else if is_llama3_instruct_template(template) {
         "llama3_instruct"
     } else if is_mistral_instruct_template(template) {
@@ -29878,6 +29945,117 @@ mod tests {
         assert!(
             reject_tools_for_windowed_arch("llama", Some(std::slice::from_ref(&tool))).is_none()
         );
+    }
+
+    /// The MobileMoE GGUF's chat template, verbatim. Before this family was
+    /// recognised it fell through to the role-colon renderer, and the model
+    /// answered a greeting by continuing the transcript forever.
+    const LLAMA4_HEADER_TEMPLATE: &str = "{{ bos_token }}{% set loop_messages = messages %}{% for message in loop_messages %}{% set content = '<|header_start|>' + message['role'] + '<|header_end|>\\n\\n' %}{% if message['content'] is string %}{% set content = content + message['content'] %}{% else %}{% for item in message['content'] %}{% if item['type'] == 'text' %}{% set content = content + item['text'] %}{% endif %}{% endfor %}{% endif %}{{ content + '<|eot|>' }}{% endfor %}{% if add_generation_prompt %}{{ '<|header_start|>assistant<|header_end|>\\n\\n' }}{% endif %}";
+
+    #[test]
+    fn renders_llama4_header_prompt_with_header_tokens_and_special_parsing() {
+        let _guard = crate::test_support::env_lock();
+        std::env::remove_var(METADATA_CHAT_TEMPLATE_ENV);
+        let tokenizer = Tokenizer {
+            model: TokenizerModel::Gpt2Bpe,
+            bpe_pre_tokenizer: BpePreTokenizer::default(),
+            tokens: Vec::new(),
+            token_to_id: HashMap::new(),
+            byte_token_to_id: HashMap::new(),
+            bpe_ranks: HashMap::new(),
+            bpe_registry: BpeRegistry::default(),
+            special: SpecialTokens::default(),
+            config: TokenizerConfig {
+                add_bos: true,
+                add_eos: false,
+                add_sep: false,
+                add_space_prefix: false,
+                remove_extra_whitespaces: false,
+            },
+            chat_template: Some(LLAMA4_HEADER_TEMPLATE.to_string()),
+            specials_index: OnceLock::new(),
+        };
+
+        assert!(tokenizer.chat_prompt_parse_special());
+        assert_eq!(
+            detect_chat_template_format(tokenizer.chat_template.as_deref().unwrap()),
+            "llama4_header_markers"
+        );
+        assert_eq!(
+            render_chat_prompt(
+                &[ChatMessage {
+                    image_urls: Vec::new(),
+                    unsupported_content_parts: Vec::new(),
+                    role: "user".to_string(),
+                    content: " hello ".to_string(),
+                }],
+                &tokenizer,
+            ),
+            "<|header_start|>user<|header_end|>\n\n hello <|eot|><|header_start|>assistant<|header_end|>\n\n"
+        );
+    }
+
+    #[test]
+    fn renders_llama4_header_prompt_with_system_and_multi_turn_messages() {
+        let _guard = crate::test_support::env_lock();
+        std::env::remove_var(METADATA_CHAT_TEMPLATE_ENV);
+        let tokenizer = Tokenizer {
+            model: TokenizerModel::Gpt2Bpe,
+            bpe_pre_tokenizer: BpePreTokenizer::default(),
+            tokens: Vec::new(),
+            token_to_id: HashMap::new(),
+            byte_token_to_id: HashMap::new(),
+            bpe_ranks: HashMap::new(),
+            bpe_registry: BpeRegistry::default(),
+            special: SpecialTokens::default(),
+            config: TokenizerConfig {
+                add_bos: true,
+                add_eos: false,
+                add_sep: false,
+                add_space_prefix: false,
+                remove_extra_whitespaces: false,
+            },
+            chat_template: Some(LLAMA4_HEADER_TEMPLATE.to_string()),
+            specials_index: OnceLock::new(),
+        };
+
+        let message = |role: &str, content: &str| ChatMessage {
+            image_urls: Vec::new(),
+            unsupported_content_parts: Vec::new(),
+            role: role.to_string(),
+            content: content.to_string(),
+        };
+
+        assert_eq!(
+            render_chat_prompt(
+                &[
+                    message("system", "Be helpful."),
+                    message("user", "Hello"),
+                    message("assistant", "Hi"),
+                    message("user", "Again"),
+                ],
+                &tokenizer,
+            ),
+            concat!(
+                "<|header_start|>system<|header_end|>\n\nBe helpful.<|eot|>",
+                "<|header_start|>user<|header_end|>\n\nHello<|eot|>",
+                "<|header_start|>assistant<|header_end|>\n\nHi<|eot|>",
+                "<|header_start|>user<|header_end|>\n\nAgain<|eot|>",
+                "<|header_start|>assistant<|header_end|>\n\n"
+            )
+        );
+    }
+
+    #[test]
+    fn llama4_header_recognizer_does_not_collide_with_llama3_instruct() {
+        // `<|eot|>` is not a substring of `<|eot_id|>`, and neither family's
+        // markers appear in the other's template. A collision here would route
+        // one family through the other's renderer and stop token.
+        let llama3 = "<|start_header_id|>{{ role }}<|end_header_id|>{{ content }}<|eot_id|>";
+        assert!(is_llama3_instruct_template(llama3));
+        assert!(!is_llama4_header_template(llama3));
+        assert!(is_llama4_header_template(LLAMA4_HEADER_TEMPLATE));
+        assert!(!is_llama3_instruct_template(LLAMA4_HEADER_TEMPLATE));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #710. MobileMoE loaded and generated correctly, but every reply through the chat endpoint was garbage, because the prompt never reached the model in the shape it was trained on.

## What was wrong

Camelid recognizes chat-template *families* by pattern-matching the template string out of the GGUF, then dispatches to a hand-written byte-faithful renderer. Meta's MobileMoE ships the Llama 4 header-marker family:

```
<|header_start|>{role}<|header_end|>

{content}<|eot|>
```

Nothing in the recognizer chain matched those markers, so the template fell all the way through to `render_role_colon_prompt`, which serves a `User: ... Assistant:` transcript. The model did the only sensible thing with a transcript and continued it, turn after turn, until it hit the token limit. It never produced its end-of-turn token because the prompt it was given never used one.

Asked "Hello", it replied `User: Hi` repeated to the cap.

## The change

- `is_llama4_header_template`, placed beside the Llama 3 recognizer. The two families are one lineage with different marker spellings and cannot cross-match: `<|header_start|>` never appears in a Llama 3 template, and `<|eot|>` is not a substring of `<|eot_id|>`.
- `render_llama4_header_prompt`, byte-faithful to the template for the generation-prompt case.
- The dispatch branch, ahead of the Llama 3 branch so the kinship is visible.
- The family's name in `detect_chat_template_format`, which had been reporting it as unparsed metadata.

The rendered string deliberately carries no BOS text. The GGUF sets `add_bos_token`, and this branch encodes with `add_special`, so the BOS token lands exactly once at token level. That is how the Llama 3 and Gemma 3 renderers resolved the same conflict; spelling BOS into the text as well is the Mistral shape, which works only because that branch pairs it with `add_special: false`.

Specials parse, because the header and end-of-turn markers are control tokens in this vocabulary. Without that the encoder would spell them out and the model would see no turn boundary at all.

## No stop-token change was needed

Worth stating, because it was the obvious suspect. Once the prompt is rendered correctly the model emits the end-of-turn token the GGUF declares as EOS, and generation halts on its own. Measured directly against the running model before writing any code.

## Verification

Against MobileMoE-S-SFT at Q8_0 on Metal, same server, temperature zero:

| prompt | before | after |
|---|---|---|
| Hello | `User: Hi` to the token limit | `Hello! How can I help you today?`, stops in 10 tokens |
| What is the capital of France? | transcript loop | `The capital of France is Paris.`, stops in 8 tokens |
| system + 2 turns of history | transcript loop | `Green.`, stops |

No marker text leaks into replies, and the same result holds in the web UI.

Three unit tests are added, mirroring the Llama 3 renderer tests: single-turn rendering with the family label, multi-turn with a system message, and a collision test asserting neither family's recognizer fires on the other's template.
