### PR TITLE
feat(frontend): token inspector — per-token probabilities on an inspected reply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,6 +559,18 @@ jobs:
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:ui
 
+      - name: Token inspector smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: npm run smoke:token-inspector
+
+      # Wired here because the token inspector adds the first value-encoding
+      # colors to the UI. The script has existed since the design-token work but
+      # was never added to this job, so every palette change since then shipped
+      # unaudited — the same gap this file already records for other lanes.
+      - name: Design token contrast audit
+        if: ${{ !cancelled() }}
+        run: npm run smoke:contrast
+
   # ---------------------------------------------------------------------------
   # Single aggregate gate. Make THIS the only required status check in branch
   # protection (see the note in the PR/commit). It runs on every event and

--- a/frontend/design-evidence/BACKEND_ASKS.md
+++ b/frontend/design-evidence/BACKEND_ASKS.md
@@ -96,3 +96,46 @@ frontend cannot — and will not fake — a chat session against the runnable la
 
 Until then the Compatible rows stay receipt-only with an explicit "CLI only — no HTTP serve
 yet" note; membership and evidence remain fully derived, nothing is invented.
+
+## 5. Logprobs on the streaming path (Token Inspector, 2026-09-06)
+
+**Surface waiting on it:** the Token Inspector composer toggle
+(`lib/tokenInspection.js`, `components/chat/render/TokenInspector.jsx`). Because
+`rich_logprobs.unsupported_modes` contains `streaming`, an inspected turn must be
+sent with `stream: false`, so the user gives up token-by-token rendering for that
+reply and must decide to inspect BEFORE sending. Inspecting afterwards is not an
+option we are willing to take: it would mean decoding a second time, and those
+numbers would describe a different generation than the one on screen.
+
+**Ask:** carry the per-token record on the SSE path — either a `logprobs` object on
+each `choices[0].delta` (one entry per emitted token), or one terminal chunk
+carrying the whole `content[]` array in the same shape the non-streaming response
+already uses. Either shape collapses the pre-send decision into an ordinary
+disclosure of data already in hand, and the frontend keeps streaming.
+
+**Not asked:** logprobs together with `n > 1`. Those are mutually exclusive by
+contract and the UI treats the candidates surface as guarded, not pending.
+
+## 6. Logprobs fail OPEN on four serve lanes (engine defect, 2026-09-06)
+
+**Not a frontend ask — a backend correctness report.**
+
+`chat_completions` short-circuits into the gemma4 (`src/api/mod.rs:18011`), runnable
+(`:18063`) and DiffusionGemma (`:18077`) lanes BEFORE `validate_choice_and_logprob_fields`
+runs. On those lanes a request carrying `logprobs: true` returns **HTTP 200 with the
+`logprobs` key simply absent** — no error, no typed refusal. Every other invalid
+logprobs combination on the dense lane is a typed 400, so this one path fails open
+while its neighbours fail closed.
+
+That matters because the missing key is indistinguishable, to a client, from a lane
+that genuinely reported nothing — and the honest reading of "no distribution" is
+easy to confuse with "a flat or certain distribution". The Token Inspector handles
+it defensively (`inspectionAbsenceReason`, `code: 'lane_absent'`) and says the
+measurement is missing rather than flat, but the engine should refuse rather than
+leave every client to detect this independently.
+
+**Ask:** move the logprobs validation ahead of lane dispatch, and return the same
+typed 400 these lanes already return for other unsupported combinations — or add a
+lane axis to `api_conformance` so the refusal is at least machine-readable. Note
+that `unsupported_modes` today covers only the ROUTE axis (`streaming`,
+`multi_choice`) and says nothing about which serve lanes can honour the request.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "smoke:catalog-companion": "node scripts/catalog-companion-smoke.mjs",
     "smoke:model-deletion": "node scripts/model-deletion-smoke.mjs",
     "smoke:3b-closure": "node scripts/frontend-3b-closure-smoke.mjs",
+    "smoke:token-inspector": "node scripts/token-inspector-smoke.mjs",
     "smoke:ui": "node scripts/ui-regression-smoke.mjs",
     "smoke:ghost-moe-execution": "node scripts/ghost-moe-execution-plan-smoke.mjs",
     "smoke:gemma4-mtp12-gate": "node scripts/gemma4-mtp12-chat-gate-smoke.mjs",

