### PR TITLE
ci: make rust-toolchain.toml the enforced source of truth for the toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
       - name: Check for private operator details
         run: bash scripts/check-public-scrub.sh
 
+      # Cheap, and it gates every job that installs a toolchain (`rust` and
+      # `desktop` both `needs:` this one), so drift fails before three OS
+      # runners spin up.
+      - name: Check toolchain pins agree with rust-toolchain.toml
+        run: bash scripts/check-toolchain-pins.sh
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -209,10 +215,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # rust-toolchain.toml is the single source of truth for the toolchain
+      # version; this ref only mirrors it. rustup treats the toolchain file as a
+      # directory override, which outranks the `rustup default` this action sets,
+      # so the version named here does NOT decide what the cargo steps below run
+      # -- the file does. Keeping them equal is what makes this step useful (it
+      # pre-installs the toolchain that will actually be used, instead of a second
+      # one nothing runs). The `public-scrub` job fails the run if they drift.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.89.0
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
+
+      # Print the toolchain that actually resolved, so a log answers "what did
+      # this run lint with?" without re-deriving it from rustup's override rules.
+      - name: Show effective toolchain
+        run: |
+          rustup show active-toolchain
+          rustc -vV
+          cargo clippy --version
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -343,10 +364,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Mirrors rust-toolchain.toml; see the note on the `rust` job's copy of
+      # this step. The toolchain file wins regardless, and `public-scrub` fails
+      # the run if this ref drifts away from it.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.89.0
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
+
+      - name: Show effective toolchain
+        run: |
+          rustup show active-toolchain
+          rustc -vV
+          cargo clippy --version
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,8 @@ jobs:
 
       # Cheap, and it gates every job that installs a toolchain (`rust` and
       # `desktop` both `needs:` this one), so drift fails before three OS
-      # runners spin up.
+      # runners spin up. Covers release.yml's four pins too — those builds ship
+      # artifacts, so they earn the same guard.
       - name: Check toolchain pins agree with rust-toolchain.toml
         run: bash scripts/check-toolchain-pins.sh
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ resolver = "2"
 name = "camelid"
 version = "0.6.1"
 edition = "2021"
+# MSRV floor, deliberately BELOW the toolchain in rust-toolchain.toml (1.95.0) —
+# these are different things and should not be "aligned". rust-toolchain.toml
+# says what CI and rustup developers build with; this says the oldest rustc the
+# crate claims to accept, and raising it to match would lock out hosts that
+# build with a distro/Homebrew rustc and no rustup (where the toolchain file is
+# inert). No CI leg builds at 1.89, so this floor is a declared intent rather
+# than a measured one; verifying it would need its own job.
 rust-version = "1.89"
 description = "Camelid: a Rust-native local GGUF inference backend with evidence-gated model compatibility"
 license = "MIT"

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -2,6 +2,7 @@
 name = "camelid-desktop"
 version = "0.6.1"
 edition = "2021"
+# MSRV floor, not the build toolchain — see the note in the workspace Cargo.toml.
 rust-version = "1.89"
 description = "Camelid Desktop — native chat app that embeds the Camelid engine as a loopback sidecar"
 license = "MIT"

--- a/docs/CONTRIBUTOR_QUICKSTART.md
+++ b/docs/CONTRIBUTOR_QUICKSTART.md
@@ -17,7 +17,9 @@ Current public support is exact-row: TinyLlama Q8_0 is the supported gate; Llama
 
 Required local tools:
 
-- Rust/Cargo 1.87+
+- Rust/Cargo via `rustup` (the exact version is pinned in
+  [`rust-toolchain.toml`](../rust-toolchain.toml) and installed automatically on
+  first `cargo` invocation in this repo)
 - Node.js + npm for `frontend/`
 - Git
 
@@ -27,6 +29,16 @@ Helpful but not required for every contribution:
 - local GGUF model files for supported-row smoke or parity work
 
 If your host exposes an older distro `cargo`, source `$HOME/.cargo/env` first or use `scripts/with-rustup-cargo.sh ...` so the rustup-managed toolchain is used.
