### PR TITLE
Stop discarding images an MCP tool returns

### DIFF
--- a/docs/reference/AUDIT_EVENTS.md
+++ b/docs/reference/AUDIT_EVENTS.md
@@ -47,7 +47,8 @@ Both events share one JSON shape. `outcome` and `duration_ms` are `null` on
   "approval_tier": "confirm",        // tier applied: "auto" | "confirm" | "deny"
   "args_digest": "sha256:9f86d0…",   // SHA-256 of the canonical args JSON
   "outcome": "ok",                   // "ok" | "error" | null (null on tool_call)
-  "duration_ms": 12                  // execution wall time | null (null on tool_call)
+  "duration_ms": 12,                 // execution wall time | null (null on tool_call)
+  "images": 0                        // images the result carried | null (null on tool_call)
 }
 ```
 
@@ -66,6 +67,11 @@ Both events share one JSON shape. `outcome` and `duration_ms` are `null` on
   shell command, a read error), not a transport error. The raw output text is
   deliberately **not** included (it, too, can carry secrets or injected
   content).
+- **`images`** — how many images the tool result carried, and never the image
+  data itself, for the same reason the raw output text is excluded. A tool can
+  return image content (an MCP server's `image` blocks, for example); the count
+  makes that visible to an operator without putting an untrusted payload on the
+  audit path.
 - **`timestamp_unix_ms`** — wall-clock at event construction. The
   `tool_result` timestamp minus the `tool_call` timestamp will be close to, but
   is not authoritative for, `duration_ms`; use `duration_ms` for timing.

--- a/src/chat/agent.rs
+++ b/src/chat/agent.rs
@@ -1603,11 +1603,10 @@ fn clip_retained(messages: &mut [AgentMsg], target_tokens: u32, calibration: Opt
                 "\n...[{} more bytes elided to fit the context budget - re-read if needed]",
                 text.len().saturating_sub(excerpt.len())
             ));
-            let clipped = if outcome.is_err() {
-                ToolOutcome::Err(excerpt)
-            } else {
-                ToolOutcome::Ok(excerpt)
-            };
+            // Rebuild through with_text rather than from text() + is_err():
+            // reconstructing the variant by hand is what silently discards any
+            // payload the reconstruction does not know about.
+            let clipped = outcome.clone().with_text(excerpt);
             messages[index] = AgentMsg::ToolResult {
                 name: name.clone(),
                 outcome: clipped,

--- a/src/chat/audit.rs
+++ b/src/chat/audit.rs
@@ -76,6 +76,11 @@ pub struct AuditEvent {
     pub args_digest: String,
     pub outcome: Option<AuditOutcome>,
     pub duration_ms: Option<u64>,
+    /// How many images the tool result carried. A count, never the bytes — the
+    /// same posture as `outcome`, since image data from an untrusted tool is
+    /// exactly the kind of payload this trail must record without transmitting.
+    /// `None` on `tool_call`.
+    pub images: Option<usize>,
 }
 
 impl AuditEvent {
@@ -89,6 +94,7 @@ impl AuditEvent {
             args_digest,
             outcome: None,
             duration_ms: None,
+            images: None,
         }
     }
 
@@ -112,6 +118,7 @@ impl AuditEvent {
                 AuditOutcome::Ok
             }),
             duration_ms: Some(duration.as_millis() as u64),
+            images: Some(outcome.images().len()),
         }
     }
 
@@ -129,6 +136,7 @@ impl AuditEvent {
             "args_digest": self.args_digest,
             "outcome": self.outcome.map(AuditOutcome::label),
             "duration_ms": self.duration_ms,
+            "images": self.images,
         })
     }
 }

--- a/src/chat/mcp.rs
+++ b/src/chat/mcp.rs
@@ -39,10 +39,11 @@ use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use super::tools::{Risk, Sandbox, ToolSpec};
+use super::tools::{Risk, Sandbox, ToolImage, ToolSpec};
 
 /// The config file, read from the workspace root only.
 pub const CONFIG_FILE: &str = "camelid.mcp.json";
@@ -58,6 +59,17 @@ const INIT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Cap on a single MCP tool result, mirroring the native output cap.
 const MAX_RESULT_BYTES: usize = 16 * 1024;
+/// Images ride beside the text rather than inside it, so they need their own
+/// bounds — an MCP server is untrusted and this payload is persisted.
+///
+/// These are sized against the agent session file, not against what an image
+/// "should" be: `agent_session::MAX_SESSION_BYTES` is 4 MiB for the *whole*
+/// transcript, and base64 costs ~4/3. Two images of 768 KiB decoded is ~2 MiB
+/// encoded, leaving half the budget for the conversation. A more generous cap
+/// would let one tool result make the session unsaveable, which loses the run
+/// rather than one image. Measured on the decoded bytes.
+const MAX_RESULT_IMAGES: usize = 2;
+const MAX_RESULT_IMAGE_BYTES: usize = 768 * 1024;
 const MAX_CONFIG_BYTES: usize = 64 * 1024;
 const MAX_SERVERS: usize = 8;
 const MAX_SERVER_ARGS: usize = 64;
@@ -664,7 +676,7 @@ impl Server {
         args: &Value,
         cancel: &AtomicBool,
         shutdown: &AtomicBool,
-    ) -> Result<String, String> {
+    ) -> Result<(String, Vec<ToolImage>), String> {
         let res = self.request(
             "tools/call",
             json!({"name": tool, "arguments": args}),
@@ -675,6 +687,7 @@ impl Server {
         // MCP returns content blocks; flatten the text ones. A server may also
         // signal a tool-level failure via isError while still returning 200.
         let mut text = String::new();
+        let mut images: Vec<ToolImage> = Vec::new();
         if let Some(blocks) = res.get("content").and_then(Value::as_array) {
             for b in blocks {
                 match b.get("type").and_then(Value::as_str) {
@@ -683,6 +696,19 @@ impl Server {
                             text.push_str(t);
                             text.push('\n');
                         }
+                    }
+                    // Keep the image out of `text` and carry it structurally.
+                    // The marker below stays byte-identical to what the
+                    // fall-through used to write, because it is still true of
+                    // what the model reads: nothing feeds these into a prompt.
+                    // Holding them here stops the discard at the boundary.
+                    Some("image") => {
+                        if let Some(image) = mcp_image_block(b) {
+                            if images.len() < MAX_RESULT_IMAGES {
+                                images.push(image);
+                            }
+                        }
+                        text.push_str("[image content omitted]\n");
                     }
                     Some(other) => text.push_str(&format!("[{other} content omitted]\n")),
                     None => {}
@@ -703,7 +729,7 @@ impl Server {
         if res.get("isError").and_then(Value::as_bool) == Some(true) {
             return Err(text);
         }
-        Ok(text)
+        Ok((text, images))
     }
 
     fn terminate(&mut self) {
@@ -967,17 +993,48 @@ pub fn has_tool(public: &str) -> bool {
         .is_some_and(|r| r.tools.iter().any(|e| e.public == public))
 }
 
+/// Parse one MCP `image` content block into a [`ToolImage`].
+///
+/// Returns `None` unless the block names a mime type the chat API's image
+/// decoder accepts and carries base64 that decodes within the size bound.
+/// Validating at the producer means a server cannot put something downstream
+/// would have to reject into a session file.
+fn mcp_image_block(block: &Value) -> Option<ToolImage> {
+    let mime = block.get("mimeType").and_then(Value::as_str)?;
+    if !matches!(mime, "image/png" | "image/jpeg" | "image/jpg") {
+        return None;
+    }
+    let data = block.get("data").and_then(Value::as_str)?;
+    // Bound the decode itself: base64 is ~4/3 of the payload, so an encoded
+    // length past that ratio cannot fit and is rejected without allocating.
+    if data.len() / 4 * 3 > MAX_RESULT_IMAGE_BYTES {
+        return None;
+    }
+    let decoded = BASE64_STANDARD.decode(data).ok()?;
+    if decoded.is_empty() || decoded.len() > MAX_RESULT_IMAGE_BYTES {
+        return None;
+    }
+    Some(ToolImage {
+        mime: mime.to_string(),
+        data_base64: data.to_string(),
+    })
+}
+
 /// Invoke a namespaced MCP tool. The returned text is untrusted data and is
 /// surfaced to the model through the same fenced tool-result path as any other.
 #[cfg(test)]
-pub fn call(public: &str, args: &Value) -> Result<String, String> {
+pub fn call(public: &str, args: &Value) -> Result<(String, Vec<ToolImage>), String> {
     call_with_cancel(public, args, &super::session::CANCEL)
 }
 
 /// Cancellation-aware invocation used by the agent loop. Only registry lookup
 /// happens under the process-wide mutex; the potentially long round trip is
 /// serialized by the selected server's own mutex.
-pub fn call_with_cancel(public: &str, args: &Value, cancel: &AtomicBool) -> Result<String, String> {
+pub fn call_with_cancel(
+    public: &str,
+    args: &Value,
+    cancel: &AtomicBool,
+) -> Result<(String, Vec<ToolImage>), String> {
     let guard = registry()
         .lock()
         .map_err(|_| "mcp registry poisoned".to_string())?;
@@ -1002,6 +1059,67 @@ pub fn call_with_cancel(public: &str, args: &Value, cancel: &AtomicBool) -> Resu
         .lock()
         .map_err(|_| format!("MCP server '{server_name}' lock poisoned"))?;
     inner.call(&tool, args, cancel, &server.stop)
+}
+
+#[cfg(test)]
+mod image_block_tests {
+    use super::*;
+
+    fn block(mime: &str, decoded_len: usize) -> Value {
+        let data = BASE64_STANDARD.encode(vec![0u8; decoded_len]);
+        json!({"type": "image", "mimeType": mime, "data": data})
+    }
+
+    #[test]
+    fn a_png_block_is_carried_rather_than_discarded() {
+        let parsed = mcp_image_block(&block("image/png", 64)).expect("a valid png is carried");
+        assert_eq!(parsed.mime, "image/png");
+        assert_eq!(
+            BASE64_STANDARD.decode(&parsed.data_base64).unwrap().len(),
+            64
+        );
+    }
+
+    #[test]
+    fn a_mime_the_image_decoder_would_reject_is_refused_at_the_producer() {
+        // Validating here means a server cannot put something downstream would
+        // have to reject into a session file.
+        for mime in ["image/gif", "image/webp", "image/svg+xml", "text/plain"] {
+            assert!(
+                mcp_image_block(&block(mime, 64)).is_none(),
+                "{mime} must not be carried"
+            );
+        }
+    }
+
+    #[test]
+    fn an_image_past_the_session_budget_is_refused() {
+        assert!(mcp_image_block(&block("image/png", MAX_RESULT_IMAGE_BYTES + 1)).is_none());
+        assert!(mcp_image_block(&block("image/png", MAX_RESULT_IMAGE_BYTES)).is_some());
+    }
+
+    #[test]
+    fn a_malformed_or_empty_block_is_refused_without_panicking() {
+        assert!(mcp_image_block(&json!({"type": "image"})).is_none());
+        assert!(mcp_image_block(&json!({"type":"image","mimeType":"image/png"})).is_none());
+        assert!(mcp_image_block(
+            &json!({"type":"image","mimeType":"image/png","data":"not base64!"})
+        )
+        .is_none());
+        assert!(
+            mcp_image_block(&json!({"type":"image","mimeType":"image/png","data":""})).is_none()
+        );
+    }
+
+    /// The images must stay OUT of the text: the text is what the model reads
+    /// and what the byte cap bounds, and base64 in there would be truncated
+    /// mid-payload as well as flooding the prompt.
+    #[test]
+    fn the_carried_image_never_enters_the_result_text() {
+        let parsed = mcp_image_block(&block("image/png", 4096)).unwrap();
+        assert!(parsed.data_base64.len() > 1024);
+        assert!(!"[image content omitted]\n".contains(&parsed.data_base64[..64]));
+    }
 }
 
 #[cfg(test)]
@@ -1423,8 +1541,9 @@ for line in sys.stdin:
         assert!(echo.description.contains("Echo a value."));
 
         // A real call round-trips, tolerating the server's non-JSON stderr noise.
-        let out = call("mcp__stub__echo", &json!({"v":"hi"})).unwrap();
+        let (out, images) = call("mcp__stub__echo", &json!({"v":"hi"})).unwrap();
         assert!(out.contains("echo:hi"), "{out}");
+        assert!(images.is_empty(), "a text-only reply carries no images");
 
         // A tool-level failure comes back as an error, not a silent success.
         let err = call("mcp__stub__boom", &json!({})).unwrap_err();

--- a/src/chat/tools.rs
+++ b/src/chat/tools.rs
@@ -187,21 +187,67 @@ pub struct ToolCall {
     pub args: Value,
 }
 
+/// An image a tool produced, carried alongside its text.
+///
+/// Base64 rather than `Vec<u8>` on purpose: this rides inside the agent session
+/// file, where a byte vector serializes as a JSON integer array (~7x the size
+/// and unreadable), and the one decoder that would ever consume it wants a
+/// base64 data URL anyway. `mime` is constrained at the producer to the types
+/// that decoder accepts, so a tool cannot manufacture something unrepresentable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolImage {
+    pub mime: String,
+    pub data_base64: String,
+}
+
 /// The result of running a tool — text the model consumes as data.
+///
+/// `OkWith` is a success that also carries images. It is deliberately a third
+/// variant rather than a field on `Ok`: the two tuple variants stay
+/// byte-identical, so the ~137 construction sites and every `matches!` pattern
+/// in the tree keep compiling.
+///
+/// Test the success/failure axis with [`ToolOutcome::is_err`], never with
+/// `matches!(out, ToolOutcome::Ok(_))` — the latter is false for an
+/// image-bearing success.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ToolOutcome {
     Ok(String),
     Err(String),
+    OkWith {
+        text: String,
+        images: Vec<ToolImage>,
+    },
 }
 
 impl ToolOutcome {
     pub fn text(&self) -> &str {
         match self {
             ToolOutcome::Ok(s) | ToolOutcome::Err(s) => s,
+            ToolOutcome::OkWith { text, .. } => text,
         }
     }
     pub fn is_err(&self) -> bool {
         matches!(self, ToolOutcome::Err(_))
+    }
+
+    /// Images this outcome carries; empty for every text-only outcome, so
+    /// existing callers need no change.
+    pub fn images(&self) -> &[ToolImage] {
+        match self {
+            ToolOutcome::OkWith { images, .. } => images,
+            _ => &[],
+        }
+    }
+
+    /// Rebuild this outcome with new text, keeping any images. Use this instead
+    /// of reconstructing from `text()` + `is_err()`, which silently drops them.
+    pub fn with_text(self, text: String) -> Self {
+        match self {
+            ToolOutcome::Ok(_) => ToolOutcome::Ok(text),
+            ToolOutcome::Err(_) => ToolOutcome::Err(text),
+            ToolOutcome::OkWith { images, .. } => ToolOutcome::OkWith { text, images },
+        }
     }
 
     pub fn clipped(self, max_bytes: usize) -> Self {
@@ -219,6 +265,12 @@ impl ToolOutcome {
         match self {
             Self::Ok(text) => Self::Ok(clip_text(text)),
             Self::Err(text) => Self::Err(clip_text(text)),
+            // Clip the text, pass the images through: the byte budget exists to
+            // bound what the model reads, and an image is not read as text.
+            Self::OkWith { text, images } => Self::OkWith {
+                text: clip_text(text),
+                images,
+            },
         }
     }
 }
@@ -1301,7 +1353,14 @@ impl Action {
             // the same fenced tool-result path as every native tool.
             Action::McpCall { name, args } => {
                 match super::mcp::call_with_cancel(name, args, cancel) {
-                    Ok(text) => ToolOutcome::Ok(clip(&text)),
+                    Ok((text, images)) if images.is_empty() => ToolOutcome::Ok(clip(&text)),
+                    // The text is clipped as before; the images ride beside it
+                    // so the byte budget for what the model reads does not
+                    // destroy them. Nothing feeds them into a prompt yet.
+                    Ok((text, images)) => ToolOutcome::OkWith {
+                        text: clip(&text),
+                        images,
+                    },
                     Err(error) => ToolOutcome::Err(error),
                 }
             }
@@ -3949,6 +4008,78 @@ fn write_summary(path: &Path, content: &str) -> String {
             };
             format!("  create: {new_lines} lines\n{}{tail}", head.join("\n"))
         }
+    }
+}
+
+#[cfg(test)]
+mod outcome_image_tests {
+    use super::*;
+
+    fn with_image(text: &str) -> ToolOutcome {
+        ToolOutcome::OkWith {
+            text: text.to_string(),
+            images: vec![ToolImage {
+                mime: "image/png".to_string(),
+                data_base64: "aGVsbG8=".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn an_image_bearing_success_is_not_an_error() {
+        let out = with_image("done");
+        assert!(!out.is_err(), "OkWith is a success");
+        assert_eq!(out.text(), "done");
+        assert_eq!(out.images().len(), 1);
+    }
+
+    #[test]
+    fn text_only_outcomes_carry_no_images() {
+        assert!(ToolOutcome::Ok("x".into()).images().is_empty());
+        assert!(ToolOutcome::Err("x".into()).images().is_empty());
+    }
+
+    /// The observation byte cap exists to bound what the model READS. An image
+    /// is not read as text, so clipping must not destroy it — this is the path
+    /// every Workspace-profile result takes at 2 KiB.
+    #[test]
+    fn clipping_bounds_the_text_and_keeps_the_images() {
+        let clipped = with_image(&"a".repeat(10_000)).clipped(128);
+        assert!(clipped.text().len() <= 128, "text is bounded");
+        assert_eq!(clipped.images().len(), 1, "the image survives clipping");
+    }
+
+    /// Rebuilding from `text()` + `is_err()` is what silently dropped payloads;
+    /// `with_text` is the replacement and must preserve them.
+    #[test]
+    fn rebuilding_with_new_text_preserves_images_and_the_error_axis() {
+        let rebuilt = with_image("original").with_text("excerpt".into());
+        assert_eq!(rebuilt.text(), "excerpt");
+        assert_eq!(rebuilt.images().len(), 1);
+        assert!(!rebuilt.is_err());
+
+        assert!(ToolOutcome::Err("boom".into())
+            .with_text("clipped".into())
+            .is_err());
+        assert!(!ToolOutcome::Ok("fine".into())
+            .with_text("clipped".into())
+            .is_err());
+    }
+
+    /// Images are persisted to the agent session file, so the encoding has to
+    /// round-trip. Base64 rather than a byte vector keeps that file readable
+    /// and roughly 7x smaller than a JSON integer array would be.
+    #[test]
+    fn an_image_bearing_outcome_round_trips_through_json() {
+        let json = serde_json::to_string(&with_image("done")).unwrap();
+        assert!(
+            json.contains("aGVsbG8="),
+            "base64 stays a string in the session file: {json}"
+        );
+        let back: ToolOutcome = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.images().len(), 1);
+        assert_eq!(back.images()[0].mime, "image/png");
+        assert_eq!(back.text(), "done");
     }
 }
 


### PR DESCRIPTION
`src/chat/mcp.rs` replaced every non-text MCP content block with the literal string `[image content omitted]` and threw the bytes away at the protocol boundary. Wire in an MCP screenshot or image-generation server today and that string is the entire result. This makes the tool layer able to hold an image and stops the discard.

## Shape

`ToolOutcome` gains a **third variant** rather than a field on `Ok`:

```rust
pub enum ToolOutcome {
    Ok(String),
    Err(String),
    OkWith { text: String, images: Vec<ToolImage> },
}
```

Both tuple variants stay byte-identical, so all ~137 construction sites and every `matches!` pattern keep compiling — exactly **two** arms had to change (`text()` and `clipped()`). A struct-shaped rewrite would have been ~137 simultaneous compile errors.

`ToolImage` carries **base64 strings, not `Vec<u8>`**. This type is persisted to the agent session file, where a byte vector serializes as a JSON integer array — roughly 7x the size and unreadable to anyone inspecting what a tool captured. `serde_bytes` is also not a dependency, and the one decoder that would ever consume this wants base64 anyway.

## Two paths that would have destroyed the payload silently

- **`clipped()`** now bounds the text and passes images through. That cap exists to bound what the model *reads*, and an image is not read as text. Without the pass-through, every Workspace-profile result loses its images at 2 KiB.
- **`clip_retained`** rebuilt the outcome from `text()` + `is_err()` — a reconstruction structurally cannot preserve something it does not know about. It now goes through a new `with_text`, so a future variant is a compile error there instead of silent loss.

## Bounds are sized against the session file

`agent_session::MAX_SESSION_BYTES` is **4 MiB for the whole transcript**, and base64 costs ~⅓ on top. Two images at 768 KiB decoded is ~2 MiB encoded, leaving half the budget for the conversation. A more generous cap would let one tool result make the session **unsaveable** — losing the whole run rather than one image. (My first draft used 8 MiB per image, which would have done exactly that.)

Mime types are validated **at the producer** to the three the chat API's image decoder accepts, so a server cannot put something downstream would have to reject into a session file. Images stay out of `text`, which also keeps them clear of the 16 KiB `MAX_RESULT_BYTES` truncation that would otherwise clip base64 mid-payload.

## Audit

The trail now records **how many** images a result carried, never the bytes — the same posture the raw output text already has, and for the same reason. An untrusted server returning image data is something an operator should be able to see. `docs/reference/AUDIT_EVENTS.md` updated.

## What this deliberately does NOT do

**Nothing feeds these into a model prompt.** No wire format changes, no contract changes. The text an MCP image block produces is byte-identical to before, so what the model reads is unchanged and the `[image content omitted]` marker stays *true*.

That restraint is not caution, it is three independent gates that make an end-to-end vision+tool loop impossible today, all outside this diff:

1. `src/api/mod.rs` returns 400 `unsupported_vision_tools` whenever tools and an image co-occur — and the agent loop emits `"tools"` on **every** step, unconditionally.
2. No ledger row is both vision-capable and tool-capable. The 6 `tool_capable` rows and the 2 `qwen35_bonsai_gpu_vision` rows are disjoint sets, and the agent loop refuses to start at five separate code sites.
3. `vision_tool_combination` is a declared `unsupported_mode` in `contract.rs`, repeated in `COMPATIBILITY.md`, and backed by a checksummed evidence bundle recording that this exact combination was *measured* to fail closed on 2026-08-01.

Lifting those needs an agent-eval PASS receipt on a 27B row and a fresh dated measurement superseding that bundle — a model run, not a code change. This PR is the half that is real today.

One more thing worth knowing before that work starts: `"qwen35_bonsai_gpu_vision".contains("qwen3")` is **true**, so the only vision family takes the qwen-native-tools branch, which `format!`s the tool result into a `<tool_response>` string. Any future design has to target that arm, not the `role:"tool"` one.

## Verification

`cargo test --all-targets` (10 new tests), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `check-public-scrub`, `check-ledger-drift`, `check-ledger-schema`.

Neither `src/api/mod.rs` nor `src/api/contract.rs` is touched, so the renderer seal never fires and the ledger does not move.

## Known limitation

An older binary loading a session containing `OkWith` reports `session … is corrupt`, which is misleading — the file is fine, the binary is old. There is no version field on `SavedAgentSession` to give a typed refusal instead. Bounded in practice: MCP is opt-in behind `--allow-mcp` plus a per-server `--trust-mcp-server`, and hard-refused under `CAMELID_PRODUCTION`, so nothing can write `OkWith` on a default install. Worth a version field before the next variant lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
