### PR TITLE
fix(macos): free a model's resident weights when it is unloaded

### DIFF
--- a/qa/evidence-bundles/macos-resident-cache-eviction-20260909/README.md
+++ b/qa/evidence-bundles/macos-resident-cache-eviction-20260909/README.md
@@ -1,0 +1,54 @@
+# Unloading a model freed almost none of its memory on macOS
+
+`release_model` drops the CPU-side registries and then calls
+`inference::reset_resident_caches`. That function has a real CUDA implementation — its own
+doc records the leak it exists to prevent, "~4.7 GB stayed on the device ... making decode
+~20x slower" — and on every non-CUDA host it was `{}`.
+
+macOS is not a host with nothing to free. `serve` turns `CAMELID_METAL_NOCOPY` on by
+default, so a model's weights ARE its page-aligned `WirePages` allocation, and the
+process-global Metal buffer cache holds an `Arc` to it. That `Arc` is the surviving owner:
+dropping every registry frees nothing, the pages stay resident for the life of the
+process, and a reload maps the file again at a new address and takes a second full copy.
+
+`results.txt` measures it. After two model switches a stock build holds **~8.2 GB for one
+live model** on a 16 GiB machine, including two independent copies of the same 3B; the
+fixed build holds **~4.1 GB**.
+
+It also made the fit advisor lie. `model_requires_unload` tells the user "Releasing it
+frees ~N GB, which should be enough" using the GGUF file size, and on macOS releasing it
+recovered approximately none of it — so the retry that message recommends could not
+succeed.
+
+## The fix, and why it is safe
+
+Sweep the no-copy map and drop entries whose backing allocation has `strong_count == 1`,
+i.e. where this cache holds the only `Arc` and the model that loaded those pages is gone.
+
+That is the entire safety argument, and it needs no ownership plumbing: an `Arc` can only
+be obtained by cloning an existing one, so anything still able to reach those pages is
+itself already counted. A live model reads `>= 2` and is kept. The cache mutex is held
+across the sweep, and a count of 1 cannot race upwards for the same reason.
+
+A blanket `clear()` would NOT be safe — some buffers wrap pages owned elsewhere, so
+clearing could free memory out from under a live model. Refcount-directed eviction cannot
+do that.
+
+`resident_weight_eviction_frees_only_pages_no_model_still_owns` asserts both directions on
+one cache — a live owner's pages survive a sweep, a dropped owner's are reclaimed and
+reported — plus idempotency, so a second unload cannot double-count.
+
+## Scope
+
+Only `q8_wire_nocopy_buffers`. The other four permanent maps hold GPU *copies* keyed by a
+source `(ptr, len)` with no owner handle to test, so nothing there can distinguish a live
+entry from a dead one; reclaiming them needs a per-model owner and is a separate change.
+The no-copy map is where the GB-scale weights actually live on the default `serve` path,
+which is why this is the one worth doing first.
+
+## Reproducing
+
+    bash evict-probe.sh <path-to-camelid> <label> <port>
+
+Run it once with a stock binary and once with this branch. Add
+`CAMELID_RESIDENT_TRACE=1` to the server to see each eviction as it happens.