+
+This matters more than it looks. `rust-toolchain.toml` is a *rustup* mechanism:
+on a host with rustup it outranks `rustup default` and pins you to the same
+toolchain CI uses, but on a host whose `cargo` comes from a distro package or
+Homebrew with **no rustup installed**, the file is inert and you silently build
+and lint with whatever version that package ships. That is a real way to get
+`clippy` findings CI does not have — or to miss ones it does — so check
+`rustc -vV` against the pinned channel before concluding that CI and your
+machine disagree about the code. Every CI leg prints its own `rustc -vV` in the
+"Show effective toolchain" step for exactly this comparison.
 
 ## Backend quickstart
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,12 @@
+# Single source of truth for the Rust toolchain this repo builds with.
+#
+# rustup reads this file as a directory override, which outranks `rustup default`
+# — so it wins over the version named by dtolnay/rust-toolchain in CI, and every
+# `cargo` invocation on a checkout of this repo runs the channel below. CI mirrors
+# it (a `uses:` ref cannot be an expression); scripts/check-toolchain-pins.sh fails
+# the build if the mirror drifts. Change the version HERE.
+#
+# Not the same as `rust-version` (MSRV) in Cargo.toml, which is a lower floor.
 [toolchain]
 channel = "1.95.0"
 profile = "minimal"

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -5,22 +5,23 @@
 # builds with. rustup reads it as a *directory override*, which outranks the
 # `rustup default` that dtolnay/rust-toolchain sets — so on a checkout of this
 # repo the file decides what every `cargo` invocation runs, and the version
-# named in ci.yml decides nothing. That asymmetry is exactly why the two drifted
-# apart unnoticed for months (rust-toolchain.toml 1.87 -> 1.95 on 2026-05-14,
-# ci.yml 1.87 -> 1.89 on 2026-06-16): the restatement was inert, so no run ever
-# went red to report the disagreement.
+# named in a workflow decides nothing. That asymmetry is exactly why the two
+# drifted apart unnoticed for months (rust-toolchain.toml 1.87 -> 1.95 on
+# 2026-05-14, ci.yml 1.87 -> 1.89 on 2026-06-16): the restatement was inert, so
+# no run ever went red to report the disagreement.
 #
-# GitHub Actions cannot interpolate an expression into a `uses:` ref, so ci.yml
-# has to spell the version out. This check is what keeps that spelling honest.
+# GitHub Actions cannot interpolate an expression into a `uses:` ref, so the
+# workflows have to spell the version out. This check keeps that spelling honest
+# across ALL of them — release.yml pins the toolchain four more times, and those
+# builds ship artifacts, so they are worth the same guard as CI.
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 toml="$root/rust-toolchain.toml"
-workflow="$root/.github/workflows/ci.yml"
+workflow_dir="$root/.github/workflows"
 
-for f in "$toml" "$workflow"; do
-  [ -f "$f" ] || { echo "check-toolchain-pins: missing $f" >&2; exit 1; }
-done
+[ -f "$toml" ] || { echo "check-toolchain-pins: missing $toml" >&2; exit 1; }
+[ -d "$workflow_dir" ] || { echo "check-toolchain-pins: missing $workflow_dir" >&2; exit 1; }
 
 # `channel = "1.95.0"`, tolerating single quotes and surrounding whitespace.
 want="$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*["'"'"']\([^"'"'"']*\)["'"'"'].*/\1/p' "$toml" | head -1)"
@@ -29,26 +30,30 @@ echo "rust-toolchain.toml channel: $want"
 
 found=0
 status=0
-while IFS= read -r hit; do
-  found=$((found + 1))
-  line="${hit%%:*}"
-  ref="$(printf '%s' "$hit" | sed 's/.*dtolnay\/rust-toolchain@\([^[:space:]"'"'"']*\).*/\1/')"
-  if [ "$ref" = "$want" ]; then
-    echo "  ok   ci.yml:$line  dtolnay/rust-toolchain@$ref"
-  else
-    echo "::error file=.github/workflows/ci.yml,line=$line::dtolnay/rust-toolchain@$ref disagrees with rust-toolchain.toml ($want). rust-toolchain.toml is the source of truth: update this ref, not the file."
-    echo "  DRIFT ci.yml:$line  dtolnay/rust-toolchain@$ref != $want"
-    status=1
-  fi
-done < <(grep -n 'dtolnay/rust-toolchain@' "$workflow" || true)
+for wf in "$workflow_dir"/*.yml "$workflow_dir"/*.yaml; do
+  [ -e "$wf" ] || continue
+  rel="${wf#"$root"/}"
+  while IFS= read -r hit; do
+    found=$((found + 1))
+    line="${hit%%:*}"
+    ref="$(printf '%s' "$hit" | sed 's/.*dtolnay\/rust-toolchain@\([^[:space:]"'"'"']*\).*/\1/')"
+    if [ "$ref" = "$want" ]; then
+      echo "  ok    $rel:$line  dtolnay/rust-toolchain@$ref"
+    else
+      echo "::error file=$rel,line=$line::dtolnay/rust-toolchain@$ref disagrees with rust-toolchain.toml ($want). rust-toolchain.toml is the source of truth: update this ref, not the file."
+      echo "  DRIFT $rel:$line  dtolnay/rust-toolchain@$ref != $want"
+      status=1
+    fi
+  done < <(grep -n 'dtolnay/rust-toolchain@' "$wf" || true)
+done
 
 # A rename or refactor that drops every pin would otherwise pass vacuously.
 if [ "$found" -eq 0 ]; then
