### PR TITLE
feat(ui): pin, archive, tag, bulk-export and import conversations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,22 @@ jobs:
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: npm run smoke:variants-browser
 
+      # Pins, archive, tags, bulk export and import. Most of this gate is the
+      # IMPORT half: it reads a user-chosen file into stored state, so the
+      # bounds, the field whitelist, the regenerated ids and the refusal to
+      # trust a claimed usage_source are all asserted here.
+      - name: Frontend conversation organization smoke
+        if: ${{ !cancelled() }}
+        run: npm run smoke:organization
+
+      # The wiring an organization feature actually fails on: a pin that still
+      # falls off the recent limit, a filter that hides everything, an archive
+      # with no way back, and the export -> import round trip through the real
+      # file picker.
+      - name: Frontend conversation organization browser smoke
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: npm run smoke:organization-browser
+
       # Covers frontend/src/lib/firstRunActivation.js and lib/modelActivation.js:
       # which model a fresh install is offered (supported_* rows only, fit-filtered,
       # smallest first) and the inspect -> load -> readiness protocol behind the one

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,8 @@
     "smoke:context-compaction": "node scripts/context-compaction-smoke.mjs",
     "smoke:continuation": "node scripts/chat-continuation-smoke.mjs",
     "smoke:variants": "node scripts/message-variants-smoke.mjs",
+    "smoke:organization": "node scripts/conversation-organization-smoke.mjs",
+    "smoke:organization-browser": "node scripts/conversation-organization-browser-smoke.mjs",
     "smoke:variants-browser": "node scripts/message-variants-browser-smoke.mjs",
     "smoke:continuation-browser": "node scripts/chat-continuation-browser-smoke.mjs",
     "smoke:flow": "node scripts/flow-visual-smoke.mjs"

