### PR TITLE
perf(metal): let a Q8_0 model keep attention-as-matmul on an F16 KV primary

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,6 +87,25 @@ token for token; leave it unset when it does not. It additionally requires
 `CAMELID_METAL_KQUANT_MM` (already on by default), and does nothing on its own.
 Receipts: `qa/evidence-bundles/metal-kquant-attn-mm-20260909/`.
 
+### Trading prefill for KV memory on Q8_0 models (macOS/Metal)
+
+A Q8_0 model keeps an F32 resident KV cache by default. `CAMELID_METAL_KV_DTYPE=f16`
+switches it to a half primary, which halves the KV footprint.
+
+Measured on an M4 / 16 GiB with Llama-3.2-3B-Instruct-Q8_0: **597 MB saved** at ~4200
+positions (6554 MB → 5957 MB physical footprint), against **~11% slower prefill** on a
+2900-token prompt (4.53 s → 5.03 s). Decode is unchanged (29.9 vs 30.0 tok/s) and
+generated text was identical on every prompt compared.
+
+The saving scales with context and layer count, so it matters most where memory is the
+binding constraint — a long-context 8B on a 16 GiB machine — and least on short prompts,
+where there is little KV to halve and the prefill cost still applies.
+
+This is off by default. Prior to the `all_q8` admission in `use_attn_mm` it was a much
+worse deal (2.24x prefill, because an F16 primary silently lost the attention-as-matmul
+lane); the numbers above are on a tree that has it. Receipts:
+`qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/`.
+
 ## Production HTTP policy
 
 Anonymous loopback serving remains the default. A non-loopback address has to answer two separate

--- a/qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/README.md
+++ b/qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/README.md
@@ -1,0 +1,43 @@
+# Q8_0 on an F16 KV primary: making the option real, and measuring it
+
+`results.txt` has the numbers. `q8kv-probe.sh` produces the speed table,
+`kvmem.sh` the footprint.
+
+## The exclusion
+
+`use_attn_mm` gated the attention-as-matmul prefill behind
+`(!self.kv16 || (use_kq_mm && kquant_attn_mm_prefill_enabled()))`. A Q8_0 model on an F16
+primary satisfies neither arm — it is `kv16`, and it is not `use_kq_mm` — so it lost a
+lane it *already had* on its F32 primary.
+
+That is a pure loss rather than a trade. `all_q8` is admitted below in the very next
+conjunct for the same reason it is admitted here: a Q8_0 model already runs this path by
+default and already accepts the half-staged scores it implies. Moving it onto an F16
+primary changes where the half K/V is read from, not whether the trade is taken. And the
+binding was already in place — `attn_k16`/`attn_v16` take `&self.cache_k[i]` when
+`self.kv16`.
+
+## Why the first number was wrong
+
+The first measurement put the F16 primary at **42.7 s** against 4.53 s. That is a real
+observation and a misleading one: about 32 s of it was a partial prompt-prefix-cache hit
+falling to the CPU dense forward — a separate defect with nothing to do with KV dtype.
+Attributing it here would have condemned the wrong thing.
+
+On a tree carrying that fix, the exclusion costs **2.24x**, which is exactly the "~2.2x"
+already recorded on `KQUANT_LANE_ENGAGED`. With this clause it is **1.11x**.
+
+## The stale half of the existing warning
+
+That same comment says the change cost "~26% decode and ~2.2x prefill". The prefill half
+reproduces. **The decode half does not** — 29.94/30.02 f32 against 29.98/30.03 f16, which
+is no difference. Split-K decode attention gained kv16-primary support after the note was
+written. Worth knowing, because that warning is the reason nobody revisits this.
+
+## What is left as a decision
+
+With the exclusion gone the F16 primary costs **~11% prefill** and **0% decode**, produces
+**identical output**, and saves **597 MB** on a 3B at ~4200 positions.
+
+This PR does not flip the default. It makes `CAMELID_METAL_KV_DTYPE=f16` a real option
+instead of a 2.24x trap, and puts numbers under the choice.

