### PR TITLE
fix(frontend): de-flake the conversation organization browser smoke

### DIFF
--- a/frontend/scripts/conversation-organization-browser-smoke.mjs
+++ b/frontend/scripts/conversation-organization-browser-smoke.mjs
@@ -181,8 +181,24 @@ try {
   /* ---- tag it, and filter by that tag ---------------------------------- */
   await openMenuFor(OLDEST)
   await page.waitForSelector('.rail-menu__tag-input', { timeout: 10000 })
-  await page.type('.rail-menu__tag-input', 'CUDA')
-  await page.keyboard.press('Enter')
+  /* Set the value and fire Enter in ONE evaluate.
+     page.type() followed by keyboard.press() spans two round trips, and the
+     menu is portalled: if React re-commits it in between, the typed value goes
+     with the replaced input and Enter then lands on an empty box, whose
+     handler returns silently. That raced about half the time. Doing both
+     against the same element reference removes the window while still going
+     through the real onKeyDown path -- React's synthetic handler is delegated
+     at the root, so a bubbling native keydown reaches it. */
+  const tagSubmitted = await page.evaluate(() => {
+    const input = document.querySelector('.rail-menu__tag-input')
+    if (!input) return false
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set
+    setter.call(input, 'CUDA')
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    return true
+  })
+  assert.equal(tagSubmitted, true, 'the tag box is reachable in the open menu')
   await page.waitForFunction(() => (
     [...document.querySelectorAll('.rail-convo__tag')].some((n) => n.textContent === 'cuda')
   ), { timeout: 10000 })


### PR DESCRIPTION
## What changed

The tag step of `smoke:organization-browser` raced roughly **half the time**. One line, in the smoke only — no product code.

## Why it raced

`page.type(...)` followed by `page.keyboard.press('Enter')` spans two round trips. The rail menu is **portalled**, so a React re-commit in between replaced the input element. The typed value went with the old element, `Enter` landed on an empty box, and the handler's `if (!value.trim()) return` did nothing — no error, no tag, just a 10s timeout on the assertion that follows.

Setting the value and dispatching `keydown` against the **same element reference in one `evaluate`** removes the window. It still exercises the real `onKeyDown` path: React's synthetic handler is delegated at the root, so a bubbling native keydown reaches it.

## How it was found

It was **green in CI and green on the feature branch** ([#751](https://github.com/timtoole02/Camelid/pull/751)). It surfaced running the full frontend smoke set against the *merged* tree after #748/#750/#751 landed — then re-running twice to tell a flake apart from a merge regression (`PASS`, then `FAIL` at the same line).

## Validation

- `smoke:organization-browser` — **5/5 green** after the fix (was ~50%)
- `smoke:continuation-browser`, `smoke:variants-browser` — **3/3 each**, unchanged

Those two set composer text behind a `data-send-ready` stability gate rather than typing into a portalled menu, which is why only this one raced. The rest of the frontend suite is green on merged main.

## Docs / compatibility rows

None. Test-harness only.
