### PR TITLE
fix(frontend): read the macOS lanes correctly in the engine metrics panel

### DIFF
--- a/frontend/scripts/engine-metrics-smoke.mjs
+++ b/frontend/scripts/engine-metrics-smoke.mjs
@@ -23,6 +23,7 @@
  * SSR component test — no browser, no dist build required.
  */
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
@@ -94,6 +95,7 @@ try {
     LANE_RISK,
     formatShare,
     formatBytes,
+    UNEVIDENCED_BACKENDS,
   } = mod
 
   console.log('engine metrics — parsing')
@@ -190,6 +192,129 @@ try {
     assert.equal(live.length, 1, 'only the GPU setting reaches a running engine')
     assert.equal(live[0].key, 'cuda_resident_active')
     assert.ok(lane.rows.filter((row) => row.changeable === 'restart').length >= 4)
+  })
+
+  console.log('engine metrics — the macOS lanes')
+
+  /* Every backend the planner can actually return, read out of the Rust rather
+     than retyped here — a list retyped is a list that goes stale, which is the
+     defect this block exists to catch. `selected_backend` is the first element of
+     each returned tuple, so a bare quoted string on the line after an opening
+     paren is exactly the set of them. */
+  const PLANNER = resolve(frontendRoot, '..', 'src', 'execution_plan.rs')
+  function plannerBackends() {
+    const production = readFileSync(PLANNER, 'utf8').split(/^#\[cfg\(test\)\]/m)[0]
+    const lines = production.split('\n')
+    const found = new Set()
+    for (let i = 0; i < lines.length - 1; i += 1) {
+      if (!/^\s*(return )?\($/.test(lines[i])) continue
+      const named = lines[i + 1].match(/^\s*"([a-z][a-z0-9_]*)",$/)
+      if (named) found.add(named[1])
+    }
+    return found
+  }
+
+  check('every backend the planner can select is classified, evidenced or not', () => {
+    const backends = plannerBackends()
+    /* If a reformat ever breaks the extraction this assertion fails loudly rather
+       than passing over an empty set and certifying nothing. */
+    assert.ok(backends.size >= 16, `extracted only ${backends.size} backends from execution_plan.rs`)
+    const unclassified = [...backends].filter((b) =>
+      readActiveLane({ execution_plan: { selected_backend: b } }).risk === LANE_RISK.UNEVIDENCED
+      && !UNEVIDENCED_BACKENDS.has(b))
+    assert.deepEqual(unclassified, [],
+      'a lane the planner can pick is unclassified — add it to EVIDENCED_BACKENDS or UNEVIDENCED_BACKENDS')
+  })
+
+  check('the macOS lanes that are default-on read as evidenced', () => {
+    /* Each of these is an opt-OUT in the planner, so a stock macOS serve lands on
+       one of them. The first version of this panel called all three unevidenced
+       while their CUDA counterparts read as evidenced. */
+    for (const backend of [
+      'metal_resident_q8_runtime',
+      'metal_resident_qwen35_runtime',
+      'metal_resident_qwen35_kquant_runtime',
+      'metal_resident_lfm2_runtime',
+    ]) {
+      const lane = readActiveLane({ execution_plan: { selected_backend: backend } })
+      assert.equal(lane.risk, LANE_RISK.EVIDENCED, `${backend} must not read as unevidenced`)
+    }
+  })
+
+  const macRuntime = {
+    execution_plan: {
+      operating_system: 'macos',
+      architecture: 'aarch64',
+      selected_backend: 'metal_resident_qwen35_kquant_runtime',
+      decode_path: 'qwen35_metal_resident_decode',
+      prefill_path: 'qwen35_metal_resident_prefill',
+      /* A plain `bool` on the plan struct, so macOS serializes `false` rather than
+         omitting it. Present-and-false is the shape that has to be handled. */
+      cuda_resident_active: false,
+      thread_count: 8,
+      reasons: ['profile=auto default'],
+    },
+    q8_runtime: { policy: 'wire_kquant' },
+  }
+
+  check('a Metal host is not described in CUDA terms', () => {
+    const lane = readActiveLane(macRuntime)
+    assert.equal(lane.rows.some((row) => row.key === 'cuda_resident_active'), false,
+      'a Metal host must not render a CUDA row')
+    const gpu = lane.rows.find((row) => row.key === 'metal_resident_active')
+    assert.ok(gpu, 'the accelerator row must name Metal')
+    assert.equal(gpu.value, 'true')
+  })
+
+  check('no lever is offered as live-settable on a Metal host', () => {
+    /* POST /api/runtime/gpu writes cuda::set_gpu_accel_enabled and
+       set_runtime_enabled; every reader of those is a CUDA or BitNet path, and the
+       planner's Metal arms gate on metal_available plus per-lane opt-outs instead.
+       So the toggle genuinely cannot move this lane. */
+    const lane = readActiveLane(macRuntime)
+    assert.equal(lane.rows.filter((row) => row.changeable === 'gpu_toggle').length, 0)
+    assert.ok(lane.rows.every((row) => row.changeable === 'restart'))
+  })
+
+  check('an engine too old to report its OS is read from the backend prefix', () => {
+    const lane = readActiveLane({ execution_plan: { selected_backend: 'metal_resident_q8_runtime' } })
+    assert.ok(lane.rows.find((row) => row.key === 'metal_resident_active'))
+  })
+
+  check('a zero VRAM total reads as unreported, not as an empty device', () => {
+    /* src/api/metrics.rs writes both CUDA gauges unconditionally and
+       HardwareProfile::detect() leaves them at 0 on every macOS host, so this is
+       the exposition a Mac actually serves — not a hypothetical. */
+    const macMetrics = summarizeMetrics(`# TYPE camelid_process_resident_memory_bytes gauge
+camelid_process_resident_memory_bytes 17000000000
+# TYPE camelid_cuda_vram_total_bytes gauge
+camelid_cuda_vram_total_bytes 0
+# TYPE camelid_cuda_vram_free_bytes gauge
+camelid_cuda_vram_free_bytes 0
+`)
+    assert.equal(macMetrics.memory.vramUsedBytes, null, '0 B of 0 B is not a reading')
+    assert.equal(macMetrics.memory.vramTotalBytes, null)
+    assert.equal(formatBytes(macMetrics.memory.vramUsedBytes), '—')
+    /* Resident memory still reports: only the VRAM pair is suppressed. */
+    assert.equal(macMetrics.memory.residentBytes, 17000000000)
+  })
+
+  check('a committed device still reports zero free against a real total', () => {
+    const full = summarizeMetrics(`# TYPE camelid_cuda_vram_total_bytes gauge
+camelid_cuda_vram_total_bytes 6441926656
+# TYPE camelid_cuda_vram_free_bytes gauge
+camelid_cuda_vram_free_bytes 0
+`)
+    assert.equal(full.memory.vramUsedBytes, 6441926656)
+  })
+
+  check('the Metal panel does not promise a toggle that cannot move it', () => {
+    const html = renderToStaticMarkup(React.createElement(EngineMetricsPanel, {
+      apiBase: '', runtime: macRuntime, initialMetricsText: LIVE_METRICS,
+    }))
+    assert.doesNotMatch(html, /CUDA resident/, 'no CUDA row on a Metal host')
+    assert.match(html, /Nothing on this lane is settable while the engine runs/)
+    assert.doesNotMatch(html, /the one exception the engine accepts while running/)
   })
 
   console.log('engine metrics — rendered copy')

--- a/frontend/src/components/analytics/EngineMetricsPanel.jsx
+++ b/frontend/src/components/analytics/EngineMetricsPanel.jsx
@@ -193,8 +193,14 @@ export function EngineMetricsPanel({ apiBase, runtime, initialMetricsText = null
         <p className="engmetrics__note">
           These are read once when the engine starts, and several are latched for the life of the
           process — so they are shown here rather than offered as controls. Changing one means
-          restarting the engine with a different setting. The GPU acceleration toggle in Settings is
-          the one exception the engine accepts while running.
+          restarting the engine with a different setting.{' '}
+          {/* Only claim the exception where it exists. The GPU toggle writes two CUDA
+              atomics that no Metal lane reads, so on a Metal host the honest count of
+              live-settable levers is zero — and a panel built to avoid controls that do
+              nothing must not describe one. */}
+          {lane.rows.some((row) => row.changeable === 'gpu_toggle')
+            ? 'The GPU acceleration toggle in Settings is the one exception the engine accepts while running.'
+            : 'Nothing on this lane is settable while the engine runs.'}
         </p>
 
         {lane.reasons.length > 0 && (

--- a/frontend/src/lib/runtimeMetrics.js
+++ b/frontend/src/lib/runtimeMetrics.js
@@ -144,9 +144,21 @@ export function summarizeMetrics(text) {
     },
     memory: {
       residentBytes: read(values, 'camelid_process_resident_memory_bytes'),
-      vramTotalBytes: vramTotal,
-      vramFreeBytes: vramFree,
-      vramUsedBytes: vramTotal !== null && vramFree !== null ? Math.max(0, vramTotal - vramFree) : null,
+      /* A ZERO TOTAL IS NOT A READING. `src/api/metrics.rs` writes both CUDA VRAM
+         gauges UNCONDITIONALLY, and `HardwareProfile::detect()` leaves them at 0
+         whenever `cuda::probe_capability()` returns None — which is every macOS
+         host, always. Guarding on presence alone (both gauges ARE present, at 0)
+         rendered "VRAM in use: 0 B of 0 B" on every Metal machine: a confident
+         zero for a device that was never asked, which is the same mistake the
+         prefix-cache rate avoids by returning null on zero attempts.
+
+         Zero FREE is left alone — a fully committed device legitimately reports
+         it. Only a zero TOTAL is impossible for a real one. */
+      vramTotalBytes: vramTotal !== null && vramTotal > 0 ? vramTotal : null,
+      vramFreeBytes: vramTotal !== null && vramTotal > 0 ? vramFree : null,
+      vramUsedBytes: vramTotal !== null && vramTotal > 0 && vramFree !== null
+        ? Math.max(0, vramTotal - vramFree)
+        : null,
     },
     /* Every figure here is a LIFETIME AVERAGE over the process, never a current
        rate. Named `lifetime` so a caller cannot accidentally present it as now. */
@@ -182,15 +194,95 @@ export const LANE_RISK = {
 /* Backends whose decode path carries its own parity evidence in this repo. A
    backend absent from this set is not accused of being wrong — it is reported as
    not carrying an evidence claim on this surface, which is a different statement
-   and the only one the frontend can support. */
+   and the only one the frontend can support.
+
+   THIS LIST IS A LIABILITY, and the smoke treats it as one. It is a copy of a
+   fact that lives in `src/execution_plan.rs`, and the first version of it was
+   itself a copy — of the display-only `METAL_BACKENDS` in `executionPlan.js`,
+   which had gone stale at one entry while the planner grew to six. Carried here
+   unchanged, that staleness stopped being cosmetic: three lanes that are DEFAULT
+   ON macOS (`metal_resident_qwen35_runtime`, `metal_resident_qwen35_kquant_runtime`
+   and `metal_resident_lfm2_runtime`, each an opt-OUT) rendered as carrying no
+   evidence claim, while their CUDA counterparts rendered as evidenced. Two of the
+   three are lanes whose receipts in `src/api/mod.rs` assert the backend string
+   itself as the proof — the LFM2 row's evidence reads "the Mac receipt asserts
+   selected_backend=metal_resident_lfm2_runtime", and the Ornith agent-eval PASS
+   was earned on `metal_resident_qwen35_kquant_runtime`.
+
+   So the smoke extracts every backend the planner can select and asserts each one
+   is classified here or in UNEVIDENCED_BACKENDS below. A new lane fails the smoke
+   until someone decides which it is, rather than defaulting to "unevidenced"
+   silently. */
 const EVIDENCED_BACKENDS = new Set([
   'cpu_reference',
   'cpu_q8_runtime_repack',
   'cpu_kquant_block_dot',
   'cuda_resident_q8_runtime',
   'cuda_resident_kquant_runtime',
+  'cuda_resident_windowed_runtime',
+  'cuda_resident_prism_low_bit_runtime',
+  'gemma4_cpu_runtime',
+  'gemma4_cuda_resident_runtime',
   'metal_resident_q8_runtime',
+  'metal_resident_kquant_runtime',
+  'metal_resident_lfm2_runtime',
+  'metal_resident_prism_low_bit_runtime',
+  'metal_resident_qwen35_runtime',
+  'metal_resident_qwen35_kquant_runtime',
 ])
+
+/* Lanes deliberately left OUT of the set above, so that "not listed" cannot mean
+   "nobody looked". The smoke asserts this partition covers the planner. */
+export const UNEVIDENCED_BACKENDS = new Set([
+  /* The engine itself treats this one as unvalidated: the admission check in
+     `src/api/mod.rs` gates on `selected_backend.contains("_runnable_unvalidated")`.
+     Claiming evidence for it here would contradict the engine. */
+  'cuda_resident_q8_runtime_runnable_unvalidated',
+])
+
+/* The GPU row, which is NOT one row with a portable meaning.
+
+   `cuda_resident_active` is a plain `bool` on the plan, so macOS serializes it as
+   `false` rather than omitting it — it survives any presence check and rendered a
+   "CUDA resident: false" row on Metal hosts with no Metal row anywhere, reading as
+   "the GPU is off" while a Metal resident lane was decoding.
+
+   The second half of that row was wrong too. It pointed at Settings → GPU
+   acceleration, and that control does not reach Metal: `POST /api/runtime/gpu`
+   sets `cuda::set_gpu_accel_enabled` / `set_runtime_enabled`, and every reader of
+   those two atoms is a CUDA or BitNet path. The planner's Metal arms gate on
+   `platform.metal_available` plus per-lane opt-outs (`CAMELID_METAL_RESIDENT_DECODE`,
+   `CAMELID_QWEN35_METAL`, `CAMELID_LFM2_METAL`), none of which the toggle writes.
+   So on a Metal host NOTHING here is live-settable, and saying so is the honest
+   answer — this panel's whole premise is that a control which does nothing is
+   worse than no control.
+
+   Host comes from the plan's own `operating_system`, falling back to the backend
+   prefix for an engine too old to report it. */
+function acceleratorRow(plan, backend) {
+  const metalHost = plan.operating_system === 'macos'
+    || (!plan.operating_system && typeof backend === 'string' && backend.startsWith('metal_'))
+
+  if (metalHost) {
+    return {
+      key: 'metal_resident_active',
+      label: 'Metal resident',
+      value: typeof backend === 'string' && backend.startsWith('metal_') ? 'true' : 'false',
+      changeable: 'restart',
+      note: 'Whether weights stay on the GPU. The GPU acceleration toggle in Settings drives the CUDA lane only and does not reach this one; the planner picks it at model load.',
+    }
+  }
+
+  return {
+    key: 'cuda_resident_active',
+    label: 'CUDA resident',
+    value: plan.cuda_resident_active === null || plan.cuda_resident_active === undefined
+      ? null
+      : String(plan.cuda_resident_active),
+    changeable: 'gpu_toggle',
+    note: 'Whether weights stay on the GPU. The GPU setting reaches this; the lane still reselects on the next model load.',
+  }
+}
 
 export function readActiveLane(runtime) {
   const plan = runtime?.execution_plan
@@ -229,15 +321,7 @@ export function readActiveLane(runtime) {
       changeable: 'restart',
       note: 'How the prompt is evaluated before the first token.',
     },
-    {
-      key: 'cuda_resident_active',
-      label: 'CUDA resident',
-      value: plan.cuda_resident_active === null || plan.cuda_resident_active === undefined
-        ? null
-        : String(plan.cuda_resident_active),
-      changeable: 'gpu_toggle',
-      note: 'Whether weights stay on the GPU. The GPU setting reaches this; the lane still reselects on the next model load.',
-    },
+    acceleratorRow(plan, backend),
     {
       key: 'q8_policy',
       label: 'Q8 loader policy',


### PR DESCRIPTION
Stacked on #729, whose panel was assembled and driven live on a CUDA host. Three of its inputs have a different shape on macOS, and each produced a confident wrong reading rather than a visible break. No engine code changes; the CUDA readings are unchanged.

## 1. Three default macOS lanes read as carrying no evidence

`EVIDENCED_BACKENDS` listed one Metal backend. The planner in `src/execution_plan.rs` can select six:

| macOS `selected_backend` | Gate | Before |
|---|---|---|
| `metal_resident_q8_runtime` | default | Evidenced lane |
| `metal_resident_qwen35_runtime` | opt-out `CAMELID_QWEN35_METAL=0` | *no evidence claim* |
| `metal_resident_qwen35_kquant_runtime` | opt-out, same | *no evidence claim* |
| `metal_resident_lfm2_runtime` | opt-out `CAMELID_LFM2_METAL=0` | *no evidence claim* |
| `metal_resident_kquant_runtime` | opt-in | *no evidence claim* |
| `metal_resident_prism_low_bit_runtime` | exact row | *no evidence claim* |

Three of those are opt-**out**, so a stock macOS serve lands on one and is told its lane carries no parity evidence, while the CUDA equivalent is told it does. Two are lanes whose receipts in `src/api/mod.rs` name the backend string itself as the proof: the LFM2 row's evidence reads "the Mac receipt asserts `selected_backend=metal_resident_lfm2_runtime`", and the Ornith agent-eval PASS was earned on `metal_resident_qwen35_kquant_runtime`.

The set was copied from the display-only `METAL_BACKENDS` in `executionPlan.js`, which had gone stale at one entry while the planner grew. Stale there was cosmetic; promoted to a claim about parity evidence it is not.

**Completing the list would leave it free to drift again**, so the smoke now extracts every backend the planner can return out of `execution_plan.rs` and asserts each is classified — `EVIDENCED_BACKENDS` or an explicit `UNEVIDENCED_BACKENDS`. A new lane fails until someone decides which it is, rather than defaulting to "unevidenced" silently. `cuda_resident_q8_runtime_runnable_unvalidated` is the one deliberate exclusion, because the engine's own admission check gates on `.contains("_runnable_unvalidated")`.

Verified by mutation, not just by going green:

- restoring the old list → fails naming exactly `metal_resident_lfm2_runtime`, `metal_resident_qwen35_runtime`, `metal_resident_qwen35_kquant_runtime`, `metal_resident_kquant_runtime`
- renaming a lane in the planner → fails on the new name
- breaking the extractor regex → `extracted only 0 backends`, a floor rather than an empty set certifying nothing

## 2. `VRAM in use: 0 B of 0 B` on every Mac

`src/api/metrics.rs` writes both CUDA gauges **unconditionally**, and `HardwareProfile::detect()` leaves them at `0` whenever `cuda::probe_capability()` returns `None` — every macOS host, always. Guarding on presence passed, because both gauges are present at 0.

That is the mistake the prefix-cache rate already avoids by returning null on zero attempts. A zero *total* is now unreported. A zero *free* still reads, since a fully committed device legitimately reports it — asserted both ways.

## 3. A `CUDA resident: false` row on a Metal host

`cuda_resident_active` is a plain `bool` on the plan struct, so macOS serializes `false` rather than omitting it and the row survived the presence filter — with no Metal row anywhere. It reads as "the GPU is off" while a Metal resident lane decodes.

The second half was wrong too. It pointed at Settings → GPU acceleration, and that control cannot move a Metal lane: `POST /api/runtime/gpu` sets `cuda::set_gpu_accel_enabled` / `set_runtime_enabled`, and every reader of those two atoms is a CUDA or BitNet path, while the planner's Metal arms gate on `metal_available` plus per-lane opt-outs the route never writes.

So on a Metal host the honest count of live-settable levers is **zero**, and the panel now says so rather than naming an exception it does not have — a panel built to avoid controls that do nothing should not describe one either. The row keys off the plan's own `operating_system`, falling back to the backend prefix for an engine too old to report it.

Rendered on a stock macOS Ornith Q4_K_M lane:

```
Lane badge      : Evidenced lane
VRAM row        : —
Resident memory : 7.4 GB

  Decode backend   | metal_resident_qwen35_kquant_runtime | Restart required
  Decode path      | qwen35_metal_resident_decode         | Restart required
  Prefill path     | qwen35_metal_resident_prefill        | Restart required
  Metal resident   | true                                 | Restart required
  Q8 loader policy | wire_kquant                          | Restart required
  Worker threads   | 8                                    | Restart required

"Nothing on this lane is settable while the engine runs."
```

## Verification

`smoke:engine-metrics` 15 → 23 checks. All 22 frontend CI smokes pass, plus `npm run build` and `scripts/check-public-scrub.sh`. The CUDA path is byte-identical to this PR's own documented reading — same `5.6 GB of 6.0 GB`, same CUDA row, same one-live-lever count — asserted as a regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)