--- a/qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/kvmem.sh
+++ b/qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/kvmem.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# What does the F16 KV primary actually save? Grow the KV cache with a deep prompt, then
+# read physical footprint. The saving is the whole point of #2, so measure it rather than
+# quoting arithmetic.
+set -uo pipefail
+BIN="$HOME/camelid-memctx/camelid-both"
+MODEL="$HOME/models/Llama-3.2-3B-Instruct-Q8_0.gguf"
+for arm in f32:default f16:f16; do
+  lbl="${arm%%:*}"; dt="${arm##*:}"; port=$((8230 + RANDOM % 40))
+  out="$HOME/camelid-memctx/kvmem-$lbl"; mkdir -p "$out"
+  if [ "$dt" = "default" ]; then "$BIN" serve --addr 127.0.0.1:$port --model "$MODEL" >"$out/o" 2>"$out/e" &
+  else CAMELID_METAL_KV_DTYPE=f16 "$BIN" serve --addr 127.0.0.1:$port --model "$MODEL" >"$out/o" 2>"$out/e" & fi
+  srv=$!
+  for _ in $(seq 1 300); do curl -s "http://127.0.0.1:$port/v1/health" 2>/dev/null | grep -q '"generation_ready":true' && break; sleep 1; done
+  fp() { footprint -p "$srv" 2>/dev/null | grep -iE "phys_footprint|Physical footprint" | tail -1 | grep -oE "[0-9.]+ *[KMG]B?" | tail -1; }
+  python3 - "$port" >/dev/null <<'PY'
+import json,sys,urllib.request
+base='http://127.0.0.1:'+sys.argv[1]
+V=['alpha','beta','gamma','delta','epsilon','zeta','eta','theta']
+s=21; o=[]
+for _ in range(3200):
+    s=(s*1103515245+12345)&0xFFFFFFFF; o.append(V[s%len(V)])
+m=json.load(urllib.request.urlopen(base+'/v1/models',timeout=30))['data'][0]['id']
+b=json.dumps({'model':m,'messages':[{'role':'user','content':'Notes:\n'+' '.join(o)+'\nWrite at length.'}],
+              'temperature':0,'max_tokens':200}).encode()
+r=urllib.request.Request(base+'/v1/chat/completions',data=b,headers={'Content-Type':'application/json'})
+urllib.request.urlopen(r,timeout=1800).read()
+PY
+  sleep 4
+  printf '%-6s deep-context footprint: %s\n' "$lbl" "$(fp)"
+  kill $srv 2>/dev/null; for _ in $(seq 1 30); do kill -0 $srv 2>/dev/null || break; sleep 1; done; kill -9 $srv 2>/dev/null
+  sleep 20
+done

