### PR TITLE
fix(api): stop the dense streaming lane duplicating a reply on a straddling stop

### DIFF
--- a/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
+++ b/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
@@ -27,7 +27,7 @@
   },
   "implementation": {
     "source_file": "src/api/mod.rs",
-    "source_git_blob_sha1": "a255d6081d1a12d8e876ed5db95ee4413618d4fb",
+    "source_git_blob_sha1": "7648cce1e54090ffa0baac909a58f2ce3cca798b",
     "architecture": "smollm3",
     "renderer": "render_smollm3_production_chat_prompt",
     "public_chokepoints": [

--- a/scripts/hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/hf-qualification-smollm3-chat-parity.mjs
@@ -93,11 +93,11 @@ const GROUNDING_FILES = Object.freeze({
   }),
   runtime_envelope: Object.freeze({
     path: 'qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json',
-    sha256: 'c0ce4c09a7e74e3710a22944c2485290bf69d602fadcc788666695c53e232689',
+    sha256: 'df191140b362b1c02946d54eeef977d6a91673654748a60061a3cf5872151ccf',
   }),
 })
 
-const RENDERER_GIT_BLOB_SHA1 = 'a255d6081d1a12d8e876ed5db95ee4413618d4fb'
+const RENDERER_GIT_BLOB_SHA1 = '7648cce1e54090ffa0baac909a58f2ce3cca798b'
 const SHAPE_CASE_ID = 'default_think_single_user_generation_prompt'
 const NORMALIZED_PROMPT_UTF8_BYTES = 1_392
 const NORMALIZED_PROMPT_SHA256 = '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1'

