### PR TITLE
feat(ui): animate the Load button while a model is loading

### DIFF
--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -6,27 +6,63 @@ export function Button({
   iconRight = null,
   block = false,
   loading = false,
+  loadingVariant = 'spinner',
+  loadingLabel = '',
   disabled = false,
   className = '',
   children,
   type = 'button',
+  'aria-label': ariaLabel,
   ...rest
 }) {
+  const isBarLoading = loading && loadingVariant === 'bar'
+  const isSpinnerLoading = loading && loadingVariant !== 'bar'
+
   const classes = [
     'cx-btn',
     `cx-btn--${variant}`,
     `cx-btn--${size}`,
     block ? 'cx-btn--block' : '',
-    loading ? 'is-loading' : '',
-    !children ? 'cx-btn--icon-only' : '',
+    isSpinnerLoading ? 'is-loading' : '',
+    isBarLoading ? 'is-loading-bar' : '',
+    !children && !isBarLoading ? 'cx-btn--icon-only' : '',
     className,
   ].filter(Boolean).join(' ')
 
+  const resolvedLabel = loadingLabel || (typeof children === 'string' ? children : 'Loading…')
+
+  // Children of a button are presentational in ARIA, so nothing rendered inside
+  // the bar reaches assistive tech — the loading state has to live on the
+  // button's own accessible name. Disabling also blurs the button, so views that
+  // need this announced should additionally render an sr-only live region (see
+  // DownloadedModelsView).
+  const label = isBarLoading ? resolvedLabel : ariaLabel
+
   return (
-    <button type={type} className={classes} aria-busy={loading || undefined} disabled={disabled || loading} {...rest}>
-      {loading && <span className="cx-btn__spinner" aria-hidden="true" />}
+    <button
+      type={type}
+      className={classes}
+      aria-busy={loading || undefined}
+      aria-label={label}
+      disabled={disabled || loading}
+      {...rest}
+    >
+      {isSpinnerLoading && <span className="cx-btn__spinner" aria-hidden="true" />}
+      {isBarLoading && (
+        <span className="cx-btn__loadbar" aria-hidden="true">
+          <span className="cx-btn__loadbar-track">
+            <span className="cx-btn__loadbar-fill" />
+            <span className="cx-btn__loadbar-shimmer" />
+            <span className="cx-btn__loadbar-line" />
+          </span>
+          <span className="cx-btn__loadbar-content">
+            <span className="cx-btn__loadbar-dot" />
+            <span className="cx-btn__loadbar-label">{resolvedLabel}</span>
+          </span>
+        </span>
+      )}
       {!loading && icon && <span className="cx-btn__icon">{icon}</span>}
-      {children && <span className="cx-btn__label">{children}</span>}
+      {!isBarLoading && children && <span className="cx-btn__label">{children}</span>}
       {!loading && iconRight && <span className="cx-btn__icon">{iconRight}</span>}
     </button>
   )

--- a/frontend/src/styles/ui.css
+++ b/frontend/src/styles/ui.css
@@ -104,6 +104,186 @@
 .cx-btn--danger .cx-btn__spinner { color: var(--color-error); }
 .cx-btn { position: relative; }
 
+/* ---- Button: Graphic Load Bar ----
+   An indeterminate "something is happening" treatment for long actions
+   (loading a model). Built ONLY from the steel-blue interactive accent:
+   verified copper is the receipt-stamp color and a load in progress is not a
+   verified claim — see the status color doctrine in tokens.css.
+
+   Reduced motion is handled globally by the `*` rule in base.css; do not add a
+   local prefers-reduced-motion block here. The text label stays visible when
+   the animations are stopped, so the state is still readable. */
+.cx-btn.is-loading-bar {
+  position: relative;
+  overflow: hidden;
+  cursor: wait;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 40%, var(--color-border-strong));
+  background: color-mix(in srgb, var(--color-surface-subtle) 90%, #000);
+}
+
+/* The button is disabled while loading, and .cx-btn:disabled dims to 0.5 —
+   which would composite the whole bar AND its label at half strength, dropping
+   the label to ~2.1-2.8:1 against the card (AA needs 4.5:1 at this size). The
+   loading state is deliberate, not unavailable, so it keeps full opacity. */
+.cx-btn.is-loading-bar:disabled { opacity: 1; }
+
+.cx-btn__loadbar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  overflow: hidden;
+}
+
+.cx-btn__loadbar-track {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  overflow: hidden;
+}
+
+.cx-btn__loadbar-fill {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-accent) 22%, transparent) 0%,
+    /* 42% is the ceiling: above it the brightest gradient stop plus a stripe
+       band pushes the label under 4.5:1 in the dark theme. */
+    color-mix(in srgb, var(--color-accent) 42%, transparent) 50%,
+    color-mix(in srgb, var(--color-accent-hover) 30%, transparent) 100%
+  );
+  background-size: 200% 100%;
+  animation: cxBarGradientSweep 2.8s ease-in-out infinite alternate;
+}
+
+/* 22.63px tile is exact, not a magic number: a -45deg gradient across a
+   22.63px square has a 32px gradient line — precisely two 16px stripe
+   periods — so the tile repeats seamlessly and one animation cycle advances
+   by exactly one tile. Do not "round" it to 22 or 24. */
+.cx-btn__loadbar-fill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.06) 0,
+    rgba(255, 255, 255, 0.06) 8px,
+    transparent 8px,
+    transparent 16px
+  );
+  background-size: 22.63px 22.63px;
+  animation: cxBarStripes 1s linear infinite;
+}
+
+.cx-btn__loadbar-line {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: color-mix(in srgb, var(--color-border-soft) 80%, transparent);
+  overflow: hidden;
+}
+
+.cx-btn__loadbar-line::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 45%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--color-accent) 35%,
+    #ffffff 70%,
+    var(--color-accent) 100%
+  );
+  border-radius: var(--radius-pill);
+  box-shadow: 0 0 8px var(--color-accent),
+    0 0 14px color-mix(in srgb, var(--color-accent) 55%, transparent);
+  animation: cxBarRunner 1.5s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+.cx-btn__loadbar-shimmer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 45%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.22) 50%,
+    transparent 100%
+  );
+  transform: translateX(-150%) skewX(-20deg);
+  animation: cxBarShimmer 2s ease-in-out infinite;
+}
+
+.cx-btn__loadbar-content {
+  position: relative;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: var(--text-xs);
+  letter-spacing: 0.01em;
+  /* Halo, not drop-shadow: mixing toward --color-bg makes it dark on the dark
+     theme and light on the light one, so the label stays readable as the
+     gradient sweeps under it — without a second palette to keep in sync. */
+  text-shadow: 0 1px 2px color-mix(in srgb, var(--color-bg) 70%, transparent);
+  pointer-events: none;
+}
+
+.cx-btn__loadbar-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  box-shadow: 0 0 6px var(--color-accent);
+  animation: cxPulse 1.2s var(--ease-standard) infinite;
+  flex-shrink: 0;
+}
+
+.cx-btn__loadbar-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@keyframes cxBarRunner {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(250%); }
+}
+
+@keyframes cxBarStripes {
+  from { background-position: 0 0; }
+  to { background-position: 22.63px 0; }
+}
+
+@keyframes cxBarGradientSweep {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 100% 50%; }
+}
+
+@keyframes cxBarShimmer {
+  0% { transform: translateX(-150%) skewX(-20deg); }
+  60%, 100% { transform: translateX(250%) skewX(-20deg); }
+}
+
 /* ---- IconButton ---- */
 .cx-iconbtn {
   display: inline-grid;

--- a/frontend/src/styles/views.css
+++ b/frontend/src/styles/views.css
@@ -513,6 +513,10 @@
   border-color: color-mix(in srgb, var(--color-ready) 44%, var(--color-border-soft));
   box-shadow: inset 3px 0 0 var(--color-ready), var(--shadow-1);
 }