--- a/qa/evidence-bundles/macos-resident-cache-eviction-20260909/evict-probe.sh
+++ b/qa/evidence-bundles/macos-resident-cache-eviction-20260909/evict-probe.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Does unloading a model actually free its weights on macOS?
+#
+# `ps -o rss` is the WRONG instrument here: the weights are page-aligned wire pages the
+# GPU reads in place, and an untouched model never faults them in (a 3.4 GB model showed
+# 189 MiB RSS). So each model is EXERCISED with a real generation to force its pages
+# resident, and the measurement is `footprint`'s physical footprint, which counts them.
+set -uo pipefail
+BIN="$1"; LABEL="$2"; PORT="$3"
+A="$HOME/models/Llama-3.2-3B-Instruct-Q8_0.gguf"
+B="$HOME/models/Llama-3.2-1B-Instruct-Q8_0.gguf"
+OUT="$HOME/camelid-memctx/evict-$LABEL"; mkdir -p "$OUT"
+
+"$BIN" serve --addr 127.0.0.1:$PORT >"$OUT/serve.out" 2>"$OUT/serve.err" &
+SRV=$!
+for _ in $(seq 1 180); do curl -s "http://127.0.0.1:$PORT/v1/health" >/dev/null 2>&1 && break; sleep 1; done
+
+fp() { footprint -p "$SRV" 2>/dev/null | grep -iE "phys_footprint|Physical footprint" | tail -1 | grep -oE "[0-9.]+ *[KMG]B?" | tail -1; }
+say() { printf '%-30s %14s\n' "$1" "$(fp)"; }
+
+load() {  # exercise the model so its wire pages are actually faulted in
+  curl -s -X POST "http://127.0.0.1:$PORT/api/models/load" -H 'Content-Type: application/json' \
+    -d "{\"path\":\"$1\",\"replace\":true}" >/dev/null 2>&1
+  local m; m=$(curl -s "http://127.0.0.1:$PORT/v1/models" | sed 's/.*"id":"\([^"]*\)".*/\1/')
+  curl -s -X POST "http://127.0.0.1:$PORT/v1/chat/completions" -H 'Content-Type: application/json' \
+    -d "{\"model\":\"$m\",\"messages\":[{\"role\":\"user\",\"content\":\"Count to five.\"}],\"max_tokens\":32,\"temperature\":0}" >/dev/null 2>&1
+  sleep 3
+}
+
+say "0 empty server"
+load "$A"; say "1 3B-Q8_0 loaded + used"
+curl -s -X POST "http://127.0.0.1:$PORT/api/models/unload" -H 'Content-Type: application/json' -d '{}' >/dev/null 2>&1
+sleep 5; say "2 after unload"
+load "$B"; say "3 1B-Q8_0 loaded + used"
+load "$A"; say "4 back to 3B-Q8_0 + used"
+curl -s -X POST "http://127.0.0.1:$PORT/api/models/unload" -H 'Content-Type: application/json' -d '{}' >/dev/null 2>&1
+sleep 5; say "5 after final unload"
+
+kill $SRV 2>/dev/null; for _ in $(seq 1 30); do kill -0 $SRV 2>/dev/null || break; sleep 1; done; kill -9 $SRV 2>/dev/null

--- a/qa/evidence-bundles/macos-resident-cache-eviction-20260909/host.txt
+++ b/qa/evidence-bundles/macos-resident-cache-eviction-20260909/host.txt
@@ -1,0 +1,6 @@
+host      tims-mac-mini-2.lan (mini2)
+cpu       Apple M4, 10 cores
+memory    17179869184 bytes (16 GiB unified)
+os        macOS 26.6.2 (25G83)
+models    Llama-3.2-3B-Instruct-Q8_0.gguf (~3.4 GB), Llama-3.2-1B-Instruct-Q8_0.gguf (~1.3 GB)
+stock     origin/main @ eb73c08f

--- a/qa/evidence-bundles/macos-resident-cache-eviction-20260909/results.txt
+++ b/qa/evidence-bundles/macos-resident-cache-eviction-20260909/results.txt
@@ -1,0 +1,45 @@
+=========================================================================
+Physical footprint (`footprint -p <pid>`) across a model-switch sequence.
+Each model is EXERCISED with a real generation after loading, because the
+weights are page-aligned wire pages the GPU reads in place and an untouched
+model never faults them in -- `ps -o rss` reported 189 MiB for a 3.4 GB model,
+which is why RSS is the wrong instrument here.
+-------------------------------------------------------------------------
+step                          STOCK run1   STOCK run2   FIXED run1   FIXED run2
+0 empty server                   8049 KB      8033 KB      8193 KB      8097 KB
+1 3B-Q8_0 loaded + used           3660 MB      3690 MB      3661 MB      3689 MB
+2 after unload                    3660 MB      3690 MB      3661 MB      3689 MB
+3 1B-Q8_0 loaded + used           4801 MB      4812 MB      3661 MB      3689 MB
+4 back to 3B-Q8_0 + used          8234 MB      8237 MB      4106 MB      4159 MB
+5 after final unload              8234 MB      8237 MB      4106 MB      4159 MB
+
+  => after two switches the stock build holds ~8.2 GB for ONE live model on a
+     16 GiB machine; the fixed build holds ~4.1 GB. About 4.1 GB recovered,
+     reproducing across two independent runs of each arm.
+
+  Stock step 4 decomposes as 3660 (first 3B) + 1141 (1B) + 3433 (a SECOND copy
+  of the 3B, mapped at a new address) -- nothing is ever released, and a reload
+  is a fresh copy rather than a re-use.
+
+=========================================================================
+WHERE THE RECLAIM HAPPENS
+   CAMELID_RESIDENT_TRACE=1 on the fixed build, same sequence:
+
+     [resident-cache] evicted 3.18 GiB of unreferenced resident weights   <- step 2, unload
+     [resident-cache] evicted 1.22 GiB of unreferenced resident weights   <- step 4, replace-load
+     [resident-cache] evicted 3.18 GiB of unreferenced resident weights   <- step 5, final unload
+
+   So eviction fires at the unload itself. `phys_footprint` does not drop on the
+   same line because the released pages are FILE-BACKED: freeing them returns
+   them to the page cache, which macOS keeps charging to the process until it is
+   reclaimed. The recovery is therefore visible as the NEXT load reusing that
+   memory instead of adding to it -- steps 3 and 4 -- rather than as an immediate
+   fall at step 2. Both readings describe the same 4.1 GB.
+
+=========================================================================
+WHAT IS NOT CLAIMED
+   * Zero effect in a one-model process. Nothing is reclaimable while the only
+     model is live, and every published throughput number uses that shape.
+   * No decode tok/s change. This is a residency fix, not a speed fix.
+   * The four copy-based weight caches are untouched; only the no-copy map has
+     an owner handle to test. See the note on `evict_unreferenced_nocopy`.

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -13406,8 +13406,27 @@ pub fn reset_resident_caches() {
     // unload path exists to prevent).
     crate::cuda::release_async_pool();
 }
