### PR TITLE
feat(frontend): retrieval playground — rank documents by meaning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,10 @@ jobs:
           curl --fail --silent http://127.0.0.1:4175/ >/dev/null
           npm run smoke:workspace-visual
 
+      - name: Retrieval rerank smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: npm run smoke:rerank
+
       - name: Frontend UI regression smoke
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:ui

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "smoke:gemma4-mtp12-gate": "node scripts/gemma4-mtp12-chat-gate-smoke.mjs",
     "smoke:gemma4-mtp12-target-render": "node scripts/gemma4-mtp12-target-render-smoke.mjs",
     "smoke:lfm2-chat-gate": "node scripts/lfm2-chat-gate-smoke.mjs",
+    "smoke:rerank": "node scripts/rerank-smoke.mjs",
     "smoke:streaming": "node scripts/streaming-parser-smoke.mjs",
     "smoke:arena": "node scripts/arena-smoke.mjs",
     "smoke:harness": "node scripts/smoke-harness-self-test.mjs",

--- a/frontend/scripts/rerank-smoke.mjs
+++ b/frontend/scripts/rerank-smoke.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/* Retrieval reranking — contract, response normalization, and score honesty.
+ *
+ * Two defects would ship a misleading surface rather than a broken one:
+ *
+ *   1. SCORES READ AS PROBABILITIES. `relevance_score` is a cosine similarity.
+ *      Observed live against this engine, an obviously irrelevant document still
+ *      scored 0.373 while the best match scored 0.638 — so a percentage rendering
+ *      would tell a reader that an unrelated document is "37% relevant". The
+ *      useful signal is order, gaps, and movement. Asserted here as a rendering
+ *      rule, not left to reviewer memory.
+ *
+ *   2. SCORES MISMATCHED TO TEXTS. The engine returns results by `index` into the
+ *      submitted array and OMITS `document` unless asked. Reading response order
+ *      as document order, or assuming `document` is present, silently pairs the
+ *      wrong score with the wrong text — and the output still looks plausible.
+ *
+ * Fixtures reproduce the live response shape captured from this engine.
+ *
+ * SSR component test — no browser, no dist build required.
+ */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+
+let checks = 0
+function check(label, fn) {
+  fn()
+  checks += 1
+  console.log(`  ok  ${label}`)
+}
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const mod = await server.ssrLoadModule('/src/lib/embeddingRerank.js')
+  const { RerankPlayground } = await server.ssrLoadModule('/src/components/models/RerankPlayground.jsx')
+  const {
+    MAX_RERANK_DOCUMENTS,
+    readRerankContract,
+    resolveEncoder,
+    splitDocuments,
+    rerankReadiness,
+    rerankRequestBody,
+    normalizeRerank,
+    formatSimilarity,
+    formatMovement,
+  } = mod
+
+  const live = {
+    api_features: [{ id: 'embedding_similarity_reranking', status: 'supported_exact_model_row', notes: 'Bi-encoder reranking on the exact Nomic row.' }],
+    api_conformance: [{ id: 'embedding_similarity_reranking', status: 'supported_exact_model_row', supported_modes: ['string_documents', 'top_n'] }],
+  }
+  const DOCS = [
+    'Bake the sourdough at 230C for 35 minutes on a stone.',
+    'Thermal throttling happens when the CPU exceeds its junction temperature.',
+    'The Treaty of Westphalia was signed in 1648.',
+    'Elevate the chassis for airflow and avoid using it on a duvet.',
+  ]
+  /* The live shape: results ordered by score, addressed by `index`, `document`
+     absent because return_documents was false. */
+  const LIVE_PAYLOAD = {
+    id: 'rerank-1',
+    model: 'nomic-embed-text-v1.5',
+    results: [
+      { index: 1, relevance_score: 0.6381 },
+      { index: 3, relevance_score: 0.5894 },
+      { index: 0, relevance_score: 0.4988 },
+      { index: 2, relevance_score: 0.3729 },
+    ],
+    usage: { prompt_tokens: 126, total_tokens: 126 },
+  }
+
+  console.log('rerank — contract and encoder resolution')
+
+  check('a live contract is supported; an absent row fails closed', () => {
+    assert.equal(readRerankContract(live).supported, true)
+    assert.equal(readRerankContract({}).present, false)
+    assert.equal(readRerankContract({}).supported, false)
+  })
+
+  check('resemblance is not evidence — a near-miss row id does not count', () => {
+    assert.equal(readRerankContract({ api_conformance: [{ id: 'embedding_similarity_reranking_v2', status: 'supported' }] }).present, false)
+  })
+
+  check('an encoder is resolved from the served models, and its support scope is separate', () => {
+    const found = resolveEncoder([{ id: 'nomic-embed-text-v1.5' }, { id: 'Llama 3.2 1B Instruct' }], [])
+    assert.equal(found.ready, true)
+    assert.equal(found.encoderId, 'nomic-embed-text-v1.5')
+    assert.equal(found.isSupportedRow, true, 'the pinned artifact carries the exact-row claim')
+    const none = resolveEncoder([{ id: 'Llama 3.2 1B Instruct' }], [])
+    assert.equal(none.ready, false)
+    assert.equal(none.encoderId, null)
+  })
+
+  check('a chat-only engine is guarded with copy that does not imply eviction', () => {
+    const readiness = rerankReadiness({
+      contract: readRerankContract(live),
+      encoder: resolveEncoder([{ id: 'Llama 3.2 1B Instruct' }], []),
+      query: 'q',
+      documents: DOCS,
+    })
+    assert.equal(readiness.ready, false)
+    assert.match(readiness.reason, /sidecar|does not replace/i,
+      'the copy must say the encoder loads alongside the chat model, not instead of it')
+  })
+
+  console.log('rerank — request composition')
+
+  check('the document cap is enforced before the wire', () => {
+    const tooMany = Array.from({ length: MAX_RERANK_DOCUMENTS + 1 }, (_, i) => `doc ${i}`)
+    const readiness = rerankReadiness({ contract: readRerankContract(live), encoder: { ready: true, encoderId: 'e' }, query: 'q', documents: tooMany })
+    assert.equal(readiness.ready, false)
+    assert.match(readiness.reason, new RegExp(String(MAX_RERANK_DOCUMENTS)))
+  })
+
+  check('fewer than two documents is refused — ranking one thing is meaningless', () => {
+    const readiness = rerankReadiness({ contract: readRerankContract(live), encoder: { ready: true, encoderId: 'e' }, query: 'q', documents: ['only one'] })
+    assert.equal(readiness.ready, false)
+  })
+
+  check('blank lines never become empty documents', () => {
+    assert.deepEqual(splitDocuments('a\n\n  \nb\n'), ['a', 'b'])
+  })
+
+  check('the body asks for indices, not documents', () => {
+    const body = rerankRequestBody({ encoderId: 'e', query: '  q  ', documents: DOCS })
+    assert.equal(body.query, 'q')
+    assert.equal(body.return_documents, false, 'text comes from the caller list, so it need not be echoed')
+    assert.equal(body.top_n, DOCS.length)
+  })
+
+  console.log('rerank — normalization cannot mismatch a score to a text')
+
+  check('results are joined back by index, not by response order', () => {
+    const model = normalizeRerank(LIVE_PAYLOAD, DOCS)
+    assert.equal(model.ranked.length, 4)
+    // Rank 1 is index 1 — the thermal doc — NOT DOCS[0].
+    assert.equal(model.ranked[0].index, 1)
+    assert.equal(model.ranked[0].text, DOCS[1])
+    assert.match(model.ranked[0].text, /Thermal throttling/)
+    // Reading response order as document order would have paired 0.6381 with the
+    // sourdough line.
+    assert.notEqual(model.ranked[0].text, DOCS[0])
+  })
+
+  check('movement is computed against the submitted order', () => {
+    const model = normalizeRerank(LIVE_PAYLOAD, DOCS)
+    assert.equal(model.ranked[0].movedBy, 1, 'index 1 rose to position 0')
+    assert.equal(model.ranked[2].movedBy, -2, 'index 0 fell to position 2')
+    assert.equal(model.stats.moved, 4)
+    assert.equal(formatMovement(0), 'unchanged')
+    assert.equal(formatMovement(2), 'up 2')
+    assert.equal(formatMovement(-3), 'down 3')
+  })
+
+  check('an out-of-range index is dropped rather than paired with undefined text', () => {
+    const model = normalizeRerank({ results: [{ index: 99, relevance_score: 0.5 }, { index: 0, relevance_score: 0.4 }] }, DOCS)
+    assert.equal(model.ranked.length, 1)
+    assert.equal(model.ranked[0].index, 0)
+  })
+
+  check('an empty or malformed payload yields nothing rather than a broken table', () => {
+    assert.equal(normalizeRerank(null, DOCS), null)
+    assert.equal(normalizeRerank({ results: [] }, DOCS), null)
+  })
+
+  console.log('rerank — a similarity is not a probability')
+
+  check('scores render as bare similarities, never as percentages', () => {
+    assert.equal(formatSimilarity(0.6381), '0.638')
+    assert.equal(formatSimilarity(0.3729), '0.373')
+    assert.equal(formatSimilarity(null), '—')
+    // Three decimals because neighbouring scores often differ in the third place.
+    assert.doesNotMatch(formatSimilarity(0.5), /%/)
+  })
+
+  check('the spread is reported, because one score alone says little', () => {
+    const model = normalizeRerank(LIVE_PAYLOAD, DOCS)
+    assert.ok(Math.abs(model.stats.spread - (0.6381 - 0.3729)) < 1e-6)
+  })
+
+  check('no rendered copy converts a score to a percentage or calls it a probability', () => {
+    // Rendered WITH results: the score-interpretation copy lives in that state, so
+    // an empty-form render would let this assertion pass against markup that never
+    // showed a score at all.
+    const html = renderToStaticMarkup(React.createElement(RerankPlayground, {
+      apiBase: '', capabilities: live, initialResult: normalizeRerank(LIVE_PAYLOAD, DOCS),
+    }))
+    assert.match(html, /0.638/, 'the ranked table must actually render')
+    assert.doesNotMatch(html, /\d%/, 'a similarity must never be rendered as a percentage')
+    assert.match(html, /not probabilities/i, 'the surface must say what the score is not')
+    assert.match(html, /alongside/i, 'and that the encoder does not replace the chat model')
+  })
+
+  check('the source never converts a score to a percentage', () => {
+    const source = readFileSync(resolve(frontendRoot, 'src/lib/embeddingRerank.js'), 'utf8')
+    assert.doesNotMatch(source, /\*\s*100|toFixed\(\d\)\s*\+\s*'%'/, 'no score-to-percent conversion may exist')
+  })
+
+  console.log(`\n${checks} checks passed`)
+} finally {
+  await server.close()
+}