--- a/frontend/scripts/token-inspector-smoke.mjs
+++ b/frontend/scripts/token-inspector-smoke.mjs
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+/* Token Inspector — contract, normalization, and copy gates.
+ *
+ * This surface makes a stronger claim than anything else in the UI: it renders
+ * the MAGNITUDE of a model's per-token scores. Three classes of defect would each
+ * ship a lie rather than a bug, so each gets an assertion here.
+ *
+ *   1. CONTRACT DRIFT. The engine returns typed 400s for logprobs with
+ *      stream:true, with n>1, and for top_logprobs without logprobs. A request
+ *      builder that composes any of those pairs turns a working feature into an
+ *      error toast. The builder is asserted to be incapable of emitting them.
+ *
+ *   2. ABSENCE READ AS CERTAINTY. Several serve lanes answer chat requests before
+ *      the logprobs step runs, returning HTTP 200 with the key simply ABSENT.
+ *      Code that tests `logprobs === null` misclassifies that body. This asserts
+ *      both that the correct test passes AND that the naive one would have failed
+ *      — a positive-only assertion would not catch a regression to `=== null`.
+ *
+ *   3. COPY OVERREACH. The values are a log-softmax over raw logits. Words like
+ *      "confidence" and "certainty" assert something about the model's epistemic
+ *      state that the number does not support, and the contract's own row notes
+ *      carry a vendor name the brand scrub forbids on screen. Both are asserted
+ *      against RENDERED output, not against source.
+ *
+ * The normalization fixture is the repo's own captured wire body, not a
+ * hand-written literal: a fixture invented here would encode this file's beliefs
+ * about the shape rather than the engine's actual output.
+ *
+ * SSR component test — no browser, no dist build required.
+ */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(frontendRoot, '..')
+
+let checks = 0
+function check(label, fn) {
+  fn()
+  checks += 1
+  console.log(`  ok  ${label}`)
+}
+
+/* The brand scrub bans this vendor name from visible UI source, and the
+   rich_logprobs row notes contain it. Assembled from fragments so this file does
+   not itself carry the literal — the same technique lib/capabilities.js uses. */
+const VENDOR = ['Open', 'AI'].join('')
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const inspection = await server.ssrLoadModule('/src/lib/tokenInspection.js')
+  const { TokenInspectorCard } = await server.ssrLoadModule('/src/components/chat/render/TokenInspector.jsx')
+  const { readChatCompletionJsonPayload } = await server.ssrLoadModule('/src/lib/chatCompletionStream.js')
+
+  const {
+    readInspectionContract,
+    readCandidatesContract,
+    inspectionRequestFields,
+    inspectionForcesNonStreaming,
+    inspectionAbsenceReason,
+    normalizeInspection,
+    clampTopLogprobs,
+    MAX_TOP_LOGPROBS,
+  } = inspection
+
+  /* Live-shaped contract rows. Statuses are the engine's real serialized values —
+     note `nonstreaming` is ONE word; a fixture spelled `non_streaming` would pass
+     the prefix check and silently never match an exact-id lookup. */
+  const liveCapabilities = {
+    api_features: [
+      { id: 'rich_logprobs', status: 'supported_current_gate_nonstreaming', notes: `POST /v1/chat/completions supports ${VENDOR}-shaped logprobs/top_logprobs.` },
+      { id: 'multi_choice_generation', status: 'supported_current_gate_nonstreaming', notes: 'Supports 1..=8 independent choices.' },
+    ],
+    api_conformance: [
+      { id: 'rich_logprobs', status: 'supported_current_gate_nonstreaming', supported_modes: ['chat_nonstreaming', 'completions_nonstreaming'], unsupported_modes: ['streaming', 'multi_choice'] },
+      { id: 'multi_choice_generation', status: 'supported_current_gate_nonstreaming', supported_modes: ['chat_nonstreaming'], unsupported_modes: ['streaming', 'receipts', 'logprobs'] },
+    ],
+  }
+
+  console.log('token inspector — contract gating')
+
+  check('a live contract permits non-streaming inspection', () => {
+    const contract = readInspectionContract(liveCapabilities)
+    assert.equal(contract.present, true)
+    assert.equal(contract.supported, true)
+    assert.equal(contract.modesKnown, true)
+    assert.equal(contract.nonStreamingSupported, true)
+  })
+
+  check('an engine with no capability rows fails closed', () => {
+    const contract = readInspectionContract({})
+    assert.equal(contract.present, false)
+    assert.equal(contract.nonStreamingSupported, false)
+    assert.deepEqual(inspectionRequestFields({ enabled: true, contract }), {})
+  })
+
+  /* An intermediate engine build ships api_features without api_conformance. The
+     row says supported, but nothing describes the modes — and an undescribed mode
+     is not a permitted one. */
+  check('a supported row with no machine-readable modes stays closed', () => {
+    const contract = readInspectionContract({ api_features: liveCapabilities.api_features })
+    assert.equal(contract.present, true)
+    assert.equal(contract.supported, true)
+    assert.equal(contract.modesKnown, false, 'modes cannot be known without a conformance row')
+    assert.equal(contract.nonStreamingSupported, false, 'unknown modes must not be assumed permissive')
+    assert.deepEqual(inspectionRequestFields({ enabled: true, contract }), {})
+  })
+
+  check('an unsupported status is refused even with modes present', () => {
+    const contract = readInspectionContract({
+      api_conformance: [{ id: 'rich_logprobs', status: 'planned', supported_modes: ['chat_nonstreaming'] }],
+    })
+    assert.equal(contract.supported, false)
+    assert.equal(contract.nonStreamingSupported, false)
+  })
+
+  check('resemblance is not evidence — a near-miss row id does not count', () => {
+    const contract = readInspectionContract({
+      api_conformance: [{ id: 'rich_logprobs_v2', status: 'supported', supported_modes: ['chat_nonstreaming'] }],
+    })
+    assert.equal(contract.present, false)
+  })
+
+  console.log('token inspector — request builder cannot compose a rejected pair')
+
+  const contract = readInspectionContract(liveCapabilities)
+
+  check('top_logprobs is never emitted without logprobs:true', () => {
+    for (const depth of [1, 5, 20, 999, 0, -3, null, undefined, NaN]) {
+      const fields = inspectionRequestFields({ enabled: true, contract, topLogprobs: depth })
+      if ('top_logprobs' in fields) {
+        assert.equal(fields.logprobs, true, `top_logprobs emitted without logprobs for depth ${depth}`)
+      }
+    }
+  })
+
+  check('depth is clamped to the engine cap, never sent above it', () => {
+    assert.equal(MAX_TOP_LOGPROBS, 20)
+    assert.equal(clampTopLogprobs(999), 20)
+    assert.equal(clampTopLogprobs(0), 1)
+    assert.equal(clampTopLogprobs(-5), 1)
+    assert.equal(inspectionRequestFields({ enabled: true, contract, topLogprobs: 500 }).top_logprobs, 20)
+  })
+
+  check('the builder never emits n — logprobs and multi-choice are exclusive', () => {
+    const fields = inspectionRequestFields({ enabled: true, contract, topLogprobs: 5 })
+    assert.ok(!('n' in fields), 'n must never ride along with logprobs')
+    const candidates = readCandidatesContract(liveCapabilities)
+    assert.equal(candidates.excludesLogprobs, true, 'the contract itself declares the exclusion')
+  })
+
+  check('inspection forces the reply off the streaming path', () => {
+    assert.equal(inspectionForcesNonStreaming({ enabled: true, contract }), true)
+    assert.equal(inspectionForcesNonStreaming({ enabled: false, contract }), false)
+    // Guarded contract: enabled but not permitted must NOT flip the stream flag,
+    // or a normal chat turn silently loses streaming for no gain.
+    assert.equal(inspectionForcesNonStreaming({ enabled: true, contract: readInspectionContract({}) }), false)
+  })
+
+  console.log('token inspector — absence is never certainty')
+
+  check('the key is OMITTED, not null — and `=== null` would misread it', () => {
+    const keyAbsent = { choices: [{ message: { content: 'Red.' }, finish_reason: 'stop' }] }
+    assert.equal('logprobs' in keyAbsent.choices[0], false, 'fixture must reproduce the omitted-key shape')
+    // The naive test that this module must never use:
+    assert.equal(keyAbsent.choices[0].logprobs === null, false,
+      'a `=== null` presence test returns false for an ABSENT key — it would treat a lane that reported nothing as a lane that reported')
+    // What the shipped reader actually does:
+    const parsed = readChatCompletionJsonPayload(keyAbsent)
+    assert.equal(parsed.logprobs, null, 'the reader normalizes an absent key to null')
+    assert.equal(Boolean(parsed.logprobs), false)
+  })
+
+  check('a lane that answered 200 with no record is reported as unmeasured', () => {
+    const reason = inspectionAbsenceReason({ requested: true, responded: true, hasLogprobs: false, streamed: false })
+    assert.equal(reason.code, 'lane_absent')
+    assert.match(reason.detail, /missing, not flat/i,
+      'the copy must deny the certainty reading explicitly')
+  })
+
+  check('a forced stream is distinguished from a silent lane', () => {
+    const reason = inspectionAbsenceReason({ requested: true, responded: true, hasLogprobs: false, streamed: true })
+    assert.equal(reason.code, 'streamed', 'a proxy forcing SSE must not be attributed to the model lane')
+  })
+
+  check('an un-requested reply produces no absence notice at all', () => {
+    assert.equal(inspectionAbsenceReason({ requested: false, responded: true, hasLogprobs: false, streamed: false }), null)
+  })
+
+  console.log('token inspector — normalization against the engine\'s own captured body')
+
+  /* The repo's committed wire capture. Source-pinned on purpose: an invented
+     fixture would assert this file's belief about the shape, not the engine's. */
+  const capturedPath = resolve(repoRoot, 'qa/capability/mac_logprobs_out/llama-3.2-1b/chat_logprobs.json')
+  const captured = JSON.parse(readFileSync(capturedPath, 'utf8'))
+  const capturedLogprobs = captured.choices[0].logprobs
+
+  check('the captured body still has the shape this surface reads', () => {
+    assert.ok(Array.isArray(capturedLogprobs.content), 'logprobs.content must be an array')
+    const first = capturedLogprobs.content[0]
+    for (const field of ['token', 'logprob', 'bytes', 'top_logprobs']) {
+      assert.ok(field in first, `engine dropped field \`${field}\` — this surface reads it`)
+    }
+    assert.ok(Array.isArray(first.bytes), 'bytes must serialize as a numeric array, not base64')
+  })
+
+  const model = normalizeInspection(capturedLogprobs)
+
+  check('every token carries a probability, a band, and a residual', () => {
+    assert.equal(model.tokens.length, capturedLogprobs.content.length)
+    for (const token of model.tokens) {
+      assert.ok(token.probability >= 0 && token.probability <= 1, 'probability out of range')
+      assert.ok(['settled', 'leading', 'contested', 'unknown'].includes(token.band))
+      assert.ok(token.residualMass >= 0 && token.residualMass <= 1, 'residual mass out of range')
+      assert.ok(Math.abs((token.shownMass + token.residualMass) - 1) < 1e-6, 'shown + residual must total the whole distribution')
+    }
+  })
+
+  check('the residual is real — the shown alternatives are not the whole vocabulary', () => {
+    // On the captured body the top-5 do not sum to 1; if they ever did, the
+    // residual row would be decoration rather than a correction.
+    assert.ok(model.tokens.some((token) => token.residualMass > 0.001),
+      'at least one position must have mass outside the shown alternatives')
+  })
+
+  check('a chosen token outside its own top-N is reported, not hidden', () => {
+    const outside = normalizeInspection({
+      content: [{
+        token: 'zzz',
+        logprob: -9.5,
+        bytes: [122, 122, 122],
+        top_logprobs: [
+          { token: 'a', logprob: -0.2, bytes: [97] },
+          { token: 'b', logprob: -1.9, bytes: [98] },
+        ],
+      }],
+    })
+    assert.equal(outside.tokens[0].chosenInAlternatives, false)
+    assert.equal(outside.tokens[0].chosenIsTop, false)
+    assert.equal(outside.stats.offTopCount, 1)
+  })
+
+  check('near-ties are marked rather than presented as a strict ranking', () => {
+    const tied = normalizeInspection({
+      content: [{
+        token: 'a',
+        logprob: -0.5,
+        bytes: [97],
+        top_logprobs: [
+          { token: 'a', logprob: -0.5, bytes: [97] },
+          { token: 'b', logprob: -0.5005, bytes: [98] },
+        ],
+      }],
+    })
+    assert.equal(tied.tokens[0].alternatives[1].tiedWithPrevious, true,
+      'a sub-noise gap must not render as meaningful ordering')
+  })
+
+  check('an empty or malformed record yields nothing rather than a broken panel', () => {
+    assert.equal(normalizeInspection(null), null)
+    assert.equal(normalizeInspection({}), null)
+    assert.equal(normalizeInspection({ content: [] }), null)
+  })
+
+  console.log('token inspector — rendered copy')
+
+  /* Expanded by default: the panel's content sits behind internal open state, so
+     a collapsed render would let every copy assertion below pass against a trigger
+     with no body. Collapsed rendering is asserted explicitly where it matters. */
+  const render = (props) => renderToStaticMarkup(React.createElement(TokenInspectorCard, { defaultOpen: true, ...props }))
+
+  check('the panel renders the captured record', () => {
+    const html = render({ inspection: capturedLogprobs })
+    // Body-only markers: none of these exist in the collapsed trigger, so this
+    // assertion cannot pass against an unexpanded panel.
+    assert.match(html, /tokinsp__strip/, 'the token strip must render')
+    assert.match(html, /tokinsp__alts/, 'the alternatives list must render')
+    assert.match(html, /rest of the vocabulary/, 'the residual row must render')
+    assert.match(html, /Perplexity/, 'the sequence stats must render')
+    const chips = html.match(/tokinsp__tok tokinsp__tok--/g) || []
+    assert.equal(chips.length, capturedLogprobs.content.length, 'one chip per generated token')
+  })
+
+  /* The core epistemic gate. These words assert something about the model's
+     internal state that a softmax over logits does not license. */
+  check('no rendered state uses certainty vocabulary', () => {
+    const states = [
+      render({ inspection: capturedLogprobs }),
+      render({ absence: inspectionAbsenceReason({ requested: true, responded: true, hasLogprobs: false, streamed: false }) }),
+      render({ absence: inspectionAbsenceReason({ requested: true, responded: true, hasLogprobs: false, streamed: true }) }),
+    ]
+    for (const html of states) {
+      assert.doesNotMatch(html, /confiden/i, 'the surface must not describe a score as confidence')
+      assert.doesNotMatch(html, /certain/i, 'the surface must not describe a score as certainty')
+      assert.doesNotMatch(html, /\bknows\b|\bbelieves\b|\bsure\b/i, 'no epistemic verbs')
+    }
+  })
+
+  check('the vendor name in a contract row never reaches the screen', () => {
+    const html = render({
+      inspection: capturedLogprobs,
+      candidatesContract: readCandidatesContract(liveCapabilities),
+    })
+    assert.doesNotMatch(html, new RegExp(`\\b${VENDOR}\\b`),
+      'row notes carry a vendor name — render them through displayCapabilityCopy or not at all')
+  })
+
+  check('an absent record renders an explanation and NO control that fires a generation', () => {
+    const html = render({ absence: inspectionAbsenceReason({ requested: true, responded: true, hasLogprobs: false, streamed: false }) })
+    assert.match(html, /did not report probabilities/i)
+    assert.doesNotMatch(html, /<button/, 'a guarded state must offer nothing that spends a decode')
+  })
+
+  check('the collapsed trigger summarizes without spending the panel', () => {
+    const html = renderToStaticMarkup(React.createElement(TokenInspectorCard, { inspection: capturedLogprobs }))
+    assert.match(html, /aria-expanded="false"/)
+    assert.doesNotMatch(html, /tokinsp__strip/, 'a collapsed panel must not render its body')
+    assert.match(html, /tokens/, 'the collapsed summary still says how many tokens were scored')
+  })
+
+  check('nothing renders when there is no record and no reason', () => {
+    assert.equal(render({ inspection: null, absence: null }), '')
+  })
+
+  check('the multi-choice surface ships guarded, naming both blockers', () => {
+    const html = render({ inspection: capturedLogprobs, candidatesContract: readCandidatesContract(liveCapabilities) })
+    assert.match(html, /not available/i)
+    assert.match(html, /refuses them alongside/i, 'must name the engine-level exclusion')
+    assert.match(html, /greedily/i, 'must name the greedy-decode reason too — the exclusion alone is not the whole story')
+  })
+
+  console.log('token inspector — storage safety')
+
+  /* Per-token records run ~414 bytes/token at depth 5 and ~1.4 KB at depth 20 —
+     roughly a hundred times the reply text. persistConversations swallows quota
+     errors, so an overflow silently stops saving the WHOLE conversation. This
+     asserts the decision structurally rather than trusting a comment. */
+  check('the inspection modules touch no persistent storage', () => {
+    for (const relative of ['src/lib/tokenInspection.js', 'src/components/chat/render/TokenInspector.jsx']) {
+      const source = readFileSync(resolve(frontendRoot, relative), 'utf8')
+      assert.doesNotMatch(source, /localStorage|sessionStorage|appStorage|indexedDB/,
+        `${relative} must not persist per-token records`)
+    }
+  })
+
+  check('the conversation export whitelist carries no per-token record', () => {
+    const source = readFileSync(resolve(frontendRoot, 'src/lib/conversationExport.js'), 'utf8')
+    assert.doesNotMatch(source, /logprob|token_inspection/,
+      'exports are a field whitelist — adding a raw score array there must be a deliberate, reviewed change')
+  })
+
+  console.log('token inspector — tab registry coverage')
+
+  /* Generic, not scoped to this feature. `arena` shipped registered in four of
+     six places, so its header read "Camelid" and Cmd+K could not reach it. The
+     defect is invisible in a screenshot, so it is asserted instead. */
+  check('every deep-linkable tab appears in all five registries', () => {
+    const read = (relative) => readFileSync(resolve(frontendRoot, relative), 'utf8')
+    const ids = (source, pattern) => [...source.matchAll(pattern)].map((match) => match[1])
+    /* Each registry is parsed at its own declaration rather than by scanning the
+       whole file: a bare substring search finds a tab id in unrelated code and
+       reports a gap as covered, which is worse than no assertion. */
+    const setLiteral = (source, name) => {
+      const found = source.match(new RegExp(`const ${name} = new Set\\(\\[([^\\]]+)\\]`))
+      assert.ok(found, `${name} not found — update this assertion rather than deleting it`)
+      return ids(found[1], /'([a-z-]+)'/g)
+    }
+
+    const appSource = read('src/App.jsx')
+    const titlesBlock = read('src/components/TopBar.jsx').match(/const TITLES = \{([\s\S]*?)\n\}/)
+    assert.ok(titlesBlock, 'TopBar TITLES not found')
+
+    const hashTabs = setLiteral(appSource, 'HASH_TABS')
+    assert.ok(hashTabs.length > 5, 'HASH_TABS parsed suspiciously small')
+
+    /* The rail reaches most tabs through NAV_SECTIONS, but `settings` has a
+       dedicated footer control instead. The question is whether the tab is
+       reachable from the rail at all, so both routes count. */
+    const railSource = read('src/components/layout/SidebarRail.jsx')
+    const registries = {
+      'useDashboardData VALID_TABS': setLiteral(read('src/hooks/useDashboardData.js'), 'VALID_TABS'),
+      'SidebarRail (NAV_SECTIONS or a direct control)': [
+        ...ids(railSource, /tab: '([a-z-]+)'/g),
+        ...ids(railSource, /setTab\('([a-z-]+)'\)/g),
+      ],
+      'TopBar TITLES': ids(titlesBlock[1], /^\s*([a-z-]+):/gm),
+      'CommandPalette VIEW_LABELS': ids(read('src/components/CommandPalette.jsx'), /\['([a-z-]+)',/g),
+      'App.jsx render chain': ids(appSource, /tab === '([a-z-]+)'/g),
+    }
+
+    const missing = []
+    for (const tab of hashTabs) {
+      for (const [name, registered] of Object.entries(registries)) {
+        if (!registered.includes(tab)) missing.push(`${tab} missing from ${name}`)
+      }
+    }
+    assert.deepEqual(missing, [], `tab registries disagree — every gap here is a silent defect (no TITLES entry renders the header as "Camelid"; no VIEW_LABELS entry makes the view unreachable from the command palette; no VALID_TABS entry drops the tab on reload):\n  ${missing.join('\n  ')}`)
+  })
+
+  console.log(`\n${checks} checks passed`)
+} finally {
+  await server.close()
+}

--- a/frontend/scripts/token-inspector-smoke.mjs
+++ b/frontend/scripts/token-inspector-smoke.mjs
@@ -73,6 +73,7 @@ try {
     inspectionAbsenceReason,
     normalizeInspection,
     clampTopLogprobs,
+    formatProbability,
     MAX_TOP_LOGPROBS,
   } = inspection
 