+/// Non-CUDA hosts have no resident CUDA engine to drop, but macOS still holds resident
+/// weights: the process-global Metal buffer cache pins each model's page-aligned wire
+/// allocation, and on the default `serve` path (`CAMELID_METAL_NOCOPY`) that allocation IS
+/// the weights. This arm was an empty stub, so `release_model` freed the registries and
+/// none of the memory — the outgoing model stayed resident for the life of the process,
+/// a reload took a second full copy at a new address, and the fit advisor's "releasing it
+/// frees ~N GB" was false on this platform. Evicting only what no live model still owns
+/// makes the existing call site do on macOS what it already did on CUDA.
 #[cfg(not(feature = "cuda"))]
-pub fn reset_resident_caches() {}
+pub fn reset_resident_caches() {
+    #[cfg(target_os = "macos")]
+    {
+        let freed = crate::metal::evict_unreferenced_resident_weights();
+        if freed > 0 && std::env::var_os("CAMELID_RESIDENT_TRACE").is_some() {
+            eprintln!(
+                "[resident-cache] evicted {:.2} GiB of unreferenced resident weights",
+                freed as f64 / (1024.0 * 1024.0 * 1024.0)
+            );
+        }
+    }
+}
 
 /// Prompt-lookup n-gram drafter: find the most recent earlier occurrence of the
 /// last `ngram` tokens and propose the up-to-`max_draft` tokens that followed it.

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -677,6 +677,59 @@ impl MetalLinearCache {
             .insert(key, (buffer.to_owned(), std::sync::Arc::clone(pages)));
         buffer
     }
