### PR TITLE
feat(ui): keep regenerated replies side by side instead of replacing them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,21 @@ jobs:
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:continuation-browser
 
+      # Regenerated replies kept side by side. The contract under test is the
+      # mirroring one: the active version's fields are also the message's own,
+      # so every existing reader keeps working without knowing versions exist.
+      - name: Frontend reply variants smoke
+        if: ${{ !cancelled() }}
+        run: npm run smoke:variants
+
+      # What a pure test cannot reach: that a re-roll does not duplicate the
+      # question or show the model the answer it is replacing, that switching
+      # moves the telemetry with the text, and that the NEXT turn sends
+      # whichever version is selected.
+      - name: Frontend reply variants browser smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: npm run smoke:variants-browser
+
       # Covers frontend/src/lib/firstRunActivation.js and lib/modelActivation.js:
       # which model a fresh install is offered (supported_* rows only, fit-filtered,
       # smallest first) and the inspect -> load -> readiness protocol behind the one

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,8 @@
     "smoke:context-meter": "node scripts/context-meter-smoke.mjs",
     "smoke:context-compaction": "node scripts/context-compaction-smoke.mjs",
     "smoke:continuation": "node scripts/chat-continuation-smoke.mjs",
+    "smoke:variants": "node scripts/message-variants-smoke.mjs",
+    "smoke:variants-browser": "node scripts/message-variants-browser-smoke.mjs",
     "smoke:continuation-browser": "node scripts/chat-continuation-browser-smoke.mjs",
     "smoke:flow": "node scripts/flow-visual-smoke.mjs"
   },