+.downloaded-model--loading {
+  border-color: color-mix(in srgb, var(--color-accent) 55%, var(--color-border-soft));
+  box-shadow: inset 3px 0 0 var(--color-accent), var(--shadow-1);
+}
 .downloaded-model__tags { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: var(--space-1); }
 .downloaded-model .cxv-card__foot {
   align-items: stretch;
@@ -527,6 +531,9 @@
   justify-content: flex-end;
 }
 .downloaded-model .cxv-card__actions .cx-btn { width: 100%; }
+/* Tracks are minmax(0, 160px) and shrink freely, so a bare 140px floor
+   overflows into the delete button on narrow cards. */
+.downloaded-model .cxv-card__actions .cx-btn.is-loading-bar { min-width: min(140px, 100%); }
 .downloaded-model .cxv-card__actions .cxv-danger { grid-column: 2; }
 .downloaded-empty {
   display: flex;

--- a/frontend/src/views/DownloadedModelsView.jsx
+++ b/frontend/src/views/DownloadedModelsView.jsx
@@ -320,6 +320,12 @@ export default function DownloadedModelsView({
         </Button>
       </div>
 
+      {/* The Load button is disabled while loading, which blurs it, so its name
+          change is never announced. This carries the state instead. */}
+      <span className="sr-only" role="status" aria-live="polite">
+        {modelAction.type === 'load' && modelAction.filename ? `Loading ${modelAction.filename}…` : ''}
+      </span>
+
       {!spine.local && spine.localLoading ? (
         <p className="lane-empty">Scanning the model folder…</p>
       ) : filteredModels.length ? (
@@ -335,9 +341,10 @@ export default function DownloadedModelsView({
             const generationCapable = isGenerationCapableModel(entry, runtime)
             const standaloneRuntime = embeddingOnly || generationCapable
             const actionBusy = Boolean(modelAction.filename)
+            const isModelLoading = modelAction.filename === entry.filename && modelAction.type === 'load'
             return (
               <article
-                className={`cxv-card downloaded-model${isActive ? ' downloaded-model--active' : ''}`}
+                className={`cxv-card downloaded-model${isActive ? ' downloaded-model--active' : ''}${isModelLoading ? ' downloaded-model--loading' : ''}`}
                 key={entry.filename}
               >
                 <div className="cxv-card__head">
@@ -391,7 +398,9 @@ export default function DownloadedModelsView({
                         size="sm"
                         icon={<IconPlay size={16} />}
                         onClick={() => load(entry)}
-                        loading={modelAction.filename === entry.filename && modelAction.type === 'load'}
+                        loading={isModelLoading}
+                        loadingVariant="bar"
+                        loadingLabel="Loading model…"
                         disabled={!canLoad || actionBusy || Boolean(deletingFilename)}
                         aria-label={`Load ${entry.filename}`}
                         title={canLoad ? 'Load this model into Camelid' : 'Camelid can’t run this model type'}


### PR DESCRIPTION
Replaces the circular spinner on a model card's **Load** button with an indeterminate load bar: a sweeping accent gradient, moving stripes, a shimmer pass, a luminous runner line, and a pulsing dot beside a "Loading model…" label. The card itself picks up a matching accent border while its model loads.

Opt-in per call site via `loadingVariant="bar"` — every other button in the app keeps the spinner, and the spinner path is untouched.

### Color

The bar is built **only** from the steel-blue interactive accent. Verified copper is the receipt-stamp color reserved for supported/verified claims (status doctrine in `tokens.css`), and a load in progress is not a verified claim.

### Contrast shapes the rest of it

- `.cx-btn:disabled` dims to `0.5`, and the button is disabled while loading — so the bar *and* its label would composite at half strength. The label measured **2.06–2.82:1** against the card, under the 4.5:1 AA floor for 12px text. A loading state is deliberate rather than unavailable, so it keeps full opacity.
- The mid gradient stop is capped at **42%** accent. Above that, the brightest point plus a stripe band puts the dark theme back under 4.5:1. It's commented in place so it doesn't get turned back up.

Worst case is now **4.94:1**, measured at every gradient stop in both themes:

```
dark   start 7.87  mid 4.94  end 6.01
light  start 8.38  mid 6.19  end 7.04
```

### Accessibility

Children of a `<button>` are presentational in ARIA, so nothing rendered inside the bar reaches assistive tech. The loading state moves to the button's own accessible name, and because disabling the button also blurs it, `DownloadedModelsView` carries an `sr-only` live region so the change is announced without focus.

Reduced motion is already handled globally by the `*` rule in `base.css`; the text label stays visible when animations stop, so the state is still readable.

### Notes

- The `22.63px` stripe tile is exact, not a magic number — a -45° gradient across that square has a 32px gradient line, precisely two 16px stripe periods, so it tiles seamlessly. Commented so it doesn't get "rounded".
- `min-width` on the loading button uses `min(140px, 100%)`; the actions grid is `minmax(0, 160px)` and shrinks freely, so a bare `140px` floor overflowed into the delete button on narrow cards.

### Verification

Full frontend CI suite run locally on this branch: `npm run build` + all 25 smokes pass, including `smoke:contrast` and `smoke:ui`. `check-public-scrub.sh` and `cargo fmt --all -- --check` both clean.

No Rust changes, hence `[ci-os: linux]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)