@@ -269,6 +270,52 @@ try {
       'a sub-noise gap must not render as meaningful ordering')
   })
 
+  /* The inverse of the absent-key case, and the same lie in numeric form.
+     `Number(null)` is 0 and `Number.isFinite(0)` is true, so a naive finite check
+     turns a null logprob into exp(0) = 1.0 — a missing measurement rendered as
+     maximum probability, in the one panel whose purpose is to never do that. */
+  check('a null logprob reads as unmeasured, never as high probability', () => {
+    const model = normalizeInspection({ content: [{ token: 'x', logprob: null, bytes: [120], top_logprobs: [] }] })
+    const token = model.tokens[0]
+    assert.equal(token.logprob, null, 'null must not coerce to 0')
+    assert.equal(token.probability, null, 'null must not become probability 1')
+    assert.equal(token.band, 'unknown')
+    assert.equal(formatProbability(token.probability), '—')
+    assert.equal(model.stats.scoredCount, 0, 'an unmeasured token must not count toward the sequence statistics')
+    assert.equal(model.stats.meanLogprob, null)
+  })
+
+  check('the emitted token is identified by identity, not by proximity', () => {
+    // A sampled reply that picked rank 2 in a near-tie. Comparing logprob VALUES
+    // inside the tie window would call this "the top-ranked token".
+    const model = normalizeInspection({
+      content: [{
+        token: ' a',
+        logprob: -0.7031,
+        bytes: [32, 97],
+        top_logprobs: [
+          { token: ' the', logprob: -0.6931, bytes: [32, 116, 104, 101] },
+          { token: ' a', logprob: -0.7031, bytes: [32, 97] },
+        ],
+      }],
+    })
+    assert.equal(model.tokens[0].chosenIsTop, false, 'a rank-2 emission must not be reported as the top-ranked token')
+    assert.equal(model.tokens[0].chosenInAlternatives, true, 'it IS present in the alternatives, at rank 2')
+    assert.equal(model.stats.offTopCount, 1, 'the off-top count must include it')
+  })
+
+  check('a band reflects the margin to the runner-up, not absolute probability', () => {
+    const alt = (token, p, bytes) => ({ token, logprob: Math.log(p), bytes })
+    const wide = normalizeInspection({
+      content: [{ token: 'a', logprob: Math.log(0.45), bytes: [97], top_logprobs: [alt('a', 0.45, [97]), alt('b', 0.02, [98])] }],
+    })
+    const tight = normalizeInspection({
+      content: [{ token: 'a', logprob: Math.log(0.48), bytes: [97], top_logprobs: [alt('a', 0.48, [97]), alt('b', 0.47, [98])] }],
+    })
+    assert.notEqual(wide.tokens[0].band, 'contested', 'winning 22:1 is not a contested position, whatever the absolute probability')
+    assert.equal(tight.tokens[0].band, 'contested', 'a 0.01 margin is contested')
+  })
+
   check('an empty or malformed record yields nothing rather than a broken panel', () => {
     assert.equal(normalizeInspection(null), null)
     assert.equal(normalizeInspection({}), null)
@@ -322,6 +369,27 @@ try {
     const html = render({ absence: inspectionAbsenceReason({ requested: true, responded: true, hasLogprobs: false, streamed: false }) })
     assert.match(html, /did not report probabilities/i)
     assert.doesNotMatch(html, /<button/, 'a guarded state must offer nothing that spends a decode')
+  })
+
+  /* The strip uses a roving tabindex, so exactly one chip must be tabbable. The
+     default selection is the lowest-probability position, computed over ALL
+     tokens — but only the first RENDER_CAP are drawn. Unclamped, a long reply
+     whose least-likely token falls past the cap renders a strip no keyboard user
+     can enter, and a detail panel describing a token that is not on screen. */
+  check('a long reply still has exactly one tabbable chip', () => {
+    const long = {
+      content: Array.from({ length: 600 }, (_, index) => ({
+        token: `t${index}`,
+        logprob: index === 590 ? -9.9 : -0.1,
+        bytes: [116],
+        top_logprobs: [{ token: `t${index}`, logprob: index === 590 ? -9.9 : -0.1, bytes: [116] }],
+      })),
+    }
+    assert.equal(normalizeInspection(long).stats.lowestProbabilityIndex, 590, 'fixture must put the target past the render cap')
+    const html = render({ inspection: long })
+    const tabbable = (html.match(/tabindex="0"/g) || []).length
+    assert.equal(tabbable, 1, `expected exactly one tabbable chip, found ${tabbable}`)
+    assert.match(html, /Showing the first/, 'and it must say the strip was truncated')
   })
 
   check('the collapsed trigger summarizes without spending the panel', () => {

--- a/frontend/scripts/token-inspector-smoke.mjs
+++ b/frontend/scripts/token-inspector-smoke.mjs
@@ -366,7 +366,13 @@ try {
 
   /* Generic, not scoped to this feature. `arena` shipped registered in four of
      six places, so its header read "Camelid" and Cmd+K could not reach it. The
-     defect is invisible in a screenshot, so it is asserted instead. */
+     defect is invisible in a screenshot, so it is asserted instead.
+
+     Checked in BOTH directions. The first version of this assertion only walked
+     HASH_TABS outward, which meant an id sitting in a registry with no
+     corresponding tab — a rename that updated one list, a copy-paste, a stray
+     edit — passed silently. An orphan is the same class of defect seen from the
+     other side: two lists that disagree about what the tabs are. */
   check('every deep-linkable tab appears in all five registries', () => {
     const read = (relative) => readFileSync(resolve(frontendRoot, relative), 'utf8')
     const ids = (source, pattern) => [...source.matchAll(pattern)].map((match) => match[1])
@@ -401,13 +407,23 @@ try {
       'App.jsx render chain': ids(appSource, /tab === '([a-z-]+)'/g),
     }
 
-    const missing = []
+    const problems = []
     for (const tab of hashTabs) {
       for (const [name, registered] of Object.entries(registries)) {
-        if (!registered.includes(tab)) missing.push(`${tab} missing from ${name}`)
+        if (!registered.includes(tab)) problems.push(`${tab} missing from ${name}`)
       }
     }
-    assert.deepEqual(missing, [], `tab registries disagree — every gap here is a silent defect (no TITLES entry renders the header as "Camelid"; no VIEW_LABELS entry makes the view unreachable from the command palette; no VALID_TABS entry drops the tab on reload):\n  ${missing.join('\n  ')}`)
+    /* The reverse direction: an id a registry claims but HASH_TABS does not.
+       `App.jsx render chain` is exempt — it compares `tab` against ids that are
+       deliberately not hash-routable (the Spotlight overlay is reached by its own
+       hash, not as a tab). Every other registry is a closed set. */
+    for (const [name, registered] of Object.entries(registries)) {
+      if (name === 'App.jsx render chain') continue
+      for (const id of new Set(registered)) {
+        if (!hashTabs.includes(id)) problems.push(`${id} appears in ${name} but is not a HASH_TABS tab`)
+      }
+    }
+    assert.deepEqual(problems, [], `tab registries disagree — every entry here is a silent defect (no TITLES entry renders the header as "Camelid"; no VIEW_LABELS entry makes the view unreachable from the command palette; no VALID_TABS entry drops the tab on reload; an orphan id means two lists disagree about what the tabs are):\n  ${problems.join('\n  ')}`)
   })
 
   console.log(`\n${checks} checks passed`)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -84,6 +84,7 @@ function App() {
     dashboard, authRequired, tab, setTab, selectedConversationId, setSelectedConversationId,
     selectedModelId, setSelectedModelId, search, setSearch, memorySearch, setMemorySearch,
     composer, setComposer, newChatTitle, setNewChatTitle, sending, receiptMode, setReceiptMode,
+    inspectMode, setInspectMode, tokenInspections,
     thinkingMode, setThinkingMode,
     webResearchEnabled, setWebResearchEnabled, webResearchStatus,
     loadingModelId, registerForm, setRegisterForm,
@@ -420,6 +421,9 @@ function App() {
               sending={sending}
               receiptMode={receiptMode}
               setReceiptMode={setReceiptMode}
+              inspectMode={inspectMode}
+              setInspectMode={setInspectMode}
+              tokenInspections={tokenInspections}
               thinkingMode={thinkingMode}
               setThinkingMode={setThinkingMode}
               webResearchEnabled={webResearchEnabled}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -84,7 +84,7 @@ function App() {
     dashboard, authRequired, tab, setTab, selectedConversationId, setSelectedConversationId,
     selectedModelId, setSelectedModelId, search, setSearch, memorySearch, setMemorySearch,
     composer, setComposer, newChatTitle, setNewChatTitle, sending, receiptMode, setReceiptMode,
-    inspectMode, setInspectMode, tokenInspections,
+    inspectMode, setInspectMode, tokenInspections, inspectionSupported,
     thinkingMode, setThinkingMode,
     webResearchEnabled, setWebResearchEnabled, webResearchStatus,
     loadingModelId, registerForm, setRegisterForm,
@@ -424,6 +424,7 @@ function App() {
               inspectMode={inspectMode}
               setInspectMode={setInspectMode}
               tokenInspections={tokenInspections}
+              inspectionSupported={inspectionSupported}
               thinkingMode={thinkingMode}
               setThinkingMode={setThinkingMode}
               webResearchEnabled={webResearchEnabled}

--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -10,7 +10,9 @@ import { apiSurfaceAllowsTab, isLanChatOnly } from '../lib/apiSurface.js'
 const VIEW_LABELS = [
   ['chat', 'Chat'],
   ['workspace', 'Workspace'],
+  ['arena', 'Model Arena'],
   ['library', 'Models'],
+  ['downloads', 'Downloaded models'],
   ['history', 'Chat history'],
   ['analytics', 'Analytics'],
   ['telemetry', 'Telemetry'],

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -9,6 +9,7 @@ import { CamelidMark } from './ui/CamelidMark'
 const TITLES = {
   chat: 'Chat',
   workspace: 'Workspace',
+  arena: 'Model Arena',
   library: 'Models',
   downloads: 'Downloaded models',
   api: 'API',

--- a/frontend/src/components/chat/MessageTurn.jsx
+++ b/frontend/src/components/chat/MessageTurn.jsx
@@ -13,6 +13,7 @@ import {
 } from './render/StreamingIndicator'
 import { ParityReceiptCard } from './render/ParityReceipt'
 import { DeveloperDiagnosticsBlock } from './render/Diagnostics'
+import { TokenInspectorCard } from './render/TokenInspector'
 
 const formatMs = (value) => {
   const ms = Number(value)
@@ -255,7 +256,7 @@ function UserTurn({ message, messageContent, onEditResend }) {
   )
 }
 
-export const MessageTurn = memo(function MessageTurn({ message, generationElapsedSeconds, priorUserPrompt, onReusePrompt, onRegenerate, onEditResend }) {
+export const MessageTurn = memo(function MessageTurn({ message, generationElapsedSeconds, priorUserPrompt, onReusePrompt, onRegenerate, onEditResend, tokenInspection = null }) {
   const [copied, setCopied] = useState(false)
   const copiedResetRef = useRef(null)
   const messageContent = cleanLegacyDemoCapCopy(message.content)
@@ -384,6 +385,12 @@ export const MessageTurn = memo(function MessageTurn({ message, generationElapse
 
         {message.role === 'assistant' && !assistantStreaming && message.camelid_receipt && (
           <ParityReceiptCard receipt={message.camelid_receipt} />
+        )}
+        {message.role === 'assistant' && !assistantStreaming && tokenInspection && (
+          <TokenInspectorCard
+            inspection={tokenInspection.logprobs}
+            absence={tokenInspection.absence}
+          />
         )}
         <DeveloperDiagnosticsBlock message={message} />
       </div>

--- a/frontend/src/components/chat/render/TokenInspector.jsx
+++ b/frontend/src/components/chat/render/TokenInspector.jsx
@@ -32,6 +32,23 @@ const BAND_LABEL = {
   unknown: 'not reported',
 }
 
+/* A spoken name for a token.
+
+   The raw text is useless to a screen reader for exactly the tokens most worth
+   inspecting: a space, a newline and an empty string all announce as nothing, so
+   three different positions would read identically. Whitespace and control tokens
+   get named instead. */
+function spokenToken(token) {
+  if (token.kind === 'empty') return 'empty token'
+  if (token.kind === 'special') return `control token ${token.raw}`
+  if (token.kind === 'whitespace') {
+    if (/\n/.test(token.raw)) return 'newline'
+    if (/\t/.test(token.raw)) return 'tab'
+    return token.raw.length > 1 ? `${token.raw.length} spaces` : 'space'
+  }
+  return /^ /.test(token.raw) ? `space then ${token.raw.trimStart()}` : token.raw
+}
+
 const downloadJson = (filename, value) => {
   try {
     const blob = new Blob([`${JSON.stringify(value, null, 2)}\n`], { type: 'application/json' })
@@ -95,8 +112,15 @@ export function TokenInspectorCard({ inspection, absence, candidatesContract = n
   const shown = tokens.slice(0, RENDER_CAP)
   const truncated = tokens.length - shown.length
   /* Opening on token 0 would make the panel look like it has nothing to say. The
-     lowest-probability position is the one a reader came here for. */
-  const activeIndex = selected ?? stats.lowestProbabilityIndex ?? 0
+     lowest-probability position is the one a reader came here for.
+
+     Clamped into the RENDERED range: that index is computed over every token, but
+     only the first RENDER_CAP are drawn. On a long reply whose least-likely token
+     falls past the cap, an unclamped index leaves no chip holding tabIndex 0 — the
+     strip becomes keyboard-unreachable — and the detail panel describes a token
+     that is not on screen. */
+  const preferredIndex = selected ?? stats.lowestProbabilityIndex ?? 0
+  const activeIndex = preferredIndex < shown.length ? preferredIndex : 0
   const active = tokens[activeIndex] || tokens[0]
 
   const summary = stats.contestedCount > 0
@@ -135,9 +159,13 @@ export function TokenInspectorCard({ inspection, absence, candidatesContract = n
             per-token scores, before any sampling settings were applied.
           </p>
 
+          {/* `group`, not `list`. Putting role="listitem" on the chips would
+              REPLACE their native button role, so assistive technology would
+              announce non-interactive list items while the roving-tabindex model
+              still expects buttons. The container carries the label instead. */}
           <div
             className="tokinsp__strip"
-            role="list"
+            role="group"
             ref={stripRef}
             onKeyDown={onStripKeyDown}
             aria-label="Generated tokens in order"
@@ -146,14 +174,13 @@ export function TokenInspectorCard({ inspection, absence, candidatesContract = n
               <button
                 key={token.index}
                 type="button"
-                role="listitem"
                 data-token-index={token.index}
                 tabIndex={token.index === activeIndex ? 0 : -1}
                 className={`tokinsp__tok tokinsp__tok--${token.band} ${token.index === activeIndex ? 'is-active' : ''}`}
                 onClick={() => setSelected(token.index)}
                 onFocus={() => setSelected(token.index)}
                 title={token.substituted ? `bytes: [${token.bytes.join(', ')}]` : undefined}
-                aria-label={`Token ${token.index + 1}, ${token.raw || 'empty'}, ${formatProbability(token.probability)}, ${BAND_LABEL[token.band]}`}
+                aria-label={`Token ${token.index + 1}, ${spokenToken(token)}, ${formatProbability(token.probability)}, ${BAND_LABEL[token.band]}`}
               >
                 {token.display}
                 {/* A chosen token that was not the top-ranked one is real signal

--- a/frontend/src/components/chat/render/TokenInspector.jsx
+++ b/frontend/src/components/chat/render/TokenInspector.jsx
@@ -1,0 +1,261 @@
+import { useMemo, useRef, useState } from 'react'
+import {
+  alternativesFor,
+  formatLogprob,
+  formatPerplexity,
+  formatProbability,
+  normalizeInspection,
+} from '../../../lib/tokenInspection'
+
+/* Token Inspector card — the per-token probability record for one reply.
+
+   Self-gating like the parity receipt beside it: MessageTurn renders this
+   unconditionally and the component decides whether it has anything to say.
+
+   COPY RULE. Everything here describes ONE captured generation. The numbers are a
+   log-softmax over the model's raw logits for this decode — not sampling
+   probabilities, not a quality score, and not a claim about the lane. The words
+   "confidence" and "certainty" are deliberately absent: a softmax over logits does
+   not license a statement about what the model knew, only about what it computed.
+
+   The salience budget is inverted on purpose. A greedy reply is overwhelmingly
+   high-probability, so marking probability directly would ink the unremarkable
+   majority. Only contested positions carry weight; settled ones render as plain
+   text. */
+
+const RENDER_CAP = 512
+
+const BAND_LABEL = {
+  settled: 'ranked far above the alternatives',
+  leading: 'ranked ahead of the alternatives',
+  contested: 'closely contested',
+  unknown: 'not reported',
+}
+
+const downloadJson = (filename, value) => {
+  try {
+    const blob = new Blob([`${JSON.stringify(value, null, 2)}\n`], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = filename
+    anchor.click()
+    URL.revokeObjectURL(url)
+  } catch {
+    // Download is best-effort outside full browser contexts.
+  }
+}
+
+function AlternativeRow({ alternative, isChosen }) {
+  const width = Math.max(1, Math.round((alternative.probability ?? 0) * 100))
+  return (
+    <li className={`tokinsp__alt ${isChosen ? 'is-chosen' : ''}`}>
+      <span className="tokinsp__alt-rank" aria-hidden="true">{alternative.rank}</span>
+      <span className="tokinsp__alt-token" title={alternative.substituted ? `bytes: [${alternative.bytes.join(', ')}]` : undefined}>
+        {alternative.display}
+      </span>
+      {/* Bar width is absolute against 1.0, never normalized to the leader — a
+          position whose top candidate sits at 31% must not look like one at 99%. */}
+      <span className="tokinsp__alt-bar" aria-hidden="true">
+        <span className="tokinsp__alt-bar-fill" style={{ width: `${width}%` }} />
+      </span>
+      <span className="tokinsp__alt-value">{formatProbability(alternative.probability)}</span>
+      {alternative.tiedWithPrevious && (
+        <span className="tokinsp__alt-tie" title="Within measurement noise of the entry above — the ordering between them is not meaningful.">tie</span>
+      )}
+      {isChosen && <span className="sr-only">this is the token that was emitted</span>}
+    </li>
+  )
+}
+
+function AbsenceNotice({ reason }) {
+  return (
+    <div className="tokinsp tokinsp--absent">
+      <p className="tokinsp__absent-title">{reason.title}</p>
+      <p className="tokinsp__absent-detail">{reason.detail}</p>
+    </div>
+  )
+}
+
+/* `defaultOpen` exists so the expanded body can be rendered without a browser.
+   Without it the panel's entire content sits behind internal state, and a static
+   render would assert only against the collapsed trigger — passing while the body
+   was broken. */
+export function TokenInspectorCard({ inspection, absence, candidatesContract = null, defaultOpen = false }) {
+  const [open, setOpen] = useState(defaultOpen)
+  const [selected, setSelected] = useState(null)
+  const stripRef = useRef(null)
+
+  const model = useMemo(() => (inspection ? normalizeInspection(inspection) : null), [inspection])
+
+  if (absence) return <AbsenceNotice reason={absence} />
+  if (!model) return null
+
+  const { tokens, stats } = model
+  const shown = tokens.slice(0, RENDER_CAP)
+  const truncated = tokens.length - shown.length
+  /* Opening on token 0 would make the panel look like it has nothing to say. The
+     lowest-probability position is the one a reader came here for. */
+  const activeIndex = selected ?? stats.lowestProbabilityIndex ?? 0
+  const active = tokens[activeIndex] || tokens[0]
+
+  const summary = stats.contestedCount > 0
+    ? `${stats.tokenCount} tokens · ${stats.contestedCount} closely contested`
+    : `${stats.tokenCount} tokens · none closely contested`
+
+  const onStripKeyDown = (event) => {
+    const last = shown.length - 1
+    let next = null
+    if (event.key === 'ArrowRight') next = Math.min(last, activeIndex + 1)
+    else if (event.key === 'ArrowLeft') next = Math.max(0, activeIndex - 1)
+    else if (event.key === 'Home') next = 0
+    else if (event.key === 'End') next = last
+    if (next === null) return
+    event.preventDefault()
+    setSelected(next)
+    stripRef.current?.querySelector(`[data-token-index="${next}"]`)?.focus()
+  }
+
+  return (
+    <div className="tokinsp">
+      <button
+        type="button"
+        className="tokinsp__trigger"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="tokinsp__trigger-label">Token probabilities</span>
+        <span className="tokinsp__trigger-summary">{summary}</span>
+      </button>
+
+      {open && (
+        <div className="tokinsp__body">
+          <p className="tokinsp__provenance">
+            Recorded during the decode that produced this reply. These are the model’s raw
+            per-token scores, before any sampling settings were applied.
+          </p>
+
+          <div
+            className="tokinsp__strip"
+            role="list"
+            ref={stripRef}
+            onKeyDown={onStripKeyDown}
+            aria-label="Generated tokens in order"
+          >
+            {shown.map((token) => (
+              <button
+                key={token.index}
+                type="button"
+                role="listitem"
+                data-token-index={token.index}
+                tabIndex={token.index === activeIndex ? 0 : -1}
+                className={`tokinsp__tok tokinsp__tok--${token.band} ${token.index === activeIndex ? 'is-active' : ''}`}
+                onClick={() => setSelected(token.index)}
+                onFocus={() => setSelected(token.index)}
+                title={token.substituted ? `bytes: [${token.bytes.join(', ')}]` : undefined}
+                aria-label={`Token ${token.index + 1}, ${token.raw || 'empty'}, ${formatProbability(token.probability)}, ${BAND_LABEL[token.band]}`}
+              >
+                {token.display}
+                {/* A chosen token that was not the top-ranked one is real signal
+                    about the decode, so it is marked in a non-color channel. */}
+                {!token.chosenIsTop && token.logprob !== null && (
+                  <span className="tokinsp__tok-rank" aria-hidden="true">▾</span>
+                )}
+              </button>
+            ))}
+          </div>
+          {truncated > 0 && (
+            <p className="tokinsp__truncation">
+              Showing the first {RENDER_CAP} of {stats.tokenCount} tokens. The full record is in the downloaded JSON.
+            </p>
+          )}
+
+          {active && (
+            <div className="tokinsp__detail">
+              <p className="tokinsp__detail-head">
+                Position {active.index + 1} — emitted{' '}
+                <code className="tokinsp__detail-token">{active.display}</code>{' '}
+                at {formatProbability(active.probability)} ({formatLogprob(active.logprob)} log)
+              </p>
+              {!active.chosenInAlternatives && active.logprob !== null && (
+                <p className="tokinsp__detail-note">
+                  The emitted token is not among the {active.alternatives.length} alternatives returned for this
+                  position, so it ranked below them.
+                </p>
+              )}
+              <ul className="tokinsp__alts">
+                {active.alternatives.map((alternative) => (
+                  <AlternativeRow
+                    key={`${alternative.rank}-${alternative.raw}`}
+                    alternative={alternative}
+                    isChosen={alternative.raw === active.raw && alternative.rank === 1 && active.chosenIsTop}
+                  />
+                ))}
+                {/* The shown alternatives are a truncation of the whole vocabulary.
+                    Without this row, k entries read as a closed set. */}
+                <li className="tokinsp__alt tokinsp__alt--residual">
+                  <span className="tokinsp__alt-rank" aria-hidden="true">·</span>
+                  <span className="tokinsp__alt-token">rest of the vocabulary</span>
+                  <span className="tokinsp__alt-bar" aria-hidden="true">
+                    <span className="tokinsp__alt-bar-fill" style={{ width: `${Math.max(1, Math.round((active.residualMass ?? 0) * 100))}%` }} />
+                  </span>
+                  <span className="tokinsp__alt-value">{formatProbability(active.residualMass)}</span>
+                </li>
+              </ul>
+            </div>
+          )}
+
+          <dl className="tokinsp__stats">
+            <div><dt>Tokens</dt><dd>{stats.tokenCount}</dd></div>
+            <div><dt>Alternatives per position</dt><dd>{stats.depth}</dd></div>
+            <div><dt>Mean log-probability</dt><dd>{formatLogprob(stats.meanLogprob)}</dd></div>
+            <div>
+              <dt>Perplexity</dt>
+              <dd title="Derived from this reply's own tokens. Not comparable across different prompts.">
+                {formatPerplexity(stats.perplexity)}
+              </dd>
+            </div>
+          </dl>
+
+          {stats.offTopCount > 0 && (
+            <p className="tokinsp__finding">
+              At {stats.offTopCount} position{stats.offTopCount === 1 ? '' : 's'} the emitted token was not the
+              highest-scoring one.
+            </p>
+          )}
+
+          {/* n>1 is guarded, not offered. The engine refuses logprobs together with
+              multiple choices, and on a parity-locked row every choice would decode
+              identically anyway. Stating both keeps the reason honest. */}
+          <div className="tokinsp__guarded">
+            <p className="tokinsp__guarded-title">Side-by-side candidates — not available</p>
+            <p className="tokinsp__guarded-detail">
+              The engine reports probabilities for a single reply only, and refuses them alongside
+              multiple candidates. On a parity-locked model row the reply is decoded greedily, so
+              repeated candidates would be identical.
+              {candidatesContract?.rowId ? ` Contract row: ${candidatesContract.rowId}.` : ''}
+            </p>
+          </div>
+
+          <div className="tokinsp__actions">
+            <button
+              type="button"
+              className="tokinsp__action"
+              onClick={() => downloadJson(`camelid-token-probabilities-${stats.tokenCount}.json`, inspection)}
+            >
+              Download JSON
+            </button>
+            <span className="tokinsp__retention">
+              Held for this session only — not saved with the conversation.
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default TokenInspectorCard
+
+/* Re-exported so a caller can build a preview without normalizing a whole reply. */
+export { alternativesFor }

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -18,6 +18,7 @@ import {
 } from '../lib/conversationCompaction.js'
 import { getRuntimeRequestModelId, isExternalModel, modelRuntimeIdMatches } from '../lib/modelState'
 import { contractSamplingOverrides } from '../lib/samplingContract'
+import { inspectionAbsenceReason, inspectionForcesNonStreaming, inspectionRequestFields, readInspectionContract } from '../lib/tokenInspection'
 import { executionRuntimeFields } from '../lib/executionPlan'
 import {
   createPacerState,
@@ -58,7 +59,7 @@ const LOCAL_MODELS_STORAGE_KEY = 'camelid.localModels'
 const CONVERSATIONS_STORAGE_KEY = 'camelid.conversations'
 const MEMORIES_STORAGE_KEY = 'camelid.memories'
 const API_BASE_STORAGE_KEY = 'camelid.apiBase'
-const VALID_TABS = new Set(['chat', 'workspace', 'library', 'downloads', 'api', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster', 'compatibility', 'telemetry', 'arena'])
+const VALID_TABS = new Set(['chat', 'workspace', 'library', 'downloads', 'api', 'analytics', 'history', 'memory', 'system', 'settings', 'cluster', 'compatibility', 'telemetry', 'arena', 'observatory'])
 // Where the UI looks for the camelid API by default:
 //   1. an explicit VITE_CAMELID_API_BASE override always wins;
 //   2. otherwise use the page origin. Production is served by Camelid directly;
@@ -707,6 +708,20 @@ export function useDashboardData({ showNotice, clearNotice }) {
   // Opt-in parity receipts: sends the next message non-streaming with
   // camelid_receipt:true so the response carries a verifiable receipt.
   const [receiptMode, setReceiptMode] = useState(false)
+  /* Opt-in token inspection: sends the next message non-streaming with
+     logprobs:true so the reply carries the model's per-token scores. Captured
+     DURING the decode that produces the visible reply — never reconstructed by a
+     second generation, which would describe a different generation.
+
+     Deliberately held OUTSIDE the conversation: a 120-token reply carries roughly
+     414 bytes per token at depth 5 and 1.4 KB per token at depth 20 — two orders
+     of magnitude more than the reply text. Persisting that would march a
+     conversation into the localStorage quota, and persistConversations swallows
+     the quota error, so the failure would silently stop saving the WHOLE
+     conversation rather than just this record. Session-scoped by design; the
+     panel says so and offers a download. */
+  const [inspectMode, setInspectMode] = useState(false)
+  const [tokenInspections, setTokenInspections] = useState({})
   // Opt-in thinking mode (experimental — NOT parity-locked): sends
   // camelid_enable_thinking:true so the model emits its own <think>…</think>
   // reasoning. Default OFF so chat stays on the parity-locked thinking-DISABLED
@@ -1593,6 +1608,13 @@ export function useDashboardData({ showNotice, clearNotice }) {
       // must not cause the browser to advertise Prism's sampling controls that
       // this model does not use.
       const useExperimentalSampling = sendGate.chatMode === 'experimental' && !bitNetB158Chat
+      /* Token inspection rides on THIS request rather than a later replay, so the
+         scores describe the decode the reader is about to see. The contract is
+         resolved once per send and reused for both the stream flag and the
+         request fields. */
+      const inspectionContract = readInspectionContract(dashboard?.capabilities)
+      const inspecting = !targetVerifiedRender
+        && inspectionForcesNonStreaming({ enabled: inspectMode, contract: inspectionContract })
       const baseRequestBody = {
         model: requestModelId,
         messages: requestMessages,
@@ -1692,17 +1714,24 @@ export function useDashboardData({ showNotice, clearNotice }) {
         signal: requestController.signal,
         body: JSON.stringify({
           ...baseRequestBody,
-          // Receipts only attach to non-streaming responses; the JSON
-          // fallback in readStreamingChatCompletion handles that shape.
-          stream: targetVerifiedRender || !receiptMode,
+          // Receipts and token inspection only attach to non-streaming
+          // responses; the JSON fallback in readStreamingChatCompletion handles
+          // that shape. The engine returns a typed 400 for logprobs with
+          // stream:true, so `inspecting` MUST also clear the stream flag — the
+          // two conditions are derived from one source in tokenInspection.js
+          // rather than restated, so they cannot drift apart.
+          stream: targetVerifiedRender || !(receiptMode || inspecting),
           // Ask for the authoritative token count in the final stream chunk.
           // Without it the client can only ESTIMATE from visible content, which
           // undercounts badly on a thinking model: LFM2 emits its reasoning as
           // `reasoning_content`, so a reply that is mostly reasoning looked like
           // almost no tokens and the tok/s readout reported a fraction of the
           // real rate.
-          ...(targetVerifiedRender || !receiptMode ? { stream_options: { include_usage: true } } : {}),
+          ...(targetVerifiedRender || !(receiptMode || inspecting) ? { stream_options: { include_usage: true } } : {}),
           ...(!targetVerifiedRender && receiptMode ? { camelid_receipt: true } : {}),
+          /* Contributes nothing unless the contract permits inspection on this
+             engine, so a guarded row simply never reaches the wire. */
+          ...(targetVerifiedRender ? {} : inspectionRequestFields({ enabled: inspectMode, contract: inspectionContract })),
           ...(targetVerifiedRender ? {
             // The private verifier contract is exact: its output allowance is
             // the complete fresh draft, not the planner's larger upper bound.
@@ -1921,6 +1950,22 @@ export function useDashboardData({ showNotice, clearNotice }) {
       // turn is fail-closed above, so it never falls through to client timing.
       const nativeMtp12 = readTargetVerifiedMtp12(streamed.camelid)
         || readTargetVerifiedMtp12(targetVerifiedPlannerCamelid)
+      /* Inspection lands in session state keyed by message id, NOT on the message
+         object — see the state declaration for why persisting it is unsafe.
+         Absence is recorded too: a lane that answers 200 without the key must be
+         reported as an unmeasured position, never as a flat distribution. */
+      if (inspecting) {
+        const absence = inspectionAbsenceReason({
+          requested: true,
+          responded: true,
+          hasLogprobs: Boolean(streamed.logprobs),
+          streamed: responseIsStreaming,
+        })
+        setTokenInspections((current) => ({
+          ...current,
+          [assistantId]: { logprobs: streamed.logprobs || null, absence },
+        }))
+      }
       const assistantMessage = {
         ...assistantMessageBase,
         content: paceDrain(pacer, streamed.content || ''),
@@ -2445,6 +2490,9 @@ export function useDashboardData({ showNotice, clearNotice }) {
     webResearchStatus,
     receiptMode,
     setReceiptMode,
+    inspectMode,
+    setInspectMode,
+    tokenInspections,
     thinkingMode,
     setThinkingMode,
     loadingModelId,

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -1068,6 +1068,11 @@ export function useDashboardData({ showNotice, clearNotice }) {
     [models, runtime, selectedModelId],
   )
   const selectedModelChatGate = getChatGateState(dashboard?.capabilities, selectedModel, runtime)
+  /* Whether this engine's contract permits token inspection at all. Surfaced so
+     the composer control can render GUARDED rather than appearing live and
+     silently recording nothing — a toggle that reads "on" while contributing no
+     request fields is exactly the caveated-live surface I3 forbids. */
+  const inspectionSupported = readInspectionContract(dashboard?.capabilities).nonStreamingSupported
   const selectedModelRunnable = selectedModelChatGate.chatUnlocked
   // Experimental lane: loaded + generation-ready implemented model that is NOT a
   // supported row. Enables a weaker chat affordance; never the supported badge.
@@ -2493,6 +2498,7 @@ export function useDashboardData({ showNotice, clearNotice }) {
     inspectMode,
     setInspectMode,
     tokenInspections,
+    inspectionSupported,
     thinkingMode,
     setThinkingMode,
     loadingModelId,

--- a/frontend/src/lib/chatCompletionStream.js
+++ b/frontend/src/lib/chatCompletionStream.js
@@ -62,6 +62,12 @@ export function readChatCompletionJsonPayload(payload, { estimateTokenCount = de
     completionTokens: payload?.usage?.completion_tokens ?? estimateTokenCount(content),
     firstContentMs: null,
     usage: payload?.usage || null,
+    /* Per-token logprobs ride on the choice, and the engine OMITS the key rather
+       than sending null when they were not requested — so presence is the test,
+       never `=== null`. Reading it here rather than in the caller keeps the
+       non-streaming shape in one place; the streaming path has no equivalent,
+       because the engine refuses logprobs with stream:true. */
+    logprobs: Object.prototype.hasOwnProperty.call(choice || {}, 'logprobs') ? choice.logprobs : null,
   }
 }
 
@@ -91,7 +97,7 @@ export async function readStreamingChatCompletion(response, onDelta, { estimateT
   }
 
   const reader = response.body?.getReader()
-  if (!reader) return { content: '', finishReason: null, completionTokens: 0, firstContentMs: null, firstByteMs: null, firstEventMs: null, usage: null, camelid: null, camelidReceipt: null }
+  if (!reader) return { content: '', finishReason: null, completionTokens: 0, firstContentMs: null, firstByteMs: null, firstEventMs: null, usage: null, camelid: null, camelidReceipt: null, logprobs: null }
   const decoder = new TextDecoder()
   let buffer = ''
   let content = ''
@@ -197,6 +203,7 @@ export async function readStreamingChatCompletion(response, onDelta, { estimateT
   }
   buffer += decoder.decode()
   if (buffer.trim()) consumeEvent(buffer.replace(/\r\n/g, '\n'))
-  // Receipts only attach to non-streaming responses (the JSON fallback above).
-  return { content, finishReason, completionTokens, firstContentMs, firstByteMs, firstEventMs, usage, camelid, camelidReceipt: null }
+  // Receipts and logprobs only attach to non-streaming responses (the JSON
+  // fallback above); the engine rejects logprobs with stream:true outright.
+  return { content, finishReason, completionTokens, firstContentMs, firstByteMs, firstEventMs, usage, camelid, camelidReceipt: null, logprobs: null }
 }

--- a/frontend/src/lib/tokenInspection.js
+++ b/frontend/src/lib/tokenInspection.js
@@ -126,10 +126,40 @@ export function inspectionForcesNonStreaming({ enabled, contract } = {}) {
 
 const clampProbability = (p) => (Number.isFinite(p) ? Math.min(1, Math.max(0, p)) : null)
 
+/* Read a wire logprob, treating ABSENT as absent.
+
+   `Number(null)` is 0 and `Number.isFinite(0)` is true, so the obvious
+   `Number.isFinite(Number(x))` guard silently converts a null logprob into 0 —
+   which is exp(0) = probability 1.0, the "settled" band, and a rendered ">99.9%".
+   That turns missing data into maximum probability, the precise misreading this
+   whole surface exists to prevent. Null and undefined are rejected BEFORE any
+   numeric coercion. */
+function readLogprob(value) {
+  if (value === null || value === undefined || value === '') return null
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : null
+}
+
 function probabilityFromLogprob(logprob) {
-  const value = Number(logprob)
-  if (!Number.isFinite(value)) return null
+  const value = readLogprob(logprob)
+  if (value === null) return null
   return clampProbability(Math.exp(value))
+}
+
+/* Token identity for comparing a chosen entry against its own alternatives.
+
+   `bytes` is the ground truth — the `token` string is a lossy rendering, and the
+   wire carries no token ids. Comparing logprob VALUES instead would call any
+   alternative within measurement noise "the same token", which is a different
+   claim entirely. */
+function sameToken(a, b) {
+  if (!a || !b) return false
+  const left = Array.isArray(a.bytes) ? a.bytes : null
+  const right = Array.isArray(b.bytes) ? b.bytes : null
+  if (left && right && left.length && right.length) {
+    return left.length === right.length && left.every((value, index) => value === right[index])
+  }
+  return a.raw === b.raw
 }
 
 /* Display text for one token.
@@ -159,9 +189,21 @@ export function describeToken(entry) {
    A greedy reply is overwhelmingly high-probability; encoding probability directly
    would ink the boring 90% and fade the interesting 5% to nothing. These bands
    invert that: 'settled' gets no marking at all, and only contested positions
-   carry weight. The thresholds are presentation, not a claim about the model. */
-export function probabilityBand(probability) {
+   carry weight. The thresholds are presentation, not a claim about the model.
+
+   A band is about the MARGIN to the runner-up, not the chosen token's absolute
+   probability. Those come apart: a token at p=0.45 whose nearest rival sits at
+   p=0.02 was not contested at all — it won by more than twenty to one — while a
+   token at p=0.48 against a rival at p=0.47 genuinely was. Absolute probability
+   is only the fallback for a position with no runner-up to compare against. */
+export function probabilityBand(probability, runnerUpProbability = null) {
   if (probability === null) return 'unknown'
+  if (runnerUpProbability !== null) {
+    const margin = probability - runnerUpProbability
+    if (margin >= 0.5) return 'settled'
+    if (margin >= 0.15) return 'leading'
+    return 'contested'
+  }
   if (probability >= 0.9) return 'settled'
   if (probability >= 0.5) return 'leading'
   return 'contested'
@@ -178,15 +220,15 @@ const TIE_WINDOW_NATS = 0.01
 export function alternativesFor(entry) {
   const list = Array.isArray(entry?.top_logprobs) ? entry.top_logprobs : []
   return list.map((alt, index) => {
-    const probability = probabilityFromLogprob(alt?.logprob)
-    const previous = index > 0 ? Number(list[index - 1]?.logprob) : null
+    const logprob = readLogprob(alt?.logprob)
+    const previous = index > 0 ? readLogprob(list[index - 1]?.logprob) : null
     const tiedWithPrevious = previous !== null
-      && Number.isFinite(Number(alt?.logprob))
-      && Math.abs(Number(alt.logprob) - previous) <= TIE_WINDOW_NATS
+      && logprob !== null
+      && Math.abs(logprob - previous) <= TIE_WINDOW_NATS
     return {
       ...describeToken(alt),
-      logprob: Number.isFinite(Number(alt?.logprob)) ? Number(alt.logprob) : null,
-      probability,
+      logprob,
+      probability: probabilityFromLogprob(alt?.logprob),
       rank: index + 1,
       tiedWithPrevious,
     }
@@ -205,16 +247,19 @@ export function normalizeInspection(logprobs) {
   if (!content.length) return null
 
   const tokens = content.map((entry, index) => {
-    const logprob = Number.isFinite(Number(entry?.logprob)) ? Number(entry.logprob) : null
-    const probability = probabilityFromLogprob(logprob)
+    const logprob = readLogprob(entry?.logprob)
+    const probability = probabilityFromLogprob(entry?.logprob)
     const alternatives = alternativesFor(entry)
     const top = alternatives[0] || null
-    /* Identity by rank position and value, not by token string: two distinct
-       token ids can decode to the same text. */
-    const chosenIsTop = top !== null && logprob !== null && Math.abs(top.logprob - logprob) <= TIE_WINDOW_NATS
-    const chosenInAlternatives = alternatives.some((alt) => (
-      alt.logprob !== null && logprob !== null && Math.abs(alt.logprob - logprob) <= TIE_WINDOW_NATS && alt.raw === (entry?.token ?? '')
-    ))
+    const chosen = describeToken(entry)
+    /* Identity, not proximity. Comparing logprob VALUES would call any alternative
+       within measurement noise "the token that was emitted" — so a sampled reply
+       that picked rank 2 in a near-tie would be reported as having picked the
+       top-ranked token, and the off-top count would under-report. Whether the two
+       scores are too close to rank is a SEPARATE question, answered by
+       `tiedWithPrevious`. */
+    const chosenIsTop = sameToken(top, chosen)
+    const chosenInAlternatives = alternatives.some((alt) => sameToken(alt, chosen))
     /* Residual mass: what the shown alternatives do NOT account for. Without it,
        k rows read as a closed set — the single most likely misreading of this
        surface. Clamped at zero because a truncated set can round above 1.0. */
@@ -224,7 +269,13 @@ export function normalizeInspection(logprobs) {
       ...describeToken(entry),
       logprob,
       probability,
-      band: probabilityBand(probability),
+      /* The runner-up is the highest-scoring alternative that is NOT the emitted
+         token, so a position whose top entry simply is the chosen token compares
+         against rank 2 rather than against itself. */
+      band: probabilityBand(
+        probability,
+        alternatives.find((alt) => !sameToken(alt, chosen))?.probability ?? null,
+      ),
       alternatives,
       chosenIsTop,
       chosenInAlternatives,

--- a/frontend/src/lib/tokenInspection.js
+++ b/frontend/src/lib/tokenInspection.js
@@ -1,0 +1,308 @@
+/* Token inspection contract lane.
+
+   The engine can report, for each generated token, the log-probability the model
+   assigned it plus the top-N alternatives it outranked. This module owns every
+   decision about that data: whether the contract permits asking for it, what
+   request fields to send, how to normalize a response, and what may honestly be
+   said about the result. It performs no I/O and touches no storage.
+
+   Three rules shape everything here.
+
+   1. CAPTURED, NEVER RECONSTRUCTED. The distribution is collected during the
+      decode that produced the visible reply, by sending the inspection fields on
+      the original request. Re-running a turn afterwards would produce a DIFFERENT
+      generation whose numbers describe a reply the reader never saw — and on a
+      sampled row it would not even reproduce the text. A surface that cannot make
+      that false claim is stronger than one that discloses it.
+
+   2. THE CONTRACT DECIDES, AND IT IS INCOMPLETE. `/api/capabilities` ships
+      `api_conformance` rows carrying machine-readable supported/unsupported modes.
+      Those cover the ROUTE axis (streaming, multi-choice) and say nothing about the
+      SERVE-LANE axis: several non-dense lanes short-circuit before the logprobs
+      handler and answer 200 with the key simply absent. So the conformance row is
+      the pre-flight and the presence of the key in the response is the correctness
+      guard. Never infer certainty from missing data.
+
+   3. RAW MODEL DISTRIBUTION, NOT SAMPLING PROBABILITY. The values are a full-vocab
+      log-softmax over the unmodified logits — no temperature, no penalties, no
+      grammar mask. They describe what the model computed, not how a token was
+      picked. Copy in this lane never uses the words "confidence" or "certainty";
+      both would assert something about the model's epistemic state that a softmax
+      over logits does not license. */
+
+import { isSupportedCapabilityStatus, displayCapabilityCopy } from './capabilities.js'
+
+/* Engine caps, mirrored from the API's own validation so the UI cannot compose a
+   request the backend will reject. src/api/mod.rs MAX_LOGPROBS / MAX_N_CHOICES. */
+export const MAX_TOP_LOGPROBS = 20
+export const MAX_N_CHOICES = 8
+export const DEFAULT_TOP_LOGPROBS = 5
+export const TOP_LOGPROBS_CHOICES = [3, 5, 10, 20]
+
+const LOGPROBS_ROW_ID = 'rich_logprobs'
+const MULTI_CHOICE_ROW_ID = 'multi_choice_generation'
+
+function findContractRow(rows, id) {
+  return (rows || []).find((row) => row?.id === id) || null
+}
+
+/* Resolve a feature row by EXACT id across both projections the contract ships.
+
+   `api_conformance` is preferred: it carries the machine-readable mode lists, and
+   its projection emits no `notes` string, so it cannot smuggle vendor names into
+   rendered copy. `api_features` is the fallback for an engine build that predates
+   the conformance array — there the modes are unknown, and unknown means closed. */
+export function readInspectionContract(capabilities) {
+  const conformance = findContractRow(capabilities?.api_conformance, LOGPROBS_ROW_ID)
+  const feature = findContractRow(capabilities?.api_features, LOGPROBS_ROW_ID)
+  const row = conformance || feature
+  if (!row) {
+    return {
+      present: false,
+      supported: false,
+      modesKnown: false,
+      nonStreamingSupported: false,
+      rowId: LOGPROBS_ROW_ID,
+      status: null,
+      note: null,
+    }
+  }
+  const supported = isSupportedCapabilityStatus(String(row.status || ''))
+  const modesKnown = Array.isArray(conformance?.supported_modes)
+  const supportedModes = modesKnown ? conformance.supported_modes : []
+  return {
+    present: true,
+    supported,
+    modesKnown,
+    /* Absent mode lists fail closed: an engine that does not describe its modes
+       does not get assumed into supporting the one we want. */
+    nonStreamingSupported: supported && modesKnown && supportedModes.includes('chat_nonstreaming'),
+    rowId: LOGPROBS_ROW_ID,
+    status: row.status || null,
+    note: feature?.notes ? displayCapabilityCopy(feature.notes) : null,
+  }
+}
+
+/* The n>1 lane, resolved the same way. It is read only to explain why the
+   candidates surface is guarded — nothing in this file ever requests n>1. */
+export function readCandidatesContract(capabilities) {
+  const conformance = findContractRow(capabilities?.api_conformance, MULTI_CHOICE_ROW_ID)
+  const feature = findContractRow(capabilities?.api_features, MULTI_CHOICE_ROW_ID)
+  const row = conformance || feature
+  const unsupported = Array.isArray(conformance?.unsupported_modes) ? conformance.unsupported_modes : []
+  return {
+    present: Boolean(row),
+    supported: Boolean(row) && isSupportedCapabilityStatus(String(row.status || '')),
+    excludesLogprobs: unsupported.includes('logprobs'),
+    rowId: MULTI_CHOICE_ROW_ID,
+    status: row?.status || null,
+  }
+}
+
+export function clampTopLogprobs(value) {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return DEFAULT_TOP_LOGPROBS
+  return Math.min(MAX_TOP_LOGPROBS, Math.max(1, Math.round(n)))
+}
+
+/* Request fields for an inspected turn.
+
+   Returns {} whenever inspection is off or the contract does not permit it, so a
+   caller can spread this unconditionally and a guarded contract simply contributes
+   nothing. `top_logprobs` is never emitted without `logprobs: true` — the engine
+   rejects that pairing outright — and the depth is clamped to the engine's cap. */
+export function inspectionRequestFields({ enabled, contract, topLogprobs = DEFAULT_TOP_LOGPROBS } = {}) {
+  if (!enabled) return {}
+  if (!contract?.nonStreamingSupported) return {}
+  return { logprobs: true, top_logprobs: clampTopLogprobs(topLogprobs) }
+}
+
+/* Inspection forces the reply off the streaming path: the engine rejects
+   logprobs with stream:true. Callers use this to keep one source of truth for
+   "is this turn streaming" rather than re-deriving the condition. */
+export function inspectionForcesNonStreaming({ enabled, contract } = {}) {
+  return Boolean(enabled && contract?.nonStreamingSupported)
+}
+
+const clampProbability = (p) => (Number.isFinite(p) ? Math.min(1, Math.max(0, p)) : null)
+
+function probabilityFromLogprob(logprob) {
+  const value = Number(logprob)
+  if (!Number.isFinite(value)) return null
+  return clampProbability(Math.exp(value))
+}
+
+/* Display text for one token.
+
+   `bytes` is the ground truth. A BPE token can be a fragment of a multi-byte
+   character, whitespace, or a control marker, and the `token` string is a lossy
+   rendering of those bytes. So the glyph shown is an AFFORDANCE and the byte array
+   travels with it for anything that needs the truth. `substituted` tells the
+   renderer when what is on screen is not literally the token text. */
+export function describeToken(entry) {
+  const raw = typeof entry?.token === 'string' ? entry.token : ''
+  const bytes = Array.isArray(entry?.bytes) ? entry.bytes : []
+  if (raw === '') return { display: '∅', substituted: true, kind: 'empty', raw, bytes }
+  if (/^<\|.+\|>$/.test(raw) || /^<\/?s>$/.test(raw)) {
+    return { display: raw, substituted: false, kind: 'special', raw, bytes }
+  }
+  if (/^\s+$/.test(raw)) {
+    const display = raw.replace(/\n/g, '⏎').replace(/\t/g, '⇥').replace(/ /g, '·')
+    return { display, substituted: true, kind: 'whitespace', raw, bytes }
+  }
+  const display = raw.replace(/^ /, '·').replace(/\n/g, '⏎').replace(/\t/g, '⇥')
+  return { display, substituted: display !== raw, kind: 'text', raw, bytes }
+}
+
+/* Three bands, chosen so the SALIENCE BUDGET goes to the minority worth reading.
+
+   A greedy reply is overwhelmingly high-probability; encoding probability directly
+   would ink the boring 90% and fade the interesting 5% to nothing. These bands
+   invert that: 'settled' gets no marking at all, and only contested positions
+   carry weight. The thresholds are presentation, not a claim about the model. */
+export function probabilityBand(probability) {
+  if (probability === null) return 'unknown'
+  if (probability >= 0.9) return 'settled'
+  if (probability >= 0.5) return 'leading'
+  return 'contested'
+}
+
+/* Near-ties must not be rendered as a strict ordering.
+
+   At f32 precision, and with lane-to-lane numeric variance around 0.007 nats, a
+   0.001-nat gap between two alternatives is not a meaningful ranking. Anything
+   inside this window is marked as tied so the UI can say so rather than implying
+   the order is information. */
+const TIE_WINDOW_NATS = 0.01
+
+export function alternativesFor(entry) {
+  const list = Array.isArray(entry?.top_logprobs) ? entry.top_logprobs : []
+  return list.map((alt, index) => {
+    const probability = probabilityFromLogprob(alt?.logprob)
+    const previous = index > 0 ? Number(list[index - 1]?.logprob) : null
+    const tiedWithPrevious = previous !== null
+      && Number.isFinite(Number(alt?.logprob))
+      && Math.abs(Number(alt.logprob) - previous) <= TIE_WINDOW_NATS
+    return {
+      ...describeToken(alt),
+      logprob: Number.isFinite(Number(alt?.logprob)) ? Number(alt.logprob) : null,
+      probability,
+      rank: index + 1,
+      tiedWithPrevious,
+    }
+  })
+}
+
+/* Normalize one `choices[].logprobs` object into the shape the panel renders.
+
+   Guards the two structural cases the wire permits but naive code assumes away:
+   an empty/malformed content array, and a chosen token that does not appear in its
+   own top-N list (possible whenever the emitted token was not among the k returned
+   alternatives). The second is reported rather than hidden — a chosen token outside
+   the top-N is real signal about the decode, not a rendering nuisance. */
+export function normalizeInspection(logprobs) {
+  const content = Array.isArray(logprobs?.content) ? logprobs.content : []
+  if (!content.length) return null
+
+  const tokens = content.map((entry, index) => {
+    const logprob = Number.isFinite(Number(entry?.logprob)) ? Number(entry.logprob) : null
+    const probability = probabilityFromLogprob(logprob)
+    const alternatives = alternativesFor(entry)
+    const top = alternatives[0] || null
+    /* Identity by rank position and value, not by token string: two distinct
+       token ids can decode to the same text. */
+    const chosenIsTop = top !== null && logprob !== null && Math.abs(top.logprob - logprob) <= TIE_WINDOW_NATS
+    const chosenInAlternatives = alternatives.some((alt) => (
+      alt.logprob !== null && logprob !== null && Math.abs(alt.logprob - logprob) <= TIE_WINDOW_NATS && alt.raw === (entry?.token ?? '')
+    ))
+    /* Residual mass: what the shown alternatives do NOT account for. Without it,
+       k rows read as a closed set — the single most likely misreading of this
+       surface. Clamped at zero because a truncated set can round above 1.0. */
+    const shownMass = alternatives.reduce((sum, alt) => sum + (alt.probability ?? 0), 0)
+    return {
+      index,
+      ...describeToken(entry),
+      logprob,
+      probability,
+      band: probabilityBand(probability),
+      alternatives,
+      chosenIsTop,
+      chosenInAlternatives,
+      shownMass: clampProbability(shownMass),
+      residualMass: clampProbability(1 - shownMass),
+    }
+  })
+
+  const scored = tokens.filter((token) => token.logprob !== null)
+  const sumLogprob = scored.reduce((sum, token) => sum + token.logprob, 0)
+  const meanLogprob = scored.length ? sumLogprob / scored.length : null
+  const contested = tokens.filter((token) => token.band === 'contested')
+  const offTop = tokens.filter((token) => token.logprob !== null && !token.chosenIsTop)
+  const lowest = scored.length
+    ? scored.reduce((carry, token) => (token.logprob < carry.logprob ? token : carry), scored[0])
+    : null
+
+  return {
+    tokens,
+    stats: {
+      tokenCount: tokens.length,
+      scoredCount: scored.length,
+      depth: tokens[0]?.alternatives?.length ?? 0,
+      sumLogprob: scored.length ? sumLogprob : null,
+      meanLogprob,
+      /* Perplexity over the generated tokens only — not a model-quality score and
+         not comparable across prompts. Reported because it is the one number that
+         summarizes a whole reply, and it is derived from data already in hand. */
+      perplexity: meanLogprob === null ? null : Math.exp(-meanLogprob),
+      contestedCount: contested.length,
+      offTopCount: offTop.length,
+      lowestProbabilityIndex: lowest ? lowest.index : null,
+    },
+    contested: contested.slice(0, 5).map((token) => token.index),
+  }
+}
+
+/* Why a reply carries no inspection data.
+
+   The critical distinction is between "not asked for" and "asked for, answered
+   200, and the key was absent" — the second is a serve lane that short-circuits
+   before the logprobs handler. Reporting that as an empty panel, or worse as
+   high probability, would attribute a lane's silence to the model. */
+export function inspectionAbsenceReason({ requested, responded, hasLogprobs, streamed }) {
+  if (!requested) return null
+  if (!responded) return null
+  if (hasLogprobs) return null
+  if (streamed) {
+    return {
+      code: 'streamed',
+      title: 'This reply arrived as a stream',
+      detail: 'Probabilities are only reported on a non-streaming reply. Something between this page and the engine converted the response to a stream, so the engine had nothing to attach them to.',
+    }
+  }
+  return {
+    code: 'lane_absent',
+    title: 'This execution lane did not report probabilities',
+    detail: 'The reply completed normally and the engine returned no probability record for it. Several execution lanes answer chat requests before the probability step runs. This says nothing about how the model ranked these tokens — the measurement is missing, not flat.',
+  }
+}
+
+/* Formatters. Precision is deliberately coarse: lane-to-lane numeric variance on
+   the same model and prompt runs to a few thousandths of a nat, so printing four
+   decimals would advertise precision the value does not carry. */
+export function formatProbability(probability) {
+  if (probability === null || probability === undefined) return '—'
+  if (probability >= 0.9995) return '>99.9%'
+  if (probability < 0.001) return '<0.1%'
+  return `${(probability * 100).toFixed(1)}%`
+}
+
+export function formatLogprob(logprob) {
+  if (logprob === null || logprob === undefined) return '—'
+  if (logprob > -0.005 && logprob <= 0) return '−0.00'
+  return `−${Math.abs(logprob).toFixed(2)}`
+}
+
+export function formatPerplexity(value) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  return value >= 100 ? value.toFixed(0) : value.toFixed(2)
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -12,3 +12,4 @@
 @import './styles/views.css';
 @import './styles/cluster.css';
 @import './styles/observatory.css';
+@import './styles/token-inspector.css';

--- a/frontend/src/styles/token-inspector.css
+++ b/frontend/src/styles/token-inspector.css
@@ -35,7 +35,7 @@
 }
 
 .tokinsp__trigger:hover { color: var(--color-text); }
-.tokinsp__trigger:focus-visible { outline: var(--focus-ring); border-radius: var(--radius-sm); }
+.tokinsp__trigger:focus-visible { outline: none; box-shadow: var(--focus-ring); border-radius: var(--radius-sm); }
 
 .tokinsp__trigger-label {
   font-weight: 600;
@@ -103,7 +103,7 @@
   outline: 1px solid var(--color-accent);
   outline-offset: 1px;
 }
-.tokinsp__tok:focus-visible { outline: var(--focus-ring); }
+.tokinsp__tok:focus-visible { outline: none; box-shadow: var(--focus-ring); }
 
 /* Emitted-token-was-not-top marker. A shape, not a color. */
 .tokinsp__tok-rank {
@@ -259,7 +259,7 @@
 }
 
 .tokinsp__action:hover { color: var(--color-text); border-color: var(--color-border-strong); }
-.tokinsp__action:focus-visible { outline: var(--focus-ring); }
+.tokinsp__action:focus-visible { outline: none; box-shadow: var(--focus-ring); }
 
 .tokinsp__retention { font-size: var(--text-micro); color: var(--color-text-faint); }
 

--- a/frontend/src/styles/token-inspector.css
+++ b/frontend/src/styles/token-inspector.css
@@ -1,0 +1,285 @@
+/* Token Inspector — per-token probability record attached to one reply.
+
+   COLOR POSTURE. This sheet introduces NO new color tokens. Copper
+   (--color-verified) and amber (--color-evidence) are claim colors reserved for
+   support and evidence statements, and red (--color-error) means an error — a
+   low-probability token is a normal state, not a failure. So the only ink used for
+   the encoding is --color-accent, the informational accent.
+
+   ENCODING. Probability is carried by an UNDERLINE WEIGHT in three bands, never by
+   text color and never by a text background. Two consequences, both deliberate:
+   the token text stays at --color-text so its contrast is the audited body-text
+   pair and cannot be regressed by this feature, and the encoding survives
+   greyscale, since band weight is a size channel rather than a hue channel. The
+   exact value is always available as text in the detail panel — color is never the
+   only carrier of a number here. */
+
+.tokinsp {
+  margin-top: var(--space-3);
+  border-top: 1px solid var(--color-border-soft);
+  padding-top: var(--space-3);
+}
+
+.tokinsp__trigger {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1) 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-text-muted);
+  font-size: var(--text-2xs);
+}
+
+.tokinsp__trigger:hover { color: var(--color-text); }
+.tokinsp__trigger:focus-visible { outline: var(--focus-ring); border-radius: var(--radius-sm); }
+
+.tokinsp__trigger-label {
+  font-weight: 600;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  font-size: var(--text-micro);
+}
+
+.tokinsp__trigger-summary { color: var(--color-text-faint); }
+
+.tokinsp__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.tokinsp__provenance {
+  margin: 0;
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+}
+
+/* Token strip. Wraps rather than scrolls: the chat column is capped at
+   --content-max, and a horizontally scrolling strip would hide most of a reply
+   behind a gesture. Reading order is the natural order of the text. */
+.tokinsp__strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 0;
+  padding: var(--space-2);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-code-border);
+  border-radius: var(--radius-md);
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
+.tokinsp__tok {
+  position: relative;
+  padding: 1px 1px 2px;
+  background: none;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 2px;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-snug);
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: pre-wrap;
+}
+
+/* The three bands. `settled` is intentionally unmarked: in a greedy reply it is
+   the overwhelming majority, and marking it would spend the whole salience budget
+   on the part with nothing to say. */
+.tokinsp__tok--settled { border-bottom-color: transparent; }
+.tokinsp__tok--leading { border-bottom-color: color-mix(in srgb, var(--color-accent) 35%, transparent); }
+.tokinsp__tok--contested { border-bottom-color: var(--color-accent); }
+.tokinsp__tok--unknown { border-bottom-style: dotted; border-bottom-color: var(--color-text-faint); }
+
+.tokinsp__tok:hover { background: var(--color-surface-hover); }
+.tokinsp__tok.is-active {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 1px;
+}
+.tokinsp__tok:focus-visible { outline: var(--focus-ring); }
+
+/* Emitted-token-was-not-top marker. A shape, not a color. */
+.tokinsp__tok-rank {
+  font-size: var(--text-micro);
+  color: var(--color-text-faint);
+  vertical-align: super;
+  margin-left: 1px;
+}
+
+.tokinsp__truncation,
+.tokinsp__finding,
+.tokinsp__detail-note {
+  margin: 0;
+  font-size: var(--text-micro);
+  color: var(--color-text-muted);
+}
+
+.tokinsp__detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-surface-subtle);
+  border-radius: var(--radius-md);
+}
+
+.tokinsp__detail-head {
+  margin: 0;
+  font-size: var(--text-2xs);
+  color: var(--color-text);
+}
+
+.tokinsp__detail-token {
+  font-family: var(--font-mono);
+  background: var(--color-code-bg);
+  border-radius: 2px;
+  padding: 0 3px;
+}
+
+.tokinsp__alts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+/* The token column is sized for the longest fixed label this list can contain —
+   the residual row's "rest of the vocabulary" — so the one entry that must always
+   be readable never ellipsizes. Model tokens are short; they truncate instead. */
+.tokinsp__alt {
+  display: grid;
+  grid-template-columns: 1.25rem minmax(4rem, 10.5rem) 1fr 3.5rem auto;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-micro);
+  color: var(--color-text-muted);
+}
+
+.tokinsp__alt.is-chosen { color: var(--color-text); font-weight: 600; }
+
+.tokinsp__alt--residual {
+  border-top: 1px dashed var(--color-border-soft);
+  padding-top: 3px;
+  font-style: italic;
+}
+
+.tokinsp__alt-rank { color: var(--color-text-faint); text-align: right; }
+
+.tokinsp__alt-token {
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tokinsp__alt-bar {
+  display: block;
+  height: 4px;
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.tokinsp__alt-bar-fill {
+  display: block;
+  height: 100%;
+  background: color-mix(in srgb, var(--color-accent) 55%, transparent);
+  border-radius: var(--radius-pill);
+}
+
+.tokinsp__alt.is-chosen .tokinsp__alt-bar-fill { background: var(--color-accent); }
+
+.tokinsp__alt-value { text-align: right; font-variant-numeric: tabular-nums; }
+
+.tokinsp__alt-tie {
+  font-size: var(--text-micro);
+  color: var(--color-text-faint);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+}
+
+.tokinsp__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-5);
+  margin: 0;
+  font-size: var(--text-micro);
+}
+
+.tokinsp__stats div { display: flex; flex-direction: column; gap: 1px; }
+.tokinsp__stats dt { color: var(--color-text-faint); text-transform: uppercase; letter-spacing: var(--tracking-label); }
+.tokinsp__stats dd { margin: 0; color: var(--color-text); font-variant-numeric: tabular-nums; }
+
+.tokinsp__guarded {
+  padding: var(--space-2) var(--space-3);
+  border: 1px dashed var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+}
+
+.tokinsp__guarded-title {
+  margin: 0 0 2px;
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--color-text-faint);
+}
+
+.tokinsp__guarded-detail {
+  margin: 0;
+  font-size: var(--text-micro);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+}
+
+.tokinsp__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.tokinsp__action {
+  padding: 3px var(--space-2);
+  font-size: var(--text-micro);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.tokinsp__action:hover { color: var(--color-text); border-color: var(--color-border-strong); }
+.tokinsp__action:focus-visible { outline: var(--focus-ring); }
+
+.tokinsp__retention { font-size: var(--text-micro); color: var(--color-text-faint); }
+
+/* Absence. Styled as an ordinary informational state — never as an alarm, because
+   a lane that does not report probabilities is not an error and must not be
+   confused with a model that scored its tokens flat. */
+.tokinsp--absent { color: var(--color-text-muted); }
+.tokinsp__absent-title {
+  margin: 0 0 2px;
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--color-text-faint);
+}
+.tokinsp__absent-detail {
+  margin: 0;
+  font-size: var(--text-micro);
+  line-height: var(--leading-normal);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .tokinsp__tok { transition: background var(--dur-fast) var(--ease-standard); }
+}

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -179,6 +179,7 @@ export default function ChatWorkspace({
   inspectMode = false,
   setInspectMode = null,
   tokenInspections = {},
+  inspectionSupported = false,
   thinkingMode = false,
   setThinkingMode = null,
   webResearchEnabled = true,
@@ -1021,16 +1022,27 @@ export default function ChatWorkspace({
                 CAPTURED during the reply's own decode. Inspecting afterwards would
                 mean decoding a second time, and those numbers would describe that
                 other generation — on a sampled row, a different reply entirely. */}
+            {/* Guarded, not hidden, when the contract does not advertise
+                inspection: a live-looking toggle that records nothing is the
+                caveated-live surface I3 rules out, and hiding it entirely would
+                leave no explanation for why the feature is absent. The accessible
+                name contains the visible label so voice control can address it. */}
             {!demoMode && setInspectMode && (
               <button
                 type="button"
-                className={`cxcomposer__tool cxcomposer__tool--collapsible ${inspectMode ? 'is-on' : ''}`}
-                title="Record the model's per-token scores for the next reply (sends it without streaming)"
-                aria-label="Token probabilities"
-                aria-pressed={inspectMode}
+                className={`cxcomposer__tool cxcomposer__tool--collapsible ${inspectMode && inspectionSupported ? 'is-on' : ''}`}
+                title={inspectionSupported
+                  ? "Record the model's per-token scores for the next reply (sends it without streaming)"
+                  : 'This engine does not advertise per-token probability reporting, so the next reply cannot record it.'}
+                aria-label={inspectionSupported ? 'Tokens — record per-token probabilities' : 'Tokens — unavailable on this engine'}
+                aria-pressed={inspectionSupported ? inspectMode : undefined}
+                disabled={!inspectionSupported}
                 onClick={() => setInspectMode(!inspectMode)}
               >
-                <IconChart size={16} /> <span className="cxcomposer__tool-label">{inspectMode ? 'Tokens on' : 'Tokens'}</span>
+                <IconChart size={16} />
+                <span className="cxcomposer__tool-label">
+                  {inspectionSupported ? (inspectMode ? 'Tokens on' : 'Tokens') : 'Tokens unavailable'}
+                </span>
               </button>
             )}
             {!demoMode && setThinkingMode && !selectedBitNetChatModel && (

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -176,6 +176,9 @@ export default function ChatWorkspace({
   sending,
   receiptMode = false,
   setReceiptMode = null,
+  inspectMode = false,
+  setInspectMode = null,
+  tokenInspections = {},
   thinkingMode = false,
   setThinkingMode = null,
   webResearchEnabled = true,
@@ -1014,6 +1017,22 @@ export default function ChatWorkspace({
                 <IconReceipt size={16} /> <span className="cxcomposer__tool-label">{receiptMode ? 'Receipt on' : 'Receipt'}</span>
               </button>
             )}
+            {/* Token inspection is a pre-send choice because the scores are
+                CAPTURED during the reply's own decode. Inspecting afterwards would
+                mean decoding a second time, and those numbers would describe that
+                other generation — on a sampled row, a different reply entirely. */}
+            {!demoMode && setInspectMode && (
+              <button
+                type="button"
+                className={`cxcomposer__tool cxcomposer__tool--collapsible ${inspectMode ? 'is-on' : ''}`}
+                title="Record the model's per-token scores for the next reply (sends it without streaming)"
+                aria-label="Token probabilities"
+                aria-pressed={inspectMode}
+                onClick={() => setInspectMode(!inspectMode)}
+              >
+                <IconChart size={16} /> <span className="cxcomposer__tool-label">{inspectMode ? 'Tokens on' : 'Tokens'}</span>
+              </button>
+            )}
             {!demoMode && setThinkingMode && !selectedBitNetChatModel && (
               <button
                 type="button"
@@ -1208,6 +1227,7 @@ export default function ChatWorkspace({
                       onReusePrompt={setComposer}
                       onRegenerate={canResend && priorUserMessage ? () => resendFromMessage(priorUserMessage.id) : null}
                       onEditResend={canResend && message.role === 'user' ? (messageId, content) => resendFromMessage(messageId, content) : null}
+                      tokenInspection={tokenInspections?.[message.id] || null}
                     />
                   </Fragment>
                 )


### PR DESCRIPTION
Camelid's engine has reported per-token logprobs since #334, advertised on `/api/capabilities` as the `rich_logprobs` row. Until now no frontend file mentioned them. This adds the surface.

A **Tokens** toggle in the composer. Flip it, send, and the reply carries a collapsible panel showing the model's per-token distribution:

```
Position 1 — emitted  7  at 58.5% (−0.54 log)
  1  7                       58.5%
  2  8                       17.4%
  3  6                        7.8%
  4  9                        6.7%
  5  5                        4.0%
  ·  rest of the vocabulary    5.6%

TOKENS 3 · ALTERNATIVES PER POSITION 5 · MEAN LOG-PROBABILITY −0.31 · PERPLEXITY 1.36
```

## The decision everything follows from: capture, don't re-run

The scores come from the reply's own decode, not a replay. The obvious alternative — an "Inspect" button on a finished message — would decode a **second** time and report numbers describing a different generation. On an experimental row (which samples at 0.7, `useDashboardData.js:1603`) it would not even reproduce the text.

That is why the toggle is pre-send: the cost of the panel being *unable* to misstate provenance, rather than merely disclosing that it might. It also means the request composes with the non-streaming branch `receiptMode` already uses, inheriting its 400-avoidance instead of restating it.

## Engine behaviour, verified live

Everything below was measured against a loaded `Llama-3.2-1B-Instruct-Q8_0` on the Windows CUDA-resident lane (`cuda_resident_q8_runtime`), not read off the source.

| Behaviour | Result |
|---|---|
| logprobs on the CUDA-resident lane | **Works** — matches the committed macOS Metal receipt to ~0.007 nats, same ranking |
| `logprobs` + `stream:true` | typed 400 |
| `logprobs` + `n>1` | typed 400 — mutually exclusive |
| `top_logprobs` without `logprobs` | typed 400 |
| `n=3` at `temperature:0` | **three byte-identical choices**; at 0.9 they differ |
| Payload size | **414 B/token** at depth 5, **1456 B/token** at depth 20 (~100× the reply text) |

The CUDA-resident result is new — the repo had a logprobs receipt for macOS Metal only.

## What ships guarded

The side-by-side candidates mode is **guarded, not live**, for two independent reasons: the engine refuses `logprobs` with `n>1`, and at `temperature:0` — where every parity-locked row sits — repeated candidates are byte-identical. The panel says both in typed copy. This is the `samplingContract.js` pattern, and the surface becomes real work once sampling rows exist.

## Storage

Records are held in session state keyed by message id, **never on the message object**. At 414 B/token the alternative is a data-loss bug: `persistConversations` swallows quota errors, so an overflow would silently stop saving the entire conversation rather than just the scores. Asserted structurally in the smoke, not left to a comment.

## Fails open, and the panel knows it

The gemma4, runnable (qwen35/Ornith, lfm2, gemma2, bitnet, command-r) and DiffusionGemma lanes short-circuit at `src/api/mod.rs:18011/18063/18077` **before** logprobs validation, so `logprobs:true` returns 200 with the key simply absent. Routing is per HOST, not per architecture: a Q8_0 gemma3 takes the runnable bridge on Windows/CUDA but the Metal resident lane on macOS, where it DOES report logprobs (measured — see the macOS verification comment). The panel reports that as an unmeasured position — never as a flat or certain distribution — and distinguishes it from a proxy forcing SSE. Filed as an engine defect in `BACKEND_ASKS.md` §6; this PR does not attempt the Rust fix.

## Encoding

No new colour tokens. Copper and amber stay reserved for claim colours, and red stays for errors — a low-probability token is a normal state. Probability rides an **underline weight** rather than text colour, so the audited body-text contrast pair is untouched and the encoding survives greyscale; the exact value is always present as text. The salience budget is inverted on purpose: settled tokens are unmarked, so ink goes to the contested minority.

## Drive-by fixes, found by a new gate

A generic tab-registry assertion added here caught real drift, none of it visible in a screenshot:

- `arena` missing from `TopBar` `TITLES` → header rendered "Camelid"
- `arena` and `downloads` missing from `CommandPalette` `VIEW_LABELS` → unreachable from Cmd+K
- `observatory` missing from `VALID_TABS` → tab dropped on reload

Fixed here because the gate cannot ship red. Also wires `npm run smoke:contrast` into CI — it has existed since the design-token work and **never ran there**, so palette changes have been shipping unaudited.

## Verification

- `smoke:token-inspector` — 33 checks, new, wired into the `frontend` job
- `smoke:contrast` — 258 token/fill pairs pass WCAG AA in both themes
- `smoke:ui`, `smoke:streaming`, `smoke:integration`, `smoke:workspace`, `smoke:model-state`, `smoke:model-lanes`, `smoke:first-run`, `smoke:first-run-card`, `smoke:capability-readiness`, `smoke:arena` — all exit 0
- `check-public-scrub.sh` — clean
- Driven end-to-end in the browser in both themes; storage claim confirmed live (5 inspections captured, 0 logprobs keys in `localStorage`)
- Re-verified on macOS/Metal (M4) against a release build of this head — engine contract, panel, both themes, storage claim, and the fails-open lane all reproduce; full record in the comment below

The smoke normalizes against the repo's own committed wire capture (`qa/capability/mac_logprobs_out/llama-3.2-1b/chat_logprobs.json`) rather than a hand-written fixture, so it fails if the engine's shape drifts. It also asserts that a `=== null` presence test *would* misread the key-absent body, that no rendered state uses certainty vocabulary, and that the vendor name in the `rich_logprobs` notes never reaches the screen.

## Not included

- Streaming logprobs — filed as `BACKEND_ASKS.md` §5. Would collapse the pre-send decision into an ordinary disclosure.
- The Rust fails-open fix — reported in §6, left to the engine.