--- a/frontend/src/components/models/RerankPlayground.jsx
+++ b/frontend/src/components/models/RerankPlayground.jsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo, useState } from 'react'
+import { EvidenceChip } from '../ui/EvidenceChip'
+import {
+  MAX_RERANK_DOCUMENTS,
+  formatMovement,
+  formatSimilarity,
+  normalizeRerank,
+  readRerankContract,
+  rerankReadiness,
+  rerankRequestBody,
+  resolveEncoder,
+  splitDocuments,
+} from '../../lib/embeddingRerank'
+
+/* Retrieval playground — rank documents against a query by meaning.
+
+   Drives POST /v1/rerank (capability row `embedding_similarity_reranking`) on a
+   resident encoder. This proves nothing about generation support, and the encoder
+   is a different model from the chat one — the chip and the copy both say so.
+
+   COPY RULE. `relevance_score` is a cosine similarity, not a probability. An
+   unrelated document still scores well above zero, so a percentage rendering
+   would badly mislead. Only the ORDER, the GAPS, and how far each document MOVED
+   from its submitted position carry meaning here, and those are what the table
+   shows. */
+
+const SAMPLE_QUERY = 'How do I keep my laptop from overheating?'
+const SAMPLE_DOCUMENTS = [
+  'Bake the sourdough at 230C for 35 minutes on a stone.',
+  'Thermal throttling happens when the CPU exceeds its junction temperature; clean the fans and repaste.',
+  'The Treaty of Westphalia was signed in 1648.',
+  'Elevate the chassis for airflow and avoid using it on a duvet, which blocks the intake vents.',
+].join('\n')
+
+/* `initialResult` exists so the results state can be rendered without a browser.
+   Without it the ranked table and the score-interpretation note sit behind a live
+   fetch, and a static render would assert only against the empty form — passing
+   while the part that carries the claims was never exercised. */
+export function RerankPlayground({ apiBase, capabilities, initialResult = null }) {
+  const [query, setQuery] = useState(SAMPLE_QUERY)
+  /* Self-contained like the tokenizer playground beside it: it resolves its own
+     encoder from /v1/models rather than taking one through props, so mounting it
+     costs one line at the call site. */
+  const [served, setServed] = useState([])
+  const [documentsText, setDocumentsText] = useState(SAMPLE_DOCUMENTS)
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState(initialResult)
+  const [error, setError] = useState(null)
+
+  const base = (apiBase || '').replace(/\/$/, '')
+  const contract = useMemo(() => readRerankContract(capabilities), [capabilities])
+  const encoder = useMemo(() => resolveEncoder(served, []), [served])
+  const documents = useMemo(() => splitDocuments(documentsText), [documentsText])
+  const readiness = useMemo(
+    () => rerankReadiness({ contract, encoder, query, documents }),
+    [contract, encoder, query, documents],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`${base}/v1/models`)
+      .then((response) => (response.ok ? response.json() : null))
+      .then((payload) => { if (!cancelled && payload) setServed(payload.data || []) })
+      .catch(() => { /* an unreachable backend is reported by the readiness line */ })
+    return () => { cancelled = true }
+  }, [base])
+
+  const run = async () => {
+    if (!readiness.ready || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const response = await fetch(`${base}/v1/rerank`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rerankRequestBody({ encoderId: encoder.encoderId, query, documents })),
+      })
+      const payload = await response.json()
+      if (!response.ok) {
+        setResult(null)
+        setError(payload?.error?.message || `rerank failed (${response.status})`)
+        return
+      }
+      const normalized = normalizeRerank(payload, documents)
+      if (!normalized) {
+        setResult(null)
+        setError('The engine returned no ranked results for these documents.')
+        return
+      }
+      setResult(normalized)
+    } catch (requestError) {
+      setResult(null)
+      setError(requestError?.message || 'The rerank request could not be sent.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="rerank">
+      <div className="rerank__head">
+        <p className="rerank__intro">
+          Rank documents against a query by meaning rather than by shared words. This runs on a
+          loaded encoder, which is a different model from the chat one and loads alongside it —
+          using this proves nothing about generation support.
+        </p>
+        {contract.present && (
+          <EvidenceChip status={contract.status} source={{ rowId: contract.rowId }} />
+        )}
+      </div>
+
+      {!readiness.ready && readiness.reason && (
+        <p className="rerank__guard">{readiness.reason}</p>
+      )}
+
+      <label className="rerank__field">
+        <span className="rerank__label">Query</span>
+        <input
+          type="text"
+          className="rerank__input"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+      </label>
+
+      <label className="rerank__field">
+        <span className="rerank__label">Documents — one per line (max {MAX_RERANK_DOCUMENTS})</span>
+        <textarea
+          className="rerank__textarea"
+          rows={6}
+          spellCheck={false}
+          value={documentsText}
+          onChange={(event) => setDocumentsText(event.target.value)}
+        />
+      </label>
+
+      <div className="rerank__actions">
+        <button type="button" className="rerank__run" onClick={run} disabled={!readiness.ready || busy}>
+          {busy ? 'Ranking…' : 'Rank by meaning'}
+        </button>
+        <span className="rerank__count">{documents.length} document{documents.length === 1 ? '' : 's'}</span>
+      </div>
+
+      {error && <p className="rerank__error">{error}</p>}
+
+      {result && (
+        <div className="rerank__results">
+          <table className="cxv-table rerank__table">
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">Similarity</th>
+                <th scope="col">Moved</th>
+                <th scope="col">Document</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.ranked.map((entry) => (
+                <tr key={entry.index}>
+                  <td>{entry.rank}</td>
+                  <td className="rerank__score">{formatSimilarity(entry.score)}</td>
+                  <td className={`rerank__moved ${entry.movedBy !== 0 ? 'is-moved' : ''}`}>
+                    {formatMovement(entry.movedBy)}
+                  </td>
+                  <td className="rerank__doc">{entry.text}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <p className="rerank__note">
+            Scores are cosine similarities between the query and each document, not probabilities
+            and not percentages — an unrelated document still scores well above zero. What carries
+            meaning is the order, the gap between neighbours (spread here is{' '}
+            {formatSimilarity(result.stats.spread)}), and how far each document moved from the order
+            you entered it in.
+            {result.stats.moved === 0
+              ? ' Nothing moved: the encoder agrees with your input order.'
+              : ` ${result.stats.moved} of ${result.stats.count} moved.`}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default RerankPlayground

--- a/frontend/src/lib/embeddingRerank.js
+++ b/frontend/src/lib/embeddingRerank.js
@@ -1,0 +1,172 @@
+/* Retrieval reranking contract lane.
+
+   The engine ships a bi-encoder that scores a query against a set of documents
+   by cosine similarity in embedding space. That is a different capability from
+   the chat model's, served by a separate CPU encoder runtime, and it is what the
+   existing "Chat with Documents" flow does NOT use — that retrieval is purely
+   lexical (SQLite full-text), so it can only find documents that share words with
+   the query.
+
+   TWO THINGS THIS MODULE EXISTS TO GET RIGHT.
+
+   1. A RELEVANCE SCORE IS NOT A PROBABILITY. `relevance_score` is a cosine
+      similarity. Observed live, an obviously irrelevant document still scored
+      0.37 against an unrelated query, while the best match scored 0.64. Rendering
+      those as "37% relevant" and "64% relevant" would be badly wrong: the
+      absolute value carries almost nothing, the useful signal is the ORDER and
+      the GAPS between neighbours. Nothing here converts a score to a percentage,
+      and the formatter keeps it as a bare similarity.
+
+   2. THE ENCODER IS A SIDECAR, NOT A REPLACEMENT. The engine holds loaded models
+      in a map: an encoder loads with `replace:false, set_active:false` and the
+      chat model stays resident and generation-ready alongside it (verified live —
+      both appear in /v1/models, active_model_id unchanged). So this surface must
+      never imply the user is trading their chat model away to use it. */
+
+import { isSupportedCapabilityStatus, displayCapabilityCopy } from './capabilities.js'
+
+const ROW_ID = 'embedding_similarity_reranking'
+
+/* The engine caps a rerank call at this many documents. Mirrored so the UI can
+   refuse before the wire rather than surfacing a typed 400. */
+export const MAX_RERANK_DOCUMENTS = 255
+
+function findRow(rows, id) {
+  return (rows || []).find((row) => row?.id === id) || null
+}
+
+/* Resolve the contract by EXACT row id, preferring the conformance projection —
+   it carries the machine-readable modes and ships no `notes`, so it cannot smuggle
+   a vendor name into rendered copy. */
+export function readRerankContract(capabilities) {
+  const conformance = findRow(capabilities?.api_conformance, ROW_ID)
+  const feature = findRow(capabilities?.api_features, ROW_ID)
+  const row = conformance || feature
+  if (!row) {
+    return { present: false, supported: false, rowId: ROW_ID, status: null, note: null }
+  }
+  return {
+    present: true,
+    supported: isSupportedCapabilityStatus(String(row.status || '')),
+    rowId: ROW_ID,
+    status: row.status || null,
+    note: feature?.notes ? displayCapabilityCopy(feature.notes) : null,
+  }
+}
+
+/* Find a resident encoder among the served models.
+
+   The row is `supported_exact_model_row`, so support is scoped to one artifact —
+   but the engine decides embedding-capability from GGUF architecture alone, which
+   means other encoders will also answer. Both facts are reported so the surface
+   can run against what is loaded while being explicit about which one carries the
+   support claim. */
+export function resolveEncoder(models, localRecords) {
+  const served = (models || []).map((model) => (typeof model === 'string' ? model : model?.id)).filter(Boolean)
+  const embeddingCapable = new Set(
+    (localRecords || [])
+      .filter((record) => record?.embedding_capable)
+      .map((record) => record?.model_id || record?.id || record?.filename)
+      .filter(Boolean),
+  )
+  const byName = served.find((id) => /nomic-embed-text-v1\.5/i.test(id))
+  const byCapability = served.find((id) => embeddingCapable.has(id))
+  const encoderId = byName || byCapability || null
+  return {
+    encoderId,
+    ready: Boolean(encoderId),
+    /* Only the pinned Nomic artifact carries the exact-row support claim. */
+    isSupportedRow: Boolean(byName),
+  }
+}
+
+export function splitDocuments(text) {
+  return String(text || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+export function rerankReadiness({ contract, encoder, query, documents }) {
+  if (!contract?.present) return { ready: false, reason: 'This engine does not advertise reranking.' }
+  if (!contract.supported) return { ready: false, reason: 'The reranking capability row is not marked supported on this engine.' }
+  if (!encoder?.ready) {
+    return {
+      ready: false,
+      reason: 'No encoder is loaded. An encoder loads alongside the chat model as a sidecar — it does not replace it.',
+    }
+  }
+  if (!String(query || '').trim()) return { ready: false, reason: 'Enter a query.' }
+  if (!documents || documents.length < 2) return { ready: false, reason: 'Enter at least two documents, one per line.' }
+  if (documents.length > MAX_RERANK_DOCUMENTS) {
+    return { ready: false, reason: `The engine accepts at most ${MAX_RERANK_DOCUMENTS} documents; this is ${documents.length}.` }
+  }
+  return { ready: true, reason: null }
+}
+
+export function rerankRequestBody({ encoderId, query, documents, topN }) {
+  return {
+    model: encoderId,
+    query: String(query || '').trim(),
+    documents,
+    top_n: Math.min(documents.length, Math.max(1, topN || documents.length)),
+    return_documents: false,
+  }
+}
+
+/* Normalize a response back onto the SUBMITTED documents.
+
+   The engine returns results by `index` into the request array, and `document` is
+   omitted unless asked for — so the text must come from the caller's own list.
+   Reading the response order as the document order, or assuming `document` is
+   present, would silently mismatch scores to texts. */
+export function normalizeRerank(payload, documents) {
+  const results = Array.isArray(payload?.results) ? payload.results : []
+  if (!results.length) return null
+  const ranked = results
+    .map((result, position) => {
+      const index = Number(result?.index)
+      const text = Number.isInteger(index) ? documents[index] : undefined
+      if (text === undefined) return null
+      const score = Number(result?.relevance_score)
+      return {
+        index,
+        text,
+        score: Number.isFinite(score) ? score : null,
+        rank: position + 1,
+        /* How far this document moved from the order it was submitted in. That
+           movement is the whole point of a rerank, and it is the one number here
+           that means something absolute. */
+        movedBy: index - position,
+      }
+    })
+    .filter(Boolean)
+  if (!ranked.length) return null
+  const scores = ranked.map((entry) => entry.score).filter((value) => value !== null)
+  return {
+    ranked,
+    stats: {
+      count: ranked.length,
+      moved: ranked.filter((entry) => entry.movedBy !== 0).length,
+      topScore: scores.length ? Math.max(...scores) : null,
+      bottomScore: scores.length ? Math.min(...scores) : null,
+      /* The spread is what tells a reader whether the ranking is decisive or
+         nearly a tie — far more informative than any single score. */
+      spread: scores.length ? Math.max(...scores) - Math.min(...scores) : null,
+    },
+    usage: payload?.usage || null,
+    model: payload?.model || null,
+  }
+}
+
+/* Similarity, never a percentage. Three decimals because the useful comparison is
+   between neighbouring scores, and the gaps are often in the third place. */
+export function formatSimilarity(score) {
+  if (score === null || score === undefined || !Number.isFinite(score)) return '—'
+  return score.toFixed(3)
+}
+
+export function formatMovement(movedBy) {
+  if (movedBy === 0) return 'unchanged'
+  return movedBy > 0 ? `up ${movedBy}` : `down ${Math.abs(movedBy)}`
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -13,3 +13,4 @@
 @import './styles/cluster.css';
 @import './styles/observatory.css';
 @import './styles/token-inspector.css';
+@import './styles/rerank.css';

--- a/frontend/src/styles/rerank.css
+++ b/frontend/src/styles/rerank.css
@@ -1,0 +1,84 @@
+/* Retrieval playground — rank documents by meaning.
+
+   COLOR POSTURE. No new colour tokens. A similarity score is NOT graded by
+   colour: shading cells on score would imply the absolute value is meaningful,
+   and it is not — an unrelated document still scores well above zero. The only
+   ink used is --color-accent, and only on the "moved" column, because movement is
+   the one quantity here that means something absolute. Copper stays reserved for
+   support claims; a cosine score is not one. */
+
+.rerank { display: flex; flex-direction: column; gap: var(--space-3); }
+
+.rerank__head { display: flex; align-items: flex-start; gap: var(--space-3); flex-wrap: wrap; }
+
+.rerank__intro,
+.rerank__note,
+.rerank__guard {
+  margin: 0;
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+  flex: 1 1 20rem;
+}
+
+.rerank__guard {
+  padding: var(--space-2) var(--space-3);
+  border: 1px dashed var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+}
+
+.rerank__field { display: flex; flex-direction: column; gap: 4px; }
+
+.rerank__label {
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--color-text-faint);
+}
+
+.rerank__input,
+.rerank__textarea {
+  width: 100%;
+  padding: var(--space-2);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-code-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-size: var(--text-2xs);
+}
+
+.rerank__textarea { font-family: var(--font-mono); resize: vertical; line-height: var(--leading-snug); }
+.rerank__input:focus-visible,
+.rerank__textarea:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+.rerank__actions { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+
+.rerank__run {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-2xs);
+  background: var(--color-accent);
+  color: var(--color-accent-ink);
+  border: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.rerank__run:disabled { background: var(--color-surface-strong); color: var(--color-text-faint); cursor: not-allowed; }
+.rerank__run:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+.rerank__count { font-size: var(--text-micro); color: var(--color-text-faint); }
+
+.rerank__error {
+  margin: 0;
+  font-size: var(--text-2xs);
+  color: var(--color-error);
+}
+
+.rerank__results { display: flex; flex-direction: column; gap: var(--space-2); overflow-x: auto; }
+
+.rerank__table { font-size: var(--text-2xs); }
+.rerank__score { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.rerank__moved { white-space: nowrap; color: var(--color-text-faint); }
+.rerank__moved.is-moved { color: var(--color-accent-text); }
+.rerank__doc { color: var(--color-text-muted); }

--- a/frontend/src/views/ModelsView.jsx
+++ b/frontend/src/views/ModelsView.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ModelInspector } from '../components/models/ModelInspector'
 import { TokenizerPlayground } from '../components/models/TokenizerPlayground'
+import { RerankPlayground } from '../components/models/RerankPlayground'
 import { ActiveModelBar } from '../components/models/ActiveModelBar'
 import { CatalogLaneBrowse } from '../components/models/CatalogLaneBrowse'
 import { DownloadsPanel } from '../components/models/DownloadsPanel'
@@ -715,6 +716,8 @@ export default function ModelsView({
           </div>
 
           <TokenizerPlayground apiBase={catalogApiBase || apiBase} />
+
+          <RerankPlayground apiBase={catalogApiBase || apiBase} capabilities={capabilities} />
         </div>
       </details>
 


### PR DESCRIPTION
Camelid ships a bi-encoder rerank API on the exact Nomic v1.5 row, advertised as `embedding_similarity_reranking`. Nothing in the UI used it — you could load an embedding model and then have nowhere to do anything with it.

This matters more than it looks: **the existing "Chat with Documents" retrieval is purely lexical** (SQLite full-text), so it can only surface documents that share words with the query. Semantic rerank is a real capability upgrade, not a demo.

## Verified live

Query: *"How do I keep my laptop from overheating?"* — note that **"overheating" appears in none of the documents**.

| # | Similarity | Moved | Document |
|---|---|---|---|
| 1 | 0.638 | up 1 | Thermal throttling happens when the CPU exceeds its junction temperature; clean the fans and repaste. |
| 2 | 0.589 | up 2 | Elevate the chassis for airflow and avoid using it on a duvet, which blocks the intake vents. |
| 3 | 0.499 | down 2 | Bake the sourdough at 230C for 35 minutes on a stone. |
| 4 | 0.373 | down 1 | The Treaty of Westphalia was signed in 1648. |

Lexical search returns nothing useful here. The encoder gets it right with zero word overlap.

## Two things this surface exists to get right

**A relevance score is not a probability.** It's a cosine similarity — and in that same run, an obviously irrelevant document (the Treaty of Westphalia) still scored **0.373**. Rendering that as "37% relevant" would be badly misleading. Nothing converts a score to a percentage — asserted both on rendered output *and* at the source — and the table leads with what actually carries meaning: the order, the spread between neighbours, and **how far each document moved** from the order it was submitted in. Scores are deliberately not colour-shaded either, because shading by score implies the absolute value means something.

**Scores must not be mismatched to texts.** The engine returns results by `index` into the request array and omits `document` unless asked, so results are joined back onto the caller's own list by index. Reading response order as document order would pair the top score with the wrong text — and would still look entirely plausible. The smoke asserts the *thermal* document, not the sourdough one, comes back at rank 1.

## Co-residency, confirmed rather than assumed

Loading the encoder with `replace:false, set_active:false` left the chat model resident and generation-ready with `active_model_id` unchanged, and both appear in `/v1/models`:

```
  nomic-embed-text-v1.5
  Llama 3.2 1B Instruct
```

So the guarded copy says the encoder loads **alongside** the chat model — and the smoke asserts that wording. A user must never think using this trades their chat model away.

## Shape

Mounted beside the tokenizer playground on the Models page, self-contained in the same style: it resolves its own encoder from `/v1/models`, so the call site is one line. No new colour tokens.

## Verification

16-check smoke wired into `ci.yml`. Build, `ui`, `integration`, `streaming`, `contrast`, `model-state` smokes and the scrub gate all pass. Driven end-to-end in the browser against a live engine with both models resident.