--- a/qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/q8kv-probe.sh
+++ b/qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/q8kv-probe.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Would a Q8_0 model be better or worse on an F16 KV primary?
+#
+# No code change needed: CAMELID_METAL_KV_DTYPE=f16 IS that override. metal.rs records
+# this having been tried before and costing "~26% decode and ~2.2x prefill on a 2k-token
+# Q8_0 run" -- but split-K has since gained kv16-primary support, so the decode half may
+# be stale. Measure rather than assume, in both directions.
+#
+# ABBA. One server per arm (the format latches in a OnceLock). Decode tok/s from a long
+# generation on a short prompt; prefill from TTFT on a long prompt.
+set -uo pipefail
+BIN="$HOME/camelid-memctx/camelid"      # stock origin/main
+MODEL="$HOME/models/Llama-3.2-3B-Instruct-Q8_0.gguf"
+
+run_arm() {
+  local label="$1" dtype="$2" port="$3"
+  local out="$HOME/camelid-memctx/q8kv-$label"; mkdir -p "$out"
+  if [ "$dtype" = "default" ]; then
+    "$BIN" serve --addr 127.0.0.1:$port --model "$MODEL" >"$out/serve.out" 2>"$out/serve.err" &
+  else
+    CAMELID_METAL_KV_DTYPE="$dtype" "$BIN" serve --addr 127.0.0.1:$port --model "$MODEL" >"$out/serve.out" 2>"$out/serve.err" &
+  fi
+  local srv=$!
+  for _ in $(seq 1 300); do curl -s "http://127.0.0.1:$port/v1/health" 2>/dev/null | grep -q '"generation_ready":true' && break; sleep 1; done
+  python3 - "$port" "$label" <<'PY'
+import json,sys,time,urllib.request
+base='http://127.0.0.1:'+sys.argv[1]; lbl=sys.argv[2]
+V=['alpha','beta','gamma','delta','epsilon','zeta','eta','theta','iota','kappa','lambda','sigma','tau','omega','rho','phi']
+def filler(sd,n):
+    s=sd&0xFFFFFFFF; o=[]
+    for _ in range(n):
+        s=(s*1103515245+12345)&0xFFFFFFFF; o.append(V[s%len(V)])
+    return ' '.join(o)
+m=json.load(urllib.request.urlopen(base+'/v1/models',timeout=30))['data'][0]['id']
+def go(prompt,maxtok):
+    b=json.dumps({'model':m,'messages':[{'role':'user','content':prompt}],
+                  'temperature':0,'max_tokens':maxtok,'stream':False}).encode()
+    r=urllib.request.Request(base+'/v1/chat/completions',data=b,headers={'Content-Type':'application/json'})
+    t=time.time()
+    with urllib.request.urlopen(r,timeout=900) as resp: j=json.load(resp)
+    return (time.time()-t)*1000, j['usage']['completion_tokens'], j['choices'][0]['message']['content']
+go('Hi.',8)  # warm
+# DECODE: short prompt, long generation -> wall is dominated by decode
+ms,ntok,_=go('Write a long detailed essay about the history of the printing press.',256)
+print(json.dumps({'arm':lbl,'metric':'decode','ms':round(ms,1),'tokens':ntok,'tok_per_s':round(ntok/(ms/1000),2)}),flush=True)
+# PREFILL: long prompt, tiny generation -> wall is dominated by prefill
+for w in (700,2200):
+    ms,_,txt=go('Notes:\n'+filler(21,w)+'\nAck.',4)
+    print(json.dumps({'arm':lbl,'metric':f'prefill-{w}w','ms':round(ms,1),'text':txt[:60]}),flush=True)
+# SHORT-CONTEXT PARITY: below 128 positions the f32 primary is read directly
+for w in (20,40):
+    ms,_,txt=go('Notes: '+filler(31,w)+'\nAck.',24)
+    print(json.dumps({'arm':lbl,'metric':f'short-{w}w','ms':round(ms,1),'text':txt[:120]}),flush=True)
+PY
+  kill $srv 2>/dev/null; for _ in $(seq 1 30); do kill -0 $srv 2>/dev/null || break; sleep 1; done; kill -9 $srv 2>/dev/null
+  sleep 20
+}
+run_arm f32-1 default 8180
+run_arm f16-1 f16     8181
+run_arm f16-2 f16     8182
+run_arm f32-2 default 8183

