### PR TITLE
feat(frontend): engine metrics and an honest active-configuration readout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,9 @@ jobs:
       - name: Retrieval rerank smoke
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:rerank
+      - name: Engine metrics smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: npm run smoke:engine-metrics
 
       - name: Frontend UI regression smoke
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}

--- a/frontend/design-evidence/BACKEND_ASKS.md
+++ b/frontend/design-evidence/BACKEND_ASKS.md
@@ -139,3 +139,62 @@ typed 400 these lanes already return for other unsupported combinations — or a
 lane axis to `api_conformance` so the refusal is at least machine-readable. Note
 that `unsupported_modes` today covers only the ROUTE axis (`streaming`,
 `multi_choice`) and says nothing about which serve lanes can honour the request.
+## 7. Host RAM total/available on an HTTP surface (Wave C, 2026-09-06)
+
+**Surface waiting on it:** Settings → Response length still renders its memory
+ceiling and projected-memory gauge ABSENT (see ask 3, 2026-06-12), and the new
+System → Engine metrics panel can show resident memory and VRAM but cannot say how
+close either is to the host's ceiling.
+
+**Ask 3 is now MOSTLY satisfied** and worth re-reading: `GET /api/runtime/memory`
+already returns `process_resident_bytes`, `model_weight_bytes_estimate`,
+`kv_cache_bytes`, `kv_cache_entries`, `kv_cache_capacity` and a per-model breakdown
+carrying `cached_tokens` — which is more than that ask requested, and enough to
+derive KV bytes per token once the cache is non-empty.
+
+**What is still missing is one field:** host total and available RAM. The engine
+ALREADY COMPUTES IT — the startup hardware probe prints
+`RAM 4.9 GiB free / 15.7 GiB total` — it simply is not on any HTTP surface. Neither
+`/v1/health`, `/api/capabilities`, `/api/runtime/memory` nor `/metrics` carries it.
+
+**Ask:** add `host_total_bytes` and `host_available_bytes` to
+`GET /api/runtime/memory` (and/or `camelid_host_memory_total_bytes` /
+`camelid_host_memory_available_bytes` gauges on `/metrics`, matching the existing
+`camelid_cuda_vram_total_bytes` / `_free_bytes` pair). No new measurement is needed;
+this is exposing a value the process already has.
+
+**Not asked:** any per-model prediction. The frontend will not estimate RAM
+client-side; it wants the ceiling so it can render a real proportion instead of
+omitting the gauge.
+
+## 8. The active value of runtime levers, over HTTP (Wave C, 2026-09-06)
+
+**Surface waiting on it:** System → Active configuration reports the lane the engine
+is on using `execution_plan` plus `q8_runtime`, which is honest but partial. It
+cannot report the ACTIVE value of the levers that most affect output — the KV dtype,
+the flash-prefill and blocked-dot gates, the speculative-decode settings — because
+no endpoint discloses them by name.
+
+**The data shape already exists in this codebase.** `eagle3_effective_env()` and
+`speculative_effective_env()` build exactly such a map, and the CLI receipt structs
+carry `effective_env` and `planner_env_updates` fields. They are simply never served.
+
+**Ask:** a read-only `GET /api/runtime/config` returning the effective values of the
+levers the engine actually consulted, e.g.
+
+```json
+{ "effective": { "CAMELID_KV_QUANT": "f32", "CAMELID_FLASH_PREFILL": "0" },
+  "latched": ["CAMELID_ATTENTION_F32_BLOCKED_DOT"],
+  "planner_managed": ["CAMELID_QWEN35_CUDA"] }
+```
+
+`latched` matters as much as the values: several gates are read once into a
+`OnceLock`, so a UI must be able to say "this cannot change without a restart"
+rather than implying it is editable. `planner_managed` matters because those keys
+are written by the planner itself at every model load — presenting one as a user
+setting would invite a user to fight the planner.
+
+**Not asked:** any route that WRITES these. The levers are read at process start and
+several are latched; a write route would be a control that silently does nothing,
+which is worse than no control. If they ever become settable, that is a separate
+engine change with its own evidence.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "smoke:model-state": "node scripts/model-state-smoke.mjs",
     "smoke:model-lanes": "node scripts/model-lanes-smoke.mjs",
     "smoke:catalog-activation": "node scripts/catalog-activation-smoke.mjs",
+    "smoke:engine-metrics": "node scripts/engine-metrics-smoke.mjs",
     "smoke:first-run": "node scripts/first-run-activation-smoke.mjs",
     "smoke:first-run-card": "node scripts/first-run-card-smoke.mjs",
     "smoke:offline-banner": "node scripts/offline-banner-smoke.mjs",

