### PR TITLE
fix(metal): stop taking a partial prefix-cache hit that lands on the CPU

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -49,6 +49,21 @@ target/release/camelid serve --model /path/to/model.gguf
 
 That startup path loads the model immediately and applies the default `auto` execution profile for the current host. Use `CAMELID_PROFILE=safe|auto|experimental|debug` when you need to change planner behavior; keep lower-level experiment env vars as developer overrides rather than the primary user workflow.
 
+### Prompt-prefix cache: partial hits on the Metal lane
+
+A partial prompt-prefix-cache hit resumes a cached session at a non-zero KV position, and
+the batched Metal prefill only builds a cache from empty — so the divergent suffix would
+fall to the CPU dense forward. Measured on an M4 / 16 GiB with
+Llama-3.2-3B-Instruct-Q4_K_M and a ~500-token prompt, taking that hit cost 20.79 s against
+1.33 s for a cold miss, and returned different tokens than a cold prefill of the same
+prompt. Camelid therefore declines a partial resume when the batched Metal prefill would
+otherwise have applied, and prefills the whole prompt on the GPU instead. Exact hits, and
+every non-Metal session, are unaffected.
+
+`CAMELID_METAL_PREFIX_PARTIAL_RESUME=1` restores the old unconditional resume. It exists
+so the measurement can be reproduced against a single binary
+(`qa/evidence-bundles/metal-partial-prefix-hit-20260909/`), not as a tuning knob.
+
 ## Production HTTP policy
 
 Anonymous loopback serving remains the default. A non-loopback address has to answer two separate

--- a/qa/evidence-bundles/metal-partial-prefix-hit-20260909/README.md
+++ b/qa/evidence-bundles/metal-partial-prefix-hit-20260909/README.md
@@ -1,0 +1,61 @@
+# The prompt-prefix cache is a 15.6x regression on the Metal K-quant lane
+
+`results.txt` has the numbers, `host.txt` the machine. `prefix-probe.sh` reproduces the
+regression against an unmodified `origin/main` binary; `verify-fix.sh` is the ABBA over
+this branch; `parity-control.sh` establishes the cold-prefill reference output.
+
+## What happens
+
+Turn 2 of any conversation carrying a system prompt shares more than
+`CAMELID_PREFIX_CACHE_MIN_TOKENS` (default 16) leading tokens with turn 1, so it takes a
+PARTIAL prompt-prefix-cache hit. `resume_partial_prefix_hit` rolls the cached session back
+to `kv_position = prefix_len > 0` — and the batched Metal prefill declines outright on a
+non-zero position, so the divergent suffix falls to the CPU dense forward.
+
+The cache built to make repeat turns fast makes them 15.6x slower, and it only bites once
+the cache actually HITS. Q8_0 escapes solely because `kv_roundtrips_through_cpu_exactly`
+refuses it entry to the pool, which leaves K-quant models roughly 18x slower than Q8_0
+from turn 2 onward despite carrying smaller weights.
+
+It is also not output-neutral. Against a cold-prefill reference the resumed path returned
+turn 0's answer for turns 1 and 2, matching on 1 of 3 prompts where the fix matches 3 of 3.
+
+## The fix
+
+`resume_partial_prefix_hit` now asks whether the batched Metal prefill would have taken
+this prompt, and declines the partial resume when it would. The caller then prefills the
+whole prompt on the GPU from position 0: faster, and the bit-exact reference path.
+
+The predicate is `metal_resident_prefill_shape_admits`, factored out of
+`try_metal_resident_prefill_inner` so both callers share one body and cannot drift about
+what "eligible" means. The prefill keeps the `position == 0` clause; the cache asks the
+same question without it.
+
+Scope, deliberately narrow:
+  * exact hits are untouched — they replay stored logits and never prefill;
+  * non-Metal sessions are untouched — the predicate is false, so they resume as before
+    (covered by `a_cpu_only_session_still_takes_the_partial_resume`);
+  * windowed archs were already refused at this site and still are.
+
+## What this is NOT
+
+A floor, not a ceiling. Declining a hit still recomputes the shared prefix. The real win
+is to CONTINUE the batched prefill from `p`: the scatter and attention uniforms already
+exist and are hardwired to zero ("base position: prefill always starts an empty cache"),
+and the MSL kernels already accept `base_position`. That is a separate change needing its
+own token-identity qualification. This one only stops the bleeding, and does so on a path
+whose correctness argument is "do what a first turn does".
+
+## Reproducing
+
+    # regression, against a stock origin/main binary
+    bash prefix-probe.sh
+
+    # the fix, ABBA, one binary both arms
+    bash verify-fix.sh
+
+    # what a cold prefill actually answers
+    bash parity-control.sh
+
+`CAMELID_METAL_PREFIX_PARTIAL_RESUME=1` restores the old behaviour so both arms come from
+the same binary. It is not a tuning knob and is documented as existing only for this A/B.

