### PR TITLE
perf(metal): reuse a conversation's GPU KV across turns instead of re-prefilling

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -2505,6 +2505,17 @@ pub struct LlamaInferenceSession {
     /// Lazily-built GPU resident-decode session (a transient on-GPU cache; rebuilt on demand
     /// and not part of the session's logical identity, so it is skipped by Clone/PartialEq/Debug).
     resident_decode: Option<metal_resident::ResidentDecodeState>,
+    /// The exact prompt whose KV rows `resident_decode` holds in `[0, len)`, or empty when
+    /// nothing is vouched for.
+    ///
+    /// This is the record prefix continuation needs: a KV row is a pure function of the
+    /// token prefix that produced it, so the next turn can reuse the leading run its prompt
+    /// shares with THIS one. Over-claiming is not a slow path, it is silently wrong output,
+    /// so the record is set only by a prefill that actually wrote those rows and is cleared
+    /// by anything that writes the cache another way. Skipped by Clone/PartialEq/Debug for
+    /// the same reason `resident_decode` is: a clone gets no engine, so it vouches for
+    /// nothing.
+    resident_tokens: Vec<u32>,
     /// CUDA analog of `resident_decode` (the GPU-resident decode engine on
     /// NVIDIA hardware). Same transient-cache role; skipped by Clone/PartialEq/Debug.
     /// When set, the session never takes the GPU-resident prefill/decode paths, keeping the
@@ -2548,6 +2559,21 @@ pub struct LlamaInferenceSession {
     /// True for a speculative draft-model session: routes its GPU resident engine to
     /// the dedicated drafter cache so draft + target models stay resident at once.
     is_drafter: bool,
+}
+
+/// Park the resident Metal engine instead of dropping it.
+///
+/// The API builds a fresh `LlamaInferenceSession` per request and lets it fall out of
+/// scope, so `Drop` is the only hook that catches every way a request can end — including
+/// the error paths, where dropping the engine is exactly what we want and parking refuses
+/// on its own (a failed prefill leaves the record and the watermark disagreeing).
+///
+/// A hollow placeholder from `take_for_step`, and every `clone()`, carry no engine, so this
+/// is a no-op for them.
+impl Drop for LlamaInferenceSession {
+    fn drop(&mut self) {
+        self.park_resident_metal_engine();
+    }
 }
 
 impl LlamaInferenceSession {
@@ -2616,6 +2642,7 @@ impl LlamaInferenceSession {
                 },
             ),
             resident_decode: self.resident_decode.take(),
+            resident_tokens: std::mem::take(&mut self.resident_tokens),
             resident_paths_disabled: self.resident_paths_disabled,
             cpu_kv_mirror_eager: self.cpu_kv_mirror_eager,
             resident_encode_ahead_enabled: self.resident_encode_ahead_enabled,
@@ -2708,6 +2735,7 @@ impl Clone for LlamaInferenceSession {
             weights: self.weights.clone(),
             kv_cache: self.kv_cache.clone(),
             resident_decode: None,
+            resident_tokens: Vec::new(),
             resident_paths_disabled: self.resident_paths_disabled,
             cpu_kv_mirror_eager: self.cpu_kv_mirror_eager,
             resident_encode_ahead_enabled: self.resident_encode_ahead_enabled,
@@ -2750,6 +2778,7 @@ impl LlamaInferenceSession {
             weights,
             kv_cache: LlamaKvCache::new(plan, kv_quant)?,
             resident_decode: None,
+            resident_tokens: Vec::new(),
             resident_paths_disabled: false,
             cpu_kv_mirror_eager: true,
             resident_encode_ahead_enabled: true,
@@ -2858,6 +2887,9 @@ impl LlamaInferenceSession {
             ));
         }
         self.resident_decode = None;
+        // The engine is gone, so nothing vouches for those rows any more. Leaving the
+        // record behind would let a later turn claim a prefix no engine holds.
+        self.resident_tokens.clear();
         self.kv_cache.rollback_to_position(position)
     }
 