--- a/frontend/scripts/conversation-organization-browser-smoke.mjs
+++ b/frontend/scripts/conversation-organization-browser-smoke.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+/* Browser-level acceptance for pinning, archiving and tagging.
+ *
+ * Requires `npm run build` first. The pure smoke owns the rules; this owns the
+ * wiring, which is where an organization feature actually fails: a control
+ * that updates storage but not the list, a pin that still falls off the end,
+ * a filter that hides everything, an archive with no way back.
+ */
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { extname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { launchBrowser } from './lib/launch-browser.mjs'
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url))
+const distDir = resolve(scriptDir, '../dist')
+const ledgerPath = resolve(scriptDir, '../../ledger/camelid-ledger.json')
+const MODEL_FILENAME = 'Qwen3-0.6B-Q8_0.gguf'
+
+const MIME = {
+  '.css': 'text/css', '.html': 'text/html', '.js': 'text/javascript', '.json': 'application/json',
+  '.png': 'image/png', '.svg': 'image/svg+xml', '.woff': 'font/woff', '.woff2': 'font/woff2',
+}
+
+if (!existsSync(distDir)) throw new Error(`missing ${distDir} -- run "npm run build" first`)
+const ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'))
+const capabilities = { ...ledger.capabilities, model_compatibility: ledger.model_rows.map((row) => row.contract) }
+
+const pageErrors = []
+const externalRequests = []
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) })
+  res.end(payload)
+}
+function sendFile(res, path) {
+  const body = readFileSync(path)
+  res.writeHead(200, { 'Content-Type': MIME[extname(path)] || 'application/octet-stream' })
+  res.end(body)
+}
+function isFile(path) { try { return statSync(path).isFile() } catch { return false } }
+
+const server = createServer(async (req, res) => {
+  try {
+    const path = new URL(req.url, 'http://127.0.0.1').pathname
+    if (path === '/v1/health') {
+      return sendJson(res, 200, {
+        ok: true, engine: 'camelid', api_surface: 'full', version: 'organization-smoke', build: 'organization-smoke',
+        backend: 'llama', model_family: 'qwen3', loaded_now: true, generation_ready: true,
+        active_model_id: MODEL_FILENAME, active_context_length: 4096, max_prompt_tokens: 4096, max_generation_tokens: 8192,
+      })
+    }
+    if (path === '/v1/models') {
+      return sendJson(res, 200, { object: 'list', data: [{ id: MODEL_FILENAME, object: 'model', created: 0, owned_by: 'camelid', meta: { n_ctx_train: 32768, n_params: 600000000, size: 639446688 } }] })
+    }
+    if (path === '/api/capabilities') return sendJson(res, 200, capabilities)
+    if (path === '/api/models/catalog/downloads') return sendJson(res, 200, [])
+    if (path === '/api/models/local') {
+      return sendJson(res, 200, {
+        models_dir: 'models',
+        models: [{ filename: MODEL_FILENAME, size_bytes: 639446688, architecture: 'qwen3', quantization: 'Q8_0', admitted: true, oracle_qualified: true, chat_capable: true, generation_capable: true, context_length: 32768, lane_class: 'supported' }],
+      })
+    }
+    if (path === '/api/models/current') {
+      return sendJson(res, 200, { id: MODEL_FILENAME, path: `models/${MODEL_FILENAME}`, gguf: { metadata: { general: { architecture: 'qwen3', file_type: 7 } } }, tokenizer: { status: 'available' } })
+    }
+    const filePath = resolve(distDir, `.${path}`)
+    if (path !== '/' && isFile(filePath)) return sendFile(res, filePath)
+    return sendFile(res, resolve(distDir, 'index.html'))
+  } catch (error) {
+    if (!res.writableEnded) sendJson(res, 500, { error: String(error) })
+  }
+})
+
+await new Promise((done) => server.listen(0, '127.0.0.1', done))
+const origin = `http://127.0.0.1:${server.address().port}`
+
+/* Eight seeded conversations: more than the rail's six-recent limit, so
+   "pinned survives the limit" is a real assertion and not a coincidence. */
+const SEEDED = Array.from({ length: 8 }, (_, i) => ({
+  id: `conversation-seed-${i}`,
+  title: `Seeded chat ${i}`,
+  created_at: `2026-09-0${(i % 8) + 1}T09:00:00.000Z`,
+  updated_at: `2026-09-0${(i % 8) + 1}T10:00:00.000Z`,
+  messages: [
+    { id: `s${i}-u`, role: 'user', content: `question ${i}` },
+    { id: `s${i}-a`, role: 'assistant', content: `answer ${i}`, finish_reason: 'stop' },
+  ],
+}))
+const OLDEST = 'Seeded chat 0'
+
+const browser = await launchBrowser({ purpose: 'the conversation organization browser smoke', headless: 'new' })
+const page = await browser.newPage()
+await page.setViewport({ width: 1280, height: 1000, deviceScaleFactor: 1 })
+page.on('pageerror', (error) => pageErrors.push(String(error)))
+await page.setRequestInterception(true)
+page.on('request', (request) => {
+  const url = request.url()
+  if (url.startsWith('data:') || url.startsWith('blob:')) return request.continue()
+  try { if (new URL(url).origin === origin) return request.continue() } catch { /* abort below */ }
+  externalRequests.push(url)
+  return request.abort()
+})
+await page.evaluateOnNewDocument((seeded) => {
+  if (window.sessionStorage.getItem('camelid.orgSmokeInitialized')) return
+  window.localStorage.clear()
+  window.localStorage.setItem('camelid.conversations', JSON.stringify(seeded))
+  window.sessionStorage.setItem('camelid.orgSmokeInitialized', 'true')
+}, SEEDED)
+
+const railTitles = () => page.$$eval('.rail-convo__main', (nodes) => nodes.map((n) => n.textContent))
+const groupLabels = () => page.$$eval('.rail__group-label', (nodes) => nodes.map((n) => n.textContent))
+
+async function openMenuFor(titleFragment) {
+  const opened = await page.evaluate((fragment) => {
+    const rows = [...document.querySelectorAll('.rail-convo')]
+    const row = rows.find((node) => node.textContent.includes(fragment))
+    const button = row?.querySelector('.rail-convo__menu-btn')
+    if (!button) return false
+    button.click()
+    return true
+  }, titleFragment)
+  assert.equal(opened, true, `no menu button for ${titleFragment}`)
+  await page.waitForSelector('.rail-menu', { timeout: 10000 })
+}
+
+async function clickMenuItem(label) {
+  const clicked = await page.evaluate((text) => {
+    const item = [...document.querySelectorAll('.rail-menu__item')].find((n) => n.textContent.trim() === text)
+    if (!item) return false
+    item.click()
+    return true
+  }, label)
+  assert.equal(clicked, true, `no menu item labelled ${label}`)
+}
+
+try {
+  await page.goto(origin, { waitUntil: 'domcontentloaded', timeout: 30000 })
+  await page.waitForSelector('.rail-convo', { timeout: 30000 })
+
+  /* ---- baseline: the rail is capped and the oldest is off the end ------- */
+  const initial = await railTitles()
+  assert.equal(initial.length, 6, 'the rail shows six recent conversations')
+  assert.equal(initial.some((t) => t.includes(OLDEST)), false, 'the oldest chat has fallen off the list — the problem pinning exists to solve')
+  assert.equal((await groupLabels()).includes('Pinned'), false, 'no Pinned group before anything is pinned')
+
+  /* ---- pin the oldest: it must come back and stay ---------------------- */
+  await page.evaluate(() => {
+    // It is off the rail, so reach it the way a user would: search.
+    const input = document.querySelector('.rail__search-input')
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set
+    setter.call(input, 'Seeded chat 0')
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  await page.waitForFunction(() => document.querySelectorAll('.rail-convo').length === 1, { timeout: 10000 })
+  await openMenuFor(OLDEST)
+  await clickMenuItem('Pin to top')
+  await page.evaluate(() => {
+    const input = document.querySelector('.rail__search-input')
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set
+    setter.call(input, '')
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  await page.waitForFunction(() => (
+    [...document.querySelectorAll('.rail__group-label')].some((n) => n.textContent === 'Pinned')
+  ), { timeout: 10000 })
+
+  const afterPin = await railTitles()
+  assert.equal(afterPin[0].includes(OLDEST), true, 'the pinned chat is now first')
+  assert.equal(
+    afterPin.length,
+    7,
+    'a pin is NOT subject to the six-recent limit — it would be worthless if it fell off again',
+  )
+  assert.equal((await groupLabels())[0], 'Pinned', 'and it has its own group above the date buckets')
+
+  /* ---- tag it, and filter by that tag ---------------------------------- */
+  await openMenuFor(OLDEST)
+  await page.waitForSelector('.rail-menu__tag-input', { timeout: 10000 })
+  await page.type('.rail-menu__tag-input', 'CUDA')
+  await page.keyboard.press('Enter')
+  await page.waitForFunction(() => (
+    [...document.querySelectorAll('.rail-convo__tag')].some((n) => n.textContent === 'cuda')
+  ), { timeout: 10000 })
+  const tagInputAfter = await page.$eval('.rail-menu__tag-input', (n) => n.value)
+  assert.equal(tagInputAfter, '', 'the tag box clears so a second tag can be typed without reopening the menu')
+  await page.keyboard.press('Escape')
+
+  await page.waitForSelector('.rail__tag-filter', { timeout: 10000 })
+  const chips = await page.$$eval('.rail__tag-chip', (nodes) => nodes.map((n) => n.textContent))
+  assert.deepEqual(chips, ['cuda'], 'the tag appears in the filter row, lowercased')
+
+  await page.click('.rail__tag-chip')
+  await page.waitForFunction(() => document.querySelectorAll('.rail-convo').length === 1, { timeout: 10000 })
+  const filtered = await railTitles()
+  assert.equal(filtered[0].includes(OLDEST), true, 'filtering by the tag narrows the list to it')
+  await page.click('.rail__tag-chip--clear')
+  await page.waitForFunction(() => document.querySelectorAll('.rail-convo').length > 1, { timeout: 10000 })
+
+  /* ---- archive: gone from the list, with a way back -------------------- */
+  const archiveTarget = 'Seeded chat 7'
+  await openMenuFor(archiveTarget)
+  await clickMenuItem('Archive')
+  await page.waitForFunction((title) => (
+    ![...document.querySelectorAll('.rail-convo__main')].some((n) => n.textContent.includes(title))
+  ), { timeout: 10000 }, archiveTarget)
+
+  await page.waitForSelector('.rail__archived-toggle', { timeout: 10000 })
+  const toggleLabel = await page.$eval('.rail__archived-toggle', (n) => n.textContent)
+  assert.match(toggleLabel, /Show archived \(1\)/, 'the archived count is visible — archiving must not look like deletion')
+
+  await page.click('.rail__archived-toggle')
+  await page.waitForFunction((title) => (
+    [...document.querySelectorAll('.rail-convo__main')].some((n) => n.textContent.includes(title))
+  ), { timeout: 10000 }, archiveTarget)
+
+  /* ---- it all survives a reload ---------------------------------------- */
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 30000 })
+  await page.waitForSelector('.rail-convo', { timeout: 30000 })
+  const stored = await page.evaluate(() => {
+    const list = JSON.parse(localStorage.getItem('camelid.conversations') || '[]')
+    return {
+      pinned: list.filter((c) => c.pinned).map((c) => c.title),
+      archived: list.filter((c) => c.archived).map((c) => c.title),
+      tags: list.find((c) => c.pinned)?.tags || [],
+      // Organizing is not editing: it must not reshuffle recency.
+      pinnedUpdatedAt: list.find((c) => c.pinned)?.updated_at,
+    }
+  })
+  assert.deepEqual(stored.pinned, [OLDEST], 'the pin survives a reload')
+  assert.deepEqual(stored.archived, ['Seeded chat 7'], 'so does the archive')
+  assert.deepEqual(stored.tags, ['cuda'], 'so does the tag')
+  assert.equal(
+    stored.pinnedUpdatedAt,
+    '2026-09-01T10:00:00.000Z',
+    'pinning and tagging leave updated_at alone — organizing a thread is not editing it',
+  )
+  assert.equal((await groupLabels())[0], 'Pinned', 'and the Pinned group is still first after a reload')
+
+
+  /* ---- export -> import round trip through the real controls ------------ */
+  /* Navigate the way a user does, through the rail, rather than by poking the
+     hash: it also proves the History nav item still reaches this view. */
+  const wentToHistory = await page.evaluate(() => {
+    const item = [...document.querySelectorAll('.rail__nav-item')].find((n) => n.textContent.includes('Chat history'))
+    if (!item) return false
+    item.click()
+    return true
+  })
+  assert.equal(wentToHistory, true, 'the rail offers a Chat history entry')
+  await page.waitForSelector('.history-view__tools', { timeout: 30000 })
+
+  const exportFile = resolve(tmpdir(), `camelid-import-smoke-${process.pid}.json`)
+  writeFileSync(exportFile, JSON.stringify({
+    format: 'camelid.conversations/v1',
+    conversations: [{
+      /* Deliberately carries an id that already exists here plus a local path
+         the exporter never writes: the import must take neither. */
+      id: 'conversation-seed-0',
+      title: 'IMPORTED-THREAD',
+      model_path: '/home/someone/.ssh/id_rsa',
+      tags: ['Imported'],
+      messages: [
+        { role: 'user', content: 'imported question' },
+        { role: 'assistant', content: 'imported answer', usage: { prompt_tokens: 4, completion_tokens: 6 }, usage_source: 'backend' },
+      ],
+    }],
+  }))
+
+  const beforeImport = await page.evaluate(() => JSON.parse(localStorage.getItem('camelid.conversations') || '[]').length)
+  const chooser = await page.$('.history-view__import-input')
+  await chooser.uploadFile(exportFile)
+  await page.waitForFunction((count) => (
+    JSON.parse(localStorage.getItem('camelid.conversations') || '[]').length === count + 1
+  ), { timeout: 15000 }, beforeImport)
+
+  const importedState = await page.evaluate(() => {
+    const list = JSON.parse(localStorage.getItem('camelid.conversations') || '[]')
+    const imported = list.find((c) => c.title === 'IMPORTED-THREAD')
+    return {
+      total: list.length,
+      seedZeroIntact: list.filter((c) => c.id === 'conversation-seed-0').length,
+      id: imported?.id,
+      tags: imported?.tags,
+      hasPath: Object.prototype.hasOwnProperty.call(imported || {}, 'model_path'),
+      usageSource: imported?.messages?.[1]?.usage_source,
+      messages: (imported?.messages || []).map((m) => m.content),
+    }
+  })
+  assert.equal(importedState.total, beforeImport + 1, 'the file adds exactly one conversation')
+  assert.equal(importedState.seedZeroIntact, 1, 'the existing conversation whose id the file claimed is untouched')
+  assert.notEqual(importedState.id, 'conversation-seed-0', 'the import got a fresh id instead of overwriting')
+  assert.deepEqual(importedState.messages, ['imported question', 'imported answer'], 'the messages arrived')
+  assert.deepEqual(importedState.tags, ['imported'], 'tags arrive normalized')
+  assert.equal(importedState.hasPath, false, 'a field the exporter never writes cannot ride in on an import')
+  assert.equal(importedState.usageSource, 'client_estimate', 'imported counts cannot claim to be this backend’s reported usage')
+  rmSync(exportFile, { force: true })
+
+  assert.deepEqual(pageErrors, [], 'the page must not raise errors')
+  assert.deepEqual(externalRequests, [], 'the smoke must not reach anything off-origin')
+
+  console.log('conversation organization browser smoke passed')
+} finally {
+  await browser.close()
+  await new Promise((done) => server.close(done))
+}

--- a/frontend/scripts/conversation-organization-smoke.mjs
+++ b/frontend/scripts/conversation-organization-smoke.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/* Conversation organization smoke: pins, archive, tags, bulk export, import.
+ *
+ * The import half carries most of the weight. It reads a file the user chose,
+ * so the file is DATA -- never a source of shape. Nothing is spread from it.
+ * These assertions are what stop a hand-written or hostile file from putting
+ * a filesystem path, a `__proto__` key, an id that overwrites existing data,
+ * or an unbounded message array into stored state.
+ */
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import { createServer } from 'vite'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const frontendRoot = resolve(scriptDir, '..')
+
+const server = await createServer({
+  root: frontendRoot,
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+
+try {
+  const org = await server.ssrLoadModule('/src/lib/conversationOrganization.js')
+  const { parseImportedConversations } = await server.ssrLoadModule('/src/lib/conversationImport.js')
+  const { exportableConversations } = await server.ssrLoadModule('/src/lib/conversationExport.js')
+
+  const chat = (id, title, extra = {}) => ({
+    id,
+    title,
+    updated_at: extra.updated_at || '2026-09-01T10:00:00.000Z',
+    created_at: '2026-09-01T09:00:00.000Z',
+    messages: [
+      { id: `${id}-u`, role: 'user', content: `question about ${title}` },
+      { id: `${id}-a`, role: 'assistant', content: `answer about ${title}` },
+    ],
+    ...extra,
+  })
+
+  /* ---- tags normalize so a filter row cannot hold two identical chips ---- */
+  assert.equal(org.normalizeTag('  Rust  '), 'rust', 'tags are trimmed and lowercased')
+  assert.equal(org.normalizeTag('a   b'), 'a b', 'inner whitespace collapses')
+  assert.equal(org.normalizeTag('x'.repeat(50)).length, org.MAX_TAG_LENGTH, 'tags are bounded')
+  assert.equal(org.normalizeTag('   '), '', 'a blank tag is no tag')
+  assert.deepEqual(
+    org.tagsOf({ tags: ['Rust', 'rust', ' RUST ', 'cuda'] }),
+    ['rust', 'cuda'],
+    'case variants of one tag collapse to one',
+  )
+
+  const tagged = org.withTagAdded(chat('c1', 'one'), 'CUDA')
+  assert.deepEqual(org.tagsOf(tagged), ['cuda'])
+  assert.deepEqual(org.tagsOf(org.withTagAdded(tagged, 'cuda')), ['cuda'], 'adding a tag twice is a no-op')
+  let saturated = chat('c1', 'one')
+  for (let i = 0; i < org.MAX_TAGS_PER_CONVERSATION + 4; i += 1) saturated = org.withTagAdded(saturated, `t${i}`)
+  assert.equal(org.tagsOf(saturated).length, org.MAX_TAGS_PER_CONVERSATION, 'tags per conversation are bounded')
+  assert.equal(org.withTagRemoved(tagged, 'cuda').tags, undefined, 'removing the last tag drops the field rather than storing []')
+
+  /* ---- pin and archive are mutually exclusive --------------------------- */
+  const pinnedThenArchived = org.withArchived(org.withPinned(chat('c1', 'one'), true), true)
+  assert.equal(org.isArchived(pinnedThenArchived), true, 'archiving a pinned thread archives it')
+  assert.equal(org.isPinned(pinnedThenArchived), false, 'and drops the pin — the two contradict')
+  const archivedThenPinned = org.withPinned(org.withArchived(chat('c1', 'one'), true), true)
+  assert.equal(org.isPinned(archivedThenPinned), true, 'pinning an archived thread pins it')
+  assert.equal(org.isArchived(archivedThenPinned), false, 'and brings it back into the list')
+  assert.equal(org.withPinned(chat('c1', 'one'), false).pinned, undefined, 'unpinning drops the field, it does not store false')
+
+  /* ---- ordering and filtering -------------------------------------------- */
+  const list = [
+    chat('old', 'oldest', { updated_at: '2026-08-01T10:00:00.000Z' }),
+    chat('new', 'newest', { updated_at: '2026-09-05T10:00:00.000Z' }),
+    chat('pin', 'pinned one', { updated_at: '2026-07-01T10:00:00.000Z', pinned: true }),
+    chat('arc', 'archived one', { updated_at: '2026-09-06T10:00:00.000Z', archived: true }),
+    chat('tag', 'tagged one', { updated_at: '2026-08-15T10:00:00.000Z', tags: ['cuda'] }),
+  ]
+
+  const ids = (result) => result.map((c) => c.id)
+  assert.deepEqual(
+    ids(org.organizeConversations(list, {})),
+    ['pin', 'new', 'tag', 'old'],
+    'pinned sorts first even when it is the OLDEST, then recency; archived is hidden',
+  )
+  assert.deepEqual(
+    ids(org.organizeConversations(list, { includeArchived: true })),
+    ['pin', 'arc', 'new', 'tag', 'old'],
+    'showing archived puts it back in recency order',
+  )
+  assert.deepEqual(ids(org.organizeConversations(list, { tags: ['cuda'] })), ['tag'], 'a tag filter narrows to that tag')
+  assert.deepEqual(
+    ids(org.organizeConversations(list, { search: 'cuda' })),
+    ['tag'],
+    'the ordinary search box matches tags too, so tags need no separate search',
+  )
+  assert.deepEqual(ids(org.organizeConversations(list, { search: 'answer about newest' })), ['new'], 'search still matches message bodies')
+  assert.deepEqual(ids(org.organizeConversations(list, { search: 'NEWEST' })), ['new'], 'search is case-insensitive')
+
+  /* An archived thread that matches an explicit tag filter is still shown:
+     filtering to a tag and getting nothing back reads as data loss. */
+  const archivedTagged = [chat('at', 'archived tagged', { archived: true, tags: ['cuda'] })]
+  assert.deepEqual(
+    ids(org.organizeConversations(archivedTagged, { tags: ['cuda'] })),
+    ['at'],
+    'an explicit tag filter reaches archived threads',
+  )
+  assert.deepEqual(ids(org.organizeConversations(archivedTagged, {})), [], 'but they stay hidden without one')
+
+  assert.deepEqual(org.allTags(list).map((t) => t.tag), ['cuda'], 'tag inventory covers the list')
+  assert.equal(org.allTags(list)[0].count, 1, 'with usage counts for the filter row')
+  assert.equal(org.archivedCount(list), 1)
+  assert.deepEqual(org.organizeConversations(null, {}), [], 'a missing list is an empty list, not a crash')
+
+  /* ---- storage normalization --------------------------------------------- */
+  const messy = org.normalizeConversationOrganization({ id: 'x', pinned: false, archived: false, tags: ['A', 'a', ''] })
+  assert.equal(messy.pinned, undefined, 'falsey organization fields are dropped rather than stored forever')
+  assert.equal(messy.archived, undefined)
+  assert.deepEqual(messy.tags, ['a'], 'tags are re-normalized on load')
+  const contradictory = org.normalizeConversationOrganization({ id: 'x', pinned: true, archived: true })
+  assert.equal(contradictory.archived, undefined, 'a file claiming both pinned and archived is resolved, not obeyed')
+
+  /* ---- bulk export ------------------------------------------------------- */
+  const bundle = exportableConversations([chat('c1', 'one', { tags: ['cuda'], pinned: true, model_path: '/home/someone/models/secret.gguf' })])
+  assert.equal(bundle.format, 'camelid.conversations/v1')
+  assert.equal(bundle.conversation_count, 1)
+  assert.deepEqual(bundle.conversations[0].tags, ['cuda'], 'tags travel so an import lands organized')
+  assert.equal(bundle.conversations[0].pinned, undefined, 'pinned describes THIS machine’s list, not the conversation')
+  assert.equal(
+    JSON.stringify(bundle).includes('secret.gguf'),
+    false,
+    'the per-conversation field whitelist still governs bulk export — local paths never leave',
+  )
+
+  /* ---- import: the untrusted half ---------------------------------------- */
+  const roundTrip = parseImportedConversations(JSON.stringify(bundle))
+  assert.equal(roundTrip.error, null, 'a bundle this app produced imports cleanly')
+  assert.equal(roundTrip.conversations.length, 1, 'round trip preserves the conversation')
+  assert.equal(roundTrip.conversations[0].messages.length, 2, 'and its messages')
+  assert.deepEqual(roundTrip.conversations[0].tags, ['cuda'], 'and its tags')
+  assert.notEqual(roundTrip.conversations[0].id, 'c1', 'ids are ALWAYS regenerated — an import must never overwrite a conversation already here')
+
+  const single = parseImportedConversations(JSON.stringify({ format: 'camelid.conversation/v1', title: 'solo', messages: [{ role: 'user', content: 'hi' }] }))
+  assert.equal(single.conversations.length, 1, 'a single-conversation export is accepted too')
+  const bare = parseImportedConversations(JSON.stringify([{ title: 'bare', messages: [{ role: 'user', content: 'hi' }] }]))
+  assert.equal(bare.conversations.length, 1, 'so is a bare array')
+
+  assert.match(parseImportedConversations('not json').error, /not valid JSON/, 'a malformed file reports rather than throws')
+  assert.match(parseImportedConversations('{"nope":1}').error, /does not look like/, 'an unrelated JSON file is rejected')
+  assert.match(parseImportedConversations('[]').error, /No conversations/, 'an empty list is reported, not silently accepted')
+
+  const hostile = parseImportedConversations(JSON.stringify([{
+    title: 'x'.repeat(400),
+    id: 'conversation-existing',
+    pinned: true,
+    archived: true,
+    model_path: '/home/someone/.ssh/id_rsa',
+    __proto__: { polluted: true },
+    tags: Array.from({ length: 40 }, (_, i) => `tag${i}`),
+    messages: [
+      { role: 'user', content: 'ok' },
+      { role: 'root', content: 'privileged' },
+      { role: 'assistant', content: '' },
+      { role: 'assistant', content: 'fine', usage: { prompt_tokens: -5, completion_tokens: 3 }, usage_source: 'backend' },
+      'not even an object',
+    ],
+  }]))
+  const [imported] = hostile.conversations
+  assert.equal(imported.title.length, 120, 'an over-long title is truncated, not stored whole')
+  assert.notEqual(imported.id, 'conversation-existing', 'a chosen id cannot target an existing conversation')
+  assert.equal(imported.pinned, undefined, 'a file cannot pin itself to the top of the list')
+  assert.equal(imported.archived, undefined)
+  assert.equal(imported.model_path, undefined, 'a field the exporter never writes cannot arrive by being present in the file')
+  assert.equal(Object.prototype.hasOwnProperty.call(imported, 'polluted'), false, 'no prototype pollution reaches stored state')
+  assert.equal(imported.tags.length, org.MAX_TAGS_PER_CONVERSATION, 'imported tags are bounded like any other')
+  assert.equal(imported.messages.length, 2, 'unknown roles, empty content and non-objects are dropped')
+  assert.deepEqual(imported.messages.map((m) => m.content), ['ok', 'fine'])
+  assert.equal(imported.messages[1].usage.prompt_tokens, 0, 'negative token counts are clamped')
+  assert.equal(
+    imported.messages[1].usage_source,
+    'client_estimate',
+    'imported counts describe someone else’s run and can never claim to be this backend’s reported usage',
+  )
+
+  const noneReadable = parseImportedConversations(JSON.stringify([{ title: 'empty', messages: [{ role: 'user', content: '   ' }] }]))
+  assert.match(noneReadable.error, /readable messages/, 'a conversation with nothing readable is reported')
+
+  const many = parseImportedConversations(JSON.stringify(
+    Array.from({ length: 600 }, (_, i) => ({ title: `c${i}`, messages: [{ role: 'user', content: 'hi' }] })),
+  ))
+  assert.equal(many.conversations.length, 500, 'an oversized import is bounded rather than accepted whole')
+
+  console.log('conversation organization smoke passed')
+} finally {
+  await server.close()
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -96,6 +96,10 @@ function App() {
     createConversation, showNewChatLanding, sendMessage, resendFromMessage, continueFromMessage,
     regenerateAsVariant, selectMessageVariant, discardMessageVariant, stopGeneration, saveToMemory,
     createMemory, updateMemory, deleteMemory, renameConversation, deleteConversation, deleteAllConversations,
+    conversationTags, archivedConversationCount, conversationTagFilter, toggleConversationTagFilter,
+    clearConversationTagFilter, showArchivedConversations, setShowArchivedConversations,
+    setConversationPinned, setConversationArchived, addConversationTag, removeConversationTag,
+    importConversationsFromText,
     activateModel, unloadCurrentModel,
     registerModel, loadDashboard, stoppingGeneration,
     apiBase, setApiBase,
@@ -349,6 +353,17 @@ function App() {
           onSelectConversation={selectConversation}
           renameConversation={renameConversation}
           requestDeleteConversation={requestDeleteConversation}
+          conversationTags={conversationTags}
+          tagFilter={conversationTagFilter}
+          onToggleTagFilter={toggleConversationTagFilter}
+          onClearTagFilter={clearConversationTagFilter}
+          archivedCount={archivedConversationCount}
+          showArchived={showArchivedConversations}
+          onToggleShowArchived={setShowArchivedConversations}
+          onTogglePin={setConversationPinned}
+          onToggleArchive={setConversationArchived}
+          onAddTag={addConversationTag}
+          onRemoveTag={removeConversationTag}
           runtime={runtime}
           apiSurface={apiSurface}
           themePreference={preference}
@@ -491,6 +506,7 @@ function App() {
           {tab === 'history' && (
             <HistoryView
               filteredConversations={filteredConversations}
+              importConversationsFromText={importConversationsFromText}
               setSelectedConversationId={selectConversation}
               setTab={navigateTab}
               deleteConversation={requestDeleteConversation}

--- a/frontend/src/components/layout/ConversationListItem.jsx
+++ b/frontend/src/components/layout/ConversationListItem.jsx
@@ -1,7 +1,8 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { clampText } from '../../lib/formatters'
-import { IconDots, IconEdit, IconTrash } from '../ui/icons'
+import { IconClose, IconDots, IconEdit, IconFile, IconPin, IconTrash } from '../ui/icons'
+import { MAX_TAG_LENGTH, isArchived, isPinned, tagsOf } from '../../lib/conversationOrganization.js'
 
 function ConversationListItemInner({
   conversation,
@@ -10,7 +11,14 @@ function ConversationListItemInner({
   onSelect,
   onRename,
   onDelete,
+  onTogglePin,
+  onToggleArchive,
+  onAddTag,
+  onRemoveTag,
 }) {
+  const pinned = isPinned(conversation)
+  const archived = isArchived(conversation)
+  const tags = tagsOf(conversation)
   /* Non-null while the menu is open: viewport coordinates for the portalled
      popover. Portalling (instead of position:absolute in the row) lets the
      menu escape the sidebar's overflow-y:auto scroll container. */
@@ -130,7 +138,16 @@ function ConversationListItemInner({
         title={rawTitle}
         onClick={() => onSelect(conversation.id)}
       >
+        {pinned && !collapsed && <IconPin size={12} className="rail-convo__pin" aria-label="Pinned" />}
         <span className="rail-convo__title">{collapsed ? rawTitle.slice(0, 1).toUpperCase() : title}</span>
+        {/* Tags are shown on the row, not only in the menu: a label nobody can
+            see is a label nobody applies twice. */}
+        {!collapsed && tags.length > 0 && (
+          <span className="rail-convo__tags">
+            {tags.slice(0, 2).map((tag) => <span key={tag} className="rail-convo__tag">{tag}</span>)}
+            {tags.length > 2 && <span className="rail-convo__tag rail-convo__tag--more">+{tags.length - 2}</span>}
+          </span>
+        )}
       </button>
       {!collapsed && (
         <div className="rail-convo__actions">
@@ -157,6 +174,63 @@ function ConversationListItemInner({
               <button type="button" role="menuitem" className="rail-menu__item" onClick={beginRename}>
                 <IconEdit size={16} /> <span>Rename</span>
               </button>
+              {onTogglePin && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="rail-menu__item"
+                  onClick={() => { closeMenu(); onTogglePin(conversation.id, !pinned) }}
+                >
+                  <IconPin size={16} /> <span>{pinned ? 'Unpin' : 'Pin to top'}</span>
+                </button>
+              )}
+              {onToggleArchive && (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="rail-menu__item"
+                  onClick={() => { closeMenu(); onToggleArchive(conversation.id, !archived) }}
+                >
+                  <IconFile size={16} /> <span>{archived ? 'Unarchive' : 'Archive'}</span>
+                </button>
+              )}
+              {onAddTag && (
+                <div className="rail-menu__tags">
+                  {tags.length > 0 && (
+                    <div className="rail-menu__tag-list">
+                      {tags.map((tag) => (
+                        <button
+                          key={tag}
+                          type="button"
+                          className="rail-menu__tag"
+                          onClick={() => onRemoveTag?.(conversation.id, tag)}
+                          title={`Remove tag “${tag}”`}
+                          aria-label={`Remove tag ${tag}`}
+                        >
+                          {tag} <IconClose size={11} />
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <input
+                    className="rail-menu__tag-input"
+                    placeholder="Add tag…"
+                    maxLength={MAX_TAG_LENGTH}
+                    aria-label={`Add a tag to ${title}`}
+                    /* Enter commits and keeps the menu open: tagging is
+                       usually more than one tag, and reopening the menu per
+                       tag is the difference between using this and not. */
+                    onKeyDown={(event) => {
+                      if (event.key !== 'Enter') return
+                      event.preventDefault()
+                      const value = event.currentTarget.value
+                      if (!value.trim()) return
+                      onAddTag(conversation.id, value)
+                      event.currentTarget.value = ''
+                    }}
+                  />
+                </div>
+              )}
               <button
                 type="button"
                 role="menuitem"

--- a/frontend/src/components/layout/SidebarRail.jsx
+++ b/frontend/src/components/layout/SidebarRail.jsx
@@ -5,6 +5,7 @@ import { ThemeToggle } from '../ui/ThemeToggle'
 import { Tooltip } from '../ui/Tooltip'
 import { ConversationListItem } from './ConversationListItem'
 import { apiSurfaceAllowsTab } from '../../lib/apiSurface.js'
+import { isPinned } from '../../lib/conversationOrganization.js'
 import {
   IconAnalytics, IconApi, IconBolt, IconChart, IconChat, IconClose, IconHistory, IconMemory, IconModels,
   IconDownload, IconNetwork, IconNewChat, IconObservatory, IconReceipt, IconSearch, IconSettings, IconSidebar, IconSystem,
@@ -73,16 +74,34 @@ export function SidebarRail({
   onSelectConversation,
   renameConversation,
   requestDeleteConversation,
+  conversationTags = [],
+  tagFilter = [],
+  onToggleTagFilter,
+  onClearTagFilter,
+  archivedCount = 0,
+  showArchived = false,
+  onToggleShowArchived,
+  onTogglePin,
+  onToggleArchive,
+  onAddTag,
+  onRemoveTag,
   runtime,
   apiSurface = 'full',
   themePreference,
   themeResolved,
   onCycleTheme,
 }) {
+  /* Pinned threads form their own group ABOVE the date buckets and are never
+     subject to the recent limit -- a pin that scrolls off after six other
+     chats is not a pin. The limit still applies to everything else, which is
+     what keeps the rail short. */
   const grouped = useMemo(() => {
+    const pinned = filteredConversations.filter(isPinned)
+    const rest = filteredConversations.filter((c) => !isPinned(c)).slice(0, RECENT_LIMIT)
     const groups = new Map(BUCKETS.map((b) => [b, []]))
-    filteredConversations.slice(0, RECENT_LIMIT).forEach((c) => groups.get(bucketFor(c.updated_at))?.push(c))
-    return BUCKETS.map((label) => ({ label, items: groups.get(label) || [] })).filter((g) => g.items.length)
+    rest.forEach((c) => groups.get(bucketFor(c.updated_at))?.push(c))
+    const dated = BUCKETS.map((label) => ({ label, items: groups.get(label) || [] })).filter((g) => g.items.length)
+    return pinned.length ? [{ label: 'Pinned', items: pinned }, ...dated] : dated
   }, [filteredConversations])
   const visibleSections = useMemo(() => NAV_SECTIONS
     .map((section) => ({
@@ -168,6 +187,33 @@ export function SidebarRail({
         )}
       </div>
 
+      {/* Tag filter. Rendered only when tags exist, so a user who never tags
+          anything sees the rail exactly as it was. */}
+      {conversationTags.length > 0 && (
+        <div className="rail__tag-filter" role="group" aria-label="Filter chats by tag">
+          {conversationTags.slice(0, 12).map(({ tag, count }) => {
+            const active = tagFilter.includes(tag)
+            return (
+              <button
+                key={tag}
+                type="button"
+                className={`rail__tag-chip ${active ? 'is-active' : ''}`}
+                aria-pressed={active}
+                onClick={() => onToggleTagFilter?.(tag)}
+                title={`${count} ${count === 1 ? 'chat' : 'chats'} tagged “${tag}”`}
+              >
+                {tag}
+              </button>
+            )
+          })}
+          {tagFilter.length > 0 && (
+            <button type="button" className="rail__tag-chip rail__tag-chip--clear" onClick={() => onClearTagFilter?.()}>
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+
       <div className="rail__scroll">
         <div className="rail__section">
           <div className="rail__section-label">Recent</div>
@@ -188,10 +234,24 @@ export function SidebarRail({
                   onSelect={onSelectConversation}
                   onRename={renameConversation}
                   onDelete={requestDeleteConversation}
+                  onTogglePin={onTogglePin}
+                  onToggleArchive={onToggleArchive}
+                  onAddTag={onAddTag}
+                  onRemoveTag={onRemoveTag}
                 />
               ))}
             </div>
           ))}
+          {archivedCount > 0 && (
+            <button
+              type="button"
+              className={`rail__archived-toggle ${showArchived ? 'is-active' : ''}`}
+              aria-pressed={showArchived}
+              onClick={() => onToggleShowArchived?.(!showArchived)}
+            >
+              {showArchived ? 'Hide archived' : `Show archived (${archivedCount})`}
+            </button>
+          )}
           {filteredConversations.length > 0 && (
             <button type="button" className="rail__nav-item" onClick={() => setTab('history')}>
               <IconHistory size={20} />

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -9,6 +9,8 @@ import { readExactTargetVerifiedRender, readTargetVerifiedMtp12 } from '../lib/n
 import { readExactTargetVerifiedSegmentedRender } from '../lib/nativeGenerationMetrics'
 import { NEW_CHAT_SENTINEL, resolveSelectedConversation, shouldCreateConversationForSend } from '../lib/chatState'
 import { normalizeStoredConversations } from '../lib/conversationStorage.js'
+import { allTags, archivedCount, organizeConversations, withArchived, withPinned, withTagAdded, withTagRemoved } from '../lib/conversationOrganization.js'
+import { parseImportedConversations } from '../lib/conversationImport.js'
 import { appStorage } from '../lib/appStorage.js'
 import { composeContextBudget } from '../lib/contextBudget.js'
 import {
@@ -703,6 +705,11 @@ export function useDashboardData({ showNotice, clearNotice }) {
   const [selectedConversationId, setSelectedConversationIdState] = useState(getInitialConversationId)
   const [selectedModelId, setSelectedModelId] = useState(getInitialModelId)
   const [search, setSearch] = useState('')
+  /* Session-scoped on purpose. A filter that survived a restart would hide
+     most of the list with no obvious cause; the pins and tags it filters on
+     are the durable part. */
+  const [conversationTagFilter, setConversationTagFilter] = useState([])
+  const [showArchivedConversations, setShowArchivedConversations] = useState(false)
   const [memorySearch, setMemorySearch] = useState('')
   const [composer, setComposer] = useState('')
   const [newChatTitle, setNewChatTitle] = useState('')
@@ -1114,14 +1121,17 @@ export function useDashboardData({ showNotice, clearNotice }) {
     ? pendingChat
     : null
 
-  const filteredConversations = useMemo(() => {
-    if (!search.trim()) return conversations
-    const q = search.toLowerCase()
-    return conversations.filter((conversation) =>
-      conversation.title.toLowerCase().includes(q)
-      || conversation.messages.some((message) => message.content.toLowerCase().includes(q)),
-    )
-  }, [conversations, search])
+  /* One place decides what the list contains and how it is ordered, so the
+     sidebar, the history page and the tag counts cannot disagree. Search now
+     also matches tags, and pinned threads sort above the rest. */
+  const filteredConversations = useMemo(() => organizeConversations(conversations, {
+    search,
+    tags: conversationTagFilter,
+    includeArchived: showArchivedConversations,
+  }), [conversations, search, conversationTagFilter, showArchivedConversations])
+
+  const conversationTags = useMemo(() => allTags(conversations), [conversations])
+  const archivedConversationCount = useMemo(() => archivedCount(conversations), [conversations])
 
   const filteredMemories = useMemo(() => {
     if (!memorySearch.trim()) return memories
@@ -2324,6 +2334,47 @@ export function useDashboardData({ showNotice, clearNotice }) {
     }
   }
 
+  const updateConversationRecord = (id, update) => {
+    persistConversations((current) => current.map((conversation) => (
+      conversation.id === id ? { ...update(conversation), updated_at: conversation.updated_at } : conversation
+    )))
+  }
+
+  /* Organizing a thread is not editing it: updated_at stays put above, so
+     pinning or tagging does not shuffle the recency order it is meant to
+     work with. */
+  const setConversationPinned = (id, pinned) => updateConversationRecord(id, (c) => withPinned(c, pinned))
+  const setConversationArchived = (id, archived) => updateConversationRecord(id, (c) => withArchived(c, archived))
+  const addConversationTag = (id, tag) => updateConversationRecord(id, (c) => withTagAdded(c, tag))
+  const removeConversationTag = (id, tag) => updateConversationRecord(id, (c) => withTagRemoved(c, tag))
+
+  const toggleConversationTagFilter = (tag) => {
+    setConversationTagFilter((current) => (
+      current.includes(tag) ? current.filter((entry) => entry !== tag) : [...current, tag]
+    ))
+  }
+  const clearConversationTagFilter = () => setConversationTagFilter([])
+
+  /* Imported threads are prepended, never merged onto existing ids: an import
+     that silently overwrites a conversation already here is worse than no
+     import at all. */
+  const importConversationsFromText = (text) => {
+    const { conversations: imported, skipped, error } = parseImportedConversations(text)
+    if (error) {
+      showNotice(error, 'error')
+      return { imported: 0, skipped }
+    }
+    persistConversations((current) => [...imported, ...current])
+    const noun = imported.length === 1 ? 'conversation' : 'conversations'
+    showNotice(
+      skipped > 0
+        ? `Imported ${imported.length} ${noun}; skipped ${skipped} with no readable messages.`
+        : `Imported ${imported.length} ${noun}.`,
+      'success',
+    )
+    return { imported: imported.length, skipped }
+  }
+
   const renameConversation = async (id, nextTitle) => {
     const trimmedTitle = nextTitle.trim()
     if (!trimmedTitle) {
@@ -2783,6 +2834,18 @@ export function useDashboardData({ showNotice, clearNotice }) {
     regenerateAsVariant,
     selectMessageVariant,
     discardMessageVariant,
+    conversationTags,
+    archivedConversationCount,
+    conversationTagFilter,
+    toggleConversationTagFilter,
+    clearConversationTagFilter,
+    showArchivedConversations,
+    setShowArchivedConversations,
+    setConversationPinned,
+    setConversationArchived,
+    addConversationTag,
+    removeConversationTag,
+    importConversationsFromText,
     stopGeneration,
     saveToMemory,
     createMemory,

--- a/frontend/src/lib/conversationExport.js
+++ b/frontend/src/lib/conversationExport.js
@@ -66,6 +66,45 @@ export function conversationToJson(conversation) {
   return JSON.stringify(exportableConversation(conversation), null, 2)
 }
 
+/* Bulk export. Same per-conversation whitelist, so the field policy above is
+   the only place that decides what may leave this machine -- a second shape
+   here is how an export starts leaking local paths again. Tags ride along so
+   an import lands organized; pinned/archived deliberately do not, because
+   they describe THIS machine's list, not the conversation. */
+export function exportableConversations(conversations) {
+  return {
+    format: 'camelid.conversations/v1',
+    exported_at: new Date().toISOString(),
+    telemetry_note: 'Timing/token fields are operational telemetry (client-measured unless usage_source=backend). They are not compatibility or support evidence.',
+    conversation_count: (conversations || []).length,
+    conversations: (conversations || []).map((conversation) => {
+      const exported = exportableConversation(conversation)
+      const tags = Array.isArray(conversation?.tags)
+        ? conversation.tags.map((tag) => String(tag)).filter(Boolean)
+        : []
+      if (tags.length) exported.tags = tags
+      return exported
+    }),
+  }
+}
+
+export function conversationsToJson(conversations) {
+  return JSON.stringify(exportableConversations(conversations), null, 2)
+}
+
+export function downloadAllConversations(conversations) {
+  const blob = new Blob([conversationsToJson(conversations)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  const stamp = new Date().toISOString().slice(0, 10)
+  anchor.href = url
+  anchor.download = `camelid-conversations-${stamp}.json`
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
 export function conversationToMarkdown(conversation) {
   const data = exportableConversation(conversation)
   const lines = [`# ${data.title}`, '']

--- a/frontend/src/lib/conversationImport.js
+++ b/frontend/src/lib/conversationImport.js
@@ -1,0 +1,134 @@
+/* Conversation import.
+
+   Export existed; import did not, which meant a transcript could leave this
+   machine but never arrive on another one. That is the actual gap: the data
+   was already portable, it just had nowhere to land.
+
+   This reads a file the user chose, so the file is DATA, never instructions
+   and never a source of shape. Nothing is spread from it. Every field is
+   copied by name, coerced to the type this app expects, and bounded. A field
+   the exporter never writes cannot arrive by being present in the JSON --
+   which is what keeps a hand-written file from injecting `pinned`, a
+   filesystem path, an enormous message array, or a `__proto__` key into
+   stored state.
+
+   Ids are always regenerated. Reusing an id from the file would let an
+   import silently overwrite a conversation already on this machine, and an
+   import that destroys existing data is worse than no import. */
+
+import { normalizeConversationOrganization, normalizeTag, MAX_TAGS_PER_CONVERSATION } from './conversationOrganization.js'
+
+export const IMPORT_FORMATS = ['camelid.conversation/v1', 'camelid.conversations/v1']
+
+const MAX_CONVERSATIONS_PER_IMPORT = 500
+const MAX_MESSAGES_PER_CONVERSATION = 5000
+const MAX_CONTENT_CHARS = 200_000
+const ROLES = ['user', 'assistant', 'system']
+
+const str = (value, max) => {
+  if (typeof value !== 'string') return ''
+  return max ? value.slice(0, max) : value
+}
+
+const isoOrNull = (value) => {
+  if (typeof value !== 'string') return null
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null
+}
+
+const finiteOrNull = (value) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+function importUsage(raw) {
+  if (!raw || typeof raw !== 'object') return null
+  const prompt = finiteOrNull(raw.prompt_tokens)
+  const completion = finiteOrNull(raw.completion_tokens)
+  if (prompt === null && completion === null) return null
+  return {
+    prompt_tokens: Math.max(0, prompt ?? 0),
+    completion_tokens: Math.max(0, completion ?? 0),
+    total_tokens: Math.max(0, (prompt ?? 0) + (completion ?? 0)),
+  }
+}
+
+function importMessage(raw, index) {
+  if (!raw || typeof raw !== 'object') return null
+  const role = ROLES.includes(raw.role) ? raw.role : null
+  if (!role) return null
+  const content = str(raw.content, MAX_CONTENT_CHARS)
+  if (!content.trim()) return null
+  const usage = importUsage(raw.usage)
+  const message = {
+    id: `imported-message-${index}-${Math.random().toString(36).slice(2, 10)}`,
+    role,
+    content,
+    created_at: isoOrNull(raw.created_at) || new Date().toISOString(),
+  }
+  const modelId = str(raw.model_id, 200)
+  if (modelId) message.model_id = modelId
+  if (usage) {
+    message.usage = usage
+    /* Imported counts describe a run on someone else's machine. Labelling
+       them as this backend's reported usage would let another engine's
+       numbers masquerade as Camelid telemetry, so they are always an
+       estimate here whatever the file claimed. */
+    message.usage_source = 'client_estimate'
+  }
+  if (['stop', 'length', 'error', 'interrupted'].includes(raw.finish_reason)) {
+    message.finish_reason = raw.finish_reason
+  }
+  return message
+}
+
+function importConversation(raw, index) {
+  if (!raw || typeof raw !== 'object') return null
+  const rawMessages = Array.isArray(raw.messages) ? raw.messages.slice(0, MAX_MESSAGES_PER_CONVERSATION) : []
+  const messages = rawMessages.map(importMessage).filter(Boolean)
+  if (!messages.length) return null
+  const created = isoOrNull(raw.created_at) || new Date().toISOString()
+  const tags = (Array.isArray(raw.tags) ? raw.tags : [])
+    .map(normalizeTag)
+    .filter(Boolean)
+    .slice(0, MAX_TAGS_PER_CONVERSATION)
+  const conversation = {
+    id: `conversation-imported-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 10)}`,
+    title: str(raw.title, 120).trim() || 'Imported conversation',
+    created_at: created,
+    updated_at: isoOrNull(raw.updated_at) || created,
+    messages,
+  }
+  const modelId = str(raw.model_id, 200)
+  if (modelId) conversation.model_id = modelId
+  if (tags.length) conversation.tags = tags
+  return normalizeConversationOrganization(conversation)
+}
+
+/* Accepts a single-conversation export, a bulk export, or a bare array.
+   Returns { conversations, skipped, error } -- never throws, because the
+   caller is a file picker and a malformed file is an ordinary outcome. */
+export function parseImportedConversations(text) {
+  let parsed
+  try {
+    parsed = JSON.parse(String(text || ''))
+  } catch {
+    return { conversations: [], skipped: 0, error: 'That file is not valid JSON.' }
+  }
+
+  let rawList
+  if (Array.isArray(parsed)) rawList = parsed
+  else if (Array.isArray(parsed?.conversations)) rawList = parsed.conversations
+  else if (parsed && typeof parsed === 'object' && Array.isArray(parsed.messages)) rawList = [parsed]
+  else {
+    return { conversations: [], skipped: 0, error: 'That file does not look like a Camelid conversation export.' }
+  }
+
+  const bounded = rawList.slice(0, MAX_CONVERSATIONS_PER_IMPORT)
+  const conversations = bounded.map(importConversation).filter(Boolean)
+  const skipped = rawList.length - conversations.length
+  if (!conversations.length) {
+    return { conversations: [], skipped, error: 'No conversations in that file had any readable messages.' }
+  }
+  return { conversations, skipped, error: null }
+}

--- a/frontend/src/lib/conversationOrganization.js
+++ b/frontend/src/lib/conversationOrganization.js
@@ -1,0 +1,175 @@
+/* Pinning, archiving and tagging for the conversation list.
+
+   The sidebar shows six recent conversations and sorts strictly by recency,
+   so the thread you keep coming back to falls off the list the moment six
+   other chats happen. Search finds it again only if you remember a word from
+   it. Pinning is the fix for that; archiving is the fix for the opposite
+   problem, a list full of threads you are done with.
+
+   Tags rather than folders. A folder is a tag that only allows one, and it
+   costs a tree the reader has to build and maintain before it helps. Tags
+   also fall out of the existing search box for free -- a tag is matched by
+   the same query that matches a title.
+
+   Every field here is optional. A conversation written before this existed
+   has no pinned/archived/tags and behaves exactly as it did. */
+
+export const MAX_TAG_LENGTH = 24
+export const MAX_TAGS_PER_CONVERSATION = 8
+
+/* Tags are compared and stored lowercased so "Rust" and "rust" are one tag
+   rather than two that look identical in a filter row. */
+export function normalizeTag(value) {
+  return String(value || '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .slice(0, MAX_TAG_LENGTH)
+    .toLowerCase()
+}
+
+export function tagsOf(conversation) {
+  const raw = Array.isArray(conversation?.tags) ? conversation.tags : []
+  const seen = new Set()
+  const tags = []
+  for (const entry of raw) {
+    const tag = normalizeTag(entry)
+    if (!tag || seen.has(tag)) continue
+    seen.add(tag)
+    tags.push(tag)
+  }
+  return tags
+}
+
+export function isPinned(conversation) {
+  return Boolean(conversation?.pinned)
+}
+
+export function isArchived(conversation) {
+  return Boolean(conversation?.archived)
+}
+
+export function withPinned(conversation, pinned) {
+  const next = { ...conversation }
+  if (pinned) {
+    next.pinned = true
+    // Pinning something you had archived is a contradiction; treat the pin as
+    // the more recent intent and bring it back into the list.
+    delete next.archived
+  } else {
+    delete next.pinned
+  }
+  return next
+}
+
+export function withArchived(conversation, archived) {
+  const next = { ...conversation }
+  if (archived) {
+    next.archived = true
+    delete next.pinned
+  } else {
+    delete next.archived
+  }
+  return next
+}
+
+export function withTagAdded(conversation, tag) {
+  const normalized = normalizeTag(tag)
+  if (!normalized) return conversation
+  const tags = tagsOf(conversation)
+  if (tags.includes(normalized)) return conversation
+  if (tags.length >= MAX_TAGS_PER_CONVERSATION) return conversation
+  return { ...conversation, tags: [...tags, normalized] }
+}
+
+export function withTagRemoved(conversation, tag) {
+  const normalized = normalizeTag(tag)
+  const tags = tagsOf(conversation).filter((entry) => entry !== normalized)
+  const next = { ...conversation }
+  if (tags.length) next.tags = tags
+  else delete next.tags
+  return next
+}
+
+/* Every tag in use, most-used first then alphabetical, so the filter row is
+   stable between renders and does not reorder as you click through it. */
+export function allTags(conversations) {
+  const counts = new Map()
+  for (const conversation of conversations || []) {
+    for (const tag of tagsOf(conversation)) {
+      counts.set(tag, (counts.get(tag) || 0) + 1)
+    }
+  }
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => (b.count - a.count) || a.tag.localeCompare(b.tag))
+}
+
+function matchesSearch(conversation, query) {
+  if (!query) return true
+  const q = query.toLowerCase()
+  if (String(conversation?.title || '').toLowerCase().includes(q)) return true
+  if (tagsOf(conversation).some((tag) => tag.includes(q))) return true
+  return (conversation?.messages || []).some((message) => (
+    String(message?.content || '').toLowerCase().includes(q)
+  ))
+}
+
+const timeOf = (conversation) => {
+  const parsed = Date.parse(conversation?.updated_at || conversation?.created_at || '')
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/* One place decides what the list contains and in what order, so the sidebar,
+   the history page and the tag counts can never disagree about it.
+
+   Archived threads are excluded unless asked for OR unless a tag filter names
+   them: filtering to a tag and getting nothing back, when the matching thread
+   is merely archived, reads as data loss. */
+export function organizeConversations(conversations, options = {}) {
+  const {
+    search = '',
+    tags: tagFilter = [],
+    includeArchived = false,
+  } = options
+  const query = String(search || '').trim().toLowerCase()
+  const wanted = (Array.isArray(tagFilter) ? tagFilter : []).map(normalizeTag).filter(Boolean)
+  const list = Array.isArray(conversations) ? conversations : []
+
+  const matched = list.filter((conversation) => {
+    if (!matchesSearch(conversation, query)) return false
+    if (wanted.length) {
+      const owned = tagsOf(conversation)
+      if (!wanted.every((tag) => owned.includes(tag))) return false
+      return true
+    }
+    return includeArchived || !isArchived(conversation)
+  })
+
+  return matched.slice().sort((a, b) => {
+    const pinDelta = Number(isPinned(b)) - Number(isPinned(a))
+    if (pinDelta) return pinDelta
+    return timeOf(b) - timeOf(a)
+  })
+}
+
+export function archivedCount(conversations) {
+  return (conversations || []).filter(isArchived).length
+}
+
+/* Storage normalization: drop empty/absent organization fields rather than
+   storing `pinned: false` and `tags: []` on every conversation forever, and
+   re-normalize tags that arrived from an import or a hand-edited file. */
+export function normalizeConversationOrganization(conversation) {
+  if (!conversation || typeof conversation !== 'object') return conversation
+  const next = { ...conversation }
+  if (next.pinned) next.pinned = true
+  else delete next.pinned
+  if (next.archived) next.archived = true
+  else delete next.archived
+  const tags = tagsOf(next).slice(0, MAX_TAGS_PER_CONVERSATION)
+  if (tags.length) next.tags = tags
+  else delete next.tags
+  // A pinned thread is never also archived, whatever the file said.
+  if (next.pinned && next.archived) delete next.archived
+  return next
+}

--- a/frontend/src/lib/conversationStorage.js
+++ b/frontend/src/lib/conversationStorage.js
@@ -1,4 +1,5 @@
 import { normalizeMessageVariants } from './messageVariants.js'
+import { normalizeConversationOrganization } from './conversationOrganization.js'
 
 export function cleanLegacyDemoCapCopy(value) {
   if (typeof value !== 'string') return value
@@ -40,7 +41,7 @@ export function normalizeStoredMessage(message, { clearStaleStreaming = false } 
 }
 
 export function normalizeStoredConversations(records, options = {}) {
-  return (Array.isArray(records) ? records : []).map((conversation) => ({
+  return (Array.isArray(records) ? records : []).map((conversation) => normalizeConversationOrganization({
     ...conversation,
     messages: Array.isArray(conversation?.messages)
       ? conversation.messages.map((message) => normalizeStoredMessage(message, options))

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -500,3 +500,103 @@
   padding: var(--space-1) var(--space-4);
   cursor: pointer;
 }
+
+/* ---- Conversation organization: pins, tags, archive ----------------------
+   All of it is conditional on the user having organized something. A rail
+   with no pins and no tags renders exactly as it did before. */
+.rail-convo__pin { flex: none; color: var(--color-accent); }
+.rail-convo__tags {
+  display: inline-flex;
+  gap: 3px;
+  margin-left: auto;
+  flex: none;
+  overflow: hidden;
+}
+.rail-convo__tag {
+  padding: 0 4px;
+  border-radius: 3px;
+  background: var(--color-surface-hover);
+  color: var(--color-text-faint);
+  font-size: var(--text-2xs);
+  line-height: 1.5;
+  max-width: 60px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rail-convo__tag--more { color: var(--color-text-muted); }
+
+.rail__tag-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0 var(--space-3) var(--space-2);
+}
+.rail__tag-chip {
+  padding: 2px var(--space-2);
+  border: 1px solid var(--color-border-soft);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+}
+.rail__tag-chip:hover { border-color: var(--color-accent); color: var(--color-text); }
+.rail__tag-chip.is-active {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-accent-contrast, #fff);
+}
+.rail__tag-chip--clear { border-style: dashed; }
+.rail__tag-chip:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+
+.rail__archived-toggle {
+  width: 100%;
+  margin-top: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-faint);
+  font-size: var(--text-2xs);
+  text-align: left;
+  cursor: pointer;
+}
+.rail__archived-toggle:hover { background: var(--color-surface-hover); color: var(--color-text-muted); }
+.rail__archived-toggle.is-active { color: var(--color-accent-text); }
+
+.rail-menu__tags {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: var(--space-1) var(--space-2);
+  border-top: 1px solid var(--color-border-soft);
+}
+.rail-menu__tag-list { display: flex; flex-wrap: wrap; gap: 3px; }
+.rail-menu__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 1px 4px;
+  border: none;
+  border-radius: 3px;
+  background: var(--color-surface-hover);
+  color: var(--color-text-muted);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+}
+.rail-menu__tag:hover { color: var(--color-error); }
+.rail-menu__tag-input {
+  width: 100%;
+  padding: 2px var(--space-1);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--text-2xs);
+}
+
+.history-view__tools { display: flex; gap: var(--space-2); align-items: center; }
+/* The picker is opened by the Import button; the input itself is never the
+   control the user sees. */
+.history-view__import-input { display: none; }

--- a/frontend/src/views/HistoryView.jsx
+++ b/frontend/src/views/HistoryView.jsx
@@ -1,8 +1,9 @@
+import { useRef } from 'react'
 import { clampText, formatCompactNumber, formatHistoryDate, formatModelLabel, formatPreview } from '../lib/formatters'
 import { Button } from '../components/ui/Button'
-import { downloadConversation } from '../lib/conversationExport'
+import { downloadAllConversations, downloadConversation } from '../lib/conversationExport'
 import { EmptyState } from '../components/ui/EmptyState'
-import { IconHistory, IconChat, IconDownload, IconTrash } from '../components/ui/icons'
+import { IconHistory, IconChat, IconDownload, IconFile, IconTrash } from '../components/ui/icons'
 
 function getConversationStats(conversation) {
   const messageCount = conversation.messages?.length || 0
@@ -11,7 +12,8 @@ function getConversationStats(conversation) {
   return { messageCount, assistantCount, latestMessage }
 }
 
-export default function HistoryView({ filteredConversations, setSelectedConversationId, setTab, deleteConversation }) {
+export default function HistoryView({ filteredConversations, setSelectedConversationId, setTab, deleteConversation, importConversationsFromText }) {
+  const importInputRef = useRef(null)
   const totalMessages = filteredConversations.reduce((sum, c) => sum + (c.messages?.length || 0), 0)
   const activeToday = filteredConversations.filter((c) => {
     if (!c.updated_at) return false
@@ -38,6 +40,48 @@ export default function HistoryView({ filteredConversations, setSelectedConversa
             <strong>{formatCompactNumber(totalMessages)}</strong>
             <small>stored locally</small>
           </div>
+        </div>
+        {/* Export existed per-conversation; import did not, which meant a
+            transcript could leave this machine but never arrive on another
+            one. Both live here, next to the list they act on. */}
+        <div className="history-view__tools">
+          <Button
+            variant="ghost"
+            icon={<IconDownload size={16} />}
+            disabled={!hasConversations}
+            onClick={() => downloadAllConversations(filteredConversations)}
+            title={hasConversations
+              ? `Export the ${filteredConversations.length} ${filteredConversations.length === 1 ? 'conversation' : 'conversations'} shown as one JSON file`
+              : 'Nothing to export in this view'}
+          >
+            Export all
+          </Button>
+          {importConversationsFromText && (
+            <>
+              <Button
+                variant="ghost"
+                icon={<IconFile size={16} />}
+                onClick={() => importInputRef.current?.click()}
+                title="Import conversations from a Camelid export file"
+              >
+                Import
+              </Button>
+              <input
+                ref={importInputRef}
+                type="file"
+                accept="application/json,.json"
+                className="history-view__import-input"
+                aria-label="Choose a Camelid export file to import"
+                onChange={async (event) => {
+                  const file = event.target.files?.[0]
+                  // Reset first: picking the same file twice must re-fire.
+                  event.target.value = ''
+                  if (!file) return
+                  importConversationsFromText(await file.text())
+                }}
+              />
+            </>
+          )}
         </div>
       </header>
 


### PR DESCRIPTION
> **Stacked on [#750](https://github.com/timtoole02/Camelid/pull/750)** → which is stacked on [#748](https://github.com/timtoole02/Camelid/pull/748). Merge order: **#748 → #750 → this**. Each retargets automatically as the one below merges.
>
> ⚠️ Do **not** pass `--delete-branch` when merging #748 or #750 — deleting a stacked PR's base closes the dependent PR.

## What changed

The rail shows **six** recent conversations sorted strictly by recency, so the thread you keep coming back to falls off the moment six other chats happen — and search finds it again only if you remember a word from it. Export existed per conversation; **import did not**, so a transcript could leave this machine but never arrive on another one.

This adds pin, archive, tags, a tag filter row, bulk export, and import.

## Tags rather than folders — a scope call worth flagging

I listed "folders" in the original gap analysis. I built **tags** instead.

A folder is a tag that allows only one, and it costs a tree the reader has to build and maintain before it helps. Tags also fall out of the existing search box for free — a tag is matched by the same query that matches a title, so there's no second search to learn. Nothing here blocks real folders later.

**Say the word if you want an actual folder tree** and I'll add it on top.

## Behaviour decisions worth reviewing

- **Pinned threads are not subject to the six-recent limit.** A pin that falls off after six chats is not a pin. They get their own group above the date buckets.
- **Pin and archive are mutually exclusive** — doing either clears the other rather than storing a contradiction.
- **Archiving shows `Show archived (N)`.** An archive with no visible way back reads as deletion.
- **Organizing is not editing**: `updated_at` is preserved across pin/archive/tag, so tagging doesn't shuffle the recency order it's meant to work with.
- **An archived thread still matches an explicit tag filter.** Filtering to a tag and getting nothing back, when the match is merely archived, reads as data loss.
- Every field is optional and absent by default — a user who never organizes anything sees the rail exactly as before.

One function (`organizeConversations`) decides what the list contains and in what order, so the sidebar, the history page and the tag counts can't disagree.

## Import treats the file as data

This reads a **user-chosen file into stored state**, so nothing is spread from it. Every field is copied by name, coerced, and bounded — a field the exporter never writes cannot arrive by being present in the JSON.

- **Ids are always regenerated.** Reusing the file's id would let an import silently overwrite a conversation already here, and an import that destroys existing data is worse than no import.
- **Imported token counts are always relabelled as estimates.** They describe a run on someone else's machine; letting another engine's numbers claim `usage_source: 'backend'` would put foreign telemetry behind Camelid's own label.
- Bulk export **reuses the existing per-conversation whitelist** rather than defining a second shape — a second shape is how an export starts leaking local paths again. Tags travel so an import lands organized; `pinned`/`archived` don't, because they describe *this machine's list*, not the conversation.

## Validation

| Gate | Covers |
|---|---|
| `smoke:organization` | tag normalization/bounds, pin↔archive exclusivity, ordering (pinned first *even when oldest*), the archived-plus-tag-filter case, storage normalization, bulk-export field policy, and a **deliberately hostile import fixture**: over-long title, colliding id, claimed `pinned`, local path, `__proto__`, 40 tags, unknown roles, empty content, a non-object message, negative token counts, and a claimed `usage_source: backend` |
| `smoke:organization-browser` | the oldest chat *starts off the rail*; pinning brings it back and keeps it past the six-recent limit; tagging shows a chip and filters; archiving hides it with a counted way back; everything survives a reload with `updated_at` intact; and a real file goes through the **real file picker** without overwriting the conversation whose id it claimed |

Full frontend smoke set green locally — 20 suites.

## Docs / compatibility rows

None. No backend change, no contract row, no support claim. All state is local.