--- a/qa/evidence-bundles/metal-partial-prefix-hit-20260909/host.txt
+++ b/qa/evidence-bundles/metal-partial-prefix-hit-20260909/host.txt
@@ -1,0 +1,13 @@
+host            tims-mac-mini-2.lan (mini2)
+cpu             Apple M4, 10 cores
+memory          17179869184 bytes (16 GiB unified)
+os              macOS 26.6.2 (25G83)
+model           Llama-3.2-3B-Instruct-Q4_K_M.gguf  sha256:6c1a2b41161032677be168d354123594...
+control model   Llama-3.2-3B-Instruct-Q8_0.gguf
+binary          camelid v0.7.2 built from this branch  sha256:feb742cde4ed171d8335dbc466e66b55...
+baseline        origin/main @ fabbb818
+
+Every arm ran on an otherwise idle machine: no other engine, no compiler. An earlier
+attempt measured 20.5 s on a prompt that settles to 1.3 s because it started ~20 s after
+a 2.5 GB engine was killed and the OS was still reclaiming, so the cooldown now waits for
+free pages to stop climbing rather than for the process to merely be gone.

--- a/qa/evidence-bundles/metal-partial-prefix-hit-20260909/parity-control.sh
+++ b/qa/evidence-bundles/metal-partial-prefix-hit-20260909/parity-control.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Reference: what does each prompt produce as the ONLY request to a fresh server?
+# That is an unambiguous cold GPU prefill with an empty cache -- the bit-exact path.
+# The fix claims turn-2 output should now equal this. The old behaviour's CPU-tail
+# resume is the arm that has to justify itself against it.
+set -uo pipefail
+BIN="$HOME/camelid-memctx/camelid-fixed"
+MODEL="$HOME/models/Llama-3.2-3B-Instruct-Q4_K_M.gguf"
+port=8150
+for sd in 500 501 502; do
+  out="$HOME/camelid-memctx/parity-$sd"; mkdir -p "$out"
+  "$BIN" serve --addr 127.0.0.1:$port --model "$MODEL" >"$out/serve.out" 2>"$out/serve.err" &
+  srv=$!
+  for _ in $(seq 1 300); do curl -s "http://127.0.0.1:$port/v1/health" 2>/dev/null | grep -q '"generation_ready":true' && break; sleep 1; done
+  python3 - "$port" "$sd" <<'PY'
+import json,sys,urllib.request
+base='http://127.0.0.1:'+sys.argv[1]; sd=int(sys.argv[2])
+V=['alpha','beta','gamma','delta','epsilon','zeta','eta','theta','iota','kappa','lambda','sigma','tau','omega','rho','phi']
+s=sd&0xFFFFFFFF; o=[]
+for _ in range(350):
+    s=(s*1103515245+12345)&0xFFFFFFFF; o.append(V[s%len(V)])
+m=json.load(urllib.request.urlopen(base+'/v1/models',timeout=30))['data'][0]['id']
+PRE='You are a terse assistant. Answer in one short sentence. Use the notes below and do not speculate beyond them.'
+b=json.dumps({'model':m,'messages':[{'role':'system','content':PRE},
+  {'role':'user','content':'Here are my notes, please read them carefully:\n\n'+' '.join(o)+'\nAck.'}],
+  'temperature':0,'max_tokens':16,'stream':False}).encode()
+r=urllib.request.Request(base+'/v1/chat/completions',data=b,headers={'Content-Type':'application/json'})
+print(f'seed {sd} COLD-REFERENCE: {json.load(urllib.request.urlopen(r,timeout=900))["choices"][0]["message"]["content"][:120]}',flush=True)
+PY
+  kill $srv 2>/dev/null; for _ in $(seq 1 30); do kill -0 $srv 2>/dev/null || break; sleep 1; done; kill -9 $srv 2>/dev/null
+  port=$((port+1)); sleep 20
+done