--- a/frontend/scripts/engine-metrics-smoke.mjs
+++ b/frontend/scripts/engine-metrics-smoke.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/* Engine metrics and active-configuration readout.
+ *
+ * Three classes of defect here would ship a confident wrong number rather than a
+ * visible break:
+ *
+ *   1. A LIFETIME AVERAGE PRESENTED AS A CURRENT RATE. Every counter the engine
+ *      exposes is cumulative since process start, so any ratio derived from two of
+ *      them describes the whole run. A server that was fast for an hour and has
+ *      been slow for a minute still reports the hour. The copy must say so.
+ *
+ *   2. ZERO ATTEMPTS RENDERED AS A ZERO RATE. A cache that has never been
+ *      consulted has an UNKNOWN hit rate, not a 0% one — reporting 0% accuses a
+ *      cache of failing when nothing ever asked it.
+ *
+ *   3. A NON-METRICS 200 READ AS AN IDLE ENGINE. A proxy that answers /metrics
+ *      with its own HTML returns 200, and a parser that shrugs at that reports an
+ *      engine with nothing to say instead of a routing fault. This actually
+ *      happened during development: the dev server proxied only /api and /v1.
+ *
+ * The fixture is the real exposition captured from a live engine.
+ *
+ * SSR component test — no browser, no dist build required.
+ */
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+
+let checks = 0
+function check(label, fn) {
+  fn()
+  checks += 1
+  console.log(`  ok  ${label}`)
+}
+
+/* Captured verbatim from a live engine (trimmed to the families under test). */
+const LIVE_METRICS = `# HELP camelid_http_requests_total HTTP requests completed.
+# TYPE camelid_http_requests_total counter
+camelid_http_requests_total 4
+# HELP camelid_http_failures_total HTTP responses with a 4xx or 5xx status.
+# TYPE camelid_http_failures_total counter
+camelid_http_failures_total 0
+# TYPE camelid_generation_requests_total counter
+camelid_generation_requests_total 2
+# TYPE camelid_generation_failures_total counter
+camelid_generation_failures_total 0
+# TYPE camelid_prompt_tokens_total counter
+camelid_prompt_tokens_total 22
+# TYPE camelid_decode_tokens_total counter
+camelid_decode_tokens_total 9
+# TYPE camelid_prompt_evaluation_duration_seconds_sum counter
+camelid_prompt_evaluation_duration_seconds_sum 1.332763
+# TYPE camelid_decode_duration_seconds_sum counter
+camelid_decode_duration_seconds_sum 0.051702
+# TYPE camelid_prompt_cache_hits_total counter
+camelid_prompt_cache_hits_total 0
+# TYPE camelid_prompt_cache_misses_total counter
+camelid_prompt_cache_misses_total 2
+# TYPE camelid_weight_cache_hits_total counter
+camelid_weight_cache_hits_total 1
+# TYPE camelid_weight_cache_misses_total counter
+camelid_weight_cache_misses_total 1
+# TYPE camelid_engine_queue_depth gauge
+camelid_engine_queue_depth 0
+# TYPE camelid_process_resident_memory_bytes gauge
+camelid_process_resident_memory_bytes 1977520128
+# TYPE camelid_cuda_vram_total_bytes gauge
+camelid_cuda_vram_total_bytes 6441926656
+# TYPE camelid_cuda_vram_free_bytes gauge
+camelid_cuda_vram_free_bytes 469762048
+`
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const mod = await server.ssrLoadModule('/src/lib/runtimeMetrics.js')
+  const { EngineMetricsPanel } = await server.ssrLoadModule('/src/components/analytics/EngineMetricsPanel.jsx')
+  const {
+    parsePrometheusText,
+    summarizeMetrics,
+    readActiveLane,
+    LANE_RISK,
+    formatShare,
+    formatBytes,
+  } = mod
+
+  console.log('engine metrics — parsing')
+
+  check('the live exposition parses into named values', () => {
+    const { values, types } = parsePrometheusText(LIVE_METRICS)
+    assert.equal(values.get('camelid_prompt_tokens_total'), 22)
+    assert.equal(values.get('camelid_cuda_vram_free_bytes'), 469762048)
+    assert.equal(types.get('camelid_engine_queue_depth'), 'gauge')
+  })
+
+  check('a labelled series is ignored rather than guessed at', () => {
+    // The engine emits no labels. If a future build does, summing across them
+    // would invent a number it never reported.
+    const { values } = parsePrometheusText('# TYPE x counter\nx{a="b"} 5\nx 7\n')
+    assert.equal(values.get('x'), 7)
+    assert.equal(values.size, 1)
+  })
+
+  check('non-metrics text yields nothing rather than a partial reading', () => {
+    assert.equal(summarizeMetrics('<!doctype html><html><body>hi</body></html>'), null)
+    assert.equal(summarizeMetrics(''), null)
+  })
+
+  console.log('engine metrics — derived figures are lifetime averages')
+
+  const summary = summarizeMetrics(LIVE_METRICS)
+
+  check('the prefill share is computed from server-reported forward time', () => {
+    // 1.332763 / (1.332763 + 0.051702) — the number a browser cannot measure.
+    assert.ok(Math.abs(summary.lifetime.prefillShare - 0.96266) < 0.001)
+    assert.equal(formatShare(summary.lifetime.prefillShare), '96.3%')
+  })
+
+  check('a cache consulted and missed is 0%, and one never consulted is unknown', () => {
+    // Consulted twice, hit zero times: 0% is the correct reading.
+    assert.equal(summary.lifetime.promptCacheHitRate, 0)
+    assert.equal(summary.lifetime.promptCacheAttempts, 2)
+    // Never consulted: unknown, NOT zero.
+    const idle = summarizeMetrics('# TYPE camelid_prompt_cache_hits_total counter\ncamelid_prompt_cache_hits_total 0\n# TYPE camelid_prompt_cache_misses_total counter\ncamelid_prompt_cache_misses_total 0\n')
+    assert.equal(idle.lifetime.promptCacheHitRate, null, 'zero attempts must not read as a zero hit rate')
+    assert.equal(formatShare(null), '—')
+  })
+
+  check('an absent metric is null, never zero', () => {
+    const sparse = summarizeMetrics('# TYPE camelid_engine_queue_depth gauge\ncamelid_engine_queue_depth 3\n')
+    assert.equal(sparse.live.queueDepth, 3)
+    assert.equal(sparse.counters.promptTokens, null, 'a metric this build does not emit is unknown')
+    assert.equal(sparse.lifetime.prefillShare, null)
+    assert.ok(sparse.missing.length > 0, 'and the absence is reported')
+  })
+
+  check('VRAM in use is derived, and only when both ends are reported', () => {
+    assert.equal(summary.memory.vramUsedBytes, 6441926656 - 469762048)
+    assert.equal(formatBytes(summary.memory.vramUsedBytes), '5.6 GB')
+    const partial = summarizeMetrics('# TYPE camelid_cuda_vram_total_bytes gauge\ncamelid_cuda_vram_total_bytes 100\n')
+    assert.equal(partial.memory.vramUsedBytes, null)
+  })
+
+  console.log('engine metrics — the active lane')
+
+  const cudaRuntime = {
+    execution_plan: {
+      selected_backend: 'cuda_resident_q8_runtime',
+      decode_path: 'q8_0_cuda_resident_decode',
+      prefill_path: 'q8_0_cuda_resident_prefill',
+      cuda_resident_active: true,
+      thread_count: 16,
+      support_level: 'supported_exact_row_smoke',
+      reasons: ['profile=auto default'],
+    },
+    q8_runtime: { policy: 'resident_q8_default' },
+  }
+
+  check('an evidenced backend is reported as such', () => {
+    const lane = readActiveLane(cudaRuntime)
+    assert.equal(lane.risk, LANE_RISK.EVIDENCED)
+    assert.ok(lane.rows.length >= 5)
+  })
+
+  check('an unrecognised backend is not accused of being wrong', () => {
+    const lane = readActiveLane({ execution_plan: { selected_backend: 'some_future_lane' } })
+    assert.equal(lane.risk, LANE_RISK.UNEVIDENCED)
+  })
+
+  check('no execution plan claims nothing either way', () => {
+    assert.equal(readActiveLane({}).risk, LANE_RISK.UNKNOWN)
+    assert.equal(readActiveLane({}).present, false)
+  })
+
+  check('exactly one lever is described as changeable while running', () => {
+    const lane = readActiveLane(cudaRuntime)
+    const live = lane.rows.filter((row) => row.changeable === 'gpu_toggle')
+    assert.equal(live.length, 1, 'only the GPU setting reaches a running engine')
+    assert.equal(live[0].key, 'cuda_resident_active')
+    assert.ok(lane.rows.filter((row) => row.changeable === 'restart').length >= 4)
+  })
+
+  console.log('engine metrics — rendered copy')
+
+  const render = (props) => renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+    apiBase: '', runtime: cudaRuntime, initialMetricsText: LIVE_METRICS, ...props,
+  }))
+
+  check('derived figures are labelled as lifetime, never as current', () => {
+    const html = render({})
+    assert.match(html, /96\.3%/, 'the prefill share must render')
+    assert.match(html, /cumulative since the engine started/i)
+    assert.match(html, /Lifetime average|whole run|Not a current rate/i)
+  })
+
+  check('the panel states why it offers no controls', () => {
+    const html = render({})
+    assert.match(html, /Restart required/)
+    assert.match(html, /latched for the life of the process/i,
+      'the absence of switches must be explained, not merely implied')
+  })
+
+  check('an unevidenced lane is not styled or worded as an error', () => {
+    const html = renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+      apiBase: '', initialMetricsText: LIVE_METRICS,
+      runtime: { execution_plan: { selected_backend: 'some_future_lane' } },
+    }))
+    /* Scoped to the lane block: the metrics section legitimately has a "Failed"
+       counter, and matching that would be a false positive about the lane's tone. */
+    const lane = html.match(/<div class="engmetrics__lane[\s\S]*?<\/div>/)
+    assert.ok(lane, 'the lane block must render')
+    assert.doesNotMatch(lane[0], /\bfail(ed|ure|s)\b/i, 'an unevidenced lane is not a failure')
+    assert.doesNotMatch(lane[0], /\berror\b|\bunsafe\b|\bdanger/i, 'and is not styled as an alarm')
+    assert.match(lane[0], /does not mean the output is wrong/i, 'it must say plainly what it is not claiming')
+  })
+
+  check('nothing renders a metric the engine did not report', () => {
+    const html = renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+      apiBase: '', runtime: cudaRuntime,
+      initialMetricsText: '# TYPE camelid_engine_queue_depth gauge\ncamelid_engine_queue_depth 0\n',
+    }))
+    // Every unreported figure is an em-dash, not a zero.
+    assert.match(html, /—/)
+    assert.match(html, /not reported by this engine build/i)
+  })
+
+  console.log(`\n${checks} checks passed`)
+} finally {
+  await server.close()
+}