+
+    /// Drop the no-copy entries whose backing allocation has no owner left, and report
+    /// the bytes released.
+    ///
+    /// `strong_count == 1` means this cache holds the ONLY `Arc`, so the model that
+    /// loaded those pages is gone. That is the whole safety argument, and it holds
+    /// without any ownership plumbing: an `Arc` can only be obtained by cloning an
+    /// existing one, so anything still able to reach these pages is itself already
+    /// counted. A live model therefore reads `>= 2` and is kept. The mutex is held
+    /// across the sweep, and a count of 1 cannot race upwards for the same reason.
+    ///
+    /// Deliberately scoped to `q8_wire_nocopy_buffers`. The other four permanent maps
+    /// hold GPU COPIES keyed by a source `(ptr, len)`, with no owner handle to test, so
+    /// nothing here can tell a live entry from a dead one — and `serve` enables
+    /// `CAMELID_METAL_NOCOPY` by default, which is what puts the GB-scale weights in
+    /// this map in the first place. Reclaiming the copy caches needs a per-model owner
+    /// and is a separate change.
+    fn evict_unreferenced_nocopy(&mut self) -> usize {
+        let mut freed = 0usize;
+        self.q8_wire_nocopy_buffers.retain(|_, (_, pages)| {
+            if std::sync::Arc::strong_count(pages) == 1 {
+                freed += pages.byte_len();
+                false
+            } else {
+                true
+            }
+        });
+        freed
+    }
+}
+
+/// Release resident weight allocations that no live model still owns; returns bytes freed.
+///
+/// `release_model` drops the CPU-side registries and then calls
+/// `inference::reset_resident_caches`, whose macOS arm was an empty stub — so on this
+/// platform unload freed the registries and essentially none of the weights. On the
+/// default `serve` path `CAMELID_METAL_NOCOPY` is on, so a model's weights ARE its
+/// `WirePages` allocation, and the process-global buffer cache is the surviving owner:
+/// the pages stay resident for the life of the process, a reload maps the file again at a
+/// new address and takes a second full copy, and the fit advisor then reads the phantom
+/// occupancy and reports that releasing the model "frees ~N GB" when it frees nothing.
+///
+/// Nothing is reclaimable while a single model is live, so this costs zero in a
+/// one-model process. It pays on switching models in place, which is what the app's Load
+/// button does.
+#[cfg(target_os = "macos")]
+pub(crate) fn evict_unreferenced_resident_weights() -> usize {
+    let Some(cache) = METAL_LINEAR_CACHE.get() else {
+        // Never populated: nothing was ever made resident in this process.
+        return 0;
+    };
+    let mut guard = cache.lock().unwrap_or_else(|p| p.into_inner());
+    guard.evict_unreferenced_nocopy()
 }
 
 /// Hardware GPU timestamps from a completed command buffer: (GPU busy window µs,