--- a/qa/evidence-bundles/metal-partial-prefix-hit-20260909/prefix-probe.sh
+++ b/qa/evidence-bundles/metal-partial-prefix-hit-20260909/prefix-probe.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Does a PARTIAL prompt-prefix-cache hit make Metal SLOWER than a cold miss?
+# Predicted: a hit rolls the session back to position>0, try_metal_resident_prefill
+# declines (metal_resident.rs:302 `|| self.kv_cache.position != 0`), and the divergent
+# tail falls to the CPU causal walk. If so, sharing a prefix is a large REGRESSION.
+set -uo pipefail
+PORT=8136
+BIN="$HOME/camelid-memctx/camelid"; MODEL="$HOME/models/Llama-3.2-3B-Instruct-Q4_K_M.gguf"
+OUT="$HOME/camelid-memctx/prefixprobe"; mkdir -p "$OUT"
+CAMELID_METAL_KQUANT_ATTN_MM=1 "$BIN" serve --addr 127.0.0.1:$PORT --model "$MODEL" >"$OUT/serve.out" 2>"$OUT/serve.err" &
+SRV=$!
+for _ in $(seq 1 300); do curl -s "http://127.0.0.1:$PORT/v1/health" 2>/dev/null | grep -q '"generation_ready":true' && break; sleep 1; done
+python3 - "$PORT" <<'PY'
+import json,sys,time,urllib.request
+base='http://127.0.0.1:'+sys.argv[1]
+V=['alpha','beta','gamma','delta','epsilon','zeta','eta','theta','iota','kappa','lambda','sigma','tau','omega','rho','phi']
+def filler(sd,n):
+    s=sd&0xFFFFFFFF; o=[]
+    for _ in range(n):
+        s=(s*1103515245+12345)&0xFFFFFFFF; o.append(V[s%len(V)])
+    return ' '.join(o)
+m=json.load(urllib.request.urlopen(base+'/v1/models',timeout=30))['data'][0]['id']
+LONG_PREAMBLE='You are a terse assistant. Answer in one short sentence. Use the notes below and do not speculate beyond them.'
+def go(sd,shared_prefix):
+    msgs=([{'role':'system','content':LONG_PREAMBLE}] if shared_prefix else [])
+    lead='Here are my notes, please read them carefully:\n\n' if shared_prefix else 'N:\n'
+    msgs=msgs+[{'role':'user','content':lead+filler(sd,350)+'\nAck.'}]
+    b=json.dumps({'model':m,'messages':msgs,'temperature':0,'max_tokens':8,'stream':False}).encode()
+    r=urllib.request.Request(base+'/v1/chat/completions',data=b,headers={'Content-Type':'application/json'})
+    t=time.time()
+    with urllib.request.urlopen(r,timeout=900) as resp: resp.read()
+    return (time.time()-t)*1000
+print('--- NO shared prefix (each request a cache MISS) ---',flush=True)
+n=300
+for i in range(3):
+    print(f'  req{i}: {go(n,False):9.1f} ms',flush=True); n+=1
+print('--- SHARED long prefix (req0 miss, then PARTIAL HITS) ---',flush=True)
+n=400
+for i in range(3):
+    print(f'  req{i}: {go(n,True):9.1f} ms',flush=True); n+=1
+PY
+kill $SRV 2>/dev/null; for _ in $(seq 1 30); do kill -0 $SRV 2>/dev/null || break; sleep 1; done; kill -9 $SRV 2>/dev/null

--- a/qa/evidence-bundles/metal-partial-prefix-hit-20260909/results.txt
+++ b/qa/evidence-bundles/metal-partial-prefix-hit-20260909/results.txt
@@ -1,0 +1,58 @@
+=========================================================================
+A. THE REGRESSION  (origin/main @ fabbb818, unmodified binary)
+   3B-Q4_K_M, ~500-token prompt, max_tokens=8, temperature=0.
+   "shared prefix" = a system message + a fixed lead-in, i.e. ordinary chat.
+-------------------------------------------------------------------------
+   NO shared prefix (every request a cache MISS)
+     req0  1336.9 ms      req1  1325.2 ms      req2  1321.6 ms
+   SHARED prefix (req0 MISS, req1+ PARTIAL HIT)
+     req0  1368.6 ms      req1 20700.8 ms      req2 20810.5 ms
+                                 ^^^^^^^^^^           ^^^^^^^^^^
+   => a partial prompt-prefix-cache HIT is 15.6x SLOWER than a MISS.
+
+   Causal chain, from CAMELID_RESIDENT_TRACE=1 on the same run:
+     "declined at site 1"  x2   -- exactly the two slow requests; zero on the
+                                   four fast ones.
+   Site 1 is the gate in try_metal_resident_prefill_inner, whose clause
+   `|| self.kv_cache.position != 0` fires because the resume set position>0.
+   The divergent suffix then runs on the CPU dense forward.
+
+B. CONTROL: Q8_0, identical prompts, same machine
+     NO shared prefix   1128.8 / 1121.2 / 1117.3 ms
+     SHARED prefix      1149.3 / 1146.0 / 1148.8 ms      declines: 0
+   Q8_0 is refused entry to the pool by kv_roundtrips_through_cpu_exactly, so it
+   never takes a partial hit and never regresses. That leaves K-quant ~18x slower
+   than Q8_0 from turn 2 of a conversation, despite the smaller weights.
+
+=========================================================================
+C. THE FIX  (this branch; ONE binary, both arms, ABBA)
+   CAMELID_METAL_PREFIX_PARTIAL_RESUME=1 restores the old unconditional resume.
+   max_tokens=16. Turn 0 is the built-in control: no cache exists yet, so every
+   arm must agree there -- and does, 1750-1768 ms.
+-------------------------------------------------------------------------
+   arm        turn0      turn1      turn2     declines
+   fixed-1   1750.3     1738.3     1736.4        0
+   old-1     1750.2    20808.8    20954.9        2
+   old-2     1755.5    21096.9    21170.5        2
+   fixed-2   1767.7     1742.9     1744.5        0
+
+   => 12.0x on turn 2+ (20.9 s -> 1.74 s). ABBA: the fixed arms bracket the old
+      arms and each pair agrees with itself, so drift cannot explain it.
+
+=========================================================================
+D. OUTPUT PARITY  (the part that makes this a correctness fix, not only perf)
+   Reference = each prompt sent as the ONLY request to a fresh server, i.e. an
+   unambiguous cold GPU prefill from an empty cache.
+-------------------------------------------------------------------------
+   seed 500  reference: "The list appears to be a repetition of the Greek alphabet."
+   seed 501  reference: "Your notes appear to be a repetition of the Greek alphabet."
+   seed 502  reference: "Your notes appear to be a repetition of the Greek alphabet."
+
+   fixed arm  turn0 "The list appears..."   turn1 "Your notes appear..."   turn2 "Your notes appear..."
+              -> matches the reference on 3 of 3.
+   old arm    turn0 "The list appears..."   turn1 "The list appears..."    turn2 "The list appears..."
+              -> matches on 1 of 3; turns 1 and 2 return turn 0's answer.
+
+   The CPU-tail resume did not merely cost time, it produced different tokens
+   than the reference path for the same prompt. Declining the partial hit
+   restores agreement.

