### PR TITLE
fix(metal): take the attention K/V element type from the caller, not process globals

### DIFF
--- a/src/metal.rs
+++ b/src/metal.rs
@@ -15435,6 +15435,9 @@ fn encode_gemma4_attention(
         &qn_buf,
         cache_k_buf,
         cache_v_buf,
+        // gemma4's KV cache is unconditionally f32 (`kv_bytes` is sized with
+        // `size_of::<f32>()`), and it stages no f16 mirrors.
+        KvOperand::F32,
         None,
         &scores_buf,
         &ctx_buf,
@@ -18153,6 +18156,78 @@ fn encode_attention_split3(
     );
 }
 
+/// The element type of the `keys` / `values` buffers a caller owns.
+///
+/// Supplied as a **witness by the buffer's owner**, never re-derived from the
+/// process-global KV format. The attention kernels declare their K/V operands as
+/// `device const float*`, `device const half*`, or a 34-byte-block Q8 layout; binding the
+/// wrong one does not fault, it reinterprets the bytes and returns plausible garbage that
+/// greedy token-identity parity cannot distinguish from a correct decode.
+///
+/// This replaces three separate process-global reads (`kvq8_enabled()`, `kv16_enabled()`,
+/// and inferring "f16 primary" from `kv16_mirrors.is_none()`). Those were correct for
+/// `ResidentDecodeState`, which maintains the invariant that mirrors exist iff the primary
+/// is f32 — but `encode_attention` is shared with the gemma4 / qwen35 / LFM2 lanes, which
+/// own unconditionally-f32 caches and pass `None` for mirrors, so "no mirrors" did not
+/// prove "half data" for them.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum KvOperand {
+    /// `device const float*` — 4 bytes/element.
+    F32,
+    /// `device const half*` — 2 bytes/element.
+    F16,
+    /// Q8_0: 34-byte blocks of 32 codes plus an f16 scale.
+    Q8,
+}
+
+#[cfg(target_os = "macos")]
+impl KvOperand {
+    /// Witness for a session that records its primary format as the `kv16`/`kvq8` pair
+    /// (`ResidentDecodeState` and `encode_attention_block`). Q8 wins over F16 because the
+    /// two are mutually exclusive at construction and Q8 is the narrower layout.
+    fn from_flags(kv16: bool, kvq8: bool) -> Self {
+        if kvq8 {
+            Self::Q8
+        } else if kv16 {
+            Self::F16
+        } else {
+            Self::F32
+        }
+    }
+}
+
+/// Which buffers the split-K decode dispatch reads, and at which element type.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SplitkKvSource {
+    /// Q8_0 primary, read in place by `attention_decode_splitk_kvq8`.
+    PrimaryQ8,
+    /// F16 primary, read in place by `attention_decode_splitk_kv16{,_direct}`.
+    PrimaryF16,
+    /// F32 primary read through its staged f16 mirrors — halves KV traffic at depth.
+    MirrorsF16,
+    /// F32 primary, read in place by `attention_decode_splitk`.
+    PrimaryF32,
+}
+
+/// Resolve the split-K K/V operand from the caller's format witness and whether f16
+/// mirrors are staged and enabled.
+///
+/// Extracted as a pure function, like `splitk_kv_format_admits`, so the routing has a
+/// GPU-free gate. The regression it pins: an F32 witness with no mirrors must read the
+/// f32 primary, NEVER `PrimaryF16`. Inferring "f16 primary" from absent mirrors held only
+/// for `ResidentDecodeState` and silently mis-typed the gemma4 / qwen35 / LFM2 caches.
+#[cfg(target_os = "macos")]
+fn splitk_kv_source(kv: KvOperand, mirrors_present: bool, mirrors_enabled: bool) -> SplitkKvSource {
+    match kv {
+        KvOperand::Q8 => SplitkKvSource::PrimaryQ8,
+        KvOperand::F16 => SplitkKvSource::PrimaryF16,
+        KvOperand::F32 if mirrors_present && mirrors_enabled => SplitkKvSource::MirrorsF16,
+        KvOperand::F32 => SplitkKvSource::PrimaryF32,
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 fn encode_attention(
@@ -18162,6 +18237,8 @@ fn encode_attention(
     query: &Buffer,
     keys: &Buffer,
     values: &Buffer,
+    // Element type of `keys`/`values` above. See `KvOperand`.
+    kv: KvOperand,
     kv16_mirrors: Option<(&Buffer, &Buffer)>,
     scores: &Buffer,
     out: &Buffer,
@@ -18179,7 +18256,8 @@ fn encode_attention(
 ) {
     // Tiled kernel (4 simdgroups/head, online softmax, no scores buffer) when enabled and
     // the head geometry allows; otherwise the one-simdgroup-per-head fallback.
-    let v2 = (attn2_enabled() || kvq8_enabled()) && head_dim.is_multiple_of(32) && head_dim <= 128;
+    let v2 =
+        (attn2_enabled() || kv == KvOperand::Q8) && head_dim.is_multiple_of(32) && head_dim <= 128;
     // Split-K flash decode for deeper contexts: the v2 kernel's one-threadgroup-per-head
     // grid leaves the GPU mostly idle while each simdgroup walks a long position range
     // serially, and GQA re-reads every K/V row once per query head. The split-K kernel
@@ -18196,7 +18274,7 @@ fn encode_attention(
     // `!kv16_enabled()` with the new gate would take split-K away from the f32 lane,
     // where it measures 1.67x on an M4.
     let splitk = v2
-        && splitk_kv_format_admits(kv16_enabled(), splitk_kv16_primary_enabled())
+        && splitk_kv_format_admits(kv == KvOperand::F16, splitk_kv16_primary_enabled())
         && splitk_attention_enabled()
         && (1..=4).contains(&group)
         && position_count >= 128;
@@ -18209,10 +18287,10 @@ fn encode_attention(
         }
         // Half-mirror reads halve the dominant KV traffic at depth; opt out with
         // CAMELID_METAL_ATTN_SPLITK_KV16=0 to keep the f32 split-K reads.
-        let use_mirrors = kv16_mirrors.is_some()
-            && !std::env::var("CAMELID_METAL_ATTN_SPLITK_KV16")
-                .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("false"));
-        if kvq8_enabled() {
+        let mirrors_enabled = !std::env::var("CAMELID_METAL_ATTN_SPLITK_KV16")
+            .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("false"));
+        let source = splitk_kv_source(kv, kv16_mirrors.is_some(), mirrors_enabled);
+        if source == SplitkKvSource::PrimaryQ8 {
             // Q8 primary: read the 34-byte-block cache directly. No mirrors exist on this
             // lane (cache_k16/cache_v16 are empty under a compressed primary), and none are
             // wanted -- the whole point is that the Q8 cache is 1.88x smaller than the f16
@@ -18221,24 +18299,25 @@ fn encode_attention(
             e.set_buffer(0, Some(query), query_off);
             e.set_buffer(1, Some(keys), 0);
             e.set_buffer(2, Some(values), 0);
-        } else if kv16_mirrors.is_none() {
-            // F16 PRIMARY. Selected on the ABSENCE OF MIRRORS, deliberately, not on
-            // `kv16_enabled()`: mirrors are allocated only when the primary is f32
-            // (`!kv16 && !kvq8`, see `ResidentDecodeState::new`), so with the Q8 arm
-            // already taken above, `None` here proves `keys`/`values` hold half data.
+        } else if source == SplitkKvSource::PrimaryF16 {
+            // F16 PRIMARY: bind the half-typed kernel straight to it.
             //
-            // Keying this off the process-global instead would reintroduce the exact
-            // hazard `kv_roundtrips_through_cpu_exactly` documents: a model switch
-            // re-decides the global while a session still holds an engine built under the
-            // previous format, so the global is a time-of-check answer to a time-of-use
-            // question. Getting it wrong here does not fail loudly -- it binds half data
-            // to `attention_decode_splitk_f32`, whose signature is `device const float*`,
-            // and returns plausible garbage. The buffer we were handed is the only
-            // trustworthy witness to its own element type.
+            // Selected on the caller's WITNESS. This arm previously tested
+            // `kv16_mirrors.is_none()`, reasoning that mirrors are allocated only when the
+            // primary is f32 (`!kv16 && !kvq8`, see `ResidentDecodeState::new`), so `None`
+            // proved half data. That invariant is real but LOCAL to
+            // `ResidentDecodeState`: `encode_attention` is also called by
+            // `encode_gemma4_attention`, `encode_qwen35_full_layer` and
+            // `encode_lfm2_attn_layer`, which own unconditionally-f32 caches and pass
+            // `None` unconditionally. Those lanes therefore took this arm and bound f32
+            // bytes to `device const half*` -- silent garbage at every depth past the
+            // split-K threshold, which their parity fixtures never reach.
             //
-            // This branch also closes that hazard in the other direction: the final
-            // `else` is now reachable only with mirrors present, i.e. a proven f32
-            // primary.
+            // Neither can the process-global answer it: `kv16_enabled()` is a
+            // time-of-check answer to a time-of-use question (a model switch re-decides it
+            // while a session still holds an engine built under the previous format), the
+            // hazard `kv_roundtrips_through_cpu_exactly` documents. The buffer's owner is
+            // the only trustworthy witness to its element type.
             if head_dim == 128 {
                 e.set_compute_pipeline_state(&k.attention_decode_splitk_kv16_direct_pipeline);
             } else {
@@ -18247,8 +18326,9 @@ fn encode_attention(
             e.set_buffer(0, Some(query), query_off);
             e.set_buffer(1, Some(keys), 0);
             e.set_buffer(2, Some(values), 0);
-        } else if use_mirrors {
-            let (mk, mv) = kv16_mirrors.expect("checked is_some above");
+        } else if source == SplitkKvSource::MirrorsF16 {
+            // F32 primary with f16 mirrors staged: half the KV traffic at depth.
+            let (mk, mv) = kv16_mirrors.expect("MirrorsF16 implies mirrors_present");
             // Direct-read variant for head_dim 128: no threadgroup staging or
             // barriers -> more resident threadgroups; GQA re-reads hit the SLC.
             // Probe @7.7k positions: 11.4ms vs 14.3ms staged (and better at
@@ -18313,7 +18393,7 @@ fn encode_attention(
     // Bit-identical three-dispatch encode of the f32 fallback kernel. Same arithmetic,
     // same order; the only difference is that the score and context phases are exposed
     // as independent threads instead of being folded onto n_heads simdgroups.
-    if !v2 && !kv16_enabled() && !kvq8_enabled() && attn_split3_enabled() {
+    if !v2 && kv == KvOperand::F32 && attn_split3_enabled() {
         let denom = pool_get(k, (n_heads * 4).max(4) as u64);
         let blocks = pool_get(k, 8);
         encode_attention_split3(
@@ -18337,13 +18417,19 @@ fn encode_attention(
         keep.push(blocks);
         return;
     }
-    let attn_pipeline = match (v2, kv16_enabled(), kvq8_enabled()) {
-        (true, _, true) => &k.attention_decode_v2_kvq8_pipeline,
-        (true, true, false) => &k.attention_decode_v2_kv16_pipeline,
-        (true, false, false) => &k.attention_decode_v2_pipeline,
-        (false, true, false) => &k.attention_decode_kv16_pipeline,
-        (false, false, false) => &k.attention_decode_pipeline,
-        (false, _, true) => unreachable!("Q8 KV requires the v2 geometry"),
+    let attn_pipeline = match (v2, kv) {
+        (true, KvOperand::Q8) => &k.attention_decode_v2_kvq8_pipeline,
+        (true, KvOperand::F16) => &k.attention_decode_v2_kv16_pipeline,
+        (true, KvOperand::F32) => &k.attention_decode_v2_pipeline,
+        (false, KvOperand::F16) => &k.attention_decode_kv16_pipeline,
+        (false, KvOperand::F32) => &k.attention_decode_pipeline,
+        // Unreachable by construction, not by env state: a Q8 witness can only come from
+        // `ResidentDecodeState::new`, which refuses `kvq8` unless
+        // `head_dim.is_multiple_of(32) && head_dim <= 128` -- exactly the `v2` predicate,
+        // whose first disjunct `kv == KvOperand::Q8` is then true. Reading the format from
+        // the process-global made this arm reachable (and a panic) on any head_dim > 128
+        // lane under `CAMELID_METAL_KV_DTYPE=q8`.
+        (false, KvOperand::Q8) => unreachable!("Q8 KV requires the v2 geometry"),
     };
     e.set_compute_pipeline_state(attn_pipeline);
     e.set_buffer(0, Some(query), query_off);
@@ -18395,6 +18481,13 @@ fn encode_attention_tree(
     query: &Buffer,
     keys: &Buffer,
     values: &Buffer,
+    // Element type of `keys`/`values`. Always `F32` in practice: `verify_batch_inner`
+    // refuses the tree lane under a compressed primary (`(self.kv16 || self.kvq8) &&
+    // tree.is_some() -> None`), because the tree kernels carry no compressed-primary
+    // non-split twins. Threaded anyway so this encoder routes off the SAME witness as
+    // `encode_attention` -- the two must agree, since their byte-identity is the
+    // correctness anchor for the whole verify lane.
+    kv: KvOperand,
     kv16_mirrors: Option<(&Buffer, &Buffer)>,
     scores: &Buffer,
     out: &Buffer,
@@ -18410,8 +18503,15 @@ fn encode_attention_tree(
 ) {
     let v2 = attn2_enabled() && head_dim.is_multiple_of(32) && head_dim <= 128;
     let group = n_heads.checked_div(n_kv_heads).unwrap_or(0);
+    // Tree split-K is mirror-only -- there is no f32 or Q8 split-K *tree* kernel -- so
+    // admit it on the witness plus the mirrors actually being present, rather than on
+    // `!kv16_enabled()`. The old form read a process-global that this session does not
+    // own: a concurrent kv16 session flipping it would silently drop this f32 session to
+    // the non-split tree kernel, diverging tree verify from the linear `encode_attention`
+    // at the same `position_count`. It also made the `expect` below reachable.
     let splitk = v2
-        && !kv16_enabled()
+        && kv == KvOperand::F32
+        && kv16_mirrors.is_some()
         && splitk_attention_enabled()
         && (1..=4).contains(&group)
         && position_count >= 128;
@@ -18425,7 +18525,7 @@ fn encode_attention_tree(
         // Tree split-K is mirror-only: read the f16 mirrors whenever present (the f32
         // split-K kernel has no tree clone). Under the default config the linear path
         // also reads the mirrors, so the two stay byte-identical.
-        let (mk, mv) = kv16_mirrors.expect("tree split-K requires f16 mirrors");
+        let (mk, mv) = kv16_mirrors.expect("gated on is_some above");
         if head_dim == 128 {
             e.set_compute_pipeline_state(&k.attention_decode_splitk_kv16_direct_tree_pipeline);
         } else {
@@ -18481,6 +18581,13 @@ fn encode_attention_tree(
         return;
     }
     // Non-split path: v2 tiled (no scores buffer) or the f32 one-simdgroup fallback.
+    // BOTH tree pipelines declare their K/V operands `device const float*`, so this path
+    // is sound only for an F32 witness. `verify_batch_inner` is what guarantees that.
+    debug_assert_eq!(
+        kv,
+        KvOperand::F32,
+        "tree attention has no compressed-primary kernel; verify_batch_inner must decline"
+    );
     let attn_pipeline = if v2 {
         &k.attention_decode_v2_tree_pipeline
     } else {
@@ -19350,6 +19457,7 @@ fn encode_attention_block(
         &query_buf,
         cache_k_buf,
         cache_v_buf,
+        KvOperand::from_flags(kv16, kvq8),
         kv16_mirrors,
         &scores_buf,
         &ctx_buf,
@@ -20813,6 +20921,9 @@ fn encode_qwen35_full_layer(
         &query,
         cache_k,
         cache_v,
+        // This lane allocates its KV at `n_kv_heads * max_positions * head_dim * 4` —
+        // f32 — and stages no f16 mirrors.
+        KvOperand::F32,
         None,
         &scores,
         &context,
@@ -21908,6 +22019,8 @@ impl Lfm2MetalDecode {
                             &query,
                             cache_k,
                             cache_v,
+                            // LFM2's KV is f32 (`... * head_dim * 4`); no mirrors.
+                            KvOperand::F32,
                             None,
                             &scores,
                             &context,
@@ -22314,6 +22427,9 @@ fn encode_lfm2_attn_layer(
         &query,
         cache_k,
         cache_v,
+        // This lane allocates its KV at `n_kv_heads * max_positions * head_dim * 4` —
+        // f32 — and stages no f16 mirrors.
+        KvOperand::F32,
         None,
         &scores,
         &context,
@@ -27819,6 +27935,7 @@ impl ResidentDecodeState {
                             &q_buf,
                             &self.cache_k[l],
                             &self.cache_v[l],
+                            KvOperand::from_flags(self.kv16, self.kvq8),
                             if self.kv16 || self.kvq8 {
                                 None
                             } else {
@@ -28508,6 +28625,7 @@ impl ResidentDecodeState {
                         &q_buf,
                         &self.cache_k[l],
                         &self.cache_v[l],
+                        KvOperand::from_flags(self.kv16, self.kvq8),
                         if self.kv16 || self.kvq8 {
                             None
                         } else {
@@ -28530,6 +28648,11 @@ impl ResidentDecodeState {
                         &q_buf,
                         &self.cache_k[l],
                         &self.cache_v[l],
+                        // `verify_batch_inner` refuses the tree lane unless the primary is
+                        // f32 with mirrors staged, so this is F32 — but derive it from the
+                        // session rather than hardcoding, so the encoder's own
+                        // `debug_assert` stays a real check.
+                        KvOperand::from_flags(self.kv16, self.kvq8),
                         Some((&self.cache_k16[l], &self.cache_v16[l])),
                         &scores_buf,
                         &ctx_buf,
@@ -30127,6 +30250,89 @@ mod tests {
         // An F16 primary is admitted only behind its own gate.
         assert!(!splitk_kv_format_admits(true, false));
         assert!(splitk_kv_format_admits(true, true));
+    }
+
+    /// `encode_attention` must take the K/V element type from the CALLER'S WITNESS, never
+    /// from process-global env state or from the absence of f16 mirrors.
+    ///
+    /// The old dispatch inferred "f16 primary" from `kv16_mirrors.is_none()`. That is a
+    /// sound inference for `ResidentDecodeState`, which allocates mirrors exactly when the
+    /// primary is f32 — but `encode_attention` is shared. `encode_gemma4_attention`,
+    /// `encode_qwen35_full_layer`, `Lfm2MetalDecode::forward_prefill_chunk` and
+    /// `encode_lfm2_attn_layer` all own unconditionally-f32 KV caches and pass `None` for
+    /// mirrors, so they took the F16 arm and bound f32 bytes to a `device const half*`
+    /// kernel — reading each f32 as two halves and returning plausible garbage.
+    ///
+    /// It was live on the shipped CLI: `apply_default_fast_stack` sets
+    /// `CAMELID_METAL_ATTN2=1`, `splitk_attention_enabled()` defaults on, and
+    /// `splitk_kv_format_admits(false, _)` admits the f32 lane, so any of those models at
+    /// `position_count >= 128` with `group in 1..=4` hit it. Their parity fixtures stop
+    /// well short of 128 positions, so token-identity could never see it — the same
+    /// measurement blind spot that shipped the CUDA `attention_batched_q8_0` defect.
+    ///
+    /// Needs no GPU: this is routing policy, not dispatch.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn splitk_kv_source_follows_the_caller_witness_not_the_absence_of_mirrors() {
+        use super::{splitk_kv_source, KvOperand, SplitkKvSource};
+
+        // THE REGRESSION. An f32 cache with no mirrors staged must read the f32 primary.
+        // Before the witness this returned the F16 primary and mis-typed the operand.
+        assert_eq!(
+            splitk_kv_source(KvOperand::F32, false, true),
+            SplitkKvSource::PrimaryF32,
+            "an f32 cache without mirrors must not be read as an f16 primary"
+        );
+        assert_eq!(
+            splitk_kv_source(KvOperand::F32, false, false),
+            SplitkKvSource::PrimaryF32
+        );
+
+        // An f32 primary with mirrors staged reads the mirrors, unless opted out.
+        assert_eq!(
+            splitk_kv_source(KvOperand::F32, true, true),
+            SplitkKvSource::MirrorsF16
+        );
+        assert_eq!(
+            splitk_kv_source(KvOperand::F32, true, false),
+            SplitkKvSource::PrimaryF32,
+            "CAMELID_METAL_ATTN_SPLITK_KV16=0 keeps the f32 reads"
+        );
+
+        // A genuine f16 primary is read in place, mirrors or not — it has none.
+        for mirrors in [false, true] {
+            for enabled in [false, true] {
+                assert_eq!(
+                    splitk_kv_source(KvOperand::F16, mirrors, enabled),
+                    SplitkKvSource::PrimaryF16
+                );
+            }
+        }
+
+        // Q8 always reads its own 34-byte-block cache; mirrors are never staged for it.
+        for mirrors in [false, true] {
+            for enabled in [false, true] {
+                assert_eq!(
+                    splitk_kv_source(KvOperand::Q8, mirrors, enabled),
+                    SplitkKvSource::PrimaryQ8
+                );
+            }
+        }
+    }
+
+    /// The witness derived from a session's `(kv16, kvq8)` pair. `ResidentDecodeState::new`
+    /// makes the two mutually exclusive, but the mapping is load-bearing enough to pin:
+    /// getting it backwards binds a Q8 block cache to a half-typed kernel.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn kv_operand_from_flags_maps_the_session_format() {
+        use super::KvOperand;
+
+        assert_eq!(KvOperand::from_flags(false, false), KvOperand::F32);
+        assert_eq!(KvOperand::from_flags(true, false), KvOperand::F16);
+        assert_eq!(KvOperand::from_flags(false, true), KvOperand::Q8);
+        // Mutually exclusive at construction; Q8 is the narrower layout, so it wins.
+        assert_eq!(KvOperand::from_flags(true, true), KvOperand::Q8);
     }
 
     /// The F16-primary resident KV cache is qualified for the K-quant lane, so

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -17925,6 +17925,96 @@ fn try_attention_splitk_kv16_for_test(
     Some(result)
 }
 
+/// Test-only direct driver for the **f32** split-K decode attention, the kernel the
+/// gemma4 / qwen35 / LFM2 lanes reach now that `encode_attention` routes on the caller's
+/// `KvOperand` witness instead of inferring "f16 primary" from absent mirrors. Mirrors
+/// `try_attention_splitk_kv16_for_test`, but binds f32 K/V and the f32 pipeline.
+#[cfg(all(test, target_os = "macos"))]
+#[allow(clippy::too_many_arguments)]
+fn try_attention_splitk_f32_for_test(
+    query: &[f32],
+    keys: &[f32],
+    values: &[f32],
+    n_heads: usize,
+    n_kv_heads: usize,
+    head_dim: usize,
+    positions: usize,
+    scale: f32,
+) -> Option<Vec<f32>> {
+    let kernel = metal_linear_kernel()?;
+    let device = &kernel.device;
+    let opts = MTLResourceOptions::StorageModeShared;
+    let q = device.new_buffer(std::mem::size_of_val(query) as u64, opts);
+    let k = device.new_buffer(std::mem::size_of_val(keys) as u64, opts);
+    let v = device.new_buffer(std::mem::size_of_val(values) as u64, opts);
+    let out = device.new_buffer((n_heads * head_dim * 4) as u64, opts);
+    let scalar = device.new_buffer(32, opts);
+    write_buffer_f32(&q, query);
+    write_buffer_f32(&k, keys);
+    write_buffer_f32(&v, values);
+    let n_splits = positions.div_ceil(64).clamp(2, 64);
+    let partials = device.new_buffer((n_heads * n_splits * (head_dim + 2) * 4) as u64, opts);
+    let splits_scalar = device.new_buffer(4, opts);
+    unsafe {
+        *(splits_scalar.contents() as *mut u32) = n_splits as u32;
+        let p = scalar.contents() as *mut u32;
+        *p = n_heads as u32;
+        *p.add(1) = head_dim as u32;
+        *p.add(2) = positions as u32;
+        *p.add(3) = (n_heads / n_kv_heads) as u32;
+        *(p.add(4) as *mut f32) = scale;
+        *p.add(5) = head_dim as u32; // position_stride (contiguous)
+        *p.add(6) = (positions * head_dim) as u32; // kv_head_stride
+        *p.add(7) = 0; // kv_base_offset
+    }
+    let cb = kernel.queue.new_command_buffer();
+    let e = cb.new_compute_command_encoder();
+    e.set_compute_pipeline_state(&kernel.attention_decode_splitk_pipeline);
+    e.set_buffer(0, Some(&q), 0);
+    e.set_buffer(1, Some(&k), 0);
+    e.set_buffer(2, Some(&v), 0);
+    e.set_buffer(3, Some(&partials), 0);
+    for i in 0..8u64 {
+        e.set_buffer(5 + i, Some(&scalar), i * 4);
+    }
+    e.set_buffer(13, Some(&splits_scalar), 0);
+    e.dispatch_thread_groups(
+        metal::MTLSize {
+            width: n_kv_heads as u64,
+            height: n_splits as u64,
+            depth: 1,
+        },
+        metal::MTLSize {
+            width: 128,
+            height: 1,
+            depth: 1,
+        },
+    );
+    e.set_compute_pipeline_state(&kernel.attention_decode_splitk_merge_pipeline);
+    e.set_buffer(0, Some(&partials), 0);
+    e.set_buffer(1, Some(&out), 0);
+    e.set_buffer(2, Some(&scalar), 4); // head_dim
+    e.set_buffer(3, Some(&splits_scalar), 0);
+    e.dispatch_thread_groups(
+        metal::MTLSize {
+            width: n_heads as u64,
+            height: 1,
+            depth: 1,
+        },
+        metal::MTLSize {
+            width: 128,
+            height: 1,
+            depth: 1,
+        },
+    );
+    e.end_encoding();
+    cb.commit();
+    cb.wait_until_completed();
+    let mut result = vec![0.0f32; n_heads * head_dim];
+    read_buffer_f32(&out, &mut result);
+    Some(result)
+}
+
 /// Test-only direct driver for the K-split GEMV pipeline (bypasses the env gate and the
 /// weight-buffer cache so parity tests control exactly what runs).
 #[cfg(all(test, target_os = "macos"))]
@@ -32615,6 +32705,96 @@ mod tests {
         .expect("v2 attention");
         for (i, (a, b)) in got.iter().zip(&expected).enumerate() {
             assert!((a - b).abs() < 1.0e-4, "dim {i}: {a} != {b}");
+        }
+    }
+
+    /// The **f32** split-K decode attention against a CPU f32 reference, at the shapes the
+    /// gemma4 / qwen35 / LFM2 lanes actually dispatch.
+    ///
+    /// This kernel previously had no correctness test of its own. It also had almost no
+    /// production traffic from those lanes: `encode_attention` inferred "f16 primary" from
+    /// `kv16_mirrors.is_none()`, and all three pass `None` unconditionally, so they were
+    /// misrouted to the half-typed kernel. Fixing the routing sends real traffic here, so
+    /// pin the arithmetic.
+    ///
+    /// head_dim 64 is the load-bearing width: it is LFM2's, and `Lfm2MetalDecode::new`
+    /// admits any `head_dim <= 128`. `positions` is swept either side of the split-K
+    /// admission threshold (`position_count >= 128`) and across the `n_splits` clamp, so a
+    /// coverage gap in the partials — the failure mode CUDA PR #714 hit, where slots that
+    /// no producer wrote were summed back uninitialised — shows up as a mismatch rather
+    /// than as plausible garbage.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn metal_attention_decode_splitk_f32_matches_cpu_reference_across_the_threshold() {
+        if !detect_metal_device().available {
+            return;
+        }
+        // (n_heads, n_kv_heads, head_dim, positions)
+        //   64/128  -- LFM2's width, exactly at the admission threshold, 2 splits
+        //   64/200  -- 4 splits, chunk 50, last split covers 50: uneven PT=8 tail
+        //   64/131  -- 3 splits of chunk 44 where the last covers 43
+        //   96/131  -- head_dim not a multiple of 64; dpl = 3, so lane dim 3 is inactive
+        //  128/131  -- full MAX_DPL = 4 width
+        for &(n_heads, n_kv_heads, head_dim, positions) in &[
+            (8usize, 4usize, 64usize, 128usize),
+            (8, 4, 64, 200),
+            (6, 2, 64, 131),
+            (6, 2, 96, 131),
+            (6, 2, 128, 131),
+        ] {
+            let scale = 1.0 / (head_dim as f32).sqrt();
+            // Exactly-representable steps keep the CPU reference and the kernel reading
+            // identical values; this lane is f32 end to end, so there is no f16 rounding
+            // to hide a real mismatch.
+            let query: Vec<f32> = (0..n_heads * head_dim)
+                .map(|i| ((i as f32 % 5.0) - 2.0) * 0.25)
+                .collect();
+            let keys: Vec<f32> = (0..n_kv_heads * positions * head_dim)
+                .map(|i| ((i as f32 % 7.0) - 3.0) * 0.25)
+                .collect();
+            let values: Vec<f32> = (0..n_kv_heads * positions * head_dim)
+                .map(|i| ((i as f32 % 9.0) - 4.0) * 0.25)
+                .collect();
+
+            let group = n_heads / n_kv_heads;
+            let mut expected = vec![0.0f32; n_heads * head_dim];
+            for h in 0..n_heads {
+                let qb = h * head_dim;
+                let kvb = (h / group) * positions * head_dim;
+                let mut scores = vec![0.0f32; positions];
+                let mut m = f32::NEG_INFINITY;
+                for (p, sc) in scores.iter_mut().enumerate() {
+                    let mut dot = 0.0f32;
+                    for d in 0..head_dim {
+                        dot += query[qb + d] * keys[kvb + p * head_dim + d];
+                    }
+                    *sc = dot * scale;
+                    m = m.max(*sc);
+                }
+                let mut sum = 0.0f32;
+                for sc in scores.iter_mut() {
+                    *sc = (*sc - m).exp();
+                    sum += *sc;
+                }
+                for d in 0..head_dim {
+                    let mut acc = 0.0f32;
+                    for (p, sc) in scores.iter().enumerate() {
+                        acc += (sc / sum) * values[kvb + p * head_dim + d];
+                    }
+                    expected[qb + d] = acc;
+                }
+            }
+
+            let got = try_attention_splitk_f32_for_test(
+                &query, &keys, &values, n_heads, n_kv_heads, head_dim, positions, scale,
+            )
+            .expect("f32 split-K attention");
+            for (i, (a, b)) in got.iter().zip(&expected).enumerate() {
+                assert!(
+                    (a - b).abs() < 1.0e-4,
+                    "head_dim {head_dim} / {positions} positions, dim {i}: {a} != {b}"
+                );
+            }
         }
     }
 

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -17656,16 +17656,6 @@ fn resident_kv_format() -> ResidentKvFormat {
     }
 }
 
-#[cfg(target_os = "macos")]
-fn kv16_enabled() -> bool {
-    resident_kv_format() == ResidentKvFormat::F16
-}
-
-#[cfg(target_os = "macos")]
-fn kvq8_enabled() -> bool {
-    resident_kv_format() == ResidentKvFormat::Q8
-}
-
 /// Admit an F16-PRIMARY resident KV cache to the split-K decode attention.
 ///
 /// The split-K gate historically read `!kv16_enabled()`, which excluded every K-quant
@@ -19177,13 +19167,10 @@ fn encode_attention_block(
     cache_k_buf: &Buffer,
     cache_v_buf: &Buffer,
     kv16_mirrors: Option<(&Buffer, &Buffer)>,
-    // Primary KV format for THIS session, threaded from `self.kv16`/`self.kvq8`
-    // rather than re-read from the process-global gates: the caller, the KV
-    // readback and the KV seed all use the per-session fields, and the window
-    // offset now rides in the same scalar as the stride (see byte 28 below).
-    // Two sources of truth here is a time-of-check/time-of-use hazard.
-    kv16: bool,
-    kvq8: bool,
+    // Primary KV format owned by this caller. Keeping this as one witness prevents an
+    // impossible `(kv16, kvq8) == (true, true)` state and stops the standalone helpers,
+    // whose inputs are always f32, from consulting resident-session global policy.
+    kv: KvOperand,
     max_positions: usize,
     write_position: usize,
     n_heads: usize,
@@ -19202,6 +19189,8 @@ fn encode_attention_block(
     split_half_pairing: bool,
     qk_l2_norm_after_rope: bool,
 ) {
+    let kv16 = kv == KvOperand::F16;
+    let kvq8 = kv == KvOperand::Q8;
     let hidden = attn_norm.len();
     let q_dim = n_heads * head_dim;
     let kv_dim = n_kv_heads * head_dim;
@@ -19547,7 +19536,7 @@ fn encode_attention_block(
         &query_buf,
         cache_k_buf,
         cache_v_buf,
-        KvOperand::from_flags(kv16, kvq8),
+        kv,
         kv16_mirrors,
         &scores_buf,
         &ctx_buf,
@@ -22894,8 +22883,9 @@ pub fn try_attention_block_resident(
         &cache_k_buf,
         &cache_v_buf,
         None,
-        kv16_enabled(),
-        kvq8_enabled(),
+        // `upload_cache_buffer` copied `&[f32]`; resident-session policy must not
+        // reinterpret this standalone helper's caller-owned bytes.
+        KvOperand::F32,
         position_count,
         position_count - 1,
         n_heads,
@@ -23032,8 +23022,9 @@ pub fn try_decode_layer_resident(
         &cache_k_buf,
         &cache_v_buf,
         None,
-        kv16_enabled(),
-        kvq8_enabled(),
+        // `upload_cache_buffer` copied `&[f32]`; resident-session policy must not
+        // reinterpret this standalone helper's caller-owned bytes.
+        KvOperand::F32,
         position_count,
         position_count - 1,
         n_heads,
@@ -23212,8 +23203,9 @@ pub fn try_decode_forward_resident(
             &cache_k_buf,
             &cache_v_buf,
             None,
-            kv16_enabled(),
-            kvq8_enabled(),
+            // `ResidentDecodeLayer` exposes f32 cache slices, so this transient
+            // standalone path always owns an f32 primary.
+            KvOperand::F32,
             position_count,
             position_count - 1,
             n_heads,
@@ -24759,8 +24751,7 @@ impl ResidentDecodeState {
                 } else {
                     Some((&self.cache_k16[i], &self.cache_v16[i]))
                 },
-                self.kv16,
-                self.kvq8,
+                KvOperand::from_flags(self.kv16, self.kvq8),
                 self.max_positions,
                 position,
                 self.n_heads,


### PR DESCRIPTION
## The bug

`encode_attention` chose between the `device const float*`, `device const half*` and
Q8-block attention kernels by reading process-global state — `kvq8_enabled()`,
`kv16_enabled()`, and inferring "f16 primary" from `kv16_mirrors.is_none()`.

That last inference is sound for `ResidentDecodeState`, which allocates mirrors exactly
when the primary is f32. It is **local to that lane**. `encode_attention` is shared, and
`encode_gemma4_attention`, `encode_qwen35_full_layer`, `encode_lfm2_attn_layer` and
`Lfm2MetalDecode::forward_prefill_chunk` all own unconditionally-f32 KV caches
(`... * head_dim * 4`; gemma4 sizes `kv_bytes` with `size_of::<f32>()`) and pass `None`
for mirrors. They took the F16 arm and bound f32 bytes to a half-typed kernel.

**LFM2 is live on the shipped CLI with no debug env.** `apply_default_fast_stack`
(`src/main.rs:8749`) sets `CAMELID_METAL_ATTN2=1`, `splitk_attention_enabled()` defaults
ON, and `splitk_kv_format_admits(false, _) = !false` admits the f32 lane.
LFM2.5-2.6B-Q8_0 is head_dim 64 (embedding_length 2048 / head_count 32) with group
32/8 = 4 — the top of the admitted `(1..=4)` range. Every gate opens at
`position_count >= 128`.

The blast radius differs per lane, and the difference matters:

| lane | head_dim | exposure |
|---|---|---|
| **LFM2** | 64 | **live today**, single model, default flags, >=128 positions |
| qwen35 (ornith-9B) | 256 | fails the `head_dim <= 128` v2 gate, so never split-K. Corrupts only via the non-split `match` after an **in-process model switch** from a K-quant Llama flips the global |
| gemma4 | 256/512 | same switch-dependent path, plus the panic below |

`set_resident_kquant_lane` is called only from the Llama resident lane, so a
single-model qwen35 process keeps `kv16_enabled() == false` and took the correct f32
kernel — which is why the existing ornith-9B agent-eval PASS is real and is unaffected
by this change.

## Evidence

LFM2.5-2.6B-Q8_0, Apple M4 / 16 GiB, `serve` + `/v1/chat/completions`, temperature 0,
identical prompt, release builds either side of this change:

| binary | prompt tokens | result |
|---|---|---|
| before | 20 | coherent output |
| **before** | **221** | **panics** |
| after | 221 | coherent output |
| after, `CAMELID_METAL_ATTN_SPLITK=0` | 221 | byte-identical to the split-K run |

The pre-fix panic is `range start index 9345848833920 out of range for slice of length
278528000` at `src/runnable/model.rs:365` (`dequant_row`). That index divides exactly:
`9345848833920 / 2176 row-bytes = 4294967295 = u32::MAX`. Reinterpreting f32 bytes as
f16 pairs lands on f16 exponent-all-ones often enough to produce NaN logits; argmax then
returned its sentinel, and the sentinel became a row index.

So the failure mode was not subtle drift. Below the threshold it is invisible; above it,
the forward pass is poisoned.

## Why it was never caught

Token-identity parity cannot see this, and the fixtures cannot reach it.
`tests/fixtures/lfm2_parity/lfm2.json` holds four fixtures of 4-7 prompt tokens with
`max_new: 24` — about 31 positions against a 128-position threshold. **The LFM2 parity
suite is structurally incapable of exercising the path it is meant to certify.**

This is the same blind spot as #714 on CUDA, where a mis-derived group id moved a logit
by 8.6 while greedy output still looked comparable to f16.

## The fix

A `KvOperand` witness supplied by the buffer's owner, replacing all three process-global
reads, plus the operand choice extracted into the pure `splitk_kv_source` so routing has
a GPU-free gate the way `splitk_kv_format_admits` already did.

Two further defects fall out of the same change:

* `unreachable!("Q8 KV requires the v2 geometry")` was reachable, and panicked, on any
  head_dim > 128 lane under `CAMELID_METAL_KV_DTYPE=q8`. With a witness it is unreachable
  by construction: a Q8 witness can only come from `ResidentDecodeState::new`, which
  already refuses `kvq8` unless `head_dim.is_multiple_of(32) && head_dim <= 128` — exactly
  the `v2` predicate.
* `encode_attention_tree` gated split-K on `!kv16_enabled()`, a global that session does
  not own, then `expect`ed the mirrors that gate does not guarantee. It now gates on the
  witness plus `kv16_mirrors.is_some()`, matching its own "mirror-only" comment and
  keeping tree verify in lockstep with the linear path whose byte-identity is the verify
  lane's correctness anchor.

## Tests

`splitk_kv_source_follows_the_caller_witness_not_the_absence_of_mirrors` — verified in
**both** directions, not asserted once. Against the pre-fix logic it fails with
`left: PrimaryF16, right: PrimaryF32`, the mis-typed operand itself.

`metal_attention_decode_splitk_f32_matches_cpu_reference_across_the_threshold` — the f32
split-K kernel had **no correctness test**, and this change sends it real traffic for the
first time from those lanes. Sweeps (8,4,64,128), (8,4,64,200), (6,2,64,131),
(6,2,96,131), (6,2,128,131): head_dim 64 is LFM2's width, 96 gives `dpl = 3` so lane dim 3
is inactive (the under-subscribed shape that made the CUDA sibling race), and positions
cross the admission threshold with chunk tails that do not divide `PT = 8`. All five match
the CPU f32 reference within 1e-4 — so the kernel the corrected routing selects is sound,
and the defect was purely the operand choice.

## Gates

Run on the mini2 M4 rig, cargo/rustc 1.94.1:

```
cargo fmt --all -- --check           clean
cargo clippy --all-targets -- -D warnings
                                     clean for this change; one PRE-EXISTING
                                     `unnecessary_cast` at src/metal.rs:47057 from
                                     ee76a22f fires on this toolchain
cargo test --lib                     2341 passed
cargo test --all-targets             2 failures, both `fabric::http` TLS loopback tests
                                     (`Connect("[::1]:PORT: Connection refused")`).
                                     Intermittent on this host and reproduce identically
                                     on pristine origin/main with these changes removed.
```

## Not fixed here

`attention_decode_splitk_kv16_direct{,_tree}` hardcode the partials row stride at
`(128 + 2)` while the host sizes `partials` by `(head_dim + 2)`. That is #714's exact
shape. It is held together only by three separate `if head_dim == 128` call-site guards
(`src/metal.rs:18242`, `:18256`, and the tree twin); one edit to any of them makes it
live. Pre-existing and independent of this fix, so it belongs in its own PR — flagged
here so it is not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