@@ -45679,6 +45732,59 @@ pub fn detect_metal_device() -> MetalDeviceInfo {
 
 #[cfg(test)]
 mod tests {
+    /// Eviction must free a dropped model's pages and must NOT touch a live model's.
+    ///
+    /// The distinction is the whole safety argument, so it is asserted in both
+    /// directions on one cache: insert while an owner is alive (a sweep must be a
+    /// no-op), then drop the owner (the same sweep must reclaim). Runs on a local
+    /// `MetalLinearCache` rather than the process-global one so it cannot perturb any
+    /// other test.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn resident_weight_eviction_frees_only_pages_no_model_still_owns() {
+        use std::io::Write;
+
+        let Some(device) = super::Device::system_default() else {
+            eprintln!("SKIP: no Metal device on this host");
+            return;
+        };
+        let mut file = tempfile::tempfile().expect("temporary wire file");
+        let bytes = vec![0u8; 64 * 1024];
+        file.write_all(&bytes).expect("write wire bytes");
+        file.flush().expect("flush wire bytes");
+        let pages = crate::wire_mmap::WirePages::read_from_file(&file, 0, bytes.len())
+            .expect("page-backed wire bytes");
+
+        let mut cache = super::MetalLinearCache::new();
+        let _buffer = cache.q8_wire_nocopy_buffer(&device, &pages);
+        assert_eq!(cache.q8_wire_nocopy_buffers.len(), 1);
+
+        // A live owner holds a second Arc, so the sweep must leave the entry alone.
+        assert_eq!(
+            cache.evict_unreferenced_nocopy(),
+            0,
+            "pages a live model still owns must never be freed"
+        );
+        assert_eq!(cache.q8_wire_nocopy_buffers.len(), 1);
+
+        // Model gone: the cache is now the only owner, which is exactly the condition
+        // that made unload free nothing on macOS.
+        drop(pages);
+        let freed = cache.evict_unreferenced_nocopy();
+        assert_eq!(
+            freed,
+            bytes.len(),
+            "the dropped model's allocation must be reported as reclaimed"
+        );
+        assert!(
+            cache.q8_wire_nocopy_buffers.is_empty(),
+            "the entry must be gone, not merely counted"
+        );
+
+        // Idempotent: a second unload must not double-count or panic.
+        assert_eq!(cache.evict_unreferenced_nocopy(), 0);
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     #[allow(clippy::single_range_in_vec_init)] // one chunk covering the whole batch


### PR DESCRIPTION
## The problem

`release_model` drops the CPU-side registries and then calls `inference::reset_resident_caches`. That function has a real CUDA implementation — its own doc records the leak it exists to prevent, *"~4.7 GB stayed on the device … making decode ~20x slower"* — and on every non-CUDA host it was `{}`.

macOS is not a host with nothing to free. `serve` turns `CAMELID_METAL_NOCOPY` on by default, so a model's weights **are** its page-aligned `WirePages` allocation, and the process-global Metal buffer cache holds an `Arc` to it. That `Arc` is the surviving owner: dropping every registry freed nothing, the pages stayed resident for the life of the process, and a reload mapped the file again at a new address and took a *second full copy*.

## Measured

M4 / 16 GiB, `footprint -p <pid>`. Each model is exercised with a real generation after loading, because the weights are wire pages the GPU reads in place and an untouched model never faults them in — `ps -o rss` reports **189 MiB for a 3.4 GB model**, so RSS cannot see this at all.

| step | stock r1 | stock r2 | **fixed r1** | **fixed r2** |
|---|---|---|---|---|
| 0 empty server | 8049 KB | 8033 KB | 8193 KB | 8097 KB |
| 1 3B-Q8_0 loaded + used | 3660 MB | 3690 MB | 3661 MB | 3689 MB |
| 2 after unload | 3660 MB | 3690 MB | 3661 MB | 3689 MB |
| 3 1B-Q8_0 loaded + used | 4801 MB | 4812 MB | **3661 MB** | **3689 MB** |
| 4 back to 3B-Q8_0 + used | 8234 MB | 8237 MB | **4106 MB** | **4159 MB** |

After two switches the stock build holds **~8.2 GB for one live model** on a 16 GiB machine. Step 4 decomposes as 3660 (first 3B) + 1141 (1B) + 3433 (a second copy of the same 3B, at a new address). The fixed build holds ~4.1 GB. **~4.1 GB recovered**, reproducing across two independent runs of each arm.

`CAMELID_RESIDENT_TRACE=1` shows where it happens:

```
[resident-cache] evicted 3.18 GiB of unreferenced resident weights   <- unload
[resident-cache] evicted 1.22 GiB of unreferenced resident weights   <- replace-load
[resident-cache] evicted 3.18 GiB of unreferenced resident weights   <- final unload
```

Eviction fires at the unload itself. `phys_footprint` does not fall on the same line because the released pages are file-backed — freeing them returns them to the page cache, which macOS keeps charging to the process until reclaimed. The recovery is therefore visible as the *next* load reusing that memory instead of adding to it (steps 3 and 4). Both readings describe the same 4.1 GB.

It also made the fit advisor lie: `model_requires_unload` tells the user *"Releasing it frees ~N GB, which should be enough"* using the GGUF file size, and on macOS releasing it recovered approximately none of it — so the retry that message recommends could not succeed. The message is now true rather than needing to change.

## Why the fix is safe

Sweep the no-copy map and drop entries whose backing allocation has `strong_count == 1` — this cache holds the only `Arc`, so the model that loaded those pages is gone.

That is the entire safety argument, and it needs no ownership plumbing: an `Arc` can only be obtained by cloning an existing one, so anything still able to reach those pages is itself already counted. A live model reads `>= 2` and is kept. The cache mutex is held across the sweep, and a count of 1 cannot race upwards for the same reason.

**A blanket `clear()` would not be safe** — some buffers wrap pages owned elsewhere, so clearing could free memory out from under a live model. Refcount-directed eviction structurally cannot.

`resident_weight_eviction_frees_only_pages_no_model_still_owns` asserts both directions on one cache (a live owner's pages survive a sweep; a dropped owner's are reclaimed and reported), plus idempotency so a second unload cannot double-count.

## Scope, and what is not claimed

Only `q8_wire_nocopy_buffers`. The other four permanent maps hold GPU *copies* keyed by a source `(ptr, len)` with no owner handle to test, so nothing there can distinguish a live entry from a dead one; reclaiming them needs a per-model owner and is a separate change. The no-copy map is where the GB-scale weights live on the default `serve` path.

- **Zero effect in a one-model process** — nothing is reclaimable while the only model is live, which is the shape every published throughput number uses.
- **No decode tok/s change.** This is a residency fix, not a speed fix.

## Gates

`cargo test --release --all-targets` 3067 passed / 0 failed / 55 ignored; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean; `audit-evidence-bundle-privacy --strict` 0 findings. `src/api/mod.rs` untouched, so the renderer seal is unaffected.

Receipts and reproduction script: `qa/evidence-bundles/macos-resident-cache-eviction-20260909/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