--- a/qa/evidence-bundles/metal-partial-prefix-hit-20260909/verify-fix.sh
+++ b/qa/evidence-bundles/metal-partial-prefix-hit-20260909/verify-fix.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Same binary, both arms. CAMELID_METAL_PREFIX_PARTIAL_RESUME=1 restores the old
+# unconditional resume, so the only difference between arms is the decision this PR
+# changes. ABBA over the two arms so drift cannot masquerade as the fix.
+set -uo pipefail
+BIN="$HOME/camelid-memctx/camelid-fixed"
+MODEL="$HOME/models/Llama-3.2-3B-Instruct-Q4_K_M.gguf"
+
+run_arm() {
+  local label="$1" forced="$2" port="$3"
+  local out="$HOME/camelid-memctx/fix-$label"; mkdir -p "$out"
+  CAMELID_METAL_PREFIX_PARTIAL_RESUME="$forced" CAMELID_RESIDENT_TRACE=1 \
+    "$BIN" serve --addr 127.0.0.1:$port --model "$MODEL" >"$out/serve.out" 2>"$out/serve.err" &
+  local srv=$!
+  for _ in $(seq 1 300); do curl -s "http://127.0.0.1:$port/v1/health" 2>/dev/null | grep -q '"generation_ready":true' && break; sleep 1; done
+  echo "--- arm $label (CAMELID_METAL_PREFIX_PARTIAL_RESUME=$forced) ---"
+  python3 - "$port" "$label" <<'PY'
+import json,sys,time,urllib.request
+base='http://127.0.0.1:'+sys.argv[1]
+V=['alpha','beta','gamma','delta','epsilon','zeta','eta','theta','iota','kappa','lambda','sigma','tau','omega','rho','phi']
+def filler(sd,n):
+    s=sd&0xFFFFFFFF; o=[]
+    for _ in range(n):
+        s=(s*1103515245+12345)&0xFFFFFFFF; o.append(V[s%len(V)])
+    return ' '.join(o)
+m=json.load(urllib.request.urlopen(base+'/v1/models',timeout=30))['data'][0]['id']
+PRE='You are a terse assistant. Answer in one short sentence. Use the notes below and do not speculate beyond them.'
+def go(sd):
+    msgs=[{'role':'system','content':PRE},
+          {'role':'user','content':'Here are my notes, please read them carefully:\n\n'+filler(sd,350)+'\nAck.'}]
+    b=json.dumps({'model':m,'messages':msgs,'temperature':0,'max_tokens':16,'stream':False}).encode()
+    r=urllib.request.Request(base+'/v1/chat/completions',data=b,headers={'Content-Type':'application/json'})
+    t=time.time()
+    with urllib.request.urlopen(r,timeout=900) as resp: j=json.load(resp)
+    return (time.time()-t)*1000, j['choices'][0]['message']['content']
+for i,sd in enumerate([500,501,502]):
+    ms,txt=go(sd)
+    print(json.dumps({'arm':sys.argv[2],'turn':i,'ms':round(ms,1),'text':txt[:120]}),flush=True)
+PY
+  kill $srv 2>/dev/null; for _ in $(seq 1 30); do kill -0 $srv 2>/dev/null || break; sleep 1; done; kill -9 $srv 2>/dev/null
+  echo "declines: $(grep -c 'declined at site' "$out/serve.err" 2>/dev/null)"
+  sleep 25
+}
+run_arm fixed-1 0 8140
+run_arm old-1   1 8141
+run_arm old-2   1 8142
+run_arm fixed-2 0 8143

