### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 # MSRV floor, deliberately BELOW the toolchain in rust-toolchain.toml (1.95.0) —
 # these are different things and should not be "aligned". rust-toolchain.toml

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 # MSRV floor, not the build toolchain — see the note in the workspace Cargo.toml.
 rust-version = "1.89"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
Version bump only: `0.6.1` → `0.7.0` across the four version-of-record files (`Cargo.toml`, `camelid-desktop/Cargo.toml`, `camelid-desktop/tauri.conf.json`, and the two `camelid`/`camelid-desktop` blocks in `Cargo.lock`). 4 files, 5 insertions, 5 deletions — no code changes.

This PR's tree is `main` + the bump, so its CI run is the authoritative signal for the release tree. Once it is green and merged, `vX.Y.Z` gets a lightweight tag on the merge commit, which is the only trigger for `release.yml`.

## What lands in 0.7.0

539 commits since v0.6.1 (2026-08-08). Highlights:

**Cluster fabric** — the whole operable surface: placement (#652) and completion-time placement (#683), streaming (#651), failover (#662) and queue-full failover (#667), health (#665), routes (#663), startup reachability (#664), access log (#666), probe cache (#656), models route (#654), client auth (#658) and client keys (#672), node TLS (#671, #685), node lifecycle (#674), cancellable dispatch (#675), node file CLI (#676), cleartext guard (#679), auth truth docs (#680), plus 3-node scale evidence (#678). LAN chat sync (#681) + responsive layout (#682) and Tailscale remote chat (#684).

**CUDA** — quantized KV cache (#677), advanced KV cache architecture (#709), dynamic flash prefill (#670), K-quant prefill matmul (#713), the `attention_batched_q8_0` correctness fix (#714), NVRTC portability + lane diagnostic (#711, #669), and the qwen35 CUDA-lane default fix (#705).

**Gemma 4** — MTP CUDA lane (#698, #700) and the 12B QAT Q4_0 rows (#722).

**Metal** — qwen35 Q5_K (#660), the M3 KV Q8 receipt (#686), Mac KV fast lane (#712).

**Benchmark system** — phases 1 through 4 (#687, #688, #694, #695).

**Agent + web** — best-in-class agent harness (#708), web research (#701) and its CUDA/UI redesign (#706), coding-agent hardening (#702), streaming tool calls (#659) and the tool-call schema envelope (#703).

**Models** — BitNet support (#642), Hugging Face catch-up (#644), phase-2 model expansion (#649), download + runnable lanes (#650), name search (#645), MobileMoE chat template (#715).

**Desktop / UI** — web QoL polish (#716), chat context meter (#704), desktop persistence (#657), load notices + engine restart (#641), chat footer + desktop chrome (#639), catalog transient fit (#638).

## Excluded

Open PRs are not in this release: #718, #717, #693, #673, #623.
