### PR TITLE
feat(frontend): render tool calls on the chat surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,9 @@ jobs:
       - name: Retrieval rerank smoke
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:rerank
+      - name: Engine metrics smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: npm run smoke:engine-metrics
 
       - name: Frontend UI regression smoke
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,6 +561,9 @@ jobs:
       - name: Engine metrics smoke
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:engine-metrics
+      - name: Tool calling smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: npm run smoke:tool-calling
 
       - name: Frontend UI regression smoke
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}

--- a/frontend/design-evidence/BACKEND_ASKS.md
+++ b/frontend/design-evidence/BACKEND_ASKS.md
@@ -139,3 +139,62 @@ typed 400 these lanes already return for other unsupported combinations — or a
 lane axis to `api_conformance` so the refusal is at least machine-readable. Note
 that `unsupported_modes` today covers only the ROUTE axis (`streaming`,
 `multi_choice`) and says nothing about which serve lanes can honour the request.
+## 7. Host RAM total/available on an HTTP surface (Wave C, 2026-09-06)
+
+**Surface waiting on it:** Settings → Response length still renders its memory
+ceiling and projected-memory gauge ABSENT (see ask 3, 2026-06-12), and the new
+System → Engine metrics panel can show resident memory and VRAM but cannot say how
+close either is to the host's ceiling.
+
+**Ask 3 is now MOSTLY satisfied** and worth re-reading: `GET /api/runtime/memory`
+already returns `process_resident_bytes`, `model_weight_bytes_estimate`,
+`kv_cache_bytes`, `kv_cache_entries`, `kv_cache_capacity` and a per-model breakdown
+carrying `cached_tokens` — which is more than that ask requested, and enough to
+derive KV bytes per token once the cache is non-empty.
+
+**What is still missing is one field:** host total and available RAM. The engine
+ALREADY COMPUTES IT — the startup hardware probe prints
+`RAM 4.9 GiB free / 15.7 GiB total` — it simply is not on any HTTP surface. Neither
+`/v1/health`, `/api/capabilities`, `/api/runtime/memory` nor `/metrics` carries it.
+
+**Ask:** add `host_total_bytes` and `host_available_bytes` to
+`GET /api/runtime/memory` (and/or `camelid_host_memory_total_bytes` /
+`camelid_host_memory_available_bytes` gauges on `/metrics`, matching the existing
+`camelid_cuda_vram_total_bytes` / `_free_bytes` pair). No new measurement is needed;
+this is exposing a value the process already has.
+
+**Not asked:** any per-model prediction. The frontend will not estimate RAM
+client-side; it wants the ceiling so it can render a real proportion instead of
+omitting the gauge.
+
+## 8. The active value of runtime levers, over HTTP (Wave C, 2026-09-06)
+
+**Surface waiting on it:** System → Active configuration reports the lane the engine
+is on using `execution_plan` plus `q8_runtime`, which is honest but partial. It
+cannot report the ACTIVE value of the levers that most affect output — the KV dtype,
+the flash-prefill and blocked-dot gates, the speculative-decode settings — because
+no endpoint discloses them by name.
+
+**The data shape already exists in this codebase.** `eagle3_effective_env()` and
+`speculative_effective_env()` build exactly such a map, and the CLI receipt structs
+carry `effective_env` and `planner_env_updates` fields. They are simply never served.
+
+**Ask:** a read-only `GET /api/runtime/config` returning the effective values of the
+levers the engine actually consulted, e.g.
+
+```json
+{ "effective": { "CAMELID_KV_QUANT": "f32", "CAMELID_FLASH_PREFILL": "0" },
+  "latched": ["CAMELID_ATTENTION_F32_BLOCKED_DOT"],
+  "planner_managed": ["CAMELID_QWEN35_CUDA"] }
+```
+
+`latched` matters as much as the values: several gates are read once into a
+`OnceLock`, so a UI must be able to say "this cannot change without a restart"
+rather than implying it is editable. `planner_managed` matters because those keys
+are written by the planner itself at every model load — presenting one as a user
+setting would invite a user to fight the planner.
+
+**Not asked:** any route that WRITES these. The levers are read at process start and
+several are latched; a write route would be a control that silently does nothing,
+which is worse than no control. If they ever become settable, that is a separate
+engine change with its own evidence.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "smoke:model-state": "node scripts/model-state-smoke.mjs",
     "smoke:model-lanes": "node scripts/model-lanes-smoke.mjs",
     "smoke:catalog-activation": "node scripts/catalog-activation-smoke.mjs",
+    "smoke:engine-metrics": "node scripts/engine-metrics-smoke.mjs",
     "smoke:first-run": "node scripts/first-run-activation-smoke.mjs",
     "smoke:first-run-card": "node scripts/first-run-card-smoke.mjs",
     "smoke:offline-banner": "node scripts/offline-banner-smoke.mjs",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "smoke:gemma4-mtp12-target-render": "node scripts/gemma4-mtp12-target-render-smoke.mjs",
     "smoke:lfm2-chat-gate": "node scripts/lfm2-chat-gate-smoke.mjs",
     "smoke:rerank": "node scripts/rerank-smoke.mjs",
+    "smoke:tool-calling": "node scripts/tool-calling-smoke.mjs",
     "smoke:streaming": "node scripts/streaming-parser-smoke.mjs",
     "smoke:arena": "node scripts/arena-smoke.mjs",
     "smoke:harness": "node scripts/smoke-harness-self-test.mjs",

--- a/frontend/scripts/engine-metrics-smoke.mjs
+++ b/frontend/scripts/engine-metrics-smoke.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/* Engine metrics and active-configuration readout.
+ *
+ * Three classes of defect here would ship a confident wrong number rather than a
+ * visible break:
+ *
+ *   1. A LIFETIME AVERAGE PRESENTED AS A CURRENT RATE. Every counter the engine
+ *      exposes is cumulative since process start, so any ratio derived from two of
+ *      them describes the whole run. A server that was fast for an hour and has
+ *      been slow for a minute still reports the hour. The copy must say so.
+ *
+ *   2. ZERO ATTEMPTS RENDERED AS A ZERO RATE. A cache that has never been
+ *      consulted has an UNKNOWN hit rate, not a 0% one — reporting 0% accuses a
+ *      cache of failing when nothing ever asked it.
+ *
+ *   3. A NON-METRICS 200 READ AS AN IDLE ENGINE. A proxy that answers /metrics
+ *      with its own HTML returns 200, and a parser that shrugs at that reports an
+ *      engine with nothing to say instead of a routing fault. This actually
+ *      happened during development: the dev server proxied only /api and /v1.
+ *
+ * The fixture is the real exposition captured from a live engine.
+ *
+ * SSR component test — no browser, no dist build required.
+ */
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+
+let checks = 0
+function check(label, fn) {
+  fn()
+  checks += 1
+  console.log(`  ok  ${label}`)
+}
+
+/* Captured verbatim from a live engine (trimmed to the families under test). */
+const LIVE_METRICS = `# HELP camelid_http_requests_total HTTP requests completed.
+# TYPE camelid_http_requests_total counter
+camelid_http_requests_total 4
+# HELP camelid_http_failures_total HTTP responses with a 4xx or 5xx status.
+# TYPE camelid_http_failures_total counter
+camelid_http_failures_total 0
+# TYPE camelid_generation_requests_total counter
+camelid_generation_requests_total 2
+# TYPE camelid_generation_failures_total counter
+camelid_generation_failures_total 0
+# TYPE camelid_prompt_tokens_total counter
+camelid_prompt_tokens_total 22
+# TYPE camelid_decode_tokens_total counter
+camelid_decode_tokens_total 9
+# TYPE camelid_prompt_evaluation_duration_seconds_sum counter
+camelid_prompt_evaluation_duration_seconds_sum 1.332763
+# TYPE camelid_decode_duration_seconds_sum counter
+camelid_decode_duration_seconds_sum 0.051702
+# TYPE camelid_prompt_cache_hits_total counter
+camelid_prompt_cache_hits_total 0
+# TYPE camelid_prompt_cache_misses_total counter
+camelid_prompt_cache_misses_total 2
+# TYPE camelid_weight_cache_hits_total counter
+camelid_weight_cache_hits_total 1
+# TYPE camelid_weight_cache_misses_total counter
+camelid_weight_cache_misses_total 1
+# TYPE camelid_engine_queue_depth gauge
+camelid_engine_queue_depth 0
+# TYPE camelid_process_resident_memory_bytes gauge
+camelid_process_resident_memory_bytes 1977520128
+# TYPE camelid_cuda_vram_total_bytes gauge
+camelid_cuda_vram_total_bytes 6441926656
+# TYPE camelid_cuda_vram_free_bytes gauge
+camelid_cuda_vram_free_bytes 469762048
+`
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const mod = await server.ssrLoadModule('/src/lib/runtimeMetrics.js')
+  const { EngineMetricsPanel } = await server.ssrLoadModule('/src/components/analytics/EngineMetricsPanel.jsx')
+  const {
+    parsePrometheusText,
+    summarizeMetrics,
+    readActiveLane,
+    LANE_RISK,
+    formatShare,
+    formatBytes,
+  } = mod
+
+  console.log('engine metrics — parsing')
+
+  check('the live exposition parses into named values', () => {
+    const { values, types } = parsePrometheusText(LIVE_METRICS)
+    assert.equal(values.get('camelid_prompt_tokens_total'), 22)
+    assert.equal(values.get('camelid_cuda_vram_free_bytes'), 469762048)
+    assert.equal(types.get('camelid_engine_queue_depth'), 'gauge')
+  })
+
+  check('a labelled series is ignored rather than guessed at', () => {
+    // The engine emits no labels. If a future build does, summing across them
+    // would invent a number it never reported.
+    const { values } = parsePrometheusText('# TYPE x counter\nx{a="b"} 5\nx 7\n')
+    assert.equal(values.get('x'), 7)
+    assert.equal(values.size, 1)
+  })
+
+  check('non-metrics text yields nothing rather than a partial reading', () => {
+    assert.equal(summarizeMetrics('<!doctype html><html><body>hi</body></html>'), null)
+    assert.equal(summarizeMetrics(''), null)
+  })
+
+  console.log('engine metrics — derived figures are lifetime averages')
+
+  const summary = summarizeMetrics(LIVE_METRICS)
+
+  check('the prefill share is computed from server-reported forward time', () => {
+    // 1.332763 / (1.332763 + 0.051702) — the number a browser cannot measure.
+    assert.ok(Math.abs(summary.lifetime.prefillShare - 0.96266) < 0.001)
+    assert.equal(formatShare(summary.lifetime.prefillShare), '96.3%')
+  })
+
+  check('a cache consulted and missed is 0%, and one never consulted is unknown', () => {
+    // Consulted twice, hit zero times: 0% is the correct reading.
+    assert.equal(summary.lifetime.promptCacheHitRate, 0)
+    assert.equal(summary.lifetime.promptCacheAttempts, 2)
+    // Never consulted: unknown, NOT zero.
+    const idle = summarizeMetrics('# TYPE camelid_prompt_cache_hits_total counter\ncamelid_prompt_cache_hits_total 0\n# TYPE camelid_prompt_cache_misses_total counter\ncamelid_prompt_cache_misses_total 0\n')
+    assert.equal(idle.lifetime.promptCacheHitRate, null, 'zero attempts must not read as a zero hit rate')
+    assert.equal(formatShare(null), '—')
+  })
+
+  check('an absent metric is null, never zero', () => {
+    const sparse = summarizeMetrics('# TYPE camelid_engine_queue_depth gauge\ncamelid_engine_queue_depth 3\n')
+    assert.equal(sparse.live.queueDepth, 3)
+    assert.equal(sparse.counters.promptTokens, null, 'a metric this build does not emit is unknown')
+    assert.equal(sparse.lifetime.prefillShare, null)
+    assert.ok(sparse.missing.length > 0, 'and the absence is reported')
+  })
+
+  check('VRAM in use is derived, and only when both ends are reported', () => {
+    assert.equal(summary.memory.vramUsedBytes, 6441926656 - 469762048)
+    assert.equal(formatBytes(summary.memory.vramUsedBytes), '5.6 GB')
+    const partial = summarizeMetrics('# TYPE camelid_cuda_vram_total_bytes gauge\ncamelid_cuda_vram_total_bytes 100\n')
+    assert.equal(partial.memory.vramUsedBytes, null)
+  })
+
+  console.log('engine metrics — the active lane')
+
+  const cudaRuntime = {
+    execution_plan: {
+      selected_backend: 'cuda_resident_q8_runtime',
+      decode_path: 'q8_0_cuda_resident_decode',
+      prefill_path: 'q8_0_cuda_resident_prefill',
+      cuda_resident_active: true,
+      thread_count: 16,
+      support_level: 'supported_exact_row_smoke',
+      reasons: ['profile=auto default'],
+    },
+    q8_runtime: { policy: 'resident_q8_default' },
+  }
+
+  check('an evidenced backend is reported as such', () => {
+    const lane = readActiveLane(cudaRuntime)
+    assert.equal(lane.risk, LANE_RISK.EVIDENCED)
+    assert.ok(lane.rows.length >= 5)
+  })
+
+  check('an unrecognised backend is not accused of being wrong', () => {
+    const lane = readActiveLane({ execution_plan: { selected_backend: 'some_future_lane' } })
+    assert.equal(lane.risk, LANE_RISK.UNEVIDENCED)
+  })
+
+  check('no execution plan claims nothing either way', () => {
+    assert.equal(readActiveLane({}).risk, LANE_RISK.UNKNOWN)
+    assert.equal(readActiveLane({}).present, false)
+  })
+
+  check('exactly one lever is described as changeable while running', () => {
+    const lane = readActiveLane(cudaRuntime)
+    const live = lane.rows.filter((row) => row.changeable === 'gpu_toggle')
+    assert.equal(live.length, 1, 'only the GPU setting reaches a running engine')
+    assert.equal(live[0].key, 'cuda_resident_active')
+    assert.ok(lane.rows.filter((row) => row.changeable === 'restart').length >= 4)
+  })
+
+  console.log('engine metrics — rendered copy')
+
+  const render = (props) => renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+    apiBase: '', runtime: cudaRuntime, initialMetricsText: LIVE_METRICS, ...props,
+  }))
+
+  check('derived figures are labelled as lifetime, never as current', () => {
+    const html = render({})
+    assert.match(html, /96\.3%/, 'the prefill share must render')
+    assert.match(html, /cumulative since the engine started/i)
+    assert.match(html, /Lifetime average|whole run|Not a current rate/i)
+  })
+
+  check('the panel states why it offers no controls', () => {
+    const html = render({})
+    assert.match(html, /Restart required/)
+    assert.match(html, /latched for the life of the process/i,
+      'the absence of switches must be explained, not merely implied')
+  })
+
+  check('an unevidenced lane is not styled or worded as an error', () => {
+    const html = renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+      apiBase: '', initialMetricsText: LIVE_METRICS,
+      runtime: { execution_plan: { selected_backend: 'some_future_lane' } },
+    }))
+    /* Scoped to the lane block: the metrics section legitimately has a "Failed"
+       counter, and matching that would be a false positive about the lane's tone. */
+    const lane = html.match(/<div class="engmetrics__lane[\s\S]*?<\/div>/)
+    assert.ok(lane, 'the lane block must render')
+    assert.doesNotMatch(lane[0], /\bfail(ed|ure|s)\b/i, 'an unevidenced lane is not a failure')
+    assert.doesNotMatch(lane[0], /\berror\b|\bunsafe\b|\bdanger/i, 'and is not styled as an alarm')
+    assert.match(lane[0], /does not mean the output is wrong/i, 'it must say plainly what it is not claiming')
+  })
+
+  check('nothing renders a metric the engine did not report', () => {
+    const html = renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+      apiBase: '', runtime: cudaRuntime,
+      initialMetricsText: '# TYPE camelid_engine_queue_depth gauge\ncamelid_engine_queue_depth 0\n',
+    }))
+    // Every unreported figure is an em-dash, not a zero.
+    assert.match(html, /—/)
+    assert.match(html, /not reported by this engine build/i)
+  })
+
+  console.log(`\n${checks} checks passed`)
+} finally {
+  await server.close()
+}