--- a/frontend/scripts/message-variants-browser-smoke.mjs
+++ b/frontend/scripts/message-variants-browser-smoke.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/* Browser-level acceptance for regenerated-reply siblings.
+ *
+ * Requires `npm run build` first. One ephemeral loopback server serves the
+ * compiled app and deterministic fixtures; every cross-origin request is
+ * aborted.
+ *
+ * The pure smoke covers the data shape. What only a real render can prove:
+ *
+ *   - regenerating adds a version instead of replacing the reply
+ *   - the regeneration request does NOT duplicate the question and does NOT
+ *     show the model the answer it is meant to replace
+ *   - switching version moves the token counts with the text
+ *   - the NEXT turn sends whichever version is selected, which is the entire
+ *     point of keeping them
+ */
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { extname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { launchBrowser } from './lib/launch-browser.mjs'
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url))
+const distDir = resolve(scriptDir, '../dist')
+const ledgerPath = resolve(scriptDir, '../../ledger/camelid-ledger.json')
+const MODEL_FILENAME = 'Qwen3-0.6B-Q8_0.gguf'
+
+const PROMPT = 'Name one animal.'
+const FOLLOW_UP = 'Why that one?'
+const ANSWERS = ['ANSWER-ALPHA is a camel.', 'ANSWER-BRAVO is a llama.', 'ANSWER-CHARLIE is a vicuna.']
+const FOLLOW_UP_ANSWER = 'Because it suits the question.'
+
+const MIME = {
+  '.css': 'text/css', '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.png': 'image/png', '.svg': 'image/svg+xml', '.woff': 'font/woff', '.woff2': 'font/woff2',
+}
+
+if (!existsSync(distDir)) throw new Error(`missing ${distDir} -- run "npm run build" first`)
+
+const ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'))
+const capabilities = { ...ledger.capabilities, model_compatibility: ledger.model_rows.map((row) => row.contract) }
+
+const chatRequests = []
+const pageErrors = []
+const externalRequests = []
+let answerIndex = 0
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) })
+  res.end(payload)
+}
+function sendFile(res, path) {
+  const body = readFileSync(path)
+  res.writeHead(200, { 'Content-Type': MIME[extname(path)] || 'application/octet-stream' })
+  res.end(body)
+}
+async function readJsonBody(req) {
+  const chunks = []
+  for await (const chunk of req) chunks.push(chunk)
+  return chunks.length ? JSON.parse(Buffer.concat(chunks).toString('utf8')) : null
+}
+/* Each answer reports a DIFFERENT completion_tokens so a footer showing the
+   wrong version's telemetry is detectable, not merely suspected. */
+function sendChatCompletion(res, content, completionTokens) {
+  res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' })
+  res.socket?.setNoDelay(true)
+  res.flushHeaders()
+  const frame = (payload) => res.write(`data: ${JSON.stringify(payload)}\n\n`)
+  frame({ choices: [{ delta: { role: 'assistant' } }] })
+  frame({ choices: [{ delta: { content } }] })
+  frame({ choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 11, completion_tokens: completionTokens, total_tokens: 11 + completionTokens } })
+  res.write('data: [DONE]\n\n')
+  res.end()
+}
+function isFile(path) { try { return statSync(path).isFile() } catch { return false } }
+
+const server = createServer(async (req, res) => {
+  try {
+    const path = new URL(req.url, 'http://127.0.0.1').pathname
+    if (path === '/v1/health') {
+      return sendJson(res, 200, {
+        ok: true, engine: 'camelid', api_surface: 'full',
+        version: 'variants-browser-smoke', build: 'variants-browser-smoke',
+        backend: 'llama', model_family: 'qwen3', loaded_now: true, generation_ready: true,
+        active_model_id: MODEL_FILENAME, active_context_length: 4096,
+        max_prompt_tokens: 4096, max_generation_tokens: 8192,
+      })
+    }
+    if (path === '/v1/models') {
+      return sendJson(res, 200, { object: 'list', data: [{ id: MODEL_FILENAME, object: 'model', created: 0, owned_by: 'camelid', meta: { n_ctx_train: 32768, n_params: 600000000, size: 639446688 } }] })
+    }
+    if (path === '/api/capabilities') return sendJson(res, 200, capabilities)
+    if (path === '/api/models/catalog/downloads') return sendJson(res, 200, [])
+    if (path === '/api/models/local') {
+      return sendJson(res, 200, {
+        models_dir: 'models',
+        models: [{ filename: MODEL_FILENAME, size_bytes: 639446688, architecture: 'qwen3', quantization: 'Q8_0', admitted: true, oracle_qualified: true, chat_capable: true, generation_capable: true, context_length: 32768, lane_class: 'supported' }],
+      })
+    }
+    if (path === '/api/models/current') {
+      return sendJson(res, 200, { id: MODEL_FILENAME, path: `models/${MODEL_FILENAME}`, gguf: { metadata: { general: { architecture: 'qwen3', file_type: 7 } } }, tokenizer: { status: 'available' } })
+    }
+    if (path === '/api/web/research' && req.method === 'POST') {
+      return sendJson(res, 200, { status: 'skipped', triggered: false, reason: 'not_needed', sources: [], warnings: [] })
+    }
+    if (path === '/v1/chat/completions' && req.method === 'POST') {
+      const body = await readJsonBody(req)
+      chatRequests.push(body)
+      const lastUser = [...(body?.messages || [])].reverse().find((m) => m?.role === 'user')
+      const text = typeof lastUser?.content === 'string' ? lastUser.content : ''
+      if (text === FOLLOW_UP) return sendChatCompletion(res, FOLLOW_UP_ANSWER, 7)
+      const content = ANSWERS[Math.min(answerIndex, ANSWERS.length - 1)]
+      answerIndex += 1
+      return sendChatCompletion(res, content, 100 + answerIndex)
+    }
+    const filePath = resolve(distDir, `.${path}`)
+    if (path !== '/' && isFile(filePath)) return sendFile(res, filePath)
+    return sendFile(res, resolve(distDir, 'index.html'))
+  } catch (error) {
+    if (!res.writableEnded) sendJson(res, 500, { error: String(error) })
+  }
+})
+
+await new Promise((done) => server.listen(0, '127.0.0.1', done))
+const origin = `http://127.0.0.1:${server.address().port}`
+
+const browser = await launchBrowser({ purpose: 'the reply-variants browser smoke', headless: 'new' })
+const page = await browser.newPage()
+await page.setViewport({ width: 1280, height: 900, deviceScaleFactor: 1 })
+page.on('pageerror', (error) => pageErrors.push(String(error)))
+await page.setRequestInterception(true)
+page.on('request', (request) => {
+  const url = request.url()
+  if (url.startsWith('data:') || url.startsWith('blob:')) return request.continue()
+  try { if (new URL(url).origin === origin) return request.continue() } catch { /* abort below */ }
+  externalRequests.push(url)
+  return request.abort()
+})
+await page.evaluateOnNewDocument(() => {
+  if (window.sessionStorage.getItem('camelid.variantsSmokeInitialized')) return
+  window.localStorage.clear()
+  window.sessionStorage.setItem('camelid.variantsSmokeInitialized', 'true')
+})
+
+const idle = () => page.waitForFunction(() => (
+  !document.querySelector('.cxcomposer__stop') && !document.querySelector('.cxturn--assistant.is-streaming')
+), { timeout: 30000 })
+
+async function sendPrompt(prompt) {
+  await page.$eval('textarea[aria-label="Message Camelid"]:not([disabled])', (textarea, value) => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set
+    setter.call(textarea, value)
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }, prompt)
+  await page.waitForFunction(() => (
+    document.querySelector('button[aria-label="Send message"]')?.getAttribute('data-send-ready') === 'true'
+  ), { timeout: 30000 })
+  await page.click('button[aria-label="Send message"]')
+  await idle()
+}
+
+const view = () => page.evaluate(() => {
+  const turns = [...document.querySelectorAll('main[data-view="chat"] .cxturn--assistant')]
+  const last = turns[turns.length - 1]
+  return {
+    assistantTurns: turns.length,
+    text: last?.querySelector('.cxturn__body')?.textContent || '',
+    nav: last?.querySelector('.cxturn__variant-count')?.textContent || null,
+    footer: last?.querySelector('.cxturn__meta')?.textContent || '',
+  }
+})
+
+try {
+  await page.goto(origin, { waitUntil: 'domcontentloaded', timeout: 30000 })
+  await page.waitForSelector('main[data-view="chat"]', { timeout: 30000 })
+  await page.waitForSelector('textarea[aria-label="Message Camelid"]:not([disabled])', { timeout: 30000 })
+  await page.waitForFunction(() => (
+    document.querySelector('button[aria-label="Send message"]')?.getAttribute('data-send-ready') !== null
+  ), { timeout: 30000 })
+
+  /* ---- 1. an ordinary reply shows no navigation ------------------------- */
+  await sendPrompt(PROMPT)
+  const first = await view()
+  assert.match(first.text, /ANSWER-ALPHA/, 'the first answer renders')
+  assert.equal(first.nav, null, 'a reply with one version shows no version control')
+
+  /* ---- 2. regenerate ADDS a version ------------------------------------ */
+  await page.click('button[aria-label^="Regenerate response"]')
+  await idle()
+  const second = await view()
+  assert.equal(second.assistantTurns, 1, 'regenerating must not open a second reply bubble')
+  assert.match(second.text, /ANSWER-BRAVO/, 'the new answer is shown')
+  assert.doesNotMatch(second.text, /ANSWER-ALPHA/, 'and only one version is shown at a time')
+  assert.equal(second.nav, '2/2', 'the first answer is kept as a sibling')
+  assert.match(second.footer, /out 102/, 'the footer reports the NEW version’s output tokens')
+
+  /* ---- 3. the regeneration request was well formed --------------------- */
+  assert.equal(chatRequests.length, 2, 'regenerating issues exactly one more request')
+  const rerollRoles = chatRequests[1].messages.map((m) => m.role)
+  assert.equal(rerollRoles.at(-1), 'user', 'the re-roll ends on the question, so the model answers it again')
+  assert.equal(
+    chatRequests[1].messages.filter((m) => m.role === 'user' && m.content === PROMPT).length,
+    1,
+    'the question must appear ONCE — a re-roll adds no user turn of its own',
+  )
+  assert.equal(
+    chatRequests[1].messages.filter((m) => typeof m.content === 'string' && m.content.includes('ANSWER-ALPHA')).length,
+    0,
+    'the model must not be shown the answer it is being asked to replace',
+  )
+
+  /* ---- 4. switching moves the telemetry with the text ------------------ */
+  await page.click('button[aria-label="Previous version of this reply"]')
+  await page.waitForFunction(() => (
+    document.querySelector('.cxturn--assistant .cxturn__body')?.textContent.includes('ANSWER-ALPHA')
+  ), { timeout: 10000 })
+  const switched = await view()
+  assert.equal(switched.nav, '1/2', 'the position updates')
+  assert.match(switched.footer, /out 101/, 'and the footer reports THIS version’s tokens, not the other one’s')
+
+  /* ---- 5. the next turn sends the SELECTED version --------------------- */
+  await sendPrompt(FOLLOW_UP)
+  const followUp = chatRequests[2]
+  const assistantSent = followUp.messages.filter((m) => m.role === 'assistant')
+  assert.equal(assistantSent.length, 1, 'one reply is sent forward, not both versions')
+  assert.match(assistantSent[0].content, /ANSWER-ALPHA/, 'the SELECTED version is what the model continues from — the whole point of keeping them')
+  assert.doesNotMatch(assistantSent[0].content, /ANSWER-BRAVO/, 'the unselected version stays out of the prompt')
+
+  /* ---- 6. it survives a reload ------------------------------------------ */
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 30000 })
+  await page.waitForSelector('main[data-view="chat"] .cxturn--assistant', { timeout: 30000 })
+  const reloaded = await page.evaluate(() => {
+    const turn = document.querySelector('main[data-view="chat"] .cxturn--assistant')
+    return {
+      nav: turn?.querySelector('.cxturn__variant-count')?.textContent || null,
+      text: turn?.querySelector('.cxturn__body')?.textContent || '',
+    }
+  })
+  assert.equal(reloaded.nav, '1/2', 'versions and the selection survive a reload')
+  assert.match(reloaded.text, /ANSWER-ALPHA/, 'showing the version that was selected')
+
+  /* ---- 7. discarding ---------------------------------------------------- */
+  await page.click('button[aria-label="Discard this version"]')
+  await page.waitForFunction(() => (
+    document.querySelector('main[data-view="chat"] .cxturn--assistant .cxturn__variant-count') === null
+  ), { timeout: 10000 })
+  const afterDiscard = await page.evaluate(() => (
+    document.querySelector('main[data-view="chat"] .cxturn--assistant .cxturn__body')?.textContent || ''
+  ))
+  assert.match(afterDiscard, /ANSWER-BRAVO/, 'discarding the shown version selects the neighbour')
+  assert.equal(
+    await page.$('main[data-view="chat"] .cxturn--assistant .cxturn__variant-count'),
+    null,
+    'and with one version left the control disappears again',
+  )
+
+  assert.deepEqual(pageErrors, [], 'the page must not raise errors')
+  assert.deepEqual(externalRequests, [], 'the smoke must not reach anything off-origin')
+
+  console.log('message variants browser smoke passed')
+} finally {
+  await browser.close()
+  await new Promise((done) => server.close(done))
+}