--- a/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
+++ b/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
@@ -27,7 +27,7 @@
   },
   "implementation": {
     "source_file": "src/api/mod.rs",
-    "source_git_blob_sha1": "d94eaa9b9795487498b38e1691cf6711a42bba01",
+    "source_git_blob_sha1": "f36207b41c39fcac4ae7b5a66ebcedfb755b4072",
     "architecture": "smollm3",
     "renderer": "render_smollm3_production_chat_prompt",
     "public_chokepoints": [

--- a/scripts/hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/hf-qualification-smollm3-chat-parity.mjs
@@ -93,11 +93,11 @@ const GROUNDING_FILES = Object.freeze({
   }),
   runtime_envelope: Object.freeze({
     path: 'qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json',
-    sha256: '545d74be75dea376c32c788a7fb8202e9690f227f3faf3989df6ff8feec39272',
+    sha256: '5c913293e548a75dbeb55af2237bde85d69024cac123b2951b4c6ae5efafaf04',
   }),
 })
 
-const RENDERER_GIT_BLOB_SHA1 = 'd94eaa9b9795487498b38e1691cf6711a42bba01'
+const RENDERER_GIT_BLOB_SHA1 = 'f36207b41c39fcac4ae7b5a66ebcedfb755b4072'
 const SHAPE_CASE_ID = 'default_think_single_user_generation_prompt'
 const NORMALIZED_PROMPT_UTF8_BYTES = 1_392
 const NORMALIZED_PROMPT_SHA256 = '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1'

