### PR TITLE
fix(metal): drop a no-op f32 cast in the gemma3 attention parity test

### DIFF
--- a/src/metal.rs
+++ b/src/metal.rs
@@ -46844,7 +46844,7 @@ mod attn_mm_parity {
                 for d in (0..hd).step_by(3) {
                     let mut o = 0f32;
                     for p2 in 0..=q {
-                        let pw = ((scores[p2] - m).exp() / l) as f32;
+                        let pw = (scores[p2] - m).exp() / l;
                         // kernel rounds P to half
                         let pw = fh(h(pw));
                         o += pw * fh(v[(z / group) * max_pos * hd + p2 * hd + d]);


### PR DESCRIPTION
## What

`cargo clippy --all-targets -- -D warnings` fails on rustc 1.94.1:

```
error: casting to the same type is unnecessary (`f32` -> `f32`)
  --> src/metal.rs:46847:34
   |
   |    let pw = ((scores[p2] - m).exp() / l) as f32;
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

`scores` is a `Vec<f32>` and `m` / `l` are both `f32`, so the expression is already
`f32` and the trailing `as f32` does nothing. This drops it, and the now-redundant
parentheses with it. One line, no behaviour change.

## Why CI never saw it

The lint sits in `mod attn_mm_parity`, gated on `cfg(all(test, target_os = "macos"))`,
so only the macOS `--all-targets` leg compiles it at all. It has been on main since
ee76a22f (2026-07-31).

The reason that leg stayed green is a toolchain pin that has drifted apart:

| Where | Version |
| --- | --- |
| `.github/workflows/ci.yml` (`dtolnay/rust-toolchain@…`) | 1.89.0 |
| `rust-toolchain.toml` (`channel`) | 1.95.0 |
| `Cargo.toml` (`rust-version`, MSRV) | 1.89 |

These were deliberately aligned once — 1e70e8838 "Align CI with pinned Rust toolchain"
set both to 1.87.0 — and then drifted: 83063cfc0 bumped only `rust-toolchain.toml` to
1.95.0, and 85a2cca77 bumped only `ci.yml` to 1.89.0. That second commit's message
("the old 1.87 pin could not build the tree at all") indicates the `ci.yml` pin is what
actually governs CI, which would make `rust-toolchain.toml`'s 1.95.0 inert.

The consequence is that anyone building through `rustup` gets 1.95.0 locally while CI
gates at 1.89.0. Reconciling the pins is deliberately **not** part of this PR — bumping
CI upward needs its blast radius measured across all three OS legs first. This change is
a no-op under either pin.

One encouraging data point for that future work: on macOS with default features at
clippy 1.94.1, this cast was the *only* finding — the rest of that leg is already clean.
The Linux `--all-features` and Windows `camelid-desktop` legs were not measured.

## Verification

Run on macOS/arm64, rustc 1.94.1:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean, 0 errors and 0 warnings.
- Positive control: reverting this one line reproduces exactly the error above and
  nothing else, failing in the `camelid (lib test)` target — confirming the passing run
  genuinely compiles that module rather than skipping it.
- `cargo test --lib` — 2338 passed, 24 ignored.
- `bash scripts/check-public-scrub.sh` — clean.

Two `fabric::http` TLS tests (`an_untrusted_ca_and_a_wrong_server_name_are_refused_before_http`,
`bearer_bytes_are_not_sent_before_the_tls_peer_is_authenticated`) fail on that host both
with and without this change. They are unrelated and are being tracked separately: the
test listeners bind `127.0.0.1:0` (IPv4 only) while the client connects by the name
`localhost`, which on a dual-stack host can resolve to `::1` first and get ECONNREFUSED.
