### PR TITLE
Make the image-input path report what it can actually do

### DIFF
--- a/frontend/scripts/web-research-smoke.mjs
+++ b/frontend/scripts/web-research-smoke.mjs
@@ -644,6 +644,18 @@ assert.match(dashboardHookSource, /fitWebResearchContext[\s\S]*deriveFittedWebRe
 assert.doesNotMatch(dashboardHookSource, /Math\.max\(1, Math\.floor\(fittedReplyBudget\.replyReserve\)\)/, 'known context overflow must never be coerced into a max_tokens=1 request')
 assert.match(dashboardHookSource, /activeContextLength:\s*runtime\?\.active_context_length/, 'send-time fitting must use the active runtime context rather than training metadata')
 assert.match(dashboardHookSource, /visionTokenAllowance:\s*runtime\?\.vision_token_allowance/, 'vision context must use a runtime allowance instead of base64 transport length')
+// The assertion above pins the CONSUMER, and passed for as long as the field
+// went unemitted — the estimator silently fell back to a stale default. Pin the
+// producer too. Three occurrences: the struct field and both HealthResponse
+// literals; a single-site check would still pass if only the busy-path
+// constructor kept it, which is the exact mistake api/mod.rs warns about.
+// Match the `field:` binding form only, so prose mentions in doc comments
+// cannot pad the count: one struct field plus two constructors.
+const apiSource = await readFile(resolve(scriptDir, '../../src/api/mod.rs'), 'utf8')
+assert.ok(
+  (apiSource.match(/vision_token_allowance:/g)?.length ?? 0) >= 3,
+  'the backend must declare vision_token_allowance and set it in BOTH health constructors, or the consumer above silently falls back to a default',
+)
 assert.doesNotMatch(dashboardHookSource, /\btools\s*:/, 'Gemma Web research must not add unsupported function tools to chat requests')
 assert.doesNotMatch(dashboardHookSource, /\btool_choice\s*:/, 'Web Auto must remain separate from native model tool selection')
 assert.doesNotMatch(dashboardHookSource, /\bcamelid_tools\s*:/, 'Web Auto must not enter a camelid_tools loop')

--- a/frontend/src/hooks/useDashboardData.js
+++ b/frontend/src/hooks/useDashboardData.js
@@ -668,8 +668,9 @@ function makeDashboard({ health, models, currentModel, capabilities, conversatio
       max_generation_tokens: Number(health?.max_generation_tokens) || null,
       model_family: optionalString(health?.model_family),
       vision_ready: Boolean(health?.vision_ready),
-      // Optional future/runtime hint. Older servers omit it, in which case the
-      // bounded estimator default matches Camelid's current image-token ceiling.
+      // Servers before this field existed omit it; the estimator then falls back
+      // to its own default, which now matches the serve path's image-token
+      // ceiling. A server that sends it stays authoritative either way.
       vision_token_allowance: Number(health?.vision_token_allowance) || null,
       q8_runtime: health?.q8_runtime || null,
       // Required for lane-scoped support truth. All Gemma 4 serve variants use

--- a/frontend/src/lib/conversationExport.js
+++ b/frontend/src/lib/conversationExport.js
@@ -8,10 +8,14 @@ const MESSAGE_EXPORT_FIELDS = [
   'id', 'role', 'content', 'created_at', 'model_id', 'model_name',
   'finish_reason', 'usage', 'usage_source', 'elapsed_ms',
   'first_content_ms', 'tokens_out_per_sec', 'support_row',
-  'web_research',
+  'web_research', 'image',
 ]
 
 const SUPPORT_ROW_FIELDS = ['id', 'status', 'supported']
+/* data_url LAST on purpose: pick() preserves this order, so the multi-megabyte
+   string lands at the end of each message object and the descriptive fields
+   stay readable at the top instead of sitting behind a wall of base64. */
+const IMAGE_EXPORT_FIELDS = ['name', 'type', 'size', 'width', 'height', 'data_url']
 const WEB_RESEARCH_FIELDS = ['reason', 'query', 'sources', 'warnings']
 const WEB_SOURCE_FIELDS = ['title', 'url']
 
@@ -49,6 +53,7 @@ export function exportableConversation(conversation) {
     messages: (conversation?.messages || []).map((message) => {
       const picked = pick(message, MESSAGE_EXPORT_FIELDS)
       if (picked.support_row) picked.support_row = pick(picked.support_row, SUPPORT_ROW_FIELDS)
+      if (picked.image) picked.image = pick(picked.image, IMAGE_EXPORT_FIELDS)
       if (picked.web_research) {
         picked.web_research = pick(picked.web_research, WEB_RESEARCH_FIELDS)
         picked.web_research.sources = (picked.web_research.sources || [])
@@ -115,6 +120,19 @@ export function conversationToMarkdown(conversation) {
     if (message.role !== 'user' && message.role !== 'assistant') continue
     lines.push(`## ${message.role === 'user' ? 'You' : 'Camelid'}`, '')
     lines.push(message.content || '', '')
+    /* Outside the assistant branch below: the attachment rides on the user
+       turn. Metadata only — a data URL would put megabytes on one line and
+       destroy the pasteability every other note here preserves. */
+    if (message.role === 'user' && message.image) {
+      const size = `${Math.round((message.image.size || 0) / 1024)} KB`
+      const dims = message.image.width && message.image.height
+        ? ` · ${message.image.width}×${message.image.height}`
+        : ''
+      lines.push(
+        `> Attached image: ${markdownLabel(message.image.name)} (${markdownLabel(message.image.type)} · ${size}${dims}) — image data is not included in Markdown; export JSON to keep it.`,
+        '',
+      )
+    }
     if (message.role === 'assistant') {
       const meta = []
       if (message.model_id) meta.push(`model \`${message.model_id}\``)

--- a/frontend/src/lib/webResearch.js
+++ b/frontend/src/lib/webResearch.js
@@ -8,7 +8,9 @@ const MAX_CONTEXT_TOTAL_CHARS = 8_000
 const MIN_CONTEXT_SOURCE_CHARS = 256
 const MIN_CONTEXT_CHUNK_CHARS = 128
 const DEFAULT_RESEARCH_TIMEOUT_MS = 45_000
-const DEFAULT_VISION_TOKEN_ALLOWANCE = 1_024
+// Matches the serve path's default per-image token ceiling, used only when the
+// server does not advertise vision_token_allowance on /v1/health.
+const DEFAULT_VISION_TOKEN_ALLOWANCE = 128
 const MAX_VISION_TOKEN_ALLOWANCE = 8_192
 const CHAT_TEMPLATE_TOKENS_PER_MESSAGE = 16
 const CHAT_TEMPLATE_BASE_TOKENS = 8

--- a/frontend/src/views/ChatWorkspace.jsx
+++ b/frontend/src/views/ChatWorkspace.jsx
@@ -133,6 +133,11 @@ async function prepareVisionAttachment(file) {
   const image = await loadBrowserImage(file)
   let blob = file
   let type = file.type
+  // Track the dimensions alongside the bytes: the resize branch below replaces
+  // the blob, and reporting the source dimensions for the resized bytes would
+  // describe an image that was never sent.
+  let width = image.naturalWidth
+  let height = image.naturalHeight
   if (file.size > MAX_VISION_UPLOAD_BYTES || Math.max(image.naturalWidth, image.naturalHeight) > MAX_VISION_EDGE) {
     const scale = Math.min(1, MAX_VISION_EDGE / Math.max(image.naturalWidth, image.naturalHeight))
     const canvas = document.createElement('canvas')
@@ -146,6 +151,10 @@ async function prepareVisionAttachment(file) {
     if (blob?.size > MAX_VISION_UPLOAD_BYTES) blob = await canvasBlob(canvas, 0.72)
     if (!blob) throw new Error('Could not prepare the selected image.')
     type = 'image/jpeg'
+    // Both canvasBlob calls encode this same canvas, so these describe the
+    // bytes actually sent under the 0.9 and the 0.72 retry path alike.
+    width = canvas.width
+    height = canvas.height
   }
   if (blob.size > MAX_VISION_UPLOAD_BYTES) {
     throw new Error('The prepared image is still too large. Choose an image under 3 MB.')
@@ -154,8 +163,8 @@ async function prepareVisionAttachment(file) {
     name: file.name,
     type,
     size: blob.size,
-    width: image.naturalWidth,
-    height: image.naturalHeight,
+    width,
+    height,
     data_url: await readAsDataUrl(blob),
   }
 }

--- a/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
+++ b/qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json
@@ -27,7 +27,7 @@
   },
   "implementation": {
     "source_file": "src/api/mod.rs",
-    "source_git_blob_sha1": "b02cbac9e48bfeeadd02758ce869abbb70efc63e",
+    "source_git_blob_sha1": "f7c4c04a0d4cd2f0443aa45a59d4912875a3c2e2",
     "architecture": "smollm3",
     "renderer": "render_smollm3_production_chat_prompt",
     "public_chokepoints": [

--- a/scripts/hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/hf-qualification-smollm3-chat-parity.mjs
@@ -93,11 +93,11 @@ const GROUNDING_FILES = Object.freeze({
   }),
   runtime_envelope: Object.freeze({
     path: 'qa/model-qualification/fixtures/smollm3-default-thinking-runtime-envelope-v1.json',
-    sha256: '25f663afe81bcd3bbc83fd1d83e6e9ff4132651aeb62e8e453e532774e822ea6',
+    sha256: '153b991ed7317e807d437eedad0149c39555ce097c146d9cae0d8c5d899b52ce',
   }),
 })
 
-const RENDERER_GIT_BLOB_SHA1 = 'b02cbac9e48bfeeadd02758ce869abbb70efc63e'
+const RENDERER_GIT_BLOB_SHA1 = 'f7c4c04a0d4cd2f0443aa45a59d4912875a3c2e2'
 const SHAPE_CASE_ID = 'default_think_single_user_generation_prompt'
 const NORMALIZED_PROMPT_UTF8_BYTES = 1_392
 const NORMALIZED_PROMPT_SHA256 = '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1'

--- a/scripts/test-hf-qualification-smollm3-chat-parity.mjs
+++ b/scripts/test-hf-qualification-smollm3-chat-parity.mjs
@@ -114,7 +114,7 @@ assert.deepEqual(TEMPLATE_IDENTITY, {
 assert.equal(GROUNDING_FILES.shape_pack.sha256,
   'd46794448b7c2585d0aa83dfd7bb17d4904c2dcbc048ade1ef68cd3863166de6')
 assert.equal(GROUNDING_FILES.runtime_envelope.sha256,
-  '25f663afe81bcd3bbc83fd1d83e6e9ff4132651aeb62e8e453e532774e822ea6')
+  '153b991ed7317e807d437eedad0149c39555ce097c146d9cae0d8c5d899b52ce')
 assert.equal(LLAMA_PIN.executable_sha256,
   '6c787bf07ac1d7e1bbaa1ee176c3ef0df58ea86494c8c1b1d2d9f4a9176b19ae')
 assert.equal(LLAMA_PIN.server_impl_sha256,
@@ -331,7 +331,7 @@ assert.equal(classifySmolLM3ChatParityError(sharedSmolError).error_code,
 
 const committedGrounding = await inspectGroundings(root)
 assert.equal(committedGrounding.renderer_git_blob_sha1,
-  'b02cbac9e48bfeeadd02758ce869abbb70efc63e')
+  'f7c4c04a0d4cd2f0443aa45a59d4912875a3c2e2')
 assert.equal(committedGrounding.shape_case.normalized_prompt_sha256,
   '7619416ae94ba9a00378d976bfa944f5ba726747f9b67ba4e862d9a7fe20e4f1')
 const shapePack = JSON.parse(await readFile(resolve(GROUNDING_FILES.shape_pack.path), 'utf8'))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -642,6 +642,12 @@ pub struct HealthResponse {
     /// True when the active runnable model has a resident Prism/Qwen3-VL
     /// projector and can accept OpenAI `image_url` chat content parts.
     pub vision_ready: bool,
+    /// Merged image tokens one attached image is charged by default, so a client
+    /// can budget its context window without guessing. `None` when the active
+    /// model cannot accept an image at all. This is the default ceiling only: a
+    /// request that sets `camelid_image_max_tokens` may legitimately cost more,
+    /// up to the hard bound this server enforces.
+    pub vision_token_allowance: Option<u32>,
     pub active_model_id: Option<String>,
     pub q8_runtime: Q8RuntimeHealth,
     pub execution_plan: Option<ExecutionPlan>,
@@ -3611,6 +3617,7 @@ async fn health_registry_snapshot(state: &AppState) -> HealthResponse {
         max_prompt_tokens,
         max_generation_tokens,
         vision_ready,
+        vision_token_allowance: vision_ready.then_some(DEFAULT_MAX_IMAGE_TOKENS),
         active_model_id: active_id_lock.clone(),
         q8_runtime: q8_runtime_health(),
         execution_plan,
@@ -3732,6 +3739,9 @@ fn busy_health_response(state: &AppState) -> HealthResponse {
         max_prompt_tokens: state.server_limits.max_prompt_tokens,
         max_generation_tokens: state.server_limits.max_generation_tokens,
         vision_ready: false,
+        // The busy snapshot cannot read the runnable registry, so it cannot know
+        // whether vision is ready — reporting an allowance here would be a guess.
+        vision_token_allowance: None,
         active_model_id: None,
         q8_runtime: q8_runtime_health(),
         execution_plan: None,
@@ -14379,6 +14389,16 @@ async fn load_runnable_serve_runtime(
 const PRISM_IMAGE_PAD: &str = "<|image_pad|>";
 const MAX_PRISM_IMAGE_BYTES: usize = 8 * 1024 * 1024;
 
+/// Merged image-token floor a chat request is charged when it does not set
+/// `camelid_image_min_tokens`.
+const DEFAULT_MIN_IMAGE_TOKENS: u32 = 8;
+/// Merged image-token ceiling a chat request is charged when it does not set
+/// `camelid_image_max_tokens`. `/v1/health` advertises this as
+/// `vision_token_allowance` so a client can budget context without guessing.
+const DEFAULT_MAX_IMAGE_TOKENS: u32 = 128;
+/// Hard bound on either override, whatever the request asks for.
+const IMAGE_TOKEN_HARD_CEILING: u32 = 1024;
+
 enum RunnablePreparedPrompt {
     Text(Vec<u32>),
     Vision {
@@ -14537,7 +14557,7 @@ fn prepare_runnable_prompt(
         return Err(api_error(
             StatusCode::SERVICE_UNAVAILABLE,
             "vision_projector_not_ready",
-            "the language model is loaded, but no Prism mmproj GGUF was found; place a *mmproj*.gguf beside the model or set CAMELID_MMPROJ before loading it"
+            "the language model is loaded, but no Prism image projector is ready: either no *mmproj*.gguf was found beside the model (set CAMELID_MMPROJ before loading it), or this build has no Metal or CUDA lane to decode with image embeddings"
                 .to_string(),
             Some("model"),
         ));
@@ -14582,10 +14602,13 @@ fn prepare_runnable_prompt(
                 None,
             )
         })?;
-    let min_image_tokens = image_min_tokens.unwrap_or(8).clamp(1, 1024) as usize;
+    let min_image_tokens = image_min_tokens
+        .unwrap_or(DEFAULT_MIN_IMAGE_TOKENS)
+        .clamp(1, IMAGE_TOKEN_HARD_CEILING) as usize;
     let max_image_tokens = image_max_tokens
-        .unwrap_or(128)
-        .clamp(min_image_tokens as u32, 1024) as usize;
+        .unwrap_or(DEFAULT_MAX_IMAGE_TOKENS)
+        .clamp(min_image_tokens as u32, IMAGE_TOKEN_HARD_CEILING)
+        as usize;
     Ok(RunnablePreparedPrompt::Vision {
         prefix,
         image_bytes: decode_prism_image_data_url(image_urls[0])?,
@@ -17547,6 +17570,12 @@ async fn llama_server_apply_template(
             )
         }
     };
+    // Ahead of validate_chat_messages: an audio-only or video-only message
+    // renders to empty content, so the generic empty-content refusal would
+    // otherwise answer first and hide which part type was actually rejected.
+    if let Some(response) = reject_unsupported_multimodal_content(&messages) {
+        return response;
+    }
     if let Err(response) = validate_chat_messages(&messages) {
         return *response;
     }
@@ -17555,6 +17584,49 @@ async fn llama_server_apply_template(
         Ok(model) => model,
         Err(response) => return response,
     };
+    // An image_url part renders to a Qwen vision marker unconditionally (see the
+    // ChatMessage Deserialize impl), so without this ladder every non-vision row
+    // answers 200 with `<|vision_start|>` sitting in the returned prompt. Refuse
+    // on the same three rungs, codes and wording the chat lane uses, so a client
+    // cannot tell the two routes apart. Architecture alone is not the predicate:
+    // the text-only qwen35 rows share it with the two Prism vision rows and are
+    // only separated by projector readiness.
+    let image_count: usize = messages
+        .iter()
+        .map(|message| message.image_urls.len())
+        .sum();
+    if image_count > 0 {
+        if image_count != 1 {
+            return api_error(
+                StatusCode::BAD_REQUEST,
+                "unsupported_image_count",
+                "Prism chat currently accepts exactly one image per request".to_string(),
+                Some("messages"),
+            );
+        }
+        if model.gguf.architecture() != Some("qwen35") {
+            return api_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "vision_model_required",
+                "image_url content requires a Prism/Qwen3.5 vision model".to_string(),
+                Some("model"),
+            );
+        }
+        let vision_ready = match resolve_runnable_runtime(&state, &None).await {
+            Ok(Some((_, runtime))) => runtime.vision_ready(),
+            Ok(None) => false,
+            Err(response) => return response,
+        };
+        if !vision_ready {
+            return api_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "vision_projector_not_ready",
+                "the language model is loaded, but no Prism image projector is ready: either no *mmproj*.gguf was found beside the model (set CAMELID_MMPROJ before loading it), or this build has no Metal or CUDA lane to decode with image embeddings"
+                    .to_string(),
+                Some("model"),
+            );
+        }
+    }
     let tokenizer = match model.tokenizer_runtime.clone() {
         Some(tokenizer) => tokenizer,
         None => match Tokenizer::from_gguf(&model.gguf) {

--- a/src/runnable/model.rs
+++ b/src/runnable/model.rs
@@ -1891,7 +1891,7 @@ impl RunnableModel {
             {
                 let _ = (prefix, image, suffix, max_new, stop, on_token);
                 Err(BackendError::UnsupportedGguf(
-                    "Prism image generation requires Metal or CUDA".into(),
+                    "generating with an attached image requires a Metal or CUDA build; this build can encode the image but has no lane to decode with it".into(),
                 ))
             }
         }
@@ -1952,7 +1952,7 @@ impl RunnableModel {
                     on_token,
                 );
                 Err(BackendError::UnsupportedGguf(
-                    "Prism image generation requires Metal or CUDA".into(),
+                    "generating with an attached image requires a Metal or CUDA build; this build can encode the image but has no lane to decode with it".into(),
                 ))
             }
         }

--- a/src/runnable/vision.rs
+++ b/src/runnable/vision.rs
@@ -178,6 +178,16 @@ pub struct PrismVisionProjector {
     cuda: PrismVisionCudaRuntime,
 }
 
+/// Whether this build has any lane that can *decode* with image embeddings.
+///
+/// Encoding an image is always possible — there is a CPU reference path — but
+/// generation with one is implemented only on Metal and CUDA. Health readiness
+/// has to answer for the whole request, so it consults this rather than asking
+/// the projector whether it can encode. Kept as a plain `const` rather than a
+/// `cfg!` at the use site so one cfg-independent test can pin it on every CI
+/// leg, including the legs that do not compile the arm it guards.
+pub(crate) const VISION_DECODE_LANE_EXISTS: bool = cfg!(any(target_os = "macos", feature = "cuda"));
+
 #[cfg(all(not(target_os = "macos"), feature = "cuda"))]
 // The encoder is a single long-lived execution object behind a mutex. Keeping
 // it inline avoids an extra heap indirection on every image request; the small
@@ -302,19 +312,52 @@ impl PrismVisionProjector {
             })?;
             self.initialize_cuda_lane(&mut lane)?;
         }
+        // Must stay `Ok` here: this runs inside the serve-runtime load, and
+        // failing would make the row unloadable for text too. Say why the image
+        // affordance will be missing instead of leaving the operator guessing.
+        #[cfg(all(not(target_os = "macos"), not(feature = "cuda")))]
+        {
+            eprintln!(
+                "[qwen3vl] projector loaded, but this build has no Metal or CUDA lane to decode \
+                 with image embeddings; image input stays unavailable and text is unaffected"
+            );
+        }
         Ok(())
     }
 
     /// Non-blocking readiness query for health/liveness endpoints. Image
     /// projection owns `cuda` for the duration of GPU execution; consulting
     /// that mutex here would let an ordinary image request stall health polls.
+    ///
+    /// This answers for the whole image request, not just the projector: a
+    /// build can encode an image on CPU and still have no lane that can decode
+    /// with it, so readiness has to account for [`VISION_DECODE_LANE_EXISTS`].
     pub fn backend_ready(&self) -> bool {
+        // A projector that can only encode is not readiness. CPU encode works
+        // everywhere, but generation with the result errors out unconditionally
+        // off Metal and CUDA, so a build with no decode lane must report false
+        // however healthy its projector is — reporting true would advertise a
+        // capability `src/api/contract.rs` scopes to
+        // `prism_single_image_data_url_metal_or_windows_cuda`.
+        if !VISION_DECODE_LANE_EXISTS {
+            return false;
+        }
+        // Truthful because both `mark_ready` call sites in `initialize_cuda_lane`
+        // now report the lane's actual final state rather than assuming success.
         #[cfg(all(not(target_os = "macos"), feature = "cuda"))]
         {
             self.cuda.is_ready()
         }
+        // macOS. Load already proved the Metal graph: `PrismVisionProjector::load`
+        // fails unless `model.metal_encoder()` succeeded, and constructing that
+        // encoder forces the process-global pipeline cache, so a projector we
+        // hold has its weights uploaded and its pipelines compiled. This is a
+        // claim about the lane existing, not a promise that every image encodes
+        // — per-request geometry can still be rejected.
         #[cfg(not(all(not(target_os = "macos"), feature = "cuda")))]
-        true
+        {
+            true
+        }
     }
 
     pub fn encode_image(
@@ -441,7 +484,10 @@ impl PrismVisionProjector {
                     "[qwen3vl] Windows CUDA projector not selected or unavailable; using CPU"
                 );
                 *lane = PrismVisionCudaLane::Disabled;
-                self.cuda.mark_ready(true);
+                // CPU encode still works, but nothing on this build can decode
+                // with the result, so readiness must reflect the lane, not the
+                // fact that we returned without an error.
+                self.cuda.mark_ready(false);
                 return Ok(());
             }
             *lane = match super::vision_cuda::CudaVisionEncoder::new() {
@@ -468,7 +514,11 @@ impl PrismVisionProjector {
             self.cuda.mark_ready(false);
             return Err(BackendError::UnsupportedGguf(diagnostic.clone()));
         }
-        self.cuda.mark_ready(true);
+        // Report the lane's actual state. Reaching here is not proof of success:
+        // a lane disabled during a previous encode is no longer `Pending`, so it
+        // skips the initialization block above and arrives here unchanged.
+        self.cuda
+            .mark_ready(matches!(*lane, PrismVisionCudaLane::Ready(_)));
         Ok(())
     }
 }
@@ -1207,6 +1257,21 @@ fn interpolate_positions_tile_major(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Deliberately cfg-independent so it runs on every CI leg, including the
+    /// ones that never compile the CPU-only arm of `backend_ready`. The defect
+    /// this guards against — advertising vision readiness on a build with no
+    /// decode lane — lived only in a configuration no CI leg builds, so a
+    /// cfg-gated test would not have caught it.
+    #[test]
+    fn vision_decode_lane_constant_agrees_with_the_lanes_that_exist() {
+        assert_eq!(
+            VISION_DECODE_LANE_EXISTS,
+            cfg!(any(target_os = "macos", feature = "cuda")),
+            "VISION_DECODE_LANE_EXISTS must track the cfgs that actually \
+             implement image decode; readiness is derived from it"
+        );
+    }
 
     #[test]
     fn qwen3vl_smart_resize_is_merge_aligned_and_bounded() {


### PR DESCRIPTION
Five defects on the existing image-**input** lane. Same shape each time: a surface claimed something the code underneath did not deliver. Found while auditing whether Camelid could generate images (it cannot — every row emits token logits; this PR is entirely about the input path it *does* have).

## 1. `/v1/health` never emitted `vision_token_allowance`

Zero Rust emitted it. Two frontend call sites read it and `web-research-smoke.mjs` asserted the *reader*, so the estimator silently fell back to `DEFAULT_VISION_TOKEN_ALLOWANCE = 1024` against a serve path whose default ceiling is 128 — an ~8x overcharge against the context window.

Exactly one image is admitted per request (`unsupported_image_count`), so 128 is the worst case for the whole request, not per image.

- Emit from **both** `HealthResponse` constructors (`None` on the busy path, which cannot read the registry and would be guessing).
- Hoist `8` / `128` / `1024` into `DEFAULT_MIN_IMAGE_TOKENS` / `DEFAULT_MAX_IMAGE_TOKENS` / `IMAGE_TOKEN_HARD_CEILING` so health and enforcement read one source. Health advertises the *default* ceiling; a request setting `camelid_image_max_tokens` may legitimately cost more.
- Lower the frontend fallback to 128 for clients on a new frontend talking to an older backend.

**The smoke is why this survived.** It pinned the consumer expression and passed continuously while nothing was emitted. It now pins the producer too — in the `field:` binding form so a doc-comment mention cannot pad the count, requiring at least 3 (declaration + both constructors). A single-site check would still pass on the busy-path-only mistake `mod.rs` already warns about. Negative-controlled: deleting one constructor fails the assertion.

## 2. `/apply-template` rendered a vision marker for any model

The marker is pushed unconditionally in `impl Deserialize for ChatMessage`, before any model exists. `/apply-template` was the one route taking `Vec<ChatMessage>` that never called `reject_unsupported_multimodal_content`, so a llama/qwen2/qwen3/phi3/gemma3 row answered **200** with `<|vision_start|>` in the returned prompt.

Now refuses on the same three rungs, codes, statuses and wording as the chat lane. **Architecture alone is not the predicate** — the four text-only `qwen35` rows share `architecture == "qwen35"` with the two Prism vision rows and are separated only by projector readiness, so an arch-only check would still have leaked on four supported rows.

The multimodal guard runs **before** `validate_chat_messages`: an audio-only or video-only message renders to empty content, so the generic empty-content refusal would otherwise answer first and hide which part type was rejected.

## 3. `backend_ready()` returned hardcoded `true`

On macOS *and* on CPU-only builds — so health advertised `vision_ready` on a build with no lane to decode with an image, contradicting `contract.rs`'s own `prism_single_image_data_url_metal_or_windows_cuda`.

- Readiness now answers for the whole request through `VISION_DECODE_LANE_EXISTS`. CPU encode works; generation with the result does not.
- The CUDA arm became *truthful*: both `mark_ready` sites report the lane's real final state. A lane disabled during an earlier encode is no longer `Pending`, so it skipped initialization and arrived at an unconditional `mark_ready(true)`.
- An operator diagnostic at load says why the affordance is missing. `ensure_backend_ready` still returns `Ok` — failing would make the row unloadable for text.

`not(macos) && not(cuda)` is compiled by **no CI leg** (it is the Pi-class aarch64-Linux config), which is why it went unnoticed and why the new test is deliberately cfg-independent — it runs on all three legs and would have caught this the day it landed.

## 4. Two follow-on message fixes

Fixing readiness alone would have replaced one false diagnostic with another: a CPU-only host *with* a valid mmproj would be told none was found. `vision_projector_not_ready` now names both causes.

`"Prism image generation requires Metal or CUDA"` said the opposite of what it meant — it sits on a fn returning `Result<Vec<u32>>`, so "generation" means generating *with* an image, not synthesizing one. It is the first thing anyone grepping this repo for image generation lands on. Both sites reworded; note `run_bench_generate_vision` reaches it from the CLI with no readiness precheck, so the wording reads for both callers.

## 5. Export dropped the image twice, and the dimensions were wrong

`MESSAGE_EXPORT_FIELDS` had no `image` entry, and Markdown had no user-turn branch (every extra render sits behind `if (message.role === 'assistant')`). JSON now carries it through a nested whitelist — `data_url` **last** on purpose, so the descriptive fields stay readable instead of sitting behind a wall of base64. Markdown emits a metadata blockquote and says the data is *not* included rather than asserting where it is; the JSON export is a separate button that may never be pressed.

`prepareVisionAttachment` returned `naturalWidth`/`naturalHeight` (pre-resize) alongside post-resize `size` and `data_url`, describing an image that was never sent. Those fields have no reader today, which is what let it go unnoticed — fix 5 is what would have made it user-facing, so the two land together.

## Verification

`cargo test --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, both renderer-seal validators, `check-ledger-drift`, `check-ledger-schema`, `check-public-scrub`, and `smoke:ui` / `smoke:web-research` / `smoke:integration`.

Renderer seal refreshed in order (fixture blob-sha1, then 3 sites, then recompute fixture sha256, then 2 sites); `shape_pack` and `LLAMA_PIN` hashes deliberately untouched. `contract.rs` is **not** edited, so no ledger regeneration — this brings code into line with the ledger rather than changing it.

One flake seen once on the sibling branch and not reproduced: `fabric::server::tests::a_query_string_is_not_recorded` failed on a single full-parallelism run, then passed isolated, module-wide, and on further full runs. Unrelated to this diff (fabric is untouched) and consistent with the known fixed-port local flake.

## Deliberately not fixed here

- The compaction path in `useDashboardData.js` still counts base64 transport length via the local `estimateTokenCount`. Moving it requires hoisting a declaration through a region pinned verbatim by a smoke.
- `ChatWorkspace.jsx` never passes `imageTokens`, so the context meter's `images` segment is always dropped — `contextBudget.js` and `context-meter-smoke.mjs` already support it; it was built and tested, never connected.
- macOS `backend_ready` could consult `!encoder.is_poisoned()`. Deferred: no production precedent in this crate, no test on any leg exercises it, and it flips a public wire field irrecoverably.

## Note on the seal

`src/api/mod.rs` is edited, so the renderer seal was recomputed against **this** repo's `mod.rs` — 3 blob-sha1 sites plus the fixture's own sha256 at 2 more, exactly 5 changed lines. `shape_pack`, `NORMALIZED_PROMPT_SHA256`, `LLAMA_PIN.*` and `LLAMA_ARCHIVE_SHA256` are deliberately untouched.

Of the currently open PRs only #623 also touches `src/api/mod.rs`; if that lands first this pin needs refreshing against the merged tree before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