--- a/frontend/scripts/engine-metrics-smoke.mjs
+++ b/frontend/scripts/engine-metrics-smoke.mjs
@@ -23,6 +23,7 @@
  * SSR component test — no browser, no dist build required.
  */
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -94,6 +95,7 @@ try {
     LANE_RISK,
     formatShare,
     formatBytes,
+    UNEVIDENCED_BACKENDS,
   } = mod
 
   console.log('engine metrics — parsing')
@@ -190,6 +192,129 @@ try {
     assert.equal(live.length, 1, 'only the GPU setting reaches a running engine')
     assert.equal(live[0].key, 'cuda_resident_active')
     assert.ok(lane.rows.filter((row) => row.changeable === 'restart').length >= 4)
+  })
+
+  console.log('engine metrics — the macOS lanes')
+
+  /* Every backend the planner can actually return, read out of the Rust rather
+     than retyped here — a list retyped is a list that goes stale, which is the
+     defect this block exists to catch. `selected_backend` is the first element of
+     each returned tuple, so a bare quoted string on the line after an opening
+     paren is exactly the set of them. */
+  const PLANNER = resolve(frontendRoot, '..', 'src', 'execution_plan.rs')
+  function plannerBackends() {
+    const production = readFileSync(PLANNER, 'utf8').split(/^#\[cfg\(test\)\]/m)[0]
+    const lines = production.split('\n')
+    const found = new Set()
+    for (let i = 0; i < lines.length - 1; i += 1) {
+      if (!/^\s*(return )?\($/.test(lines[i])) continue
+      const named = lines[i + 1].match(/^\s*"([a-z][a-z0-9_]*)",$/)
+      if (named) found.add(named[1])
+    }
+    return found
+  }
+
+  check('every backend the planner can select is classified, evidenced or not', () => {
+    const backends = plannerBackends()
+    /* If a reformat ever breaks the extraction this assertion fails loudly rather
+       than passing over an empty set and certifying nothing. */
+    assert.ok(backends.size >= 16, `extracted only ${backends.size} backends from execution_plan.rs`)
+    const unclassified = [...backends].filter((b) =>
+      readActiveLane({ execution_plan: { selected_backend: b } }).risk === LANE_RISK.UNEVIDENCED
+      && !UNEVIDENCED_BACKENDS.has(b))
+    assert.deepEqual(unclassified, [],
+      'a lane the planner can pick is unclassified — add it to EVIDENCED_BACKENDS or UNEVIDENCED_BACKENDS')
+  })
+
+  check('the macOS lanes that are default-on read as evidenced', () => {
+    /* Each of these is an opt-OUT in the planner, so a stock macOS serve lands on
+       one of them. The first version of this panel called all three unevidenced
+       while their CUDA counterparts read as evidenced. */
+    for (const backend of [
+      'metal_resident_q8_runtime',
+      'metal_resident_qwen35_runtime',
+      'metal_resident_qwen35_kquant_runtime',
+      'metal_resident_lfm2_runtime',
+    ]) {
+      const lane = readActiveLane({ execution_plan: { selected_backend: backend } })
+      assert.equal(lane.risk, LANE_RISK.EVIDENCED, `${backend} must not read as unevidenced`)
+    }
+  })
+
+  const macRuntime = {
+    execution_plan: {
+      operating_system: 'macos',
+      architecture: 'aarch64',
+      selected_backend: 'metal_resident_qwen35_kquant_runtime',
+      decode_path: 'qwen35_metal_resident_decode',
+      prefill_path: 'qwen35_metal_resident_prefill',
+      /* A plain `bool` on the plan struct, so macOS serializes `false` rather than
+         omitting it. Present-and-false is the shape that has to be handled. */
+      cuda_resident_active: false,
+      thread_count: 8,
+      reasons: ['profile=auto default'],
+    },
+    q8_runtime: { policy: 'wire_kquant' },
+  }
+
+  check('a Metal host is not described in CUDA terms', () => {
+    const lane = readActiveLane(macRuntime)
+    assert.equal(lane.rows.some((row) => row.key === 'cuda_resident_active'), false,
+      'a Metal host must not render a CUDA row')
+    const gpu = lane.rows.find((row) => row.key === 'metal_resident_active')
+    assert.ok(gpu, 'the accelerator row must name Metal')
+    assert.equal(gpu.value, 'true')
+  })
+
+  check('no lever is offered as live-settable on a Metal host', () => {
+    /* POST /api/runtime/gpu writes cuda::set_gpu_accel_enabled and
+       set_runtime_enabled; every reader of those is a CUDA or BitNet path, and the
+       planner's Metal arms gate on metal_available plus per-lane opt-outs instead.
+       So the toggle genuinely cannot move this lane. */
+    const lane = readActiveLane(macRuntime)
+    assert.equal(lane.rows.filter((row) => row.changeable === 'gpu_toggle').length, 0)
+    assert.ok(lane.rows.every((row) => row.changeable === 'restart'))
+  })
+
+  check('an engine too old to report its OS is read from the backend prefix', () => {
+    const lane = readActiveLane({ execution_plan: { selected_backend: 'metal_resident_q8_runtime' } })
+    assert.ok(lane.rows.find((row) => row.key === 'metal_resident_active'))
+  })
+
+  check('a zero VRAM total reads as unreported, not as an empty device', () => {
+    /* src/api/metrics.rs writes both CUDA gauges unconditionally and
+       HardwareProfile::detect() leaves them at 0 on every macOS host, so this is
+       the exposition a Mac actually serves — not a hypothetical. */
+    const macMetrics = summarizeMetrics(`# TYPE camelid_process_resident_memory_bytes gauge
+camelid_process_resident_memory_bytes 17000000000
+# TYPE camelid_cuda_vram_total_bytes gauge
+camelid_cuda_vram_total_bytes 0
+# TYPE camelid_cuda_vram_free_bytes gauge
+camelid_cuda_vram_free_bytes 0
+`)
+    assert.equal(macMetrics.memory.vramUsedBytes, null, '0 B of 0 B is not a reading')
+    assert.equal(macMetrics.memory.vramTotalBytes, null)
+    assert.equal(formatBytes(macMetrics.memory.vramUsedBytes), '—')
+    /* Resident memory still reports: only the VRAM pair is suppressed. */
+    assert.equal(macMetrics.memory.residentBytes, 17000000000)
+  })
+
+  check('a committed device still reports zero free against a real total', () => {
+    const full = summarizeMetrics(`# TYPE camelid_cuda_vram_total_bytes gauge
+camelid_cuda_vram_total_bytes 6441926656
+# TYPE camelid_cuda_vram_free_bytes gauge
+camelid_cuda_vram_free_bytes 0
+`)
+    assert.equal(full.memory.vramUsedBytes, 6441926656)
+  })
+
+  check('the Metal panel does not promise a toggle that cannot move it', () => {
+    const html = renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+      apiBase: '', runtime: macRuntime, initialMetricsText: LIVE_METRICS,
+    }))
+    assert.doesNotMatch(html, /CUDA resident/, 'no CUDA row on a Metal host')
+    assert.match(html, /Nothing on this lane is settable while the engine runs/)
+    assert.doesNotMatch(html, /the one exception the engine accepts while running/)
   })
 
   console.log('engine metrics — rendered copy')

