### PR TITLE
feat(frontend): structured output studio with observed mask evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,6 +563,10 @@ jobs:
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:ui
 
+      - name: Structured output smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: npm run smoke:structured-output
+
       - name: Token inspector smoke
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:token-inspector

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "smoke:catalog-companion": "node scripts/catalog-companion-smoke.mjs",
     "smoke:model-deletion": "node scripts/model-deletion-smoke.mjs",
     "smoke:3b-closure": "node scripts/frontend-3b-closure-smoke.mjs",
+    "smoke:structured-output": "node scripts/structured-output-smoke.mjs",
     "smoke:token-inspector": "node scripts/token-inspector-smoke.mjs",
     "smoke:ui": "node scripts/ui-regression-smoke.mjs",
     "smoke:ghost-moe-execution": "node scripts/ghost-moe-execution-plan-smoke.mjs",

--- a/frontend/scripts/structured-output-smoke.mjs
+++ b/frontend/scripts/structured-output-smoke.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/* Structured output — contract, request composition, and the honesty of the verdict.
+ *
+ * The defect this surface is most likely to ship is a claim, not a crash. A
+ * constrained response is byte-for-byte the same SHAPE as an unconstrained one:
+ * no field, flag, header or finish_reason says a mask was applied. So a panel that
+ * renders "constrained" on the strength of a 200 is asserting something it cannot
+ * see, and it would look completely correct in a screenshot.
+ *
+ * Three classes of assertion here:
+ *
+ *   1. THE REQUEST CANNOT BE AMBIGUOUS. The engine returns a typed 400 when two
+ *      constraint forms arrive together, and another when a constraint arrives
+ *      with stream:true — and its streaming decoder never builds a grammar state,
+ *      so that route refusal is the only thing between a streamed constrained
+ *      request and silently unconstrained output. The builder is asserted to be
+ *      structurally incapable of composing either.
+ *
+ *   2. THE VERDICT NEVER OUTRUNS THE EVIDENCE. Only an observed diverted position
+ *      on a greedy turn earns the strong claim. Conformance is explicitly weaker,
+ *      because an unconstrained model can emit valid JSON by luck.
+ *
+ *   3. THE VALIDATOR ADMITS WHAT IT DID NOT CHECK. This is not a JSON Schema
+ *      implementation; silently skipping unimplemented keywords would report
+ *      "valid" for a document it never examined.
+ *
+ * SSR component test — no browser, no dist build required.
+ */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+
+let checks = 0
+function check(label, fn) {
+  fn()
+  checks += 1
+  console.log(`  ok  ${label}`)
+}
+
+const VENDOR = ['Open', 'AI'].join('')
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const mod = await server.ssrLoadModule('/src/lib/structuredOutput.js')
+  const { StructuredOutputCard } = await server.ssrLoadModule('/src/components/chat/render/StructuredOutput.jsx')
+  const {
+    STRUCTURED_MODES,
+    DEFAULT_SCHEMA,
+    readStructuredOutputContract,
+    structuredOutputRequestFields,
+    structuredOutputForcesNonStreaming,
+    structuredOutputReadiness,
+    assessStructuredReply,
+    parseSchemaText,
+  } = mod
+
+  const live = {
+    api_features: [{
+      id: 'llguidance_structured_outputs',
+      status: 'supported_current_gate_nonstreaming',
+      notes: `Constrained decoding for ${VENDOR}-shaped response_format requests.`,
+    }],
+    api_conformance: [{
+      id: 'llguidance_structured_outputs',
+      status: 'supported_current_gate_nonstreaming',
+      supported_modes: ['chat_nonstreaming', 'responses_nonstreaming'],
+      unsupported_modes: ['streaming', 'raw_completions'],
+    }],
+  }
+
+  console.log('structured output — contract gating')
+
+  check('a live contract permits non-streaming constrained decoding', () => {
+    const contract = readStructuredOutputContract(live)
+    assert.equal(contract.present, true)
+    assert.equal(contract.supported, true)
+    assert.equal(contract.nonStreamingSupported, true)
+  })
+
+  check('an engine with no row fails closed and contributes no request fields', () => {
+    const contract = readStructuredOutputContract({})
+    assert.equal(contract.nonStreamingSupported, false)
+    assert.deepEqual(
+      structuredOutputRequestFields({ enabled: true, mode: STRUCTURED_MODES.JSON_OBJECT, contract }),
+      {},
+    )
+  })
+
+  check('a supported row with no machine-readable modes stays closed', () => {
+    const contract = readStructuredOutputContract({ api_features: live.api_features })
+    assert.equal(contract.supported, true)
+    assert.equal(contract.modesKnown, false)
+    assert.equal(contract.nonStreamingSupported, false, 'unknown modes must not be assumed permissive')
+  })
+
+  check('resemblance is not evidence — a near-miss row id does not count', () => {
+    const contract = readStructuredOutputContract({
+      api_conformance: [{ id: 'llguidance_structured_outputs_v2', status: 'supported', supported_modes: ['chat_nonstreaming'] }],
+    })
+    assert.equal(contract.present, false)
+  })
+
+  console.log('structured output — the request cannot be ambiguous')
+
+  const contract = readStructuredOutputContract(live)
+
+  check('exactly one constraint form is ever emitted', () => {
+    for (const mode of [STRUCTURED_MODES.JSON_OBJECT, STRUCTURED_MODES.JSON_SCHEMA, STRUCTURED_MODES.GRAMMAR]) {
+      const fields = structuredOutputRequestFields({
+        enabled: true, mode, contract, schemaText: DEFAULT_SCHEMA, grammarText: 'start: "x"',
+      })
+      const keys = Object.keys(fields)
+      assert.deepEqual(keys, ['response_format'], `mode ${mode} emitted ${keys.join(', ')}`)
+      // The engine 400s on response_format + top-level json_schema/grammar together.
+      assert.ok(!('json_schema' in fields), 'top-level json_schema must never ride along')
+      assert.ok(!('grammar' in fields), 'top-level grammar must never ride along')
+    }
+  })
+
+  check('the json_schema envelope is the nested chat shape, not the raw schema', () => {
+    const fields = structuredOutputRequestFields({
+      enabled: true, mode: STRUCTURED_MODES.JSON_SCHEMA, contract, schemaText: DEFAULT_SCHEMA,
+    })
+    // Three different locations exist for this object across routes; the wrong one
+    // is a 400 with no hint.
+    assert.equal(fields.response_format.type, 'json_schema')
+    assert.ok(fields.response_format.json_schema.schema.properties, 'schema must sit at response_format.json_schema.schema')
+  })
+
+  check('an unparseable schema produces no constraint rather than a bad one', () => {
+    assert.deepEqual(
+      structuredOutputRequestFields({ enabled: true, mode: STRUCTURED_MODES.JSON_SCHEMA, contract, schemaText: '{ not json' }),
+      {},
+    )
+    assert.equal(parseSchemaText('{ not json').ok, false)
+    assert.equal(parseSchemaText('[1,2]').ok, false, 'a schema must be an object, not an array')
+  })
+
+  check('a constraint forces the turn off the streaming path', () => {
+    assert.equal(structuredOutputForcesNonStreaming({ enabled: true, mode: STRUCTURED_MODES.JSON_SCHEMA, contract }), true)
+    assert.equal(structuredOutputForcesNonStreaming({ enabled: true, mode: STRUCTURED_MODES.OFF, contract }), false)
+    // Guarded contract must NOT flip the stream flag — that would cost streaming
+    // for no constraint at all.
+    assert.equal(
+      structuredOutputForcesNonStreaming({ enabled: true, mode: STRUCTURED_MODES.JSON_SCHEMA, contract: readStructuredOutputContract({}) }),
+      false,
+    )
+  })
+
+  check('readiness explains a blocked send rather than sending unconstrained', () => {
+    assert.equal(structuredOutputReadiness({ enabled: true, mode: STRUCTURED_MODES.JSON_SCHEMA, contract, schemaText: DEFAULT_SCHEMA }).ready, true)
+    const bad = structuredOutputReadiness({ enabled: true, mode: STRUCTURED_MODES.JSON_SCHEMA, contract, schemaText: '{ nope' })
+    assert.equal(bad.ready, false)
+    assert.match(bad.reason, /valid JSON/i)
+    const noRow = structuredOutputReadiness({ enabled: true, mode: STRUCTURED_MODES.JSON_OBJECT, contract: readStructuredOutputContract({}) })
+    assert.equal(noRow.ready, false)
+    assert.match(noRow.reason, /does not advertise/i)
+  })
+
+  console.log('structured output — the verdict never outruns the evidence')
+
+  const conforming = '{"title":"t","sentiment":"positive","score":4,"tags":["a"]}'
+
+  check('a 200 with no observed divergence claims only that it was accepted', () => {
+    const a = assessStructuredReply({ content: 'plain prose', mode: STRUCTURED_MODES.JSON_OBJECT, divertedPositions: null })
+    assert.equal(a.evidence, 'accepted')
+    assert.equal(a.parses, false)
+  })
+
+  check('conforming output is explicitly weaker than observed divergence', () => {
+    const conforms = assessStructuredReply({ content: conforming, mode: STRUCTURED_MODES.JSON_SCHEMA, schemaText: DEFAULT_SCHEMA, divertedPositions: 0 })
+    assert.equal(conforms.evidence, 'conforms')
+    const diverted = assessStructuredReply({ content: conforming, mode: STRUCTURED_MODES.JSON_SCHEMA, schemaText: DEFAULT_SCHEMA, divertedPositions: 3 })
+    assert.equal(diverted.evidence, 'diverted', 'an observed diverted position is the stronger claim')
+  })
+
+  check('divergence on a SAMPLED turn does not earn the strong claim', () => {
+    // Off-argmax emission is only mask evidence when decoding was greedy; a
+    // sampled turn produces it routinely.
+    const sampled = assessStructuredReply({ content: conforming, mode: STRUCTURED_MODES.JSON_SCHEMA, schemaText: DEFAULT_SCHEMA, divertedPositions: 3, greedy: false })
+    assert.notEqual(sampled.evidence, 'diverted')
+  })
+
+  check('schema problems are reported, not swallowed', () => {
+    const wrong = assessStructuredReply({
+      content: '{"title":"t","sentiment":"ecstatic","score":"four","tags":"a"}',
+      mode: STRUCTURED_MODES.JSON_SCHEMA,
+      schemaText: DEFAULT_SCHEMA,
+      divertedPositions: 0,
+    })
+    assert.equal(wrong.parses, true)
+    assert.ok(wrong.problems.length >= 3, `expected enum, integer and array problems, got ${JSON.stringify(wrong.problems)}`)
+    assert.ok(wrong.problems.some((p) => /sentiment/.test(p)), 'the enum violation must be named')
+    assert.notEqual(wrong.evidence, 'conforms', 'a reply with schema problems must not read as conforming')
+  })
+
+  console.log('structured output — rendered copy')
+
+  const render = (record) => renderToStaticMarkup(React.createElement(StructuredOutputCard, { record }))
+
+  check('the card never asserts enforcement it cannot observe', () => {
+    const html = render({ content: conforming, mode: STRUCTURED_MODES.JSON_SCHEMA, schemaText: DEFAULT_SCHEMA, divertedPositions: 0 })
+    assert.match(html, /Matches the schema/)
+    // The words that would overclaim from a 200 alone.
+    assert.doesNotMatch(html, /\bguarantee/i)
+    assert.doesNotMatch(html, /\benforced\b/i)
+    assert.doesNotMatch(html, /\bproves\b/i)
+    assert.match(html, /not proof/i, 'the weaker verdict must say what it is not')
+  })
+
+  check('the vendor name never reaches the screen', () => {
+    const html = render({ content: conforming, mode: STRUCTURED_MODES.JSON_SCHEMA, schemaText: DEFAULT_SCHEMA, divertedPositions: 2 })
+    assert.doesNotMatch(html, new RegExp(`\\b${VENDOR}\\b`))
+  })
+
+  check('unchecked schema keywords are disclosed', () => {
+    const html = render({
+      content: '{"a":1}',
+      mode: STRUCTURED_MODES.JSON_SCHEMA,
+      schemaText: '{"type":"object","properties":{"a":{"minimum":0}}}',
+      divertedPositions: 0,
+    })
+    assert.match(html, /Not checked here/i, 'a keyword this page does not implement must be named, not silently passed')
+  })
+
+  check('nothing renders without a record', () => {
+    assert.equal(renderToStaticMarkup(React.createElement(StructuredOutputCard, { record: null })), '')
+  })
+
+  console.log('structured output — source-level guarantees')
+
+  check('the lib module never composes two constraint forms', () => {
+    const source = readFileSync(resolve(frontendRoot, 'src/lib/structuredOutput.js'), 'utf8')
+    // Each builder branch returns immediately; a fallthrough that merged two
+    // forms would be a 400 on every send.
+    const returns = source.match(/return \{ response_format:/g) || []
+    assert.ok(returns.length >= 3, 'each mode returns its own single-key object')
+    assert.doesNotMatch(source, /localStorage|sessionStorage|indexedDB/, 'schemas are session state, not persisted')
+  })
+
+  console.log(`\n${checks} checks passed`)
+} finally {
+  await server.close()
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -85,6 +85,8 @@ function App() {
     selectedModelId, setSelectedModelId, search, setSearch, memorySearch, setMemorySearch,
     composer, setComposer, newChatTitle, setNewChatTitle, sending, receiptMode, setReceiptMode,
     inspectMode, setInspectMode, tokenInspections, inspectionSupported,
+    structuredMode, setStructuredMode, structuredSchema, setStructuredSchema,
+    structuredGrammar, setStructuredGrammar, structuredRecords, structuredSupported, structuredReadiness,
     thinkingMode, setThinkingMode,
     webResearchEnabled, setWebResearchEnabled, webResearchStatus,
     loadingModelId, registerForm, setRegisterForm,
@@ -425,6 +427,15 @@ function App() {
               setInspectMode={setInspectMode}
               tokenInspections={tokenInspections}
               inspectionSupported={inspectionSupported}
+              structuredMode={structuredMode}
+              setStructuredMode={setStructuredMode}
+              structuredSchema={structuredSchema}
+              setStructuredSchema={setStructuredSchema}
+              structuredGrammar={structuredGrammar}
+              setStructuredGrammar={setStructuredGrammar}
+              structuredRecords={structuredRecords}
+              structuredSupported={structuredSupported}
+              structuredReadiness={structuredReadiness}
               thinkingMode={thinkingMode}
               setThinkingMode={setThinkingMode}
               webResearchEnabled={webResearchEnabled}

--- a/frontend/src/components/chat/MessageTurn.jsx
+++ b/frontend/src/components/chat/MessageTurn.jsx
@@ -14,6 +14,7 @@ import {
 import { ParityReceiptCard } from './render/ParityReceipt'
 import { DeveloperDiagnosticsBlock } from './render/Diagnostics'
 import { TokenInspectorCard } from './render/TokenInspector'
+import { StructuredOutputCard } from './render/StructuredOutput'
 
 const formatMs = (value) => {
   const ms = Number(value)
@@ -256,7 +257,7 @@ function UserTurn({ message, messageContent, onEditResend }) {
   )
 }
 
-export const MessageTurn = memo(function MessageTurn({ message, generationElapsedSeconds, priorUserPrompt, onReusePrompt, onRegenerate, onEditResend, tokenInspection = null }) {
+export const MessageTurn = memo(function MessageTurn({ message, generationElapsedSeconds, priorUserPrompt, onReusePrompt, onRegenerate, onEditResend, tokenInspection = null, structuredRecord = null }) {
   const [copied, setCopied] = useState(false)
   const copiedResetRef = useRef(null)
   const messageContent = cleanLegacyDemoCapCopy(message.content)
@@ -385,6 +386,9 @@ export const MessageTurn = memo(function MessageTurn({ message, generationElapse
 
         {message.role === 'assistant' && !assistantStreaming && message.camelid_receipt && (
           <ParityReceiptCard receipt={message.camelid_receipt} />
+        )}
+        {message.role === 'assistant' && !assistantStreaming && structuredRecord && (
+          <StructuredOutputCard record={structuredRecord} />
         )}
         {message.role === 'assistant' && !assistantStreaming && tokenInspection && (
           <TokenInspectorCard

--- a/frontend/src/components/chat/render/StructuredOutput.jsx
+++ b/frontend/src/components/chat/render/StructuredOutput.jsx
@@ -1,0 +1,100 @@
+import { useMemo, useState } from 'react'
+import { EVIDENCE_COPY, assessStructuredReply } from '../../../lib/structuredOutput'
+
+/* Structured-output card — what a constrained reply actually demonstrates.
+
+   Self-gating like the parity receipt and the token inspector beside it.
+
+   COPY RULE. The engine returns no field saying a constraint was applied, so this
+   card must never render "constrained" on the strength of a 200. It reports the
+   strongest thing it can actually see, in this order:
+
+     Mask observed   an emitted token was not the highest-scoring one on a greedy
+                     turn — the returned scores are unmasked, so the constraint
+                     demonstrably moved the decode
+     Matches schema  parsed and satisfied every keyword this page checks
+     Parsed          valid JSON, nothing shown about the constraint
+     Accepted        the request was accepted; that is all
+
+   The first is evidence. The rest are consistent-with, and say so. */
+
+function Row({ label, children }) {
+  return (
+    <div className="structout__row">
+      <dt>{label}</dt>
+      <dd>{children}</dd>
+    </div>
+  )
+}
+
+export function StructuredOutputCard({ record }) {
+  const [showRaw, setShowRaw] = useState(false)
+  const assessment = useMemo(() => (record ? assessStructuredReply(record) : null), [record])
+  if (!assessment) return null
+
+  const copy = EVIDENCE_COPY[assessment.evidence] || EVIDENCE_COPY.accepted
+  const isJsonMode = assessment.mode === 'json_object' || assessment.mode === 'json_schema'
+
+  return (
+    <div className="structout">
+      <div className="structout__head">
+        <span className="structout__label">Structured output</span>
+        <span className={`structout__verdict structout__verdict--${assessment.evidence}`}>{copy.label}</span>
+      </div>
+      <p className="structout__detail">{copy.detail}</p>
+
+      <dl className="structout__rows">
+        <Row label="Constraint">
+          {assessment.mode === 'grammar' ? 'Lark grammar' : assessment.mode === 'json_schema' ? 'JSON schema' : 'JSON object'}
+        </Row>
+        {isJsonMode && (
+          <Row label="Parses">
+            {assessment.parses ? 'yes' : `no — ${assessment.parseError}`}
+          </Row>
+        )}
+        {assessment.schemaChecked && (
+          <Row label="Schema">
+            {assessment.problems.length === 0
+              ? 'every checked keyword satisfied'
+              : `${assessment.problems.length} problem${assessment.problems.length === 1 ? '' : 's'}`}
+          </Row>
+        )}
+        {assessment.diverted !== null && (
+          <Row label="Diverted positions">{assessment.diverted}</Row>
+        )}
+      </dl>
+
+      {assessment.problems.length > 0 && (
+        <ul className="structout__problems">
+          {assessment.problems.slice(0, 8).map((problem) => (
+            <li key={problem}>{problem}</li>
+          ))}
+        </ul>
+      )}
+
+      {/* Naming what was NOT examined is the point: a validator that quietly
+          skipped the keywords it does not implement would report "valid" for a
+          document it never checked. */}
+      {assessment.unchecked.length > 0 && (
+        <p className="structout__unchecked">
+          Not checked here: {assessment.unchecked.slice(0, 6).join(', ')}
+          {assessment.unchecked.length > 6 ? ` and ${assessment.unchecked.length - 6} more` : ''} — this page checks
+          types, required keys and enums only, not the full schema dialect.
+        </p>
+      )}
+
+      {assessment.parses && (
+        <>
+          <button type="button" className="structout__toggle" onClick={() => setShowRaw((v) => !v)} aria-expanded={showRaw}>
+            {showRaw ? 'Hide parsed value' : 'Show parsed value'}
+          </button>
+          {showRaw && (
+            <pre className="structout__json">{JSON.stringify(assessment.parsed, null, 2)}</pre>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+export default StructuredOutputCard

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -18,7 +18,8 @@ import {
 } from '../lib/conversationCompaction.js'
 import { getRuntimeRequestModelId, isExternalModel, modelRuntimeIdMatches } from '../lib/modelState'
 import { contractSamplingOverrides } from '../lib/samplingContract'
-import { inspectionAbsenceReason, inspectionForcesNonStreaming, inspectionRequestFields, readInspectionContract } from '../lib/tokenInspection'
+import { inspectionAbsenceReason, inspectionForcesNonStreaming, inspectionRequestFields, normalizeInspection, readInspectionContract } from '../lib/tokenInspection'
+import { STRUCTURED_MODES, DEFAULT_SCHEMA, DEFAULT_GRAMMAR, readStructuredOutputContract, structuredOutputForcesNonStreaming, structuredOutputRequestFields, structuredOutputReadiness } from '../lib/structuredOutput'
 import { executionRuntimeFields } from '../lib/executionPlan'
 import {
   createPacerState,
@@ -721,6 +722,13 @@ export function useDashboardData({ showNotice, clearNotice }) {
      conversation rather than just this record. Session-scoped by design; the
      panel says so and offers a download. */
   const [inspectMode, setInspectMode] = useState(false)
+  /* Constrained decoding is a per-turn choice like inspection, and for the same
+     reason: the engine refuses a constraint on a streaming request, so the turn
+     has to be composed non-streaming before it is sent. */
+  const [structuredMode, setStructuredMode] = useState(STRUCTURED_MODES.OFF)
+  const [structuredSchema, setStructuredSchema] = useState(DEFAULT_SCHEMA)
+  const [structuredGrammar, setStructuredGrammar] = useState(DEFAULT_GRAMMAR)
+  const [structuredRecords, setStructuredRecords] = useState({})
   const [tokenInspections, setTokenInspections] = useState({})
   // Opt-in thinking mode (experimental — NOT parity-locked): sends
   // camelid_enable_thinking:true so the model emits its own <think>…</think>
@@ -1073,6 +1081,15 @@ export function useDashboardData({ showNotice, clearNotice }) {
      silently recording nothing — a toggle that reads "on" while contributing no
      request fields is exactly the caveated-live surface I3 forbids. */
   const inspectionSupported = readInspectionContract(dashboard?.capabilities).nonStreamingSupported
+  const structuredContract = readStructuredOutputContract(dashboard?.capabilities)
+  const structuredSupported = structuredContract.nonStreamingSupported
+  const structuredReadiness = structuredOutputReadiness({
+    enabled: structuredMode !== STRUCTURED_MODES.OFF,
+    mode: structuredMode,
+    contract: structuredContract,
+    schemaText: structuredSchema,
+    grammarText: structuredGrammar,
+  })
   const selectedModelRunnable = selectedModelChatGate.chatUnlocked
   // Experimental lane: loaded + generation-ready implemented model that is NOT a
   // supported row. Enables a weaker chat affordance; never the supported badge.
@@ -1620,6 +1637,15 @@ export function useDashboardData({ showNotice, clearNotice }) {
       const inspectionContract = readInspectionContract(dashboard?.capabilities)
       const inspecting = !targetVerifiedRender
         && inspectionForcesNonStreaming({ enabled: inspectMode, contract: inspectionContract })
+      /* A constraint and stream:true is a hard 400, and the streaming decode job
+         never builds a grammar state — that route refusal is the only thing
+         standing between a streamed constrained request and silently
+         unconstrained output. Derived from one predicate with the request fields
+         so the two cannot drift. */
+      const sendStructuredContract = readStructuredOutputContract(dashboard?.capabilities)
+      const constraining = !targetVerifiedRender
+        && structuredOutputForcesNonStreaming({ enabled: true, mode: structuredMode, contract: sendStructuredContract })
+        && structuredOutputReadiness({ enabled: true, mode: structuredMode, contract: sendStructuredContract, schemaText: structuredSchema, grammarText: structuredGrammar }).ready
       const baseRequestBody = {
         model: requestModelId,
         messages: requestMessages,
@@ -1725,18 +1751,19 @@ export function useDashboardData({ showNotice, clearNotice }) {
           // stream:true, so `inspecting` MUST also clear the stream flag — the
           // two conditions are derived from one source in tokenInspection.js
           // rather than restated, so they cannot drift apart.
-          stream: targetVerifiedRender || !(receiptMode || inspecting),
+          stream: targetVerifiedRender || !(receiptMode || inspecting || constraining),
           // Ask for the authoritative token count in the final stream chunk.
           // Without it the client can only ESTIMATE from visible content, which
           // undercounts badly on a thinking model: LFM2 emits its reasoning as
           // `reasoning_content`, so a reply that is mostly reasoning looked like
           // almost no tokens and the tok/s readout reported a fraction of the
           // real rate.
-          ...(targetVerifiedRender || !(receiptMode || inspecting) ? { stream_options: { include_usage: true } } : {}),
+          ...(targetVerifiedRender || !(receiptMode || inspecting || constraining) ? { stream_options: { include_usage: true } } : {}),
           ...(!targetVerifiedRender && receiptMode ? { camelid_receipt: true } : {}),
           /* Contributes nothing unless the contract permits inspection on this
              engine, so a guarded row simply never reaches the wire. */
           ...(targetVerifiedRender ? {} : inspectionRequestFields({ enabled: inspectMode, contract: inspectionContract })),
+          ...(targetVerifiedRender ? {} : structuredOutputRequestFields({ enabled: true, mode: structuredMode, contract: sendStructuredContract, schemaText: structuredSchema, grammarText: structuredGrammar })),
           ...(targetVerifiedRender ? {
             // The private verifier contract is exact: its output allowance is
             // the complete fresh draft, not the planner's larger upper bound.
@@ -1969,6 +1996,24 @@ export function useDashboardData({ showNotice, clearNotice }) {
         setTokenInspections((current) => ({
           ...current,
           [assistantId]: { logprobs: streamed.logprobs || null, absence },
+        }))
+      }
+      /* The strongest evidence a constrained reply can carry is a position whose
+         emitted token was not the highest-scoring one — the returned scores are
+         unmasked, so that is the mask visibly diverting the decode. It is only
+         available when token inspection was ALSO requested, which is why the
+         composer says so rather than the card inventing a weaker claim. */
+      if (constraining) {
+        const record = normalizeInspection(streamed.logprobs || null)
+        setStructuredRecords((current) => ({
+          ...current,
+          [assistantId]: {
+            content: streamed.content || '',
+            mode: structuredMode,
+            schemaText: structuredSchema,
+            divertedPositions: record ? record.stats.offTopCount : null,
+            greedy: !useExperimentalSampling,
+          },
         }))
       }
       const assistantMessage = {
@@ -2499,6 +2544,15 @@ export function useDashboardData({ showNotice, clearNotice }) {
     setInspectMode,
     tokenInspections,
     inspectionSupported,
+    structuredMode,
+    setStructuredMode,
+    structuredSchema,
+    setStructuredSchema,
+    structuredGrammar,
+    setStructuredGrammar,
+    structuredRecords,
+    structuredSupported,
+    structuredReadiness,
     thinkingMode,
     setThinkingMode,
     loadingModelId,

--- a/frontend/src/lib/structuredOutput.js
+++ b/frontend/src/lib/structuredOutput.js
@@ -1,0 +1,284 @@
+/* Structured-output contract lane.
+
+   The engine can constrain decoding to a JSON schema or a Lark grammar, masking
+   the token distribution at every step so the reply cannot leave the grammar.
+   This module owns every decision about that: whether the contract permits it,
+   which of the mutually-exclusive request forms to send, and — the hard part —
+   what may honestly be claimed about a reply that came back.
+
+   THE CENTRAL PROBLEM. A constrained response is byte-for-byte the same SHAPE as
+   an unconstrained one. There is no field, flag, header or finish_reason
+   asserting that a constraint was compiled or applied. So a 200 proves the
+   request was accepted, and nothing more. Any surface that renders "constrained"
+   on the strength of a 200 is asserting something it cannot see.
+
+   What CAN be shown, in descending order of strength:
+
+     1. DIVERTED TOKENS. The mask is applied to a clone of the logits, and the
+        raw distribution is what gets returned. So with `logprobs:true` on a
+        greedy turn, a position whose emitted token is NOT the argmax of its own
+        top-N is direct evidence the mask moved the decode — the model wanted
+        something else and was not allowed it. This is observed, not asserted.
+     2. SCHEMA CONFORMANCE. The reply parses, and validates against the schema
+        the user submitted. Necessary but not sufficient: an unconstrained model
+        can emit valid JSON by luck.
+     3. THE NEGATIVE-SPACE GUARANTEE. Every path that could silently drop a
+        constraint is a typed refusal before generation — an ambiguous request
+        form, an uncompilable schema, a lane that cannot enforce, and streaming.
+        So a 200 means no such path was taken. Worth stating; not proof of a mask.
+
+   Copy in this lane says which of those it is standing on, and never rounds 2 up
+   to 1. */
+
+import { isSupportedCapabilityStatus, displayCapabilityCopy } from './capabilities.js'
+
+const ROW_ID = 'llguidance_structured_outputs'
+
+export const STRUCTURED_MODES = {
+  OFF: 'off',
+  JSON_OBJECT: 'json_object',
+  JSON_SCHEMA: 'json_schema',
+  GRAMMAR: 'grammar',
+}
+
+/* A schema that exercises the interesting cases — required keys, an enum, a
+   bounded number, a nested array — so the first run shows the mask doing real
+   work rather than agreeing with the model. */
+export const DEFAULT_SCHEMA = `{
+  "type": "object",
+  "properties": {
+    "title": { "type": "string" },
+    "sentiment": { "type": "string", "enum": ["positive", "neutral", "negative"] },
+    "score": { "type": "integer" },
+    "tags": { "type": "array", "items": { "type": "string" } }
+  },
+  "required": ["title", "sentiment", "score", "tags"]
+}`
+
+export const DEFAULT_GRAMMAR = `start: answer
+answer: "YES" | "NO" | "MAYBE"`
+
+function findRow(rows, id) {
+  return (rows || []).find((row) => row?.id === id) || null
+}
+
+/* Resolve the contract by EXACT row id.
+
+   `api_conformance` is preferred for two reasons: it carries the machine-readable
+   mode lists, and its projection ships no `notes` string — so it cannot smuggle a
+   vendor name into rendered copy. `api_features` is the fallback for an engine
+   that predates the conformance array; there the modes are unknown, and unknown
+   fails closed. */
+export function readStructuredOutputContract(capabilities) {
+  const conformance = findRow(capabilities?.api_conformance, ROW_ID)
+  const feature = findRow(capabilities?.api_features, ROW_ID)
+  const row = conformance || feature
+  if (!row) {
+    return {
+      present: false,
+      supported: false,
+      modesKnown: false,
+      nonStreamingSupported: false,
+      rowId: ROW_ID,
+      status: null,
+      note: null,
+    }
+  }
+  const supported = isSupportedCapabilityStatus(String(row.status || ''))
+  const modesKnown = Array.isArray(conformance?.supported_modes)
+  const supportedModes = modesKnown ? conformance.supported_modes : []
+  return {
+    present: true,
+    supported,
+    modesKnown,
+    nonStreamingSupported: supported && modesKnown && supportedModes.includes('chat_nonstreaming'),
+    rowId: ROW_ID,
+    status: row.status || null,
+    note: feature?.notes ? displayCapabilityCopy(feature.notes) : null,
+  }
+}
+
+export function parseSchemaText(schemaText) {
+  const text = String(schemaText || '').trim()
+  if (!text) return { ok: false, error: 'Enter a JSON schema.', value: null }
+  let value
+  try {
+    value = JSON.parse(text)
+  } catch (error) {
+    return { ok: false, error: `Not valid JSON: ${error.message}`, value: null }
+  }
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return { ok: false, error: 'A JSON schema must be an object.', value: null }
+  }
+  return { ok: true, error: null, value }
+}
+
+/* Build the request fields for exactly ONE constraint form.
+
+   The engine refuses an ambiguous request — two constraint forms in one body is a
+   typed 400 before generation — so this returns at most one key and never
+   composes them. It returns {} whenever the mode is off or the contract does not
+   permit constrained decoding, so a caller can spread it unconditionally. */
+export function structuredOutputRequestFields({ enabled, mode, contract, schemaText, grammarText } = {}) {
+  if (!enabled || mode === STRUCTURED_MODES.OFF) return {}
+  if (!contract?.nonStreamingSupported) return {}
+  if (mode === STRUCTURED_MODES.JSON_OBJECT) {
+    return { response_format: { type: 'json_object' } }
+  }
+  if (mode === STRUCTURED_MODES.JSON_SCHEMA) {
+    const parsed = parseSchemaText(schemaText)
+    if (!parsed.ok) return {}
+    /* The nested `json_schema.schema` envelope is the chat shape. The top-level
+       llama.cpp `json_schema` field takes a RAW schema, and the Responses route
+       uses `text.format.schema` — three different locations for the same object,
+       and sending the wrong one is a 400 with no hint. */
+    return { response_format: { type: 'json_schema', json_schema: { schema: parsed.value } } }
+  }
+  if (mode === STRUCTURED_MODES.GRAMMAR) {
+    const grammar = String(grammarText || '').trim()
+    if (!grammar) return {}
+    return { response_format: { type: 'grammar', grammar } }
+  }
+  return {}
+}
+
+/* A constraint and stream:true is a hard 400, and the streaming decode job never
+   builds a grammar state at all — that route-level refusal is the ONLY thing
+   standing between a streamed constrained request and silently unconstrained
+   output. Derived from one predicate so the stream flag and the constraint fields
+   cannot drift apart. */
+export function structuredOutputForcesNonStreaming({ enabled, mode, contract } = {}) {
+  return Boolean(enabled && mode !== STRUCTURED_MODES.OFF && contract?.nonStreamingSupported)
+}
+
+/* Whether the composed request is actually sendable, and if not, why — so the
+   composer can explain rather than silently sending an unconstrained turn. */
+export function structuredOutputReadiness({ enabled, mode, contract, schemaText, grammarText } = {}) {
+  if (!enabled || mode === STRUCTURED_MODES.OFF) return { ready: false, reason: null }
+  if (!contract?.present) {
+    return { ready: false, reason: 'This engine does not advertise constrained decoding.' }
+  }
+  if (!contract.nonStreamingSupported) {
+    return { ready: false, reason: 'This engine advertises constrained decoding but does not describe a supported non-streaming mode for it.' }
+  }
+  if (mode === STRUCTURED_MODES.JSON_SCHEMA) {
+    const parsed = parseSchemaText(schemaText)
+    if (!parsed.ok) return { ready: false, reason: parsed.error }
+  }
+  if (mode === STRUCTURED_MODES.GRAMMAR && !String(grammarText || '').trim()) {
+    return { ready: false, reason: 'Enter a grammar.' }
+  }
+  return { ready: true, reason: null }
+}
+
+/* Minimal structural validation of a reply against the submitted schema.
+
+   Deliberately NOT a JSON Schema implementation — it checks the handful of
+   keywords the default schema uses and reports everything else as unchecked. A
+   validator that silently ignored the keywords it does not implement would report
+   "valid" for a document it never examined, which is the same class of lie this
+   whole surface exists to avoid. */
+function validateAgainstSchema(value, schema, path = '$') {
+  const problems = []
+  const unchecked = []
+  const type = schema?.type
+  const typeOf = (v) => (Array.isArray(v) ? 'array' : v === null ? 'null' : typeof v)
+  if (type === 'object') {
+    if (typeOf(value) !== 'object') return { problems: [`${path} should be an object, got ${typeOf(value)}`], unchecked }
+    for (const key of schema.required || []) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) problems.push(`${path}.${key} is required but missing`)
+    }
+    for (const [key, sub] of Object.entries(schema.properties || {})) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) continue
+      const nested = validateAgainstSchema(value[key], sub, `${path}.${key}`)
+      problems.push(...nested.problems)
+      unchecked.push(...nested.unchecked)
+    }
+    return { problems, unchecked }
+  }
+  if (type === 'array') {
+    if (!Array.isArray(value)) return { problems: [`${path} should be an array, got ${typeOf(value)}`], unchecked }
+    value.forEach((item, index) => {
+      if (!schema.items) return
+      const nested = validateAgainstSchema(item, schema.items, `${path}[${index}]`)
+      problems.push(...nested.problems)
+      unchecked.push(...nested.unchecked)
+    })
+    return { problems, unchecked }
+  }
+  if (Array.isArray(schema?.enum)) {
+    if (!schema.enum.includes(value)) problems.push(`${path} should be one of ${schema.enum.join(', ')}, got ${JSON.stringify(value)}`)
+    return { problems, unchecked }
+  }
+  if (type === 'string' && typeOf(value) !== 'string') problems.push(`${path} should be a string, got ${typeOf(value)}`)
+  else if (type === 'integer' && !Number.isInteger(value)) problems.push(`${path} should be an integer, got ${JSON.stringify(value)}`)
+  else if (type === 'number' && typeof value !== 'number') problems.push(`${path} should be a number, got ${typeOf(value)}`)
+  else if (type === 'boolean' && typeof value !== 'boolean') problems.push(`${path} should be a boolean, got ${typeOf(value)}`)
+  else if (type === undefined) unchecked.push(path)
+  return { problems, unchecked }
+}
+
+/* Assess a reply. `divertedPositions` comes from the token record when one was
+   captured: the count of positions whose emitted token was not the highest-scoring
+   one. Under a greedy turn that is the mask's fingerprint. */
+export function assessStructuredReply({ content, mode, schemaText, divertedPositions = null, greedy = true }) {
+  const text = String(content ?? '')
+  const wantsJson = mode === STRUCTURED_MODES.JSON_OBJECT || mode === STRUCTURED_MODES.JSON_SCHEMA
+  const result = {
+    mode,
+    parsed: null,
+    parses: false,
+    parseError: null,
+    problems: [],
+    unchecked: [],
+    schemaChecked: false,
+    diverted: divertedPositions,
+    /* The honest headline. `enforced` is never true from a 200 alone — only a
+       diverted position observed on a greedy turn earns it. */
+    evidence: 'accepted',
+  }
+  if (wantsJson) {
+    try {
+      result.parsed = JSON.parse(text)
+      result.parses = true
+    } catch (error) {
+      result.parseError = error.message
+    }
+    if (result.parses && mode === STRUCTURED_MODES.JSON_SCHEMA) {
+      const schema = parseSchemaText(schemaText)
+      if (schema.ok) {
+        const checked = validateAgainstSchema(result.parsed, schema.value)
+        result.problems = checked.problems
+        result.unchecked = checked.unchecked
+        result.schemaChecked = true
+      }
+    }
+  }
+  if (greedy && Number.isFinite(Number(divertedPositions)) && Number(divertedPositions) > 0) {
+    result.evidence = 'diverted'
+  } else if (result.parses && result.problems.length === 0 && result.schemaChecked) {
+    result.evidence = 'conforms'
+  } else if (result.parses) {
+    result.evidence = 'parses'
+  }
+  return result
+}
+
+export const EVIDENCE_COPY = {
+  diverted: {
+    label: 'Mask observed',
+    detail: 'At one or more positions the emitted token was not the highest-scoring one. Because the returned scores are the model’s unmasked distribution, that is direct evidence the constraint moved this decode.',
+  },
+  conforms: {
+    label: 'Matches the schema',
+    detail: 'The reply parsed and satisfied every keyword this page checks. That is consistent with the constraint being applied, but a model can also produce conforming output on its own — it is not proof the mask acted.',
+  },
+  parses: {
+    label: 'Parsed',
+    detail: 'The reply is valid JSON. Nothing here shows whether the constraint shaped it.',
+  },
+  accepted: {
+    label: 'Request accepted',
+    detail: 'The engine accepted the constraint and returned a reply. It reports no field saying a mask was applied, so this page cannot claim more than that from the response alone.',
+  },
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -14,3 +14,4 @@
 @import './styles/observatory.css';
 @import './styles/token-inspector.css';
 @import './styles/rerank.css';
+@import './styles/structured-output.css';

--- a/frontend/src/styles/structured-output.css
+++ b/frontend/src/styles/structured-output.css
@@ -1,0 +1,161 @@
+/* Structured output — what a constrained reply demonstrates.
+
+   COLOR POSTURE. No new color tokens. The verdict chip is the one place a status
+   colour is used, and the choice is deliberate: "Mask observed" is the only state
+   backed by an observation, and it still does not earn copper — copper is
+   reserved for supported/verified support claims, and a mask acting on one reply
+   is not a support claim. It uses amber (--color-evidence), the bounded-evidence
+   ink, which is exactly what this is. The weaker states are muted text, not
+   colour, so the scale reads as strength-of-evidence rather than pass/fail. */
+
+.structout {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border-soft);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.structout__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.structout__label {
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--color-text-faint);
+  font-weight: 600;
+}
+
+.structout__verdict {
+  font-size: var(--text-micro);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-soft);
+  color: var(--color-text-muted);
+}
+
+/* Only the observed state is inked. */
+.structout__verdict--diverted {
+  color: var(--color-evidence);
+  border-color: color-mix(in srgb, var(--color-evidence) 45%, transparent);
+}
+
+.structout__detail,
+.structout__unchecked {
+  margin: 0;
+  font-size: var(--text-micro);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+}
+
+.structout__rows {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-5);
+  margin: 0;
+  font-size: var(--text-micro);
+}
+
+.structout__row { display: flex; flex-direction: column; gap: 1px; }
+.structout__row dt { color: var(--color-text-faint); text-transform: uppercase; letter-spacing: var(--tracking-label); }
+.structout__row dd { margin: 0; color: var(--color-text); }
+
+.structout__problems {
+  margin: 0;
+  padding-left: var(--space-4);
+  font-size: var(--text-micro);
+  color: var(--color-text-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.structout__toggle {
+  align-self: flex-start;
+  padding: 3px var(--space-2);
+  font-size: var(--text-micro);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.structout__toggle:hover { color: var(--color-text); border-color: var(--color-border-strong); }
+.structout__toggle:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+.structout__json {
+  margin: 0;
+  padding: var(--space-2);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-code-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  line-height: var(--leading-snug);
+  color: var(--color-text);
+  max-height: 16rem;
+  overflow: auto;
+}
+
+/* Composer schema editor. A bare textarea by choice: adding a code-editor
+   dependency to ship one field would be a larger decision than this feature. */
+.structout-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-2);
+}
+
+.structout-editor__modes { display: flex; gap: var(--space-2); flex-wrap: wrap; }
+
+.structout-editor__mode {
+  padding: 2px var(--space-2);
+  font-size: var(--text-micro);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+}
+
+.structout-editor__mode.is-on {
+  color: var(--color-accent-text);
+  border-color: var(--color-accent);
+}
+
+.structout-editor__mode:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+.structout-editor__field {
+  width: 100%;
+  min-height: 8rem;
+  resize: vertical;
+  padding: var(--space-2);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-code-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  line-height: var(--leading-snug);
+  color: var(--color-text);
+}
+
+.structout-editor__field:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+.structout-editor__status {
+  margin: 0;
+  font-size: var(--text-micro);
+  color: var(--color-text-muted);
+}
+
+.structout-editor__status.is-invalid { color: var(--color-warning); }

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -180,6 +180,15 @@ export default function ChatWorkspace({
   setInspectMode = null,
   tokenInspections = {},
   inspectionSupported = false,
+  structuredMode = 'off',
+  setStructuredMode = null,
+  structuredSchema = '',
+  setStructuredSchema = null,
+  structuredGrammar = '',
+  setStructuredGrammar = null,
+  structuredRecords = {},
+  structuredSupported = false,
+  structuredReadiness = { ready: false, reason: null },
   thinkingMode = false,
   setThinkingMode = null,
   webResearchEnabled = true,
@@ -835,6 +844,50 @@ export default function ChatWorkspace({
           onClose={() => setShowControls(false)}
         />
       )}
+      {structuredSupported && structuredMode !== 'off' && setStructuredMode && (
+        <div className="structout-editor">
+          <div className="structout-editor__modes" role="group" aria-label="Constraint form">
+            {[
+              ['json_schema', 'JSON schema'],
+              ['json_object', 'Any JSON'],
+              ['grammar', 'Grammar'],
+            ].map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                className={`structout-editor__mode ${structuredMode === value ? 'is-on' : ''}`}
+                aria-pressed={structuredMode === value}
+                onClick={() => setStructuredMode(value)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {structuredMode === 'json_schema' && (
+            <textarea
+              className="structout-editor__field"
+              aria-label="JSON schema"
+              spellCheck={false}
+              value={structuredSchema}
+              onChange={(event) => setStructuredSchema?.(event.target.value)}
+            />
+          )}
+          {structuredMode === 'grammar' && (
+            <textarea
+              className="structout-editor__field"
+              aria-label="Grammar"
+              spellCheck={false}
+              value={structuredGrammar}
+              onChange={(event) => setStructuredGrammar?.(event.target.value)}
+            />
+          )}
+          <p className={`structout-editor__status ${structuredReadiness.ready ? '' : 'is-invalid'}`}>
+            {structuredReadiness.ready
+              ? 'The next reply is constrained to this. Turn on Tokens as well to see whether the constraint actually diverted the decode.'
+              : structuredReadiness.reason}
+          </p>
+        </div>
+      )}
       <div
         className="cxcomposer__box"
         onDragOver={(e) => {
@@ -1016,6 +1069,29 @@ export default function ChatWorkspace({
                 onClick={() => setReceiptMode(!receiptMode)}
               >
                 <IconReceipt size={16} /> <span className="cxcomposer__tool-label">{receiptMode ? 'Receipt on' : 'Receipt'}</span>
+              </button>
+            )}
+            {/* Constrained decoding is a pre-send choice: the engine refuses a
+                constraint on a streaming request, and its streaming decoder never
+                builds a grammar state at all, so the turn must be composed
+                non-streaming before it is sent. Guarded when the contract does not
+                advertise it, rather than live-with-a-disclaimer. */}
+            {!demoMode && setStructuredMode && (
+              <button
+                type="button"
+                className={`cxcomposer__tool cxcomposer__tool--collapsible ${structuredMode !== 'off' && structuredSupported ? 'is-on' : ''}`}
+                title={structuredSupported
+                  ? 'Constrain the next reply to a JSON schema or grammar (sends it without streaming)'
+                  : 'This engine does not advertise constrained decoding.'}
+                aria-label={structuredSupported ? 'Structured output' : 'Structured output — unavailable on this engine'}
+                aria-pressed={structuredSupported ? structuredMode !== 'off' : undefined}
+                disabled={!structuredSupported}
+                onClick={() => setStructuredMode(structuredMode === 'off' ? 'json_schema' : 'off')}
+              >
+                <IconFile size={16} />
+                <span className="cxcomposer__tool-label">
+                  {!structuredSupported ? 'Schema unavailable' : structuredMode === 'off' ? 'Schema' : 'Schema on'}
+                </span>
               </button>
             )}
             {/* Token inspection is a pre-send choice because the scores are
@@ -1240,6 +1316,7 @@ export default function ChatWorkspace({
                       onRegenerate={canResend && priorUserMessage ? () => resendFromMessage(priorUserMessage.id) : null}
                       onEditResend={canResend && message.role === 'user' ? (messageId, content) => resendFromMessage(messageId, content) : null}
                       tokenInspection={tokenInspections?.[message.id] || null}
+                      structuredRecord={structuredRecords?.[message.id] || null}
                     />
                   </Fragment>
                 )


### PR DESCRIPTION
> Rebased onto `main` now that #724 has merged; this targets `main` directly and is mergeable.
>
> **Overlaps #730** (tool calls) on `App.jsx`, `MessageTurn.jsx`, `useDashboardData.js`, `styles.css` and `ChatWorkspace.jsx` — the same composer and message-panel wiring points. Either order works; whichever merges second needs a rebase.

The engine has shipped token-level constrained decoding via LLGuidance since the `llguidance_structured_outputs` row was added. No frontend file mentioned it. This adds the surface: constrain the next reply to a JSON schema, any JSON object, or a Lark grammar — plus a per-message card reporting what that reply *actually demonstrates*.

## The hard part is the claim, not the request

**A constrained response is byte-for-byte the same shape as an unconstrained one.** No field, flag, header or `finish_reason` says a mask was applied. A 200 proves the request was accepted and nothing more — so a card that renders "constrained" on that basis is asserting something it cannot see, and would look perfectly correct in a screenshot.

There is one honest way to do better, and it falls out of how the engine works: **the mask is applied to a clone of the logits, and the raw distribution is what gets returned.** So on a greedy turn with `logprobs` requested, a position whose emitted token is *not* the argmax of its own top-N is direct evidence the constraint diverted the decode — the model wanted something else and was not allowed it.

Verified live on `Llama-3.2-1B-Instruct-Q8_0`, schema-constrained:

```
{"title": "Review: Outstanding Coffee and Friendly Staff",
 "sentiment": "positive", "score": -1,
 "tags": ["outstanding coffee", "friendly staff", "good experience"]}

51 tokens · 13 DIVERTED positions (emitted != argmax)
```

You can *see* the constraint working. That's the differentiator — nobody else shows this.

## The verdict ladder

| Verdict | Basis |
|---|---|
| **Mask observed** | a diverted position on a greedy turn — **evidence** |
| Matches the schema | parsed and satisfied every checked keyword — *consistent with*, and the copy says so, because a model can emit valid JSON by luck |
| Parsed | valid JSON; nothing shown about the constraint |
| Accepted | the request was accepted. That is all. |

Divergence on a **sampled** turn does not earn the strong claim — off-argmax emission is routine there. That distinction is asserted in the smoke, not just intended.

## Request composition is structurally unambiguous

The engine 400s when two constraint forms arrive together, and again when any constraint arrives with `stream:true` — and its streaming decoder **never builds a grammar state at all**, so that route refusal is the only thing between a streamed constrained request and silently unconstrained output. The builder emits exactly one `response_format` key and cannot compose a second form; the stream flag and the constraint fields derive from one predicate so they cannot drift.

All four refusals confirmed live:

| Request | Result |
|---|---|
| constraint + `stream:true` | 400 — not supported with streaming |
| two constraint forms at once | 400 — mutually exclusive |
| `json_schema` with no `schema` key | 400 — requires `json_schema.schema` |
| uncompilable grammar | 400 — not supported by LLGuidance |
| plain `json_object` (control) | 200 |

The nested `response_format.json_schema.schema` envelope is asserted explicitly: three different locations exist for that object across routes, and the wrong one is a 400 with no hint.

## The validator admits what it didn't check

Types, required keys and enums only — and it **names** the keywords it skipped. Silently ignoring unimplemented keywords would report "valid" for a document it never examined, which is the same class of lie the rest of this surface exists to avoid.

## Verification

18-check smoke wired into `ci.yml`. Frontend build, plus `token-inspector`, `ui`, `integration`, `streaming`, `contrast`, `model-state` smokes and the scrub gate all pass.

## Not included

The embeddings/rerank playground — the other half of this tier — is a separate build. Recon resolved its one open question: an encoder and a chat model **can** be co-resident (the frontend already loads encoders as sidecars with `replace:false`), so a retrieval playground never evicts your chat model. It needs a 146 MB Nomic encoder to validate against, which is an operator action.