--- a/frontend/scripts/engine-metrics-smoke.mjs
+++ b/frontend/scripts/engine-metrics-smoke.mjs
@@ -23,6 +23,7 @@
  * SSR component test — no browser, no dist build required.
  */
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -94,6 +95,7 @@ try {
     LANE_RISK,
     formatShare,
     formatBytes,
+    UNEVIDENCED_BACKENDS,
   } = mod
 
   console.log('engine metrics — parsing')
@@ -190,6 +192,129 @@ try {
     assert.equal(live.length, 1, 'only the GPU setting reaches a running engine')
     assert.equal(live[0].key, 'cuda_resident_active')
     assert.ok(lane.rows.filter((row) => row.changeable === 'restart').length >= 4)
+  })
+
+  console.log('engine metrics — the macOS lanes')
+
+  /* Every backend the planner can actually return, read out of the Rust rather
+     than retyped here — a list retyped is a list that goes stale, which is the
+     defect this block exists to catch. `selected_backend` is the first element of
+     each returned tuple, so a bare quoted string on the line after an opening
+     paren is exactly the set of them. */
+  const PLANNER = resolve(frontendRoot, '..', 'src', 'execution_plan.rs')
+  function plannerBackends() {
+    const production = readFileSync(PLANNER, 'utf8').split(/^#\[cfg\(test\)\]/m)[0]
+    const lines = production.split('\n')
+    const found = new Set()
+    for (let i = 0; i < lines.length - 1; i += 1) {
+      if (!/^\s*(return )?\($/.test(lines[i])) continue
+      const named = lines[i + 1].match(/^\s*"([a-z][a-z0-9_]*)",$/)
+      if (named) found.add(named[1])
+    }
+    return found
+  }
+
+  check('every backend the planner can select is classified, evidenced or not', () => {
+    const backends = plannerBackends()
+    /* If a reformat ever breaks the extraction this assertion fails loudly rather
+       than passing over an empty set and certifying nothing. */
+    assert.ok(backends.size >= 16, `extracted only ${backends.size} backends from execution_plan.rs`)
+    const unclassified = [...backends].filter((b) =>
+      readActiveLane({ execution_plan: { selected_backend: b } }).risk === LANE_RISK.UNEVIDENCED
+      && !UNEVIDENCED_BACKENDS.has(b))
+    assert.deepEqual(unclassified, [],
+      'a lane the planner can pick is unclassified — add it to EVIDENCED_BACKENDS or UNEVIDENCED_BACKENDS')
+  })
+
+  check('the macOS lanes that are default-on read as evidenced', () => {
+    /* Each of these is an opt-OUT in the planner, so a stock macOS serve lands on
+       one of them. The first version of this panel called all three unevidenced
+       while their CUDA counterparts read as evidenced. */
+    for (const backend of [
+      'metal_resident_q8_runtime',
+      'metal_resident_qwen35_runtime',
+      'metal_resident_qwen35_kquant_runtime',
+      'metal_resident_lfm2_runtime',
+    ]) {
+      const lane = readActiveLane({ execution_plan: { selected_backend: backend } })
+      assert.equal(lane.risk, LANE_RISK.EVIDENCED, `${backend} must not read as unevidenced`)
+    }
+  })
+
+  const macRuntime = {
+    execution_plan: {
+      operating_system: 'macos',
+      architecture: 'aarch64',
+      selected_backend: 'metal_resident_qwen35_kquant_runtime',
+      decode_path: 'qwen35_metal_resident_decode',
+      prefill_path: 'qwen35_metal_resident_prefill',
+      /* A plain `bool` on the plan struct, so macOS serializes `false` rather than
+         omitting it. Present-and-false is the shape that has to be handled. */
+      cuda_resident_active: false,
+      thread_count: 8,
+      reasons: ['profile=auto default'],
+    },
+    q8_runtime: { policy: 'wire_kquant' },
+  }
+
+  check('a Metal host is not described in CUDA terms', () => {
+    const lane = readActiveLane(macRuntime)
+    assert.equal(lane.rows.some((row) => row.key === 'cuda_resident_active'), false,
+      'a Metal host must not render a CUDA row')
+    const gpu = lane.rows.find((row) => row.key === 'metal_resident_active')
+    assert.ok(gpu, 'the accelerator row must name Metal')
+    assert.equal(gpu.value, 'true')
+  })
+
+  check('no lever is offered as live-settable on a Metal host', () => {
+    /* POST /api/runtime/gpu writes cuda::set_gpu_accel_enabled and
+       set_runtime_enabled; every reader of those is a CUDA or BitNet path, and the
+       planner's Metal arms gate on metal_available plus per-lane opt-outs instead.
+       So the toggle genuinely cannot move this lane. */
+    const lane = readActiveLane(macRuntime)
+    assert.equal(lane.rows.filter((row) => row.changeable === 'gpu_toggle').length, 0)
+    assert.ok(lane.rows.every((row) => row.changeable === 'restart'))
+  })
+
+  check('an engine too old to report its OS is read from the backend prefix', () => {
+    const lane = readActiveLane({ execution_plan: { selected_backend: 'metal_resident_q8_runtime' } })
+    assert.ok(lane.rows.find((row) => row.key === 'metal_resident_active'))
+  })
+
+  check('a zero VRAM total reads as unreported, not as an empty device', () => {
+    /* src/api/metrics.rs writes both CUDA gauges unconditionally and
+       HardwareProfile::detect() leaves them at 0 on every macOS host, so this is
+       the exposition a Mac actually serves — not a hypothetical. */
+    const macMetrics = summarizeMetrics(`# TYPE camelid_process_resident_memory_bytes gauge
+camelid_process_resident_memory_bytes 17000000000
+# TYPE camelid_cuda_vram_total_bytes gauge
+camelid_cuda_vram_total_bytes 0
+# TYPE camelid_cuda_vram_free_bytes gauge
+camelid_cuda_vram_free_bytes 0
+`)
+    assert.equal(macMetrics.memory.vramUsedBytes, null, '0 B of 0 B is not a reading')
+    assert.equal(macMetrics.memory.vramTotalBytes, null)
+    assert.equal(formatBytes(macMetrics.memory.vramUsedBytes), '—')
+    /* Resident memory still reports: only the VRAM pair is suppressed. */
+    assert.equal(macMetrics.memory.residentBytes, 17000000000)
+  })
+
+  check('a committed device still reports zero free against a real total', () => {
+    const full = summarizeMetrics(`# TYPE camelid_cuda_vram_total_bytes gauge
+camelid_cuda_vram_total_bytes 6441926656
+# TYPE camelid_cuda_vram_free_bytes gauge
+camelid_cuda_vram_free_bytes 0
+`)
+    assert.equal(full.memory.vramUsedBytes, 6441926656)
+  })
+
+  check('the Metal panel does not promise a toggle that cannot move it', () => {
+    const html = renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+      apiBase: '', runtime: macRuntime, initialMetricsText: LIVE_METRICS,
+    }))
+    assert.doesNotMatch(html, /CUDA resident/, 'no CUDA row on a Metal host')
+    assert.match(html, /Nothing on this lane is settable while the engine runs/)
+    assert.doesNotMatch(html, /the one exception the engine accepts while running/)
   })
 
   console.log('engine metrics — rendered copy')

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -537,7 +537,7 @@ function App() {
             />
           )}
 