--- a/frontend/scripts/message-variants-smoke.mjs
+++ b/frontend/scripts/message-variants-smoke.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/* Regenerated-reply siblings smoke.
+ *
+ * The contract that matters is the mirroring one: the active variant's fields
+ * are ALSO the message's own fields, so every existing reader (renderer,
+ * exporter, request builder, context estimator, telemetry footer) keeps
+ * working without knowing variants exist. If a switch ever leaves the message
+ * showing one alternative's text beside another's token counts, that is the
+ * bug this file is here to catch.
+ */
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const {
+    activeVariantIndexOf,
+    canBranchMessage,
+    hasVariants,
+    normalizeMessageVariants,
+    snapshotVariant,
+    variantCountOf,
+    variantsOf,
+    withActiveVariant,
+    withActiveVariantRemoved,
+    withVariantAppended,
+  } = await server.ssrLoadModule('/src/lib/messageVariants.js')
+
+  const reply = (content, extra = {}) => ({
+    id: 'm1',
+    role: 'assistant',
+    content,
+    finish_reason: 'stop',
+    usage: { prompt_tokens: 10, completion_tokens: content.length, total_tokens: 10 + content.length },
+    ...extra,
+  })
+
+  /* ---- migration: a pre-variants message IS its own first variant -------- */
+  const legacy = reply('the only answer')
+  assert.equal(variantCountOf(legacy), 1, 'a stored reply with no variants counts as one')
+  assert.equal(hasVariants(legacy), false, 'and does not claim to have alternatives')
+  assert.equal(activeVariantIndexOf(legacy), 0, 'its active index is its only index')
+  assert.equal(variantsOf(legacy)[0].content, 'the only answer', 'migration happens on read, with no rewrite of stored data')
+
+  /* ---- a variant is the message minus its identity ----------------------- */
+  const snapshot = snapshotVariant(reply('x', { camelid_receipt: { seal: 'abc' }, variants: ['ignored'] }))
+  assert.equal(snapshot.id, undefined, 'identity fields never enter a variant')
+  assert.equal(snapshot.role, undefined)
+  assert.equal(snapshot.variants, undefined, 'variants do not nest inside variants')
+  assert.deepEqual(snapshot.camelid_receipt, { seal: 'abc' }, 'everything else rides along — defining a variant by subtraction means new reply fields carry automatically')
+
+  /* ---- appending ---------------------------------------------------------- */
+  const two = withVariantAppended(legacy, reply('a second answer'))
+  assert.equal(variantCountOf(two), 2, 'regenerating adds a sibling rather than replacing')
+  assert.equal(activeVariantIndexOf(two), 1, 'and selects the new one')
+  assert.equal(two.content, 'a second answer', 'the message mirrors the active variant')
+  assert.equal(two.id, 'm1', 'the message keeps its identity across a re-roll')
+  assert.equal(two.variants[0].content, 'the only answer', 'the original is still there')
+
+  const three = withVariantAppended(two, reply('a third answer'))
+  assert.equal(variantCountOf(three), 3, 'a re-roll of a re-roll keeps the whole set rather than collapsing to two')
+  assert.deepEqual(
+    three.variants.map((v) => v.content),
+    ['the only answer', 'a second answer', 'a third answer'],
+    'siblings stay in generation order',
+  )
+
+  /* ---- switching mirrors EVERY field, not just the text ------------------ */
+  const back = withActiveVariant(three, 0)
+  assert.equal(back.content, 'the only answer', 'switching shows the chosen text')
+  assert.equal(
+    back.usage.completion_tokens,
+    'the only answer'.length,
+    'and its OWN token counts — a footer describing a different answer is the bug this guards',
+  )
+  assert.equal(back.active_variant, 0)
+  assert.equal(variantCountOf(back), 3, 'switching never loses siblings')
+  assert.equal(withActiveVariant(three, 99).active_variant, 2, 'an out-of-range index is clamped, not crashed')
+  assert.equal(withActiveVariant(three, -5).active_variant, 0, 'including below zero')
+
+  /* ---- discarding -------------------------------------------------------- */
+  const discarded = withActiveVariantRemoved(withActiveVariant(three, 1))
+  assert.equal(variantCountOf(discarded), 2, 'discarding removes exactly one')
+  assert.deepEqual(discarded.variants.map((v) => v.content), ['the only answer', 'a third answer'])
+  assert.equal(discarded.content, 'a third answer', 'and selects a neighbour')
+  const lastOne = withActiveVariantRemoved(legacy)
+  assert.equal(variantCountOf(lastOne), 1, 'the last remaining version cannot be discarded')
+  assert.equal(lastOne.content, 'the only answer', 'a reply with no content has nothing to render')
+
+  /* ---- eligibility -------------------------------------------------------- */
+  assert.equal(canBranchMessage(reply('done')), true)
+  assert.equal(canBranchMessage({ ...reply('x'), streaming: true }), false, 'a streaming reply is not finished')
+  assert.equal(canBranchMessage({ ...reply('x'), role: 'user' }), false, 'user turns use Edit & resend, which changes the question instead of re-asking it')
+  assert.equal(canBranchMessage(reply('   ')), false, 'an empty reply has nothing to re-roll')
+  assert.equal(canBranchMessage(null), false)
+
+  /* ---- storage normalization --------------------------------------------- */
+  const desynced = { id: 'm1', role: 'assistant', content: 'STALE', usage: { completion_tokens: 999 }, variants: [{ content: 'first' }, { content: 'second' }], active_variant: 1 }
+  const fixed = normalizeMessageVariants(desynced)
+  assert.equal(fixed.content, 'second', 'a hand-edited or restored transcript is re-synced to its active variant')
+  assert.equal(fixed.usage, undefined, 'stale mirrored fields the active variant does not carry are dropped, not left behind')
+  const singleton = normalizeMessageVariants({ id: 'm1', role: 'assistant', content: 'x', variants: [{ content: 'x' }], active_variant: 0 })
+  assert.equal(singleton.variants, undefined, 'a single-element variant list carries no alternatives and is not stored')
+  assert.equal(singleton.content, 'x', 'while the reply itself is untouched')
+  const userTurn = { id: 'u1', role: 'user', content: 'hi' }
+  assert.deepEqual(normalizeMessageVariants(userTurn), userTurn, 'user turns pass through unchanged')
+
+  /* ---- storage round trip ------------------------------------------------- */
+  const { normalizeStoredConversations } = await server.ssrLoadModule('/src/lib/conversationStorage.js')
+  const [restored] = normalizeStoredConversations([{ id: 'c1', messages: [desynced] }])
+  assert.equal(restored.messages[0].content, 'second', 'the same re-sync happens on every conversation load')
+
+  /* ---- the control ------------------------------------------------------- */
+  const { MessageTurn } = await server.ssrLoadModule('/src/components/chat/MessageTurn.jsx')
+  const renderTurn = (message, props = {}) => renderToStaticMarkup(React.createElement(MessageTurn, { message, ...props }))
+
+  const plain = renderTurn(reply('just one'))
+  assert.doesNotMatch(plain, /cxturn__variants/, 'a reply with one version shows no navigation — an ordinary thread is visually unchanged')
+
+  const branched = renderTurn(three, { onSelectVariant: () => {}, onDiscardVariant: () => {} })
+  assert.match(branched, /cxturn__variants/, 'a re-rolled reply shows navigation')
+  assert.match(branched, /3\/3/, 'labelled with position and total')
+  assert.match(branched, /aria-label="Reply 3 of 3"/, 'and announced to a screen reader')
+  assert.match(branched, /Previous version of this reply/, 'with a way back to the earlier answer')
+  assert.match(branched, /Discard this version/, 'and a way to drop the one shown')
+
+  const noDiscard = renderTurn(three, { onSelectVariant: () => {} })
+  assert.doesNotMatch(noDiscard, /Discard this version/, 'discard is withheld while a turn is in flight')
+  assert.match(noDiscard, /cxturn__variants/, 'but navigation stays usable — switching costs nothing')
+
+  /* Regenerate's promise differs by position, so its label must too. */
+  const keeps = renderTurn(reply('x'), { onRegenerate: () => {} })
+  assert.match(keeps, /keeps this one alongside it/, 'on the last reply, Regenerate says the answer is kept')
+  const replaces = renderTurn(reply('x'), { onRegenerate: () => {}, regenerateReplacesThread: true })
+  assert.match(replaces, /every turn after it/, 'mid-thread it warns that later turns go with it')
+
+  console.log('message variants smoke passed')
+} finally {
+  await server.close()
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -93,7 +93,8 @@ function App() {
     loadingModelId, registerForm, setRegisterForm,
     conversations, memories, filteredConversations, models, runtime, selectedConversation,
     selectedModel, selectedModelRunnable, selectedModelExperimental, latestAssistantMessage, pendingConversation,
-    createConversation, showNewChatLanding, sendMessage, resendFromMessage, continueFromMessage, stopGeneration, saveToMemory,
+    createConversation, showNewChatLanding, sendMessage, resendFromMessage, continueFromMessage,
+    regenerateAsVariant, selectMessageVariant, discardMessageVariant, stopGeneration, saveToMemory,
     createMemory, updateMemory, deleteMemory, renameConversation, deleteConversation, deleteAllConversations,
     activateModel, unloadCurrentModel,
     registerModel, loadDashboard, stoppingGeneration,
@@ -421,6 +422,9 @@ function App() {
               sendMessage={sendMessage}
               resendFromMessage={resendFromMessage}
               continueFromMessage={continueFromMessage}
+              regenerateAsVariant={regenerateAsVariant}
+              selectMessageVariant={selectMessageVariant}
+              discardMessageVariant={discardMessageVariant}
               stopGeneration={stopGeneration}
               sending={sending}
               receiptMode={receiptMode}

--- a/frontend/src/components/chat/MessageTurn.jsx
+++ b/frontend/src/components/chat/MessageTurn.jsx
@@ -1,10 +1,11 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import { Avatar } from '../ui/Avatar'
 import { EvidenceChip } from '../ui/EvidenceChip'
-import { IconCopy, IconCheck, IconRefresh, IconEdit, IconSearch, IconExternal, IconPlay } from '../ui/icons'
+import { IconCopy, IconCheck, IconRefresh, IconEdit, IconSearch, IconExternal, IconPlay, IconTrash } from '../ui/icons'
 import { AssistantMarkdown, copyText, hasOpenCodeFence } from '../../lib/markdown'
 import { capabilityStatusLabel } from '../../lib/capabilities'
 import { continuationCountOf } from '../../lib/chatContinuation'
+import { activeVariantIndexOf, variantCountOf } from '../../lib/messageVariants'
 import { formatModelLabel } from '../../lib/formatters'
 import { cleanLegacyDemoCapCopy } from '../../lib/conversationStorage'
 import {
@@ -99,6 +100,52 @@ function WebResearchSources({ research }) {
         </div>
       )}
     </details>
+  )
+}
+
+/* Sibling navigation for a re-rolled reply.
+
+   Placed at the START of the actions row, before Copy and Regenerate: it is
+   the control that tells the reader the other answers still exist, and it is
+   useless if they have to discover it after pressing the button that used to
+   destroy them. Hidden entirely at one variant, so an ordinary reply is
+   visually unchanged. */
+function VariantNav({ index, count, onSelect, onDiscard }) {
+  if (count <= 1) return null
+  const goto = (next) => onSelect?.((next + count) % count)
+  return (
+    <span className="cxturn__variants" role="group" aria-label={`Reply ${index + 1} of ${count}`}>
+      <button
+        type="button"
+        className="cxturn__variant-step"
+        onClick={() => goto(index - 1)}
+        aria-label="Previous version of this reply"
+        title="Previous version of this reply"
+      >
+        ‹
+      </button>
+      <span className="cxturn__variant-count" aria-live="polite">{index + 1}/{count}</span>
+      <button
+        type="button"
+        className="cxturn__variant-step"
+        onClick={() => goto(index + 1)}
+        aria-label="Next version of this reply"
+        title="Next version of this reply"
+      >
+        ›
+      </button>
+      {onDiscard && (
+        <button
+          type="button"
+          className="cxturn__variant-step cxturn__variant-discard"
+          onClick={() => onDiscard()}
+          aria-label="Discard this version"
+          title="Discard the version shown; the others are kept"
+        >
+          <IconTrash size={13} />
+        </button>
+      )}
+    </span>
   )
 }
 
@@ -270,7 +317,7 @@ function UserTurn({ message, messageContent, onEditResend }) {
   )
 }
 