--- a/scripts/test-hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/test-hf-qualification-smollm3-chat-parity.mjs
@@ -114,7 +114,7 @@ assert.deepEqual(TEMPLATE_IDENTITY, {
 assert.equal(GROUNDING_FILES.shape_pack.sha256,
   'd46794448b7c2585d0aa83dfd7bb17d4904c2dcbc048ade1ef68cd3863166de6')
 assert.equal(GROUNDING_FILES.runtime_envelope.sha256,
-  '545d74be75dea376c32c788a7fb8202e9690f227f3faf3989df6ff8feec39272')
+  '5c913293e548a75dbeb55af2237bde85d69024cac123b2951b4c6ae5efafaf04')
 assert.equal(LLAMA_PIN.executable_sha256,
   '6c787bf07ac1d7e1bbaa1ee176c3ef0df58ea86494c8c1b1d2d9f4a9176b19ae')
 assert.equal(LLAMA_PIN.server_impl_sha256,
@@ -331,7 +331,7 @@ assert.equal(classifySmolLM3ChatParityError(sharedSmolError).error_code,
 
 const committedGrounding = await inspectGroundings(root)
 assert.equal(committedGrounding.renderer_git_blob_sha1,
-  'd94eaa9b9795487498b38e1691cf6711a42bba01')
+  'f36207b41c39fcac4ae7b5a66ebcedfb755b4072')
 assert.equal(committedGrounding.shape_case.normalized_prompt_sha256,
   '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1')
 const shapePack = JSON.parse(await readFile(resolve(GROUNDING_FILES.shape_pack.path), 'utf8'))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22095,6 +22095,24 @@ fn store_prompt_prefix_cache(prepared: &mut PreparedGeneration, step: &LlamaGene
 /// A malformed/stale cache entry must never make generation fail: when
 /// rollback cannot establish the requested prefix position the caller retains
 /// the fresh session and performs a cold prefill.
+/// `1` restores the unconditional partial resume this function used to do, so the
+/// regression it now avoids can be measured against the SAME binary. Not a tuning knob:
+/// the only reason to set it is to reproduce the A/B in
+/// `qa/evidence-bundles/metal-partial-prefix-hit-*`.
+fn partial_resume_forced() -> bool {
+    partial_resume_forced_from(
+        std::env::var("CAMELID_METAL_PREFIX_PARTIAL_RESUME")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// The env half of [`partial_resume_forced`], split out so the DEFAULT is covered by a
+/// test rather than by whatever the ambient environment happens to hold.
+fn partial_resume_forced_from(value: Option<&str>) -> bool {
+    matches!(value, Some(v) if v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
 fn resume_partial_prefix_hit(
     prepared: &mut PreparedGeneration,
     mut cached_session: LlamaInferenceSession,
@@ -22102,6 +22120,24 @@ fn resume_partial_prefix_hit(
     input: &mut Vec<u32>,
 ) {
     if crate::model::arch_has_windowed_attention(&prepared.session.config) {
+        return;
+    }
+    // A partial hit is only worth taking if the divergent suffix can still be prefilled
+    // on the GPU. It cannot: resuming sets `kv_position = prefix_len > 0`, and the
+    // batched Metal prefill declines outright on a non-zero position, dropping the
+    // suffix onto the CPU dense forward. Measured on an M4 / 16 GiB,
+    // Llama-3.2-3B-Instruct-Q4_K_M, ~500-token prompt: cold miss 1.33 s, partial hit
+    // 20.79 s. Taking the hit was a 15.6x LOSS on exactly the shape it was built for —
+    // turn 2 of a conversation with a system prompt.
+    //
+    // Declining leaves `prepared.session` as the fresh session, so the caller prefills
+    // the whole prompt on the GPU from position 0: faster, and the bit-exact reference
+    // path. Exact hits never reach here (they replay stored logits and skip prefill).
+    if !partial_resume_forced()
+        && prepared
+            .session
+            .metal_resident_prefill_would_apply(prepared.token_ids.len())
+    {
         return;
     }
     if cached_session.rollback_to_position(prefix_len).is_ok() {
@@ -31875,6 +31911,60 @@ mod tests {
             "the control fixture must store — otherwise this test is not \
              exercising the windowed-arch bypass"
         );
+    }
+
+    /// The partial-resume escape hatch is OFF unless explicitly set to 1/true. It exists
+    /// only to reproduce the A/B against one binary, so anything else — unset, empty, 0,
+    /// or a stray value — must leave the regression avoided.
+    #[test]
+    fn partial_resume_is_forced_only_by_an_explicit_opt_in() {
+        assert!(!partial_resume_forced_from(None));
+        assert!(!partial_resume_forced_from(Some("")));
+        assert!(!partial_resume_forced_from(Some("0")));
+        assert!(!partial_resume_forced_from(Some("false")));
+        assert!(!partial_resume_forced_from(Some("yes")));
+        assert!(partial_resume_forced_from(Some("1")));
+        assert!(partial_resume_forced_from(Some("true")));
+        assert!(partial_resume_forced_from(Some("TRUE")));
+    }
+
+    /// A partial resume must be declined whenever the batched Metal prefill would have
+    /// taken the prompt, because resuming forces the divergent suffix onto the CPU dense
+    /// forward: measured 1.33 s -> 20.79 s on Llama-3.2-3B-Instruct-Q4_K_M, and the CPU
+    /// tail also diverges from the cold-prefill reference tokens. This covers the
+    /// bookkeeping half with no GPU: a tiny CPU fixture is never resident-eligible, so
+    /// the predicate must answer `false` and the resume must still happen — which is what
+    /// keeps every non-Metal deployment on exactly its previous behaviour.
+    #[test]
+    fn a_cpu_only_session_still_takes_the_partial_resume() {
+        let _env_guard = crate::test_support::env_lock();
+        let cold = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
+        assert!(
+            !cold.metal_resident_prefill_would_apply(3),
+            "a tiny CPU fixture must not claim the batched Metal prefill applies"
+        );
+        assert!(
+            !cold.metal_resident_prefill_would_apply(0),
+            "a degenerate length must never admit the batched prefill"
+        );
+
+        let mut warm = LlamaInferenceSession::new(tiny_config(), tiny_weights()).unwrap();
+        warm.generate_next_token_with_history_diagnostics(
+            &[1, 2],
+            crate::inference::LlamaSampler::Greedy,
+            &[1, 2],
+            false,
+            None,
+        )
+        .unwrap();
+        let mut prepared = prepared_for_cache("tiny", "model-a.gguf", vec![1, 2, 1], cold);
+        let mut input = prepared.token_ids.clone();
+        resume_partial_prefix_hit(&mut prepared, warm, 2, &mut input);
+        assert!(
+            prepared.timings.prompt_cache_hit,
+            "the CPU path keeps its partial resume: nothing about it regressed"
+        );
+        assert_eq!(input, vec![1], "the CPU path resumes from the suffix");
     }
 
     /// gemma3→Metal Phase 3a hazard H1, resume sites: a windowed-attention

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -267,6 +267,67 @@ impl super::LlamaInferenceSession {
             .is_some())
     }
 
+    /// The arming and shape conditions the batched Metal prefill needs, DELIBERATELY
+    /// excluding the KV-position clause.
+    ///
+    /// Split out because two callers need the same predicate for different reasons.
+    /// `try_metal_resident_prefill_inner` adds `kv_cache.position == 0`, because the
+    /// batched prefill builds a cache from empty. The prompt-prefix cache asks WITHOUT
+    /// that clause, because it needs to know whether this prompt would have taken the
+    /// batched path had it not resumed a cached session — see
+    /// `metal_resident_prefill_would_apply`. Keeping one body means the two can never
+    /// drift into disagreeing about eligibility.
+    fn metal_resident_prefill_shape_admits(&self, n_tokens: usize) -> Result<bool> {
+        // Two independent arming gates for two different batched prefills:
+        //   * CAMELID_METAL_RESIDENT_PREFILL — the existing (non-windowed) `prefill_tokens`,
+        //     which fails closed on gemma3 (schedule / sandwich norms / GeGLU) and on
+        //     head_dim > 128;
+        //   * CAMELID_GEMMA3_BATCH_PREFILL — the long-prompt TTFT campaign's
+        //     `prefill_tokens_windowed`, gemma3-only, default ON since Phase 4 with
+        //     `=0` as the operator opt-out. Its two inner flags
+        //     (CAMELID_GEMMA3_PREFILL_MM, CAMELID_GEMMA3_PREFILL_ATTN_MM) are read
+        //     inside that call and are likewise default-ON opt-outs.
+        let gemma3_batched = self.gemma3_batched_prefill_armed();
+        let resident_prefill_armed = std::env::var("CAMELID_METAL_RESIDENT_PREFILL")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        Ok((resident_prefill_armed || gemma3_batched)
+            && (2..=16384).contains(&n_tokens)
+            && self.weights.layer_range.is_none()
+            && self.resident_decode_eligible(false)?)
+    }
+
+    /// Would a prompt of `n_tokens` take the batched Metal prefill, if it started from an
+    /// empty cache?
+    ///
+    /// Asked by the prompt-prefix cache before it resumes a PARTIAL hit. A partial hit
+    /// rolls the cached session back to `kv_position = p > 0`, and the position clause in
+    /// `try_metal_resident_prefill_inner` then declines the batched prefill outright, so
+    /// the divergent suffix falls to the CPU dense forward. That is not a smaller win, it
+    /// is a large loss: measured on an M4 / 16 GiB with Llama-3.2-3B-Instruct-Q4_K_M and a
+    /// ~500-token prompt, a cold miss prefills in 1.33 s and a partial hit takes 20.79 s —
+    /// a 15.6x REGRESSION, from the second turn of any conversation carrying a system
+    /// prompt. Q8_0 escapes it only because `kv_roundtrips_through_cpu_exactly` refuses it
+    /// entry to the pool at all, which leaves K-quant models ~18x slower than Q8_0 on
+    /// turn 2 despite being the smaller weights.
+    ///
+    /// So the cache declines the partial resume when this returns true and pays a cold GPU
+    /// prefill instead — faster, and the bit-exact reference path. Exact hits are
+    /// unaffected: they replay a stored logits vector and never prefill at all.
+    ///
+    /// This is a floor, not the ceiling. Threading a base position through
+    /// `prefill_tokens` so the batched prefill can CONTINUE from `p` would beat both arms;
+    /// the scatter and attention uniforms are already there and hardwired to zero
+    /// (`src/metal.rs`, "base position: prefill always starts an empty cache"), and the
+    /// MSL kernels already take `base_position`.
+    pub(crate) fn metal_resident_prefill_would_apply(&self, n_tokens: usize) -> bool {
+        // Eligibility probing must never itself fail a request: an Err here means "cannot
+        // establish that the batched path applies", which is exactly the conservative
+        // answer (keep the existing resume behaviour).
+        self.metal_resident_prefill_shape_admits(n_tokens)
+            .unwrap_or(false)
+    }
+
     /// Shared resident prefill builder. A successful result owns a live resident session at
     /// `token_ids.len()` and carries requested pre-layer activation snapshots; `None` keeps the
     /// ordinary lossless fallback contract.
@@ -282,25 +343,18 @@ impl super::LlamaInferenceSession {
                 token_ids.len()
             );
         }
-        // Two independent arming gates for two different batched prefills:
-        //   * CAMELID_METAL_RESIDENT_PREFILL — the existing (non-windowed) `prefill_tokens`,
-        //     which fails closed on gemma3 (schedule / sandwich norms / GeGLU) and on
-        //     head_dim > 128;
-        //   * CAMELID_GEMMA3_BATCH_PREFILL — the long-prompt TTFT campaign's
-        //     `prefill_tokens_windowed`, gemma3-only, default ON since Phase 4 with
-        //     `=0` as the operator opt-out. Its two inner flags
-        //     (CAMELID_GEMMA3_PREFILL_MM, CAMELID_GEMMA3_PREFILL_ATTN_MM) are read
-        //     inside that call and are likewise default-ON opt-outs.
+        // Which of the two batched prefills this call will drive; the arming half of the
+        // same question lives in `metal_resident_prefill_shape_admits`, which documents
+        // both gates.
         let gemma3_batched = self.gemma3_batched_prefill_armed();
-        let resident_prefill_armed = std::env::var("CAMELID_METAL_RESIDENT_PREFILL")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-        if (!resident_prefill_armed && !gemma3_batched)
-            || token_ids.len() < 2
-            || token_ids.len() > 16384
-            || self.kv_cache.position != 0
-            || self.weights.layer_range.is_some()
-            || !self.resident_decode_eligible(false)?
+        // Position first, deliberately. `resident_decode_eligible` inside
+        // `metal_resident_prefill_shape_admits` emits `[resident-eligible]` trace lines,
+        // and the original `||` chain short-circuited at this clause before reaching it.
+        // Testing position first preserves that exactly: a resumed session at position>0
+        // declines here without ever probing eligibility, so CAMELID_RESIDENT_TRACE output
+        // is unchanged. Every other clause is a pure predicate, so their order is free.
+        if self.kv_cache.position != 0
+            || !self.metal_resident_prefill_shape_admits(token_ids.len())?
         {
             if trace {
                 eprintln!("[resident-prefill] try_metal_resident_prefill declined at site 1");


### PR DESCRIPTION
## The problem

A partial prompt-prefix-cache hit resumes the cached session at `kv_position = prefix_len > 0`. The batched Metal prefill only builds a cache from empty, so it declines outright (`try_metal_resident_prefill_inner`, the `|| self.kv_cache.position != 0` clause) and the divergent suffix falls to the CPU dense forward.

So the cache is a **regression on exactly the shape it exists for**. Turn 2 of any conversation carrying a system prompt clears `CAMELID_PREFIX_CACHE_MIN_TOKENS` (default 16) and takes a partial hit.

Measured on an M4 / 16 GiB, Llama-3.2-3B-Instruct-Q4_K_M, ~500-token prompt, against a stock `origin/main` binary:

```
NO shared prefix (every request a cache MISS)
  req0  1336.9 ms   req1  1325.2 ms   req2  1321.6 ms
SHARED prefix (req0 MISS, req1+ PARTIAL HIT)
  req0  1368.6 ms   req1 20700.8 ms   req2 20810.5 ms
```

**15.6x slower because the cache hit.** `CAMELID_RESIDENT_TRACE=1` on the same run emits `declined at site 1` exactly twice — the two slow requests, and none of the four fast ones.

Q8_0 is the control: identical prompts, `1128.8 / 1121.2 / 1117.3` then `1149.3 / 1146.0 / 1148.8`, zero declines. It escapes only because `kv_roundtrips_through_cpu_exactly` refuses it entry to the pool at all — which leaves K-quant models **~18x slower than Q8_0 from turn 2 onward**, despite carrying smaller weights.

### It is also not output-neutral

Reference = each prompt sent as the only request to a fresh server, i.e. an unambiguous cold GPU prefill from an empty cache.

| seed | reference | with fix | before |
|---|---|---|---|
| 500 | "The list appears…" | ✅ | ✅ |
| 501 | "Your notes appear…" | ✅ | ❌ "The list appears…" |
| 502 | "Your notes appear…" | ✅ | ❌ "The list appears…" |

The resumed path returned turn 0's answer for turns 1 and 2. Matching 1 of 3, where declining the hit matches 3 of 3.

## The fix

`resume_partial_prefix_hit` asks whether the batched Metal prefill would have taken this prompt, and declines the resume when it would. The caller then prefills the whole prompt on the GPU from position 0 — faster, and the bit-exact reference path.

The predicate is `metal_resident_prefill_shape_admits`, factored out of the prefill's own gate so the two share one body and cannot drift about what "eligible" means. The prefill keeps the `position == 0` clause; the cache asks the same question without it. Position is tested first so `resident_decode_eligible` stays short-circuited on a resumed session and `CAMELID_RESIDENT_TRACE` output is unchanged.

Scope is deliberately narrow:

- **exact hits untouched** — they replay stored logits and never prefill;
- **non-Metal sessions untouched** — the predicate is false, so they resume exactly as before (`a_cpu_only_session_still_takes_the_partial_resume`);
- **windowed archs** were already refused at this site and still are.

## Verification

One binary, both arms, ABBA so drift cannot masquerade as the fix. `CAMELID_METAL_PREFIX_PARTIAL_RESUME=1` restores the old behaviour.

| arm | turn0 | turn1 | turn2 | declines |
|---|---|---|---|---|
| fixed-1 | 1750.3 | **1738.3** | **1736.4** | 0 |
| old-1 | 1750.2 | 20808.8 | 20954.9 | 2 |
| old-2 | 1755.5 | 21096.9 | 21170.5 | 2 |
| fixed-2 | 1767.7 | **1742.9** | **1744.5** | 0 |

**12.0x on turn 2+.** Turn 0 is the built-in control — no cache exists yet, and all four arms agree there.

Gates: `cargo test --release --all-targets` 3068 passed / 0 failed / 55 ignored; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean; `audit-evidence-bundle-privacy --strict` 0 findings; ledger/fit/cuda-parity gates pass. The `src/api/mod.rs` renderer seal is refreshed across all five sites and `test-hf-qualification-smollm3-chat-parity.mjs` passes.

## What this is not

A floor, not a ceiling. Declining a hit still recomputes the shared prefix. The real win is to **continue** the batched prefill from `p`: the scatter and attention uniforms already exist and are hardwired to zero (`base position: prefill always starts an empty cache`), and the MSL kernels already accept `base_position`. That is a separate change needing its own token-identity qualification. This one only stops the bleeding, on a path whose correctness argument is "do what a first turn does".

Evidence and reproduction scripts: `qa/evidence-bundles/metal-partial-prefix-hit-20260909/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