-          {tab === 'system' && <SystemView runtime={runtime} selectedModel={selectedModel} capabilities={dashboard?.capabilities} />}
+          {tab === 'system' && <SystemView runtime={runtime} selectedModel={selectedModel} capabilities={dashboard?.capabilities} metricsApiBase={apiBase} />}
 
           {tab === 'settings' && (
             <SettingsView

--- a/frontend/src/components/analytics/EngineMetricsPanel.jsx
+++ b/frontend/src/components/analytics/EngineMetricsPanel.jsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react'
+import {
+  LANE_RISK,
+  LANE_RISK_COPY,
+  formatBytes,
+  formatCount,
+  formatRate,
+  formatSeconds,
+  formatShare,
+  readActiveLane,
+  summarizeMetrics,
+} from '../../lib/runtimeMetrics'
+
+/* Engine metrics — what the SERVER reports about itself.
+
+   Distinct from the Telemetry view, which times requests in this browser and is
+   therefore client-measured. These numbers come from the engine's own /metrics
+   surface, and they include quantities a browser cannot observe at all: how often
+   the prompt-prefix cache was reused, how forward time split between evaluating
+   prompts and decoding, how deep the job queue got.
+
+   COPY RULE. Every counter here is cumulative since the engine started, so every
+   derived figure is a LIFETIME AVERAGE and is labelled as one. A server that ran
+   fast for an hour and has been slow for a minute still reports the hour, and a
+   panel that called that "current" would be lying with true numbers.
+
+   The second section is the quarantined half: which lane the engine is decoding
+   on, and whether that lane carries parity evidence here. It offers no controls,
+   because the engine has none — one HTTP route mutates runtime configuration and
+   the rest are read once at process start. A toggle would save a value and do
+   nothing. */
+
+const REFRESH_MS = 5000
+
+function Stat({ label, value, hint }) {
+  return (
+    <div className="engmetrics__stat">
+      <dt>{label}</dt>
+      <dd title={hint}>{value}</dd>
+    </div>
+  )
+}
+
+export function EngineMetricsPanel({ apiBase, runtime, initialMetricsText = null }) {
+  const [summary, setSummary] = useState(() => (initialMetricsText ? summarizeMetrics(initialMetricsText) : null))
+  const [error, setError] = useState(null)
+  const base = (apiBase || '').replace(/\/$/, '')
+
+  useEffect(() => {
+    if (initialMetricsText) return undefined
+    let cancelled = false
+    const load = async () => {
+      try {
+        const response = await fetch(`${base}/metrics`)
+        if (!response.ok) {
+          if (!cancelled) setError(`The engine returned ${response.status} for /metrics.`)
+          return
+        }
+        const text = await response.text()
+        if (cancelled) return
+        const next = summarizeMetrics(text)
+        setSummary(next)
+        /* A 200 that is not Prometheus text is a different fault from an engine
+           with nothing to report — most often a proxy answering /metrics itself.
+           Saying which one keeps a routing problem from reading as an idle engine. */
+        setError(next
+          ? null
+          : /^\s*#\s*(HELP|TYPE)/m.test(text)
+            ? 'The engine reported no metrics.'
+            : 'The response to /metrics was not Prometheus text — something between this page and the engine answered it.')
+      } catch {
+        if (!cancelled) setError('The engine is not reachable.')
+      }
+    }
+    load()
+    const timer = setInterval(load, REFRESH_MS)
+    return () => { cancelled = true; clearInterval(timer) }
+  }, [base, initialMetricsText])
+
+  const lane = readActiveLane(runtime)
+  const laneCopy = LANE_RISK_COPY[lane.risk]
+
+  return (
+    <div className="engmetrics">
+      <section className="engmetrics__section">
+        <h2>Engine metrics</h2>
+        <p className="engmetrics__intro">
+          Reported by the engine about itself, not measured in this browser. Counters are
+          cumulative since the engine started, so every average below covers its whole run.
+        </p>
+
+        {error && <p className="engmetrics__error">{error}</p>}
+
+        {summary && (
+          <>
+            <dl className="engmetrics__stats">
+              <Stat
+                label="Prefix cache reuse"
+                value={formatShare(summary.lifetime.promptCacheHitRate)}
+                hint="Share of completed generations that reused a cached prompt prefix instead of re-evaluating it. Lifetime average."
+              />
+              <Stat
+                label="Time spent on prompts"
+                value={formatShare(summary.lifetime.prefillShare)}
+                hint="Share of forward time spent evaluating prompts rather than decoding. Lifetime average."
+              />
+              <Stat
+                label="Decode rate"
+                value={formatRate(summary.lifetime.decodeTokensPerSecond)}
+                hint="Decoded tokens divided by decode time, over the engine's whole run. Not a current rate."
+              />
+              <Stat
+                label="Weights reused"
+                value={formatShare(summary.lifetime.weightCacheHitRate)}
+                hint="Share of generations that reused already-loaded weights. Lifetime average."
+              />
+            </dl>
+
+            <dl className="engmetrics__stats engmetrics__stats--muted">
+              <Stat label="Generations" value={formatCount(summary.counters.genRequests)} />
+              <Stat label="Failed" value={formatCount(summary.counters.genFailures)} />
+              <Stat label="Prompt tokens" value={formatCount(summary.counters.promptTokens)} />
+              <Stat label="Decoded tokens" value={formatCount(summary.counters.decodeTokens)} />
+              <Stat label="Prompt time" value={formatSeconds(summary.lifetime.promptSeconds)} />
+              <Stat label="Decode time" value={formatSeconds(summary.lifetime.decodeSeconds)} />
+            </dl>
+
+            <dl className="engmetrics__stats engmetrics__stats--muted">
+              <Stat label="Queue depth" value={formatCount(summary.live.queueDepth)} hint="Queued plus active engine jobs, right now." />
+              <Stat label="Waiting" value={formatCount(summary.live.queuedTasks)} />
+              <Stat label="Resident memory" value={formatBytes(summary.memory.residentBytes)} />
+              <Stat
+                label="VRAM in use"
+                value={summary.memory.vramUsedBytes === null
+                  ? '—'
+                  : `${formatBytes(summary.memory.vramUsedBytes)} of ${formatBytes(summary.memory.vramTotalBytes)}`}
+                hint="From the engine's cached hardware probe."
+              />
+            </dl>
+
+            {summary.lifetime.promptCacheAttempts === 0 && (
+              <p className="engmetrics__note">
+                The prefix cache has not been consulted yet, so its reuse rate is unknown rather than zero.
+              </p>
+            )}
+            {summary.missing.length > 0 && (
+              <p className="engmetrics__note">
+                {summary.missing.length} metric{summary.missing.length === 1 ? '' : 's'} this page knows about
+                {summary.missing.length === 1 ? ' is' : ' are'} not reported by this engine build.
+              </p>
+            )}
+          </>
+        )}
+      </section>
+
+      <section className="engmetrics__section">
+        <h2>Active configuration</h2>
+        <div className={`engmetrics__lane engmetrics__lane--${lane.risk}`}>
+          <span className="engmetrics__lane-label">{laneCopy.label}</span>
+          <p className="engmetrics__lane-detail">{laneCopy.detail}</p>
+        </div>
+
+        {lane.rows.length > 0 && (
+          <table className="cxv-table engmetrics__table">
+            <thead>
+              <tr>
+                <th scope="col">Setting</th>
+                <th scope="col">Active value</th>
+                <th scope="col">Changing it</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lane.rows.map((row) => (
+                <tr key={row.key}>
+                  <td>
+                    {row.label}
+                    <span className="engmetrics__row-note">{row.note}</span>
+                  </td>
+                  <td className="engmetrics__value">{row.value}</td>
+                  <td className="engmetrics__change">
+                    {row.changeable === 'gpu_toggle'
+                      ? 'Settings → GPU acceleration'
+                      : 'Restart required'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {/* The reason this section has no switches. Stated once, plainly, rather
+            than implied by their absence. */}
+        <p className="engmetrics__note">
+          These are read once when the engine starts, and several are latched for the life of the
+          process — so they are shown here rather than offered as controls. Changing one means
+          restarting the engine with a different setting. The GPU acceleration toggle in Settings is
+          the one exception the engine accepts while running.
+        </p>
+
+        {lane.reasons.length > 0 && (
+          <details className="engmetrics__reasons">
+            <summary>Why the engine chose this lane</summary>
+            <ul>
+              {lane.reasons.map((reason) => <li key={reason}>{reason}</li>)}
+            </ul>
+          </details>
+        )}
+      </section>
+    </div>
+  )
+}
+
+export default EngineMetricsPanel

--- a/frontend/src/components/analytics/EngineMetricsPanel.jsx
+++ b/frontend/src/components/analytics/EngineMetricsPanel.jsx
@@ -193,8 +193,14 @@ export function EngineMetricsPanel({ apiBase, runtime, initialMetricsText = null
         <p className="engmetrics__note">
           These are read once when the engine starts, and several are latched for the life of the
           process — so they are shown here rather than offered as controls. Changing one means
-          restarting the engine with a different setting. The GPU acceleration toggle in Settings is
-          the one exception the engine accepts while running.
+          restarting the engine with a different setting.{' '}
+          {/* Only claim the exception where it exists. The GPU toggle writes two CUDA
+              atomics that no Metal lane reads, so on a Metal host the honest count of
+              live-settable levers is zero — and a panel built to avoid controls that do
+              nothing must not describe one. */}
+          {lane.rows.some((row) => row.changeable === 'gpu_toggle')
+            ? 'The GPU acceleration toggle in Settings is the one exception the engine accepts while running.'
+            : 'Nothing on this lane is settable while the engine runs.'}
         </p>
 
         {lane.reasons.length > 0 && (

--- a/frontend/src/lib/runtimeMetrics.js
+++ b/frontend/src/lib/runtimeMetrics.js
@@ -1,0 +1,324 @@
+/* Server-reported runtime metrics, and the risk posture of the active lane.
+
+   Two surfaces are served from this module, and they are deliberately different
+   in kind.
+
+   THE SAFE ONE reads GET /metrics — the engine's own Prometheus exposition. This
+   is server truth, unlike the request timings the Telemetry view measures in the
+   browser, and it carries quantities the browser cannot see at all: how often the
+   prompt-prefix cache was reused, how the engine's time split between evaluating
+   prompts and decoding, how deep the job queue got, real resident memory and VRAM.
+   Reading it cannot change anything.
+
+   THE QUARANTINED ONE reads the execution plan already on /v1/health and reports
+   WHICH LANE the engine is currently decoding on, and whether that lane is the one
+   the model's parity evidence was produced on. It offers no controls, because the
+   engine has none to offer: exactly one HTTP route mutates runtime configuration
+   (POST /api/runtime/gpu), and the rest of the levers are environment variables
+   read once at process start — several latched in a OnceLock, so they cannot
+   change after the first forward pass even if something could write them. A toggle
+   here would save a value and silently do nothing, which is a worse failure than
+   an honest readout.
+
+   THE CENTRAL ARITHMETIC TRAP. Every counter below is CUMULATIVE SINCE PROCESS
+   START. A rate derived from two counters is therefore a lifetime average, never a
+   current rate — a server that was fast for an hour and has been slow for a minute
+   still reports the hour. Nothing here calls a derived value "current", and every
+   derived figure is labelled as a lifetime average at the point of use. */
+
+/* Metrics whose absence is meaningful rather than zero. An engine build that does
+   not emit one of these should show "not reported", not a confident 0. */
+const KNOWN_METRICS = [
+  'camelid_http_requests_total',
+  'camelid_http_failures_total',
+  'camelid_http_request_duration_seconds_sum',
+  'camelid_generation_requests_total',
+  'camelid_generation_failures_total',
+  'camelid_prompt_tokens_total',
+  'camelid_decode_tokens_total',
+  'camelid_generation_duration_seconds_sum',
+  'camelid_prompt_evaluation_duration_seconds_sum',
+  'camelid_decode_duration_seconds_sum',
+  'camelid_prompt_cache_hits_total',
+  'camelid_prompt_cache_misses_total',
+  'camelid_weight_cache_hits_total',
+  'camelid_weight_cache_misses_total',
+  'camelid_engine_queue_depth',
+  'camelid_engine_queued_tasks',
+  'camelid_engine_active_slots',
+  'camelid_engine_active_generated_tokens',
+  'camelid_engine_active_elapsed_seconds',
+  'camelid_engine_active_stalled_seconds',
+  'camelid_process_resident_memory_bytes',
+  'camelid_cuda_vram_total_bytes',
+  'camelid_cuda_vram_free_bytes',
+]
+
+/* Parse Prometheus text exposition.
+
+   The engine emits no labels on any series (verified against a live instance), so
+   this handles the unlabelled `name value` form and deliberately IGNORES a labelled
+   sample rather than guessing how to aggregate one — silently summing across
+   labels would invent a number the engine never reported. */
+export function parsePrometheusText(text) {
+  const values = new Map()
+  const types = new Map()
+  const help = new Map()
+  for (const rawLine of String(text || '').split('\n')) {
+    const line = rawLine.trim()
+    if (!line) continue
+    if (line.startsWith('#')) {
+      const typeMatch = line.match(/^#\s+TYPE\s+(\S+)\s+(\S+)/)
+      if (typeMatch) types.set(typeMatch[1], typeMatch[2])
+      const helpMatch = line.match(/^#\s+HELP\s+(\S+)\s+(.*)$/)
+      if (helpMatch) help.set(helpMatch[1], helpMatch[2])
+      continue
+    }
+    const sample = line.match(/^([A-Za-z_:][A-Za-z0-9_:]*)\s+(.+)$/)
+    if (!sample) continue
+    const [, name, rawValue] = sample
+    if (name.includes('{')) continue
+    const value = Number(rawValue.trim())
+    if (!Number.isFinite(value)) continue
+    values.set(name, value)
+  }
+  return { values, types, help }
+}
+
+const read = (values, name) => (values.has(name) ? values.get(name) : null)
+
+/* A ratio of two counters, or null when the denominator is zero.
+
+   Zero attempts is NOT a 0% hit rate — it is an unknown one, and rendering 0%
+   there would report a cache as failing when it was never asked. */
+function ratio(hits, misses) {
+  if (hits === null || misses === null) return null
+  const total = hits + misses
+  if (total <= 0) return null
+  return hits / total
+}
+
+export function summarizeMetrics(text) {
+  const { values, help } = parsePrometheusText(text)
+  if (!values.size) return null
+
+  const httpRequests = read(values, 'camelid_http_requests_total')
+  const httpFailures = read(values, 'camelid_http_failures_total')
+  const genRequests = read(values, 'camelid_generation_requests_total')
+  const genFailures = read(values, 'camelid_generation_failures_total')
+  const promptTokens = read(values, 'camelid_prompt_tokens_total')
+  const decodeTokens = read(values, 'camelid_decode_tokens_total')
+  const promptSeconds = read(values, 'camelid_prompt_evaluation_duration_seconds_sum')
+  const decodeSeconds = read(values, 'camelid_decode_duration_seconds_sum')
+  const cacheHits = read(values, 'camelid_prompt_cache_hits_total')
+  const cacheMisses = read(values, 'camelid_prompt_cache_misses_total')
+  const weightHits = read(values, 'camelid_weight_cache_hits_total')
+  const weightMisses = read(values, 'camelid_weight_cache_misses_total')
+  const vramTotal = read(values, 'camelid_cuda_vram_total_bytes')
+  const vramFree = read(values, 'camelid_cuda_vram_free_bytes')
+
+  const forwardSeconds = promptSeconds !== null && decodeSeconds !== null
+    ? promptSeconds + decodeSeconds
+    : null
+
+  return {
+    /* Raw, exactly as reported. */
+    raw: values,
+    help,
+    missing: KNOWN_METRICS.filter((name) => !values.has(name)),
+    counters: {
+      httpRequests,
+      httpFailures,
+      genRequests,
+      genFailures,
+      promptTokens,
+      decodeTokens,
+    },
+    live: {
+      queueDepth: read(values, 'camelid_engine_queue_depth'),
+      queuedTasks: read(values, 'camelid_engine_queued_tasks'),
+      activeSlots: read(values, 'camelid_engine_active_slots'),
+      activeTokens: read(values, 'camelid_engine_active_generated_tokens'),
+      activeElapsedSeconds: read(values, 'camelid_engine_active_elapsed_seconds'),
+      activeStalledSeconds: read(values, 'camelid_engine_active_stalled_seconds'),
+    },
+    memory: {
+      residentBytes: read(values, 'camelid_process_resident_memory_bytes'),
+      vramTotalBytes: vramTotal,
+      vramFreeBytes: vramFree,
+      vramUsedBytes: vramTotal !== null && vramFree !== null ? Math.max(0, vramTotal - vramFree) : null,
+    },
+    /* Every figure here is a LIFETIME AVERAGE over the process, never a current
+       rate. Named `lifetime` so a caller cannot accidentally present it as now. */
+    lifetime: {
+      promptCacheHitRate: ratio(cacheHits, cacheMisses),
+      promptCacheAttempts: cacheHits !== null && cacheMisses !== null ? cacheHits + cacheMisses : null,
+      weightCacheHitRate: ratio(weightHits, weightMisses),
+      /* The share of forward time spent evaluating prompts rather than decoding.
+         On long contexts this is the number that explains where the wall time
+         went, and the browser cannot measure it. */
+      prefillShare: forwardSeconds !== null && forwardSeconds > 0 ? promptSeconds / forwardSeconds : null,
+      promptSeconds,
+      decodeSeconds,
+      decodeTokensPerSecond: decodeTokens !== null && decodeSeconds !== null && decodeSeconds > 0
+        ? decodeTokens / decodeSeconds
+        : null,
+      httpFailureRate: ratio(httpFailures, httpRequests !== null && httpFailures !== null ? httpRequests - httpFailures : null),
+      generationFailureRate: ratio(genFailures, genRequests !== null && genFailures !== null ? genRequests - genFailures : null),
+    },
+  }
+}
+
+/* ---- The quarantined half: which lane is the engine actually on? ---- */
+
+/* Risk classes, in the sense that matters to a user: not "is this fast" but
+   "can this hand me a different answer than the evidence was produced with". */
+export const LANE_RISK = {
+  EVIDENCED: 'evidenced',
+  UNEVIDENCED: 'unevidenced',
+  UNKNOWN: 'unknown',
+}
+
+/* Backends whose decode path carries its own parity evidence in this repo. A
+   backend absent from this set is not accused of being wrong — it is reported as
+   not carrying an evidence claim on this surface, which is a different statement
+   and the only one the frontend can support. */
+const EVIDENCED_BACKENDS = new Set([
+  'cpu_reference',
+  'cpu_q8_runtime_repack',
+  'cpu_kquant_block_dot',
+  'cuda_resident_q8_runtime',
+  'cuda_resident_kquant_runtime',
+  'metal_resident_q8_runtime',
+])
+
+export function readActiveLane(runtime) {
+  const plan = runtime?.execution_plan
+  if (!plan) {
+    return { present: false, risk: LANE_RISK.UNKNOWN, rows: [], supportLevel: null, reasons: [] }
+  }
+  const backend = plan.selected_backend || null
+  const risk = backend === null
+    ? LANE_RISK.UNKNOWN
+    : EVIDENCED_BACKENDS.has(backend)
+      ? LANE_RISK.EVIDENCED
+      : LANE_RISK.UNEVIDENCED
+
+  /* Each row names the lever, its current value, and — the part that matters —
+     whether it can be changed without restarting the engine. Exactly one of these
+     is live-settable; saying so plainly is the whole point. */
+  const rows = [
+    {
+      key: 'selected_backend',
+      label: 'Decode backend',
+      value: backend,
+      changeable: 'restart',
+      note: 'Chosen by the planner from the model, the host and the GPU setting.',
+    },
+    {
+      key: 'decode_path',
+      label: 'Decode path',
+      value: plan.decode_path || null,
+      changeable: 'restart',
+      note: 'The kernel lane each generated token goes through.',
+    },
+    {
+      key: 'prefill_path',
+      label: 'Prefill path',
+      value: plan.prefill_path || null,
+      changeable: 'restart',
+      note: 'How the prompt is evaluated before the first token.',
+    },
+    {
+      key: 'cuda_resident_active',
+      label: 'CUDA resident',
+      value: plan.cuda_resident_active === null || plan.cuda_resident_active === undefined
+        ? null
+        : String(plan.cuda_resident_active),
+      changeable: 'gpu_toggle',
+      note: 'Whether weights stay on the GPU. The GPU setting reaches this; the lane still reselects on the next model load.',
+    },
+    {
+      key: 'q8_policy',
+      label: 'Q8 loader policy',
+      value: runtime?.q8_runtime?.policy || null,
+      changeable: 'restart',
+      note: 'The effective loader path, which outranks the environment flag that requests it.',
+    },
+    {
+      key: 'thread_count',
+      label: 'Worker threads',
+      value: plan.thread_count === null || plan.thread_count === undefined ? null : String(plan.thread_count),
+      changeable: 'restart',
+      note: 'Set at startup with --threads.',
+    },
+  ].filter((row) => row.value !== null)
+
+  return {
+    present: true,
+    risk,
+    backend,
+    rows,
+    supportLevel: plan.support_level || null,
+    exactRow: plan.exact_model_row || null,
+    /* The planner's own explanation of why it chose this lane. Rendering it beats
+       any summary this module could write, because it is the engine's reasoning
+       rather than the browser's guess at it. */
+    reasons: Array.isArray(plan.reasons) ? plan.reasons : [],
+  }
+}
+
+export const LANE_RISK_COPY = {
+  [LANE_RISK.EVIDENCED]: {
+    label: 'Evidenced lane',
+    detail: 'The engine is decoding on a backend that carries parity evidence in this repository. That is a statement about the lane, not about this particular reply.',
+  },
+  [LANE_RISK.UNEVIDENCED]: {
+    label: 'Lane without an evidence claim here',
+    detail: 'The engine is decoding on a backend this page cannot match to a parity-checked lane. That does not mean the output is wrong — it means this surface will not claim it was produced on an evidenced path.',
+  },
+  [LANE_RISK.UNKNOWN]: {
+    label: 'Lane not reported',
+    detail: 'No execution plan is available, usually because no model is loaded. Nothing is claimed either way.',
+  },
+}
+
+/* ---- Formatters ---- */
+
+export function formatBytes(bytes) {
+  if (bytes === null || bytes === undefined || !Number.isFinite(bytes)) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let value = bytes / 1024
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${units[unit]}`
+}
+
+/* A share, rendered as a percentage — legitimate here because these ARE
+   proportions of a whole, unlike a similarity score. */
+export function formatShare(share) {
+  if (share === null || share === undefined || !Number.isFinite(share)) return '—'
+  if (share > 0 && share < 0.001) return '<0.1%'
+  return `${(share * 100).toFixed(1)}%`
+}
+
+export function formatCount(value) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  return value.toLocaleString()
+}
+
+export function formatSeconds(value) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  if (value < 1) return `${(value * 1000).toFixed(0)} ms`
+  if (value < 120) return `${value.toFixed(1)} s`
+  return `${(value / 60).toFixed(1)} min`
+}
+
+export function formatRate(value) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  return `${value.toFixed(1)}/s`
+}

--- a/frontend/src/lib/runtimeMetrics.js
+++ b/frontend/src/lib/runtimeMetrics.js
@@ -144,9 +144,21 @@ export function summarizeMetrics(text) {
     },
     memory: {
       residentBytes: read(values, 'camelid_process_resident_memory_bytes'),
-      vramTotalBytes: vramTotal,
-      vramFreeBytes: vramFree,
-      vramUsedBytes: vramTotal !== null && vramFree !== null ? Math.max(0, vramTotal - vramFree) : null,
+      /* A ZERO TOTAL IS NOT A READING. `src/api/metrics.rs` writes both CUDA VRAM
+         gauges UNCONDITIONALLY, and `HardwareProfile::detect()` leaves them at 0
+         whenever `cuda::probe_capability()` returns None — which is every macOS
+         host, always. Guarding on presence alone (both gauges ARE present, at 0)
+         rendered "VRAM in use: 0 B of 0 B" on every Metal machine: a confident
+         zero for a device that was never asked, which is the same mistake the
+         prefix-cache rate avoids by returning null on zero attempts.
+
+         Zero FREE is left alone — a fully committed device legitimately reports
+         it. Only a zero TOTAL is impossible for a real one. */
+      vramTotalBytes: vramTotal !== null && vramTotal > 0 ? vramTotal : null,
+      vramFreeBytes: vramTotal !== null && vramTotal > 0 ? vramFree : null,
+      vramUsedBytes: vramTotal !== null && vramTotal > 0 && vramFree !== null
+        ? Math.max(0, vramTotal - vramFree)
+        : null,
     },
     /* Every figure here is a LIFETIME AVERAGE over the process, never a current
        rate. Named `lifetime` so a caller cannot accidentally present it as now. */
@@ -182,15 +194,95 @@ export const LANE_RISK = {
 /* Backends whose decode path carries its own parity evidence in this repo. A
    backend absent from this set is not accused of being wrong — it is reported as
    not carrying an evidence claim on this surface, which is a different statement
-   and the only one the frontend can support. */
+   and the only one the frontend can support.
+
+   THIS LIST IS A LIABILITY, and the smoke treats it as one. It is a copy of a
+   fact that lives in `src/execution_plan.rs`, and the first version of it was
+   itself a copy — of the display-only `METAL_BACKENDS` in `executionPlan.js`,
+   which had gone stale at one entry while the planner grew to six. Carried here
+   unchanged, that staleness stopped being cosmetic: three lanes that are DEFAULT
+   ON macOS (`metal_resident_qwen35_runtime`, `metal_resident_qwen35_kquant_runtime`
+   and `metal_resident_lfm2_runtime`, each an opt-OUT) rendered as carrying no
+   evidence claim, while their CUDA counterparts rendered as evidenced. Two of the
+   three are lanes whose receipts in `src/api/mod.rs` assert the backend string
+   itself as the proof — the LFM2 row's evidence reads "the Mac receipt asserts
+   selected_backend=metal_resident_lfm2_runtime", and the Ornith agent-eval PASS
+   was earned on `metal_resident_qwen35_kquant_runtime`.
+
+   So the smoke extracts every backend the planner can select and asserts each one
+   is classified here or in UNEVIDENCED_BACKENDS below. A new lane fails the smoke
+   until someone decides which it is, rather than defaulting to "unevidenced"
+   silently. */
 const EVIDENCED_BACKENDS = new Set([
   'cpu_reference',
   'cpu_q8_runtime_repack',
   'cpu_kquant_block_dot',
   'cuda_resident_q8_runtime',
   'cuda_resident_kquant_runtime',
+  'cuda_resident_windowed_runtime',
+  'cuda_resident_prism_low_bit_runtime',
+  'gemma4_cpu_runtime',
+  'gemma4_cuda_resident_runtime',
   'metal_resident_q8_runtime',
+  'metal_resident_kquant_runtime',
+  'metal_resident_lfm2_runtime',
+  'metal_resident_prism_low_bit_runtime',
+  'metal_resident_qwen35_runtime',
+  'metal_resident_qwen35_kquant_runtime',
 ])
+
+/* Lanes deliberately left OUT of the set above, so that "not listed" cannot mean
+   "nobody looked". The smoke asserts this partition covers the planner. */
+export const UNEVIDENCED_BACKENDS = new Set([
+  /* The engine itself treats this one as unvalidated: the admission check in
+     `src/api/mod.rs` gates on `selected_backend.contains("_runnable_unvalidated")`.
+     Claiming evidence for it here would contradict the engine. */
+  'cuda_resident_q8_runtime_runnable_unvalidated',
+])
+
+/* The GPU row, which is NOT one row with a portable meaning.
+
+   `cuda_resident_active` is a plain `bool` on the plan, so macOS serializes it as
+   `false` rather than omitting it — it survives any presence check and rendered a
+   "CUDA resident: false" row on Metal hosts with no Metal row anywhere, reading as
+   "the GPU is off" while a Metal resident lane was decoding.
+
+   The second half of that row was wrong too. It pointed at Settings → GPU
+   acceleration, and that control does not reach Metal: `POST /api/runtime/gpu`
+   sets `cuda::set_gpu_accel_enabled` / `set_runtime_enabled`, and every reader of
+   those two atoms is a CUDA or BitNet path. The planner's Metal arms gate on
+   `platform.metal_available` plus per-lane opt-outs (`CAMELID_METAL_RESIDENT_DECODE`,
+   `CAMELID_QWEN35_METAL`, `CAMELID_LFM2_METAL`), none of which the toggle writes.
+   So on a Metal host NOTHING here is live-settable, and saying so is the honest
+   answer — this panel's whole premise is that a control which does nothing is
+   worse than no control.
+
+   Host comes from the plan's own `operating_system`, falling back to the backend
+   prefix for an engine too old to report it. */
+function acceleratorRow(plan, backend) {
+  const metalHost = plan.operating_system === 'macos'
+    || (!plan.operating_system && typeof backend === 'string' && backend.startsWith('metal_'))
+
+  if (metalHost) {
+    return {
+      key: 'metal_resident_active',
+      label: 'Metal resident',
+      value: typeof backend === 'string' && backend.startsWith('metal_') ? 'true' : 'false',
+      changeable: 'restart',
+      note: 'Whether weights stay on the GPU. The GPU acceleration toggle in Settings drives the CUDA lane only and does not reach this one; the planner picks it at model load.',
+    }
+  }
+
+  return {
+    key: 'cuda_resident_active',
+    label: 'CUDA resident',
+    value: plan.cuda_resident_active === null || plan.cuda_resident_active === undefined
+      ? null
+      : String(plan.cuda_resident_active),
+    changeable: 'gpu_toggle',
+    note: 'Whether weights stay on the GPU. The GPU setting reaches this; the lane still reselects on the next model load.',
+  }
+}
 
 export function readActiveLane(runtime) {
   const plan = runtime?.execution_plan
@@ -229,15 +321,7 @@ export function readActiveLane(runtime) {
       changeable: 'restart',
       note: 'How the prompt is evaluated before the first token.',
     },
-    {
-      key: 'cuda_resident_active',
-      label: 'CUDA resident',
-      value: plan.cuda_resident_active === null || plan.cuda_resident_active === undefined
-        ? null
-        : String(plan.cuda_resident_active),
-      changeable: 'gpu_toggle',
-      note: 'Whether weights stay on the GPU. The GPU setting reaches this; the lane still reselects on the next model load.',
-    },
+    acceleratorRow(plan, backend),
     {
       key: 'q8_policy',
       label: 'Q8 loader policy',

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -15,3 +15,4 @@
 @import './styles/token-inspector.css';
 @import './styles/rerank.css';
 @import './styles/structured-output.css';
+@import './styles/engine-metrics.css';

--- a/frontend/src/styles/engine-metrics.css
+++ b/frontend/src/styles/engine-metrics.css
@@ -1,0 +1,101 @@
+/* Engine metrics and active configuration.
+
+   COLOR POSTURE. No new colour tokens. The lane badge is the only place a status
+   colour appears, and the choice is deliberate: an EVIDENCED lane is a claim about
+   parity evidence, which is exactly what copper (--color-verified) is reserved
+   for — this is one of the few surfaces entitled to it. A lane without an evidence
+   claim is NOT an error and never uses red; it takes the calm muted slate the
+   token file reserves for "unsupported", which the doctrine says is never styled
+   as an alarm. */
+
+.engmetrics { display: flex; flex-direction: column; gap: var(--space-6); }
+.engmetrics__section { display: flex; flex-direction: column; gap: var(--space-3); }
+.engmetrics__section h2 { margin: 0; font-size: var(--text-md); color: var(--color-text); }
+
+.engmetrics__intro,
+.engmetrics__note {
+  margin: 0;
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+}
+
+.engmetrics__error { margin: 0; font-size: var(--text-2xs); color: var(--color-warning); }
+
+.engmetrics__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: var(--space-3);
+  margin: 0;
+  padding: var(--space-3);
+  background: var(--color-surface-subtle);
+  border-radius: var(--radius-md);
+}
+
+.engmetrics__stat { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.engmetrics__stat dt {
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--color-text-faint);
+}
+.engmetrics__stat dd {
+  margin: 0;
+  font-size: var(--text-lg);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.engmetrics__stats--muted { background: none; padding: 0 var(--space-3); }
+.engmetrics__stats--muted .engmetrics__stat dd { font-size: var(--text-sm); color: var(--color-text-muted); }
+
+.engmetrics__lane {
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.engmetrics__lane-label {
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  font-weight: 600;
+  color: var(--color-text-faint);
+}
+
+.engmetrics__lane-detail {
+  margin: 0;
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+}
+
+/* Copper is earned here: this row states that the active lane carries parity
+   evidence, which is precisely the claim copper is reserved for. */
+.engmetrics__lane--evidenced {
+  border-color: color-mix(in srgb, var(--color-verified) 40%, transparent);
+}
+.engmetrics__lane--evidenced .engmetrics__lane-label { color: var(--color-verified); }
+
+/* Not an alarm. The doctrine keeps 'unsupported' calm and muted. */
+.engmetrics__lane--unevidenced .engmetrics__lane-label,
+.engmetrics__lane--unknown .engmetrics__lane-label { color: var(--color-unsupported); }
+
+.engmetrics__table { font-size: var(--text-2xs); width: 100%; }
+.engmetrics__value { font-family: var(--font-mono); color: var(--color-text); word-break: break-word; }
+.engmetrics__change { color: var(--color-text-faint); white-space: nowrap; }
+
+.engmetrics__row-note {
+  display: block;
+  font-size: var(--text-micro);
+  color: var(--color-text-faint);
+  margin-top: 2px;
+}
+
+.engmetrics__reasons { font-size: var(--text-2xs); color: var(--color-text-muted); }
+.engmetrics__reasons summary { cursor: pointer; color: var(--color-text-faint); }
+.engmetrics__reasons ul { margin: var(--space-2) 0 0; padding-left: var(--space-4); display: flex; flex-direction: column; gap: 3px; }

--- a/frontend/src/views/SystemView.jsx
+++ b/frontend/src/views/SystemView.jsx
@@ -1,3 +1,4 @@
+import { EngineMetricsPanel } from '../components/analytics/EngineMetricsPanel'
 import { displayCapabilityCopy, displayCapabilityId, exactRowSupportLanes, findCompatibilityHint, formatCapabilityStatus, isExactCompatibilityHint, isSupportedCapabilityStatus } from '../lib/capabilities'
 import { getChatGateState } from '../lib/chatGate'
 import { describeModelState } from '../lib/modelState'
@@ -22,7 +23,7 @@ function supportLaneTitle(lane) {
   return 'Throughput readiness'
 }
 
-export default function SystemView({ runtime, selectedModel, capabilities }) {
+export default function SystemView({ runtime, selectedModel, capabilities, metricsApiBase = '' }) {
   const runtimePill = runtimeReadinessLabel(runtime)
   const selectedModelName = selectedModel?.name || 'No next-chat model selected'
   const apiBase = runtime?.api_base || 'Local API unavailable'
@@ -218,6 +219,8 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
           )}
         </div>
       </section>
+
+      <EngineMetricsPanel apiBase={metricsApiBase} runtime={runtime} />
     </section>
   )
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -175,6 +175,9 @@ export default defineConfig({
     port: 4175,
     proxy: {
       '/api': apiProxy(),
+      // Served by the engine, same-origin in production. Without this the dev
+      // server answers /metrics with the SPA's own HTML and a 200.
+      '/metrics': apiProxy(),
       '/v1': apiProxy(),
     },
   },


### PR DESCRIPTION
Two surfaces on the System page, deliberately different in kind: what the engine **reports** about itself, and what lane it is **actually on**.

## Engine metrics — the safe half

Reads the engine's own `/metrics` exposition. This is *server truth*, unlike the Telemetry view which times requests in the browser, and it carries quantities a browser cannot observe at all. Measured live on this box:

| | |
|---|---|
| **Time spent on prompts** | **96.3%** |
| Decode rate | 174.1/s *(lifetime)* |
| Weights reused | 50.0% |
| VRAM in use | 5.6 GB of 6.0 GB |
| Resident memory | 1.8 GB |

That first number is the prefill-vs-decode split, visible for the first time — and it's the one that explains where long-context wall time actually goes. The prompt-prefix cache reuse rate is there too, which is the lever behind the follow-up-turn speedup and was previously unobservable.

**Every counter is cumulative since process start**, so every derived figure is a lifetime average and is labelled as one. A server that ran fast for an hour and has been slow for a minute still reports the hour; calling that "current" would lie with true numbers.

Three readings the parser refuses to make:

- **A cache never consulted has an unknown hit rate, not 0%** — reporting 0% would accuse a cache of failing when nothing ever asked it. (A cache consulted *and missed* genuinely is 0%; both cases are asserted.)
- **A metric this build doesn't emit is null, never zero**, and the absence is reported.
- **A 200 that isn't Prometheus text is a routing fault, not an idle engine.** This actually happened while building: the dev server proxied only `/api` and `/v1`, so `/metrics` returned the SPA's own HTML with a 200. Fixed in `vite.config.js`; the error copy now distinguishes the two.

## Active configuration — the quarantined half

It offers **no controls, because the engine has none to offer.** Exactly one HTTP route mutates runtime configuration (`POST /api/runtime/gpu`, writing two process atomics). No route sets any `CAMELID_*` variable, and several gates are latched in a `OnceLock` so they can't change after the first forward pass even if one did. A toggle here would save a value and silently do nothing — the same defect fixed in the sampling lane.

So it reports the lane instead:

| Setting | Active value | Changing it |
|---|---|---|
| Decode backend | `cuda_resident_q8_runtime` | Restart required |
| Decode path | `q8_0_cuda_resident_decode` | Restart required |
| Prefill path | `q8_0_cuda_resident_prefill` | Restart required |
| CUDA resident | `true` | Settings → GPU acceleration |
| Q8 loader policy | `resident_q8_default` | Restart required |
| Worker threads | `16` | Restart required |

Exactly one row is reachable while running, and the smoke asserts that count.

The badge says whether the backend carries parity evidence here. **Copper is used, and earned, only for the evidenced case** — this is one of the few surfaces entitled to it. A lane *without* an evidence claim is not an error and is never styled as one: the copy says plainly that it does not mean the output is wrong, only that this page won't claim an evidenced path. The planner's own `reasons` are rendered rather than summarized.

## Two backend asks filed

- **Host RAM total/available on an HTTP surface.** The engine already computes it — the startup probe prints `RAM 4.9 GiB free / 15.7 GiB total` — it's just never served. This closes most of June's ask 3, which `/api/runtime/memory` has since largely satisfied on its own (it already returns `kv_cache_bytes` and per-model `cached_tokens`).
- **A read-only effective-lever route.** The data shape already exists in `eagle3_effective_env()` and the CLI receipt structs; it's simply never served. Explicitly **not** asking for a write route, for the reason above.

## Verification

15-check smoke wired into `ci.yml`. Build, `ui`, `integration`, `streaming`, `contrast`, `model-state` and the scrub gate pass. Driven live against a running engine with a loaded model.