-export const MessageTurn = memo(function MessageTurn({ message, generationElapsedSeconds, priorUserPrompt, onReusePrompt, onRegenerate, onEditResend, onContinue, tokenInspection = null, structuredRecord = null, toolCallRepeat = null }) {
+export const MessageTurn = memo(function MessageTurn({ message, generationElapsedSeconds, priorUserPrompt, onReusePrompt, onRegenerate, onEditResend, onContinue, onSelectVariant, onDiscardVariant, regenerateReplacesThread = false, tokenInspection = null, structuredRecord = null, toolCallRepeat = null }) {
   const [copied, setCopied] = useState(false)
   const copiedResetRef = useRef(null)
   const messageContent = cleanLegacyDemoCapCopy(message.content)
@@ -290,6 +337,11 @@ export const MessageTurn = memo(function MessageTurn({ message, generationElapse
   const showInterruptedWarning = message.role === 'assistant' && !assistantStreaming && message.finish_reason === 'interrupted'
   const showReusePromptAction = Boolean(priorUserPrompt) && (showErrorWarning || showInterruptedWarning)
   const showMessageActions = message.role === 'assistant' && Boolean(String(messageContent || '').trim())
+  const variantCount = variantCountOf(message)
+  const variantIndex = activeVariantIndexOf(message)
+  /* Navigation stays usable while another turn streams: switching is a local
+     edit with no request behind it. */
+  const showVariantNav = message.role === 'assistant' && !assistantStreaming && variantCount > 1
 
   useEffect(() => () => {
     if (copiedResetRef.current) window.clearTimeout(copiedResetRef.current)
@@ -373,8 +425,16 @@ export const MessageTurn = memo(function MessageTurn({ message, generationElapse
           <div className="cxturn__warning cxturn__warning--interrupted" role="status">Generation was interrupted before the reply finished.</div>
         )}
 
-        {(showMessageActions || showReusePromptAction) && (
+        {(showMessageActions || showReusePromptAction || showVariantNav) && (
           <div className="cxturn__actions" aria-label="Message actions">
+            {showVariantNav && (
+              <VariantNav
+                index={variantIndex}
+                count={variantCount}
+                onSelect={onSelectVariant}
+                onDiscard={onDiscardVariant}
+              />
+            )}
             {showMessageActions && (
               <button
                 type="button"
@@ -387,12 +447,20 @@ export const MessageTurn = memo(function MessageTurn({ message, generationElapse
               </button>
             )}
             {showMessageActions && onRegenerate && (
+              /* Two different promises behind one icon, so the label has to
+                 carry the difference: on the last reply the answer on screen
+                 is KEPT as a sibling; mid-thread it is replaced along with
+                 every turn after it. */
               <button
                 type="button"
                 className="cxturn__action cxturn__action--icon"
                 onClick={() => onRegenerate()}
-                title="Regenerate response"
-                aria-label="Regenerate response"
+                title={regenerateReplacesThread
+                  ? 'Regenerate — replaces this reply and every turn after it'
+                  : 'Regenerate — writes another answer and keeps this one alongside it'}
+                aria-label={regenerateReplacesThread
+                  ? 'Regenerate response, replacing this reply and every turn after it'
+                  : 'Regenerate response, keeping this one as another version'}
               >
                 <IconRefresh size={16} />
               </button>

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -19,6 +19,7 @@ import {
 import { getRuntimeRequestModelId, isExternalModel, modelRuntimeIdMatches } from '../lib/modelState'
 import { contractSamplingOverrides } from '../lib/samplingContract'
 import { CONTINUATION_INSTRUCTION, canContinueMessage, joinContinuation, mergeContinuedUsage } from '../lib/chatContinuation'
+import { canBranchMessage, variantsOf, withActiveVariant, withActiveVariantRemoved, withVariantAppended } from '../lib/messageVariants'
 import { inspectionAbsenceReason, inspectionForcesNonStreaming, inspectionRequestFields, normalizeInspection, readInspectionContract } from '../lib/tokenInspection'
 import { STRUCTURED_MODES, DEFAULT_SCHEMA, DEFAULT_GRAMMAR, readStructuredOutputContract, structuredOutputForcesNonStreaming, structuredOutputRequestFields, structuredOutputReadiness } from '../lib/structuredOutput'
 import { DEFAULT_TOOLS, detectRepeatedCall, normalizeToolCalls, readModelToolCapability, readToolContract, toolCallSignature, toolReadiness, toolRequestFields } from '../lib/toolCalling'
@@ -1192,6 +1193,46 @@ export function useDashboardData({ showNotice, clearNotice }) {
     return true
   }
 
+  /* Re-roll a reply, keeping the one already there as a sibling. Regenerate
+     was destructive before this: if the first answer was better it was gone,
+     which is exactly what makes people not press it. */
+  const regenerateAsVariant = async (messageId) => {
+    const target = (selectedConversation?.messages || []).find((message) => message.id === messageId)
+    if (!canBranchMessage(target)) return
+    await sendMessage({ variantOfMessageId: messageId })
+  }
+
+  /* Switching is a pure local edit -- no request, no model, no cost -- so it
+     stays available while another turn is streaming. */
+  const selectMessageVariant = (messageId, index) => {
+    persistConversations((current) => current.map((conversation) => (
+      conversation.id === selectedConversationIdRef.current
+        ? {
+            ...conversation,
+            messages: (conversation.messages || []).map((message) => (
+              message.id === messageId ? withActiveVariant(message, index) : message
+            )),
+          }
+        : conversation
+    )))
+  }
+
+  /* Discarding the shown alternative selects a neighbour. The last remaining
+     one cannot be discarded: a reply with no content has nothing to render. */
+  const discardMessageVariant = (messageId) => {
+    persistConversations((current) => current.map((conversation) => (
+      conversation.id === selectedConversationIdRef.current
+        ? {
+            ...conversation,
+            messages: (conversation.messages || []).map((message) => (
+              message.id === messageId ? withActiveVariantRemoved(message) : message
+            )),
+            updated_at: nowIso(),
+          }
+        : conversation
+    )))
+  }
+
   /* Resume a reply that stopped on the response budget. The gate checks, the
      model lane and the send path are the ordinary ones -- only the transcript
      bookkeeping differs, and that lives in sendMessage. */
@@ -1217,6 +1258,7 @@ export function useDashboardData({ showNotice, clearNotice }) {
       citations = [],
       truncateFromMessageId = null,
       continueFromMessageId = null,
+      variantOfMessageId = null,
     } = options
     /* Continuing supplies its own request text, so it never reads the composer
        and never blocks on an empty one. */
@@ -1224,11 +1266,34 @@ export function useDashboardData({ showNotice, clearNotice }) {
       ? (selectedConversation?.messages || []).find((message) => message.id === continueFromMessageId) || null
       : null
     if (continueFromMessageId && !canContinueMessage(continuedMessage)) return
+    /* Regenerating into a variant re-asks the SAME question: the prompt is
+       already the last turn of the stored history, so no user turn is added
+       and the reply lands on the existing message as a new alternative. */
+    const variantMessage = variantOfMessageId
+      ? (selectedConversation?.messages || []).find((message) => message.id === variantOfMessageId) || null
+      : null
+    if (variantOfMessageId && !canBranchMessage(variantMessage)) return
+    const reusedMessage = continuedMessage || variantMessage
     const continuationPrefix = continuedMessage ? String(continuedMessage.content || '') : ''
     const continuedCompletionTokens = continuedMessage
       ? Math.max(0, Number(continuedMessage.usage?.completion_tokens) || 0)
       : 0
-    const draftContent = continuedMessage ? CONTINUATION_INSTRUCTION : (overrideContent ?? composer)
+    /* Neither reuse path reads the composer. A continuation supplies its own
+       instruction; a variant re-sends the question already in the transcript. */
+    const priorPromptForVariant = variantMessage
+      ? (() => {
+          const messages = selectedConversation?.messages || []
+          const at = messages.findIndex((message) => message.id === variantOfMessageId)
+          const prior = at > 0 ? [...messages.slice(0, at)].reverse().find((m) => m.role === 'user') : null
+          return String(prior?.content || '')
+        })()
+      : ''
+    if (variantMessage && !priorPromptForVariant.trim()) return
+    const draftContent = continuedMessage
+      ? CONTINUATION_INSTRUCTION
+      : variantMessage
+        ? priorPromptForVariant
+        : (overrideContent ?? composer)
     if (!draftContent.trim()) return
     // Supported rows chat through the full gate. Implemented-but-unsupported rows
     // chat through the weaker EXPERIMENTAL lane (every turn marked unverified). Only
@@ -1275,12 +1340,21 @@ export function useDashboardData({ showNotice, clearNotice }) {
       const continueIndex = continueFromMessageId
         ? (conversation.messages || []).findIndex((message) => message.id === continueFromMessageId)
         : -1
+      const variantIndex = variantOfMessageId
+        ? (conversation.messages || []).findIndex((message) => message.id === variantOfMessageId)
+        : -1
       const baseMessages = truncateIndex >= 0
         ? (conversation.messages || []).slice(0, truncateIndex)
         : continueIndex >= 0
           ? (conversation.messages || []).slice(0, continueIndex + 1)
-          : (conversation.messages || [])
-      const history = [...baseMessages, userMessage]
+          : variantIndex >= 0
+            /* Everything BEFORE the reply being re-rolled, which already ends
+               with the question that produced it. */
+            ? (conversation.messages || []).slice(0, variantIndex)
+            : (conversation.messages || [])
+      /* A variant adds no user turn: appending one would duplicate the
+         question in the prompt and in the transcript. */
+      const history = variantMessage ? [...baseMessages] : [...baseMessages, userMessage]
         // A token budget can end entirely inside a model-hidden channel. Keep
         // that diagnostic turn in the transcript, but never feed an empty
         // assistant message back into the next model prompt.
@@ -1377,7 +1451,7 @@ export function useDashboardData({ showNotice, clearNotice }) {
       /* The continuation instruction is request-only: storing it would leave a
          "Continue your previous reply..." turn in the transcript and re-send it
          on every later turn. */
-      if (!continuedMessage) {
+      if (!reusedMessage) {
         persistConversations((current) => current.map((item) => (
           item.id === conversation.id
             ? {
@@ -1623,7 +1697,7 @@ export function useDashboardData({ showNotice, clearNotice }) {
       /* Continuing reuses the truncated message's id, so every stream patch
          below lands on the reply already on screen instead of opening a second
          bubble under it. */
-      assistantId = continuedMessage ? continuedMessage.id : makeId('message')
+      assistantId = reusedMessage ? reusedMessage.id : makeId('message')
       /* Snapshot of the support claim that was active when this send left the
          composer: row id + status only (never paths) so the message footer can
          cite the exact contract row that gated this generation. */
@@ -1637,8 +1711,16 @@ export function useDashboardData({ showNotice, clearNotice }) {
       const experimentalLaneAtSend = sendGate.chatMode === 'experimental'
       const assistantMessageBase = {
         ...(continuedMessage || {}),
+        /* A variant is a FRESH reply that only shares an id and a sibling
+           list. Spreading the old reply here would carry its receipt, its web
+           sources and its continuation count onto a generation that produced
+           none of them. */
+        ...(variantMessage ? { variants: variantsOf(variantMessage) } : {}),
         id: assistantId,
         role: 'assistant',
+        /* A continuation keeps what it already generated on screen; a variant
+           starts empty, and its siblings ride along untouched until the
+           terminal write appends this reply to them. */
         content: continuationPrefix,
         model_id: selectedModelId,
         model_name: selectedModel?.name || selectedModelId,
@@ -1674,10 +1756,10 @@ export function useDashboardData({ showNotice, clearNotice }) {
         item.id === conversation.id
           ? {
               ...item,
-              title: item.title === 'New conversation' && !continuedMessage
+              title: item.title === 'New conversation' && !reusedMessage
                 ? messageContent.slice(0, 64)
                 : item.title,
-              messages: continuedMessage
+              messages: reusedMessage
                 ? (item.messages || []).map((message) => (
                     message.id === assistantId ? assistantMessageBase : message
                   ))
@@ -2158,7 +2240,12 @@ export function useDashboardData({ showNotice, clearNotice }) {
           ? {
               ...item,
               messages: (item.messages || []).map((message) => (
-                message.id === assistantId ? assistantMessage : message
+                message.id === assistantId
+                  /* Siblings come from the message as it was BEFORE this
+                     regeneration, so a re-roll of a re-roll keeps the whole
+                     set rather than collapsing to two. */
+                  ? (variantMessage ? withVariantAppended(variantMessage, assistantMessage) : assistantMessage)
+                  : message
               )),
               updated_at: nowIso(),
             }
@@ -2693,6 +2780,9 @@ export function useDashboardData({ showNotice, clearNotice }) {
     sendMessage,
     resendFromMessage,
     continueFromMessage,
+    regenerateAsVariant,
+    selectMessageVariant,
+    discardMessageVariant,
     stopGeneration,
     saveToMemory,
     createMemory,

--- a/frontend/src/lib/conversationStorage.js
+++ b/frontend/src/lib/conversationStorage.js
@@ -1,3 +1,5 @@
+import { normalizeMessageVariants } from './messageVariants.js'
+
 export function cleanLegacyDemoCapCopy(value) {
   if (typeof value !== 'string') return value
   const stripped = value
@@ -15,7 +17,12 @@ export function cleanLegacyDemoCapCopy(value) {
 
 export function normalizeStoredMessage(message, { clearStaleStreaming = false } = {}) {
   if (!message || typeof message !== 'object') return message
-  const { demo_token_cap: _demoTokenCap, ...rest } = message
+  const { demo_token_cap: _demoTokenCap, ...stored } = message
+  /* Keep the sibling list and the mirrored top-level fields in step. A
+     transcript restored from an export, hand-edited, or written by a build
+     that predates variants must never render one alternative's text beside
+     another's token counts. */
+  const rest = normalizeMessageVariants(stored)
   const content = cleanLegacyDemoCapCopy(rest.content)
   if (clearStaleStreaming && rest.streaming) {
     return {

--- a/frontend/src/lib/messageVariants.js
+++ b/frontend/src/lib/messageVariants.js
@@ -1,0 +1,125 @@
+/* Regenerated replies kept side by side.
+
+   Regenerate used to be destructive: the reply you had was replaced by the
+   one you got, and if the first was better it was gone. Keeping both makes
+   Regenerate safe to press, which is the only way it is actually useful.
+
+   SHAPE, and it is the whole design: a variant is the message MINUS its
+   identity fields, and the active variant's fields are ALSO mirrored onto the
+   message itself. Every existing reader -- the renderer, the exporter, the
+   context-budget estimator, the request builder, the telemetry footer -- keeps
+   reading `message.content` and `message.usage` and never learns that variants
+   exist. Only the code that switches between them looks at the array.
+
+   Defining a variant by subtraction rather than by an explicit field list is
+   deliberate: replies grow fields often (receipts, tool calls, research
+   sources, continuation counts), and an allow-list would silently stop
+   carrying each new one across a switch. */
+
+const IDENTITY_FIELDS = ['id', 'role', 'variants', 'active_variant']
+
+export function snapshotVariant(message) {
+  const variant = {}
+  for (const [key, value] of Object.entries(message || {})) {
+    if (IDENTITY_FIELDS.includes(key)) continue
+    variant[key] = value
+  }
+  return variant
+}
+
+/* A message stored before variants existed has none; it IS its own first
+   variant. Migrating on read rather than rewriting stored conversations means
+   an older transcript needs no upgrade step and a downgrade loses only the
+   alternatives, never the reply. */
+export function variantsOf(message) {
+  const stored = Array.isArray(message?.variants) ? message.variants : null
+  if (stored && stored.length) return stored
+  return message ? [snapshotVariant(message)] : []
+}
+
+export function variantCountOf(message) {
+  return variantsOf(message).length
+}
+
+export function activeVariantIndexOf(message) {
+  const count = variantCountOf(message)
+  if (count === 0) return 0
+  const stored = Number(message?.active_variant)
+  if (!Number.isFinite(stored)) return count - 1
+  return Math.min(Math.max(Math.trunc(stored), 0), count - 1)
+}
+
+export function hasVariants(message) {
+  return variantCountOf(message) > 1
+}
+
+/* Only assistant replies branch. A user turn has Edit & resend, which is a
+   different operation: it changes the question rather than re-asking it. */
+export function canBranchMessage(message) {
+  return Boolean(message)
+    && message.role === 'assistant'
+    && !message.streaming
+    && Boolean(String(message.content || '').trim())
+}
+
+export function withActiveVariant(message, index) {
+  const variants = variantsOf(message)
+  if (!variants.length) return message
+  const bounded = Math.min(Math.max(Math.trunc(Number(index) || 0), 0), variants.length - 1)
+  return {
+    id: message.id,
+    role: message.role,
+    variants,
+    active_variant: bounded,
+    ...variants[bounded],
+  }
+}
+
+/* Append a freshly generated reply as the newest variant and select it.
+   `next` is an ordinary message object; its identity fields are dropped. */
+export function withVariantAppended(message, next) {
+  const variants = [...variantsOf(message), snapshotVariant(next)]
+  return {
+    id: message.id,
+    role: message.role,
+    variants,
+    active_variant: variants.length - 1,
+    ...variants[variants.length - 1],
+  }
+}
+
+/* Discard the active variant and select a neighbour. Returns the message
+   unchanged when it is the last one standing: deleting it would leave a reply
+   with no content, and the transcript has no way to render that. */
+export function withActiveVariantRemoved(message) {
+  const variants = variantsOf(message)
+  if (variants.length <= 1) return message
+  const active = activeVariantIndexOf(message)
+  const remaining = variants.filter((_, index) => index !== active)
+  const nextActive = Math.min(active, remaining.length - 1)
+  return {
+    id: message.id,
+    role: message.role,
+    variants: remaining,
+    active_variant: nextActive,
+    ...remaining[nextActive],
+  }
+}
+
+/* Storage normalization: keep `variants`/`active_variant` internally
+   consistent, and keep the mirrored top-level fields in step with the active
+   variant. A transcript edited by hand, restored from an export, or written by
+   an older build must not render one variant's text beside another's token
+   counts. */
+export function normalizeMessageVariants(message) {
+  if (!message || message.role !== 'assistant') return message
+  if (!Array.isArray(message.variants) || message.variants.length <= 1) {
+    if (message.variants === undefined && message.active_variant === undefined) return message
+    // A single or empty array carries no alternatives worth storing.
+    const { variants, active_variant: activeVariant, ...rest } = message
+    void variants
+    void activeVariant
+    return rest
+  }
+  return withActiveVariant(message, activeVariantIndexOf(message))
+}

--- a/frontend/src/styles/chat.css
+++ b/frontend/src/styles/chat.css
@@ -1385,3 +1385,42 @@
   border-top: 1px solid var(--color-border-soft, #2a333f);
 }
 
+
+/* ---- Regenerated-reply siblings -----------------------------------------
+   Sits at the head of the actions row. Kept quiet: on a reply with one
+   version it is not rendered at all, so this must never make an ordinary
+   thread look busier than it did before regenerating became safe. */
+.cxturn__variants {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  margin-right: var(--space-1);
+  padding: 1px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-sm);
+}
+.cxturn__variant-step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 2px;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  line-height: 1;
+  cursor: pointer;
+}
+.cxturn__variant-step:hover { background: var(--color-surface-hover); color: var(--color-text); }
+.cxturn__variant-step:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+.cxturn__variant-discard:hover { color: var(--color-error); }
+.cxturn__variant-count {
+  padding: 0 var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--color-text-faint);
+  font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -17,6 +17,7 @@ import { ChatControls } from '../components/chat/ChatControls'
 import { ContextMeter } from '../components/chat/ContextMeter'
 import { composeContextBudget } from '../lib/contextBudget.js'
 import { canContinueMessage } from '../lib/chatContinuation.js'
+import { canBranchMessage } from '../lib/messageVariants.js'
 import {
   AUTO_COMPACT_THRESHOLD_PERCENT,
   applySendCompaction,
@@ -176,6 +177,9 @@ export default function ChatWorkspace({
   sendMessage,
   resendFromMessage = null,
   continueFromMessage = null,
+  regenerateAsVariant = null,
+  selectMessageVariant = null,
+  discardMessageVariant = null,
   stopGeneration,
   sending,
   receiptMode = false,
@@ -1356,6 +1360,15 @@ export default function ChatWorkspace({
                   && canChat
                   && isLastMessage
                   && canContinueMessage(message)
+                /* Re-rolling the LAST reply keeps the old one as a sibling --
+                   nothing after it can go stale, because nothing is after it.
+                   Mid-thread it stays the old resend, which does discard the
+                   turns below and now says so. */
+                const canBranchHere = Boolean(regenerateAsVariant)
+                  && !requestActive
+                  && canChat
+                  && isLastMessage
+                  && canBranchMessage(message)
                 const priorMessage = index > 0 ? visibleMessages[index - 1] : null
                 const dayKey = dayKeyOf(message.created_at)
                 const priorDayKey = priorMessage ? dayKeyOf(priorMessage.created_at) : null
@@ -1372,7 +1385,12 @@ export default function ChatWorkspace({
                       generationElapsedSeconds={generationElapsedSeconds}
                       priorUserPrompt={priorUserPrompt}
                       onReusePrompt={setComposer}
-                      onRegenerate={canResend && priorUserMessage ? () => resendFromMessage(priorUserMessage.id) : null}
+                      onRegenerate={canBranchHere
+                        ? () => regenerateAsVariant(message.id)
+                        : (canResend && priorUserMessage ? () => resendFromMessage(priorUserMessage.id) : null)}
+                      regenerateReplacesThread={!canBranchHere}
+                      onSelectVariant={selectMessageVariant ? (index) => selectMessageVariant(message.id, index) : null}
+                      onDiscardVariant={discardMessageVariant && !requestActive ? () => discardMessageVariant(message.id) : null}
                       onEditResend={canResend && message.role === 'user' ? (messageId, content) => resendFromMessage(messageId, content) : null}
                       onContinue={canContinue ? () => continueFromMessage(message.id) : null}
                       tokenInspection={tokenInspections?.[message.id] || null}


### PR DESCRIPTION
> **Stacked on [#748](https://github.com/timtoole02/Camelid/pull/748)** (base is `feat/chat-continue-truncated`, not `main`) — both restructure the same message plumbing in `useDashboardData.js`/`MessageTurn.jsx`. Merge #748 first; this retargets to `main` automatically.
>
> ⚠️ Do **not** pass `--delete-branch` when merging #748 — deleting a stacked PR's base closes the dependent PR.

## What changed

Regenerate was **destructive**: the reply you had was replaced by the one you got, and if the first was better it was gone. That is exactly why people learn not to press it. Now it adds a version and keeps the current one, with `‹ 1/2 ›` navigation.

## Shape — the one design decision worth reviewing

A variant is **the message minus its identity fields**, and the active variant's fields are *also mirrored onto the message itself*.

That means every existing reader — renderer, exporter, request builder, context-budget estimator, telemetry footer — keeps reading `message.content` and `message.usage` and never learns variants exist. Only the switching code touches the array.

Defining a variant *by subtraction* rather than by an allow-list is deliberate: replies grow fields often (receipts, tool calls, research sources, continuation counts), and an explicit list would silently stop carrying each new one across a switch.

A message stored before this existed **is its own first variant**, migrated on read — no upgrade step, and a downgrade loses the alternatives but never the reply.

## What Regenerate now means (two cases, deliberately)

| Position | Behaviour | Tooltip |
|---|---|---|
| **Last reply** | adds a version, keeps the current one | "writes another answer and keeps this one alongside it" |
| **Mid-thread** | unchanged — resends and replaces the turns below | "replaces this reply and every turn after it" |

The old label said neither. **Known limit, stated rather than hidden:** mid-thread regeneration still replaces the turns after it — branching a whole subtree is a larger change than this one.

Switching is a pure local edit with no request behind it, so it stays usable while another turn streams. Discard drops the version on screen and selects a neighbour; the last one standing can't be discarded, because a reply with no content has nothing to render.

## Validation

| Gate | Covers |
|---|---|
| `smoke:variants` | migration from pre-variant storage, append/switch/discard, index clamping, eligibility, desync repair, and that a one-version reply renders **no control at all** (an ordinary thread is visually unchanged) |
| `smoke:variants-browser` | one bubble not two; the re-roll request carries the question **exactly once** and does **not** carry the answer it is replacing; the footer's token count moves with the selected text; versions survive a reload; and — the whole point — **the next turn sends whichever version is selected** |

Each fixture answer reports a *different* `completion_tokens`, so a footer left showing the wrong version's telemetry is detectable rather than merely suspected.

Full affected smoke set green locally (12 suites).

## Docs / compatibility rows

None. No backend change, no contract row, no support claim — the re-roll goes through the ordinary gate-checked send path.
