### PR TITLE
docs: simplify README and move detailed setup into guides

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,6 +1,6 @@
 # Camelid Documentation Index
 
-Last updated: 2026-07-30
+Last updated: 2026-09-07
 
 This index helps readers navigate the public Markdown set.
 
@@ -14,7 +14,9 @@ This index helps readers navigate the public Markdown set.
 
 Read these first:
 
-- [`README.md`](README.md) — product overview, milestone story, and current exact-row support table
+- [`README.md`](README.md) — product overview, quick start, and starter models
+- [`docs/MODELS.md`](docs/MODELS.md) — full download catalog, model setup, and validation details
+- [`docs/REMOTE_CHAT.md`](docs/REMOTE_CHAT.md) — browser chat over a private LAN or Tailscale
 - [`COMPATIBILITY.md`](COMPATIBILITY.md) — authoritative support ledger and at-a-glance release contract
 - [`STATUS.md`](./docs/reference/STATUS.md) — current milestone/evidence snapshot and exact blockers
 - [`BENCHMARKS.md`](docs/benchmarks/BENCHMARKS.md) — public performance snapshot and benchmark-claim rules

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # 🐪 Camelid
 
-**Run supported GGUF language, vision, and embedding models locally with a Rust-native engine.**
+**Local AI, powered by Rust.**
 
-Desktop app, browser chat, terminal UI, and an OpenAI-compatible API—all backed by the same local runtime.
+Run supported GGUF models on your own hardware through a desktop app, browser chat, terminal, or OpenAI-compatible API.
 
 [![CI][ci-badge]][ci-workflow]
 [![Latest release][release-badge]][latest-release]
@@ -20,22 +20,12 @@ Desktop app, browser chat, terminal UI, and an OpenAI-compatible API—all backe
 
 <div align="center"><sub>Camelid's local web UI—a dark, collapsed-rail chat surface served directly from the engine binary.</sub></div>
 
-Camelid loads GGUF models and runs inference on your hardware. Its tokenizer, model loader, CPU kernels, and Metal and CUDA execution paths are implemented in this repository and distributed as a single Rust binary—no Python, Node.js, or Docker is required at runtime.
-
-## What is Camelid?
-
-Camelid is an open-source, Rust-native local AI inference engine for running supported GGUF large language models (LLMs), vision-language models (VLMs), and embedding models on Windows, macOS, and Linux. Use it as a desktop app, a browser-based local AI chat interface, a terminal application, or a self-hosted OpenAI-compatible API for your own tools and applications.
-
-Model inference runs on your hardware, with CPU execution, Apple Silicon Metal acceleration, and NVIDIA CUDA acceleration available within the documented support boundaries. Camelid is designed for private local AI chat, offline inference after model download, GGUF model testing, and local LLM application development without a Python, Node.js, or Docker runtime.
-
 ## Why Camelid?
 
-- **Local by default.** Models and inference stay on your machine unless you expose the server.
-- **One engine, several interfaces.** Use the desktop app, browser chat, terminal UI, or HTTP API.
-- **Simple distribution.** The engine and web UI ship together as one binary.
-- **Hardware acceleration.** Use Metal on Apple Silicon, CUDA on supported NVIDIA paths, or CPU fallback.
-- **Developer APIs.** Build against chat, Responses, embeddings, reranking, and structured-output endpoints.
-- **Evidence-backed compatibility.** Support applies to exact model files and quantizations validated against a pinned llama.cpp reference.
+- **Private local inference.** Run language, vision, and embedding models on your own hardware, offline after downloading the model files.
+- **One Rust engine.** The engine and web UI ship as a single binary, with no Python, Node.js, or Docker required at runtime.
+- **Hardware acceleration.** Use Metal on Apple Silicon, CUDA on supported NVIDIA paths, or CPU fallback on Windows, macOS, and Linux.
+- **Tested compatibility.** Supported model files and quantizations are validated against a pinned llama.cpp reference, with explicit limits for each tested configuration.
 
 ## Quick start
 
@@ -74,142 +64,30 @@ Camelid opens `http://127.0.0.1:8181`. Use `camelid chat` for the terminal UI, o
 
 Run `camelid pull` without an argument to list the curated model catalog.
 