@@ -13542,6 +13574,11 @@ pub fn reset_resident_caches() {
 pub fn reset_resident_caches() {
     #[cfg(target_os = "macos")]
     {
+        // Drop the parked resident engine FIRST. It holds this model's GPU KV cache and,
+        // more to the point, it is the thing standing between the weight buffers and the
+        // eviction sweep below — a parked engine outliving its model would keep its
+        // allocation referenced and make the sweep a no-op.
+        metal_resident::clear_parked_resident_metal();
         let freed = crate::metal::evict_unreferenced_resident_weights();
         if freed > 0 && std::env::var_os("CAMELID_RESIDENT_TRACE").is_some() {
             eprintln!(

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -9,6 +9,159 @@ use crate::metal;
 
 pub(super) type ResidentDecodeState = metal::ResidentDecodeState;
 
+/// The engine geometry a parked state was built for. Compared on reclaim so a state can
+/// only ever be handed to a session whose dimensions match it exactly — a key collision, or
+/// the same model id reloaded at different dimensions, must rebuild rather than reuse.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) struct ResidentMetalGeometry {
+    n_layers: usize,
+    n_heads: usize,
+    n_kv_heads: usize,
+    head_dim: usize,
+    hidden: usize,
+    ffn_dim: usize,
+}
+
+/// A resident Metal engine parked between requests, with the prompt its KV rows hold.
+///
+/// The API builds a fresh `LlamaInferenceSession` per request, so a session-owned engine
+/// dies at the end of every turn and the next turn re-prefills the whole conversation.
+/// CUDA does not have this problem because its engine lives in a process-global cache. This
+/// is the Metal equivalent, kept deliberately smaller: the session still OWNS the engine
+/// while it runs, and only hands it back here on the way out, so the ~30 sites that use
+/// `resident_decode` are untouched.
+struct ResidentMetalParking {
+    /// `LlamaInferenceSession::resident_cache_key` — the API sets it from the model id
+    /// precisely so the same model is recognised across separately-loaded weight Arcs.
+    key: u64,
+    geometry: ResidentMetalGeometry,
+    state: ResidentDecodeState,
+    /// The prompt whose rows `state` holds in `[0, tokens.len())`. `state.filled()` is kept
+    /// equal to this length when parking, so the record and the watermark cannot disagree.
+    tokens: Vec<u32>,
+}
+
+/// The single parking slot. One entry, like the CUDA engine cache: two models alternating
+/// will evict each other rather than both staying resident, which is the same trade that
+/// cache already makes and is what a 16 GiB unified-memory budget wants.
+fn resident_metal_park() -> &'static std::sync::Mutex<Option<ResidentMetalParking>> {
+    static PARK: std::sync::OnceLock<std::sync::Mutex<Option<ResidentMetalParking>>> =
+        std::sync::OnceLock::new();
+    PARK.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+/// Drop whatever is parked. Used when a model is released, and by tests that must not
+/// inherit another test's engine.
+pub(crate) fn clear_parked_resident_metal() {
+    *resident_metal_park()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner()) = None;
+}
+
+/// Hand a finished engine back for the next request, or drop it.
+///
+/// The two directions of disagreement between the record and the watermark are NOT
+/// symmetric, and treating them alike is what makes parking never fire:
+///
+/// * `filled > tokens.len()` is the ORDINARY case, not an error. Decode advances the
+///   watermark past the prompt, one row per generated token, so by the time a request ends
+///   the engine holds prompt + reply while the record names only the prompt. Those extra
+///   rows are real K/V, they simply have no name here, so the watermark is rewound to the
+///   record and they stop being vouched for. The next turn overwrites them anyway: its
+///   prompt continues from the end of THIS prompt, and the reply is re-prefilled as part of
+///   its suffix. (Recording generated tokens too would extend the reuse across the reply;
+///   that is a follow-up, not a correctness matter.)
+/// * `filled < tokens.len()` IS an error — the record claims rows the engine never wrote,
+///   which is what a failed prefill or a rewind leaves behind. Keep nothing.
+fn park_resident_metal(
+    key: u64,
+    geometry: ResidentMetalGeometry,
+    mut state: ResidentDecodeState,
+    tokens: Vec<u32>,
+) {
+    if tokens.is_empty() || state.filled() < tokens.len() {
+        return;
+    }
+    state.set_filled(tokens.len());
+    *resident_metal_park()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner()) = Some(ResidentMetalParking {
+        key,
+        geometry,
+        state,
+        tokens,
+    });
+}
+
+/// Take the parked engine when it belongs to this model AND was built at these dimensions.
+///
+/// Both halves matter. The key alone does not pin geometry — the same model id reloaded with
+/// a different context or layer range would collide — and handing a session an engine whose
+/// per-layer strides differ from its own would read another shape's rows as if they were
+/// this one's.
+fn reclaim_resident_metal(
+    key: u64,
+    geometry: ResidentMetalGeometry,
+) -> Option<(ResidentDecodeState, Vec<u32>)> {
+    let mut guard = resident_metal_park()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let matches = guard
+        .as_ref()
+        .is_some_and(|p| p.key == key && p.geometry == geometry);
+    if !matches {
+        return None;
+    }
+    guard.take().map(|p| (p.state, p.tokens))
+}
+
+/// Leading run two token sequences share.
+fn common_prefix_len(a: &[u32], b: &[u32]) -> usize {
+    a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+impl ResidentMetalGeometry {
+    fn of(state: &ResidentDecodeState) -> Self {
+        let (n_layers, n_heads, n_kv_heads, head_dim, hidden, ffn_dim) = state.geometry();
+        Self {
+            n_layers,
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            hidden,
+            ffn_dim,
+        }
+    }
+}
+
+impl super::LlamaInferenceSession {
+    /// Hand this session's resident Metal engine to the parking slot on the way out, so the
+    /// next turn of the same conversation can continue from the rows it already holds.
+    ///
+    /// Called from `Drop`, which is the only hook that catches every way a request ends —
+    /// the API builds a fresh session per request and simply lets it fall out of scope.
+    /// Everything that would make the handoff unsafe is refused rather than papered over:
+    /// no model identity, no engine, or a record that disagrees with the watermark.
+    pub(super) fn park_resident_metal_engine(&mut self) {
+        // Never park what can never be continued. Continuation is admitted only on an F32
+        // KV primary (see `metal::resident_kv_primary_is_half`), so on a half primary this
+        // would hold a GPU KV cache alive between requests to no purpose. Refusing here
+        // keeps that configuration byte-for-byte on its previous behaviour.
+        if metal::resident_kv_primary_is_half() {
+            return;
+        }
+        let Some(key) = self.resident_cache_key else {
+            return;
+        };
+        let Some(state) = self.resident_decode.take() else {
+            return;
+        };
+        let tokens = std::mem::take(&mut self.resident_tokens);
+        let geometry = ResidentMetalGeometry::of(&state);
+        park_resident_metal(key, geometry, state, tokens);
+    }
+}
+
 #[derive(Clone, Copy)]
 enum MetalSampleRequest {
     Greedy {
@@ -447,26 +600,87 @@ impl super::LlamaInferenceSession {
                 .as_ref()
                 .is_some_and(|g| g.rope_neox_pairing);
         let schedule = self.gemma3_resident_schedule(0..n_layers);
-        let mut session = match metal::ResidentDecodeState::new(
+        // Prefix continuation: an engine parked by an earlier turn of this conversation may
+        // already hold the leading rows this prompt needs. Reclaim it only when the model
+        // identity AND the geometry both match, then reuse the run its recorded prompt
+        // shares with this one.
+        //
+        // The claim is bounded three ways, and all three carry weight: by the RECORD (rows
+        // whose tokens we know), by `filled()` (rows the engine still vouches for), and by
+        // `n - 1` so the prefill still ends by writing the last position, which is the state
+        // the decode lane expects. Capture mode opts out — it has no continuation entry
+        // point, and a diagnostic path is not worth a second one.
+        let geometry = ResidentMetalGeometry {
             n_layers,
             n_heads,
-            n_kv,
+            n_kv_heads: n_kv,
             head_dim,
-            dims.embedding_length,
-            dims.feed_forward_length,
-            initial_positions,
-            kv_cap,
-            rms_eps,
-            split_half_pairing,
-            schedule,
-        ) {
-            Some(s) => s,
-            None => {
-                if trace {
-                    eprintln!("[resident-prefill] try_metal_resident_prefill declined at site 4");
+            hidden: dims.embedding_length,
+            ffn_dim: dims.feed_forward_length,
+        };
+        let reclaimed = self
+            .resident_cache_key
+            .and_then(|key| reclaim_resident_metal(key, geometry))
+            .and_then(|(mut state, parked)| {
+                // Decide the claim BEFORE committing to the engine. A reclaimed engine is
+                // only safe for a CONTINUATION: it carries the previous turn's KV, and a
+                // from-scratch prefill driven through one produced corrupt output where a
+                // fresh (zero-filled) engine was correct. So with nothing to reuse, drop it
+                // and take the ordinary build path.
+                let reuse = if capture_layer_ids.is_empty() && !metal::resident_kv_primary_is_half()
+                {
+                    common_prefix_len(&parked, token_ids)
+                        .min(state.filled())
+                        .min(n.saturating_sub(1))
+                } else {
+                    0
+                };
+                // Reuse has to be worth what it costs. A parked engine was sized for the
+                // prompt that built it, so continuing a much longer one through it forces a
+                // KV growth realloc — and growth reallocates, zero-fills and blits the
+                // whole cache behind a blocking wait. Measured: the server's own 10-token
+                // warm-up parked an engine whose 2 shared positions turn 1 then "reused",
+                // paying that growth to save two rows — 6.8 s against 2.1 s for simply
+                // building at the right size. A fresh engine is allocated for the prompt it
+                // will actually hold, so below this floor that is strictly better.
+                const MIN_REUSE_POSITIONS: usize = 256;
+                if reuse < MIN_REUSE_POSITIONS {
+                    return None;
                 }
-                return Ok(None);
+                // Drop the watermark to exactly the reused span BEFORE prefilling the rest,
+                // so a failure below leaves no claim on rows this prefill never wrote.
+                state.set_filled(reuse);
+                Some((state, reuse))
+            });
+        let mut reused = 0usize;
+        let mut session = match reclaimed {
+            Some((state, reuse)) => {
+                reused = reuse;
+                state
             }
+            None => match metal::ResidentDecodeState::new(
+                n_layers,
+                n_heads,
+                n_kv,
+                head_dim,
+                dims.embedding_length,
+                dims.feed_forward_length,
+                initial_positions,
+                kv_cap,
+                rms_eps,
+                split_half_pairing,
+                schedule,
+            ) {
+                Some(s) => s,
+                None => {
+                    if trace {
+                        eprintln!(
+                            "[resident-prefill] try_metal_resident_prefill declined at site 4"
+                        );
+                    }
+                    return Ok(None);
+                }
+            },
         };
 
         let session_us = session_started.elapsed().as_micros();
@@ -533,6 +747,74 @@ impl super::LlamaInferenceSession {
                     metal::gemma3_batch_prefill_rows(),
                 )
                 .map(|_| Vec::new())
+        } else if reused > 0 {
+            // Continue over the reused rows. The RoPE tables are indexed by batch row, so
+            // they are sliced to `[reused, n)` exactly as the embeddings are.
+            let hidden = dims.embedding_length;
+            let half_rope = cos_all.len() / n;
+            let continued = session
+                .prefill_tokens_from(
+                    &embeddings.data[reused * hidden..],
+                    n - reused,
+                    &layer_views,
+                    &cos_all[reused * half_rope..],
+                    &sin_all[reused * half_rope..],
+                    scale,
+                    reused,
+                )
+                .map(|_| Vec::new());
+            match continued {
+                Some(v) => Some(v),
+                // Continuation is refused off the attention-as-matmul lane. That is a
+                // correctness gate, not a failure: fall back to a cold full prefill of the
+                // whole prompt rather than dropping the request to the CPU. The rewind
+                // below is what makes the retry legitimate — the engine must claim nothing
+                // before a prefill that starts from empty.
+                None => {
+                    if trace {
+                        eprintln!(
+                            "[resident-prefill] continuation declined (reuse={reused}); \
+                             rebuilding for a full prefill"
+                        );
+                    }
+                    reused = 0;
+                    // REBUILD rather than rewind. A reclaimed engine is only safe on the
+                    // path prefix continuation was proven on; driving a from-scratch
+                    // prefill through one produced corrupt output (measured: turns 2+ of a
+                    // 3B-Q4_K_M chat degenerated to "!!!!" where a fresh engine was
+                    // correct, and a fresh engine differs exactly in carrying no prior KV).
+                    // `ResidentDecodeState::new` zero-fills, so a fresh engine restores the
+                    // from-empty precondition every non-continuation prefill assumes.
+                    let schedule = self.gemma3_resident_schedule(0..n_layers);
+                    match metal::ResidentDecodeState::new(
+                        n_layers,
+                        n_heads,
+                        n_kv,
+                        head_dim,
+                        dims.embedding_length,
+                        dims.feed_forward_length,
+                        initial_positions,
+                        kv_cap,
+                        rms_eps,
+                        split_half_pairing,
+                        schedule,
+                    ) {
+                        Some(fresh) => {
+                            session = fresh;
+                            session.prefill_tokens_with_layer_inputs(
+                                &embeddings.data,
+                                n,
+                                &layer_views,
+                                &cos_all,
+                                &sin_all,
+                                scale,
+                                capture_layer_ids,
+                            )
+                        }
+                        None => None,
+                    }
+                }
+            }
         } else {
             session.prefill_tokens_with_layer_inputs(
                 &embeddings.data,
@@ -573,6 +855,16 @@ impl super::LlamaInferenceSession {
         // GPU cache now holds positions 0..n; the resident decode continues this sequence.
         self.kv_cache.position = n;
         self.resident_decode = Some(session);
+        // Record the sequence those rows hold, so a later turn of this conversation can
+        // continue from it. Only a prefill that actually wrote them may set this.
+        self.resident_tokens = token_ids.to_vec();
+        if trace && reused > 0 {
+            eprintln!(
+                "[resident-prefill] prefix continuation: reused {reused} of {n} positions, \
+                 prefilled {}",
+                n - reused
+            );
+        }
         if trace {
             eprintln!("[resident-prefill] try_metal_resident_prefill OK");
         }
@@ -1136,6 +1428,11 @@ impl super::LlamaInferenceSession {
             }
             session.set_filled(position);
             self.resident_decode = Some(session);
+            // These rows were RESEEDED from the CPU KV cache, which stores f16-rounded
+            // values — not bit-identical to what a GPU prefill would have written. A later
+            // turn must not treat them as a known-good prefix, which is the whole reason
+            // prefix continuation never round-trips through the host. Stop vouching.
+            self.resident_tokens.clear();
         }
 
         // gemma3 FFN activation is GeGLU; every other arch on this lane is SiLU.
@@ -1829,5 +2126,101 @@ impl super::LlamaInferenceSession {
         _capture_layer_ids: &[usize],
     ) -> Result<Option<LlamaGreedyVerifyCapture>> {
         Ok(None)
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod parking_tests {
+    use super::*;
+
+    /// A minimal engine. `None` on a host with no Metal device, which skips the test.
+    fn tiny_state(hidden: usize) -> Option<ResidentDecodeState> {
+        metal::ResidentDecodeState::new(1, 1, 1, 32, hidden, 64, 8, 8, 1.0e-5, false, None)
+    }
+
+    /// The slot has exactly one writer in the test binary: this module. A session parks
+    /// only when `resident_cache_key` is set, and only the API sets it, so no other test
+    /// can leave an engine here or take this one.
+    #[test]
+    fn a_parked_engine_is_reclaimed_only_by_an_exact_key_and_geometry_match() {
+        clear_parked_resident_metal();
+        let Some(mut state) = tiny_state(32) else {
+            eprintln!("SKIP: no Metal device");
+            return;
+        };
+        state.set_filled(3);
+        let geometry = ResidentMetalGeometry::of(&state);
+        park_resident_metal(0xD00D, geometry, state, vec![7, 8, 9]);
+
+        assert!(
+            reclaim_resident_metal(0xBEEF, geometry).is_none(),
+            "another model's key must not take this engine"
+        );
+        let mut other = geometry;
+        other.hidden += 128;
+        assert!(
+            reclaim_resident_metal(0xD00D, other).is_none(),
+            "a geometry mismatch must rebuild, never reuse another shape's strides"
+        );
+
+        let (state, tokens) =
+            reclaim_resident_metal(0xD00D, geometry).expect("an exact match reclaims");
+        assert_eq!(tokens, vec![7, 8, 9], "the record must survive parking");
+        assert_eq!(
+            state.filled(),
+            3,
+            "the watermark must survive parking, or the next turn cannot bound its claim"
+        );
+        assert!(
+            reclaim_resident_metal(0xD00D, geometry).is_none(),
+            "reclaiming takes the engine: the slot must not hand the same one out twice"
+        );
+    }
+
+    /// Parking is refused when the record and the watermark disagree, because that is
+    /// exactly the state a failed prefill or a rewind leaves behind — rows the record
+    /// claims but the engine does not hold, or rows it holds but cannot name. Reusing
+    /// either as a known prefix is silently wrong output.
+    #[test]
+    fn an_engine_whose_record_disagrees_with_its_watermark_is_not_parked() {
+        clear_parked_resident_metal();
+        let Some(mut state) = tiny_state(32) else {
+            eprintln!("SKIP: no Metal device");
+            return;
+        };
+        state.set_filled(2);
+        let geometry = ResidentMetalGeometry::of(&state);
+        park_resident_metal(0xD00D, geometry, state, vec![7, 8, 9]);
+        assert!(
+            reclaim_resident_metal(0xD00D, geometry).is_none(),
+            "filled=2 against a 3-token record claims rows never written: drop, do not park"
+        );
+
+        // The opposite direction is ordinary, not an error: decode leaves the watermark
+        // past the prompt, and parking rewinds it to the record rather than refusing.
+        clear_parked_resident_metal();
+        let Some(mut state) = tiny_state(32) else {
+            return;
+        };
+        state.set_filled(6); // prompt of 3, then 3 generated tokens
+        let geometry = ResidentMetalGeometry::of(&state);
+        park_resident_metal(0xD00D, geometry, state, vec![7, 8, 9]);
+        let (state, tokens) = reclaim_resident_metal(0xD00D, geometry)
+            .expect("a decoded-past engine must still park: this is every real request");
+        assert_eq!(tokens, vec![7, 8, 9]);
+        assert_eq!(
+            state.filled(),
+            3,
+            "the watermark must be rewound to the record, so the next turn cannot claim              generated rows the record does not name"
+        );
+
+        clear_parked_resident_metal();
+        let Some(state) = tiny_state(32) else { return };
+        let geometry = ResidentMetalGeometry::of(&state);
+        park_resident_metal(0xD00D, geometry, state, Vec::new());
+        assert!(
+            reclaim_resident_metal(0xD00D, geometry).is_none(),
+            "an empty record vouches for nothing and must not park"
+        );
     }
 }

--- a/src/inference/metal_resident.rs
+++ b/src/inference/metal_resident.rs
@@ -52,6 +52,13 @@ fn resident_metal_park() -> &'static std::sync::Mutex<Option<ResidentMetalParkin
 
 /// Drop whatever is parked. Used when a model is released, and by tests that must not
 /// inherit another test's engine.
+///
+/// macOS-only: its sole caller is the macOS arm of `reset_resident_caches`, and nothing can
+/// park on a target with no resident engine, so on every other target this is dead code
+/// that `-D dead-code` rejects. The park/reclaim pair below stays unconditional because the
+/// `Drop` hook and the prefill both reach them on every target — they simply decline at
+/// runtime.
+#[cfg(target_os = "macos")]
 pub(crate) fn clear_parked_resident_metal() {
     *resident_metal_park()
         .lock()

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -45466,6 +45466,28 @@ impl ResidentDecodeState {
         None
     }
 
+    /// Non-macOS stub: there is no resident engine, so continuation never applies. Present
+    /// because `inference::metal_resident` compiles on every target.
+    #[allow(clippy::too_many_arguments)]
+    pub fn prefill_tokens_from(
+        &mut self,
+        _embeddings: &[f32],
+        _n_tokens: usize,
+        _layers: &[ResidentLayerWeights],
+        _cos_all: &[f32],
+        _sin_all: &[f32],
+        _scale: f32,
+        _base_position: usize,
+    ) -> Option<()> {
+        None
+    }
+
+    /// Non-macOS stub: zeroed geometry. Nothing can park on this target, so no caller ever
+    /// compares it.
+    pub fn geometry(&self) -> (usize, usize, usize, usize, usize, usize) {
+        (0, 0, 0, 0, 0, 0)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn prefill_tokens_windowed(
         &mut self,

--- a/src/metal.rs
+++ b/src/metal.rs
@@ -30501,6 +30501,31 @@ fn kv16_enabled() -> bool {
     resident_kv_format() == ResidentKvFormat::F16
 }
 
+/// True when the resident KV primary is the half cache rather than an F32 primary with
+/// half mirrors.
+///
+/// Read by prefix continuation, which is admitted ONLY on an F32 primary. Continuation is
+/// bit-identical there (`metal_prefix_continuation_is_bit_identical_to_a_cold_prefill`,
+/// and end-to-end on Llama-3.2-3B-Q8_0: four chat turns correct, reusing 1014/1170/1322 of
+/// each prompt). On an F16 primary the same path measurably produces WRONG OUTPUT --
+/// Llama-3.2-3B-Q4_K_M degenerates to "!!!!" from turn 2 while a cold prefill of the same
+/// conversation is correct -- and the cause is not yet understood. The scatter is not it:
+/// `kv_scatter_batch_kv16` already takes `base_position` and writes
+/// `(h * max_positions + base_position + t)`.
+///
+/// So this fails closed on the configuration that is not proven, rather than shipping a
+/// lane that is right for one KV format and silently wrong for the other.
+#[cfg(target_os = "macos")]
+pub fn resident_kv_primary_is_half() -> bool {
+    kv16_enabled()
+}
+
+/// Non-macOS stub: there is no resident Metal KV cache to describe.
+#[cfg(not(target_os = "macos"))]
+pub fn resident_kv_primary_is_half() -> bool {
+    false
+}
+
 #[cfg(target_os = "macos")]
 fn kvq8_enabled() -> bool {
     resident_kv_format() == ResidentKvFormat::Q8
@@ -39512,6 +39537,20 @@ impl ResidentDecodeState {
     /// Positions currently materialized in the KV cache (seeded + appended).
     pub fn filled(&self) -> usize {
         self.filled
+    }
+
+    /// The dimensions this engine was built for. Read when parking it between requests: a
+    /// parked engine may only be handed back to a session whose geometry matches exactly,
+    /// because every per-layer stride below is derived from these.
+    pub fn geometry(&self) -> (usize, usize, usize, usize, usize, usize) {
+        (
+            self.n_layers,
+            self.n_heads,
+            self.n_kv_heads,
+            self.head_dim,
+            self.hidden,
+            self.ffn_dim,
+        )
     }
 
     /// Whether THIS engine's KV survives a GPU -> CPU -> GPU round trip unchanged.


### PR DESCRIPTION
## The problem

The API builds a fresh `LlamaInferenceSession` per request, so the Metal resident engine — and the GPU KV it holds — died at the end of every turn, and turn N re-prefilled the whole conversation. CUDA does not have this problem because its engine lives in a process-global cache; its own comment says why: *"the API server clones a fresh session per request, so this can't live in the session."*

#739 stopped the bleeding (it declined a prefix-cache hit that would fall to the CPU). #743 made continuation expressible. This makes it reachable.

## Measured

M4 / 16 GiB, Llama-3.2-3B-Instruct-Q8_0, a 4-turn chat where each turn re-sends the whole conversation — the shape a chat client actually produces:

| turn | before | after | |
|---|---|---|---|
| 1 | 2092 ms | 2079 ms | unchanged |
| 2 | 2465 ms | **757 ms** | 3.3x |
| 3 | 2753 ms | **749 ms** | 3.7x |
| 4 | 3035 ms | **758 ms** | 4.0x |

Reusing 1014 / 1170 / 1322 positions of each prompt. **Turn latency goes flat where it used to grow with the conversation**, so the gap widens the longer the chat runs. Output correct on every turn.

## Design

The session still **owns** the engine while it runs and only hands it back on the way out, so the ~30 sites that use `resident_decode` are untouched.

The slot is keyed on `resident_cache_key` — which already exists, and which the API already sets from the model id precisely so one model is recognised across separately-loaded weight `Arc`s — **plus the engine geometry**, compared exactly so a key collision or a reload at different dimensions rebuilds rather than reusing another shape's strides.

Parking happens in `Drop`: the only hook that catches every way a request can end, including the error paths, where refusing on a disagreeing record is exactly what you want.

## It fails closed on an F16 KV primary

Continuation is bit-identical on an F32 primary and **measurably wrong on a half primary**: Llama-3.2-3B-Q4_K_M degenerates to `!!!!` from turn 2 where a cold prefill of the same conversation is correct.

The cause is not understood. The scatter is not it — `kv_scatter_batch_kv16` already takes `base_position` and writes `(h * max_positions + base_position + t)`. So that configuration **parks nothing and reclaims nothing**, and is byte-for-byte on its previous behaviour:

```
Q4_K_M with this change : 3409 / 4090 / 4751 / 5450 ms, correct
Q4_K_M control          : 3401 / 4088 / 4745 / 5456 ms, correct
```

Shipping a lane that is right for one KV format and silently wrong for the other is not worth the turns it would save.

**The bit-identity unit test did not catch that, and could not**: its fixture is Q8_0, so it only ever exercised the fused RoPE+scatter path. That gap is the reason the end-to-end run happened, and the reason this PR is scoped the way it is.

## Two other things the measurement found

**Parking never fired at first.** The guard demanded `filled == tokens.len()`, but decode advances `filled` one row per generated token — so by the end of a request *every real session* disagreed. The two directions are not symmetric: `filled >` the record is the **ordinary** case (rewind the watermark to the record), `filled <` is the error a failed prefill or a rewind leaves (keep nothing).

**Turn 1 regressed 3.3x.** The server's own 10-token warm-up parked an engine whose 2 shared positions turn 1 then "reused", paying a full KV growth realloc — which reallocates, zero-fills and blits behind a blocking wait — to save two rows. Continuation now needs 256 shared positions to be worth taking; below that, a fresh engine sized for the prompt it will actually hold is strictly better.

## Safety

The record is set only by a prefill that wrote those rows, and cleared by anything that writes the cache another way:

- the **CPU-KV reseed** in the decode path — those rows are f16-rounded, not what a GPU prefill would have written, which is the whole reason continuation never round-trips through the host;
- `rollback_to_position`, where the engine is dropped outright.

`reset_resident_caches` drops the parked engine, so a model unload frees its KV and a parked engine cannot keep #741's weight-eviction sweep from seeing its allocation.

Tests: `a_parked_engine_is_reclaimed_only_by_an_exact_key_and_geometry_match` (wrong key refused, wrong geometry refused, exact match reclaims, and the slot does not hand the same engine out twice) and `an_engine_whose_record_disagrees_with_its_watermark_is_not_parked` (both directions, including that the decode-past case *does* park with the watermark rewound — that being every real request).

`cargo test --release --all-targets`: **3073 passed, 0 failed, 55 ignored**. clippy `-D warnings` and fmt clean.

## Follow-ups

- Root-cause the F16-primary divergence and lift the gate.
- Record generated tokens too, extending reuse across the assistant reply rather than only the prompt.
- **#717 is the right foundation for making this robust.** Parking keeps an engine alive across requests, so an engine built under one process-global KV state can be reused under another — precisely #717's failure mode, reachable through a new door. Its `KvOperand` witness makes that structurally impossible; the globals do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
