### PR TITLE
chore(release): bump version to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "camelid"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "camelid-desktop"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "camelid"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 # MSRV floor, deliberately BELOW the toolchain in rust-toolchain.toml (1.95.0) —
 # these are different things and should not be "aligned". rust-toolchain.toml

--- a/camelid-desktop/Cargo.toml
+++ b/camelid-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camelid-desktop"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 # MSRV floor, not the build toolchain — see the note in the workspace Cargo.toml.
 rust-version = "1.89"

--- a/camelid-desktop/tauri.conf.json
+++ b/camelid-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Camelid Desktop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "identifier": "app.camelid.desktop",
   "build": {
     "frontendDist": "./splash"


### PR DESCRIPTION
## Release v0.7.3

This bumps the version to 0.7.3 so the release is cut from exactly `main` plus this bump. Once this PR is green and merged, the merge commit gets a lightweight `v0.7.3` tag, and pushing that tag triggers `release.yml`.

**The bump:** 4 files, 5 lines: `Cargo.toml`, `camelid-desktop/Cargo.toml`, `camelid-desktop/tauri.conf.json`, and only the `camelid` / `camelid-desktop` blocks in `Cargo.lock`. No line-ending churn. The two `0.7.2` mentions under `qa/evidence-bundles/` are records of past builds and stay as they are.

## What ships: 21 PRs since v0.7.2

**WebUI**
- #748 continue a reply that stopped on the response budget
- #750 keep regenerated replies side by side instead of replacing them
- #751 pin, archive, tag, bulk-export and import conversations
- #749 render math (KaTeX) in assistant replies
- #755 draw Mermaid diagrams in assistant replies
- #744 animate the Load button while a model is loading
- #752 de-flake the conversation-organization browser smoke

**Tools and images**
- #753 make the image-input path report what it can actually do
- #754 stop discarding images an MCP tool returns

**CUDA**
- #737 continue a resident prefill from the KV it already holds
- #738 mirror the resident KV back to the host lazily, not every request
- #746 measure `CAMELID_FLASH_PREFILL`, and correct two claims it fails

**Metal / macOS**
- #718 make the split-K kv16 `_direct` precondition a single guard
- #739 stop taking a partial prefix-cache hit that lands on the CPU
- #740 measure and document the K-quant attention-as-matmul trade
- #741 free a model's resident weights when it is unloaded
- #742 let a Q8_0 model keep attention-as-matmul on an F16 KV primary
- #743 let the batched prefill continue from a non-zero base position
- #745 reuse a conversation's GPU KV across turns instead of re-prefilling

**Housekeeping**
- #735 simplify the README and move detailed setup into guides
- #747 remove the unreachable paged/radix KV modules

`release.yml` generates the release notes automatically (`generate_release_notes: true`).

## After merge

1. Tag the merge commit `v0.7.3` (lightweight) and push the tag, which triggers `release.yml`.
2. Expect **11 assets**: 5 payloads, each with a `.sha256`, plus the signed Windows installer, which has no `.sha256` by design. `verify-release-assets` demotes an incomplete release to a prerelease, so `latest` can't point at a broken one.
3. Check the shipped artifact: download the Windows zip, verify its digest and Authenticode signature, and A/B it against v0.7.2 on the same models directory.
