### PR TITLE
Let the macOS window be moved again

### DIFF
--- a/camelid-desktop/capabilities/default.json
+++ b/camelid-desktop/capabilities/default.json
@@ -1,7 +1,12 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Core permissions for the Camelid Desktop main window. The window displays the local splash (which polls startup_snapshot) and is then navigated by the Rust side to the loopback sidecar UI; the embedded UI's own grants live in the remote sidecar-ui capability.",
+  "description": "Core permissions for the Camelid Desktop main window. The window displays the local splash (which polls startup_snapshot) and is then navigated by the Rust side to the loopback sidecar UI; the embedded UI's own grants live in the remote sidecar-ui capability. Start-dragging is granted here too: the splash renders the same shell and the same drag strip, and on macOS that strip is the window's only drag handle.",
   "windows": ["main"],
-  "permissions": ["core:default", "allow-startup-snapshot", "allow-retry-startup"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-start-dragging",
+    "allow-startup-snapshot",
+    "allow-retry-startup"
+  ]
 }

--- a/camelid-desktop/capabilities/sidecar.json
+++ b/camelid-desktop/capabilities/sidecar.json
@@ -1,13 +1,14 @@
 {
   "$schema": "../gen/schemas/remote-schema.json",
   "identifier": "sidecar-ui",
-  "description": "Allows the Camelid loopback sidecar UI to call narrow model-directory and Camelid-keyed UI-storage commands. No arbitrary filesystem permission is granted: the folder picker is scoped on the Rust side, and UI state is confined to the app-data directory.",
+  "description": "Allows the Camelid loopback sidecar UI to call narrow model-directory and Camelid-keyed UI-storage commands. No arbitrary filesystem permission is granted: the folder picker is scoped on the Rust side, and UI state is confined to the app-data directory. It also grants start-dragging, which the macOS window cannot be moved without: the window is titleBarStyle Overlay with hiddenTitle, so there is no OS titlebar to grab and the only drag handle is the app's own data-tauri-drag-region strip -- and core:default does NOT carry that permission (core:window:default is a read-only set).",
   "windows": ["main"],
   "remote": {
     "urls": ["http://127.0.0.1:*", "http://localhost:*"]
   },
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     "allow-choose-models-directory",
     "allow-reset-models-directory",
     "allow-read-ui-storage",

--- a/camelid-desktop/src/main.rs
+++ b/camelid-desktop/src/main.rs
@@ -498,4 +498,63 @@ mod tests {
                 .is_err()
         );
     }
+
+    /// Every capability that owns the `main` window must grant start-dragging.
+    ///
+    /// This is a regression guard for a bug that shipped in v0.7.0 and made the
+    /// macOS window impossible to move at all. The window is `titleBarStyle:
+    /// "Overlay"` with `hiddenTitle`, so the OS titlebar is ours to draw and the
+    /// app's own `data-tauri-drag-region` strip is the window's ONLY drag
+    /// handle. That strip fires `startDragging` over IPC — and `core:default`
+    /// does not carry the permission for it: `core:window:default` is a
+    /// read-only set (sizes, positions, `is-*`, monitors, theme, and
+    /// `internal-toggle-maximize`).
+    ///
+    /// The failure is silent and easy to reintroduce, because the ACL denial
+    /// produces no build error and no crash — just a window that will not move,
+    /// while double-click-to-zoom keeps working and makes it look like the
+    /// titlebar is fine. Assert the grant instead of trusting a review to spot
+    /// its absence.
+    ///
+    /// `spotlight-ui` is deliberately excluded: that window is a centred,
+    /// always-on-top overlay that is positioned, never dragged.
+    #[test]
+    fn main_window_capabilities_grant_start_dragging() {
+        const DRAG: &str = "core:window:allow-start-dragging";
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("capabilities");
+        let mut checked = 0;
+
+        for entry in std::fs::read_dir(&dir).expect("capabilities directory") {
+            let path = entry.expect("capability entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let raw = std::fs::read_to_string(&path).expect("read capability");
+            let value: serde_json::Value = serde_json::from_str(&raw).expect("capability is JSON");
+
+            let owns_main = value["windows"]
+                .as_array()
+                .is_some_and(|w| w.iter().any(|entry| entry == "main"));
+            if !owns_main {
+                continue;
+            }
+
+            let permissions = value["permissions"].as_array().expect("permissions array");
+            assert!(
+                permissions.iter().any(|p| p == DRAG),
+                "{} owns the main window but does not grant {DRAG}; the macOS window \
+                 cannot be moved without it",
+                path.display()
+            );
+            checked += 1;
+        }
+
+        // Both the splash capability and the remote loopback one own `main`. If
+        // this count ever drops, a capability was renamed or removed and the
+        // loop above silently stopped checking anything.
+        assert_eq!(
+            checked, 2,
+            "expected exactly two capabilities owning the main window"
+        );
+    }
 }


### PR DESCRIPTION
## The bug

Since **v0.7.0**, the macOS window cannot be moved. Not "hard to grab" — immovable.

`titleBarStyle: "Overlay"` with `hiddenTitle` (added by the UI redesign, #706) hands the whole titlebar strip to the web content, so the app's own `data-tauri-drag-region` element is the only drag handle the window has. That element fires `startDragging` over IPC, and the ACL denies it.

The reason is easy to miss: `core:window:default` — the set `core:default` pulls in — is **read-only**. Its entire contents are sizes, positions, `is-*`, monitors, theme, and `internal-toggle-maximize`. `allow-start-dragging` is not in it, and no capability in this app named it.

The tell is the asymmetry: **double-click-to-zoom worked the whole time**, because `internal-toggle-maximize` *is* in the default set. Only dragging was denied.

## The fix

`core:window:allow-start-dragging` on both capabilities that own the `main` window:

- **`sidecar-ui`** — the remote loopback origin that actually renders the shell.
- **`default`** — the local splash, which renders the same shell and the same strip.

`spotlight-ui` is deliberately left alone: that window is a centred, always-on-top, transparent overlay that is positioned, not dragged.

## Verification

- **Build-resolved ACL** (`OUT_DIR/capabilities.json` from a real bundle build) now shows `core:window:allow-start-dragging` on `default` and `sidecar-ui`, and correctly absent from `spotlight-ui`.
- **The layout was cleared separately**, so the permission is the only thing that was wrong: in a real 1180px viewport the drag strip measures 1180×28 pinned to the top and wins `elementFromPoint` at every x across its width, and no ancestor sets a transform/filter/backdrop-filter that would break its `position: fixed`.
- `scripts/check-public-scrub.sh` clean; the macOS bundle builds (`scripts/build-macos-desktop.sh` produced a signed .app and DMG).

**Not yet done: an interactive drag on a running window.** That needs screen control I do not have, so the last mile is one launch by a human. The built bundle is ready for that check.

## Related

Same failure mode as the v0.4.5 ACL bug (#542): the loopback UI is a *remote* origin, and a remote origin gets only what a capability explicitly names. Worth remembering next time a window command silently stops working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)