-  echo "::error file=.github/workflows/ci.yml::no dtolnay/rust-toolchain@<version> pin found; if the toolchain install moved, update scripts/check-toolchain-pins.sh to match." >&2
+  echo "::error::no dtolnay/rust-toolchain@<version> pin found in $workflow_dir; if the toolchain install moved, update scripts/check-toolchain-pins.sh to match." >&2
   exit 1
 fi
 
 if [ "$status" -eq 0 ]; then
-  echo "check-toolchain-pins: $found pin(s) agree with rust-toolchain.toml."
+  echo "check-toolchain-pins: $found pin(s) across $(ls "$workflow_dir"/*.yml "$workflow_dir"/*.yaml 2>/dev/null | wc -l | tr -d ' ') workflow file(s) agree with rust-toolchain.toml."
 fi
 exit "$status"

--- a/scripts/check-toolchain-pins.sh
+++ b/scripts/check-toolchain-pins.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Fail when a restated Rust toolchain version disagrees with rust-toolchain.toml.
+#
+# rust-toolchain.toml is the single source of truth for the toolchain this repo
+# builds with. rustup reads it as a *directory override*, which outranks the
+# `rustup default` that dtolnay/rust-toolchain sets — so on a checkout of this
+# repo the file decides what every `cargo` invocation runs, and the version
+# named in ci.yml decides nothing. That asymmetry is exactly why the two drifted
+# apart unnoticed for months (rust-toolchain.toml 1.87 -> 1.95 on 2026-05-14,
+# ci.yml 1.87 -> 1.89 on 2026-06-16): the restatement was inert, so no run ever
+# went red to report the disagreement.
+#
+# GitHub Actions cannot interpolate an expression into a `uses:` ref, so ci.yml
+# has to spell the version out. This check is what keeps that spelling honest.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+toml="$root/rust-toolchain.toml"
+workflow="$root/.github/workflows/ci.yml"
+
+for f in "$toml" "$workflow"; do
+  [ -f "$f" ] || { echo "check-toolchain-pins: missing $f" >&2; exit 1; }
+done
+
+# `channel = "1.95.0"`, tolerating single quotes and surrounding whitespace.
+want="$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*["'"'"']\([^"'"'"']*\)["'"'"'].*/\1/p' "$toml" | head -1)"
+[ -n "$want" ] || { echo "check-toolchain-pins: no channel in $toml" >&2; exit 1; }
+echo "rust-toolchain.toml channel: $want"
+
+found=0
+status=0
+while IFS= read -r hit; do
+  found=$((found + 1))
+  line="${hit%%:*}"
+  ref="$(printf '%s' "$hit" | sed 's/.*dtolnay\/rust-toolchain@\([^[:space:]"'"'"']*\).*/\1/')"
+  if [ "$ref" = "$want" ]; then
+    echo "  ok   ci.yml:$line  dtolnay/rust-toolchain@$ref"
+  else
+    echo "::error file=.github/workflows/ci.yml,line=$line::dtolnay/rust-toolchain@$ref disagrees with rust-toolchain.toml ($want). rust-toolchain.toml is the source of truth: update this ref, not the file."
+    echo "  DRIFT ci.yml:$line  dtolnay/rust-toolchain@$ref != $want"
+    status=1
+  fi
+done < <(grep -n 'dtolnay/rust-toolchain@' "$workflow" || true)
+
+# A rename or refactor that drops every pin would otherwise pass vacuously.
+if [ "$found" -eq 0 ]; then
+  echo "::error file=.github/workflows/ci.yml::no dtolnay/rust-toolchain@<version> pin found; if the toolchain install moved, update scripts/check-toolchain-pins.sh to match." >&2
+  exit 1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "check-toolchain-pins: $found pin(s) agree with rust-toolchain.toml."
+fi
+exit "$status"