--- a/scripts/test-hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/test-hf-qualification-smollm3-chat-parity.mjs
@@ -114,7 +114,7 @@ assert.deepEqual(TEMPLATE_IDENTITY, {
 assert.equal(GROUNDING_FILES.shape_pack.sha256,
   'd46794448b7c2585d0aa83dfd7bb17d4904c2dcbc048ade1ef68cd3863166de6')
 assert.equal(GROUNDING_FILES.runtime_envelope.sha256,
-  'c0ce4c09a7e74e3710a22944c2485290bf69d602fadcc788666695c53e232689')
+  'df191140b362b1c02946d54eeef977d6a91673654748a60061a3cf5872151ccf')
 assert.equal(LLAMA_PIN.executable_sha256,
   '6c787bf07ac1d7e1bbaa1ee176c3ef0df58ea86494c8c1b1d2d9f4a9176b19ae')
 assert.equal(LLAMA_PIN.server_impl_sha256,
@@ -331,7 +331,7 @@ assert.equal(classifySmolLM3ChatParityError(sharedSmolError).error_code,
 
 const committedGrounding = await inspectGroundings(root)
 assert.equal(committedGrounding.renderer_git_blob_sha1,
-  'a255d6081d1a12d8e876ed5db95ee4413618d4fb')
+  '7648cce1e54090ffa0baac909a58f2ce3cca798b')
 assert.equal(committedGrounding.shape_case.normalized_prompt_sha256,
   '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1')
 const shapePack = JSON.parse(await readFile(resolve(GROUNDING_FILES.shape_pack.path), 'utf8'))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23345,7 +23345,7 @@ fn stream_prompt_cache_prologue(
     // with correct usage but no content delta. Longer cached streams also must
     // establish `streamed_text` before subsequent deltas are diffed.
     if !generated.is_empty() {
-        let mut text = match prepared.tokenizer.decode(generated, true) {
+        let text = match prepared.tokenizer.decode(generated, true) {
             Ok(text) => text,
             Err(err) => {
                 send(StreamDecodeEvent::Failed {
@@ -23355,9 +23355,10 @@ fn stream_prompt_cache_prologue(
                 return StreamPrologue::Stop;
             }
         };
-        if *finish_reason == "stop" {
-            text = truncate_at_stop_sequence(text, &prepared.stop_sequences);
-        }
+        // A cached prefix must seed `streamed_text` with the SAME stop-safe bound the
+        // loop below uses, or the first post-prologue step diffs against an
+        // untruncated seed and reproduces the duplication this bound prevents.
+        let text = stop_visible_text(text, &prepared.stop_sequences, *finish_reason == "stop");
         if !text.is_empty() {
             *streamed_text = text.clone();
             *first_content_ms = Some(generation_started.elapsed().as_millis());
@@ -23461,6 +23462,19 @@ fn run_stream_decode_job(
             .checked_sub(generation_started.elapsed())
             .is_none()
         {
+            // The run is over: nothing further can complete a stop sequence, so
+            // release whatever the hold-back is still sitting on before the client
+            // sees the timeout frame.
+            let pending = stop_hold_back_flush(
+                &prepared.tokenizer,
+                &generated,
+                &streamed_text,
+                &prepared.stop_sequences,
+            );
+            if !pending.is_empty() {
+                streamed_text.push_str(&pending);
+                send(StreamDecodeEvent::Delta(pending));
+            }
             send(StreamDecodeEvent::TimedOut {
                 timeout: request_timeout,
                 elapsed: generation_started.elapsed(),
@@ -23545,7 +23559,7 @@ fn run_stream_decode_job(
             }
         }
 
-        let mut text = match prepared.tokenizer.decode(&generated, true) {
+        let text = match prepared.tokenizer.decode(&generated, true) {
             Ok(text) => text,
             Err(err) => {
                 send(StreamDecodeEvent::Failed {
@@ -23555,13 +23569,11 @@ fn run_stream_decode_job(
                 return;
             }
         };
-        if finish_reason == "stop" {
-            text = truncate_at_stop_sequence(text, &prepared.stop_sequences);
-        }
-        let delta = text
-            .strip_prefix(&streamed_text)
-            .map(str::to_owned)
-            .unwrap_or_else(|| text.clone());
+        // Whether the loop below will terminate on this step. Computed BEFORE the
+        // emit so the final step can release the hold-back in the same delta.
+        let is_final = finish_reason != "length" || generated.len() >= prepared.max_tokens as usize;
+        let text = stop_visible_text(text, &prepared.stop_sequences, is_final);
+        let delta = stream_delta(&text, &streamed_text, &prepared.stop_sequences);
         streamed_text = text;
         if !delta.is_empty() {
             if first_content_ms.is_none() {
@@ -23757,6 +23769,19 @@ impl CooperativeStreamDecodeJob {
         if self.finished {
             return engine::StepOutcome::Complete;
         }
+        // Every clean termination funnels through here, including the re-entry path
+        // at the top of `step` that never re-decodes. Release any held tail before
+        // the Finished event; a no-op when the emit above already released it.
+        let pending = stop_hold_back_flush(
+            &self.prepared.tokenizer,
+            &self.generated,
+            &self.streamed_text,
+            &self.prepared.stop_sequences,
+        );
+        if !pending.is_empty() {
+            self.streamed_text.push_str(&pending);
+            self.send(StreamDecodeEvent::Delta(pending));
+        }
         log_speculative_summary(&self.prepared, self.generated.len());
         self.prepared.timings.generate = self.generation_started.elapsed().as_millis();
         self.prepared.timings.generation =
@@ -23842,6 +23867,18 @@ impl CooperativeStreamDecodeJob {
             .checked_sub(self.generation_started.elapsed())
             .is_none()
         {
+            // Same reasoning as the exclusive job: release the hold-back before the
+            // client sees the timeout frame, or those bytes are lost.
+            let pending = stop_hold_back_flush(
+                &self.prepared.tokenizer,
+                &self.generated,
+                &self.streamed_text,
+                &self.prepared.stop_sequences,
+            );
+            if !pending.is_empty() {
+                self.streamed_text.push_str(&pending);
+                self.send(StreamDecodeEvent::Delta(pending));
+            }
             self.send(StreamDecodeEvent::TimedOut {
                 timeout: self.request_timeout,
                 elapsed: self.generation_started.elapsed(),
@@ -23932,7 +23969,7 @@ impl CooperativeStreamDecodeJob {
                 .record_progress(self.generated.len());
         }
 
-        let mut text = match self.prepared.tokenizer.decode(&self.generated, true) {
+        let text = match self.prepared.tokenizer.decode(&self.generated, true) {
             Ok(text) => text,
             Err(err) => {
                 self.send(StreamDecodeEvent::Failed {
@@ -23943,13 +23980,12 @@ impl CooperativeStreamDecodeJob {
                 return engine::StepOutcome::Complete;
             }
         };
-        if self.finish_reason == "stop" {
-            text = truncate_at_stop_sequence(text, &self.prepared.stop_sequences);
-        }
-        let delta = text
-            .strip_prefix(&self.streamed_text)
-            .map(str::to_owned)
-            .unwrap_or_else(|| text.clone());
+        // Whether this step terminates the job (same condition as the tail below).
+        // Computed BEFORE the emit so the final step releases the hold-back here.
+        let is_final = self.finish_reason != "length"
+            || self.generated.len() >= self.prepared.max_tokens as usize;
+        let text = stop_visible_text(text, &self.prepared.stop_sequences, is_final);
+        let delta = stream_delta(&text, &self.streamed_text, &self.prepared.stop_sequences);
         self.streamed_text = text;
         if !delta.is_empty() {
             if self.first_content_ms.is_none() {
@@ -24376,6 +24412,63 @@ fn stop_safe_stream_len(text: &str, stop_sequences: &[String]) -> usize {
     // `ends_with` can only succeed for `held <= text.len()`, so this cannot underflow;
     // a byte-equal tail of a valid UTF-8 string starts on a char boundary.
     complete.min(text.len() - held)
+}
+
+/// Incremental delta for a streaming reply.
+///
+/// With stop sequences live the visible text can be CUT, and a cut can land behind
+/// what the client already holds. The right answer then is "nothing new" — never
+/// "here is the whole reply again", which is precisely what duplicated the reply on
+/// this lane when a stop string straddled a token boundary. With no stop sequences
+/// requested the original fallback is preserved byte-for-byte, so those requests
+/// cannot take a different branch than they did before.
+fn stream_delta(visible: &str, streamed: &str, stop_sequences: &[String]) -> String {
+    match visible.strip_prefix(streamed) {
+        Some(rest) => rest.to_string(),
+        None if !stop_sequences.is_empty() => String::new(),
+        None => visible.to_string(),
+    }
+}
+
+/// Release whatever the stop hold-back is still withholding, as a delta to send.
+///
+/// Generation is over at every call site, so nothing further can complete a stop
+/// sequence and only a COMPLETE match still cuts. Without this a run that ends
+/// while a proper prefix of a stop string is held — max_tokens reached, or the
+/// request timing out — silently loses those trailing bytes.
+///
+/// Empty when no sequences were requested, so the certified no-stop path never
+/// gains an event.
+fn stop_hold_back_flush(
+    tokenizer: &Tokenizer,
+    generated: &[u32],
+    streamed_text: &str,
+    stop_sequences: &[String],
+) -> String {
+    if stop_sequences.is_empty() {
+        return String::new();
+    }
+    let Ok(text) = tokenizer.decode(generated, true) else {
+        return String::new();
+    };
+    truncate_at_stop_sequence(text, stop_sequences)
+        .strip_prefix(streamed_text)
+        .map(str::to_owned)
+        .unwrap_or_default()
+}
+
+/// The text of an in-progress reply that may be streamed on THIS step.
+///
+/// `is_final` is the step on which the decode loop terminates: the cut is settled,
+/// so the whole truncated text is released. Until then a stop string may still be
+/// straddling the token boundary, and bytes streamed before the match completes
+/// cannot be taken back — so the reply is bounded at the stop-safe length.
+fn stop_visible_text(mut text: String, stop_sequences: &[String], is_final: bool) -> String {
+    if is_final {
+        return truncate_at_stop_sequence(text, stop_sequences);
+    }
+    text.truncate(stop_safe_stream_len(&text, stop_sequences));
+    text
 }
 
 fn validate_chat_messages(messages: &[ChatMessage]) -> std::result::Result<(), Box<Response>> {

--- a/tests/api_vertical_slice.rs
+++ b/tests/api_vertical_slice.rs
@@ -4923,6 +4923,89 @@ async fn streaming_completion_honors_stop_sequence_finish_reason() {
     assert!(body.contains("data: [DONE]"));
 }
 
+/// A stop string that STRADDLES a token boundary. The tiny fixture emits `<unk>`
+/// per step, so `"><"` spans the join between token 1 and token 2: it is absent
+/// from `"<unk>"` and present in `"<unk><unk>"`, starting at byte 4 — BEHIND the
+/// end of the text already streamed.
+///
+/// The lane used to decode the full reply each step, truncate at the match start,
+/// and diff with `strip_prefix`. On this input the truncated text is SHORTER than
+/// what the client already holds, `strip_prefix` returns None, and the fallback
+/// re-emitted the entire reply as one delta — the client, which concatenates
+/// deltas verbatim, saw the reply's prefix twice.
+///
+/// The old assertions never concatenated the deltas, which is why it shipped. This
+/// one does, and pins the streamed answer to the non-streamed one.
+#[tokio::test]
+async fn streaming_completion_stop_straddling_a_token_matches_the_nonstreaming_answer() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tiny-generation.gguf");
+    write_generation_gguf(&path);
+
+    let app = camelid::api::router();
+    let load_body = serde_json::json!({"path": path, "id": "tiny-generation"});
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/models/load")
+                .header("content-type", "application/json")
+                .body(Body::from(load_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let request = |stream: bool| {
+        Request::builder()
+            .method("POST")
+            .uri("/v1/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(format!(
+                r#"{{"model":"tiny-generation","prompt":"hello","max_tokens":2,"stream":{stream},"stop":"><"}}"#
+            )))
+            .unwrap()
+    };
+
+    let response = app.clone().oneshot(request(false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let nonstreaming: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    let expected = nonstreaming["choices"][0]["text"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert_eq!(expected, "<unk", "fixture changed: {nonstreaming}");
+    assert_eq!(nonstreaming["choices"][0]["finish_reason"], "stop");
+
+    let response = app.oneshot(request(true)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+    // Reassemble the reply exactly as a client does.
+    let mut streamed = String::new();
+    for line in body.lines() {
+        let Some(payload) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if payload.trim() == "[DONE]" {
+            continue;
+        }
+        let chunk: serde_json::Value = serde_json::from_str(payload).unwrap();
+        if let Some(text) = chunk["choices"][0]["text"].as_str() {
+            streamed.push_str(text);
+        }
+    }
+    assert_eq!(
+        streamed, expected,
+        "streamed deltas must concatenate to the non-streamed answer; got {streamed:?}\n{body}"
+    );
+    assert!(body.contains("\"finish_reason\":\"stop\""));
+}
+
 #[tokio::test]
 async fn completion_endpoint_streams_openai_compatible_sse_chunks() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Fixes a pre-existing defect on the **dense** streaming lane: a stop string that straddles a token boundary makes both streaming jobs re-emit the entire reply as one delta, on top of everything already streamed.

> Reuses the `stop_safe_stream_len` helper introduced by #725, now merged. Based on `main`.

## The defect

`streamed_text` after step n-1 is the UNTRUNCATED decode, which by construction contains no stop match. So a match found at step n must END past `len(text_{n-1})` but may START before it. `truncate_at_stop_sequence` cuts at the match START, so the truncated text is strictly SHORTER than what the client already holds, `strip_prefix` returns `None`, and the `unwrap_or_else(|| text.clone())` fallback sends the whole reply again. `chatCompletionStream.js` concatenates deltas verbatim, so the user sees the prefix twice.

Both jobs carry it — `run_stream_decode_job` and `CooperativeStreamDecodeJob::step` — and both are production-reachable (cooperative when `continuous_batch_slots() > 1` and CUDA resident decode is inactive, exclusive otherwise).

## Captured on the wire

Tiny fixture, `stop: "><"`, `max_tokens: 2`. The sequence is absent from `"<unk>"` and present in `"<unk><unk>"` starting at byte 4 — behind the end of what was already sent:

```
delta 1: {"text":"<unk>"}    <- full, untruncated
delta 2: {"text":"<unk"}     <- the entire truncated reply, re-emitted
client:  "<unk><unk"         vs non-streaming "<unk"
```

That is the actual SSE body from the parent commit, printed by the new test's failure.

## The fix

Reuses `stop_safe_stream_len` from #725. While generation continues the visible text is bounded at the stop-safe length, so bytes a later cut would remove are never streamed. On the terminating step the cut is settled and the whole truncated text is released. `is_final` is computed **before** the emit, from the same condition the loop tail already uses, so the release lands in the same delta rather than a step later.

Three supporting pieces, each closing a way the tail could still be lost or duplicated:

- **`stream_delta`** replaces the `unwrap_or_else(|| text.clone())` fallback. With stop sequences live a failed `strip_prefix` now yields nothing rather than the whole reply — re-sending *is* the bug, and the diff rests on detokenization being append-only, so a violation should degrade to silence rather than duplication. With no stop sequences the original fallback is preserved byte-for-byte.
- **`stop_hold_back_flush`** releases a held tail at every terminal exit that does not re-decode: `finish_clean` (the cooperative job's single clean-termination funnel, also reachable from the top of `step`) and both timeout paths. Without it, a run ending while a proper prefix of a stop string is held — `max_tokens` reached, or a timeout — silently drops those bytes.
- **The shared streaming prologue** seeds `streamed_text` from a prompt-cache hit and needed the same bound, or the first post-prologue step diffs against an untruncated seed and reproduces the defect.

## Why it shipped

`streaming_completion_honors_stop_sequence_finish_reason` asserts only `finish_reason` and `[DONE]`. It never concatenates the deltas, so the duplication was invisible to it.

The new `streaming_completion_stop_straddling_a_token_matches_the_nonstreaming_answer` reassembles the SSE stream exactly as a client does and pins it to the non-streamed answer for the same request. **Verified to fail on the parent commit and pass here** — the failure output above is from that run.

## No-op without `stop`

`stop_safe_stream_len` returns `text.len()` on its first line for an empty set, `truncate_at_stop_sequence` is identity, `stop_hold_back_flush` returns empty, and `stream_delta` keeps the original fallback. No certified no-stop request can take a different branch, which is what keeps the hash-pinned evidence on this lane untouched.

## Gates

3054 tests pass, 0 failures. `clippy --all-targets -D warnings` clean, `fmt --check` clean, 47/47 validation scripts, ledger drift clean, public scrub clean. Renderer seal re-pinned after fmt; `render_smollm3_production_chat_prompt` is byte-identical to the sealed blob and the SmolLM3 mention count is unchanged, so the churn is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