--- a/frontend/scripts/tool-calling-smoke.mjs
+++ b/frontend/scripts/tool-calling-smoke.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/* Tool calling — gating, normalization, loop detection, and copy that does not
+ * claim more than happened.
+ *
+ * The defects that matter here are claims and silent mismatches, not crashes:
+ *
+ *   1. SAYING SOMETHING RAN. Nothing in this lane executes anything. A card that
+ *      implies a tool was invoked would misdescribe the single most consequential
+ *      fact about the turn.
+ *
+ *   2. CLAIMING THE ENGINE ENFORCES THIS GATE. It does not. POST
+ *      /v1/chat/completions gates on the chat TEMPLATE and never reads
+ *      `tool_capable`; a row with tool_capable:false whose template carries tools
+ *      is accepted with a 200 and returns unchecked calls. This lane is
+ *      deliberately stricter, and the copy must own that as a product choice.
+ *
+ *   3. A LOOPING MODEL RENDERED AS PROGRESS. Verified live: given a tool result,
+ *      Llama 3.2 3B re-issued the identical call. Detection must ignore the call
+ *      id, because the runnable lane mints non-unique ids (call_0, call_1).
+ *
+ * The response fixture is the engine's own committed capture, not a hand-written
+ * literal.
+ *
+ * SSR component test — no browser, no dist build required.
+ */
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+const repoRoot = resolve(frontendRoot, '..')
+
+let checks = 0
+function check(label, fn) {
+  fn()
+  checks += 1
+  console.log(`  ok  ${label}`)
+}
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const mod = await server.ssrLoadModule('/src/lib/toolCalling.js')
+  const { ToolCallsCard } = await server.ssrLoadModule('/src/components/chat/render/ToolCalls.jsx')
+  const {
+    DEFAULT_TOOLS,
+    readToolContract,
+    parseToolDefinitions,
+    toolRequestFields,
+    toolReadiness,
+    normalizeToolCalls,
+    toolCallSignature,
+    detectRepeatedCall,
+    replyCarriesRawEnvelope,
+  } = mod
+
+  const live = {
+    api_features: [{ id: 'streaming_tool_calls', status: 'supported_current_gate', notes: 'Tool-capable chat streams emit tool_calls deltas.' }],
+    api_conformance: [{ id: 'streaming_tool_calls', status: 'supported_current_gate', supported_modes: ['chat_completions_sse', 'responses_sse'], unsupported_modes: ['uncertified_model_tool_templates'] }],
+  }
+  const capable = { capable: true, reason: null, rowId: 'llama32_3b_instruct_q8_0' }
+
+  console.log('tool calling — contract gating')
+
+  check('a live contract is supported; an absent row fails closed', () => {
+    assert.equal(readToolContract(live).supported, true)
+    assert.equal(readToolContract({}).present, false)
+    assert.deepEqual(toolRequestFields({ enabled: true, contract: readToolContract({}), capability: capable, toolsText: DEFAULT_TOOLS }), {})
+  })
+
+  check('resemblance is not evidence — a near-miss row id does not count', () => {
+    assert.equal(readToolContract({ api_conformance: [{ id: 'streaming_tool_calls_v2', status: 'supported' }] }).present, false)
+  })
+
+  check('an engine row alone does not license tools — the model gate also applies', () => {
+    const fields = toolRequestFields({
+      enabled: true, contract: readToolContract(live),
+      capability: { capable: false, reason: 'no receipt' }, toolsText: DEFAULT_TOOLS,
+    })
+    assert.deepEqual(fields, {}, 'a model without a tool receipt must contribute no tools field')
+  })
+
+  check('the guarded reason does not claim the engine enforces this gate', () => {
+    // The engine gates on the chat template and never reads tool_capable. Copy
+    // asserting otherwise would be a false statement about the backend.
+    const readiness = toolReadiness({
+      enabled: true, contract: readToolContract(live),
+      capability: { capable: false, reason: 'This model has no tool receipt. The engine may still accept tools for it, but the results are unchecked, so Camelid does not offer them here.' },
+      toolsText: DEFAULT_TOOLS,
+    })
+    assert.equal(readiness.ready, false)
+    assert.doesNotMatch(readiness.reason, /refused by the engine|engine refuses/i)
+    assert.match(readiness.reason, /may still accept|unchecked/i)
+  })
+
+  console.log('tool calling — request composition')
+
+  check('the default tool definition is valid', () => {
+    const parsed = parseToolDefinitions(DEFAULT_TOOLS)
+    assert.equal(parsed.ok, true)
+    assert.equal(parsed.value[0].function.name, 'get_weather')
+  })
+
+  check('a malformed tools array is explained at edit time, not sent', () => {
+    for (const [text, pattern] of [
+      ['{ not json', /valid JSON/i],
+      ['{}', /array/i],
+      ['[]', /at least one/i],
+      ['[{"type":"x"}]', /"type" must be "function"/],
+      ['[{"type":"function","function":{}}]', /name" is required/],
+    ]) {
+      const parsed = parseToolDefinitions(text)
+      assert.equal(parsed.ok, false, `expected ${text} to be rejected`)
+      assert.match(parsed.error, pattern)
+      assert.deepEqual(
+        toolRequestFields({ enabled: true, contract: readToolContract(live), capability: capable, toolsText: text }),
+        {},
+        'an invalid definition must contribute no tools field',
+      )
+    }
+  })
+
+  check('tools ride on the ordinary send and never force it off the stream', () => {
+    // Unlike receipts and constrained decoding, tool calling is supported on the
+    // streaming path — so nothing here may touch the stream flag.
+    const fields = toolRequestFields({ enabled: true, contract: readToolContract(live), capability: capable, toolsText: DEFAULT_TOOLS })
+    assert.deepEqual(Object.keys(fields), ['tools'])
+    assert.ok(!('stream' in fields))
+  })
+
+  console.log('tool calling — normalization')
+
+  /* The engine's own captured response, if the repo carries it. */
+  const fixturePath = resolve(repoRoot, 'qa/capability/mac_tools_out/llama-3.2-3b/p1.json')
+  if (existsSync(fixturePath)) {
+    check('the committed engine capture still has the shape this surface reads', () => {
+      const captured = JSON.parse(readFileSync(fixturePath, 'utf8'))
+      const message = captured.choices[0].message
+      assert.equal(captured.choices[0].finish_reason, 'tool_calls')
+      const calls = normalizeToolCalls(message.tool_calls)
+      assert.ok(calls && calls.length >= 1)
+      assert.equal(typeof calls[0].name, 'string')
+      assert.ok(calls[0].parsedArguments, 'arguments must parse from the real capture')
+    })
+  } else {
+    console.log('  --  engine capture fixture absent on this branch; skipped')
+  }
+
+  check('malformed arguments are reported, never swallowed', () => {
+    const calls = normalizeToolCalls([{ id: 'c', type: 'function', function: { name: 'f', arguments: '{not json' } }])
+    assert.equal(calls[0].parsedArguments, null)
+    assert.ok(calls[0].parseError, 'the parse failure must be surfaced')
+    assert.equal(calls[0].rawArguments, '{not json', 'and the raw text preserved')
+  })
+
+  check('an empty or absent list yields nothing rather than an empty card', () => {
+    assert.equal(normalizeToolCalls(null), null)
+    assert.equal(normalizeToolCalls([]), null)
+  })
+
+  console.log('tool calling — loop detection')
+
+  check('a repeated call is detected across differing ids and whitespace', () => {
+    const first = normalizeToolCalls([{ id: 'call_a', type: 'function', function: { name: 'get_weather', arguments: '{"city":"Paris"}' } }])
+    // Same request, different id and spacing — the runnable lane mints
+    // non-unique ids (call_0, call_1), so identity must not depend on them.
+    const again = normalizeToolCalls([{ id: 'call_0', type: 'function', function: { name: 'get_weather', arguments: '{"city": "Paris"}' } }])
+    assert.equal(detectRepeatedCall([], first).repeated, false, 'the first call is not a repeat')
+    const verdict = detectRepeatedCall(first.map(toolCallSignature), again)
+    assert.equal(verdict.repeated, true)
+    assert.equal(verdict.name, 'get_weather')
+  })
+
+  check('a genuinely different call is not flagged', () => {
+    const first = normalizeToolCalls([{ id: 'a', type: 'function', function: { name: 'get_weather', arguments: '{"city":"Paris"}' } }])
+    const other = normalizeToolCalls([{ id: 'b', type: 'function', function: { name: 'get_weather', arguments: '{"city":"Berlin"}' } }])
+    assert.equal(detectRepeatedCall(first.map(toolCallSignature), other).repeated, false)
+  })
+
+  console.log('tool calling — the runnable lane leaves its envelope in the text')
+
+  check('a raw envelope in the reply is detected, and ordinary prose is not', () => {
+    assert.equal(replyCarriesRawEnvelope('The weather in Paris is mild.'), false)
+    assert.equal(replyCarriesRawEnvelope(''), false)
+    assert.equal(replyCarriesRawEnvelope('<function=get_weather><parameter=city>Paris</parameter></function>'), true)
+    assert.equal(replyCarriesRawEnvelope('<tool_call>{"name":"x"}</tool_call>'), true)
+    assert.equal(replyCarriesRawEnvelope('[TOOL_CALLS] foo'), true)
+  })
+
+  console.log('tool calling — rendered copy')
+
+  const CALLS = [{ id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '{"city":"Paris"}' } }]
+  const render = (props) => renderToStaticMarkup(React.createElement(ToolCallsCard, { toolCalls: CALLS, ...props }))
+
+  check('the card never says anything ran', () => {
+    const html = render({})
+    assert.match(html, /get_weather/)
+    assert.match(html, /Nothing\s*has run/i)
+    assert.doesNotMatch(html, /\bexecuted\b|\bwas run\b|\bresult:/i)
+    assert.doesNotMatch(html, /\bsucceeded\b|\bcompleted successfully\b/i)
+  })
+
+  check('a repeat is named as a repeat, not shown as progress', () => {
+    const html = render({ repeated: { repeated: true, name: 'get_weather', signature: 's' } })
+    assert.match(html, /same call as before/i)
+    assert.match(html, /not using the result/i)
+  })
+
+  check('the duplicated-envelope case is explained rather than looking like two requests', () => {
+    const html = render({ replyContent: '<function=get_weather><parameter=city>Paris</parameter></function>' })
+    assert.match(html, /same request, not two requests/i)
+  })
+
+  check('nothing renders without calls', () => {
+    assert.equal(renderToStaticMarkup(React.createElement(ToolCallsCard, { toolCalls: null })), '')
+  })
+
+  check('the lane executes nothing — asserted at the source', () => {
+    const source = readFileSync(resolve(frontendRoot, 'src/lib/toolCalling.js'), 'utf8')
+    const component = readFileSync(resolve(frontendRoot, 'src/components/chat/render/ToolCalls.jsx'), 'utf8')
+    for (const [name, text] of [['lib', source], ['component', component]]) {
+      assert.doesNotMatch(text, /\beval\(|new Function\(|child_process|\bexec\(/, `${name} must contain no execution path`)
+    }
+  })
+
+  console.log(`\n${checks} checks passed`)
+} finally {
+  await server.close()
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -537,7 +537,7 @@ function App() {
             />
           )}
 
-          {tab === 'system' && <SystemView runtime={runtime} selectedModel={selectedModel} capabilities={dashboard?.capabilities} />}
+          {tab === 'system' && <SystemView runtime={runtime} selectedModel={selectedModel} capabilities={dashboard?.capabilities} metricsApiBase={apiBase} />}
 
           {tab === 'settings' && (
             <SettingsView

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -87,6 +87,7 @@ function App() {
     inspectMode, setInspectMode, tokenInspections, inspectionSupported,
     structuredMode, setStructuredMode, structuredSchema, setStructuredSchema,
     structuredGrammar, setStructuredGrammar, structuredRecords, structuredSupported, structuredReadiness,
+    toolsEnabled, setToolsEnabled, toolsText, setToolsText, toolContract, toolCapability, toolsReadiness, toolCallSignatures,
     thinkingMode, setThinkingMode,
     webResearchEnabled, setWebResearchEnabled, webResearchStatus,
     loadingModelId, registerForm, setRegisterForm,
@@ -436,6 +437,13 @@ function App() {
               structuredRecords={structuredRecords}
               structuredSupported={structuredSupported}
               structuredReadiness={structuredReadiness}
+              toolsEnabled={toolsEnabled}
+              setToolsEnabled={setToolsEnabled}
+              toolsText={toolsText}
+              setToolsText={setToolsText}
+              toolCapability={toolCapability}
+              toolsReadiness={toolsReadiness}
+              toolCallSignatures={toolCallSignatures}
               thinkingMode={thinkingMode}
               setThinkingMode={setThinkingMode}
               webResearchEnabled={webResearchEnabled}

--- a/frontend/src/components/analytics/EngineMetricsPanel.jsx
+++ b/frontend/src/components/analytics/EngineMetricsPanel.jsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react'
+import {
+  LANE_RISK,
+  LANE_RISK_COPY,
+  formatBytes,
+  formatCount,
+  formatRate,
+  formatSeconds,
+  formatShare,
+  readActiveLane,
+  summarizeMetrics,
+} from '../../lib/runtimeMetrics'
+
+/* Engine metrics — what the SERVER reports about itself.
+
+   Distinct from the Telemetry view, which times requests in this browser and is
+   therefore client-measured. These numbers come from the engine's own /metrics
+   surface, and they include quantities a browser cannot observe at all: how often
+   the prompt-prefix cache was reused, how forward time split between evaluating
+   prompts and decoding, how deep the job queue got.
+
+   COPY RULE. Every counter here is cumulative since the engine started, so every
+   derived figure is a LIFETIME AVERAGE and is labelled as one. A server that ran
+   fast for an hour and has been slow for a minute still reports the hour, and a
+   panel that called that "current" would be lying with true numbers.
+
+   The second section is the quarantined half: which lane the engine is decoding
+   on, and whether that lane carries parity evidence here. It offers no controls,
+   because the engine has none — one HTTP route mutates runtime configuration and
+   the rest are read once at process start. A toggle would save a value and do
+   nothing. */
+
+const REFRESH_MS = 5000
+
+function Stat({ label, value, hint }) {
+  return (
+    <div className="engmetrics__stat">
+      <dt>{label}</dt>
+      <dd title={hint}>{value}</dd>
+    </div>
+  )
+}
+
+export function EngineMetricsPanel({ apiBase, runtime, initialMetricsText = null }) {
+  const [summary, setSummary] = useState(() => (initialMetricsText ? summarizeMetrics(initialMetricsText) : null))
+  const [error, setError] = useState(null)
+  const base = (apiBase || '').replace(/\/$/, '')
+
+  useEffect(() => {
+    if (initialMetricsText) return undefined
+    let cancelled = false
+    const load = async () => {
+      try {
+        const response = await fetch(`${base}/metrics`)
+        if (!response.ok) {
+          if (!cancelled) setError(`The engine returned ${response.status} for /metrics.`)
+          return
+        }
+        const text = await response.text()
+        if (cancelled) return
+        const next = summarizeMetrics(text)
+        setSummary(next)
+        /* A 200 that is not Prometheus text is a different fault from an engine
+           with nothing to report — most often a proxy answering /metrics itself.
+           Saying which one keeps a routing problem from reading as an idle engine. */
+        setError(next
+          ? null
+          : /^\s*#\s*(HELP|TYPE)/m.test(text)
+            ? 'The engine reported no metrics.'
+            : 'The response to /metrics was not Prometheus text — something between this page and the engine answered it.')
+      } catch {
+        if (!cancelled) setError('The engine is not reachable.')
+      }
+    }
+    load()
+    const timer = setInterval(load, REFRESH_MS)
+    return () => { cancelled = true; clearInterval(timer) }
+  }, [base, initialMetricsText])
+
+  const lane = readActiveLane(runtime)
+  const laneCopy = LANE_RISK_COPY[lane.risk]
+
+  return (
+    <div className="engmetrics">
+      <section className="engmetrics__section">
+        <h2>Engine metrics</h2>
+        <p className="engmetrics__intro">
+          Reported by the engine about itself, not measured in this browser. Counters are
+          cumulative since the engine started, so every average below covers its whole run.
+        </p>
+
+        {error && <p className="engmetrics__error">{error}</p>}
+
+        {summary && (
+          <>
+            <dl className="engmetrics__stats">
+              <Stat
+                label="Prefix cache reuse"
+                value={formatShare(summary.lifetime.promptCacheHitRate)}
+                hint="Share of completed generations that reused a cached prompt prefix instead of re-evaluating it. Lifetime average."
+              />
+              <Stat
+                label="Time spent on prompts"
+                value={formatShare(summary.lifetime.prefillShare)}
+                hint="Share of forward time spent evaluating prompts rather than decoding. Lifetime average."
+              />
+              <Stat
+                label="Decode rate"
+                value={formatRate(summary.lifetime.decodeTokensPerSecond)}
+                hint="Decoded tokens divided by decode time, over the engine's whole run. Not a current rate."
+              />
+              <Stat
+                label="Weights reused"
+                value={formatShare(summary.lifetime.weightCacheHitRate)}
+                hint="Share of generations that reused already-loaded weights. Lifetime average."
+              />
+            </dl>
+
+            <dl className="engmetrics__stats engmetrics__stats--muted">
+              <Stat label="Generations" value={formatCount(summary.counters.genRequests)} />
+              <Stat label="Failed" value={formatCount(summary.counters.genFailures)} />
+              <Stat label="Prompt tokens" value={formatCount(summary.counters.promptTokens)} />
+              <Stat label="Decoded tokens" value={formatCount(summary.counters.decodeTokens)} />
+              <Stat label="Prompt time" value={formatSeconds(summary.lifetime.promptSeconds)} />
+              <Stat label="Decode time" value={formatSeconds(summary.lifetime.decodeSeconds)} />
+            </dl>
+
+            <dl className="engmetrics__stats engmetrics__stats--muted">
+              <Stat label="Queue depth" value={formatCount(summary.live.queueDepth)} hint="Queued plus active engine jobs, right now." />
+              <Stat label="Waiting" value={formatCount(summary.live.queuedTasks)} />
+              <Stat label="Resident memory" value={formatBytes(summary.memory.residentBytes)} />
+              <Stat
+                label="VRAM in use"
+                value={summary.memory.vramUsedBytes === null
+                  ? '—'
+                  : `${formatBytes(summary.memory.vramUsedBytes)} of ${formatBytes(summary.memory.vramTotalBytes)}`}
+                hint="From the engine's cached hardware probe."
+              />
+            </dl>
+
+            {summary.lifetime.promptCacheAttempts === 0 && (
+              <p className="engmetrics__note">
+                The prefix cache has not been consulted yet, so its reuse rate is unknown rather than zero.
+              </p>
+            )}
+            {summary.missing.length > 0 && (
+              <p className="engmetrics__note">
+                {summary.missing.length} metric{summary.missing.length === 1 ? '' : 's'} this page knows about
+                {summary.missing.length === 1 ? ' is' : ' are'} not reported by this engine build.
+              </p>
+            )}
+          </>
+        )}
+      </section>
+
+      <section className="engmetrics__section">
+        <h2>Active configuration</h2>
+        <div className={`engmetrics__lane engmetrics__lane--${lane.risk}`}>
+          <span className="engmetrics__lane-label">{laneCopy.label}</span>
+          <p className="engmetrics__lane-detail">{laneCopy.detail}</p>
+        </div>
+
+        {lane.rows.length > 0 && (
+          <table className="cxv-table engmetrics__table">
+            <thead>
+              <tr>
+                <th scope="col">Setting</th>
+                <th scope="col">Active value</th>
+                <th scope="col">Changing it</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lane.rows.map((row) => (
+                <tr key={row.key}>
+                  <td>
+                    {row.label}
+                    <span className="engmetrics__row-note">{row.note}</span>
+                  </td>
+                  <td className="engmetrics__value">{row.value}</td>
+                  <td className="engmetrics__change">
+                    {row.changeable === 'gpu_toggle'
+                      ? 'Settings → GPU acceleration'
+                      : 'Restart required'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {/* The reason this section has no switches. Stated once, plainly, rather
+            than implied by their absence. */}
+        <p className="engmetrics__note">
+          These are read once when the engine starts, and several are latched for the life of the
+          process — so they are shown here rather than offered as controls. Changing one means
+          restarting the engine with a different setting. The GPU acceleration toggle in Settings is
+          the one exception the engine accepts while running.
+        </p>
+
+        {lane.reasons.length > 0 && (
+          <details className="engmetrics__reasons">
+            <summary>Why the engine chose this lane</summary>
+            <ul>
+              {lane.reasons.map((reason) => <li key={reason}>{reason}</li>)}
+            </ul>
+          </details>
+        )}
+      </section>
+    </div>
+  )
+}
+
+export default EngineMetricsPanel

--- a/frontend/src/components/analytics/EngineMetricsPanel.jsx
+++ b/frontend/src/components/analytics/EngineMetricsPanel.jsx
@@ -193,8 +193,14 @@ export function EngineMetricsPanel({ apiBase, runtime, initialMetricsText = null
         <p className="engmetrics__note">
           These are read once when the engine starts, and several are latched for the life of the
           process — so they are shown here rather than offered as controls. Changing one means
-          restarting the engine with a different setting. The GPU acceleration toggle in Settings is
-          the one exception the engine accepts while running.
+          restarting the engine with a different setting.{' '}
+          {/* Only claim the exception where it exists. The GPU toggle writes two CUDA
+              atomics that no Metal lane reads, so on a Metal host the honest count of
+              live-settable levers is zero — and a panel built to avoid controls that do
+              nothing must not describe one. */}
+          {lane.rows.some((row) => row.changeable === 'gpu_toggle')
+            ? 'The GPU acceleration toggle in Settings is the one exception the engine accepts while running.'
+            : 'Nothing on this lane is settable while the engine runs.'}
         </p>
 
         {lane.reasons.length > 0 && (

--- a/frontend/src/components/chat/MessageTurn.jsx
+++ b/frontend/src/components/chat/MessageTurn.jsx
@@ -15,6 +15,7 @@ import { ParityReceiptCard } from './render/ParityReceipt'
 import { DeveloperDiagnosticsBlock } from './render/Diagnostics'
 import { TokenInspectorCard } from './render/TokenInspector'
 import { StructuredOutputCard } from './render/StructuredOutput'
+import { ToolCallsCard } from './render/ToolCalls'
 
 const formatMs = (value) => {
   const ms = Number(value)
@@ -257,7 +258,7 @@ function UserTurn({ message, messageContent, onEditResend }) {
   )
 }
 
-export const MessageTurn = memo(function MessageTurn({ message, generationElapsedSeconds, priorUserPrompt, onReusePrompt, onRegenerate, onEditResend, tokenInspection = null, structuredRecord = null }) {
+export const MessageTurn = memo(function MessageTurn({ message, generationElapsedSeconds, priorUserPrompt, onReusePrompt, onRegenerate, onEditResend, tokenInspection = null, structuredRecord = null, toolCallRepeat = null }) {
   const [copied, setCopied] = useState(false)
   const copiedResetRef = useRef(null)
   const messageContent = cleanLegacyDemoCapCopy(message.content)
@@ -395,6 +396,9 @@ export const MessageTurn = memo(function MessageTurn({ message, generationElapse
             inspection={tokenInspection.logprobs}
             absence={tokenInspection.absence}
           />
+        )}
+        {message.role === 'assistant' && !assistantStreaming && message.tool_calls && (
+          <ToolCallsCard toolCalls={message.tool_calls} repeated={toolCallRepeat} replyContent={messageContent} />
         )}
         <DeveloperDiagnosticsBlock message={message} />
       </div>

--- a/frontend/src/components/chat/render/ToolCalls.jsx
+++ b/frontend/src/components/chat/render/ToolCalls.jsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { formatArguments, normalizeToolCalls, replyCarriesRawEnvelope } from '../../../lib/toolCalling'
+
+/* Tool calls — what the model ASKED to call.
+
+   Self-gating like the parity receipt beside it.
+
+   COPY RULE, and it is the whole point of this component: nothing here ran.
+   The model produced a request, the turn ended with finish_reason "tool_calls",
+   and that is the entire event. This card never says a tool executed, never
+   implies a result, and offers no way to run one — a browser executing
+   model-chosen calls against the user's machine is a different and much larger
+   proposition than showing what was asked for.
+
+   The arguments are a JSON string the MODEL wrote. They can be malformed and can
+   disagree with the schema that was offered. A parse failure is shown, not
+   swallowed: a model emitting broken arguments is a real thing to know, and
+   presenting it as a clean call would hide it. */
+
+export function ToolCallsCard({ toolCalls, repeated = null, replyContent = '' }) {
+  const [expanded, setExpanded] = useState(true)
+  const calls = normalizeToolCalls(toolCalls)
+  if (!calls) return null
+
+  return (
+    <div className="toolcalls">
+      <button
+        type="button"
+        className="toolcalls__trigger"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <span className="toolcalls__label">Tool call requested</span>
+        <span className="toolcalls__summary">
+          {calls.length === 1 ? calls[0].name || 'unnamed' : `${calls.length} calls`}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="toolcalls__body">
+          <p className="toolcalls__note">
+            The model ended this turn by asking to call {calls.length === 1 ? 'this' : 'these'}. Nothing
+            has run — Camelid does not execute tool calls from the browser. Supply a result below to
+            continue the conversation.
+          </p>
+
+          {replyCarriesRawEnvelope(replyContent) && (
+            <p className="toolcalls__note">
+              This lane also left the model&rsquo;s raw call markup in the reply text above. The calls
+              below were lifted from it — the two describe the same request, not two requests.
+            </p>
+          )}
+
+          {repeated?.repeated && (
+            <p className="toolcalls__repeat">
+              This is the same call as before{repeated.name ? ` (${repeated.name})` : ''}, with the same
+              arguments. The model is not using the result it was given, so continuing again will
+              probably repeat it.
+            </p>
+          )}
+
+          <ul className="toolcalls__list">
+            {calls.map((call) => (
+              <li key={call.id || call.index} className="toolcalls__call">
+                <div className="toolcalls__call-head">
+                  {/* Rendered as text, never as markup: a tool name is model output. */}
+                  <code className="toolcalls__name">{call.name || '(no name)'}</code>
+                  {call.id && <span className="toolcalls__id">{call.id}</span>}
+                </div>
+                {call.parseError ? (
+                  <p className="toolcalls__parse-error">
+                    The model&rsquo;s arguments are not valid JSON ({call.parseError}). Shown exactly as
+                    they arrived:
+                  </p>
+                ) : null}
+                <pre className="toolcalls__args">{formatArguments(call)}</pre>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ToolCallsCard

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -20,6 +20,7 @@ import { getRuntimeRequestModelId, isExternalModel, modelRuntimeIdMatches } from
 import { contractSamplingOverrides } from '../lib/samplingContract'
 import { inspectionAbsenceReason, inspectionForcesNonStreaming, inspectionRequestFields, normalizeInspection, readInspectionContract } from '../lib/tokenInspection'
 import { STRUCTURED_MODES, DEFAULT_SCHEMA, DEFAULT_GRAMMAR, readStructuredOutputContract, structuredOutputForcesNonStreaming, structuredOutputRequestFields, structuredOutputReadiness } from '../lib/structuredOutput'
+import { DEFAULT_TOOLS, detectRepeatedCall, normalizeToolCalls, readModelToolCapability, readToolContract, toolCallSignature, toolReadiness, toolRequestFields } from '../lib/toolCalling'
 import { executionRuntimeFields } from '../lib/executionPlan'
 import {
   createPacerState,
@@ -730,6 +731,15 @@ export function useDashboardData({ showNotice, clearNotice }) {
   const [structuredGrammar, setStructuredGrammar] = useState(DEFAULT_GRAMMAR)
   const [structuredRecords, setStructuredRecords] = useState({})
   const [tokenInspections, setTokenInspections] = useState({})
+  /* Tool definitions are a per-session editing surface, not a persisted setting:
+     they are a developer probe against the loaded model, and a stale definition
+     silently shaping a later conversation would be worse than retyping one. */
+  const [toolsEnabled, setToolsEnabled] = useState(false)
+  const [toolsText, setToolsText] = useState(DEFAULT_TOOLS)
+  /* Signatures of every call already requested in this conversation, so a model
+     that ignores a tool result and re-asks can be named rather than looping
+     invisibly. Verified live: Llama 3.2 3B does exactly this. */
+  const [toolCallSignatures, setToolCallSignatures] = useState({})
   // Opt-in thinking mode (experimental — NOT parity-locked): sends
   // camelid_enable_thinking:true so the model emits its own <think>…</think>
   // reasoning. Default OFF so chat stays on the parity-locked thinking-DISABLED
@@ -1090,6 +1100,9 @@ export function useDashboardData({ showNotice, clearNotice }) {
     schemaText: structuredSchema,
     grammarText: structuredGrammar,
   })
+  const toolContract = readToolContract(dashboard?.capabilities)
+  const toolCapability = readModelToolCapability(dashboard?.capabilities, selectedModel, runtime)
+  const toolsReadiness = toolReadiness({ enabled: toolsEnabled, contract: toolContract, capability: toolCapability, toolsText })
   const selectedModelRunnable = selectedModelChatGate.chatUnlocked
   // Experimental lane: loaded + generation-ready implemented model that is NOT a
   // supported row. Enables a weaker chat affordance; never the supported badge.
@@ -1764,6 +1777,11 @@ export function useDashboardData({ showNotice, clearNotice }) {
              engine, so a guarded row simply never reaches the wire. */
           ...(targetVerifiedRender ? {} : inspectionRequestFields({ enabled: inspectMode, contract: inspectionContract })),
           ...(targetVerifiedRender ? {} : structuredOutputRequestFields({ enabled: true, mode: structuredMode, contract: sendStructuredContract, schemaText: structuredSchema, grammarText: structuredGrammar })),
+          /* Tool calling is supported on BOTH the streaming and non-streaming
+             paths, so unlike receipts and constrained decoding it does not force
+             the turn off the stream. Contributes nothing unless the engine row
+             AND the loaded model both carry the capability. */
+          ...(targetVerifiedRender ? {} : toolRequestFields({ enabled: toolsEnabled, contract: toolContract, capability: toolCapability, toolsText })),
           ...(targetVerifiedRender ? {
             // The private verifier contract is exact: its output allowance is
             // the complete fresh draft, not the planner's larger upper bound.
@@ -2016,6 +2034,17 @@ export function useDashboardData({ showNotice, clearNotice }) {
           },
         }))
       }
+      /* Record what was asked so a later identical request can be named. Keyed
+         by conversation: a repeat only means something within one thread. */
+      if (streamed.toolCalls && streamed.toolCalls.length) {
+        const signatures = (normalizeToolCalls(streamed.toolCalls) || []).map(toolCallSignature).filter(Boolean)
+        if (signatures.length) {
+          setToolCallSignatures((current) => ({
+            ...current,
+            [conversation.id]: [...(current[conversation.id] || []), ...signatures],
+          }))
+        }
+      }
       const assistantMessage = {
         ...assistantMessageBase,
         content: paceDrain(pacer, streamed.content || ''),
@@ -2036,6 +2065,9 @@ export function useDashboardData({ showNotice, clearNotice }) {
         camelid: streamed.camelid || null,
         planner_camelid: targetVerifiedPlannerCamelid,
         camelid_receipt: streamed.camelidReceipt || null,
+        /* Persisted on the message: unlike per-token logprobs these are small, and
+           a turn that ended in a tool request is meaningless without them. */
+        tool_calls: streamed.toolCalls || null,
         planner_ms: targetVerifiedPlannerMs,
         target_verified_render: targetVerifiedRender,
         segmented_target_verified_render: segmentedTargetVerifiedRender,
@@ -2553,6 +2585,14 @@ export function useDashboardData({ showNotice, clearNotice }) {
     structuredRecords,
     structuredSupported,
     structuredReadiness,
+    toolsEnabled,
+    setToolsEnabled,
+    toolsText,
+    setToolsText,
+    toolContract,
+    toolCapability,
+    toolsReadiness,
+    toolCallSignatures,
     thinkingMode,
     setThinkingMode,
     loadingModelId,

--- a/frontend/src/lib/chatCompletionStream.js
+++ b/frontend/src/lib/chatCompletionStream.js
@@ -68,6 +68,10 @@ export function readChatCompletionJsonPayload(payload, { estimateTokenCount = de
        non-streaming shape in one place; the streaming path has no equivalent,
        because the engine refuses logprobs with stream:true. */
     logprobs: Object.prototype.hasOwnProperty.call(choice || {}, 'logprobs') ? choice.logprobs : null,
+    /* A tool-capable model can end a turn by asking to call something instead of
+       writing prose: finish_reason is "tool_calls" and content is empty. Dropping
+       this key made such a turn render as a blank reply. */
+    toolCalls: Array.isArray(choice?.message?.tool_calls) ? choice.message.tool_calls : null,
   }
 }
 
@@ -97,7 +101,7 @@ export async function readStreamingChatCompletion(response, onDelta, { estimateT
   }
 
   const reader = response.body?.getReader()
-  if (!reader) return { content: '', finishReason: null, completionTokens: 0, firstContentMs: null, firstByteMs: null, firstEventMs: null, usage: null, camelid: null, camelidReceipt: null, logprobs: null }
+  if (!reader) return { content: '', finishReason: null, completionTokens: 0, firstContentMs: null, firstByteMs: null, firstEventMs: null, usage: null, camelid: null, camelidReceipt: null, logprobs: null, toolCalls: null }
   const decoder = new TextDecoder()
   let buffer = ''
   let content = ''
@@ -105,6 +109,12 @@ export async function readStreamingChatCompletion(response, onDelta, { estimateT
   let completionTokens = 0
   let usage = null
   let camelid = null
+  /* Tool calls arrive as a delta on the assistant turn. Verified against a live
+     engine: this build sends one COMPLETE call per delta — id, name and the whole
+     argument string together — rather than streaming argument fragments that a
+     client must concatenate. Accumulated by index anyway, so a future build that
+     does fragment them does not silently truncate. */
+  const toolCallsByIndex = new Map()
   const streamStartedAt = performance.now()
   let firstByteMs = null
   let firstEventMs = null
@@ -144,6 +154,15 @@ export async function readStreamingChatCompletion(response, onDelta, { estimateT
       const role = choice?.delta?.role ?? null
       const delta = choice?.delta?.content ?? choice?.text ?? ''
       const segment = choice?.delta?.camelid_segment
+      for (const call of choice?.delta?.tool_calls || []) {
+        const index = Number.isInteger(call?.index) ? call.index : toolCallsByIndex.size
+        const existing = toolCallsByIndex.get(index) || { index, id: null, type: 'function', function: { name: '', arguments: '' } }
+        if (call?.id) existing.id = call.id
+        if (call?.type) existing.type = call.type
+        if (call?.function?.name) existing.function.name = call.function.name
+        if (typeof call?.function?.arguments === 'string') existing.function.arguments += call.function.arguments
+        toolCallsByIndex.set(index, existing)
+      }
       // Reasoning deltas are GENERATED TOKENS even though they are not visible
       // content. A thinking model can spend an entire reply in `reasoning_content`
       // (LFM2's generation prompt opens a <think> block), so counting only
@@ -204,6 +223,10 @@ export async function readStreamingChatCompletion(response, onDelta, { estimateT
   buffer += decoder.decode()
   if (buffer.trim()) consumeEvent(buffer.replace(/\r\n/g, '\n'))
   // Receipts and logprobs only attach to non-streaming responses (the JSON
-  // fallback above); the engine rejects logprobs with stream:true outright.
-  return { content, finishReason, completionTokens, firstContentMs, firstByteMs, firstEventMs, usage, camelid, camelidReceipt: null, logprobs: null }
+  // fallback above); the engine rejects logprobs with stream:true outright. Tool
+  // calls are the exception — they DO arrive on the streaming path.
+  const toolCalls = toolCallsByIndex.size
+    ? [...toolCallsByIndex.entries()].sort((a, b) => a[0] - b[0]).map(([, call]) => call)
+    : null
+  return { content, finishReason, completionTokens, firstContentMs, firstByteMs, firstEventMs, usage, camelid, camelidReceipt: null, logprobs: null, toolCalls }
 }

--- a/frontend/src/lib/runtimeMetrics.js
+++ b/frontend/src/lib/runtimeMetrics.js
@@ -1,0 +1,324 @@
+/* Server-reported runtime metrics, and the risk posture of the active lane.
+
+   Two surfaces are served from this module, and they are deliberately different
+   in kind.
+
+   THE SAFE ONE reads GET /metrics — the engine's own Prometheus exposition. This
+   is server truth, unlike the request timings the Telemetry view measures in the
+   browser, and it carries quantities the browser cannot see at all: how often the
+   prompt-prefix cache was reused, how the engine's time split between evaluating
+   prompts and decoding, how deep the job queue got, real resident memory and VRAM.
+   Reading it cannot change anything.
+
+   THE QUARANTINED ONE reads the execution plan already on /v1/health and reports
+   WHICH LANE the engine is currently decoding on, and whether that lane is the one
+   the model's parity evidence was produced on. It offers no controls, because the
+   engine has none to offer: exactly one HTTP route mutates runtime configuration
+   (POST /api/runtime/gpu), and the rest of the levers are environment variables
+   read once at process start — several latched in a OnceLock, so they cannot
+   change after the first forward pass even if something could write them. A toggle
+   here would save a value and silently do nothing, which is a worse failure than
+   an honest readout.
+
+   THE CENTRAL ARITHMETIC TRAP. Every counter below is CUMULATIVE SINCE PROCESS
+   START. A rate derived from two counters is therefore a lifetime average, never a
+   current rate — a server that was fast for an hour and has been slow for a minute
+   still reports the hour. Nothing here calls a derived value "current", and every
+   derived figure is labelled as a lifetime average at the point of use. */
+
+/* Metrics whose absence is meaningful rather than zero. An engine build that does
+   not emit one of these should show "not reported", not a confident 0. */
+const KNOWN_METRICS = [
+  'camelid_http_requests_total',
+  'camelid_http_failures_total',
+  'camelid_http_request_duration_seconds_sum',
+  'camelid_generation_requests_total',
+  'camelid_generation_failures_total',
+  'camelid_prompt_tokens_total',
+  'camelid_decode_tokens_total',
+  'camelid_generation_duration_seconds_sum',
+  'camelid_prompt_evaluation_duration_seconds_sum',
+  'camelid_decode_duration_seconds_sum',
+  'camelid_prompt_cache_hits_total',
+  'camelid_prompt_cache_misses_total',
+  'camelid_weight_cache_hits_total',
+  'camelid_weight_cache_misses_total',
+  'camelid_engine_queue_depth',
+  'camelid_engine_queued_tasks',
+  'camelid_engine_active_slots',
+  'camelid_engine_active_generated_tokens',
+  'camelid_engine_active_elapsed_seconds',
+  'camelid_engine_active_stalled_seconds',
+  'camelid_process_resident_memory_bytes',
+  'camelid_cuda_vram_total_bytes',
+  'camelid_cuda_vram_free_bytes',
+]
+
+/* Parse Prometheus text exposition.
+
+   The engine emits no labels on any series (verified against a live instance), so
+   this handles the unlabelled `name value` form and deliberately IGNORES a labelled
+   sample rather than guessing how to aggregate one — silently summing across
+   labels would invent a number the engine never reported. */
+export function parsePrometheusText(text) {
+  const values = new Map()
+  const types = new Map()
+  const help = new Map()
+  for (const rawLine of String(text || '').split('\n')) {
+    const line = rawLine.trim()
+    if (!line) continue
+    if (line.startsWith('#')) {
+      const typeMatch = line.match(/^#\s+TYPE\s+(\S+)\s+(\S+)/)
+      if (typeMatch) types.set(typeMatch[1], typeMatch[2])
+      const helpMatch = line.match(/^#\s+HELP\s+(\S+)\s+(.*)$/)
+      if (helpMatch) help.set(helpMatch[1], helpMatch[2])
+      continue
+    }
+    const sample = line.match(/^([A-Za-z_:][A-Za-z0-9_:]*)\s+(.+)$/)
+    if (!sample) continue
+    const [, name, rawValue] = sample
+    if (name.includes('{')) continue
+    const value = Number(rawValue.trim())
+    if (!Number.isFinite(value)) continue
+    values.set(name, value)
+  }
+  return { values, types, help }
+}
+
+const read = (values, name) => (values.has(name) ? values.get(name) : null)
+
+/* A ratio of two counters, or null when the denominator is zero.
+
+   Zero attempts is NOT a 0% hit rate — it is an unknown one, and rendering 0%
+   there would report a cache as failing when it was never asked. */
+function ratio(hits, misses) {
+  if (hits === null || misses === null) return null
+  const total = hits + misses
+  if (total <= 0) return null
+  return hits / total
+}
+
+export function summarizeMetrics(text) {
+  const { values, help } = parsePrometheusText(text)
+  if (!values.size) return null
+
+  const httpRequests = read(values, 'camelid_http_requests_total')
+  const httpFailures = read(values, 'camelid_http_failures_total')
+  const genRequests = read(values, 'camelid_generation_requests_total')
+  const genFailures = read(values, 'camelid_generation_failures_total')
+  const promptTokens = read(values, 'camelid_prompt_tokens_total')
+  const decodeTokens = read(values, 'camelid_decode_tokens_total')
+  const promptSeconds = read(values, 'camelid_prompt_evaluation_duration_seconds_sum')
+  const decodeSeconds = read(values, 'camelid_decode_duration_seconds_sum')
+  const cacheHits = read(values, 'camelid_prompt_cache_hits_total')
+  const cacheMisses = read(values, 'camelid_prompt_cache_misses_total')
+  const weightHits = read(values, 'camelid_weight_cache_hits_total')
+  const weightMisses = read(values, 'camelid_weight_cache_misses_total')
+  const vramTotal = read(values, 'camelid_cuda_vram_total_bytes')
+  const vramFree = read(values, 'camelid_cuda_vram_free_bytes')
+
+  const forwardSeconds = promptSeconds !== null && decodeSeconds !== null
+    ? promptSeconds + decodeSeconds
+    : null
+
+  return {
+    /* Raw, exactly as reported. */
+    raw: values,
+    help,
+    missing: KNOWN_METRICS.filter((name) => !values.has(name)),
+    counters: {
+      httpRequests,
+      httpFailures,
+      genRequests,
+      genFailures,
+      promptTokens,
+      decodeTokens,
+    },
+    live: {
+      queueDepth: read(values, 'camelid_engine_queue_depth'),
+      queuedTasks: read(values, 'camelid_engine_queued_tasks'),
+      activeSlots: read(values, 'camelid_engine_active_slots'),
+      activeTokens: read(values, 'camelid_engine_active_generated_tokens'),
+      activeElapsedSeconds: read(values, 'camelid_engine_active_elapsed_seconds'),
+      activeStalledSeconds: read(values, 'camelid_engine_active_stalled_seconds'),
+    },
+    memory: {
+      residentBytes: read(values, 'camelid_process_resident_memory_bytes'),
+      vramTotalBytes: vramTotal,
+      vramFreeBytes: vramFree,
+      vramUsedBytes: vramTotal !== null && vramFree !== null ? Math.max(0, vramTotal - vramFree) : null,
+    },
+    /* Every figure here is a LIFETIME AVERAGE over the process, never a current
+       rate. Named `lifetime` so a caller cannot accidentally present it as now. */
+    lifetime: {
+      promptCacheHitRate: ratio(cacheHits, cacheMisses),
+      promptCacheAttempts: cacheHits !== null && cacheMisses !== null ? cacheHits + cacheMisses : null,
+      weightCacheHitRate: ratio(weightHits, weightMisses),
+      /* The share of forward time spent evaluating prompts rather than decoding.
+         On long contexts this is the number that explains where the wall time
+         went, and the browser cannot measure it. */
+      prefillShare: forwardSeconds !== null && forwardSeconds > 0 ? promptSeconds / forwardSeconds : null,
+      promptSeconds,
+      decodeSeconds,
+      decodeTokensPerSecond: decodeTokens !== null && decodeSeconds !== null && decodeSeconds > 0
+        ? decodeTokens / decodeSeconds
+        : null,
+      httpFailureRate: ratio(httpFailures, httpRequests !== null && httpFailures !== null ? httpRequests - httpFailures : null),
+      generationFailureRate: ratio(genFailures, genRequests !== null && genFailures !== null ? genRequests - genFailures : null),
+    },
+  }
+}
+
+/* ---- The quarantined half: which lane is the engine actually on? ---- */
+
+/* Risk classes, in the sense that matters to a user: not "is this fast" but
+   "can this hand me a different answer than the evidence was produced with". */
+export const LANE_RISK = {
+  EVIDENCED: 'evidenced',
+  UNEVIDENCED: 'unevidenced',
+  UNKNOWN: 'unknown',
+}
+
+/* Backends whose decode path carries its own parity evidence in this repo. A
+   backend absent from this set is not accused of being wrong — it is reported as
+   not carrying an evidence claim on this surface, which is a different statement
+   and the only one the frontend can support. */
+const EVIDENCED_BACKENDS = new Set([
+  'cpu_reference',
+  'cpu_q8_runtime_repack',
+  'cpu_kquant_block_dot',
+  'cuda_resident_q8_runtime',
+  'cuda_resident_kquant_runtime',
+  'metal_resident_q8_runtime',
+])
+
+export function readActiveLane(runtime) {
+  const plan = runtime?.execution_plan
+  if (!plan) {
+    return { present: false, risk: LANE_RISK.UNKNOWN, rows: [], supportLevel: null, reasons: [] }
+  }
+  const backend = plan.selected_backend || null
+  const risk = backend === null
+    ? LANE_RISK.UNKNOWN
+    : EVIDENCED_BACKENDS.has(backend)
+      ? LANE_RISK.EVIDENCED
+      : LANE_RISK.UNEVIDENCED
+
+  /* Each row names the lever, its current value, and — the part that matters —
+     whether it can be changed without restarting the engine. Exactly one of these
+     is live-settable; saying so plainly is the whole point. */
+  const rows = [
+    {
+      key: 'selected_backend',
+      label: 'Decode backend',
+      value: backend,
+      changeable: 'restart',
+      note: 'Chosen by the planner from the model, the host and the GPU setting.',
+    },
+    {
+      key: 'decode_path',
+      label: 'Decode path',
+      value: plan.decode_path || null,
+      changeable: 'restart',
+      note: 'The kernel lane each generated token goes through.',
+    },
+    {
+      key: 'prefill_path',
+      label: 'Prefill path',
+      value: plan.prefill_path || null,
+      changeable: 'restart',
+      note: 'How the prompt is evaluated before the first token.',
+    },
+    {
+      key: 'cuda_resident_active',
+      label: 'CUDA resident',
+      value: plan.cuda_resident_active === null || plan.cuda_resident_active === undefined
+        ? null
+        : String(plan.cuda_resident_active),
+      changeable: 'gpu_toggle',
+      note: 'Whether weights stay on the GPU. The GPU setting reaches this; the lane still reselects on the next model load.',
+    },
+    {
+      key: 'q8_policy',
+      label: 'Q8 loader policy',
+      value: runtime?.q8_runtime?.policy || null,
+      changeable: 'restart',
+      note: 'The effective loader path, which outranks the environment flag that requests it.',
+    },
+    {
+      key: 'thread_count',
+      label: 'Worker threads',
+      value: plan.thread_count === null || plan.thread_count === undefined ? null : String(plan.thread_count),
+      changeable: 'restart',
+      note: 'Set at startup with --threads.',
+    },
+  ].filter((row) => row.value !== null)
+
+  return {
+    present: true,
+    risk,
+    backend,
+    rows,
+    supportLevel: plan.support_level || null,
+    exactRow: plan.exact_model_row || null,
+    /* The planner's own explanation of why it chose this lane. Rendering it beats
+       any summary this module could write, because it is the engine's reasoning
+       rather than the browser's guess at it. */
+    reasons: Array.isArray(plan.reasons) ? plan.reasons : [],
+  }
+}
+
+export const LANE_RISK_COPY = {
+  [LANE_RISK.EVIDENCED]: {
+    label: 'Evidenced lane',
+    detail: 'The engine is decoding on a backend that carries parity evidence in this repository. That is a statement about the lane, not about this particular reply.',
+  },
+  [LANE_RISK.UNEVIDENCED]: {
+    label: 'Lane without an evidence claim here',
+    detail: 'The engine is decoding on a backend this page cannot match to a parity-checked lane. That does not mean the output is wrong — it means this surface will not claim it was produced on an evidenced path.',
+  },
+  [LANE_RISK.UNKNOWN]: {
+    label: 'Lane not reported',
+    detail: 'No execution plan is available, usually because no model is loaded. Nothing is claimed either way.',
+  },
+}
+
+/* ---- Formatters ---- */
+
+export function formatBytes(bytes) {
+  if (bytes === null || bytes === undefined || !Number.isFinite(bytes)) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let value = bytes / 1024
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${units[unit]}`
+}
+
+/* A share, rendered as a percentage — legitimate here because these ARE
+   proportions of a whole, unlike a similarity score. */
+export function formatShare(share) {
+  if (share === null || share === undefined || !Number.isFinite(share)) return '—'
+  if (share > 0 && share < 0.001) return '<0.1%'
+  return `${(share * 100).toFixed(1)}%`
+}
+
+export function formatCount(value) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  return value.toLocaleString()
+}
+
+export function formatSeconds(value) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  if (value < 1) return `${(value * 1000).toFixed(0)} ms`
+  if (value < 120) return `${value.toFixed(1)} s`
+  return `${(value / 60).toFixed(1)} min`
+}
+
+export function formatRate(value) {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  return `${value.toFixed(1)}/s`
+}

--- a/frontend/src/lib/runtimeMetrics.js
+++ b/frontend/src/lib/runtimeMetrics.js
@@ -144,9 +144,21 @@ export function summarizeMetrics(text) {
     },
     memory: {
       residentBytes: read(values, 'camelid_process_resident_memory_bytes'),
-      vramTotalBytes: vramTotal,
-      vramFreeBytes: vramFree,
-      vramUsedBytes: vramTotal !== null && vramFree !== null ? Math.max(0, vramTotal - vramFree) : null,
+      /* A ZERO TOTAL IS NOT A READING. `src/api/metrics.rs` writes both CUDA VRAM
+         gauges UNCONDITIONALLY, and `HardwareProfile::detect()` leaves them at 0
+         whenever `cuda::probe_capability()` returns None — which is every macOS
+         host, always. Guarding on presence alone (both gauges ARE present, at 0)
+         rendered "VRAM in use: 0 B of 0 B" on every Metal machine: a confident
+         zero for a device that was never asked, which is the same mistake the
+         prefix-cache rate avoids by returning null on zero attempts.
+
+         Zero FREE is left alone — a fully committed device legitimately reports
+         it. Only a zero TOTAL is impossible for a real one. */
+      vramTotalBytes: vramTotal !== null && vramTotal > 0 ? vramTotal : null,
+      vramFreeBytes: vramTotal !== null && vramTotal > 0 ? vramFree : null,
+      vramUsedBytes: vramTotal !== null && vramTotal > 0 && vramFree !== null
+        ? Math.max(0, vramTotal - vramFree)
+        : null,
     },
     /* Every figure here is a LIFETIME AVERAGE over the process, never a current
        rate. Named `lifetime` so a caller cannot accidentally present it as now. */
@@ -182,15 +194,95 @@ export const LANE_RISK = {
 /* Backends whose decode path carries its own parity evidence in this repo. A
    backend absent from this set is not accused of being wrong — it is reported as
    not carrying an evidence claim on this surface, which is a different statement
-   and the only one the frontend can support. */
+   and the only one the frontend can support.
+
+   THIS LIST IS A LIABILITY, and the smoke treats it as one. It is a copy of a
+   fact that lives in `src/execution_plan.rs`, and the first version of it was
+   itself a copy — of the display-only `METAL_BACKENDS` in `executionPlan.js`,
+   which had gone stale at one entry while the planner grew to six. Carried here
+   unchanged, that staleness stopped being cosmetic: three lanes that are DEFAULT
+   ON macOS (`metal_resident_qwen35_runtime`, `metal_resident_qwen35_kquant_runtime`
+   and `metal_resident_lfm2_runtime`, each an opt-OUT) rendered as carrying no
+   evidence claim, while their CUDA counterparts rendered as evidenced. Two of the
+   three are lanes whose receipts in `src/api/mod.rs` assert the backend string
+   itself as the proof — the LFM2 row's evidence reads "the Mac receipt asserts
+   selected_backend=metal_resident_lfm2_runtime", and the Ornith agent-eval PASS
+   was earned on `metal_resident_qwen35_kquant_runtime`.
+
+   So the smoke extracts every backend the planner can select and asserts each one
+   is classified here or in UNEVIDENCED_BACKENDS below. A new lane fails the smoke
+   until someone decides which it is, rather than defaulting to "unevidenced"
+   silently. */
 const EVIDENCED_BACKENDS = new Set([
   'cpu_reference',
   'cpu_q8_runtime_repack',
   'cpu_kquant_block_dot',
   'cuda_resident_q8_runtime',
   'cuda_resident_kquant_runtime',
+  'cuda_resident_windowed_runtime',
+  'cuda_resident_prism_low_bit_runtime',
+  'gemma4_cpu_runtime',
+  'gemma4_cuda_resident_runtime',
   'metal_resident_q8_runtime',
+  'metal_resident_kquant_runtime',
+  'metal_resident_lfm2_runtime',
+  'metal_resident_prism_low_bit_runtime',
+  'metal_resident_qwen35_runtime',
+  'metal_resident_qwen35_kquant_runtime',
 ])
+
+/* Lanes deliberately left OUT of the set above, so that "not listed" cannot mean
+   "nobody looked". The smoke asserts this partition covers the planner. */
+export const UNEVIDENCED_BACKENDS = new Set([
+  /* The engine itself treats this one as unvalidated: the admission check in
+     `src/api/mod.rs` gates on `selected_backend.contains("_runnable_unvalidated")`.
+     Claiming evidence for it here would contradict the engine. */
+  'cuda_resident_q8_runtime_runnable_unvalidated',
+])
+
+/* The GPU row, which is NOT one row with a portable meaning.
+
+   `cuda_resident_active` is a plain `bool` on the plan, so macOS serializes it as
+   `false` rather than omitting it — it survives any presence check and rendered a
+   "CUDA resident: false" row on Metal hosts with no Metal row anywhere, reading as
+   "the GPU is off" while a Metal resident lane was decoding.
+
+   The second half of that row was wrong too. It pointed at Settings → GPU
+   acceleration, and that control does not reach Metal: `POST /api/runtime/gpu`
+   sets `cuda::set_gpu_accel_enabled` / `set_runtime_enabled`, and every reader of
+   those two atoms is a CUDA or BitNet path. The planner's Metal arms gate on
+   `platform.metal_available` plus per-lane opt-outs (`CAMELID_METAL_RESIDENT_DECODE`,
+   `CAMELID_QWEN35_METAL`, `CAMELID_LFM2_METAL`), none of which the toggle writes.
+   So on a Metal host NOTHING here is live-settable, and saying so is the honest
+   answer — this panel's whole premise is that a control which does nothing is
+   worse than no control.
+
+   Host comes from the plan's own `operating_system`, falling back to the backend
+   prefix for an engine too old to report it. */
+function acceleratorRow(plan, backend) {
+  const metalHost = plan.operating_system === 'macos'
+    || (!plan.operating_system && typeof backend === 'string' && backend.startsWith('metal_'))
+
+  if (metalHost) {
+    return {
+      key: 'metal_resident_active',
+      label: 'Metal resident',
+      value: typeof backend === 'string' && backend.startsWith('metal_') ? 'true' : 'false',
+      changeable: 'restart',
+      note: 'Whether weights stay on the GPU. The GPU acceleration toggle in Settings drives the CUDA lane only and does not reach this one; the planner picks it at model load.',
+    }
+  }
+
+  return {
+    key: 'cuda_resident_active',
+    label: 'CUDA resident',
+    value: plan.cuda_resident_active === null || plan.cuda_resident_active === undefined
+      ? null
+      : String(plan.cuda_resident_active),
+    changeable: 'gpu_toggle',
+    note: 'Whether weights stay on the GPU. The GPU setting reaches this; the lane still reselects on the next model load.',
+  }
+}
 
 export function readActiveLane(runtime) {
   const plan = runtime?.execution_plan
@@ -229,15 +321,7 @@ export function readActiveLane(runtime) {
       changeable: 'restart',
       note: 'How the prompt is evaluated before the first token.',
     },
-    {
-      key: 'cuda_resident_active',
-      label: 'CUDA resident',
-      value: plan.cuda_resident_active === null || plan.cuda_resident_active === undefined
-        ? null
-        : String(plan.cuda_resident_active),
-      changeable: 'gpu_toggle',
-      note: 'Whether weights stay on the GPU. The GPU setting reaches this; the lane still reselects on the next model load.',
-    },
+    acceleratorRow(plan, backend),
     {
       key: 'q8_policy',
       label: 'Q8 loader policy',

--- a/frontend/src/lib/toolCalling.js
+++ b/frontend/src/lib/toolCalling.js
@@ -1,0 +1,261 @@
+/* Tool-calling contract lane.
+
+   A tool-capable model can answer a turn by asking to CALL something instead of
+   writing prose: the reply comes back with `finish_reason: "tool_calls"`, empty
+   content, and a list of requested calls. This module owns whether that may be
+   offered, how the request is composed, and — the part that needs care — what the
+   result means.
+
+   THREE RULES SHAPE EVERYTHING HERE.
+
+   1. A TOOL CALL IS A REQUEST, NOT AN ACTION. Nothing in this lane executes
+      anything. The model asked; that is all that happened. Copy never says a tool
+      "ran", and the surface offers no way to run one — a browser that executed
+      model-chosen calls against the user's machine would be a different and much
+      larger security proposition than showing what was asked.
+
+   2. THE ARGUMENTS ARE MODEL-GENERATED TEXT. `function.arguments` is a JSON
+      *string* the model produced. It can be malformed, it can disagree with the
+      schema that was offered, and it is not trustworthy input. It is parsed
+      defensively and rendered as data.
+
+   3. MODELS LOOP. Verified live: given a tool result, Llama 3.2 3B re-issued the
+      identical call rather than using it. A surface that offers a continuation
+      without detecting that will spin. `detectRepeatedCall` exists for exactly
+      this and is asserted in the smoke.
+
+   Gating is doubly conditional: the ENGINE must advertise `streaming_tool_calls`,
+   and the LOADED MODEL must carry a `tool_capable` compatibility row.
+
+   That second condition is STRICTER THAN THE ENGINE'S, on purpose, and the
+   distinction matters. `POST /v1/chat/completions` gates on the chat TEMPLATE, not
+   on `tool_capable` — it never reads that bit. A model whose row says
+   `tool_capable: false` but whose template happens to carry tools is accepted with
+   a 200 and returns degraded calls. (Templates with no tools branch DO fail closed,
+   with a typed 422 `unsupported_chat_template`, but that is a different gate.)
+   `tool_capable` is the receipt saying those calls were actually checked, so this
+   lane requires it — and nothing here claims the engine does. */
+
+import { findCompatibilityHint, isSupportedCapabilityStatus, displayCapabilityCopy } from './capabilities.js'
+
+const ROW_ID = 'streaming_tool_calls'
+
+export const DEFAULT_TOOLS = `[
+  {
+    "type": "function",
+    "function": {
+      "name": "get_weather",
+      "description": "Get the current weather for a city",
+      "parameters": {
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"]
+      }
+    }
+  }
+]`
+
+function findRow(rows, id) {
+  return (rows || []).find((row) => row?.id === id) || null
+}
+
+/* The engine half of the gate: does this build speak the tool-call protocol? */
+export function readToolContract(capabilities) {
+  const conformance = findRow(capabilities?.api_conformance, ROW_ID)
+  const feature = findRow(capabilities?.api_features, ROW_ID)
+  const row = conformance || feature
+  if (!row) {
+    return { present: false, supported: false, rowId: ROW_ID, status: null, note: null }
+  }
+  return {
+    present: true,
+    supported: isSupportedCapabilityStatus(String(row.status || '')),
+    rowId: ROW_ID,
+    status: row.status || null,
+    note: feature?.notes ? displayCapabilityCopy(feature.notes) : null,
+  }
+}
+
+/* The model half of the gate.
+
+   `tool_capable` is a per-row receipt, not a family trait: a model is tool-capable
+   because that exact artifact has a certified tool template, and a neighbouring
+   quantization of the same model may not. Resolved by exact row, matching the
+   discipline the rest of the compatibility surface uses. */
+export function readModelToolCapability(capabilities, model, runtime) {
+  if (!runtime?.loaded_now) return { capable: false, reason: 'No model is loaded.', rowId: null }
+  /* Resolved through the shared compatibility resolver rather than by matching an
+     id string. `runtime.active_model_id` is a DISPLAY name ("Llama 3.2 3B
+     Instruct") while a compatibility row is a slug (`llama32_3b_instruct_q8_0`),
+     so a naive comparison never matches and every model looks uncertified. This
+     is the same call WorkspaceView makes for the same question. */
+  const compatibility = findCompatibilityHint(capabilities, model, null)
+  const row = compatibility?.target || null
+  if (!row || !compatibility?.exact) {
+    return { capable: false, reason: 'The loaded model has no exact compatibility row, so no tool receipt applies to it.', rowId: row?.id || null }
+  }
+  const supported = isSupportedCapabilityStatus(String(row.status || ''))
+  if (!row.tool_capable) {
+    /* Deliberately STRICTER than the engine. POST /v1/chat/completions gates on
+       the chat TEMPLATE, not on this bit — a row with tool_capable:false whose
+       template happens to carry tools will be accepted with a 200 and return
+       degraded calls. `tool_capable` is the receipt saying the calls were checked;
+       offering the control without it would invite exactly that degraded result.
+       So this is a product choice, and the copy must not claim the engine
+       enforces it. */
+    return {
+      capable: false,
+      reason: 'This model has no tool receipt. The engine may still accept tools for it, but the results are unchecked, so Camelid does not offer them here.',
+      rowId: row.id || null,
+    }
+  }
+  if (!supported) {
+    return {
+      capable: false,
+      reason: 'This model claims a tool template but its row is not marked supported, so the claim is not carried here.',
+      rowId: row.id || null,
+    }
+  }
+  return { capable: true, reason: null, rowId: row.id || null }
+}
+
+/* Validate a tools array. The engine rejects a malformed one, so catching it here
+   turns a typed 400 at send time into an explanation at edit time. */
+export function parseToolDefinitions(text) {
+  const raw = String(text || '').trim()
+  if (!raw) return { ok: false, error: 'Define at least one tool.', value: null }
+  let value
+  try {
+    value = JSON.parse(raw)
+  } catch (error) {
+    return { ok: false, error: `Not valid JSON: ${error.message}`, value: null }
+  }
+  if (!Array.isArray(value)) return { ok: false, error: 'Tools must be a JSON array.', value: null }
+  if (!value.length) return { ok: false, error: 'Define at least one tool.', value: null }
+  for (const [index, tool] of value.entries()) {
+    if (tool?.type !== 'function') {
+      return { ok: false, error: `Tool ${index + 1}: "type" must be "function".`, value: null }
+    }
+    const name = tool?.function?.name
+    if (typeof name !== 'string' || !name.trim()) {
+      return { ok: false, error: `Tool ${index + 1}: "function.name" is required.`, value: null }
+    }
+  }
+  return { ok: true, error: null, value }
+}
+
+export function toolRequestFields({ enabled, contract, capability, toolsText } = {}) {
+  if (!enabled) return {}
+  if (!contract?.supported || !capability?.capable) return {}
+  const parsed = parseToolDefinitions(toolsText)
+  if (!parsed.ok) return {}
+  return { tools: parsed.value }
+}
+
+export function toolReadiness({ enabled, contract, capability, toolsText } = {}) {
+  if (!enabled) return { ready: false, reason: null }
+  if (!contract?.present) return { ready: false, reason: 'This engine does not advertise tool calling.' }
+  if (!contract.supported) return { ready: false, reason: 'The tool-calling capability row is not marked supported on this engine.' }
+  if (!capability?.capable) return { ready: false, reason: capability?.reason || 'The loaded model is not tool-capable.' }
+  const parsed = parseToolDefinitions(toolsText)
+  if (!parsed.ok) return { ready: false, reason: parsed.error }
+  return { ready: true, reason: null }
+}
+
+/* Normalize the tool calls on a reply.
+
+   `arguments` is a JSON string the MODEL wrote. Parsing it is best-effort and its
+   failure is reported rather than hidden: a malformed argument object is a real
+   thing to know about a model, and swallowing the error would present a broken
+   call as a clean one. */
+export function normalizeToolCalls(toolCalls) {
+  const list = Array.isArray(toolCalls) ? toolCalls : []
+  if (!list.length) return null
+  return list.map((call, index) => {
+    const rawArguments = call?.function?.arguments
+    let parsedArguments = null
+    let parseError = null
+    if (typeof rawArguments === 'string' && rawArguments.trim()) {
+      try {
+        parsedArguments = JSON.parse(rawArguments)
+      } catch (error) {
+        parseError = error.message
+      }
+    } else if (rawArguments && typeof rawArguments === 'object') {
+      parsedArguments = rawArguments
+    }
+    return {
+      index,
+      id: typeof call?.id === 'string' ? call.id : null,
+      name: typeof call?.function?.name === 'string' ? call.function.name : null,
+      rawArguments: typeof rawArguments === 'string' ? rawArguments : JSON.stringify(rawArguments ?? null),
+      parsedArguments,
+      parseError,
+    }
+  })
+}
+
+/* A signature that identifies "the same call again".
+
+   Name plus arguments, with the arguments normalized through a parse where
+   possible so that whitespace differences do not read as a different call. */
+export function toolCallSignature(call) {
+  if (!call) return ''
+  const args = call.parsedArguments !== null && call.parsedArguments !== undefined
+    ? JSON.stringify(call.parsedArguments)
+    : String(call.rawArguments || '')
+  return `${call.name || ''}::${args}`
+}
+
+/* Detect a model that is not consuming tool results.
+
+   Observed live: given "12C, light rain" for get_weather(Paris), Llama 3.2 3B
+   asked for get_weather(Paris) again. Without this, a continuation UI loops
+   forever and looks like a hang. Returns the repeated signature so the surface can
+   name what is repeating rather than saying something vague. */
+export function detectRepeatedCall(previousSignatures, calls) {
+  const seen = new Set(previousSignatures || [])
+  for (const call of calls || []) {
+    const signature = toolCallSignature(call)
+    if (signature && seen.has(signature)) {
+      return { repeated: true, signature, name: call.name || null }
+    }
+  }
+  return { repeated: false, signature: null, name: null }
+}
+
+/* Build the tool-result message that continues the conversation.
+
+   The engine accepts the standard shape: an assistant turn carrying the calls,
+   then one `role:"tool"` message per call carrying `tool_call_id`. Verified live
+   against a running engine. */
+export function toolResultMessage(call, content) {
+  return { role: 'tool', tool_call_id: call?.id || '', content: String(content ?? '') }
+}
+
+export function assistantToolCallMessage(rawToolCalls) {
+  return { role: 'assistant', content: '', tool_calls: rawToolCalls }
+}
+
+/* Whether the reply text still carries the model's raw tool-call envelope.
+
+   The capability row claims calls are surfaced "without leaking the model's raw
+   tool-call envelope", and on the dense lane that holds — content comes back
+   empty. The runnable lane (qwen35/Ornith) is different: it lifts the structured
+   calls out of the text but KEEPS the text, so the same reply carries both. A
+   surface that rendered that content as prose would show the user a wall of
+   markup next to a tidy card and look broken. Detected rather than assumed, so a
+   lane that stops doing it needs no change here. */
+export function replyCarriesRawEnvelope(content) {
+  const text = String(content || '')
+  if (!text.trim()) return false
+  return /<function\s*=|<\/?tool_call>|\[TOOL_CALLS\]|<\|python_tag\|>/.test(text)
+}
+
+export function formatArguments(call) {
+  if (!call) return ''
+  if (call.parsedArguments !== null && call.parsedArguments !== undefined) {
+    return JSON.stringify(call.parsedArguments, null, 2)
+  }
+  return String(call.rawArguments || '')
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -15,3 +15,4 @@
 @import './styles/token-inspector.css';
 @import './styles/rerank.css';
 @import './styles/structured-output.css';
+@import './styles/engine-metrics.css';

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -16,3 +16,4 @@
 @import './styles/rerank.css';
 @import './styles/structured-output.css';
 @import './styles/engine-metrics.css';
+@import './styles/tool-calls.css';

--- a/frontend/src/styles/engine-metrics.css
+++ b/frontend/src/styles/engine-metrics.css
@@ -1,0 +1,101 @@
+/* Engine metrics and active configuration.
+
+   COLOR POSTURE. No new colour tokens. The lane badge is the only place a status
+   colour appears, and the choice is deliberate: an EVIDENCED lane is a claim about
+   parity evidence, which is exactly what copper (--color-verified) is reserved
+   for — this is one of the few surfaces entitled to it. A lane without an evidence
+   claim is NOT an error and never uses red; it takes the calm muted slate the
+   token file reserves for "unsupported", which the doctrine says is never styled
+   as an alarm. */
+
+.engmetrics { display: flex; flex-direction: column; gap: var(--space-6); }
+.engmetrics__section { display: flex; flex-direction: column; gap: var(--space-3); }
+.engmetrics__section h2 { margin: 0; font-size: var(--text-md); color: var(--color-text); }
+
+.engmetrics__intro,
+.engmetrics__note {
+  margin: 0;
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+}
+
+.engmetrics__error { margin: 0; font-size: var(--text-2xs); color: var(--color-warning); }
+
+.engmetrics__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: var(--space-3);
+  margin: 0;
+  padding: var(--space-3);
+  background: var(--color-surface-subtle);
+  border-radius: var(--radius-md);
+}
+
+.engmetrics__stat { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.engmetrics__stat dt {
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  color: var(--color-text-faint);
+}
+.engmetrics__stat dd {
+  margin: 0;
+  font-size: var(--text-lg);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.engmetrics__stats--muted { background: none; padding: 0 var(--space-3); }
+.engmetrics__stats--muted .engmetrics__stat dd { font-size: var(--text-sm); color: var(--color-text-muted); }
+
+.engmetrics__lane {
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.engmetrics__lane-label {
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  font-weight: 600;
+  color: var(--color-text-faint);
+}
+
+.engmetrics__lane-detail {
+  margin: 0;
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+}
+
+/* Copper is earned here: this row states that the active lane carries parity
+   evidence, which is precisely the claim copper is reserved for. */
+.engmetrics__lane--evidenced {
+  border-color: color-mix(in srgb, var(--color-verified) 40%, transparent);
+}
+.engmetrics__lane--evidenced .engmetrics__lane-label { color: var(--color-verified); }
+
+/* Not an alarm. The doctrine keeps 'unsupported' calm and muted. */
+.engmetrics__lane--unevidenced .engmetrics__lane-label,
+.engmetrics__lane--unknown .engmetrics__lane-label { color: var(--color-unsupported); }
+
+.engmetrics__table { font-size: var(--text-2xs); width: 100%; }
+.engmetrics__value { font-family: var(--font-mono); color: var(--color-text); word-break: break-word; }
+.engmetrics__change { color: var(--color-text-faint); white-space: nowrap; }
+
+.engmetrics__row-note {
+  display: block;
+  font-size: var(--text-micro);
+  color: var(--color-text-faint);
+  margin-top: 2px;
+}
+
+.engmetrics__reasons { font-size: var(--text-2xs); color: var(--color-text-muted); }
+.engmetrics__reasons summary { cursor: pointer; color: var(--color-text-faint); }
+.engmetrics__reasons ul { margin: var(--space-2) 0 0; padding-left: var(--space-4); display: flex; flex-direction: column; gap: 3px; }

--- a/frontend/src/styles/tool-calls.css
+++ b/frontend/src/styles/tool-calls.css
@@ -1,0 +1,130 @@
+/* Tool calls — what the model asked to call.
+
+   COLOR POSTURE. No new colour tokens. Nothing here is copper: a tool call is a
+   model output, not a verified claim. Nothing here is red either — a model asking
+   to call something is a normal turn ending, not an error. The one inked state is
+   the repeat warning, which uses amber (--color-evidence), the bounded-evidence
+   ink: "we observed the same call twice" is exactly a bounded observation. */
+
+.toolcalls {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border-soft);
+}
+
+.toolcalls__trigger {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1) 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-text-muted);
+}
+
+.toolcalls__trigger:hover { color: var(--color-text); }
+.toolcalls__trigger:focus-visible { outline: none; box-shadow: var(--focus-ring); border-radius: var(--radius-sm); }
+
+.toolcalls__label {
+  font-size: var(--text-micro);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-label);
+  font-weight: 600;
+}
+
+.toolcalls__summary { font-size: var(--text-2xs); color: var(--color-text-faint); font-family: var(--font-mono); }
+
+.toolcalls__body { display: flex; flex-direction: column; gap: var(--space-2); margin-top: var(--space-2); }
+
+.toolcalls__note,
+.toolcalls__parse-error {
+  margin: 0;
+  font-size: var(--text-micro);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+}
+
+/* A repeated identical call is a bounded observation about this conversation,
+   not a failure — amber, never red. */
+.toolcalls__repeat {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-micro);
+  line-height: var(--leading-normal);
+  color: var(--color-text-muted);
+  border: 1px solid color-mix(in srgb, var(--color-evidence) 40%, transparent);
+  border-radius: var(--radius-md);
+}
+
+.toolcalls__list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-2); }
+
+.toolcalls__call {
+  padding: var(--space-2);
+  background: var(--color-surface-subtle);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.toolcalls__call-head { display: flex; align-items: baseline; gap: var(--space-2); flex-wrap: wrap; }
+
+.toolcalls__name {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--color-text);
+  background: var(--color-code-bg);
+  border-radius: 2px;
+  padding: 0 4px;
+}
+
+.toolcalls__id { font-size: var(--text-micro); color: var(--color-text-faint); font-family: var(--font-mono); }
+
+.toolcalls__args {
+  margin: 0;
+  padding: var(--space-2);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-code-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  line-height: var(--leading-snug);
+  color: var(--color-text);
+  max-height: 12rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Composer tool editor. */
+.tooldef {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-2);
+}
+
+.tooldef__field {
+  width: 100%;
+  min-height: 9rem;
+  resize: vertical;
+  padding: var(--space-2);
+  background: var(--color-code-bg);
+  border: 1px solid var(--color-code-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  line-height: var(--leading-snug);
+  color: var(--color-text);
+}
+
+.tooldef__field:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.tooldef__status { margin: 0; font-size: var(--text-micro); color: var(--color-text-muted); }
+.tooldef__status.is-invalid { color: var(--color-warning); }

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { getChatGateState } from '../lib/chatGate'
 import { getRuntimeRequestModelId } from '../lib/modelState'
+import { detectRepeatedCall, normalizeToolCalls } from '../lib/toolCalling'
 import { displayQuantLabel, exactArtifactFilenameForRow } from '../lib/capabilities'
 import { formatModelLabel } from '../lib/formatters'
 import { isEmbeddingOnlyModel, isGenerationCapableModel } from '../lib/modelCapabilities.js'
@@ -190,6 +191,13 @@ export default function ChatWorkspace({
   structuredRecords = {},
   structuredSupported = false,
   structuredReadiness = { ready: false, reason: null },
+  toolsEnabled = false,
+  setToolsEnabled = null,
+  toolsText = '',
+  setToolsText = null,
+  toolCapability = { capable: false, reason: null },
+  toolsReadiness = { ready: false, reason: null },
+  toolCallSignatures = {},
   thinkingMode = false,
   setThinkingMode = null,
   webResearchEnabled = true,
@@ -889,6 +897,22 @@ export default function ChatWorkspace({
           </p>
         </div>
       )}
+      {toolCapability.capable && toolsEnabled && setToolsText && (
+        <div className="tooldef">
+          <textarea
+            className="tooldef__field"
+            aria-label="Tool definitions"
+            spellCheck={false}
+            value={toolsText}
+            onChange={(event) => setToolsText(event.target.value)}
+          />
+          <p className={`tooldef__status ${toolsReadiness.ready ? '' : 'is-invalid'}`}>
+            {toolsReadiness.ready
+              ? 'Offered to the model on the next turn. Camelid does not execute tool calls — a request comes back for you to answer.'
+              : toolsReadiness.reason}
+          </p>
+        </div>
+      )}
       <div
         className="cxcomposer__box"
         onDragOver={(e) => {
@@ -1122,6 +1146,29 @@ export default function ChatWorkspace({
                 </span>
               </button>
             )}
+            {/* Guarded on BOTH halves of the gate: the engine must advertise the
+                protocol and the LOADED MODEL must carry a tool receipt. The second
+                half is STRICTER than the engine — POST /v1/chat/completions gates
+                on the chat template and never reads tool_capable — so the copy
+                says Camelid declines, not that the engine refuses. */}
+            {!demoMode && setToolsEnabled && (
+              <button
+                type="button"
+                className={`cxcomposer__tool cxcomposer__tool--collapsible ${toolsEnabled && toolCapability.capable ? 'is-on' : ''}`}
+                title={toolCapability.capable
+                  ? 'Offer tools to the model on the next turn'
+                  : toolCapability.reason || 'This model is not tool-capable.'}
+                aria-label={toolCapability.capable ? 'Tools' : 'Tools — unavailable for this model'}
+                aria-pressed={toolCapability.capable ? toolsEnabled : undefined}
+                disabled={!toolCapability.capable}
+                onClick={() => setToolsEnabled(!toolsEnabled)}
+              >
+                <IconBolt size={16} />
+                <span className="cxcomposer__tool-label">
+                  {!toolCapability.capable ? 'Tools unavailable' : toolsEnabled ? 'Tools on' : 'Tools'}
+                </span>
+              </button>
+            )}
             {!demoMode && setThinkingMode && !selectedBitNetChatModel && (
               <button
                 type="button"
@@ -1318,6 +1365,12 @@ export default function ChatWorkspace({
                       onEditResend={canResend && message.role === 'user' ? (messageId, content) => resendFromMessage(messageId, content) : null}
                       tokenInspection={tokenInspections?.[message.id] || null}
                       structuredRecord={structuredRecords?.[message.id] || null}
+                      toolCallRepeat={message.tool_calls
+                        ? detectRepeatedCall(
+                            (toolCallSignatures?.[selectedConversation?.id] || []).slice(0, -1 * (message.tool_calls.length || 1)),
+                            normalizeToolCalls(message.tool_calls) || [],
+                          )
+                        : null}
                     />
                   </Fragment>
                 )

--- a/frontend/src/views/SystemView.jsx
+++ b/frontend/src/views/SystemView.jsx
@@ -1,3 +1,4 @@
+import { EngineMetricsPanel } from '../components/analytics/EngineMetricsPanel'
 import { displayCapabilityCopy, displayCapabilityId, exactRowSupportLanes, findCompatibilityHint, formatCapabilityStatus, isExactCompatibilityHint, isSupportedCapabilityStatus } from '../lib/capabilities'
 import { getChatGateState } from '../lib/chatGate'
 import { describeModelState } from '../lib/modelState'
@@ -22,7 +23,7 @@ function supportLaneTitle(lane) {
   return 'Throughput readiness'
 }
 
-export default function SystemView({ runtime, selectedModel, capabilities }) {
+export default function SystemView({ runtime, selectedModel, capabilities, metricsApiBase = '' }) {
   const runtimePill = runtimeReadinessLabel(runtime)
   const selectedModelName = selectedModel?.name || 'No next-chat model selected'
   const apiBase = runtime?.api_base || 'Local API unavailable'
@@ -218,6 +219,8 @@ export default function SystemView({ runtime, selectedModel, capabilities }) {
           )}
         </div>
       </section>
+
+      <EngineMetricsPanel apiBase={metricsApiBase} runtime={runtime} />
     </section>
   )
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -175,6 +175,9 @@ export default defineConfig({
     port: 4175,
     proxy: {
       '/api': apiProxy(),
+      // Served by the engine, same-origin in production. Without this the dev
+      // server answers /metrics with the SPA's own HTML and a 200.
+      '/metrics': apiProxy(),
       '/v1': apiProxy(),
     },
   },


### PR DESCRIPTION
> **Overlaps #726** (structured outputs) on `App.jsx`, `MessageTurn.jsx`, `useDashboardData.js`, `styles.css` and `ChatWorkspace.jsx` — the same composer and message-panel wiring points. Either order works; whichever merges second needs a rebase.

`/api/capabilities` advertises `streaming_tool_calls` as `supported_current_gate`. The chat surface had zero handling for it — `chatCompletionStream.js` read only `delta.content`, so a tool-capable model ending a turn with `finish_reason: "tool_calls"` and empty content rendered as a **blank bubble**.

Verified live against `Llama-3.2-3B-Instruct-Q8_0`, a `tool_capable` row:

```
finish_reason: tool_calls   content: ""
tool_calls: [{ id: "call_072ec0…", type: "function",
               function: { name: "get_weather", arguments: "{\"city\":\"Paris\"}" } }]
```

Streaming carries the whole call in **one delta** — id, name and the complete argument string together — not fragmented arguments. The reader accumulates by index anyway, so a future build that *does* fragment them won't silently truncate.

## Three things this surface refuses to get wrong

**Nothing ran.** A tool call is a *request*; the model asked and the turn ended. The card never says a tool executed and offers no way to run one — a browser executing model-chosen calls against the user's machine is a different and much larger proposition. Asserted against rendered output **and** at the source: no `eval`, no `Function`, no `exec` anywhere in the lane.

**The gate is stricter than the engine's, and says so.** `POST /v1/chat/completions` gates on the chat **template** and never reads `tool_capable` — a row with `tool_capable: false` whose template happens to carry tools is accepted with a 200 and returns unchecked calls. `tool_capable` is the receipt that those calls were actually checked, so this lane requires it, *as a product choice*. An earlier draft of the copy claimed the engine enforced it; the smoke now asserts that claim is absent.

**Models loop.** Given the tool result, the 3B model re-issued the identical call instead of using it — verified live. Detection deliberately ignores the call `id`, because the runnable lane mints non-unique ids (`call_0`, `call_1`) under a constant response id; matching on id would miss every repeat there.

## Lane differences handled

The runnable/Ornith lane lifts structured calls out of the reply but **keeps the raw `<function=…>` envelope in `content`**, so one turn carries both. The capability row's "without leaking the raw envelope" holds on the dense lane only. Detected rather than assumed, and explained in the card so two views of one request don't read as two requests.

Model-written arguments are parsed defensively: a malformed argument object is reported with the raw text preserved, because a model emitting broken JSON is a real thing to know.

## Verification

18-check smoke wired into `ci.yml`, normalizing against the engine's own committed capture (`qa/capability/mac_tools_out/llama-3.2-3b/p1.json`). Build, `tool-calling`, `token-inspector`, `ui`, `integration`, `streaming`, `contrast`, `model-state`, `first-run-card` and the scrub gate all pass. Driven end-to-end in the browser.

Rebased onto `main` after #724 merged; both features verified together after resolving the overlap in `MessageTurn`, `useDashboardData`, `chatCompletionStream` and `ChatWorkspace`.

## MCP is deliberately not included

`serve` accepts no `--allow-mcp` / `--trust-mcp-server` flags, and `src/api/` contains **no MCP surface at all** — so the engine behind the browser has no MCP capability. A browser manager would mean adding MCP to the HTTP server, which changes the threat model: today an MCP server can only be trusted at the command line by someone on that machine, and `serve` can listen on a LAN. `mcp.rs` states that "off unless explicitly trusted" is *enforced, not described*. That decision belongs to you, not to a UI PR.