### PR DESCRIPTION
## What

`.github/workflows/ci.yml` and `rust-toolchain.toml` disagreed about the Rust toolchain (1.89.0 vs 1.95.0). This makes **`rust-toolchain.toml` the single source of truth** and adds a CI gate so the drift cannot silently return.

## The premise was wrong, and measuring changed the fix

The natural reading is that `dtolnay/rust-toolchain@1.89.0` governs CI, so CI gates at 1.89 while rustup developers get 1.95. That is backwards.

rustup applies `rust-toolchain.toml` as a **directory override**, which outranks the `rustup default` the action sets. The action never exports `RUSTUP_TOOLCHAIN` (its own steps use an explicit `rustc +1.89.0`, which does not leak into later steps), so the file wins. From run [33878433797](https://github.com/timtoole02/Camelid/actions/runs/33878433797) (main @ `a8ea3d70`, all green), rustup says so itself:

```
info: note that the toolchain '1.95.0-x86_64-unknown-linux-gnu' is currently in use
      (overridden by '/home/runner/work/Camelid/Camelid/rust-toolchain.toml')   [ubuntu]
      '1.95.0-aarch64-apple-darwin'   (overridden by ...)                        [macos]
      '1.95.0-x86_64-pc-windows-msvc' (overridden by ...)                        [windows, desktop]
```

and the `cargo clippy` steps carry no `RUSTUP_TOOLCHAIN` in their env. **CI has been gating at 1.95.0 all along.** The 1.89.0 pin bought a second toolchain download nothing ran, and computed the action's `cachekey` from the wrong rustc.

## Blast radius: already measured, and it is zero

Because CI already runs 1.95.0, the four legs that would be "bumped" are green at the target toolchain **today**: ubuntu `--all-features`, macos default, windows default, and the windows `camelid-desktop` leg. No new lints to triage.

The `clippy::unnecessary_cast` that started this is consistent with that, not against it: it sits in `mod attn_mm_parity`, gated `cfg(all(test, target_os = "macos"))`, and was reported by a **Homebrew rustc 1.94.1 with no rustup** — where `rust-toolchain.toml` is inert. That host is *older* than CI, not newer. CI at 1.95.0 lints that module (`Compiling camelid` appears in the macOS clippy step) and does not flag it.

## Changes

- **`ci.yml`**: both pins `1.89.0` → `1.95.0`, commented as mirrors of the file.
- **`scripts/check-toolchain-pins.sh`** (new), run from `public-scrub` — which both toolchain-installing jobs already `needs:`, so drift fails before three OS runners start. Fails on disagreement, and on *no pin found*, so a refactor cannot pass it vacuously. A `uses:` ref cannot be an expression, so the restatement is unavoidable; this keeps it honest.
- **"Show effective toolchain"** step (`rustup show active-toolchain`, `rustc -vV`, `cargo clippy --version`) on the `rust` and `desktop` jobs — the permanent instrument. **This PR's own run is the empirical confirmation.**
- **`rust-version` stays 1.89**, now commented. MSRV is a floor, not the build toolchain; raising it to 1.95 would lock out hosts building with a Homebrew/distro rustc and no rustup. No CI leg builds at the floor, so it is a declared intent, not a measured one — now stated rather than implied.
- **`CONTRIBUTOR_QUICKSTART.md`**: fixes a third, staler restatement ("Rust/Cargo 1.87+") and documents the no-rustup case.

## Verification

- `scripts/check-toolchain-pins.sh` passes on this tree, and fails on all four drift shapes: both pins stale, one pin stale, pins removed entirely, file bumped ahead of `ci.yml`.
- `ci.yml` parses; new steps land in the intended jobs.
- `scripts/check-public-scrub.sh` clean.

## Not included

The `unnecessary_cast` fix itself — it is unpushed on a separate local branch and is a no-op either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