-> [!WARNING]
-> A non-loopback listener requires authentication and either TLS or an explicit cleartext
-> acknowledgement. For browser Chat on a trusted private LAN, bind
-> the laptop's specific LAN address, start with a model, and use the restricted surface:
->
-> ```bash
-> camelid serve --addr <LAPTOP-LAN-IP>:8181 --model models/Llama-3.2-3B-Instruct-Q8_0.gguf --api-key-file ./camelid-api.key --lan-chat-only --allow-cleartext-remote
-> ```
->
-> The phone is only a web interface; inference stays on the laptop. Plain HTTP is not encrypted, and
-> `--allow-cleartext-remote` acknowledges that risk rather than protecting the traffic. Chat history
-> is still stored separately in each browser. Run `camelid lan-key` on the laptop to
-> create or display the key shared with the phone. The mobile Chat model selector may switch only
-> among local GGUF files already in the configured models directory. See
-> [configuration](docs/CONFIGURATION.md) for the exact route boundary, key rotation, firewall
-> guidance, CORS, TLS, and remote-deployment options.
-
-For private Chat across different networks, keep Camelid on `127.0.0.1`, install Tailscale on both
-devices, and run `camelid remote-chat start` after the authenticated `--lan-chat-only` listener is
-healthy. Camelid prints a tailnet-only HTTPS URL; the browser still requires the Camelid API key.
-This workflow never enables Tailscale Funnel. See [configuration](docs/CONFIGURATION.md#private-cross-network-browser-chat-with-tailscale).
+> [!NOTE]
+> To chat from another device, see the [remote browser chat guide](docs/REMOTE_CHAT.md). Non-loopback listeners require authentication and either TLS or an explicit cleartext acknowledgement.
 
 ## Supported models
 
-Camelid deliberately supports exact model-and-quantization combinations rather than entire model families. Each supported file is validated token-for-token against a pinned llama.cpp reference. Files outside the supported set fail closed instead of silently using an unverified path.
+Start with one of these five options. Support applies to exact model files, quantizations, and tested execution paths; see the [compatibility ledger](COMPATIBILITY.md) for each model's limits.
 
-Good starting points:
-
-| Goal | Model | Pull ID |
+| Best for | Model | Pull ID |
 |---|---|---|
-| Smallest end-to-end test (~1.2 GB) | TinyLlama 1.1B Chat Q8_0 | `tinyllama` |
-| **Recommended first model** | Llama 3.2 3B Instruct Q8_0 | `3b_instruct_q8` |
+| **First chat** | Llama 3.2 3B Instruct Q8_0 | `3b_instruct_q8` |
+| Small end-to-end test (~1.2 GB) | TinyLlama 1.1B Chat Q8_0 | `tinyllama` |
 | Compact Windows CPU or tested M4 Metal chat (~2.9 GB) | LFM2.5 2.6B Q8_0 | `lfm2_5_2_6b` |
-| Local embeddings and semantic retrieval | Nomic Embed Text v1.5 Q8_0 | `nomic` |
-| Fits a 16 GB Apple Silicon Mac | Mistral 7B Instruct v0.3 Q8_0 | `mistral` |
-| Fast 12B-class reasoning on a tested 16 GB M4 Mac | Gemma 4 12B-It QAT Q4_0 | `gemma4_12b_it_qat_q4_0` |
-| Reasoning and coding on a small budget | Qwen3 4B Q4_K_M | `qwen3_4b_q4` |
-| Compact PrismML GPU model | Bonsai 4B Q1_0 | `bonsai_4b_q1` |
-| PrismML browser/API vision | Bonsai 27B Q1_0 | `bonsai_27b_q1` |
+| Local embeddings (CPU) | Nomic Embed Text v1.5 Q8_0 | `nomic` |
+| Chat on a 16 GB Apple Silicon Mac | Mistral 7B Instruct v0.3 Q8_0 | `mistral` |
 
-### Full `camelid pull` catalog
+Llama 3.2 3B and LFM2.5 have support limited to the documented exact-file smoke tests; broader context, hardware, and behavior do not inherit that support.
 
-Run `camelid pull <id>` to download a model into `./models`. Pull IDs resolve by unique substring; if a fragment matches several rows, Camelid lists the matches instead of guessing.
+[Browse the full catalog and validation details](docs/MODELS.md), including coding, vision, and experimental models. Gemma 4 12B-It QAT Q4_0 is available for a tested 16 GB M4 Mac, with **validation pending**. Download availability does not imply verified support.
 
-| Model | Quant | Arch | Size | Pull ID | GGUF file |
-|---|---|---|---:|---|---|
-| **Microsoft BitNet b1.58 2B 4T** *(experimental)* | `I2_S` | `bitnet-b1.58` | 1.2 GB | `bitnet_b1_58_2b_4t_i2_s` | `ggml-model-i2_s.gguf` |
-| **Microsoft BitNet Embedding 0.6B** *(experimental)* | `I2_S` | `qwen3` | 0.4 GB | `bitnet_embedding_0_6b_i2_s` | `bitnet-embeddings-0.6b-bf16-i2_s.gguf` |
-| **Microsoft BitNet Embedding 270M** *(experimental)* | `I2_S` | `gemma3` | 0.4 GB | `bitnet_embedding_270m_i2_s` | `bitnet-embeddings-270m-bf16-i2_s.gguf` |
-| **Nomic Embed Text v1.5** | `Q8_0` | `nomic-bert` | 0.15 GB | `nomic` | `nomic-embed-text-v1.5.Q8_0.gguf` |
-| **TinyLlama 1.1B Chat** | `Q8_0` | `llama` | 1.2 GB | `tinyllama` | `tinyllama-1.1b-chat-v1.0.Q8_0.gguf` |
-| **Llama 3.2 1B Instruct** | `Q8_0` | `llama` | 1.3 GB | `1b_instruct_q8` | `Llama-3.2-1B-Instruct-Q8_0.gguf` |
-| **Llama 3.2 1B Instruct** | `IQ4_XS` | `llama` | 0.7 GB | `iq4_xs` | `Llama-3.2-1B-Instruct-IQ4_XS.gguf` |
-| **Llama 3.2 3B Instruct** | `Q8_0` | `llama` | 3.4 GB | `3b_instruct_q8` | `Llama-3.2-3B-Instruct-Q8_0.gguf` |
-| **Llama 3.2 3B Instruct** | `Q4_K_M` | `llama` | 2.0 GB | `3b_instruct_q4` | `Llama-3.2-3B-Instruct-Q4_K_M.gguf` |
-| **Llama 3.2 3B Instruct** | `Q5_K_M` | `llama` | 2.3 GB | `3b_instruct_q5` | `Llama-3.2-3B-Instruct-Q5_K_M.gguf` |
-| **Llama 3 8B Instruct** | `Q8_0` | `llama` | 8.5 GB | `llama3_8b` | `Meta-Llama-3-8B-Instruct.Q8_0.gguf` |
-| **Llama 3.1 8B Instruct** | `Q8_0` | `llama` | 8.5 GB | `llama31_8b` | `Meta-Llama-3.1-8B-Instruct-Q8_0.gguf` |
-| **Gemma 3 1B-It** | `Q8_0` | `gemma3` | 1.1 GB | `gemma_3_1b` | `gemma-3-1b-it-Q8_0.gguf` |
-| **Gemma 4 E2B-It** | `Q8_0` | `gemma4` | 5.0 GB | `gemma4_e2b` | `gemma-4-E2B-it-Q8_0.gguf` |
-| **Gemma 4 E4B-It** | `Q8_0` | `gemma4` | 8.2 GB | `gemma4_e4b` | `gemma-4-E4B-it-Q8_0.gguf` |
-| **Gemma 4 12B-It QAT** — fast single-Mac Metal lane *(active validation)* | `Q4_0` | `gemma4` | 7.0 GB | `gemma4_12b_it_qat_q4_0` | `gemma-4-12b-it-qat-q4_0.gguf` |
-| **Gemma 4 12B-It** — legacy two-Mac distributed lane | `Q8_0` | `gemma4` | 12.7 GB | `gemma4_12b` | `gemma-4-12b-it-Q8_0.gguf` |
-| **Gemma 4 26B-A4B-It QAT** — single-Mac Ghost-MoE/MTP | `Q4_0` | `gemma4` | 14.4 GB | `gemma4_26b` | `gemma-4-26B_q4_0-it.gguf` |
-| **Qwen3 0.6B** | `Q8_0` | `qwen3` | 0.6 GB | `qwen3_0_6b` | `Qwen3-0.6B-Q8_0.gguf` |
-| **Qwen3 1.7B** | `Q8_0` | `qwen3` | 1.8 GB | `qwen3_1_7b` | `Qwen3-1.7B-Q8_0.gguf` |
-| **Qwen3 4B** | `Q8_0` | `qwen3` | 4.3 GB | `qwen3_4b_q8` | `Qwen3-4B-Q8_0.gguf` |
-| **Qwen3 4B** | `Q4_K_M` | `qwen3` | 2.5 GB | `qwen3_4b_q4` | `Qwen3-4B-Q4_K_M.gguf` |
-| **Qwen3 8B** | `Q8_0` | `qwen3` | 8.7 GB | `qwen3_8b` | `Qwen3-8B-Q8_0.gguf` |
-| **Qwen3 14B** *(active validation; not supported)* | `Q4_K_M` | `qwen3` | 9.0 GB | `qwen3_14b` | `Qwen3-14B-Q4_K_M.gguf` |
-| **Mistral 7B Instruct v0.3** | `Q8_0` | `llama` | 7.7 GB | `mistral` | `Mistral-7B-Instruct-v0.3-Q8_0.gguf` |
-| **Mistral Nemo Instruct 2407** *(validation hold; not supported)* | `Q4_K_M` | `llama` | 7.5 GB | `mistral_nemo` | `Mistral-Nemo-Instruct-2407.Q4_K_M.gguf` |
-| **LFM2.5 2.6B** *(supported exact-row smoke)* | `Q8_0` | `lfm2` | 2.9 GB | `lfm2_5_2_6b` | `LFM2.5-2.6B-Q8_0.gguf` |
-| **Phi-3-mini-4k-instruct** *(supported exact-row smoke on Windows x86_64)* | `Q8_0` | `phi3` | 4.1 GB | `phi3` | `Phi-3-mini-4k-instruct-Q8_0.gguf` |
-| **DeepSeek R1 Distill Qwen 7B** | `Q8_0` | `qwen25` | 8.1 GB | `distill_qwen` | `DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf` |
-| **DeepSeek R1 Distill Llama 8B** | `Q8_0` | `llama` | 8.5 GB | `distill_llama` | `DeepSeek-R1-Distill-Llama-8B-Q8_0.gguf` |
-| **DeepSeek R1 0528 Qwen3 8B** *(validation hold; not supported)* | `Q4_K_M` | `qwen3` | 5.0 GB | `deepseek_r1_0528` | `DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf` |
-| **Qwen2.5 Coder 7B** | `Q8_0` | `qwen25` | 8.1 GB | `qwen25_coder` | `qwen2.5-coder-7b-instruct-q8_0.gguf` |
-| **Ornith 1.0 9B** — hybrid DeltaNet, `tool_capable` | `Q8_0` | `qwen35` | 9.5 GB | `ornith` | `ornith-1.0-9b-Q8_0.gguf` |
-| **Bonsai 4B** | `Q1_0` | `qwen3` | 0.6 GB | `bonsai_4b_q1` | `Bonsai-4B-Q1_0.gguf` |
-| **Ternary Bonsai 4B** | `Q2_0` | `qwen3` | 1.1 GB | `bonsai_4b_q2` | `Ternary-Bonsai-4B-Q2_0.gguf` |
-| **Ternary Bonsai 4B** | `PQ2_0` | `qwen3` | 1.1 GB | `bonsai_4b_pq2` | `Ternary-Bonsai-4B-PQ2_0.gguf` |
-| **Bonsai 8B** | `Q1_0` | `qwen3` | 1.2 GB | `bonsai_8b_q1` | `Bonsai-8B-Q1_0.gguf` |
-| **Ternary Bonsai 8B** | `Q2_0` | `qwen3` | 2.2 GB | `bonsai_8b_q2` | `Ternary-Bonsai-8B-Q2_0.gguf` |
-| **Bonsai 27B** | `Q1_0` | `qwen35` | 3.8 GB | `bonsai_27b_q1` | `Bonsai-27B-Q1_0.gguf` |
-| **Ternary Bonsai 27B** | `Q2_0` | `qwen35` | 7.2 GB | `bonsai_27b_q2` | `Ternary-Bonsai-27B-Q2_0.gguf` |
+<a id="full-camelid-pull-catalog"></a>
+<a id="multimodal-image-chat"></a>
+<a id="embeddings-and-reranking"></a>
 
-The 7.0 GB Gemma 4 12B QAT Q4_0 row is the recommended 12B download. It runs on a single tested 16 GB M4 Mac through Camelid's accelerated Metal path; its exact-row support promotion is still in progress, so the Models page labels it as validation pending. The older 12.7 GB Q8_0 artifact remains available for the validated two-host distributed lane. Nine hash-pinned Phase 2 rows are **Runnable with disclosed reference-output variance**: LFM2.5 1.2B Thinking Q8_0, Gemma 3 4B-It Q8_0, Llama 3.1 8B Instruct Q8_0, Qwen 2.5 0.5B/1.5B Instruct Q8_0, Qwen 3.5 4B/9B Q8_0, DeepSeek R1 Distill Qwen 1.5B Q8_0, and Aya Expanse 8B Q4_K_M. They use the normal download-and-start path and may be used for local chat; one or more strict greedy token-ID probes differ from pinned llama.cpp, so the UI keeps an amber warning and withholds Verified/Supported, tools, and broader-context claims.
-
-Mistral Nemo Instruct 2407 Q4_K_M, Qwen3 14B Q4_K_M, and DeepSeek R1 0528 Qwen3 8B Q4_K_M are downloadable catalog rows, not supported rows. The pinned bring-up evidence records Mistral Nemo cross-backend divergence and a blocked external comparator, Qwen3 14B without an external oracle or chat/API proof, and DeepSeek cross-backend divergence plus a missing native R1 marker/tool renderer. None inherits support from its architecture or a smaller sibling.
-
-The three BitNet rows are bring-up targets, not promoted support rows yet. Camelid
-can parse and execute their official canonical `I2_S` GGUF graphs through cleanroom
-CPU, Metal, and CUDA projection kernels. Runtime-selectable `i2_s`, `tl1`, and `tl2`
-strategies operate on the same published bytes; they do not claim compatibility with
-BitNet.cpp's separately permuted TL files. Reference parity and bounded-context /
-embedding-vector receipts remain outstanding. See
-[the BitNet runtime notes](docs/architecture/BITNET.md).
-
-Gemma 4 26B-A4B QAT does **not** require two Macs. It runs on one 16 GB M4 Mac
-through the opt-in Ghost-MoE Metal lane, which repacks the routed experts into a
-paged `.cghost` artifact and keeps a bounded, persistent expert working set in unified memory
-(measured 17–20 tok/s steady-state decode on the tested M4). The distributed lane remains
-available as an alternative, but it is not a requirement. Replies on the single-Mac lane are
-currently marked experimental with no parity guarantee. Setup, the recommended serve profile,
-and measured receipts live in [docs/runtime/ghost-mode.md](docs/runtime/ghost-mode.md#ghost-moe-v2-gemma-4-26b-a4b).
-
-The full catalog, exact hashes, supported execution paths, and claim boundaries live in:
-
-- [COMPATIBILITY.md](COMPATIBILITY.md)—authoritative supported-row ledger
-- [SUPPORT_MATRIX_v0.1.md](./docs/reference/SUPPORT_MATRIX_v0.1.md)—per-row support boundaries
-- [RECEIPTS.md](./docs/reference/RECEIPTS.md)—reproducible validation receipts
-- [benchmarks](docs/benchmarks/BENCHMARKS.md)—recorded performance measurements
-
-Selected validation highlight:
-
-| Model row | Quant | Evidence |
-|---|---|---|
-| Mistral 7B Instruct v0.3 | Q8_0 | Exact-row smoke + bounded context 512→8192 + GPU/CPU parity |
-| LFM2.5 2.6B | Q8_0 | Hash-pinned exact-row smoke on Windows CPU/runnable and Apple M4 macOS 26.5 arm64 resident Metal: 96/96 short greedy tokens, exact 512-token chat prompt + 8/8 reference-oracle tokens/text, and API/Models-page/WebUI/SSE smoke |
-
-The LFM2.5 promotion is limited to `LiquidAI/LFM2.5-2.6B-GGUF@b421ad1d549afeda6a0fb2ad3a697cb5a7879adc`, file `LFM2.5-2.6B-Q8_0.gguf` (2,874,779,456 bytes, SHA-256 `36587fdf27bdfc69caf2637273679a0870ec155162161bde6fd16e8c70bdb757`). The Windows x86_64 CPU/runnable proof remains recorded at `qa/evidence-bundles/lfm2-2.6b-q8-phase1-promotion-20260810/`. The Apple M4 macOS 26.5 arm64 receipt at `qa/evidence-bundles/lfm2-2.6b-q8-macos-metal-20260810-head-d31e5cb0/` independently asserts the resident-Metal execution plan, 96/96 short greedy token IDs, the exact 512-token prompt plus 8/8 generated IDs/text against pinned llama.cpp b9632 (`acd79d603`), and API/Models-page/WebUI non-streaming plus 128-ceiling SSE smoke. The 512-token/8-token oracle checks are reference-only; raw `/v1/completions` and tools remain typed fail-closed. Sampling beyond deterministic greedy, context above 512, neighboring rows, production throughput, CUDA, other Apple hardware, broad platform portability, and broader LFM2 support remain unclaimed.
-
-The Phi-3 promotion is limited to `Phi-3-mini-4k-instruct-Q8_0.gguf` (4,061,221,376 bytes, SHA-256 `0ac8ee48aeebf7d1b354691fd1e29e91c32ad88bbad10ad45ac880dcd4372a47`) on Windows x86_64 using the CPU-reference prefill/decode lane. The receipt at `qa/model-qualification/phi3-mini-windows-support-20260811.json` records successful API load/readiness and exact agreement with pinned llama.cpp `acd79d603` for generated IDs `[3681, 29889, 13, 32001, 3869]`. Bounded context packs, performance, tools, neighboring Phi files, Linux, and macOS remain unclaimed.
-
-### Multimodal image chat
-
-Seven hash-pinned PrismML Bonsai GGUFs are supported on Apple Silicon Metal and Windows x86_64 CUDA: 4B Q1/Q2/PQ2, 8B Q1/Q2, and 27B Q1/Q2. Both 27B rows support multimodal PNG/JPEG input in browser chat and OpenAI-compatible Chat Completions when paired with the Qwen3-VL projector.
-
-The **Arch** column reports what each GGUF declares in `general.architecture`, so it is not uniform across this family: the 4B and 8B files declare `qwen3` and only the 27B files declare `qwen35`. The two labels bind different engines, so the split is real rather than a typo.
-
-The desktop **Models** page downloads the projector automatically with either 27B model. For a CLI installation, place `Ternary-Bonsai-27B-mmproj-Q8_0.gguf` beside the model GGUF or set `CAMELID_MMPROJ`, then run `camelid serve` normally. See [COMPATIBILITY.md](COMPATIBILITY.md) for the exact artifacts and validated scope.
-
-### Embeddings and reranking
-
-The exact Nomic Embed Text v1.5 Q8_0 row supports OpenAI-compatible `/v1/embeddings`, Matryoshka dimensions, cosine-similarity reranking through `/v1/rerank`, and optional in-memory semantic retrieval for Workspace. The encoder currently runs on CPU; other embedding families and quantizations fail closed. See the [embedding API guide](docs/architecture/EMBEDDINGS.md) for loading and request examples.
+For [image chat](docs/MODELS.md#multimodal-image-chat) and [embeddings and reranking](docs/MODELS.md#embeddings-and-reranking), see the model guide for supported files and setup.
 
 ## Ways to use Camelid
 
@@ -265,6 +143,8 @@ See the [contributor quick start](docs/CONTRIBUTOR_QUICKSTART.md) for prerequisi
 ## Documentation
 
 - [Documentation index](DOCS.md)
+- [Model catalog and validation](docs/MODELS.md)
+- [Remote browser chat](docs/REMOTE_CHAT.md)
 - [Configuration reference](docs/CONFIGURATION.md)
 - [Architecture](docs/architecture/ARCHITECTURE.md)
 - [Validation matrix](docs/VALIDATION_MATRIX.md)

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -114,4 +114,3 @@ The desktop **Models** page downloads the projector automatically with either 27
 ### Embeddings and reranking
 
 The exact Nomic Embed Text v1.5 Q8_0 row supports OpenAI-compatible `/v1/embeddings`, Matryoshka dimensions, cosine-similarity reranking through `/v1/rerank`, and optional in-memory semantic retrieval for Workspace. The encoder currently runs on CPU; other embedding families and quantizations fail closed. See the [embedding API guide](architecture/EMBEDDINGS.md) for loading and request examples.
-

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,0 +1,117 @@
+# Model catalog and validation
+
+Camelid deliberately supports exact model-and-quantization combinations rather than entire model families. Each supported file is validated token-for-token against a pinned llama.cpp reference. Files outside the supported set fail closed instead of silently using an unverified path.
+
+## Model suggestions
+
+Support is specific to the exact file and execution path. Downloadable models may still be experimental or awaiting validation. [Back to the quick start](../README.md#quick-start).
+
+| Goal | Model | Pull ID |
+|---|---|---|
+| Smallest end-to-end test (~1.2 GB) | TinyLlama 1.1B Chat Q8_0 | `tinyllama` |
+| **Recommended first model** | Llama 3.2 3B Instruct Q8_0 | `3b_instruct_q8` |
+| Compact Windows CPU or tested M4 Metal chat (~2.9 GB) | LFM2.5 2.6B Q8_0 | `lfm2_5_2_6b` |
+| Local embeddings and semantic retrieval | Nomic Embed Text v1.5 Q8_0 | `nomic` |
+| Fits a 16 GB Apple Silicon Mac | Mistral 7B Instruct v0.3 Q8_0 | `mistral` |
+| 12B reasoning on a tested 16 GB M4 Mac (**validation pending**) | Gemma 4 12B-It QAT Q4_0 | `gemma4_12b_it_qat_q4_0` |
+| Reasoning and coding on a small budget | Qwen3 4B Q4_K_M | `qwen3_4b_q4` |
+| Compact PrismML GPU model | Bonsai 4B Q1_0 | `bonsai_4b_q1` |
+| PrismML browser/API vision | Bonsai 27B Q1_0 | `bonsai_27b_q1` |
+
+### Full `camelid pull` catalog
+
+Run `camelid pull <id>` to download a model into `./models`. Pull IDs resolve by unique substring; if a fragment matches several rows, Camelid lists the matches instead of guessing.
+
+| Model | Quant | Arch | Size | Pull ID | GGUF file |
+|---|---|---|---:|---|---|
+| **Microsoft BitNet b1.58 2B 4T** *(experimental)* | `I2_S` | `bitnet-b1.58` | 1.2 GB | `bitnet_b1_58_2b_4t_i2_s` | `ggml-model-i2_s.gguf` |
+| **Microsoft BitNet Embedding 0.6B** *(experimental)* | `I2_S` | `qwen3` | 0.4 GB | `bitnet_embedding_0_6b_i2_s` | `bitnet-embeddings-0.6b-bf16-i2_s.gguf` |
+| **Microsoft BitNet Embedding 270M** *(experimental)* | `I2_S` | `gemma3` | 0.4 GB | `bitnet_embedding_270m_i2_s` | `bitnet-embeddings-270m-bf16-i2_s.gguf` |
+| **Nomic Embed Text v1.5** | `Q8_0` | `nomic-bert` | 0.15 GB | `nomic` | `nomic-embed-text-v1.5.Q8_0.gguf` |
+| **TinyLlama 1.1B Chat** | `Q8_0` | `llama` | 1.2 GB | `tinyllama` | `tinyllama-1.1b-chat-v1.0.Q8_0.gguf` |
+| **Llama 3.2 1B Instruct** | `Q8_0` | `llama` | 1.3 GB | `1b_instruct_q8` | `Llama-3.2-1B-Instruct-Q8_0.gguf` |
+| **Llama 3.2 1B Instruct** | `IQ4_XS` | `llama` | 0.7 GB | `iq4_xs` | `Llama-3.2-1B-Instruct-IQ4_XS.gguf` |
+| **Llama 3.2 3B Instruct** | `Q8_0` | `llama` | 3.4 GB | `3b_instruct_q8` | `Llama-3.2-3B-Instruct-Q8_0.gguf` |
+| **Llama 3.2 3B Instruct** | `Q4_K_M` | `llama` | 2.0 GB | `3b_instruct_q4` | `Llama-3.2-3B-Instruct-Q4_K_M.gguf` |
+| **Llama 3.2 3B Instruct** | `Q5_K_M` | `llama` | 2.3 GB | `3b_instruct_q5` | `Llama-3.2-3B-Instruct-Q5_K_M.gguf` |
+| **Llama 3 8B Instruct** | `Q8_0` | `llama` | 8.5 GB | `llama3_8b` | `Meta-Llama-3-8B-Instruct.Q8_0.gguf` |
+| **Llama 3.1 8B Instruct** | `Q8_0` | `llama` | 8.5 GB | `llama31_8b` | `Meta-Llama-3.1-8B-Instruct-Q8_0.gguf` |
+| **Gemma 3 1B-It** | `Q8_0` | `gemma3` | 1.1 GB | `gemma_3_1b` | `gemma-3-1b-it-Q8_0.gguf` |
+| **Gemma 4 E2B-It** | `Q8_0` | `gemma4` | 5.0 GB | `gemma4_e2b` | `gemma-4-E2B-it-Q8_0.gguf` |
+| **Gemma 4 E4B-It** | `Q8_0` | `gemma4` | 8.2 GB | `gemma4_e4b` | `gemma-4-E4B-it-Q8_0.gguf` |
+| **Gemma 4 12B-It QAT** — fast single-Mac Metal lane *(active validation)* | `Q4_0` | `gemma4` | 7.0 GB | `gemma4_12b_it_qat_q4_0` | `gemma-4-12b-it-qat-q4_0.gguf` |
+| **Gemma 4 12B-It** — legacy two-Mac distributed lane | `Q8_0` | `gemma4` | 12.7 GB | `gemma4_12b` | `gemma-4-12b-it-Q8_0.gguf` |
+| **Gemma 4 26B-A4B-It QAT** — single-Mac Ghost-MoE/MTP | `Q4_0` | `gemma4` | 14.4 GB | `gemma4_26b` | `gemma-4-26B_q4_0-it.gguf` |
+| **Qwen3 0.6B** | `Q8_0` | `qwen3` | 0.6 GB | `qwen3_0_6b` | `Qwen3-0.6B-Q8_0.gguf` |
+| **Qwen3 1.7B** | `Q8_0` | `qwen3` | 1.8 GB | `qwen3_1_7b` | `Qwen3-1.7B-Q8_0.gguf` |
+| **Qwen3 4B** | `Q8_0` | `qwen3` | 4.3 GB | `qwen3_4b_q8` | `Qwen3-4B-Q8_0.gguf` |
+| **Qwen3 4B** | `Q4_K_M` | `qwen3` | 2.5 GB | `qwen3_4b_q4` | `Qwen3-4B-Q4_K_M.gguf` |
+| **Qwen3 8B** | `Q8_0` | `qwen3` | 8.7 GB | `qwen3_8b` | `Qwen3-8B-Q8_0.gguf` |
+| **Qwen3 14B** *(active validation; not supported)* | `Q4_K_M` | `qwen3` | 9.0 GB | `qwen3_14b` | `Qwen3-14B-Q4_K_M.gguf` |
+| **Mistral 7B Instruct v0.3** | `Q8_0` | `llama` | 7.7 GB | `mistral` | `Mistral-7B-Instruct-v0.3-Q8_0.gguf` |
+| **Mistral Nemo Instruct 2407** *(validation hold; not supported)* | `Q4_K_M` | `llama` | 7.5 GB | `mistral_nemo` | `Mistral-Nemo-Instruct-2407.Q4_K_M.gguf` |
+| **LFM2.5 2.6B** *(supported exact-row smoke)* | `Q8_0` | `lfm2` | 2.9 GB | `lfm2_5_2_6b` | `LFM2.5-2.6B-Q8_0.gguf` |
+| **Phi-3-mini-4k-instruct** *(supported exact-row smoke on Windows x86_64)* | `Q8_0` | `phi3` | 4.1 GB | `phi3` | `Phi-3-mini-4k-instruct-Q8_0.gguf` |
+| **DeepSeek R1 Distill Qwen 7B** | `Q8_0` | `qwen25` | 8.1 GB | `distill_qwen` | `DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf` |
+| **DeepSeek R1 Distill Llama 8B** | `Q8_0` | `llama` | 8.5 GB | `distill_llama` | `DeepSeek-R1-Distill-Llama-8B-Q8_0.gguf` |
+| **DeepSeek R1 0528 Qwen3 8B** *(validation hold; not supported)* | `Q4_K_M` | `qwen3` | 5.0 GB | `deepseek_r1_0528` | `DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf` |
+| **Qwen2.5 Coder 7B** | `Q8_0` | `qwen25` | 8.1 GB | `qwen25_coder` | `qwen2.5-coder-7b-instruct-q8_0.gguf` |
+| **Ornith 1.0 9B** — hybrid DeltaNet, `tool_capable` | `Q8_0` | `qwen35` | 9.5 GB | `ornith` | `ornith-1.0-9b-Q8_0.gguf` |
+| **Bonsai 4B** | `Q1_0` | `qwen3` | 0.6 GB | `bonsai_4b_q1` | `Bonsai-4B-Q1_0.gguf` |
+| **Ternary Bonsai 4B** | `Q2_0` | `qwen3` | 1.1 GB | `bonsai_4b_q2` | `Ternary-Bonsai-4B-Q2_0.gguf` |
+| **Ternary Bonsai 4B** | `PQ2_0` | `qwen3` | 1.1 GB | `bonsai_4b_pq2` | `Ternary-Bonsai-4B-PQ2_0.gguf` |
+| **Bonsai 8B** | `Q1_0` | `qwen3` | 1.2 GB | `bonsai_8b_q1` | `Bonsai-8B-Q1_0.gguf` |
+| **Ternary Bonsai 8B** | `Q2_0` | `qwen3` | 2.2 GB | `bonsai_8b_q2` | `Ternary-Bonsai-8B-Q2_0.gguf` |
+| **Bonsai 27B** | `Q1_0` | `qwen35` | 3.8 GB | `bonsai_27b_q1` | `Bonsai-27B-Q1_0.gguf` |
+| **Ternary Bonsai 27B** | `Q2_0` | `qwen35` | 7.2 GB | `bonsai_27b_q2` | `Ternary-Bonsai-27B-Q2_0.gguf` |
+
+The 7.0 GB Gemma 4 12B QAT Q4_0 row is the recommended 12B download. It runs on a single tested 16 GB M4 Mac through Camelid's accelerated Metal path; its exact-row support promotion is still in progress, so the Models page labels it as validation pending. The older 12.7 GB Q8_0 artifact remains available for the validated two-host distributed lane. Nine hash-pinned Phase 2 rows are **Runnable with disclosed reference-output variance**: LFM2.5 1.2B Thinking Q8_0, Gemma 3 4B-It Q8_0, Llama 3.1 8B Instruct Q8_0, Qwen 2.5 0.5B/1.5B Instruct Q8_0, Qwen 3.5 4B/9B Q8_0, DeepSeek R1 Distill Qwen 1.5B Q8_0, and Aya Expanse 8B Q4_K_M. They use the normal download-and-start path and may be used for local chat; one or more strict greedy token-ID probes differ from pinned llama.cpp, so the UI keeps an amber warning and withholds Verified/Supported, tools, and broader-context claims.
+
+Mistral Nemo Instruct 2407 Q4_K_M, Qwen3 14B Q4_K_M, and DeepSeek R1 0528 Qwen3 8B Q4_K_M are downloadable catalog rows, not supported rows. The pinned bring-up evidence records Mistral Nemo cross-backend divergence and a blocked external comparator, Qwen3 14B without an external oracle or chat/API proof, and DeepSeek cross-backend divergence plus a missing native R1 marker/tool renderer. None inherits support from its architecture or a smaller sibling.
+
+The three BitNet rows are bring-up targets, not promoted support rows yet. Camelid
+can parse and execute their official canonical `I2_S` GGUF graphs through cleanroom
+CPU, Metal, and CUDA projection kernels. Runtime-selectable `i2_s`, `tl1`, and `tl2`
+strategies operate on the same published bytes; they do not claim compatibility with
+BitNet.cpp's separately permuted TL files. Reference parity and bounded-context /
+embedding-vector receipts remain outstanding. See
+[the BitNet runtime notes](architecture/BITNET.md).
+
+Gemma 4 26B-A4B QAT does **not** require two Macs. It runs on one 16 GB M4 Mac
+through the opt-in Ghost-MoE Metal lane, which repacks the routed experts into a
+paged `.cghost` artifact and keeps a bounded, persistent expert working set in unified memory
+(measured 17–20 tok/s steady-state decode on the tested M4). The distributed lane remains
+available as an alternative, but it is not a requirement. Replies on the single-Mac lane are
+currently marked experimental with no parity guarantee. Setup, the recommended serve profile,
+and measured receipts live in [docs/runtime/ghost-mode.md](runtime/ghost-mode.md#ghost-moe-v2-gemma-4-26b-a4b).
+
+The full catalog, exact hashes, supported execution paths, and claim boundaries live in:
+
+- [COMPATIBILITY.md](../COMPATIBILITY.md)—authoritative supported-row ledger
+- [SUPPORT_MATRIX_v0.1.md](reference/SUPPORT_MATRIX_v0.1.md)—per-row support boundaries
+- [RECEIPTS.md](reference/RECEIPTS.md)—reproducible validation receipts
+- [benchmarks](benchmarks/BENCHMARKS.md)—recorded performance measurements
+
+## Validation highlights
+
+| Model row | Quant | Evidence |
+|---|---|---|
+| Mistral 7B Instruct v0.3 | Q8_0 | Exact-row smoke + bounded context 512→8192 + GPU/CPU parity |
+| LFM2.5 2.6B | Q8_0 | Hash-pinned exact-row smoke on Windows CPU/runnable and Apple M4 macOS 26.5 arm64 resident Metal: 96/96 short greedy tokens, exact 512-token chat prompt + 8/8 reference-oracle tokens/text, and API/Models-page/WebUI/SSE smoke |
+
+The LFM2.5 promotion is limited to `LiquidAI/LFM2.5-2.6B-GGUF@b421ad1d549afeda6a0fb2ad3a697cb5a7879adc`, file `LFM2.5-2.6B-Q8_0.gguf` (2,874,779,456 bytes, SHA-256 `36587fdf27bdfc69caf2637273679a0870ec155162161bde6fd16e8c70bdb757`). The Windows x86_64 CPU/runnable proof remains recorded at `qa/evidence-bundles/lfm2-2.6b-q8-phase1-promotion-20260810/`. The Apple M4 macOS 26.5 arm64 receipt at `qa/evidence-bundles/lfm2-2.6b-q8-macos-metal-20260810-head-d31e5cb0/` independently asserts the resident-Metal execution plan, 96/96 short greedy token IDs, the exact 512-token prompt plus 8/8 generated IDs/text against pinned llama.cpp b9632 (`acd79d603`), and API/Models-page/WebUI non-streaming plus 128-ceiling SSE smoke. The 512-token/8-token oracle checks are reference-only; raw `/v1/completions` and tools remain typed fail-closed. Sampling beyond deterministic greedy, context above 512, neighboring rows, production throughput, CUDA, other Apple hardware, broad platform portability, and broader LFM2 support remain unclaimed.
+
+The Phi-3 promotion is limited to `Phi-3-mini-4k-instruct-Q8_0.gguf` (4,061,221,376 bytes, SHA-256 `0ac8ee48aeebf7d1b354691fd1e29e91c32ad88bbad10ad45ac880dcd4372a47`) on Windows x86_64 using the CPU-reference prefill/decode lane. The receipt at `qa/model-qualification/phi3-mini-windows-support-20260811.json` records successful API load/readiness and exact agreement with pinned llama.cpp `acd79d603` for generated IDs `[3681, 29889, 13, 32001, 3869]`. Bounded context packs, performance, tools, neighboring Phi files, Linux, and macOS remain unclaimed.
+
+### Multimodal image chat
+
+Seven hash-pinned PrismML Bonsai GGUFs are supported on Apple Silicon Metal and Windows x86_64 CUDA: 4B Q1/Q2/PQ2, 8B Q1/Q2, and 27B Q1/Q2. Both 27B rows support multimodal PNG/JPEG input in browser chat and OpenAI-compatible Chat Completions when paired with the Qwen3-VL projector.
+
+The **Arch** column reports what each GGUF declares in `general.architecture`, so it is not uniform across this family: the 4B and 8B files declare `qwen3` and only the 27B files declare `qwen35`. The two labels bind different engines, so the split is real rather than a typo.
+
+The desktop **Models** page downloads the projector automatically with either 27B model. For a CLI installation, place `Ternary-Bonsai-27B-mmproj-Q8_0.gguf` beside the model GGUF or set `CAMELID_MMPROJ`, then run `camelid serve` normally. See [COMPATIBILITY.md](../COMPATIBILITY.md) for the exact artifacts and validated scope.
+
+### Embeddings and reranking
+
+The exact Nomic Embed Text v1.5 Q8_0 row supports OpenAI-compatible `/v1/embeddings`, Matryoshka dimensions, cosine-similarity reranking through `/v1/rerank`, and optional in-memory semantic retrieval for Workspace. The encoder currently runs on CPU; other embedding families and quantizations fail closed. See the [embedding API guide](architecture/EMBEDDINGS.md) for loading and request examples.
+

--- a/docs/REMOTE_CHAT.md
+++ b/docs/REMOTE_CHAT.md
@@ -1,0 +1,30 @@
+# Remote browser chat
+
+Use Camelid from another device while inference stays on the host computer. For local setup, start with the [quick start](../README.md#quick-start).
+
+## Trusted private LAN
+
+> [!WARNING]
+> A non-loopback listener requires authentication and either TLS or an explicit cleartext
+> acknowledgement. For browser Chat on a trusted private LAN, bind
+> the laptop's specific LAN address, start with a model, and use the restricted surface:
+>
+> ```bash
+> camelid serve --addr <LAPTOP-LAN-IP>:8181 --model models/Llama-3.2-3B-Instruct-Q8_0.gguf --api-key-file ./camelid-api.key --lan-chat-only --allow-cleartext-remote
+> ```
+>
+> The phone is only a web interface; inference stays on the laptop. Plain HTTP is not encrypted, and
+> `--allow-cleartext-remote` acknowledges that risk rather than protecting the traffic. Chat history
+> is still stored separately in each browser. Run `camelid lan-key` on the laptop to
+> create or display the key shared with the phone. The mobile Chat model selector may switch only
+> among local GGUF files already in the configured models directory. See
+> [configuration](CONFIGURATION.md) for the exact route boundary, key rotation, firewall
+> guidance, CORS, TLS, and remote-deployment options.
+
+## Across networks with Tailscale
+
+For private Chat across different networks, keep Camelid on `127.0.0.1`, install Tailscale on both
+devices, and run `camelid remote-chat start` after the authenticated `--lan-chat-only` listener is
+healthy. Camelid prints a tailnet-only HTTPS URL; the browser still requires the Camelid API key.
+This workflow never enables Tailscale Funnel. See [configuration](CONFIGURATION.md#private-cross-network-browser-chat-with-tailscale).
+

--- a/docs/REMOTE_CHAT.md
+++ b/docs/REMOTE_CHAT.md
@@ -27,4 +27,3 @@ For private Chat across different networks, keep Camelid on `127.0.0.1`, install
 devices, and run `camelid remote-chat start` after the authenticated `--lan-chat-only` listener is
 healthy. Camelid prints a tailnet-only HTTPS URL; the browser still requires the Camelid API key.
 This workflow never enables Tailscale Funnel. See [configuration](CONFIGURATION.md#private-cross-network-browser-chat-with-tailscale).
-

--- a/scripts/check-ledger-drift.mjs
+++ b/scripts/check-ledger-drift.mjs
@@ -9,9 +9,10 @@
 //      ledger disagrees (provenance excluded). This is what makes "the ledger" ==
 //      "the code": a contract change with no `extract-capabilities-to-ledger.mjs`
 //      re-run is caught here.
-//   B. Surface non-contradiction — the public supported-models tables (README and
-//      COMPATIBILITY) may not claim support the contract denies. A doc row that
-//      maps to a ledger row whose status is not `supported*` is a hard failure.
+//   B. Surface non-contradiction — the public supported-models tables (the model
+//      catalog, in README or docs/MODELS.md, and COMPATIBILITY) may not claim
+//      support the contract denies. A doc row that maps to a ledger row whose
+//      status is not `supported*` is a hard failure.
 //      Rows that don't map are LOGGED, never silently skipped, and never fail
 //      (no false positives — only a confirmed contradiction goes red). This is the
 //      class of drift that produced the Mistral fixture bug fixed under Amendment 1.
@@ -116,11 +117,19 @@ async function checkSupportedTables(committed) {
     }
   }
 
-  // README supported-models table (every data row is a support claim)
-  const readme = await readFile(join(ROOT, 'README.md'), 'utf8')
-  const rt = parseTable(readme, /^\|\s*Model row\s*\|\s*Quant\s*\|/)
-  if (!rt) fail('README.md supported-models table (| Model row | Quant | ...) not found')
-  else for (const c of rt) consider('README supported-models', c[0], c[1], true)
+  // Supported-models table (every data row is a support claim). It has lived in
+  // README.md and in docs/MODELS.md; search both so relocating the table cannot
+  // silently drop the guard, and fail only if it exists on neither surface.
+  let foundSupportedTable = false
+  for (const rel of ['README.md', join('docs', 'MODELS.md')]) {
+    const p = join(ROOT, rel)
+    if (!(await exists(p))) continue
+    const rt = parseTable(await readFile(p, 'utf8'), /^\|\s*Model row\s*\|\s*Quant\s*\|/)
+    if (!rt) continue
+    foundSupportedTable = true
+    for (const c of rt) consider(`${rel} supported-models`, c[0], c[1], true)
+  }
+  if (!foundSupportedTable) fail('supported-models table (| Model row | Quant | ...) not found in README.md or docs/MODELS.md')
 
   // COMPATIBILITY at-a-glance (support claim = "Public claim" says supported)
   const compat = await readFile(join(ROOT, 'COMPATIBILITY.md'), 'utf8')
@@ -186,7 +195,7 @@ async function checkSha256(committed) {
   if (!canonicalByFile.size) { info('sha256 agreement: no ledger-anchored full sha256 to check'); return }
   const knownShas = new Set([...canonicalByFile.values()].map((v) => v.sha))
   let verified = 0
-  for (const rel of ['README.md', 'COMPATIBILITY.md', join('docs', 'reference', 'STATUS.md'), join('src', 'api', 'mod.rs')]) {
+  for (const rel of ['README.md', 'COMPATIBILITY.md', join('docs', 'MODELS.md'), join('docs', 'reference', 'STATUS.md'), join('src', 'api', 'mod.rs')]) {
     const p = join(ROOT, rel)
     if (!(await exists(p))) continue
     const { verified: v, findings } = shaFindings(rel, await readFile(p, 'utf8'), canonicalByFile, knownShas)

--- a/scripts/check-public-evidence-claims.mjs
+++ b/scripts/check-public-evidence-claims.mjs
@@ -61,7 +61,8 @@ function validateMistralSupportPromotionManifest(bundleRel, manifest) {
 
 async function validateMistralSupportSurfaceText() {
   const required = new Map([
-    ['README.md', ['Mistral 7B Instruct v0.3 | Q8_0', 'Exact-row smoke + bounded context 512']],
+    ['README.md', ['Mistral 7B Instruct v0.3 Q8_0', 'docs/MODELS.md']],
+    ['docs/MODELS.md', ['Mistral 7B Instruct v0.3 | Q8_0', 'Exact-row smoke + bounded context 512']],
     ['docs/reference/STATUS.md', ['Mistral 7B Instruct v0.3 Q8_0 is promoted to supported exact-row smoke', 'mistral-7b-v0.3-q8-support-promotion-20260605T090914Z-head-d7b1699/manifest.json']],
     ['ROADMAP.md', ['Mistral 7B Instruct v0.3 Q8_0 is supported as exact-row smoke', 'support-promotion API/WebUI smoke bundle']],
     ['COMPATIBILITY.md', ['Mistral-7B-Instruct-v0.3.Q8_0.gguf is supported exact-row smoke', 'mistral-7b-v0.3-q8-support-promotion-20260605T090914Z-head-d7b1699/manifest.json']],


### PR DESCRIPTION
The README repeated the introduction and placed the full model catalog and validation receipts ahead of the interface and API examples. Shorten it to a concise overview, four benefits, a focused quick start, and five starter models with explicit support limits.

Move the existing catalog, validation details, and remote-chat instructions into linked guides, update the documentation index, and make Gemma 4 12B QAT validation status visible beside its mention. Preserve the screenshot and caption. Update the evidence guard to check the relocated Mistral details as well as the README link.

Validation: public evidence claim checker (166 manifests, 50 summaries), its existing test suite, screenshot guard, public scrub, 80 local file/anchor links, and git diff --check. No runtime or compatibility ledger changes.