--- a/qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/results.txt
+++ b/qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/results.txt
@@ -1,0 +1,56 @@
+=========================================================================
+What an F16 KV primary costs a Q8_0 model, and what it saves.
+M4 / 16 GiB, Llama-3.2-3B-Instruct-Q8_0, ABBA (f32, f16, f16, f32).
+The F16 primary is selected with CAMELID_METAL_KV_DTYPE=f16 -- no default is
+changed by this PR.
+-------------------------------------------------------------------------
+WITH THIS CLAUSE (and the partial-prefix-hit fix):
+
+  metric               f32 r1    f32 r2    f16 r1    f16 r2    ratio
+  decode tok/s          29.94     30.02     29.98     30.03    1.00
+  prefill 700w  (ms)     1518      1521      1677      1674    1.10x
+  prefill 2200w (ms)     4532      4540      5036      5031    1.11x
+  short 20w     (ms)     1006      1008      1010      1013    1.00
+  short 40w     (ms)     1016      1019      1024      1023    1.01
+
+  Generated text identical across all arms on every prompt.
+
+MEMORY, measured with `footprint` after growing the cache on a ~4200-position
+prompt:
+
+  f32 primary   6554 MB
+  f16 primary   5957 MB      -> 597 MB saved
+
+=========================================================================
+HOW THE PRIOR "9.4x" DECOMPOSES
+   A first run measured the f16 arm at 42.7 s on the 2200w prompt. That figure
+   is real but is TWO separate defects stacked, only one of which is this one:
+
+     42.70 s   stock origin/main, F16 primary
+              -32.5 s   partial prompt-prefix-cache hit falling to the CPU dense
+                        forward (fixed separately; nothing to do with KV dtype)
+     10.15 s   -> 2.24x vs the 4.53 s F32 baseline. THIS is the attention-as-matmul
+                        exclusion, and it reproduces the "~2.2x" recorded on
+                        KQUANT_LANE_ENGAGED.
+              - 5.1 s   this clause
+      5.03 s   -> 1.11x
+
+   Reporting the 42.7 s as the cost of the KV dtype would have been wrong, and
+   the two must be measured on a tree carrying both fixes to see either clearly.
+
+=========================================================================
+ON THE STALE WARNING
+   The KQUANT_LANE_ENGAGED comment says moving Q8_0 onto a half KV cache "cost
+   ~26% decode and ~2.2x prefill". The prefill half reproduces exactly. The
+   DECODE half does not: 29.94/30.02 (f32) against 29.98/30.03 (f16) is no
+   difference at all. Split-K decode attention gained kv16-primary support after
+   that note was written, so that half of the warning is now out of date.
+
+=========================================================================
+WHAT THIS PR DOES AND DOES NOT DO
+   DOES: remove the exclusion, so a Q8_0 model on an F16 primary keeps the
+   attention-as-matmul prefill it already had on its F32 primary. This makes
+   CAMELID_METAL_KV_DTYPE=f16 a usable option instead of a 2.24x trap.
+
+   DOES NOT: change any default. Whether 597 MB is worth 11% prefill is a
+   product decision, and it is now a decision that can be made on numbers.

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -40455,11 +40455,25 @@ impl ResidentDecodeState {
         let use_attn_mm = (!has_moe || (moe_prefill_mm_enabled() && moe_prefill_grouped_enabled()))
             // An F16 primary IS the half cache this path reads, exactly as it is for the
             // split-K decode attention: `attn_k16`/`attn_v16` below bind the primary
-            // instead of the (empty) mirrors. Scoped to the K-quant MM lane rather than
-            // opened for every kv16 primary, so the blast radius is the lane being
-            // measured -- a Q8_0 model forced to `CAMELID_METAL_KV_DTYPE=f16` keeps its
-            // current behaviour.
-            && (!self.kv16 || (use_kq_mm && kquant_attn_mm_prefill_enabled()))
+            // instead of the (empty) mirrors.
+            //
+            // `all_q8` is admitted here for the same reason it is admitted below: a Q8_0
+            // model already runs this path by default on its F32 primary, and already
+            // accepts the half-staged scores that come with it. Being moved onto an F16
+            // primary does not change that trade -- it only changes where the half K/V is
+            // read from -- so excluding it was a pure loss.
+            //
+            // Measured on an M4 / 16 GiB with Llama-3.2-3B-Instruct-Q8_0 under
+            // `CAMELID_METAL_KV_DTYPE=f16`, ~2900-token prompt, against the 4.53 s F32
+            // default. Without this clause the F16 primary took 10.15 s, a 2.24x prefill
+            // regression -- which is the "~2.2x" the KQUANT_LANE_ENGAGED comment records,
+            // reproduced. With it, 5.03 s: 1.11x, with decode and output unchanged.
+            //
+            // (A first measurement of the same case read 42.7 s. That was NOT this
+            // exclusion: ~32 s of it was the partial-prefix-cache hit falling to the CPU
+            // dense forward, fixed separately. Worth stating because the two stack, and
+            // the larger number is the one an unpatched tree will show.)
+            && (!self.kv16 || all_q8 || (use_kq_mm && kquant_attn_mm_prefill_enabled()))
             && (!self.kvq8 || stage_q8_kv)
             && (!stage_q8_kv || q8_stage_bytes.is_some())
             // A K-quant model staged onto the MM lane has the same half activation stream
@@ -40472,8 +40486,9 @@ impl ResidentDecodeState {
             // `attn_k16`/`attn_v16` selection below takes `&self.cache_k[i]` when
             // `self.kv16`, i.e. the primary IS the half cache, exactly as the upper
             // comment says. (Under `kv16 || kvq8` the f16 mirrors are `Vec::new()`, so
-            // binding those instead would have been the bug.) What the conjunct still
-            // excludes is a Q8_0 model on an F16 primary, which is not `use_kq_mm`.
+            // binding those instead would have been the bug.) A Q8_0 model on an F16
+            // primary is admitted by the `all_q8` arm added above, for the reason given
+            // there, so the conjunct now excludes nothing that reaches this lane.
             && (all_q8 || (use_kq_mm && kquant_attn_mm_prefill_enabled()))
             && mm_prefill_enabled()
             && !has_qk_norm


### PR DESCRIPTION
## The exclusion

`use_attn_mm` gated the attention-as-matmul prefill behind `(!self.kv16 || (use_kq_mm && kquant_attn_mm_prefill_enabled()))`. A Q8_0 model on an F16 primary satisfies neither arm — it *is* `kv16`, and it is not `use_kq_mm` — so it lost a lane it **already had** on its F32 primary.

That is a pure loss rather than a trade. `all_q8` is admitted in the very next conjunct for the same reason it belongs here: a Q8_0 model already runs this path by default and already accepts the half-staged scores it implies. Moving it onto an F16 primary changes *where the half K/V is read from*, not whether the trade is taken. The binding was already in place — `attn_k16`/`attn_v16` take `&self.cache_k[i]` when `self.kv16`.

**No defaults change.** This makes `CAMELID_METAL_KV_DTYPE=f16` a usable option instead of a 2.24x trap.

## Measured

M4 / 16 GiB, Llama-3.2-3B-Instruct-Q8_0, ABBA (f32, f16, f16, f32):

| metric | f32 r1 | f32 r2 | f16 r1 | f16 r2 | ratio |
|---|---|---|---|---|---|
| decode tok/s | 29.94 | 30.02 | 29.98 | 30.03 | **1.00** |
| prefill 700w (ms) | 1518 | 1521 | 1677 | 1674 | 1.10x |
| prefill 2200w (ms) | 4532 | 4540 | 5036 | 5031 | **1.11x** |
| short 20w (ms) | 1006 | 1008 | 1010 | 1013 | 1.00 |
| short 40w (ms) | 1016 | 1019 | 1024 | 1023 | 1.01 |

Generated text identical across all arms on every prompt.

Footprint (`footprint -p`) after growing the cache on a ~4200-position prompt: **6554 MB → 5957 MB, 597 MB saved.**

## Where a 9.4x first reading went

The same case first measured **42.7 s**. That is a real observation and a misleading one — it is two defects stacked, only one of which is this:

```
42.70 s   stock, F16 primary
         −32.5 s   a partial prompt-prefix-cache hit falling to the CPU dense forward
                   — a separate defect, nothing to do with KV dtype
10.15 s   → 2.24x vs the 4.53 s F32 baseline. THIS is the exclusion, and it
                   reproduces the "~2.2x" recorded on KQUANT_LANE_ENGAGED.
         − 5.1 s   this clause
 5.03 s   → 1.11x
```

Attributing the 42.7 s to KV dtype would have condemned the wrong thing. The two have to be measured on a tree carrying both fixes to see either clearly.

## The other half of that warning is stale

`KQUANT_LANE_ENGAGED` records that moving Q8_0 onto a half KV cache cost *"~26% decode and ~2.2x prefill"*. The prefill half reproduces exactly. **The decode half does not** — 29.94/30.02 against 29.98/30.03 is no difference at all — because split-K decode attention gained kv16-primary support after that note was written.

Worth surfacing, because that warning is plausibly the reason nobody has revisited this.

## What is left as a decision

With the exclusion gone, an F16 primary costs **~11% prefill** and **0% decode**, produces **identical output**, and saves **597 MB** on a 3B at ~4200 positions — scaling with context and layer count, so it matters most where memory is the binding constraint (a long-context 8B on a 16 GiB machine).

This PR deliberately does not flip the default. Whether 597 MB is worth 11% prefill is a product call, and it is now one that can be made on numbers rather than on a half-stale comment.

## Gates

`cargo test --release --all-targets` 3066 passed / 0 failed / 55 ignored; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean; `audit-evidence-bundle-privacy --strict` 0 findings. `src/api/mod.rs` untouched, so the renderer seal is unaffected.

Receipts and reproduction scripts: `qa/evidence-bundles/metal-q8-f16-kv-primary-20260909/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
